### PR TITLE
refactor: consolidate tests into focused modules

### DIFF
--- a/tests/agent-registration.ts
+++ b/tests/agent-registration.ts
@@ -1,0 +1,377 @@
+/**
+ * Agent Registration Tests
+ *
+ * Tests for agent registration, updates, and deregistration functionality.
+ * Covers: registerAgent, updateAgent, deregisterAgent instructions.
+ *
+ * Run with: npx ts-mocha tests/agent-registration.ts
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { expect } from "chai";
+import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { AgencCoordination } from "../target/types/agenc_coordination";
+import {
+  CAPABILITY_COMPUTE,
+  CAPABILITY_INFERENCE,
+  CAPABILITY_ARBITER,
+  deriveProtocolPda,
+  deriveAgentPda,
+  generateRunId,
+  makeAgentId,
+  fundWallet,
+  fundWallets,
+  initializeProtocolIfNeeded,
+  disableRateLimits,
+  registerAgent,
+  registerAgentSafe,
+} from "./utils/test-helpers";
+
+describe("Agent Registration", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.AgencCoordination as Program<AgencCoordination>;
+  const protocolPda = deriveProtocolPda(program.programId);
+  const runId = generateRunId();
+
+  let treasury: Keypair;
+  let treasuryPubkey: PublicKey;
+
+  before(async () => {
+    console.log("\n========================================");
+    console.log("Agent Registration Tests");
+    console.log("Program ID:", program.programId.toBase58());
+    console.log("Run ID:", runId);
+    console.log("========================================\n");
+
+    treasury = Keypair.generate();
+    await fundWallet(provider.connection, treasury);
+
+    treasuryPubkey = await initializeProtocolIfNeeded(
+      program,
+      protocolPda,
+      treasury,
+      provider.wallet as anchor.Wallet
+    );
+
+    await disableRateLimits(program, protocolPda, provider.wallet as anchor.Wallet);
+  });
+
+  // ============================================================================
+  // Registration Happy Paths
+  // ============================================================================
+
+  describe("Registration Happy Paths", () => {
+    it("registers agent with minimum stake", async () => {
+      const wallet = Keypair.generate();
+      await fundWallet(provider.connection, wallet, 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("min-stake", runId);
+      const agentPda = await registerAgent(
+        program,
+        protocolPda,
+        agentId,
+        wallet,
+        CAPABILITY_COMPUTE,
+        LAMPORTS_PER_SOL / 10
+      );
+
+      const agent = await program.account.agentRegistration.fetch(agentPda);
+      expect(agent.authority.toBase58()).to.equal(wallet.publicKey.toBase58());
+      expect(agent.capabilities.toNumber()).to.equal(CAPABILITY_COMPUTE);
+      expect(agent.stake.toNumber()).to.be.greaterThan(0);
+      expect(agent.status).to.equal(1); // Active
+      console.log("  Agent registered with minimum stake");
+    });
+
+    it("registers agent with multiple capabilities", async () => {
+      const wallet = Keypair.generate();
+      await fundWallet(provider.connection, wallet, 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("multi-cap", runId);
+      const capabilities = CAPABILITY_COMPUTE | CAPABILITY_INFERENCE | CAPABILITY_ARBITER;
+      const agentPda = await registerAgent(
+        program,
+        protocolPda,
+        agentId,
+        wallet,
+        capabilities
+      );
+
+      const agent = await program.account.agentRegistration.fetch(agentPda);
+      expect(agent.capabilities.toNumber() & CAPABILITY_COMPUTE).to.be.greaterThan(0);
+      expect(agent.capabilities.toNumber() & CAPABILITY_INFERENCE).to.be.greaterThan(0);
+      expect(agent.capabilities.toNumber() & CAPABILITY_ARBITER).to.be.greaterThan(0);
+      console.log("  Agent registered with multiple capabilities");
+    });
+
+    it("registers agent with custom endpoint", async () => {
+      const wallet = Keypair.generate();
+      await fundWallet(provider.connection, wallet, 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("custom-ep", runId);
+      const agentPda = deriveAgentPda(agentId, program.programId);
+
+      await program.methods
+        .registerAgent(
+          Array.from(agentId),
+          new BN(CAPABILITY_COMPUTE),
+          "https://my-custom-endpoint.example.com/api/v2",
+          null,
+          new BN(LAMPORTS_PER_SOL / 10)
+        )
+        .accountsPartial({
+          agent: agentPda,
+          protocolConfig: protocolPda,
+          authority: wallet.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([wallet])
+        .rpc({ skipPreflight: true });
+
+      const agent = await program.account.agentRegistration.fetch(agentPda);
+      expect(agent.endpoint).to.include("my-custom-endpoint");
+      console.log("  Agent registered with custom endpoint");
+    });
+  });
+
+  // ============================================================================
+  // Registration Rejection Cases
+  // ============================================================================
+
+  describe("Registration Rejection Cases", () => {
+    it("rejects duplicate agent ID registration", async () => {
+      const wallet1 = Keypair.generate();
+      const wallet2 = Keypair.generate();
+      await fundWallets(provider.connection, [wallet1, wallet2], 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("dup-test", runId);
+
+      // First registration succeeds
+      await registerAgent(program, protocolPda, agentId, wallet1);
+
+      // Second registration with same ID fails
+      try {
+        await registerAgent(program, protocolPda, agentId, wallet2);
+        expect.fail("Should have rejected duplicate registration");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("already in use") || msg.includes("AlreadyRegistered")
+        );
+        console.log("  Duplicate registration rejected");
+      }
+    });
+
+    it("rejects registration with insufficient stake", async () => {
+      const wallet = Keypair.generate();
+      await fundWallet(provider.connection, wallet, 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("low-stake", runId);
+      const agentPda = deriveAgentPda(agentId, program.programId);
+
+      try {
+        await program.methods
+          .registerAgent(
+            Array.from(agentId),
+            new BN(CAPABILITY_COMPUTE),
+            "https://test.example.com",
+            null,
+            new BN(1) // 1 lamport - below minimum
+          )
+          .accountsPartial({
+            agent: agentPda,
+            protocolConfig: protocolPda,
+            authority: wallet.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([wallet])
+          .rpc();
+        expect.fail("Should have rejected insufficient stake");
+      } catch (e: any) {
+        expect(e.message).to.include("InsufficientStake");
+        console.log("  Insufficient stake rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Update Agent Tests
+  // ============================================================================
+
+  describe("Update Agent", () => {
+    let agentOwner: Keypair;
+    let agentId: Buffer;
+    let agentPda: PublicKey;
+
+    before(async () => {
+      agentOwner = Keypair.generate();
+      await fundWallet(provider.connection, agentOwner, 2 * LAMPORTS_PER_SOL);
+
+      agentId = makeAgentId("update-test", runId);
+      agentPda = await registerAgent(
+        program,
+        protocolPda,
+        agentId,
+        agentOwner,
+        CAPABILITY_COMPUTE
+      );
+    });
+
+    it("allows owner to update capabilities", async () => {
+      const newCapabilities = CAPABILITY_COMPUTE | CAPABILITY_INFERENCE;
+
+      await program.methods
+        .updateAgent(new BN(newCapabilities), null, null, null)
+        .accountsPartial({
+          agent: agentPda,
+          authority: agentOwner.publicKey,
+        })
+        .signers([agentOwner])
+        .rpc();
+
+      const agent = await program.account.agentRegistration.fetch(agentPda);
+      expect(agent.capabilities.toNumber()).to.equal(newCapabilities);
+      console.log("  Capabilities updated by owner");
+    });
+
+    it("allows owner to update endpoint", async () => {
+      await program.methods
+        .updateAgent(null, "https://new-endpoint.example.com", null, null)
+        .accountsPartial({
+          agent: agentPda,
+          authority: agentOwner.publicKey,
+        })
+        .signers([agentOwner])
+        .rpc();
+
+      const agent = await program.account.agentRegistration.fetch(agentPda);
+      expect(agent.endpoint).to.include("new-endpoint");
+      console.log("  Endpoint updated by owner");
+    });
+
+    it("rejects update by non-owner", async () => {
+      const nonOwner = Keypair.generate();
+      await fundWallet(provider.connection, nonOwner);
+
+      try {
+        await program.methods
+          .updateAgent(new BN(CAPABILITY_ARBITER), null, null, null)
+          .accountsPartial({
+            agent: agentPda,
+            authority: nonOwner.publicKey,
+          })
+          .signers([nonOwner])
+          .rpc();
+        expect.fail("Should have rejected non-owner update");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("UnauthorizedAgent") || msg.includes("constraint")
+        );
+        console.log("  Non-owner update rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Deregistration Tests
+  // ============================================================================
+
+  describe("Deregistration", () => {
+    it("allows owner to deregister inactive agent", async () => {
+      const wallet = Keypair.generate();
+      await fundWallet(provider.connection, wallet, 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("dereg-ok", runId);
+      const agentPda = await registerAgent(program, protocolPda, agentId, wallet);
+
+      const balanceBefore = await provider.connection.getBalance(wallet.publicKey);
+
+      await program.methods
+        .deregisterAgent()
+        .accountsPartial({
+          agent: agentPda,
+          protocolConfig: protocolPda,
+          authority: wallet.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([wallet])
+        .rpc();
+
+      const balanceAfter = await provider.connection.getBalance(wallet.publicKey);
+      expect(balanceAfter).to.be.greaterThan(balanceBefore * 0.9);
+      console.log("  Agent deregistered and stake returned");
+    });
+
+    it("rejects deregistration by non-owner", async () => {
+      const owner = Keypair.generate();
+      const nonOwner = Keypair.generate();
+      await fundWallets(provider.connection, [owner, nonOwner], 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("dereg-fail", runId);
+      const agentPda = await registerAgent(program, protocolPda, agentId, owner);
+
+      try {
+        await program.methods
+          .deregisterAgent()
+          .accountsPartial({
+            agent: agentPda,
+            protocolConfig: protocolPda,
+            authority: nonOwner.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([nonOwner])
+          .rpc();
+        expect.fail("Should have rejected non-owner deregistration");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("UnauthorizedAgent") || msg.includes("constraint")
+        );
+        console.log("  Non-owner deregistration rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Agent Status Queries
+  // ============================================================================
+
+  describe("Agent Status Queries", () => {
+    it("correctly reports agent status as active", async () => {
+      const wallet = Keypair.generate();
+      await fundWallet(provider.connection, wallet, 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("status-test", runId);
+      const agentPda = await registerAgent(program, protocolPda, agentId, wallet);
+
+      const agent = await program.account.agentRegistration.fetch(agentPda);
+      expect(agent.status).to.equal(1); // Active
+      expect(agent.tasksCompleted).to.equal(0);
+      expect(agent.activeTasks).to.equal(0);
+      console.log("  Agent status query successful");
+    });
+
+    it("tracks agent statistics correctly", async () => {
+      const wallet = Keypair.generate();
+      await fundWallet(provider.connection, wallet, 2 * LAMPORTS_PER_SOL);
+
+      const agentId = makeAgentId("stats-test", runId);
+      const agentPda = await registerAgent(program, protocolPda, agentId, wallet);
+
+      const agent = await program.account.agentRegistration.fetch(agentPda);
+      expect(agent.totalEarned.toNumber()).to.equal(0);
+      expect(agent.tasksCompleted).to.equal(0);
+      expect(agent.disputesWon).to.equal(0);
+      expect(agent.disputesLost).to.equal(0);
+      console.log("  Agent statistics initialized correctly");
+    });
+  });
+
+  after(() => {
+    console.log("\n========================================");
+    console.log("Agent Registration Tests Complete");
+    console.log("========================================\n");
+  });
+});

--- a/tests/disputes.ts
+++ b/tests/disputes.ts
@@ -1,0 +1,586 @@
+/**
+ * Dispute System Tests
+ *
+ * Tests for dispute initiation, voting, and resolution.
+ * Covers: initiateDispute, voteDispute, resolveDispute instructions.
+ *
+ * Run with: npx ts-mocha tests/disputes.ts
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { expect } from "chai";
+import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { AgencCoordination } from "../target/types/agenc_coordination";
+import {
+  CAPABILITY_COMPUTE,
+  CAPABILITY_ARBITER,
+  TASK_TYPE_EXCLUSIVE,
+  HASH_SIZE,
+  VALID_EVIDENCE,
+  deriveProtocolPda,
+  deriveAgentPda,
+  deriveTaskPda,
+  deriveEscrowPda,
+  deriveClaimPda,
+  deriveDisputePda,
+  deriveVotePda,
+  generateRunId,
+  makeAgentId,
+  makeTaskId,
+  makeDisputeId,
+  fundWallet,
+  fundWallets,
+  initializeProtocolIfNeeded,
+  disableRateLimits,
+  registerAgent,
+  createTask,
+  claimTask,
+  WorkerPool,
+} from "./utils/test-helpers";
+
+describe("Dispute System", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.AgencCoordination as Program<AgencCoordination>;
+  const protocolPda = deriveProtocolPda(program.programId);
+  const runId = generateRunId();
+
+  // Resolution types
+  const RESOLUTION_REFUND = 0;
+  const RESOLUTION_COMPLETE = 1;
+  const RESOLUTION_SLASH = 2;
+
+  // Voting period (from protocol config)
+  const VOTING_PERIOD = 24 * 60 * 60; // 24 hours
+
+  let treasury: Keypair;
+  let treasuryPubkey: PublicKey;
+  let creator: Keypair;
+  let creatorAgentPda: PublicKey;
+  let workerPool: WorkerPool;
+
+  before(async () => {
+    console.log("\n========================================");
+    console.log("Dispute System Tests");
+    console.log("Program ID:", program.programId.toBase58());
+    console.log("Run ID:", runId);
+    console.log("========================================\n");
+
+    treasury = Keypair.generate();
+    creator = Keypair.generate();
+    await fundWallets(provider.connection, [treasury, creator], 10 * LAMPORTS_PER_SOL);
+
+    treasuryPubkey = await initializeProtocolIfNeeded(
+      program,
+      protocolPda,
+      treasury,
+      provider.wallet as anchor.Wallet
+    );
+
+    await disableRateLimits(program, protocolPda, provider.wallet as anchor.Wallet);
+
+    // Register creator agent
+    const creatorAgentId = makeAgentId("disp-creator", runId);
+    creatorAgentPda = await registerAgent(
+      program,
+      protocolPda,
+      creatorAgentId,
+      creator,
+      CAPABILITY_COMPUTE
+    );
+
+    // Initialize worker pool with arbiter capability
+    workerPool = new WorkerPool(program, protocolPda, provider, runId);
+    await workerPool.initialize(15);
+
+    console.log("  Setup complete\n");
+  });
+
+  // Helper to create a claimed task for dispute testing
+  async function createClaimedTask(suffix: string): Promise<{
+    taskPda: PublicKey;
+    escrowPda: PublicKey;
+    claimPda: PublicKey;
+    worker: { wallet: Keypair; agentId: Buffer; agentPda: PublicKey };
+    taskId: Buffer;
+  }> {
+    const taskId = makeTaskId(`disp-${suffix}`, runId);
+    const { taskPda, escrowPda } = await createTask({
+      program,
+      protocolPda,
+      taskId,
+      creatorAgentPda,
+      creatorWallet: creator,
+      reward: LAMPORTS_PER_SOL / 10,
+    });
+
+    const worker = await workerPool.createFreshWorker(CAPABILITY_COMPUTE | CAPABILITY_ARBITER);
+    const claimPda = await claimTask(
+      program,
+      protocolPda,
+      taskPda,
+      worker.agentPda,
+      worker.wallet
+    );
+
+    return { taskPda, escrowPda, claimPda, worker, taskId };
+  }
+
+  // ============================================================================
+  // Dispute Initiation
+  // ============================================================================
+
+  describe("Dispute Initiation", () => {
+    it("allows worker to initiate dispute on in-progress task", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("init-1");
+      const disputeId = makeDisputeId("init-1", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.alloc(HASH_SIZE, 0x11)),
+          RESOLUTION_REFUND,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      const dispute = await program.account.dispute.fetch(disputePda);
+      expect(dispute.status).to.deep.equal({ active: {} });
+      expect(dispute.resolutionType).to.deep.equal({ refund: {} });
+      expect(dispute.votesFor).to.equal(0);
+      expect(dispute.votesAgainst).to.equal(0);
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ disputed: {} });
+
+      console.log("  Dispute initiated on in-progress task");
+    });
+
+    it("sets correct voting deadline (24 hours from creation)", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("init-2");
+      const disputeId = makeDisputeId("init-2", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      const beforeTimestamp = Math.floor(Date.now() / 1000);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.alloc(HASH_SIZE, 0x22)),
+          RESOLUTION_COMPLETE,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      const afterTimestamp = Math.floor(Date.now() / 1000);
+      const dispute = await program.account.dispute.fetch(disputePda);
+
+      expect(dispute.votingDeadline.toNumber()).to.be.at.least(beforeTimestamp + VOTING_PERIOD - 10);
+      expect(dispute.votingDeadline.toNumber()).to.be.at.most(afterTimestamp + VOTING_PERIOD + 10);
+
+      console.log("  Voting deadline set correctly");
+    });
+
+    it("rejects dispute on open task", async () => {
+      const taskId = makeTaskId("disp-open", runId);
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      const disputeId = makeDisputeId("open", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+      const worker = await workerPool.createFreshWorker(CAPABILITY_COMPUTE | CAPABILITY_ARBITER);
+
+      try {
+        await program.methods
+          .initiateDispute(
+            Array.from(disputeId),
+            Array.from(taskId),
+            Array.from(Buffer.alloc(HASH_SIZE, 0x33)),
+            RESOLUTION_REFUND,
+            VALID_EVIDENCE
+          )
+          .accountsPartial({
+            dispute: disputePda,
+            task: taskPda,
+            agent: worker.agentPda,
+            authority: worker.wallet.publicKey,
+            protocolConfig: protocolPda,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([worker.wallet])
+          .rpc();
+        expect.fail("Should have rejected dispute on open task");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("TaskNotInProgress") || msg.includes("constraint")
+        );
+        console.log("  Dispute on open task rejected");
+      }
+    });
+
+    it("rejects dispute with insufficient evidence", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("init-3");
+      const disputeId = makeDisputeId("init-3", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      try {
+        await program.methods
+          .initiateDispute(
+            Array.from(disputeId),
+            Array.from(taskId),
+            Array.from(Buffer.alloc(HASH_SIZE, 0x44)),
+            RESOLUTION_REFUND,
+            "Too short" // Less than 50 characters
+          )
+          .accountsPartial({
+            dispute: disputePda,
+            task: taskPda,
+            agent: worker.agentPda,
+            authority: worker.wallet.publicKey,
+            protocolConfig: protocolPda,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([worker.wallet])
+          .rpc();
+        expect.fail("Should have rejected insufficient evidence");
+      } catch (e: any) {
+        expect(e.message).to.include("InsufficientEvidence");
+        console.log("  Insufficient evidence rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Dispute Voting
+  // ============================================================================
+
+  describe("Dispute Voting", () => {
+    it("allows arbiter to vote on dispute", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("vote-1");
+      const disputeId = makeDisputeId("vote-1", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.alloc(HASH_SIZE, 0x55)),
+          RESOLUTION_REFUND,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      // Create an arbiter to vote
+      const arbiter = await workerPool.createFreshWorker(CAPABILITY_COMPUTE | CAPABILITY_ARBITER);
+      const votePda = deriveVotePda(disputePda, arbiter.agentPda, program.programId);
+
+      await program.methods
+        .voteDispute(true) // Vote in favor
+        .accountsPartial({
+          dispute: disputePda,
+          vote: votePda,
+          arbiter: arbiter.agentPda,
+          authority: arbiter.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([arbiter.wallet])
+        .rpc({ skipPreflight: true });
+
+      const dispute = await program.account.dispute.fetch(disputePda);
+      expect(dispute.votesFor).to.equal(1);
+      expect(dispute.votesAgainst).to.equal(0);
+
+      console.log("  Arbiter voted on dispute");
+    });
+
+    it("records votes correctly (for and against)", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("vote-2");
+      const disputeId = makeDisputeId("vote-2", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.alloc(HASH_SIZE, 0x66)),
+          RESOLUTION_COMPLETE,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      // First arbiter votes FOR
+      const arbiter1 = await workerPool.createFreshWorker(CAPABILITY_COMPUTE | CAPABILITY_ARBITER);
+      const vote1Pda = deriveVotePda(disputePda, arbiter1.agentPda, program.programId);
+
+      await program.methods
+        .voteDispute(true)
+        .accountsPartial({
+          dispute: disputePda,
+          vote: vote1Pda,
+          arbiter: arbiter1.agentPda,
+          authority: arbiter1.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([arbiter1.wallet])
+        .rpc({ skipPreflight: true });
+
+      // Second arbiter votes AGAINST
+      const arbiter2 = await workerPool.createFreshWorker(CAPABILITY_COMPUTE | CAPABILITY_ARBITER);
+      const vote2Pda = deriveVotePda(disputePda, arbiter2.agentPda, program.programId);
+
+      await program.methods
+        .voteDispute(false)
+        .accountsPartial({
+          dispute: disputePda,
+          vote: vote2Pda,
+          arbiter: arbiter2.agentPda,
+          authority: arbiter2.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([arbiter2.wallet])
+        .rpc({ skipPreflight: true });
+
+      const dispute = await program.account.dispute.fetch(disputePda);
+      expect(dispute.votesFor).to.equal(1);
+      expect(dispute.votesAgainst).to.equal(1);
+
+      console.log("  Votes for and against recorded correctly");
+    });
+
+    it("rejects duplicate vote from same arbiter", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("vote-3");
+      const disputeId = makeDisputeId("vote-3", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.alloc(HASH_SIZE, 0x77)),
+          RESOLUTION_REFUND,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      const arbiter = await workerPool.createFreshWorker(CAPABILITY_COMPUTE | CAPABILITY_ARBITER);
+      const votePda = deriveVotePda(disputePda, arbiter.agentPda, program.programId);
+
+      // First vote
+      await program.methods
+        .voteDispute(true)
+        .accountsPartial({
+          dispute: disputePda,
+          vote: votePda,
+          arbiter: arbiter.agentPda,
+          authority: arbiter.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([arbiter.wallet])
+        .rpc({ skipPreflight: true });
+
+      // Try to vote again
+      try {
+        await program.methods
+          .voteDispute(false)
+          .accountsPartial({
+            dispute: disputePda,
+            vote: votePda,
+            arbiter: arbiter.agentPda,
+            authority: arbiter.wallet.publicKey,
+            protocolConfig: protocolPda,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([arbiter.wallet])
+          .rpc();
+        expect.fail("Should have rejected duplicate vote");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("AlreadyVoted") || msg.includes("already in use")
+        );
+        console.log("  Duplicate vote rejected");
+      }
+    });
+
+    it("rejects vote from non-arbiter", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("vote-4");
+      const disputeId = makeDisputeId("vote-4", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.alloc(HASH_SIZE, 0x88)),
+          RESOLUTION_REFUND,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      // Create agent WITHOUT arbiter capability
+      const nonArbiter = await workerPool.createFreshWorker(CAPABILITY_COMPUTE); // No ARBITER
+      const votePda = deriveVotePda(disputePda, nonArbiter.agentPda, program.programId);
+
+      try {
+        await program.methods
+          .voteDispute(true)
+          .accountsPartial({
+            dispute: disputePda,
+            vote: votePda,
+            arbiter: nonArbiter.agentPda,
+            authority: nonArbiter.wallet.publicKey,
+            protocolConfig: protocolPda,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([nonArbiter.wallet])
+          .rpc();
+        expect.fail("Should have rejected non-arbiter vote");
+      } catch (e: any) {
+        expect(e.message).to.include("NotArbiter");
+        console.log("  Non-arbiter vote rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Dispute State
+  // ============================================================================
+
+  describe("Dispute State", () => {
+    it("dispute starts with Active status", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("state-1");
+      const disputeId = makeDisputeId("state-1", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.alloc(HASH_SIZE, 0x99)),
+          RESOLUTION_REFUND,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      const dispute = await program.account.dispute.fetch(disputePda);
+      expect(dispute.status).to.deep.equal({ active: {} });
+      expect(dispute.initiator.toBase58()).to.equal(worker.agentPda.toBase58());
+
+      console.log("  Dispute starts with Active status");
+    });
+
+    it("stores evidence hash correctly", async () => {
+      const { taskPda, worker, taskId } = await createClaimedTask("state-2");
+      const disputeId = makeDisputeId("state-2", runId);
+      const disputePda = deriveDisputePda(disputeId, program.programId);
+      const evidenceHash = Buffer.alloc(HASH_SIZE, 0xAA);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(evidenceHash),
+          RESOLUTION_COMPLETE,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+        })
+        .signers([worker.wallet])
+        .rpc({ skipPreflight: true });
+
+      const dispute = await program.account.dispute.fetch(disputePda);
+      expect(Buffer.from(dispute.evidenceHash)).to.deep.equal(evidenceHash);
+
+      console.log("  Evidence hash stored correctly");
+    });
+  });
+
+  after(() => {
+    console.log("\n========================================");
+    console.log("Dispute System Tests Complete");
+    console.log("========================================\n");
+  });
+});

--- a/tests/protocol-config.ts
+++ b/tests/protocol-config.ts
@@ -1,0 +1,263 @@
+/**
+ * Protocol Configuration Tests
+ *
+ * Tests for protocol initialization and configuration updates.
+ * Covers: initializeProtocol, updateProtocolFee, updateRateLimits instructions.
+ *
+ * Run with: npx ts-mocha tests/protocol-config.ts
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { expect } from "chai";
+import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { AgencCoordination } from "../target/types/agenc_coordination";
+import {
+  deriveProtocolPda,
+  generateRunId,
+  fundWallet,
+  fundWallets,
+} from "./utils/test-helpers";
+
+describe("Protocol Configuration", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.AgencCoordination as Program<AgencCoordination>;
+  const protocolPda = deriveProtocolPda(program.programId);
+  const runId = generateRunId();
+
+  let treasury: Keypair;
+
+  before(async () => {
+    console.log("\n========================================");
+    console.log("Protocol Configuration Tests");
+    console.log("Program ID:", program.programId.toBase58());
+    console.log("Run ID:", runId);
+    console.log("========================================\n");
+
+    treasury = Keypair.generate();
+    await fundWallet(provider.connection, treasury);
+  });
+
+  // ============================================================================
+  // Protocol Initialization
+  // ============================================================================
+
+  describe("Protocol Initialization", () => {
+    it("initializes protocol with valid parameters", async () => {
+      // Note: Protocol may already be initialized from previous tests
+      // This test verifies the config can be fetched
+      try {
+        await program.methods
+          .initializeProtocol(
+            51,                              // dispute_quorum_percent
+            100,                             // dispute_vote_period
+            new BN(LAMPORTS_PER_SOL / 10),   // min_stake
+            1,                               // min_multisig_signers
+            [provider.wallet.publicKey]      // multisig_signers
+          )
+          .accountsPartial({
+            protocolConfig: protocolPda,
+            treasury: treasury.publicKey,
+            authority: provider.wallet.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .remainingAccounts([
+            { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
+          ])
+          .rpc({ skipPreflight: true });
+        console.log("  Protocol initialized");
+      } catch (e: any) {
+        if (e.message?.includes("already in use")) {
+          console.log("  Protocol already initialized (expected)");
+        } else {
+          throw e;
+        }
+      }
+
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      expect(config.isInitialized).to.be.true;
+      expect(config.disputeQuorumPercent).to.be.at.least(1);
+      expect(config.disputeQuorumPercent).to.be.at.most(100);
+      console.log("  Protocol config verified");
+    });
+
+    it("stores correct treasury address", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      expect(config.treasury).to.be.instanceOf(PublicKey);
+      // Treasury should be a valid pubkey (not zero)
+      expect(config.treasury.toBase58()).to.not.equal(PublicKey.default.toBase58());
+      console.log("  Treasury address:", config.treasury.toBase58().slice(0, 16) + "...");
+    });
+
+    it("stores minimum stake requirement", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      expect(config.minStake.toNumber()).to.be.greaterThan(0);
+      console.log("  Min stake:", config.minStake.toNumber() / LAMPORTS_PER_SOL, "SOL");
+    });
+
+    it("stores multisig configuration", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      expect(config.minMultisigSigners).to.be.at.least(1);
+      expect(config.multisigSigners.length).to.be.at.least(config.minMultisigSigners);
+      console.log("  Multisig threshold:", config.minMultisigSigners);
+    });
+  });
+
+  // ============================================================================
+  // Protocol Fee Updates
+  // ============================================================================
+
+  describe("Protocol Fee Updates", () => {
+    it("reads current protocol fee", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      // Fee is in basis points (0-1000 = 0-10%)
+      expect(config.protocolFeeBps).to.be.at.least(0);
+      expect(config.protocolFeeBps).to.be.at.most(1000);
+      console.log("  Current protocol fee:", config.protocolFeeBps, "bps");
+    });
+
+    it("requires multisig for fee updates", async () => {
+      // Attempting to update fee without proper multisig should fail
+      // unless we're already a multisig signer
+      try {
+        await program.methods
+          .updateProtocolFee(100) // 1% fee
+          .accountsPartial({
+            protocolConfig: protocolPda,
+          })
+          .remainingAccounts([
+            { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
+          ])
+          .rpc();
+        console.log("  Fee updated (user is multisig signer)");
+      } catch (e: any) {
+        if (e.message?.includes("MultisigNotEnoughSigners")) {
+          console.log("  Fee update rejected (not enough signers)");
+        } else {
+          // If we are a multisig signer, update succeeded
+          console.log("  Fee update result:", e.message.slice(0, 50));
+        }
+      }
+    });
+
+    it("rejects invalid fee (> 1000 bps)", async () => {
+      try {
+        await program.methods
+          .updateProtocolFee(1001) // 10.01% - too high
+          .accountsPartial({
+            protocolConfig: protocolPda,
+          })
+          .remainingAccounts([
+            { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
+          ])
+          .rpc();
+        expect.fail("Should have rejected invalid fee");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("InvalidProtocolFee") || msg.includes("constraint")
+        );
+        console.log("  Invalid fee rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Rate Limit Configuration
+  // ============================================================================
+
+  describe("Rate Limit Configuration", () => {
+    it("reads current rate limits", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      console.log("  Task creation cooldown:", config.taskCreationCooldown?.toNumber() || 0, "s");
+      console.log("  Max tasks per 24h:", config.maxTasksPer24h || "unlimited");
+      console.log("  Dispute cooldown:", config.disputeInitiationCooldown?.toNumber() || 0, "s");
+    });
+
+    it("allows disabling rate limits", async () => {
+      try {
+        await program.methods
+          .updateRateLimits(
+            new BN(0),  // task_creation_cooldown = 0 (disabled)
+            0,          // max_tasks_per_24h = 0 (unlimited)
+            new BN(0),  // dispute_initiation_cooldown = 0 (disabled)
+            0,          // max_disputes_per_24h = 0 (unlimited)
+            new BN(0)   // min_stake_for_dispute = 0
+          )
+          .accountsPartial({
+            protocolConfig: protocolPda,
+          })
+          .remainingAccounts([
+            { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
+          ])
+          .rpc();
+        console.log("  Rate limits disabled");
+      } catch (e: any) {
+        if (e.message?.includes("MultisigNotEnoughSigners")) {
+          console.log("  Rate limit update rejected (not enough signers)");
+        } else {
+          throw e;
+        }
+      }
+    });
+  });
+
+  // ============================================================================
+  // Protocol Statistics
+  // ============================================================================
+
+  describe("Protocol Statistics", () => {
+    it("tracks total tasks created", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      expect(config.totalTasksCreated.toNumber()).to.be.at.least(0);
+      console.log("  Total tasks created:", config.totalTasksCreated.toNumber());
+    });
+
+    it("tracks total rewards distributed", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      expect(config.totalRewardsDistributed.toNumber()).to.be.at.least(0);
+      console.log("  Total rewards distributed:", config.totalRewardsDistributed.toNumber() / LAMPORTS_PER_SOL, "SOL");
+    });
+
+    it("tracks protocol version", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      expect(config.version).to.be.at.least(1);
+      console.log("  Protocol version:", config.version);
+    });
+  });
+
+  // ============================================================================
+  // Multisig Validation
+  // ============================================================================
+
+  describe("Multisig Validation", () => {
+    it("rejects duplicate multisig signers", async () => {
+      // This would be tested during initialization with duplicate signers
+      // For existing protocol, we verify the current signers are unique
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      const signers = config.multisigSigners.filter(
+        (s: PublicKey) => !s.equals(PublicKey.default)
+      );
+      const uniqueSigners = new Set(signers.map((s: PublicKey) => s.toBase58()));
+      expect(signers.length).to.equal(uniqueSigners.size);
+      console.log("  Multisig signers are unique:", signers.length);
+    });
+
+    it("validates minimum signers threshold", async () => {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      const validSigners = config.multisigSigners.filter(
+        (s: PublicKey) => !s.equals(PublicKey.default)
+      );
+      expect(validSigners.length).to.be.at.least(config.minMultisigSigners);
+      console.log("  Min signers:", config.minMultisigSigners, ", Actual:", validSigners.length);
+    });
+  });
+
+  after(() => {
+    console.log("\n========================================");
+    console.log("Protocol Configuration Tests Complete");
+    console.log("========================================\n");
+  });
+});

--- a/tests/task-lifecycle.ts
+++ b/tests/task-lifecycle.ts
@@ -1,0 +1,681 @@
+/**
+ * Task Lifecycle Tests
+ *
+ * Tests for the complete task lifecycle: creation, claiming, completion, and cancellation.
+ * Covers: createTask, claimTask, completeTask, cancelTask instructions.
+ *
+ * Run with: npx ts-mocha tests/task-lifecycle.ts
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { expect } from "chai";
+import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { AgencCoordination } from "../target/types/agenc_coordination";
+import {
+  CAPABILITY_COMPUTE,
+  CAPABILITY_INFERENCE,
+  TASK_TYPE_EXCLUSIVE,
+  TASK_TYPE_COLLABORATIVE,
+  TASK_TYPE_COMPETITIVE,
+  HASH_SIZE,
+  RESULT_DATA_SIZE,
+  deriveProtocolPda,
+  deriveAgentPda,
+  deriveTaskPda,
+  deriveEscrowPda,
+  deriveClaimPda,
+  generateRunId,
+  makeAgentId,
+  makeTaskId,
+  fundWallet,
+  fundWallets,
+  initializeProtocolIfNeeded,
+  disableRateLimits,
+  registerAgent,
+  createTask,
+  claimTask,
+  completeTask,
+  cancelTask,
+  WorkerPool,
+} from "./utils/test-helpers";
+
+describe("Task Lifecycle", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace.AgencCoordination as Program<AgencCoordination>;
+  const protocolPda = deriveProtocolPda(program.programId);
+  const runId = generateRunId();
+
+  let treasury: Keypair;
+  let treasuryPubkey: PublicKey;
+  let creator: Keypair;
+  let creatorAgentPda: PublicKey;
+  let workerPool: WorkerPool;
+
+  before(async () => {
+    console.log("\n========================================");
+    console.log("Task Lifecycle Tests");
+    console.log("Program ID:", program.programId.toBase58());
+    console.log("Run ID:", runId);
+    console.log("========================================\n");
+
+    treasury = Keypair.generate();
+    creator = Keypair.generate();
+    await fundWallets(provider.connection, [treasury, creator], 10 * LAMPORTS_PER_SOL);
+
+    treasuryPubkey = await initializeProtocolIfNeeded(
+      program,
+      protocolPda,
+      treasury,
+      provider.wallet as anchor.Wallet
+    );
+
+    await disableRateLimits(program, protocolPda, provider.wallet as anchor.Wallet);
+
+    // Register creator agent
+    const creatorAgentId = makeAgentId("creator", runId);
+    creatorAgentPda = await registerAgent(
+      program,
+      protocolPda,
+      creatorAgentId,
+      creator,
+      CAPABILITY_COMPUTE
+    );
+
+    // Initialize worker pool
+    workerPool = new WorkerPool(program, protocolPda, provider, runId);
+    await workerPool.initialize(10);
+
+    console.log("  Setup complete\n");
+  });
+
+  // ============================================================================
+  // Task Creation
+  // ============================================================================
+
+  describe("Task Creation", () => {
+    it("creates exclusive task with escrowed reward", async () => {
+      const taskId = makeTaskId("create-1", runId);
+      const reward = LAMPORTS_PER_SOL / 10;
+
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        reward,
+        taskType: TASK_TYPE_EXCLUSIVE,
+      });
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ open: {} });
+      expect(task.rewardAmount.toNumber()).to.equal(reward);
+      expect(task.maxWorkers).to.equal(1);
+      expect(task.currentWorkers).to.equal(0);
+      expect(task.taskType).to.deep.equal({ exclusive: {} });
+
+      const escrowBalance = await provider.connection.getBalance(escrowPda);
+      expect(escrowBalance).to.be.greaterThanOrEqual(reward);
+
+      console.log("  Exclusive task created with escrow");
+    });
+
+    it("creates collaborative task with multiple workers", async () => {
+      const taskId = makeTaskId("create-2", runId);
+
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        maxWorkers: 3,
+        taskType: TASK_TYPE_COLLABORATIVE,
+      });
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.taskType).to.deep.equal({ collaborative: {} });
+      expect(task.maxWorkers).to.equal(3);
+
+      console.log("  Collaborative task created");
+    });
+
+    it("creates competitive task", async () => {
+      const taskId = makeTaskId("create-3", runId);
+
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        maxWorkers: 5,
+        taskType: TASK_TYPE_COMPETITIVE,
+      });
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.taskType).to.deep.equal({ competitive: {} });
+      expect(task.maxWorkers).to.equal(5);
+
+      console.log("  Competitive task created");
+    });
+
+    it("creates private task with constraint hash", async () => {
+      const taskId = makeTaskId("create-4", runId);
+      const constraintHash = Buffer.alloc(HASH_SIZE, 0x42);
+
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        constraintHash,
+      });
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(Buffer.from(task.constraintHash)).to.deep.equal(constraintHash);
+
+      console.log("  Private task created with constraint hash");
+    });
+  });
+
+  // ============================================================================
+  // Task Claiming
+  // ============================================================================
+
+  describe("Task Claiming", () => {
+    it("allows qualified agent to claim task", async () => {
+      const taskId = makeTaskId("claim-1", runId);
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        capabilities: CAPABILITY_COMPUTE,
+      });
+
+      const worker = workerPool.getWorker();
+      const claimPda = await claimTask(
+        program,
+        protocolPda,
+        taskPda,
+        worker.agentPda,
+        worker.wallet
+      );
+
+      const claim = await program.account.taskClaim.fetch(claimPda);
+      expect(claim.task.toBase58()).to.equal(taskPda.toBase58());
+      expect(claim.worker.toBase58()).to.equal(worker.agentPda.toBase58());
+      expect(claim.isCompleted).to.be.false;
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ inProgress: {} });
+      expect(task.currentWorkers).to.equal(1);
+
+      console.log("  Task claimed successfully");
+    });
+
+    it("allows multiple workers to claim collaborative task", async () => {
+      const taskId = makeTaskId("claim-2", runId);
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        maxWorkers: 3,
+        taskType: TASK_TYPE_COLLABORATIVE,
+      });
+
+      const worker1 = workerPool.getWorker();
+      const worker2 = workerPool.getWorker();
+
+      await claimTask(program, protocolPda, taskPda, worker1.agentPda, worker1.wallet);
+      await claimTask(program, protocolPda, taskPda, worker2.agentPda, worker2.wallet);
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.currentWorkers).to.equal(2);
+
+      console.log("  Multiple workers claimed collaborative task");
+    });
+
+    it("rejects claim on fully claimed task", async () => {
+      const taskId = makeTaskId("claim-3", runId);
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        maxWorkers: 1,
+      });
+
+      const worker1 = workerPool.getWorker();
+      const worker2 = workerPool.getWorker();
+
+      await claimTask(program, protocolPda, taskPda, worker1.agentPda, worker1.wallet);
+
+      try {
+        await claimTask(program, protocolPda, taskPda, worker2.agentPda, worker2.wallet);
+        expect.fail("Should have rejected claim on full task");
+      } catch (e: any) {
+        expect(e.message).to.include("TaskFullyClaimed");
+        console.log("  Claim on full task rejected");
+      }
+    });
+
+    it("rejects duplicate claim by same worker", async () => {
+      const taskId = makeTaskId("claim-4", runId);
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        maxWorkers: 3,
+        taskType: TASK_TYPE_COLLABORATIVE,
+      });
+
+      const worker = workerPool.getWorker();
+      await claimTask(program, protocolPda, taskPda, worker.agentPda, worker.wallet);
+
+      try {
+        await claimTask(program, protocolPda, taskPda, worker.agentPda, worker.wallet);
+        expect.fail("Should have rejected duplicate claim");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("AlreadyClaimed") || msg.includes("already in use")
+        );
+        console.log("  Duplicate claim rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Task Completion
+  // ============================================================================
+
+  describe("Task Completion", () => {
+    it("completes task and pays reward", async () => {
+      const taskId = makeTaskId("complete-1", runId);
+      const reward = LAMPORTS_PER_SOL / 10;
+
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        reward,
+      });
+
+      const worker = await workerPool.createFreshWorker();
+      const claimPda = await claimTask(
+        program,
+        protocolPda,
+        taskPda,
+        worker.agentPda,
+        worker.wallet
+      );
+
+      const balanceBefore = await provider.connection.getBalance(worker.wallet.publicKey);
+
+      await completeTask(
+        program,
+        protocolPda,
+        taskPda,
+        claimPda,
+        escrowPda,
+        worker.agentPda,
+        worker.wallet,
+        treasuryPubkey
+      );
+
+      const balanceAfter = await provider.connection.getBalance(worker.wallet.publicKey);
+      expect(balanceAfter).to.be.greaterThan(balanceBefore);
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ completed: {} });
+      expect(task.completions).to.equal(1);
+
+      const claim = await program.account.taskClaim.fetch(claimPda);
+      expect(claim.isCompleted).to.be.true;
+
+      console.log("  Task completed and reward paid");
+    });
+
+    it("updates worker statistics on completion", async () => {
+      const taskId = makeTaskId("complete-2", runId);
+      const reward = LAMPORTS_PER_SOL / 10;
+
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        reward,
+      });
+
+      const worker = await workerPool.createFreshWorker();
+      const agentBefore = await program.account.agentRegistration.fetch(worker.agentPda);
+      const tasksBefore = agentBefore.tasksCompleted;
+
+      const claimPda = await claimTask(
+        program,
+        protocolPda,
+        taskPda,
+        worker.agentPda,
+        worker.wallet
+      );
+
+      await completeTask(
+        program,
+        protocolPda,
+        taskPda,
+        claimPda,
+        escrowPda,
+        worker.agentPda,
+        worker.wallet,
+        treasuryPubkey
+      );
+
+      const agentAfter = await program.account.agentRegistration.fetch(worker.agentPda);
+      expect(agentAfter.tasksCompleted).to.equal(tasksBefore + 1);
+      expect(agentAfter.totalEarned.toNumber()).to.be.greaterThan(0);
+
+      console.log("  Worker statistics updated");
+    });
+
+    it("competitive task allows only first completion", async () => {
+      const taskId = makeTaskId("complete-3", runId);
+
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        maxWorkers: 2,
+        taskType: TASK_TYPE_COMPETITIVE,
+      });
+
+      const worker1 = await workerPool.createFreshWorker();
+      const worker2 = await workerPool.createFreshWorker();
+
+      const claim1Pda = await claimTask(program, protocolPda, taskPda, worker1.agentPda, worker1.wallet);
+      const claim2Pda = await claimTask(program, protocolPda, taskPda, worker2.agentPda, worker2.wallet);
+
+      // First worker completes
+      await completeTask(
+        program,
+        protocolPda,
+        taskPda,
+        claim1Pda,
+        escrowPda,
+        worker1.agentPda,
+        worker1.wallet,
+        treasuryPubkey
+      );
+
+      // Second worker tries to complete
+      try {
+        await completeTask(
+          program,
+          protocolPda,
+          taskPda,
+          claim2Pda,
+          escrowPda,
+          worker2.agentPda,
+          worker2.wallet,
+          treasuryPubkey
+        );
+        expect.fail("Should have rejected second completion");
+      } catch (e: any) {
+        expect(e.message).to.include("CompetitiveTaskAlreadyWon");
+        console.log("  Second completion on competitive task rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Task Cancellation
+  // ============================================================================
+
+  describe("Task Cancellation", () => {
+    it("allows creator to cancel unclaimed task", async () => {
+      const taskId = makeTaskId("cancel-1", runId);
+      const reward = LAMPORTS_PER_SOL / 10;
+
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+        reward,
+      });
+
+      const balanceBefore = await provider.connection.getBalance(creator.publicKey);
+
+      await cancelTask(program, taskPda, escrowPda, creator);
+
+      const balanceAfter = await provider.connection.getBalance(creator.publicKey);
+      expect(balanceAfter).to.be.greaterThan(balanceBefore * 0.99);
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ cancelled: {} });
+
+      console.log("  Unclaimed task cancelled with refund");
+    });
+
+    it("rejects cancellation by non-creator", async () => {
+      const taskId = makeTaskId("cancel-2", runId);
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      const nonCreator = Keypair.generate();
+      await fundWallet(provider.connection, nonCreator);
+
+      try {
+        await program.methods
+          .cancelTask()
+          .accountsPartial({
+            task: taskPda,
+            escrow: escrowPda,
+            creator: nonCreator.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([nonCreator])
+          .rpc();
+        expect.fail("Should have rejected non-creator cancellation");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("UnauthorizedTaskAction") ||
+          msg.includes("InvalidCreator") ||
+          msg.includes("constraint")
+        );
+        console.log("  Non-creator cancellation rejected");
+      }
+    });
+
+    it("rejects cancellation of claimed task", async () => {
+      const taskId = makeTaskId("cancel-3", runId);
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      const worker = workerPool.getWorker();
+      await claimTask(program, protocolPda, taskPda, worker.agentPda, worker.wallet);
+
+      try {
+        await cancelTask(program, taskPda, escrowPda, creator);
+        expect.fail("Should have rejected cancellation of claimed task");
+      } catch (e: any) {
+        expect(e.message).to.include("TaskCannotBeCancelled");
+        console.log("  Claimed task cancellation rejected");
+      }
+    });
+  });
+
+  // ============================================================================
+  // Task State Machine Validation
+  // ============================================================================
+
+  describe("State Machine Validation", () => {
+    it("Open -> InProgress (via claim)", async () => {
+      const taskId = makeTaskId("state-1", runId);
+      const { taskPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      let task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ open: {} });
+
+      const worker = workerPool.getWorker();
+      await claimTask(program, protocolPda, taskPda, worker.agentPda, worker.wallet);
+
+      task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ inProgress: {} });
+
+      console.log("  Open -> InProgress transition verified");
+    });
+
+    it("InProgress -> Completed (via complete)", async () => {
+      const taskId = makeTaskId("state-2", runId);
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      const worker = await workerPool.createFreshWorker();
+      const claimPda = await claimTask(program, protocolPda, taskPda, worker.agentPda, worker.wallet);
+
+      let task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ inProgress: {} });
+
+      await completeTask(
+        program,
+        protocolPda,
+        taskPda,
+        claimPda,
+        escrowPda,
+        worker.agentPda,
+        worker.wallet,
+        treasuryPubkey
+      );
+
+      task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ completed: {} });
+
+      console.log("  InProgress -> Completed transition verified");
+    });
+
+    it("Open -> Cancelled (via cancel)", async () => {
+      const taskId = makeTaskId("state-3", runId);
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      let task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ open: {} });
+
+      await cancelTask(program, taskPda, escrowPda, creator);
+
+      task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ cancelled: {} });
+
+      console.log("  Open -> Cancelled transition verified");
+    });
+
+    it("rejects claim on cancelled task", async () => {
+      const taskId = makeTaskId("state-4", runId);
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      await cancelTask(program, taskPda, escrowPda, creator);
+
+      const worker = workerPool.getWorker();
+      try {
+        await claimTask(program, protocolPda, taskPda, worker.agentPda, worker.wallet);
+        expect.fail("Should have rejected claim on cancelled task");
+      } catch (e: any) {
+        expect(e.message).to.include("TaskNotOpen");
+        console.log("  Claim on cancelled task rejected");
+      }
+    });
+
+    it("rejects claim on completed task", async () => {
+      const taskId = makeTaskId("state-5", runId);
+      const { taskPda, escrowPda } = await createTask({
+        program,
+        protocolPda,
+        taskId,
+        creatorAgentPda,
+        creatorWallet: creator,
+      });
+
+      const worker1 = await workerPool.createFreshWorker();
+      const claimPda = await claimTask(program, protocolPda, taskPda, worker1.agentPda, worker1.wallet);
+
+      await completeTask(
+        program,
+        protocolPda,
+        taskPda,
+        claimPda,
+        escrowPda,
+        worker1.agentPda,
+        worker1.wallet,
+        treasuryPubkey
+      );
+
+      const worker2 = workerPool.getWorker();
+      try {
+        await claimTask(program, protocolPda, taskPda, worker2.agentPda, worker2.wallet);
+        expect.fail("Should have rejected claim on completed task");
+      } catch (e: any) {
+        expect(e.message).to.satisfy((msg: string) =>
+          msg.includes("TaskNotOpen") || msg.includes("TaskFullyClaimed")
+        );
+        console.log("  Claim on completed task rejected");
+      }
+    });
+  });
+
+  after(() => {
+    console.log("\n========================================");
+    console.log("Task Lifecycle Tests Complete");
+    console.log("========================================\n");
+  });
+});

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -1,0 +1,575 @@
+/**
+ * Shared test utilities for AgenC integration tests.
+ *
+ * Provides common setup, PDA derivation, worker pool management,
+ * and helper functions used across test files.
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { AgencCoordination } from "../../target/types/agenc_coordination";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const CAPABILITY_COMPUTE = 1 << 0;
+export const CAPABILITY_STORAGE = 1 << 1;
+export const CAPABILITY_INFERENCE = 1 << 2;
+export const CAPABILITY_NETWORK = 1 << 3;
+export const CAPABILITY_COORDINATOR = 1 << 4;
+export const CAPABILITY_ARBITER = 1 << 7;
+
+export const TASK_TYPE_EXCLUSIVE = 0;
+export const TASK_TYPE_COLLABORATIVE = 1;
+export const TASK_TYPE_COMPETITIVE = 2;
+
+export const HASH_SIZE = 32;
+export const RESULT_DATA_SIZE = 64;
+
+export const ZK_VERIFIER_PROGRAM_ID = new PublicKey("8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ");
+
+// Evidence must be at least 50 characters per initiate_dispute.rs requirements
+export const VALID_EVIDENCE = "This is valid dispute evidence that exceeds the minimum 50 character requirement for the dispute system.";
+
+// ============================================================================
+// Test Context
+// ============================================================================
+
+export interface TestContext {
+  provider: anchor.AnchorProvider;
+  program: Program<AgencCoordination>;
+  protocolPda: PublicKey;
+  runId: string;
+  treasury: Keypair;
+  treasuryPubkey: PublicKey;
+}
+
+export interface WorkerInfo {
+  wallet: Keypair;
+  agentId: Buffer;
+  agentPda: PublicKey;
+  inUse?: boolean;
+}
+
+// ============================================================================
+// PDA Derivation
+// ============================================================================
+
+export function deriveProtocolPda(programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("protocol")],
+    programId
+  )[0];
+}
+
+export function deriveAgentPda(agentId: Buffer, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("agent"), agentId],
+    programId
+  )[0];
+}
+
+export function deriveTaskPda(creatorPubkey: PublicKey, taskId: Buffer, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("task"), creatorPubkey.toBuffer(), taskId],
+    programId
+  )[0];
+}
+
+export function deriveEscrowPda(taskPda: PublicKey, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("escrow"), taskPda.toBuffer()],
+    programId
+  )[0];
+}
+
+export function deriveClaimPda(taskPda: PublicKey, workerPda: PublicKey, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("claim"), taskPda.toBuffer(), workerPda.toBuffer()],
+    programId
+  )[0];
+}
+
+export function deriveDisputePda(disputeId: Buffer, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("dispute"), disputeId],
+    programId
+  )[0];
+}
+
+export function deriveVotePda(disputePda: PublicKey, voterPda: PublicKey, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("vote"), disputePda.toBuffer(), voterPda.toBuffer()],
+    programId
+  )[0];
+}
+
+// ============================================================================
+// ID Generation
+// ============================================================================
+
+export function generateRunId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+}
+
+export function makeAgentId(prefix: string, runId: string): Buffer {
+  return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+}
+
+export function makeTaskId(prefix: string, runId: string): Buffer {
+  return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+}
+
+export function makeDisputeId(prefix: string, runId: string): Buffer {
+  return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+}
+
+// ============================================================================
+// Setup Helpers
+// ============================================================================
+
+export async function fundWallet(
+  connection: anchor.web3.Connection,
+  wallet: Keypair,
+  amount: number = 10 * LAMPORTS_PER_SOL
+): Promise<void> {
+  const sig = await connection.requestAirdrop(wallet.publicKey, amount);
+  await connection.confirmTransaction(sig, "confirmed");
+}
+
+export async function fundWallets(
+  connection: anchor.web3.Connection,
+  wallets: Keypair[],
+  amount: number = 10 * LAMPORTS_PER_SOL
+): Promise<void> {
+  const sigs = await Promise.all(
+    wallets.map(w => connection.requestAirdrop(w.publicKey, amount))
+  );
+  await Promise.all(
+    sigs.map(sig => connection.confirmTransaction(sig, "confirmed"))
+  );
+}
+
+export async function initializeProtocolIfNeeded(
+  program: Program<AgencCoordination>,
+  protocolPda: PublicKey,
+  treasury: Keypair,
+  authority: anchor.Wallet
+): Promise<PublicKey> {
+  try {
+    await program.methods
+      .initializeProtocol(
+        51,                              // dispute_quorum_percent
+        100,                             // dispute_vote_period
+        new BN(LAMPORTS_PER_SOL / 10),   // min_stake
+        1,                               // min_multisig_signers
+        [authority.publicKey]            // multisig_signers
+      )
+      .accountsPartial({
+        protocolConfig: protocolPda,
+        treasury: treasury.publicKey,
+        authority: authority.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .remainingAccounts([
+        { pubkey: authority.publicKey, isSigner: true, isWritable: false },
+      ])
+      .rpc({ skipPreflight: true });
+    return treasury.publicKey;
+  } catch (e: any) {
+    // Protocol may already be initialized
+    if (e.message?.includes("already in use")) {
+      const config = await program.account.protocolConfig.fetch(protocolPda);
+      return config.treasury;
+    }
+    throw e;
+  }
+}
+
+export async function disableRateLimits(
+  program: Program<AgencCoordination>,
+  protocolPda: PublicKey,
+  authority: anchor.Wallet
+): Promise<void> {
+  try {
+    await program.methods
+      .updateRateLimits(
+        new BN(0),  // task_creation_cooldown = 0 (disabled)
+        0,          // max_tasks_per_24h = 0 (unlimited)
+        new BN(0),  // dispute_initiation_cooldown = 0 (disabled)
+        0,          // max_disputes_per_24h = 0 (unlimited)
+        new BN(0)   // min_stake_for_dispute = 0
+      )
+      .accountsPartial({
+        protocolConfig: protocolPda,
+      })
+      .remainingAccounts([
+        { pubkey: authority.publicKey, isSigner: true, isWritable: false },
+      ])
+      .rpc();
+  } catch (e) {
+    // May already be configured
+  }
+}
+
+// ============================================================================
+// Agent Registration
+// ============================================================================
+
+export async function registerAgent(
+  program: Program<AgencCoordination>,
+  protocolPda: PublicKey,
+  agentId: Buffer,
+  wallet: Keypair,
+  capabilities: number = CAPABILITY_COMPUTE,
+  stake: number = LAMPORTS_PER_SOL / 10
+): Promise<PublicKey> {
+  const agentPda = deriveAgentPda(agentId, program.programId);
+
+  await program.methods
+    .registerAgent(
+      Array.from(agentId),
+      new BN(capabilities),
+      `https://agent-${agentId.toString("hex").slice(0, 8)}.example.com`,
+      null,
+      new BN(stake)
+    )
+    .accountsPartial({
+      agent: agentPda,
+      protocolConfig: protocolPda,
+      authority: wallet.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([wallet])
+    .rpc({ skipPreflight: true });
+
+  return agentPda;
+}
+
+export async function registerAgentSafe(
+  program: Program<AgencCoordination>,
+  protocolPda: PublicKey,
+  agentId: Buffer,
+  wallet: Keypair,
+  capabilities: number = CAPABILITY_COMPUTE,
+  stake: number = LAMPORTS_PER_SOL / 10
+): Promise<PublicKey> {
+  const agentPda = deriveAgentPda(agentId, program.programId);
+
+  try {
+    await program.methods
+      .registerAgent(
+        Array.from(agentId),
+        new BN(capabilities),
+        `https://agent-${agentId.toString("hex").slice(0, 8)}.example.com`,
+        null,
+        new BN(stake)
+      )
+      .accountsPartial({
+        agent: agentPda,
+        protocolConfig: protocolPda,
+        authority: wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([wallet])
+      .rpc({ skipPreflight: true });
+  } catch (e: any) {
+    // Agent may already be registered
+    if (!e.message?.includes("already")) {
+      throw e;
+    }
+  }
+
+  return agentPda;
+}
+
+// ============================================================================
+// Task Operations
+// ============================================================================
+
+export interface CreateTaskParams {
+  program: Program<AgencCoordination>;
+  protocolPda: PublicKey;
+  taskId: Buffer;
+  creatorAgentPda: PublicKey;
+  creatorWallet: Keypair;
+  capabilities?: number;
+  reward?: number;
+  maxWorkers?: number;
+  taskType?: number;
+  constraintHash?: Buffer;
+  deadline?: number;
+}
+
+export async function createTask(params: CreateTaskParams): Promise<{
+  taskPda: PublicKey;
+  escrowPda: PublicKey;
+}> {
+  const {
+    program,
+    protocolPda,
+    taskId,
+    creatorAgentPda,
+    creatorWallet,
+    capabilities = CAPABILITY_COMPUTE,
+    reward = LAMPORTS_PER_SOL / 10,
+    maxWorkers = 1,
+    taskType = TASK_TYPE_EXCLUSIVE,
+    constraintHash = Buffer.alloc(HASH_SIZE, 0),
+    deadline = 0,
+  } = params;
+
+  const taskPda = deriveTaskPda(creatorWallet.publicKey, taskId, program.programId);
+  const escrowPda = deriveEscrowPda(taskPda, program.programId);
+
+  await program.methods
+    .createTask(
+      Array.from(taskId),
+      new BN(capabilities),
+      Array.from(Buffer.alloc(64, 0)), // description
+      new BN(reward),
+      maxWorkers,
+      new BN(deadline),
+      taskType,
+      Array.from(constraintHash)
+    )
+    .accountsPartial({
+      task: taskPda,
+      escrow: escrowPda,
+      creatorAgent: creatorAgentPda,
+      protocolConfig: protocolPda,
+      authority: creatorWallet.publicKey,
+      creator: creatorWallet.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([creatorWallet])
+    .rpc({ skipPreflight: true });
+
+  return { taskPda, escrowPda };
+}
+
+export async function claimTask(
+  program: Program<AgencCoordination>,
+  protocolPda: PublicKey,
+  taskPda: PublicKey,
+  workerAgentPda: PublicKey,
+  workerWallet: Keypair
+): Promise<PublicKey> {
+  const claimPda = deriveClaimPda(taskPda, workerAgentPda, program.programId);
+
+  await program.methods
+    .claimTask()
+    .accountsPartial({
+      task: taskPda,
+      claim: claimPda,
+      worker: workerAgentPda,
+      protocolConfig: protocolPda,
+      authority: workerWallet.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([workerWallet])
+    .rpc({ skipPreflight: true });
+
+  return claimPda;
+}
+
+export async function completeTask(
+  program: Program<AgencCoordination>,
+  protocolPda: PublicKey,
+  taskPda: PublicKey,
+  claimPda: PublicKey,
+  escrowPda: PublicKey,
+  workerAgentPda: PublicKey,
+  workerWallet: Keypair,
+  treasuryPubkey: PublicKey
+): Promise<void> {
+  const proofHash = Buffer.alloc(HASH_SIZE, 0x11);
+  const resultData = Buffer.alloc(RESULT_DATA_SIZE, 0x22);
+
+  await program.methods
+    .completeTask(Array.from(proofHash), Array.from(resultData))
+    .accountsPartial({
+      task: taskPda,
+      claim: claimPda,
+      escrow: escrowPda,
+      worker: workerAgentPda,
+      authority: workerWallet.publicKey,
+      treasury: treasuryPubkey,
+      protocolConfig: protocolPda,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([workerWallet])
+    .rpc({ skipPreflight: true });
+}
+
+export async function cancelTask(
+  program: Program<AgencCoordination>,
+  taskPda: PublicKey,
+  escrowPda: PublicKey,
+  creatorWallet: Keypair
+): Promise<void> {
+  await program.methods
+    .cancelTask()
+    .accountsPartial({
+      task: taskPda,
+      escrow: escrowPda,
+      creator: creatorWallet.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([creatorWallet])
+    .rpc({ skipPreflight: true });
+}
+
+// ============================================================================
+// Worker Pool
+// ============================================================================
+
+export class WorkerPool {
+  private workers: WorkerInfo[] = [];
+  private program: Program<AgencCoordination>;
+  private protocolPda: PublicKey;
+  private provider: anchor.AnchorProvider;
+  private runId: string;
+  private counter: number = 0;
+
+  constructor(
+    program: Program<AgencCoordination>,
+    protocolPda: PublicKey,
+    provider: anchor.AnchorProvider,
+    runId: string
+  ) {
+    this.program = program;
+    this.protocolPda = protocolPda;
+    this.provider = provider;
+    this.runId = runId;
+  }
+
+  async initialize(size: number = 20): Promise<void> {
+    const wallets: Keypair[] = [];
+    const airdropSigs: string[] = [];
+
+    for (let i = 0; i < size; i++) {
+      const wallet = Keypair.generate();
+      wallets.push(wallet);
+      const sig = await this.provider.connection.requestAirdrop(
+        wallet.publicKey,
+        10 * LAMPORTS_PER_SOL
+      );
+      airdropSigs.push(sig);
+    }
+
+    await Promise.all(
+      airdropSigs.map(sig =>
+        this.provider.connection.confirmTransaction(sig, "confirmed")
+      )
+    );
+
+    const registerPromises = wallets.map(async (wallet, i) => {
+      const agentId = makeAgentId(`pool${i}`, this.runId);
+      const agentPda = deriveAgentPda(agentId, this.program.programId);
+
+      await this.program.methods
+        .registerAgent(
+          Array.from(agentId),
+          new BN(CAPABILITY_COMPUTE | CAPABILITY_INFERENCE | CAPABILITY_ARBITER),
+          `https://pool-worker-${i}.example.com`,
+          null,
+          new BN(LAMPORTS_PER_SOL / 10)
+        )
+        .accountsPartial({
+          agent: agentPda,
+          protocolConfig: this.protocolPda,
+          authority: wallet.publicKey,
+        })
+        .signers([wallet])
+        .rpc({ skipPreflight: true });
+
+      this.workers.push({ wallet, agentId, agentPda, inUse: false });
+    });
+
+    await Promise.all(registerPromises);
+  }
+
+  getWorker(): WorkerInfo {
+    const worker = this.workers.find(w => !w.inUse);
+    if (!worker) {
+      throw new Error("Worker pool exhausted");
+    }
+    worker.inUse = true;
+    return worker;
+  }
+
+  releaseWorker(worker: WorkerInfo): void {
+    const poolWorker = this.workers.find(
+      w => w.agentPda.equals(worker.agentPda)
+    );
+    if (poolWorker) {
+      poolWorker.inUse = false;
+    }
+  }
+
+  async createFreshWorker(capabilities: number = CAPABILITY_COMPUTE): Promise<WorkerInfo> {
+    // Try pool first
+    const poolWorker = this.workers.find(w => !w.inUse);
+    if (poolWorker) {
+      poolWorker.inUse = true;
+      return poolWorker;
+    }
+
+    // Create new worker
+    this.counter++;
+    const wallet = Keypair.generate();
+    const agentId = makeAgentId(`fresh${this.counter}`, this.runId);
+    const agentPda = deriveAgentPda(agentId, this.program.programId);
+
+    await fundWallet(this.provider.connection, wallet, 5 * LAMPORTS_PER_SOL);
+
+    await this.program.methods
+      .registerAgent(
+        Array.from(agentId),
+        new BN(capabilities),
+        `https://fresh-worker-${this.counter}.example.com`,
+        null,
+        new BN(LAMPORTS_PER_SOL / 10)
+      )
+      .accountsPartial({
+        agent: agentPda,
+        protocolConfig: this.protocolPda,
+        authority: wallet.publicKey,
+      })
+      .signers([wallet])
+      .rpc({ skipPreflight: true });
+
+    return { wallet, agentId, agentPda };
+  }
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export function createTestProof(options: {
+  proofSize?: number;
+  constraintHash?: Buffer;
+  outputCommitment?: Buffer;
+  expectedBinding?: Buffer;
+} = {}) {
+  const proofSize = options.proofSize ?? 388;
+  const constraintHash = options.constraintHash ?? Buffer.alloc(HASH_SIZE, 0x01);
+  const outputCommitment = options.outputCommitment ?? Buffer.alloc(HASH_SIZE, 0x02);
+  const expectedBinding = options.expectedBinding ?? Buffer.alloc(HASH_SIZE, 0x03);
+
+  return {
+    proofData: Buffer.alloc(proofSize, 0xAA),
+    constraintHash: Array.from(constraintHash),
+    outputCommitment: Array.from(outputCommitment),
+    expectedBinding: Array.from(expectedBinding),
+  };
+}


### PR DESCRIPTION
## Summary
  Establishes new test organization pattern:
  - tests/utils/test-helpers.ts: Shared utilities, PDA derivation, worker pool
  - tests/agent-registration.ts: Agent registration, update, deregistration
  - tests/task-lifecycle.ts: Task create, claim, complete, cancel
  - tests/disputes.ts: Dispute initiation, voting
  - tests/protocol-config.ts: Protocol init, fee updates, rate limits

  Each file is self-contained with setup/teardown. Shared helpers
  extracted to utils/ to avoid duplication.

  This is the first phase of consolidation from the 7891-line test_1.ts.
  Subsequent PRs will migrate remaining tests.

Relates to #95
