### PR TITLE
feat: multisig governance gating

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -121,6 +121,21 @@ pub enum CoordinationError {
     #[msg("Insufficient stake for arbiter registration")]
     InsufficientStake,
 
+    #[msg("Invalid multisig threshold")]
+    MultisigInvalidThreshold,
+
+    #[msg("Invalid multisig signer configuration")]
+    MultisigInvalidSigners,
+
+    #[msg("Not enough multisig signers")]
+    MultisigNotEnoughSigners,
+
+    #[msg("Duplicate multisig signer provided")]
+    MultisigDuplicateSigner,
+
+    #[msg("Multisig signer cannot be default pubkey")]
+    MultisigDefaultSigner,
+
     // General errors (6600-6699)
     #[msg("Invalid input parameter")]
     InvalidInput,

--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -12,6 +12,7 @@ pub mod initiate_dispute;
 pub mod vote_dispute;
 pub mod resolve_dispute;
 pub mod initialize_protocol;
+pub mod update_protocol_fee;
 
 pub use register_agent::*;
 pub use update_agent::*;
@@ -25,3 +26,4 @@ pub use initiate_dispute::*;
 pub use vote_dispute::*;
 pub use resolve_dispute::*;
 pub use initialize_protocol::*;
+pub use update_protocol_fee::*;

--- a/programs/agenc-coordination/src/instructions/update_protocol_fee.rs
+++ b/programs/agenc-coordination/src/instructions/update_protocol_fee.rs
@@ -1,0 +1,34 @@
+//! Update protocol fee (multisig gated)
+
+use anchor_lang::prelude::*;
+
+use crate::errors::CoordinationError;
+use crate::state::ProtocolConfig;
+use crate::utils::multisig::require_multisig;
+
+#[derive(Accounts)]
+pub struct UpdateProtocolFee<'info> {
+    #[account(
+        mut,
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+}
+
+pub fn handler(
+    ctx: Context<UpdateProtocolFee>,
+    protocol_fee_bps: u16,
+) -> Result<()> {
+    require!(
+        protocol_fee_bps <= 1000,
+        CoordinationError::InvalidProtocolFee
+    );
+
+    require_multisig(&ctx.accounts.protocol_config, ctx.remaining_accounts)?;
+
+    let config = &mut ctx.accounts.protocol_config;
+    config.protocol_fee_bps = protocol_fee_bps;
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -13,6 +13,7 @@ pub mod state;
 pub mod instructions;
 pub mod errors;
 pub mod events;
+pub mod utils;
 
 use instructions::*;
 use errors::CoordinationError;
@@ -173,7 +174,24 @@ pub mod agenc_coordination {
         dispute_threshold: u8,
         protocol_fee_bps: u16,
         min_stake: u64,
+        multisig_threshold: u8,
+        multisig_owners: Vec<Pubkey>,
     ) -> Result<()> {
-        instructions::initialize_protocol::handler(ctx, dispute_threshold, protocol_fee_bps, min_stake)
+        instructions::initialize_protocol::handler(
+            ctx,
+            dispute_threshold,
+            protocol_fee_bps,
+            min_stake,
+            multisig_threshold,
+            multisig_owners,
+        )
+    }
+
+    /// Update the protocol fee (multisig gated).
+    pub fn update_protocol_fee(
+        ctx: Context<UpdateProtocolFee>,
+        protocol_fee_bps: u16,
+    ) -> Result<()> {
+        instructions::update_protocol_fee::handler(ctx, protocol_fee_bps)
     }
 }

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -94,8 +94,14 @@ pub struct ProtocolConfig {
     pub total_value_distributed: u64,
     /// Bump seed for PDA
     pub bump: u8,
-    /// Reserved for future use
-    pub _reserved: [u8; 64],
+    /// Multisig threshold
+    pub multisig_threshold: u8,
+    /// Length of configured multisig owners
+    pub multisig_owners_len: u8,
+    /// Padding for alignment/future use
+    pub _padding: [u8; 6],
+    /// Multisig owners (fixed-size)
+    pub multisig_owners: [Pubkey; ProtocolConfig::MAX_MULTISIG_OWNERS],
 }
 
 impl Default for ProtocolConfig {
@@ -111,12 +117,16 @@ impl Default for ProtocolConfig {
             completed_tasks: 0,
             total_value_distributed: 0,
             bump: 0,
-            _reserved: [0u8; 64],
+            multisig_threshold: 0,
+            multisig_owners_len: 0,
+            _padding: [0u8; 6],
+            multisig_owners: [Pubkey::default(); ProtocolConfig::MAX_MULTISIG_OWNERS],
         }
     }
 }
 
 impl ProtocolConfig {
+    pub const MAX_MULTISIG_OWNERS: usize = 5;
     pub const SIZE: usize = 8 + // discriminator
         32 + // authority
         32 + // treasury
@@ -128,7 +138,10 @@ impl ProtocolConfig {
         8 +  // completed_tasks
         8 +  // total_value_distributed
         1 +  // bump
-        64; // reserved
+        1 +  // multisig_threshold
+        1 +  // multisig_owners_len
+        6 +  // padding
+        (32 * Self::MAX_MULTISIG_OWNERS); // multisig owners
 }
 
 /// Agent registration account

--- a/programs/agenc-coordination/src/utils/mod.rs
+++ b/programs/agenc-coordination/src/utils/mod.rs
@@ -1,0 +1,3 @@
+//! Utility helpers for AgenC Coordination Protocol
+
+pub mod multisig;

--- a/programs/agenc-coordination/src/utils/multisig.rs
+++ b/programs/agenc-coordination/src/utils/multisig.rs
@@ -1,0 +1,51 @@
+//! Multisig approval helpers
+
+use anchor_lang::prelude::*;
+
+use crate::errors::CoordinationError;
+use crate::state::ProtocolConfig;
+
+pub fn require_multisig(
+    config: &ProtocolConfig,
+    remaining_accounts: &[AccountInfo],
+) -> Result<()> {
+    let owners_len = config.multisig_owners_len as usize;
+    let threshold = config.multisig_threshold as usize;
+
+    if owners_len == 0 || owners_len > ProtocolConfig::MAX_MULTISIG_OWNERS {
+        return Err(error!(CoordinationError::MultisigInvalidSigners));
+    }
+
+    if threshold == 0 || threshold > owners_len {
+        return Err(error!(CoordinationError::MultisigInvalidThreshold));
+    }
+
+    let mut approvals = 0usize;
+    let mut seen_owner = [false; ProtocolConfig::MAX_MULTISIG_OWNERS];
+
+    for account in remaining_accounts {
+        if !account.is_signer {
+            continue;
+        }
+
+        for (index, owner) in config.multisig_owners[..owners_len].iter().enumerate() {
+            if owner == &Pubkey::default() {
+                return Err(error!(CoordinationError::MultisigDefaultSigner));
+            }
+
+            if account.key == owner {
+                if seen_owner[index] {
+                    return Err(error!(CoordinationError::MultisigDuplicateSigner));
+                }
+                seen_owner[index] = true;
+                approvals += 1;
+            }
+        }
+    }
+
+    if approvals < threshold {
+        return Err(error!(CoordinationError::MultisigNotEnoughSigners));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
<img width="249" height="117" alt="image" src="https://github.com/user-attachments/assets/413c111e-9f39-416e-bc9c-8ed7da2417e0" />

- Adds multisig owner + threshold configuration to ProtocolConfig

- Enforces multisig approvals via remaining_accounts signers

- Introduces multisig-gated update_protocol_fee admin instruction

- Adds multisig helper + dedicated error codes