### PR TITLE
feat(runtime): add wallet types and helpers

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -63,3 +63,15 @@ export {
   getAnchorErrorMessage,
   isRuntimeError,
 } from './types/index.js';
+
+// Wallet types and helpers
+export {
+  Wallet,
+  SignMessageWallet,
+  KeypairFileError,
+  keypairToWallet,
+  loadKeypairFromFile,
+  loadKeypairFromFileSync,
+  getDefaultKeypairPath,
+  loadDefaultKeypair,
+} from './types/wallet';

--- a/runtime/src/types/wallet.test.ts
+++ b/runtime/src/types/wallet.test.ts
@@ -1,0 +1,412 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  Keypair,
+  Transaction,
+  VersionedTransaction,
+  SystemProgram,
+  TransactionMessage,
+} from '@solana/web3.js';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  keypairToWallet,
+  loadKeypairFromFile,
+  loadKeypairFromFileSync,
+  getDefaultKeypairPath,
+  loadDefaultKeypair,
+  KeypairFileError,
+  Wallet,
+} from './wallet';
+
+describe('keypairToWallet', () => {
+  it('returns wallet with correct publicKey', () => {
+    const keypair = Keypair.generate();
+    const wallet = keypairToWallet(keypair);
+
+    expect(wallet.publicKey.equals(keypair.publicKey)).toBe(true);
+  });
+
+  it('signTransaction signs legacy Transaction', async () => {
+    const keypair = Keypair.generate();
+    const wallet = keypairToWallet(keypair);
+
+    const tx = new Transaction();
+    tx.recentBlockhash = 'GfVcyD4kkTrj4bKc7WA9sZCin9JDbdT4Zkd3EittNR1W';
+    tx.feePayer = keypair.publicKey;
+    tx.add(
+      SystemProgram.transfer({
+        fromPubkey: keypair.publicKey,
+        toPubkey: Keypair.generate().publicKey,
+        lamports: 1000,
+      })
+    );
+
+    const signedTx = await wallet.signTransaction(tx);
+
+    expect(signedTx).toBe(tx);
+    expect(tx.signatures.length).toBeGreaterThan(0);
+    expect(tx.signatures[0].signature).not.toBeNull();
+  });
+
+  it('signTransaction signs VersionedTransaction', async () => {
+    const keypair = Keypair.generate();
+    const wallet = keypairToWallet(keypair);
+
+    const recentBlockhash = 'GfVcyD4kkTrj4bKc7WA9sZCin9JDbdT4Zkd3EittNR1W';
+    const message = new TransactionMessage({
+      payerKey: keypair.publicKey,
+      recentBlockhash,
+      instructions: [
+        SystemProgram.transfer({
+          fromPubkey: keypair.publicKey,
+          toPubkey: Keypair.generate().publicKey,
+          lamports: 1000,
+        }),
+      ],
+    }).compileToV0Message();
+
+    const tx = new VersionedTransaction(message);
+
+    const signedTx = await wallet.signTransaction(tx);
+
+    expect(signedTx).toBe(tx);
+    expect(tx.signatures.length).toBe(1);
+    expect(tx.signatures[0]).not.toEqual(new Uint8Array(64));
+  });
+
+  it('signAllTransactions signs multiple transactions', async () => {
+    const keypair = Keypair.generate();
+    const wallet = keypairToWallet(keypair);
+
+    const recentBlockhash = 'GfVcyD4kkTrj4bKc7WA9sZCin9JDbdT4Zkd3EittNR1W';
+
+    const tx1 = new Transaction();
+    tx1.recentBlockhash = recentBlockhash;
+    tx1.feePayer = keypair.publicKey;
+    tx1.add(
+      SystemProgram.transfer({
+        fromPubkey: keypair.publicKey,
+        toPubkey: Keypair.generate().publicKey,
+        lamports: 1000,
+      })
+    );
+
+    const tx2 = new Transaction();
+    tx2.recentBlockhash = recentBlockhash;
+    tx2.feePayer = keypair.publicKey;
+    tx2.add(
+      SystemProgram.transfer({
+        fromPubkey: keypair.publicKey,
+        toPubkey: Keypair.generate().publicKey,
+        lamports: 2000,
+      })
+    );
+
+    const signedTxs = await wallet.signAllTransactions([tx1, tx2]);
+
+    expect(signedTxs).toHaveLength(2);
+    expect(signedTxs[0]).toBe(tx1);
+    expect(signedTxs[1]).toBe(tx2);
+    expect(tx1.signatures[0].signature).not.toBeNull();
+    expect(tx2.signatures[0].signature).not.toBeNull();
+  });
+
+  it('implements Wallet interface', () => {
+    const keypair = Keypair.generate();
+    const wallet = keypairToWallet(keypair);
+
+    // Type assertion - this should compile without errors
+    const _walletInterface: Wallet = wallet;
+    expect(_walletInterface).toBeDefined();
+  });
+});
+
+describe('loadKeypairFromFile', () => {
+  const tmpDir = os.tmpdir();
+  const validKeypairPath = path.join(tmpDir, 'test-keypair-valid.json');
+  const invalidJsonPath = path.join(tmpDir, 'test-keypair-invalid.json');
+  const wrongSizePath = path.join(tmpDir, 'test-keypair-wrongsize.json');
+  const invalidBytePath = path.join(tmpDir, 'test-keypair-invalidbyte.json');
+  const nonArrayPath = path.join(tmpDir, 'test-keypair-nonarray.json');
+  const negativeBytePath = path.join(tmpDir, 'test-keypair-negative.json');
+  const floatBytePath = path.join(tmpDir, 'test-keypair-float.json');
+
+  let testKeypair: Keypair;
+
+  beforeAll(() => {
+    testKeypair = Keypair.generate();
+
+    // Write valid keypair file
+    fs.writeFileSync(
+      validKeypairPath,
+      JSON.stringify(Array.from(testKeypair.secretKey))
+    );
+
+    // Write invalid JSON file
+    fs.writeFileSync(invalidJsonPath, 'not valid json{');
+
+    // Write wrong size array
+    fs.writeFileSync(wrongSizePath, JSON.stringify([1, 2, 3, 4, 5]));
+
+    // Write array with invalid byte value (> 255)
+    const invalidBytes = Array(64).fill(0);
+    invalidBytes[10] = 256;
+    fs.writeFileSync(invalidBytePath, JSON.stringify(invalidBytes));
+
+    // Write non-array JSON (object instead of array)
+    fs.writeFileSync(nonArrayPath, JSON.stringify({ foo: 'bar' }));
+
+    // Write array with negative byte value
+    const negativeBytes = Array(64).fill(0);
+    negativeBytes[5] = -1;
+    fs.writeFileSync(negativeBytePath, JSON.stringify(negativeBytes));
+
+    // Write array with float byte value
+    const floatBytes = Array(64).fill(0);
+    floatBytes[3] = 1.5;
+    fs.writeFileSync(floatBytePath, JSON.stringify(floatBytes));
+  });
+
+  afterAll(() => {
+    // Cleanup test files
+    const filesToClean = [
+      validKeypairPath,
+      invalidJsonPath,
+      wrongSizePath,
+      invalidBytePath,
+      nonArrayPath,
+      negativeBytePath,
+      floatBytePath,
+    ];
+    for (const f of filesToClean) {
+      try {
+        fs.unlinkSync(f);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  });
+
+  it('loads valid keypair file', async () => {
+    const loaded = await loadKeypairFromFile(validKeypairPath);
+
+    expect(loaded.publicKey.equals(testKeypair.publicKey)).toBe(true);
+    expect(loaded.secretKey).toEqual(testKeypair.secretKey);
+  });
+
+  it('throws KeypairFileError for missing file', async () => {
+    const nonExistentPath = path.join(tmpDir, 'does-not-exist.json');
+
+    await expect(loadKeypairFromFile(nonExistentPath)).rejects.toThrow(
+      KeypairFileError
+    );
+    await expect(loadKeypairFromFile(nonExistentPath)).rejects.toThrow(
+      `Keypair file not found: ${nonExistentPath}`
+    );
+  });
+
+  it('throws KeypairFileError for invalid JSON', async () => {
+    await expect(loadKeypairFromFile(invalidJsonPath)).rejects.toThrow(
+      KeypairFileError
+    );
+    await expect(loadKeypairFromFile(invalidJsonPath)).rejects.toThrow(
+      `Invalid JSON in keypair file: ${invalidJsonPath}`
+    );
+  });
+
+  it('throws KeypairFileError for wrong array size', async () => {
+    await expect(loadKeypairFromFile(wrongSizePath)).rejects.toThrow(
+      KeypairFileError
+    );
+    await expect(loadKeypairFromFile(wrongSizePath)).rejects.toThrow(
+      'must contain 64 bytes, got 5'
+    );
+  });
+
+  it('throws KeypairFileError for invalid byte value', async () => {
+    await expect(loadKeypairFromFile(invalidBytePath)).rejects.toThrow(
+      KeypairFileError
+    );
+    await expect(loadKeypairFromFile(invalidBytePath)).rejects.toThrow(
+      'Invalid byte value at index 10: 256'
+    );
+  });
+
+  it('throws KeypairFileError for non-array JSON', async () => {
+    await expect(loadKeypairFromFile(nonArrayPath)).rejects.toThrow(
+      KeypairFileError
+    );
+    await expect(loadKeypairFromFile(nonArrayPath)).rejects.toThrow(
+      'must contain a JSON array, got object'
+    );
+  });
+
+  it('throws KeypairFileError for negative byte value', async () => {
+    await expect(loadKeypairFromFile(negativeBytePath)).rejects.toThrow(
+      KeypairFileError
+    );
+    await expect(loadKeypairFromFile(negativeBytePath)).rejects.toThrow(
+      'Invalid byte value at index 5: -1'
+    );
+  });
+
+  it('throws KeypairFileError for float byte value', async () => {
+    await expect(loadKeypairFromFile(floatBytePath)).rejects.toThrow(
+      KeypairFileError
+    );
+    await expect(loadKeypairFromFile(floatBytePath)).rejects.toThrow(
+      'Invalid byte value at index 3: 1.5'
+    );
+  });
+});
+
+describe('loadKeypairFromFileSync', () => {
+  const tmpDir = os.tmpdir();
+  const validKeypairPath = path.join(tmpDir, 'test-keypair-sync-valid.json');
+  const invalidJsonPath = path.join(tmpDir, 'test-keypair-sync-invalid.json');
+
+  let testKeypair: Keypair;
+
+  beforeAll(() => {
+    testKeypair = Keypair.generate();
+
+    fs.writeFileSync(
+      validKeypairPath,
+      JSON.stringify(Array.from(testKeypair.secretKey))
+    );
+
+    fs.writeFileSync(invalidJsonPath, 'not valid json{');
+  });
+
+  afterAll(() => {
+    try {
+      fs.unlinkSync(validKeypairPath);
+    } catch {
+      // Ignore
+    }
+    try {
+      fs.unlinkSync(invalidJsonPath);
+    } catch {
+      // Ignore
+    }
+  });
+
+  it('loads valid keypair file synchronously', () => {
+    const loaded = loadKeypairFromFileSync(validKeypairPath);
+
+    expect(loaded.publicKey.equals(testKeypair.publicKey)).toBe(true);
+    expect(loaded.secretKey).toEqual(testKeypair.secretKey);
+  });
+
+  it('throws KeypairFileError for missing file', () => {
+    const nonExistentPath = path.join(tmpDir, 'sync-does-not-exist.json');
+
+    expect(() => loadKeypairFromFileSync(nonExistentPath)).toThrow(
+      KeypairFileError
+    );
+    expect(() => loadKeypairFromFileSync(nonExistentPath)).toThrow(
+      `Keypair file not found: ${nonExistentPath}`
+    );
+  });
+
+  it('throws KeypairFileError for invalid JSON', () => {
+    expect(() => loadKeypairFromFileSync(invalidJsonPath)).toThrow(
+      KeypairFileError
+    );
+  });
+
+  it('behaves identically to async version', async () => {
+    const asyncResult = await loadKeypairFromFile(validKeypairPath);
+    const syncResult = loadKeypairFromFileSync(validKeypairPath);
+
+    expect(syncResult.publicKey.equals(asyncResult.publicKey)).toBe(true);
+    expect(syncResult.secretKey).toEqual(asyncResult.secretKey);
+  });
+});
+
+describe('getDefaultKeypairPath', () => {
+  it('returns correct format', () => {
+    const defaultPath = getDefaultKeypairPath();
+
+    expect(defaultPath).toContain('.config');
+    expect(defaultPath).toContain('solana');
+    expect(defaultPath).toContain('id.json');
+    expect(defaultPath.startsWith(os.homedir())).toBe(true);
+  });
+
+  it('returns path under home directory', () => {
+    const defaultPath = getDefaultKeypairPath();
+    const expectedPath = path.join(os.homedir(), '.config', 'solana', 'id.json');
+
+    expect(defaultPath).toBe(expectedPath);
+  });
+});
+
+describe('loadDefaultKeypair', () => {
+  it('attempts to load from default path', async () => {
+    const defaultPath = getDefaultKeypairPath();
+
+    // loadDefaultKeypair should either succeed (if default keypair exists)
+    // or fail with an error referencing the default path
+    try {
+      const keypair = await loadDefaultKeypair();
+      // If it succeeds, verify it returned a valid keypair
+      expect(keypair.publicKey).toBeDefined();
+      expect(keypair.secretKey).toHaveLength(64);
+    } catch (err) {
+      // If it fails, verify the error references the default path
+      expect(err).toBeInstanceOf(KeypairFileError);
+      expect((err as KeypairFileError).filePath).toBe(defaultPath);
+    }
+  });
+
+  it('uses the same path as getDefaultKeypairPath', async () => {
+    const defaultPath = getDefaultKeypairPath();
+
+    // Both functions should reference the same path
+    const loadDefaultResult = loadDefaultKeypair();
+    const loadFromPathResult = loadKeypairFromFile(defaultPath);
+
+    // Both should resolve/reject consistently
+    const [defaultOutcome, pathOutcome] = await Promise.allSettled([
+      loadDefaultResult,
+      loadFromPathResult,
+    ]);
+
+    expect(defaultOutcome.status).toBe(pathOutcome.status);
+
+    if (defaultOutcome.status === 'fulfilled' && pathOutcome.status === 'fulfilled') {
+      expect(defaultOutcome.value.publicKey.equals(pathOutcome.value.publicKey)).toBe(true);
+    }
+  });
+});
+
+describe('KeypairFileError', () => {
+  it('has correct name and message', () => {
+    const error = new KeypairFileError('Test message', '/path/to/file.json');
+
+    expect(error.name).toBe('KeypairFileError');
+    expect(error.message).toBe('Test message');
+    expect(error.filePath).toBe('/path/to/file.json');
+    expect(error.cause).toBeUndefined();
+  });
+
+  it('preserves cause error', () => {
+    const cause = new Error('Original error');
+    const error = new KeypairFileError(
+      'Wrapped message',
+      '/path/to/file.json',
+      cause
+    );
+
+    expect(error.cause).toBe(cause);
+  });
+
+  it('is instanceof Error', () => {
+    const error = new KeypairFileError('Test', '/path');
+
+    expect(error instanceof Error).toBe(true);
+    expect(error instanceof KeypairFileError).toBe(true);
+  });
+});

--- a/runtime/src/types/wallet.ts
+++ b/runtime/src/types/wallet.ts
@@ -1,0 +1,269 @@
+/**
+ * Wallet type definitions and helpers for @agenc/runtime
+ *
+ * Provides Anchor-compatible wallet interfaces that work with both
+ * Node.js Keypairs and browser wallet adapters.
+ */
+
+import {
+  Keypair,
+  PublicKey,
+  Transaction,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+/**
+ * Anchor-compatible wallet interface.
+ *
+ * This interface is compatible with:
+ * - Anchor's `Wallet` class (for Keypair wrapping)
+ * - Solana wallet adapters (e.g., @solana/wallet-adapter-base)
+ */
+export interface Wallet {
+  /** The wallet's public key */
+  publicKey: PublicKey;
+
+  /**
+   * Sign a single transaction.
+   * @param tx - Transaction to sign (legacy or versioned)
+   * @returns The signed transaction
+   */
+  signTransaction<T extends Transaction | VersionedTransaction>(tx: T): Promise<T>;
+
+  /**
+   * Sign multiple transactions.
+   * @param txs - Array of transactions to sign
+   * @returns Array of signed transactions
+   */
+  signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]>;
+}
+
+/**
+ * Extended wallet interface with optional message signing.
+ *
+ * Some wallets (like Phantom) support signing arbitrary messages.
+ * This is useful for authentication and off-chain signatures.
+ */
+export interface SignMessageWallet extends Wallet {
+  /**
+   * Sign an arbitrary message (optional capability).
+   * @param message - The message bytes to sign
+   * @returns The signature bytes
+   */
+  signMessage?(message: Uint8Array): Promise<Uint8Array>;
+}
+
+/**
+ * Error thrown when loading a keypair file fails.
+ */
+export class KeypairFileError extends Error {
+  /** The file path that caused the error */
+  public readonly filePath: string;
+  /** The underlying error, if any */
+  public readonly cause?: Error;
+
+  constructor(message: string, filePath: string, cause?: Error) {
+    super(message);
+    this.name = 'KeypairFileError';
+    this.filePath = filePath;
+    this.cause = cause;
+    // Maintain proper stack trace in V8 environments
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, KeypairFileError);
+    }
+  }
+}
+
+/**
+ * Wrap a Keypair as an Anchor-compatible Wallet.
+ *
+ * @example
+ * ```typescript
+ * import { Keypair } from '@solana/web3.js';
+ * import { keypairToWallet } from '@agenc/runtime';
+ *
+ * const keypair = Keypair.generate();
+ * const wallet = keypairToWallet(keypair);
+ *
+ * // Use with AnchorProvider
+ * const provider = new AnchorProvider(connection, wallet, {});
+ * ```
+ *
+ * @param keypair - The Keypair to wrap
+ * @returns A Wallet interface wrapping the keypair
+ */
+export function keypairToWallet(keypair: Keypair): Wallet {
+  return {
+    publicKey: keypair.publicKey,
+
+    async signTransaction<T extends Transaction | VersionedTransaction>(tx: T): Promise<T> {
+      if (tx instanceof VersionedTransaction) {
+        tx.sign([keypair]);
+      } else {
+        tx.partialSign(keypair);
+      }
+      return tx;
+    },
+
+    async signAllTransactions<T extends Transaction | VersionedTransaction>(txs: T[]): Promise<T[]> {
+      for (const tx of txs) {
+        if (tx instanceof VersionedTransaction) {
+          tx.sign([keypair]);
+        } else {
+          tx.partialSign(keypair);
+        }
+      }
+      return txs;
+    },
+  };
+}
+
+/**
+ * Get the default Solana keypair file path.
+ *
+ * @returns Path to `~/.config/solana/id.json`
+ */
+export function getDefaultKeypairPath(): string {
+  return path.join(os.homedir(), '.config', 'solana', 'id.json');
+}
+
+/**
+ * Parse keypair JSON content into a Keypair.
+ *
+ * @param content - The JSON string content
+ * @param filePath - The file path (for error messages)
+ * @returns The parsed Keypair
+ * @throws KeypairFileError if the content is invalid
+ */
+function parseKeypairJson(content: string, filePath: string): Keypair {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    throw new KeypairFileError(
+      `Invalid JSON in keypair file: ${filePath}`,
+      filePath,
+      err instanceof Error ? err : undefined
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new KeypairFileError(
+      `Keypair file must contain a JSON array, got ${typeof parsed}`,
+      filePath
+    );
+  }
+
+  if (parsed.length !== 64) {
+    throw new KeypairFileError(
+      `Keypair file must contain 64 bytes, got ${parsed.length}`,
+      filePath
+    );
+  }
+
+  // Validate each byte value
+  for (let i = 0; i < parsed.length; i++) {
+    const value = parsed[i];
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 255) {
+      throw new KeypairFileError(
+        `Invalid byte value at index ${i}: ${value}`,
+        filePath
+      );
+    }
+  }
+
+  return Keypair.fromSecretKey(Uint8Array.from(parsed as number[]));
+}
+
+/**
+ * Load a Keypair from a JSON file asynchronously.
+ *
+ * The file should contain a JSON array of 64 bytes representing
+ * the secret key (as exported by `solana-keygen`).
+ *
+ * @example
+ * ```typescript
+ * const keypair = await loadKeypairFromFile('./my-keypair.json');
+ * ```
+ *
+ * @param filePath - Path to the keypair JSON file
+ * @returns The loaded Keypair
+ * @throws KeypairFileError if the file doesn't exist, contains invalid JSON,
+ *         or doesn't contain a valid 64-byte array
+ */
+export async function loadKeypairFromFile(filePath: string): Promise<Keypair> {
+  let content: string;
+  try {
+    content = await fsPromises.readFile(filePath, 'utf-8');
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      throw new KeypairFileError(
+        `Keypair file not found: ${filePath}`,
+        filePath,
+        err
+      );
+    }
+    throw new KeypairFileError(
+      `Failed to read keypair file: ${filePath}`,
+      filePath,
+      err instanceof Error ? err : undefined
+    );
+  }
+
+  return parseKeypairJson(content, filePath);
+}
+
+/**
+ * Load a Keypair from a JSON file synchronously.
+ *
+ * @example
+ * ```typescript
+ * const keypair = loadKeypairFromFileSync('./my-keypair.json');
+ * ```
+ *
+ * @param filePath - Path to the keypair JSON file
+ * @returns The loaded Keypair
+ * @throws KeypairFileError if the file doesn't exist, contains invalid JSON,
+ *         or doesn't contain a valid 64-byte array
+ */
+export function loadKeypairFromFileSync(filePath: string): Keypair {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    if (err instanceof Error && 'code' in err && err.code === 'ENOENT') {
+      throw new KeypairFileError(
+        `Keypair file not found: ${filePath}`,
+        filePath,
+        err
+      );
+    }
+    throw new KeypairFileError(
+      `Failed to read keypair file: ${filePath}`,
+      filePath,
+      err instanceof Error ? err : undefined
+    );
+  }
+
+  return parseKeypairJson(content, filePath);
+}
+
+/**
+ * Load the default Solana keypair from `~/.config/solana/id.json`.
+ *
+ * @example
+ * ```typescript
+ * const keypair = await loadDefaultKeypair();
+ * const wallet = keypairToWallet(keypair);
+ * ```
+ *
+ * @returns The loaded Keypair
+ * @throws KeypairFileError if the default keypair file doesn't exist or is invalid
+ */
+export async function loadDefaultKeypair(): Promise<Keypair> {
+  return loadKeypairFromFile(getDefaultKeypairPath());
+}

--- a/sdk/dist/index.js
+++ b/sdk/dist/index.js
@@ -33,6 +33,7 @@ __export(index_exports, {
   DEFAULT_FEE_PERCENT: () => DEFAULT_FEE_PERCENT,
   DEVNET_RPC: () => DEVNET_RPC,
   DISCRIMINATOR_SIZE: () => DISCRIMINATOR_SIZE,
+  FIELD_MODULUS: () => FIELD_MODULUS,
   HASH_SIZE: () => HASH_SIZE,
   MAINNET_RPC: () => MAINNET_RPC,
   OUTPUT_FIELD_COUNT: () => OUTPUT_FIELD_COUNT,
@@ -49,6 +50,7 @@ __export(index_exports, {
   VERIFICATION_COMPUTE_UNITS: () => VERIFICATION_COMPUTE_UNITS,
   VERIFIER_PROGRAM_ID: () => VERIFIER_PROGRAM_ID,
   VERSION: () => VERSION,
+  calculateEscrowFee: () => calculateEscrowFee,
   checkToolsAvailable: () => checkToolsAvailable,
   claimTask: () => claimTask,
   completeTask: () => completeTask,
@@ -56,11 +58,18 @@ __export(index_exports, {
   computeCommitment: () => computeCommitment,
   computeConstraintHash: () => computeConstraintHash,
   computeExpectedBinding: () => computeExpectedBinding,
+  computeHashesViaNargo: () => computeHashesViaNargo,
   createTask: () => createTask,
+  deriveClaimPda: () => deriveClaimPda,
+  deriveEscrowPda: () => deriveEscrowPda,
+  deriveTaskPda: () => deriveTaskPda,
+  formatTaskState: () => formatTaskState,
   generateProof: () => generateProof,
   generateSalt: () => generateSalt,
   getTask: () => getTask,
+  getTasksByCreator: () => getTasksByCreator,
   pubkeyToField: () => pubkeyToField,
+  requireTools: () => requireTools,
   verifyProofLocally: () => verifyProofLocally
 });
 module.exports = __toCommonJS(index_exports);
@@ -179,12 +188,14 @@ var AgenCPrivacyClient = class {
       await loadPrivacyCash();
       this.privacyCashLoaded = true;
     }
+    const enableDebug = process.env.AGENC_DEBUG === "true";
     this.privacyCash = createPrivacyCash({
       RPC_url: this.rpcUrl,
       owner,
-      enableDebug: true
+      enableDebug
     });
-    console.log("Privacy Cash client initialized for:", owner.publicKey.toBase58());
+    const pubkeyStr = owner.publicKey.toBase58();
+    console.log("Privacy Cash client initialized for:", pubkeyStr.substring(0, 8) + "..." + pubkeyStr.substring(pubkeyStr.length - 4));
   }
   /**
    * Shield escrow funds into Privacy Cash pool
@@ -243,7 +254,10 @@ var AgenCPrivacyClient = class {
       worker: worker.publicKey
     });
     const proofTxSignature = await this.connection.sendTransaction(tx, [worker]);
-    await this.connection.confirmTransaction(proofTxSignature);
+    const confirmation = await this.connection.confirmTransaction(proofTxSignature, "confirmed");
+    if (confirmation.value.err) {
+      throw new Error(`Transaction failed: ${JSON.stringify(confirmation.value.err)}`);
+    }
     console.log("Proof verified on-chain:", proofTxSignature);
     console.log("Step 3/3: Withdrawing shielded escrow via Privacy Cash...");
     const withdrawResult = await this.privacyCash.withdraw({
@@ -448,10 +462,18 @@ var PrivacyClient = class {
   }
   /**
    * Shield SOL into the privacy pool
+   * @param lamports - Amount in lamports to shield (must be positive integer)
+   * @throws Error if lamports is invalid or client not initialized
    */
   async shield(lamports) {
     if (!this.wallet || !this.privacyClient) {
       throw new Error("Client not initialized. Call init() first.");
+    }
+    if (!Number.isInteger(lamports) || lamports <= 0) {
+      throw new Error("Invalid lamports amount: must be a positive integer");
+    }
+    if (lamports > Number.MAX_SAFE_INTEGER) {
+      throw new Error("Lamports amount exceeds safe integer limit");
     }
     const result = await this.privacyClient.shieldEscrow(this.wallet, lamports);
     return {
@@ -492,9 +514,26 @@ var PrivacyClient = class {
   }
   /**
    * Parse SOL string to lamports
+   *
+   * Note: For large SOL amounts (> ~9 million SOL), consider using BigInt
+   * to avoid floating point precision issues. This method validates inputs
+   * and throws on invalid values.
+   *
+   * @param sol - SOL amount as string or number
+   * @returns lamports as number (safe for amounts < MAX_SAFE_INTEGER / LAMPORTS_PER_SOL)
+   * @throws Error if input is invalid or would cause precision loss
    */
   static parseSol(sol) {
     const value = typeof sol === "string" ? parseFloat(sol) : sol;
+    if (!Number.isFinite(value) || value < 0) {
+      throw new Error("Invalid SOL amount: must be a non-negative finite number");
+    }
+    const maxSafeSol = Number.MAX_SAFE_INTEGER / import_web33.LAMPORTS_PER_SOL;
+    if (value > maxSafeSol) {
+      throw new Error(
+        `SOL amount ${value} exceeds safe precision limit (${maxSafeSol.toFixed(9)} SOL). Use BigInt for larger amounts.`
+      );
+    }
     return Math.floor(value * import_web33.LAMPORTS_PER_SOL);
   }
 };
@@ -519,40 +558,8 @@ function validateCircuitPath2(circuitPath) {
 }
 var FIELD_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 var FIELD_HEX_LENGTH = HASH_SIZE * 2;
-var BYTE_BASE = 256n;
 var DEFAULT_CIRCUIT_PATH = "./circuits/task_completion";
-function poseidonHash2(a, b) {
-  return (0, import_poseidon2.poseidon2Hash)([a % FIELD_MODULUS, b % FIELD_MODULUS, 0n, 0n]);
-}
-function poseidonHash4(input) {
-  if (input.length !== OUTPUT_FIELD_COUNT) {
-    throw new Error(`Input must be exactly ${OUTPUT_FIELD_COUNT} elements`);
-  }
-  return (0, import_poseidon2.poseidon2Hash)(input.map((x) => x % FIELD_MODULUS));
-}
-function pubkeyToField(pubkey) {
-  const bytes = pubkey.toBytes();
-  let field = 0n;
-  for (const byte of bytes) {
-    field = (field * BYTE_BASE + BigInt(byte)) % FIELD_MODULUS;
-  }
-  return field;
-}
-function computeExpectedBinding(taskPda, agentPubkey, outputCommitment) {
-  const taskField = pubkeyToField(taskPda);
-  const agentField = pubkeyToField(agentPubkey);
-  const binding = poseidonHash2(taskField, agentField);
-  return poseidonHash2(binding, outputCommitment % FIELD_MODULUS);
-}
-function computeConstraintHash(output) {
-  if (output.length !== OUTPUT_FIELD_COUNT) {
-    throw new Error(`Output must be exactly ${OUTPUT_FIELD_COUNT} field elements`);
-  }
-  return poseidonHash4(output);
-}
-function computeCommitment(constraintHash, salt) {
-  return poseidonHash2(constraintHash, salt);
-}
+var DEFAULT_HASH_HELPER_PATH = "./circuits/hash_helper";
 var BITS_PER_BYTE = 8n;
 function generateSalt() {
   const bytes = new Uint8Array(HASH_SIZE);
@@ -563,40 +570,80 @@ function generateSalt() {
   }
   return salt % FIELD_MODULUS;
 }
-function generateProverToml(params) {
-  const taskBytes = Array.from(params.taskPda.toBytes());
-  const agentBytes = Array.from(params.agentPubkey.toBytes());
-  const expectedBinding = computeExpectedBinding(
-    params.taskPda,
-    params.agentPubkey,
-    params.outputCommitment
-  );
+async function computeHashesViaNargo(taskPda, agentPubkey, output, salt, hashHelperPath = DEFAULT_HASH_HELPER_PATH) {
+  validateCircuitPath2(hashHelperPath);
+  if (output.length !== OUTPUT_FIELD_COUNT) {
+    throw new Error(`Output must be exactly ${OUTPUT_FIELD_COUNT} field elements`);
+  }
+  const taskBytes = Array.from(taskPda.toBytes());
+  const agentBytes = Array.from(agentPubkey.toBytes());
+  const proverToml = `task_id = [${taskBytes.join(", ")}]
+agent_pubkey = [${agentBytes.join(", ")}]
+output = [${output.map((o) => `"${o.toString()}"`).join(", ")}]
+salt = "${salt.toString()}"
+`;
+  const proverTomlPath = path3.join(hashHelperPath, "Prover.toml");
+  fs2.writeFileSync(proverTomlPath, proverToml);
+  try {
+    const result = (0, import_child_process2.execSync)("nargo execute", {
+      cwd: hashHelperPath,
+      encoding: "utf-8",
+      timeout: 6e4
+    });
+    const outputMatch = result.match(/Circuit output: \((0x[0-9a-fA-F]+), (0x[0-9a-fA-F]+), (0x[0-9a-fA-F]+)\)/);
+    if (!outputMatch) {
+      throw new Error(`Failed to parse hash_helper output: ${result}`);
+    }
+    return {
+      constraintHash: BigInt(outputMatch[1]),
+      outputCommitment: BigInt(outputMatch[2]),
+      expectedBinding: BigInt(outputMatch[3])
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Hash computation failed: ${message}`);
+  }
+}
+function generateProverToml(taskPda, agentPubkey, output, salt, hashes) {
+  const taskBytes = Array.from(taskPda.toBytes());
+  const agentBytes = Array.from(agentPubkey.toBytes());
   return `task_id = [${taskBytes.join(", ")}]
 agent_pubkey = [${agentBytes.join(", ")}]
-constraint_hash = "0x${params.constraintHash.toString("hex")}"
-output_commitment = "0x${params.outputCommitment.toString(16)}"
-expected_binding = "0x${expectedBinding.toString(16)}"
-output = [${params.output.map((o) => `"${o.toString()}"`).join(", ")}]
-salt = "${params.salt.toString()}"
+constraint_hash = "0x${hashes.constraintHash.toString(16).padStart(FIELD_HEX_LENGTH, "0")}"
+output_commitment = "0x${hashes.outputCommitment.toString(16).padStart(FIELD_HEX_LENGTH, "0")}"
+expected_binding = "0x${hashes.expectedBinding.toString(16).padStart(FIELD_HEX_LENGTH, "0")}"
+output = [${output.map((o) => `"${o.toString()}"`).join(", ")}]
+salt = "${salt.toString()}"
 `;
+}
+function bigintToBytes32(value) {
+  const hex = value.toString(16).padStart(FIELD_HEX_LENGTH, "0");
+  return Buffer.from(hex, "hex");
 }
 async function generateProof(params) {
   const circuitPath = params.circuitPath || DEFAULT_CIRCUIT_PATH;
+  const hashHelperPath = params.hashHelperPath || DEFAULT_HASH_HELPER_PATH;
   validateCircuitPath2(circuitPath);
+  validateCircuitPath2(hashHelperPath);
   const startTime = Date.now();
-  const expectedBindingBigint = computeExpectedBinding(
+  const hashes = await computeHashesViaNargo(
     params.taskPda,
     params.agentPubkey,
-    params.outputCommitment
+    params.output,
+    params.salt,
+    hashHelperPath
   );
   const proverTomlPath = path3.join(circuitPath, "Prover.toml");
-  const proofOutputPath = path3.join(circuitPath, "target/task_completion.proof");
-  const witnessPath = path3.join(circuitPath, "target/task_completion.gz");
   const targetDir = path3.join(circuitPath, "target");
   if (!fs2.existsSync(targetDir)) {
     fs2.mkdirSync(targetDir, { recursive: true });
   }
-  fs2.writeFileSync(proverTomlPath, generateProverToml(params));
+  fs2.writeFileSync(
+    proverTomlPath,
+    generateProverToml(params.taskPda, params.agentPubkey, params.output, params.salt, hashes)
+  );
+  const proofOutputPath = path3.join(circuitPath, "target/task_completion.proof");
+  const witnessPath = path3.join(circuitPath, "target/task_completion.gz");
   try {
     (0, import_child_process2.execSync)("nargo execute", { cwd: circuitPath, stdio: "pipe", timeout: 12e4 });
     (0, import_child_process2.execSync)(
@@ -605,11 +652,12 @@ async function generateProof(params) {
     );
     const proof = fs2.readFileSync(proofOutputPath);
     const publicWitness = fs2.readFileSync(witnessPath);
-    const expectedBinding = bigintToBytes32(expectedBindingBigint);
     return {
       proof,
       publicWitness,
-      expectedBinding,
+      constraintHash: bigintToBytes32(hashes.constraintHash),
+      outputCommitment: bigintToBytes32(hashes.outputCommitment),
+      expectedBinding: bigintToBytes32(hashes.expectedBinding),
       proofSize: proof.length,
       generationTime: Date.now() - startTime
     };
@@ -617,10 +665,6 @@ async function generateProof(params) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`Proof generation failed: ${message}`);
   }
-}
-function bigintToBytes32(value) {
-  const hex = value.toString(16).padStart(FIELD_HEX_LENGTH, "0");
-  return Buffer.from(hex, "hex");
 }
 async function verifyProofLocally(proof, publicWitness, circuitPath = DEFAULT_CIRCUIT_PATH) {
   validateCircuitPath2(circuitPath);
@@ -651,19 +695,60 @@ async function verifyProofLocally(proof, publicWitness, circuitPath = DEFAULT_CI
   }
 }
 function checkToolsAvailable() {
-  let nargo = false;
-  let sunspot = false;
+  const result = { nargo: false, sunspot: false };
   try {
-    (0, import_child_process2.execSync)("nargo --version", { stdio: "pipe" });
-    nargo = true;
+    const nargoOutput = (0, import_child_process2.execSync)("nargo --version", { stdio: "pipe", encoding: "utf-8" });
+    result.nargo = true;
+    result.nargoVersion = nargoOutput.trim();
   } catch {
   }
   try {
-    (0, import_child_process2.execSync)("sunspot --version", { stdio: "pipe" });
-    sunspot = true;
+    const sunspotOutput = (0, import_child_process2.execSync)("sunspot --version", { stdio: "pipe", encoding: "utf-8" });
+    result.sunspot = true;
+    result.sunspotVersion = sunspotOutput.trim();
   } catch {
   }
-  return { nargo, sunspot };
+  return result;
+}
+function requireTools(requireSunspot = true) {
+  const tools = checkToolsAvailable();
+  if (!tools.nargo) {
+    throw new Error(
+      "nargo not found. Install with:\n  curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash\n  noirup\n\nSee: https://noir-lang.org/docs/getting_started/installation"
+    );
+  }
+  if (requireSunspot && !tools.sunspot) {
+    throw new Error(
+      "sunspot not found. Install with:\n  1. Install Go 1.21+\n  2. git clone https://github.com/Sunspot-Network/sunspot\n  3. cd sunspot/go && go build -o sunspot\n  4. Add to PATH\n\nSee: circuits/README.md for detailed instructions"
+    );
+  }
+}
+var BYTE_BASE = 256n;
+function pubkeyToField(pubkey) {
+  const bytes = pubkey.toBytes();
+  let field = 0n;
+  for (const byte of bytes) {
+    field = (field * BYTE_BASE + BigInt(byte)) % FIELD_MODULUS;
+  }
+  return field;
+}
+function computeConstraintHash(output) {
+  console.warn("DEPRECATED: computeConstraintHash uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.");
+  if (output.length !== OUTPUT_FIELD_COUNT) {
+    throw new Error(`Output must be exactly ${OUTPUT_FIELD_COUNT} field elements`);
+  }
+  return (0, import_poseidon2.poseidon2Hash)(output.map((x) => x % FIELD_MODULUS));
+}
+function computeCommitment(constraintHash, salt) {
+  console.warn("DEPRECATED: computeCommitment uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.");
+  return (0, import_poseidon2.poseidon2Hash)([constraintHash % FIELD_MODULUS, salt % FIELD_MODULUS, 0n, 0n]);
+}
+function computeExpectedBinding(taskPda, agentPubkey, outputCommitment) {
+  console.warn("DEPRECATED: computeExpectedBinding uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.");
+  const taskField = pubkeyToField(taskPda);
+  const agentField = pubkeyToField(agentPubkey);
+  const binding = (0, import_poseidon2.poseidon2Hash)([taskField, agentField, 0n, 0n]);
+  return (0, import_poseidon2.poseidon2Hash)([binding, outputCommitment % FIELD_MODULUS, 0n, 0n]);
 }
 
 // src/tasks.ts
@@ -680,6 +765,12 @@ function getAccount(program, name) {
   return account;
 }
 function deriveTaskPda(taskId, programId = PROGRAM_ID) {
+  if (!Number.isInteger(taskId) || taskId < 0) {
+    throw new Error("Invalid taskId: must be a non-negative integer");
+  }
+  if (taskId > Number.MAX_SAFE_INTEGER) {
+    throw new Error("Invalid taskId: exceeds maximum safe integer");
+  }
   const taskIdBuffer = Buffer.alloc(U64_SIZE);
   taskIdBuffer.writeBigUInt64LE(BigInt(taskId));
   const [pda] = import_web34.PublicKey.findProgramAddressSync(
@@ -725,6 +816,7 @@ async function createTask(connection, program, creator, params) {
     protocolState: protocolPda,
     systemProgram: import_web34.SystemProgram.programId
   }).signers([creator]).rpc();
+  await connection.confirmTransaction(tx, "confirmed");
   return { taskId, txSignature: tx };
 }
 async function claimTask(connection, program, agent, taskId) {
@@ -741,6 +833,7 @@ async function claimTask(connection, program, agent, taskId) {
     taskClaim: claimPda,
     systemProgram: import_web34.SystemProgram.programId
   }).signers([agent]).rpc();
+  await connection.confirmTransaction(tx, "confirmed");
   return { txSignature: tx };
 }
 async function completeTask(connection, program, worker, taskId, resultHash) {
@@ -758,6 +851,7 @@ async function completeTask(connection, program, worker, taskId, resultHash) {
     creator: task.creator,
     systemProgram: import_web34.SystemProgram.programId
   }).signers([worker]).rpc();
+  await connection.confirmTransaction(tx, "confirmed");
   return { txSignature: tx };
 }
 async function completeTaskPrivate(connection, program, worker, taskId, proof, verifierProgramId) {
@@ -789,6 +883,7 @@ async function completeTaskPrivate(connection, program, worker, taskId, proof, v
     authority: worker.publicKey,
     systemProgram: import_web34.SystemProgram.programId
   }).signers([worker]).rpc();
+  await connection.confirmTransaction(tx, "confirmed");
   return { txSignature: tx };
 }
 async function getTask(connection, program, taskId) {
@@ -796,6 +891,10 @@ async function getTask(connection, program, taskId) {
   try {
     const task = await getAccount(program, "task").fetch(taskPda);
     const taskData = task;
+    if (taskData.creator === void 0 || taskData.state === void 0) {
+      console.warn("Task account data missing required fields");
+      return null;
+    }
     return {
       taskId,
       state: taskData.state,
@@ -806,9 +905,69 @@ async function getTask(connection, program, taskId) {
       claimedBy: taskData.claimedBy || null,
       completedAt: taskData.completedAt?.toNumber() || null
     };
-  } catch {
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    if (errorMessage.includes("Account does not exist") || errorMessage.includes("could not find account")) {
+      return null;
+    }
+    console.warn(`getTask(${taskId}) encountered unexpected error:`, errorMessage);
     return null;
   }
+}
+async function getTasksByCreator(connection, program, creator) {
+  const tasks = await getAccount(program, "task").all([
+    {
+      memcmp: {
+        offset: DISCRIMINATOR_SIZE,
+        // After discriminator
+        bytes: creator.toBase58()
+      }
+    }
+  ]);
+  const result = [];
+  for (let idx = 0; idx < tasks.length; idx++) {
+    const t = tasks[idx];
+    const data = t.account;
+    if (data.creator === void 0 || data.state === void 0) {
+      console.warn(`Task at index ${idx} missing required fields, skipping`);
+      continue;
+    }
+    result.push({
+      taskId: data.taskId?.toNumber() ?? idx,
+      // Use actual taskId if available, fallback to index
+      state: data.state,
+      creator: data.creator,
+      escrowLamports: data.escrowLamports?.toNumber() || 0,
+      deadline: data.deadline?.toNumber() || 0,
+      constraintHash: data.constraintHash ? Buffer.from(data.constraintHash) : null,
+      claimedBy: data.claimedBy || null,
+      completedAt: data.completedAt?.toNumber() || null
+    });
+  }
+  return result;
+}
+function formatTaskState(state) {
+  const states = {
+    [0 /* Open */]: "Open",
+    [1 /* Claimed */]: "Claimed",
+    [2 /* Completed */]: "Completed",
+    [3 /* Disputed */]: "Disputed",
+    [4 /* Cancelled */]: "Cancelled"
+  };
+  return states[state] || "Unknown";
+}
+function calculateEscrowFee(escrowLamports, feePercentage = DEFAULT_FEE_PERCENT) {
+  if (escrowLamports < 0 || !Number.isFinite(escrowLamports)) {
+    throw new Error("Invalid escrow amount: must be a non-negative finite number");
+  }
+  if (feePercentage < 0 || feePercentage > PERCENT_BASE || !Number.isFinite(feePercentage)) {
+    throw new Error(`Invalid fee percentage: must be between 0 and ${PERCENT_BASE}`);
+  }
+  const maxSafeMultiplier = Math.floor(Number.MAX_SAFE_INTEGER / PERCENT_BASE);
+  if (escrowLamports > maxSafeMultiplier) {
+    throw new Error("Escrow amount too large: would cause arithmetic overflow");
+  }
+  return Math.floor(escrowLamports * feePercentage / PERCENT_BASE);
 }
 
 // src/index.ts
@@ -818,6 +977,7 @@ var VERSION = "1.0.0";
   DEFAULT_FEE_PERCENT,
   DEVNET_RPC,
   DISCRIMINATOR_SIZE,
+  FIELD_MODULUS,
   HASH_SIZE,
   MAINNET_RPC,
   OUTPUT_FIELD_COUNT,
@@ -834,6 +994,7 @@ var VERSION = "1.0.0";
   VERIFICATION_COMPUTE_UNITS,
   VERIFIER_PROGRAM_ID,
   VERSION,
+  calculateEscrowFee,
   checkToolsAvailable,
   claimTask,
   completeTask,
@@ -841,10 +1002,17 @@ var VERSION = "1.0.0";
   computeCommitment,
   computeConstraintHash,
   computeExpectedBinding,
+  computeHashesViaNargo,
   createTask,
+  deriveClaimPda,
+  deriveEscrowPda,
+  deriveTaskPda,
+  formatTaskState,
   generateProof,
   generateSalt,
   getTask,
+  getTasksByCreator,
   pubkeyToField,
+  requireTools,
   verifyProofLocally
 });

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -22,6 +22,7 @@ export {
   generateSalt,
   checkToolsAvailable,
   requireTools,
+  pubkeyToField,
   FIELD_MODULUS,
   // Types
   ProofGenerationParams,

--- a/sdk/src/proofs.ts
+++ b/sdk/src/proofs.ts
@@ -349,6 +349,27 @@ export function requireTools(requireSunspot: boolean = true): void {
 
 import { poseidon2Hash } from '@zkpassport/poseidon2';
 
+/** Base for byte-to-field conversion */
+const BYTE_BASE = 256n;
+
+/**
+ * Convert a PublicKey to a field element.
+ *
+ * Interprets the 32-byte public key as a big-endian integer and reduces
+ * it modulo the BN254 scalar field.
+ *
+ * @param pubkey - The public key to convert
+ * @returns The field element representation
+ */
+export function pubkeyToField(pubkey: PublicKey): bigint {
+  const bytes = pubkey.toBytes();
+  let field = 0n;
+  for (const byte of bytes) {
+    field = (field * BYTE_BASE + BigInt(byte)) % FIELD_MODULUS;
+  }
+  return field;
+}
+
 /** @deprecated Use computeHashesViaNargo instead - JS hash may not match circuit */
 export function computeConstraintHash(output: bigint[]): bigint {
   console.warn('DEPRECATED: computeConstraintHash uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.');
@@ -371,15 +392,6 @@ export function computeExpectedBinding(
   outputCommitment: bigint
 ): bigint {
   console.warn('DEPRECATED: computeExpectedBinding uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.');
-  const BYTE_BASE = 256n;
-  const pubkeyToField = (pubkey: PublicKey): bigint => {
-    const bytes = pubkey.toBytes();
-    let field = 0n;
-    for (const byte of bytes) {
-      field = (field * BYTE_BASE + BigInt(byte)) % FIELD_MODULUS;
-    }
-    return field;
-  };
   const taskField = pubkeyToField(taskPda);
   const agentField = pubkeyToField(agentPubkey);
   const binding = poseidon2Hash([taskField, agentField, 0n, 0n]);


### PR DESCRIPTION
## Summary

Implements Issue #112 - Wallet Types for `@agenc/runtime` Phase 1.

## New Exports in @agenc/runtime

| Export | Type | Description |
|--------|------|-------------|
| `Wallet` | interface | Anchor-compatible wallet interface |
| `SignMessageWallet` | interface | Extends Wallet with optional `signMessage` |
| `KeypairFileError` | class | Error class for keypair file operations |
| `keypairToWallet()` | function | Wrap Keypair as Wallet |
| `loadKeypairFromFile()` | function | Async keypair loading from JSON |
| `loadKeypairFromFileSync()` | function | Sync keypair loading |
| `getDefaultKeypairPath()` | function | Returns `~/.config/solana/id.json` |
| `loadDefaultKeypair()` | function | Load default Solana keypair |

## Bonus Fix

Also exports `pubkeyToField` from `@agenc/sdk` - this was previously a local function inside `computeExpectedBinding()` but tests were trying to import it, causing 6 test failures.

## Test Plan

- [x] 24 new wallet tests (all passing)
- [x] 33 SDK tests (all passing, including previously failing pubkeyToField tests)
- [x] TypeScript strict mode
- [x] Build verification

Closes #112