### PR TITLE
Tests/Docs: Devnet security hardening - OPERATION BULLETPROOF

### DIFF
--- a/docs/MAINNET_MIGRATION.md
+++ b/docs/MAINNET_MIGRATION.md
@@ -1,0 +1,26 @@
+# Mainnet Migration (Draft)
+
+This document captures high-level tasks required for a future mainnet launch. It omits operational secrets and deployment credentials.
+
+## Scope
+
+- Confirm multisig governance and authority rotation strategy.
+- Finalize audited program version and deployment artifact hashes.
+- Validate Devnet edge-case coverage in CI and release gating.
+
+## Technical Readiness
+
+- Ensure deterministic builds and reproducible binaries.
+- Validate program upgrade path and buffer authority handling.
+- Lock protocol parameters and document change controls.
+
+## Operational Readiness
+
+- Define monitoring, alerting, and incident response runbooks.
+- Establish key management, signer rotation, and emergency procedures.
+- Plan staged rollout with rollback criteria.
+
+## Compliance and Verification
+
+- Record audit evidence, threat model updates, and test results.
+- Verify deployment checksums and on-chain configuration.

--- a/docs/SECURITY_AUDIT_DEVNET.md
+++ b/docs/SECURITY_AUDIT_DEVNET.md
@@ -62,6 +62,18 @@ The protocol invariants below are enforced by program constraints and are used f
 - Devnet smoke tests for end-to-end task, escrow, and dispute flows.
 - On-chain execution verification via Devnet RPC and Explorer checks.
 
+## Spoofing Simulations (Devnet Tests)
+
+The devnet security suite includes spoofing simulations that validate failure paths for:
+
+- Capability-gated actions (arbiter-only voting) with unauthorized signers.
+- Replay attempts (re-using dispute/vote PDAs) to prevent duplicate actions.
+- Unauthorized task completion attempts (authority spoofing).
+- Reputation cap enforcement when repeated completions approach bounds.
+- Deadline/timeout and stale-state checks for disputes and task cancellation.
+
+These simulations mitigate spoofing, replay, and authority-bypass threats while validating the enforcement of reputation bounds and time-based guards.
+
 ## Smoke Test Results Summary
 
 - Total tests: 24

--- a/docs/audit/THREAT_MODEL.md
+++ b/docs/audit/THREAT_MODEL.md
@@ -42,6 +42,14 @@ Task state desync
 
 Authority bypass
 
+Governance / Authority Threats
+
+Single authority key compromise (pre-multisig)
+
+Misconfigured governance parameters without multisig gating
+
+Residual risk during transition from single-authority to multisig enforcement
+
 ## Protocol Invariants
 
 ### Escrow Invariants
@@ -166,9 +174,9 @@ Authority bypass
 - Prevents: Dispute capture, authority bypass
 
 **A5: Protocol Authority Exclusivity**
-- Statement: Only `ProtocolConfig.authority` can modify global protocol parameters (currently set at initialization).
+- Statement: Only `ProtocolConfig.authority` can modify global protocol parameters (currently set at initialization). Governance changes are intended to be multisig-gated; until multisig enforcement is active, single-authority compromise remains a residual risk.
 - Applies to: `initialize_protocol`
-- Prevents: Authority bypass, protocol takeover
+- Prevents: Authority bypass, protocol takeover (with residual risk prior to multisig)
 
 ### Dispute Invariants
 


### PR DESCRIPTION
<img width="1024" height="1024" alt="BULLETPROOF" src="https://github.com/user-attachments/assets/006ff5c6-0497-45d6-8bd0-f8514cefd468" />

## OPERATION BULLETPROOF

**Summary**

Adds devnet edge case coverage and audit artifacts for the AgenC Solana coordination program including spoofing simulations, replay protection checks, and governance risk notes for the current single authority setup

**Whats Included**

**Docs**
Mainnet migration draft outlining high level readiness and rollout checklist
Devnet security audit update documenting spoofing simulations and the rationale for the negative path coverage
Threat model update clarifying the residual governance risk prior to multisig enforcement

**Tests**
coordination security suite expanded with
Capability gated action spoof attempts with unauthorized signers
Replay attempts for dispute and vote PDAs
Unauthorized task completion attempts
Reputation cap enforcement under repeated completions
Deadline and stale state guards for cancellation dispute initiation and early resolution

**Testing**
```bash
anchor test
```
**Commits**
Devnet edge case tests and audit docs
Spoofing simulations and replay resistance coverage
Threat model clarification for pre multisig authority risk