### PR TITLE
2025-01-26_main-include-fix

### DIFF
--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#include "./src/agent_framework.c"
+#include "./include/agent_framework.h"
 #include <stdio.h>
 
 // clang-format off

--- a/main.c
+++ b/main.c
@@ -1,4 +1,4 @@
-#include "../include/agent_framework.h"
+#include "./src/agent_framework.c"
 #include <stdio.h>
 
 // clang-format off


### PR DESCRIPTION
Issue : 
Current include in main.c
Line 1: #include "../include/agent_framework.h"

Error:
On build/compile the following errors would trigger 

2.654 /usr/bin/ld: /tmp/ccyaFYDi.o: in function `main':
2.654 main.c:(.text+0x13): undefined reference to `create_agent'
2.654 /usr/bin/ld: main.c:(.text+0x1c): undefined reference to `create_agent_manager'
2.654 /usr/bin/ld: main.c:(.text+0x33): undefined reference to `register_agent'
2.654 /usr/bin/ld: main.c:(.text+0x3f): undefined reference to `start_agent_manager'
2.654 /usr/bin/ld: main.c:(.text+0x4b): undefined reference to `stop_agent_manager'
2.654 /usr/bin/ld: main.c:(.text+0x57): undefined reference to `destroy_agent_manager'
2.655 collect2: error: ld returned 1 exit status

Fix:
Changing #include "../include/agent_framework.h" to  #include "./include/agent_framework.h
