### PR TITLE
feat(runtime): add error types and Anchor error code mapping

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -35,3 +35,31 @@ export class AgentRuntime {
     return this.config.rpcUrl;
   }
 }
+
+// Error types, constants, and helpers
+export {
+  // Error constants
+  RuntimeErrorCodes,
+  AnchorErrorCodes,
+  // Error types
+  type RuntimeErrorCode,
+  type AnchorErrorCode,
+  type AnchorErrorName,
+  type ParsedAnchorError,
+  // Error classes
+  RuntimeError,
+  AgentNotRegisteredError,
+  AgentAlreadyRegisteredError,
+  ValidationError,
+  RateLimitError,
+  InsufficientStakeError,
+  ActiveTasksError,
+  PendingDisputeVotesError,
+  RecentVoteActivityError,
+  // Error helper functions
+  isAnchorError,
+  parseAnchorError,
+  getAnchorErrorName,
+  getAnchorErrorMessage,
+  isRuntimeError,
+} from './types/index.js';

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -1,0 +1,664 @@
+import { describe, it, expect } from 'vitest';
+import {
+  // Constants
+  RuntimeErrorCodes,
+  AnchorErrorCodes,
+  // Types (imported for testing)
+  type RuntimeErrorCode,
+  type AnchorErrorCode,
+  type AnchorErrorName,
+  type ParsedAnchorError,
+  // Base error class
+  RuntimeError,
+  // Specific error classes
+  AgentNotRegisteredError,
+  AgentAlreadyRegisteredError,
+  ValidationError,
+  RateLimitError,
+  InsufficientStakeError,
+  ActiveTasksError,
+  PendingDisputeVotesError,
+  RecentVoteActivityError,
+  // Helper functions
+  isAnchorError,
+  parseAnchorError,
+  getAnchorErrorName,
+  getAnchorErrorMessage,
+  isRuntimeError,
+} from './errors';
+
+describe('RuntimeErrorCodes', () => {
+  it('has all expected error codes', () => {
+    expect(RuntimeErrorCodes.AGENT_NOT_REGISTERED).toBe('AGENT_NOT_REGISTERED');
+    expect(RuntimeErrorCodes.AGENT_ALREADY_REGISTERED).toBe('AGENT_ALREADY_REGISTERED');
+    expect(RuntimeErrorCodes.VALIDATION_ERROR).toBe('VALIDATION_ERROR');
+    expect(RuntimeErrorCodes.RATE_LIMIT_ERROR).toBe('RATE_LIMIT_ERROR');
+    expect(RuntimeErrorCodes.INSUFFICIENT_STAKE).toBe('INSUFFICIENT_STAKE');
+    expect(RuntimeErrorCodes.ACTIVE_TASKS_ERROR).toBe('ACTIVE_TASKS_ERROR');
+    expect(RuntimeErrorCodes.PENDING_DISPUTE_VOTES).toBe('PENDING_DISPUTE_VOTES');
+    expect(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY).toBe('RECENT_VOTE_ACTIVITY');
+  });
+
+  it('has exactly 8 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(8);
+  });
+});
+
+describe('AnchorErrorCodes', () => {
+  it('has exactly 78 error codes (6000-6077)', () => {
+    expect(Object.keys(AnchorErrorCodes)).toHaveLength(78);
+  });
+
+  it('has codes in range 6000-6077', () => {
+    const codes = Object.values(AnchorErrorCodes);
+    const minCode = Math.min(...codes);
+    const maxCode = Math.max(...codes);
+
+    expect(minCode).toBe(6000);
+    expect(maxCode).toBe(6077);
+  });
+
+  it('has sequential codes (no gaps)', () => {
+    const codes = Object.values(AnchorErrorCodes).sort((a, b) => a - b);
+    for (let i = 0; i < codes.length; i++) {
+      expect(codes[i]).toBe(6000 + i);
+    }
+  });
+
+  it('has correct agent error codes (6000-6007)', () => {
+    expect(AnchorErrorCodes.AgentAlreadyRegistered).toBe(6000);
+    expect(AnchorErrorCodes.AgentNotFound).toBe(6001);
+    expect(AnchorErrorCodes.AgentNotActive).toBe(6002);
+    expect(AnchorErrorCodes.InsufficientCapabilities).toBe(6003);
+    expect(AnchorErrorCodes.MaxActiveTasksReached).toBe(6004);
+    expect(AnchorErrorCodes.AgentHasActiveTasks).toBe(6005);
+    expect(AnchorErrorCodes.UnauthorizedAgent).toBe(6006);
+    expect(AnchorErrorCodes.AgentRegistrationRequired).toBe(6007);
+  });
+
+  it('has correct task error codes (6008-6023)', () => {
+    expect(AnchorErrorCodes.TaskNotFound).toBe(6008);
+    expect(AnchorErrorCodes.TaskNotOpen).toBe(6009);
+    expect(AnchorErrorCodes.TaskFullyClaimed).toBe(6010);
+    expect(AnchorErrorCodes.TaskExpired).toBe(6011);
+    expect(AnchorErrorCodes.TaskNotExpired).toBe(6012);
+    expect(AnchorErrorCodes.DeadlinePassed).toBe(6013);
+    expect(AnchorErrorCodes.TaskNotInProgress).toBe(6014);
+    expect(AnchorErrorCodes.TaskAlreadyCompleted).toBe(6015);
+    expect(AnchorErrorCodes.TaskCannotBeCancelled).toBe(6016);
+    expect(AnchorErrorCodes.UnauthorizedTaskAction).toBe(6017);
+    expect(AnchorErrorCodes.InvalidCreator).toBe(6018);
+    expect(AnchorErrorCodes.InvalidTaskType).toBe(6019);
+    expect(AnchorErrorCodes.CompetitiveTaskAlreadyWon).toBe(6020);
+    expect(AnchorErrorCodes.NoWorkers).toBe(6021);
+    expect(AnchorErrorCodes.ConstraintHashMismatch).toBe(6022);
+    expect(AnchorErrorCodes.NotPrivateTask).toBe(6023);
+  });
+
+  it('has correct claim error codes (6024-6032)', () => {
+    expect(AnchorErrorCodes.AlreadyClaimed).toBe(6024);
+    expect(AnchorErrorCodes.NotClaimed).toBe(6025);
+    expect(AnchorErrorCodes.ClaimAlreadyCompleted).toBe(6026);
+    expect(AnchorErrorCodes.ClaimNotExpired).toBe(6027);
+    expect(AnchorErrorCodes.InvalidProof).toBe(6028);
+    expect(AnchorErrorCodes.ZkVerificationFailed).toBe(6029);
+    expect(AnchorErrorCodes.InvalidProofSize).toBe(6030);
+    expect(AnchorErrorCodes.InvalidProofBinding).toBe(6031);
+    expect(AnchorErrorCodes.InvalidOutputCommitment).toBe(6032);
+  });
+
+  it('has correct dispute error codes (6033-6047)', () => {
+    expect(AnchorErrorCodes.DisputeNotActive).toBe(6033);
+    expect(AnchorErrorCodes.VotingEnded).toBe(6034);
+    expect(AnchorErrorCodes.VotingNotEnded).toBe(6035);
+    expect(AnchorErrorCodes.AlreadyVoted).toBe(6036);
+    expect(AnchorErrorCodes.NotArbiter).toBe(6037);
+    expect(AnchorErrorCodes.InsufficientVotes).toBe(6038);
+    expect(AnchorErrorCodes.DisputeAlreadyResolved).toBe(6039);
+    expect(AnchorErrorCodes.UnauthorizedResolver).toBe(6040);
+    expect(AnchorErrorCodes.ActiveDisputeVotes).toBe(6041);
+    expect(AnchorErrorCodes.RecentVoteActivity).toBe(6042);
+    expect(AnchorErrorCodes.InsufficientEvidence).toBe(6043);
+    expect(AnchorErrorCodes.EvidenceTooLong).toBe(6044);
+    expect(AnchorErrorCodes.DisputeNotExpired).toBe(6045);
+    expect(AnchorErrorCodes.SlashAlreadyApplied).toBe(6046);
+    expect(AnchorErrorCodes.DisputeNotResolved).toBe(6047);
+  });
+
+  it('has correct state error codes (6048-6050)', () => {
+    expect(AnchorErrorCodes.VersionMismatch).toBe(6048);
+    expect(AnchorErrorCodes.StateKeyExists).toBe(6049);
+    expect(AnchorErrorCodes.StateNotFound).toBe(6050);
+  });
+
+  it('has correct protocol error codes (6051-6061)', () => {
+    expect(AnchorErrorCodes.ProtocolAlreadyInitialized).toBe(6051);
+    expect(AnchorErrorCodes.ProtocolNotInitialized).toBe(6052);
+    expect(AnchorErrorCodes.InvalidProtocolFee).toBe(6053);
+    expect(AnchorErrorCodes.InvalidDisputeThreshold).toBe(6054);
+    expect(AnchorErrorCodes.InsufficientStake).toBe(6055);
+    expect(AnchorErrorCodes.MultisigInvalidThreshold).toBe(6056);
+    expect(AnchorErrorCodes.MultisigInvalidSigners).toBe(6057);
+    expect(AnchorErrorCodes.MultisigNotEnoughSigners).toBe(6058);
+    expect(AnchorErrorCodes.MultisigDuplicateSigner).toBe(6059);
+    expect(AnchorErrorCodes.MultisigDefaultSigner).toBe(6060);
+    expect(AnchorErrorCodes.MultisigSignerNotSystemOwned).toBe(6061);
+  });
+
+  it('has correct general error codes (6062-6068)', () => {
+    expect(AnchorErrorCodes.InvalidInput).toBe(6062);
+    expect(AnchorErrorCodes.ArithmeticOverflow).toBe(6063);
+    expect(AnchorErrorCodes.VoteOverflow).toBe(6064);
+    expect(AnchorErrorCodes.InsufficientFunds).toBe(6065);
+    expect(AnchorErrorCodes.CorruptedData).toBe(6066);
+    expect(AnchorErrorCodes.StringTooLong).toBe(6067);
+    expect(AnchorErrorCodes.InvalidAccountOwner).toBe(6068);
+  });
+
+  it('has correct rate limiting error codes (6069-6071)', () => {
+    expect(AnchorErrorCodes.RateLimitExceeded).toBe(6069);
+    expect(AnchorErrorCodes.CooldownNotElapsed).toBe(6070);
+    expect(AnchorErrorCodes.InsufficientStakeForDispute).toBe(6071);
+  });
+
+  it('has correct version/upgrade error codes (6072-6077)', () => {
+    expect(AnchorErrorCodes.VersionMismatchProtocol).toBe(6072);
+    expect(AnchorErrorCodes.AccountVersionTooOld).toBe(6073);
+    expect(AnchorErrorCodes.AccountVersionTooNew).toBe(6074);
+    expect(AnchorErrorCodes.InvalidMigrationSource).toBe(6075);
+    expect(AnchorErrorCodes.InvalidMigrationTarget).toBe(6076);
+    expect(AnchorErrorCodes.UnauthorizedUpgrade).toBe(6077);
+  });
+});
+
+describe('RuntimeError', () => {
+  it('has correct properties', () => {
+    const error = new RuntimeError('Test message', RuntimeErrorCodes.VALIDATION_ERROR);
+
+    expect(error.name).toBe('RuntimeError');
+    expect(error.message).toBe('Test message');
+    expect(error.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('is instanceof Error', () => {
+    const error = new RuntimeError('Test', RuntimeErrorCodes.VALIDATION_ERROR);
+
+    expect(error instanceof Error).toBe(true);
+    expect(error instanceof RuntimeError).toBe(true);
+  });
+
+  it('has stack trace', () => {
+    const error = new RuntimeError('Test', RuntimeErrorCodes.VALIDATION_ERROR);
+
+    expect(error.stack).toBeDefined();
+    expect(error.stack).toContain('RuntimeError');
+  });
+});
+
+describe('AgentNotRegisteredError', () => {
+  it('has correct message and code', () => {
+    const error = new AgentNotRegisteredError();
+
+    expect(error.name).toBe('AgentNotRegisteredError');
+    expect(error.message).toBe('Agent is not registered in the protocol');
+    expect(error.code).toBe(RuntimeErrorCodes.AGENT_NOT_REGISTERED);
+  });
+
+  it('is instanceof RuntimeError', () => {
+    const error = new AgentNotRegisteredError();
+
+    expect(error instanceof RuntimeError).toBe(true);
+    expect(error instanceof Error).toBe(true);
+  });
+});
+
+describe('AgentAlreadyRegisteredError', () => {
+  it('has correct message, code, and agentId', () => {
+    const error = new AgentAlreadyRegisteredError('agent-123');
+
+    expect(error.name).toBe('AgentAlreadyRegisteredError');
+    expect(error.message).toBe('Agent "agent-123" is already registered');
+    expect(error.code).toBe(RuntimeErrorCodes.AGENT_ALREADY_REGISTERED);
+    expect(error.agentId).toBe('agent-123');
+  });
+
+  it('is instanceof RuntimeError', () => {
+    const error = new AgentAlreadyRegisteredError('test');
+
+    expect(error instanceof RuntimeError).toBe(true);
+  });
+});
+
+describe('ValidationError', () => {
+  it('has correct message and code', () => {
+    const error = new ValidationError('Invalid endpoint URL');
+
+    expect(error.name).toBe('ValidationError');
+    expect(error.message).toBe('Invalid endpoint URL');
+    expect(error.code).toBe(RuntimeErrorCodes.VALIDATION_ERROR);
+  });
+});
+
+describe('RateLimitError', () => {
+  it('has correct properties', () => {
+    const cooldownEnds = new Date('2024-01-01T12:00:00Z');
+    const error = new RateLimitError('task_creation', cooldownEnds);
+
+    expect(error.name).toBe('RateLimitError');
+    expect(error.message).toContain('task_creation');
+    expect(error.message).toContain(cooldownEnds.toISOString());
+    expect(error.code).toBe(RuntimeErrorCodes.RATE_LIMIT_ERROR);
+    expect(error.limitType).toBe('task_creation');
+    expect(error.cooldownEnds).toBe(cooldownEnds);
+  });
+});
+
+describe('InsufficientStakeError', () => {
+  it('has correct properties with bigint values', () => {
+    const required = BigInt('1000000000000');
+    const available = BigInt('500000000000');
+    const error = new InsufficientStakeError(required, available);
+
+    expect(error.name).toBe('InsufficientStakeError');
+    expect(error.message).toContain('1000000000000');
+    expect(error.message).toContain('500000000000');
+    expect(error.code).toBe(RuntimeErrorCodes.INSUFFICIENT_STAKE);
+    expect(error.required).toBe(required);
+    expect(error.available).toBe(available);
+  });
+
+  it('handles large bigint values correctly', () => {
+    const required = BigInt('9007199254740993'); // Larger than MAX_SAFE_INTEGER
+    const available = BigInt('1');
+    const error = new InsufficientStakeError(required, available);
+
+    expect(error.required).toBe(required);
+    expect(error.available).toBe(available);
+  });
+});
+
+describe('ActiveTasksError', () => {
+  it('has correct properties', () => {
+    const error = new ActiveTasksError(5);
+
+    expect(error.name).toBe('ActiveTasksError');
+    expect(error.message).toContain('5 active tasks');
+    expect(error.code).toBe(RuntimeErrorCodes.ACTIVE_TASKS_ERROR);
+    expect(error.activeTaskCount).toBe(5);
+  });
+
+  it('handles singular correctly', () => {
+    const error = new ActiveTasksError(1);
+
+    expect(error.message).toContain('1 active task');
+    expect(error.message).not.toContain('tasks');
+  });
+});
+
+describe('PendingDisputeVotesError', () => {
+  it('has correct properties', () => {
+    const error = new PendingDisputeVotesError(3);
+
+    expect(error.name).toBe('PendingDisputeVotesError');
+    expect(error.message).toContain('3 pending dispute votes');
+    expect(error.code).toBe(RuntimeErrorCodes.PENDING_DISPUTE_VOTES);
+    expect(error.voteCount).toBe(3);
+  });
+
+  it('handles singular correctly', () => {
+    const error = new PendingDisputeVotesError(1);
+
+    expect(error.message).toContain('1 pending dispute vote');
+    expect(error.message).not.toContain('votes');
+  });
+});
+
+describe('RecentVoteActivityError', () => {
+  it('has correct properties', () => {
+    const lastVote = new Date('2024-01-01T10:00:00Z');
+    const error = new RecentVoteActivityError(lastVote);
+
+    expect(error.name).toBe('RecentVoteActivityError');
+    expect(error.message).toContain('24 hours');
+    expect(error.message).toContain(lastVote.toISOString());
+    expect(error.code).toBe(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY);
+    expect(error.lastVoteTimestamp).toBe(lastVote);
+  });
+});
+
+describe('isAnchorError', () => {
+  it('returns true for direct code property', () => {
+    const error = { code: 6000 };
+    expect(isAnchorError(error, AnchorErrorCodes.AgentAlreadyRegistered)).toBe(true);
+  });
+
+  it('returns false for wrong code', () => {
+    const error = { code: 6000 };
+    expect(isAnchorError(error, AnchorErrorCodes.AgentNotFound)).toBe(false);
+  });
+
+  it('handles Anchor SDK errorCode format', () => {
+    const error = {
+      errorCode: {
+        code: 'AgentNotFound',
+        number: 6001,
+      },
+    };
+    expect(isAnchorError(error, AnchorErrorCodes.AgentNotFound)).toBe(true);
+    expect(isAnchorError(error, AnchorErrorCodes.AgentAlreadyRegistered)).toBe(false);
+  });
+
+  it('handles nested error.error format', () => {
+    const error = {
+      error: {
+        errorCode: {
+          code: 'TaskNotOpen',
+          number: 6009,
+        },
+      },
+    };
+    expect(isAnchorError(error, AnchorErrorCodes.TaskNotOpen)).toBe(true);
+  });
+
+  it('handles transaction logs', () => {
+    const error = {
+      logs: [
+        'Program log: AnchorError',
+        'Program log: Error Code: AgentNotFound. Error Number: 6001. Message: Agent not found',
+      ],
+    };
+    expect(isAnchorError(error, AnchorErrorCodes.AgentNotFound)).toBe(true);
+    expect(isAnchorError(error, AnchorErrorCodes.AgentAlreadyRegistered)).toBe(false);
+  });
+
+  it('handles hex error code in message', () => {
+    const error = {
+      message: 'failed to send transaction: Transaction simulation failed: custom program error: 0x1770',
+    };
+    // 0x1770 = 6000
+    expect(isAnchorError(error, AnchorErrorCodes.AgentAlreadyRegistered)).toBe(true);
+  });
+
+  it('handles decimal error code in message', () => {
+    const error = {
+      message: 'Error Number: 6024',
+    };
+    expect(isAnchorError(error, AnchorErrorCodes.AlreadyClaimed)).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isAnchorError(null, AnchorErrorCodes.AgentNotFound)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isAnchorError(undefined, AnchorErrorCodes.AgentNotFound)).toBe(false);
+  });
+
+  it('returns false for non-object', () => {
+    expect(isAnchorError('error', AnchorErrorCodes.AgentNotFound)).toBe(false);
+    expect(isAnchorError(123, AnchorErrorCodes.AgentNotFound)).toBe(false);
+  });
+
+  it('returns false for empty object', () => {
+    expect(isAnchorError({}, AnchorErrorCodes.AgentNotFound)).toBe(false);
+  });
+});
+
+describe('parseAnchorError', () => {
+  it('parses direct code property', () => {
+    const error = { code: 6000 };
+    const parsed = parseAnchorError(error);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.code).toBe(6000);
+    expect(parsed?.name).toBe('AgentAlreadyRegistered');
+    expect(parsed?.message).toBe('Agent is already registered');
+  });
+
+  it('parses Anchor SDK errorCode format', () => {
+    const error = {
+      errorCode: {
+        code: 'TaskExpired',
+        number: 6011,
+      },
+    };
+    const parsed = parseAnchorError(error);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.code).toBe(6011);
+    expect(parsed?.name).toBe('TaskExpired');
+    expect(parsed?.message).toBe('Task has expired');
+  });
+
+  it('parses nested error.error format', () => {
+    const error = {
+      error: {
+        errorCode: {
+          code: 'ZkVerificationFailed',
+          number: 6029,
+        },
+      },
+    };
+    const parsed = parseAnchorError(error);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.code).toBe(6029);
+    expect(parsed?.name).toBe('ZkVerificationFailed');
+  });
+
+  it('parses transaction logs', () => {
+    const error = {
+      logs: [
+        'Program log: Error Code: DisputeNotActive. Error Number: 6033. Some message',
+      ],
+    };
+    const parsed = parseAnchorError(error);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.code).toBe(6033);
+    expect(parsed?.name).toBe('DisputeNotActive');
+  });
+
+  it('parses hex error code in message', () => {
+    const error = {
+      message: 'custom program error: 0x17b5', // 6069
+    };
+    const parsed = parseAnchorError(error);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.code).toBe(6069);
+    expect(parsed?.name).toBe('RateLimitExceeded');
+  });
+
+  it('parses decimal error code in message', () => {
+    const error = {
+      message: 'Error Number: 6055',
+    };
+    const parsed = parseAnchorError(error);
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.code).toBe(6055);
+    expect(parsed?.name).toBe('InsufficientStake');
+  });
+
+  it('returns null for unknown error code', () => {
+    const error = { code: 9999 };
+    const parsed = parseAnchorError(error);
+
+    expect(parsed).toBeNull();
+  });
+
+  it('returns null for code outside range', () => {
+    expect(parseAnchorError({ code: 5999 })).toBeNull();
+    expect(parseAnchorError({ code: 6078 })).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(parseAnchorError(null)).toBeNull();
+    expect(parseAnchorError(undefined)).toBeNull();
+  });
+
+  it('returns null for non-object', () => {
+    expect(parseAnchorError('error')).toBeNull();
+    expect(parseAnchorError(123)).toBeNull();
+  });
+
+  it('returns correct message for all error codes', () => {
+    // Test a sampling of error codes to ensure messages are mapped
+    const testCases = [
+      { code: 6000, expected: 'Agent is already registered' },
+      { code: 6029, expected: 'ZK proof verification failed' },
+      { code: 6055, expected: 'Insufficient stake for arbiter registration' },
+      { code: 6077, expected: 'Only upgrade authority can perform this action' },
+    ];
+
+    for (const { code, expected } of testCases) {
+      const parsed = parseAnchorError({ code });
+      expect(parsed?.message).toBe(expected);
+    }
+  });
+});
+
+describe('getAnchorErrorName', () => {
+  it('returns correct name for valid code', () => {
+    expect(getAnchorErrorName(6000)).toBe('AgentAlreadyRegistered');
+    expect(getAnchorErrorName(6029)).toBe('ZkVerificationFailed');
+    expect(getAnchorErrorName(6077)).toBe('UnauthorizedUpgrade');
+  });
+
+  it('returns undefined for invalid code', () => {
+    expect(getAnchorErrorName(5999)).toBeUndefined();
+    expect(getAnchorErrorName(6078)).toBeUndefined();
+    expect(getAnchorErrorName(0)).toBeUndefined();
+  });
+
+  it('returns name for all 78 codes', () => {
+    for (let code = 6000; code <= 6077; code++) {
+      const name = getAnchorErrorName(code);
+      expect(name).toBeDefined();
+      expect(typeof name).toBe('string');
+    }
+  });
+});
+
+describe('getAnchorErrorMessage', () => {
+  it('returns correct message for valid code', () => {
+    expect(getAnchorErrorMessage(6000)).toBe('Agent is already registered');
+    expect(getAnchorErrorMessage(6029)).toBe('ZK proof verification failed');
+  });
+
+  it('returns message for all 78 codes', () => {
+    for (let code = 6000; code <= 6077; code++) {
+      const message = getAnchorErrorMessage(code as AnchorErrorCode);
+      expect(message).toBeDefined();
+      expect(typeof message).toBe('string');
+      expect(message.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('isRuntimeError', () => {
+  it('returns true for RuntimeError instance', () => {
+    const error = new RuntimeError('Test', RuntimeErrorCodes.VALIDATION_ERROR);
+    expect(isRuntimeError(error)).toBe(true);
+  });
+
+  it('returns true for subclasses', () => {
+    expect(isRuntimeError(new AgentNotRegisteredError())).toBe(true);
+    expect(isRuntimeError(new AgentAlreadyRegisteredError('test'))).toBe(true);
+    expect(isRuntimeError(new ValidationError('test'))).toBe(true);
+    expect(isRuntimeError(new RateLimitError('test', new Date()))).toBe(true);
+    expect(isRuntimeError(new InsufficientStakeError(1n, 0n))).toBe(true);
+    expect(isRuntimeError(new ActiveTasksError(1))).toBe(true);
+    expect(isRuntimeError(new PendingDisputeVotesError(1))).toBe(true);
+    expect(isRuntimeError(new RecentVoteActivityError(new Date()))).toBe(true);
+  });
+
+  it('returns false for regular Error', () => {
+    expect(isRuntimeError(new Error('Test'))).toBe(false);
+  });
+
+  it('returns false for non-errors', () => {
+    expect(isRuntimeError(null)).toBe(false);
+    expect(isRuntimeError(undefined)).toBe(false);
+    expect(isRuntimeError('error')).toBe(false);
+    expect(isRuntimeError({ message: 'error' })).toBe(false);
+  });
+
+  it('provides type guard functionality', () => {
+    const error: unknown = new ValidationError('test');
+
+    if (isRuntimeError(error)) {
+      // TypeScript should recognize error.code is accessible
+      expect(error.code).toBe(RuntimeErrorCodes.VALIDATION_ERROR);
+    } else {
+      throw new Error('Should have passed type guard');
+    }
+  });
+});
+
+describe('Error inheritance chain', () => {
+  it('all specific errors extend RuntimeError', () => {
+    const errors = [
+      new AgentNotRegisteredError(),
+      new AgentAlreadyRegisteredError('test'),
+      new ValidationError('test'),
+      new RateLimitError('test', new Date()),
+      new InsufficientStakeError(1n, 0n),
+      new ActiveTasksError(1),
+      new PendingDisputeVotesError(1),
+      new RecentVoteActivityError(new Date()),
+    ];
+
+    for (const error of errors) {
+      expect(error instanceof RuntimeError).toBe(true);
+      expect(error instanceof Error).toBe(true);
+    }
+  });
+
+  it('error names are distinct', () => {
+    const names = [
+      new RuntimeError('', RuntimeErrorCodes.VALIDATION_ERROR).name,
+      new AgentNotRegisteredError().name,
+      new AgentAlreadyRegisteredError('test').name,
+      new ValidationError('test').name,
+      new RateLimitError('test', new Date()).name,
+      new InsufficientStakeError(1n, 0n).name,
+      new ActiveTasksError(1).name,
+      new PendingDisputeVotesError(1).name,
+      new RecentVoteActivityError(new Date()).name,
+    ];
+
+    const uniqueNames = new Set(names);
+    expect(uniqueNames.size).toBe(names.length);
+  });
+});
+
+describe('Type exports', () => {
+  it('RuntimeErrorCode is assignable from RuntimeErrorCodes values', () => {
+    const code: RuntimeErrorCode = RuntimeErrorCodes.VALIDATION_ERROR;
+    expect(code).toBe('VALIDATION_ERROR');
+  });
+
+  it('AnchorErrorCode is assignable from AnchorErrorCodes values', () => {
+    const code: AnchorErrorCode = AnchorErrorCodes.AgentNotFound;
+    expect(code).toBe(6001);
+  });
+
+  it('AnchorErrorName is assignable from AnchorErrorCodes keys', () => {
+    const name: AnchorErrorName = 'AgentNotFound';
+    expect(name).toBe('AgentNotFound');
+  });
+
+  it('ParsedAnchorError has correct shape', () => {
+    const parsed: ParsedAnchorError = {
+      code: 6000,
+      name: 'AgentAlreadyRegistered',
+      message: 'Agent is already registered',
+    };
+
+    expect(parsed.code).toBe(6000);
+    expect(parsed.name).toBe('AgentAlreadyRegistered');
+    expect(parsed.message).toBe('Agent is already registered');
+  });
+});

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -1,0 +1,832 @@
+/**
+ * Error types and utilities for @agenc/runtime
+ *
+ * Provides custom runtime error classes, complete Anchor error code mapping,
+ * and helper functions for error handling in AgenC applications.
+ */
+
+// ============================================================================
+// Runtime Error Codes
+// ============================================================================
+
+/**
+ * String error codes for runtime-specific errors.
+ * These are distinct from Anchor program errors.
+ */
+export const RuntimeErrorCodes = {
+  /** Agent is not registered in the protocol */
+  AGENT_NOT_REGISTERED: 'AGENT_NOT_REGISTERED',
+  /** Agent is already registered */
+  AGENT_ALREADY_REGISTERED: 'AGENT_ALREADY_REGISTERED',
+  /** Input validation failed */
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  /** Rate limit exceeded */
+  RATE_LIMIT_ERROR: 'RATE_LIMIT_ERROR',
+  /** Insufficient stake for operation */
+  INSUFFICIENT_STAKE: 'INSUFFICIENT_STAKE',
+  /** Agent has active tasks preventing operation */
+  ACTIVE_TASKS_ERROR: 'ACTIVE_TASKS_ERROR',
+  /** Agent has pending dispute votes */
+  PENDING_DISPUTE_VOTES: 'PENDING_DISPUTE_VOTES',
+  /** Agent has recent vote activity */
+  RECENT_VOTE_ACTIVITY: 'RECENT_VOTE_ACTIVITY',
+} as const;
+
+/** Union type of all runtime error code values */
+export type RuntimeErrorCode = (typeof RuntimeErrorCodes)[keyof typeof RuntimeErrorCodes];
+
+// ============================================================================
+// Anchor Error Codes (78 codes: 6000-6077)
+// ============================================================================
+
+/**
+ * Numeric error codes matching the Anchor program's CoordinationError enum.
+ * Codes are organized by category as defined in programs/agenc-coordination/src/errors.rs
+ */
+export const AnchorErrorCodes = {
+  // Agent errors (6000-6007)
+  /** Agent is already registered */
+  AgentAlreadyRegistered: 6000,
+  /** Agent not found */
+  AgentNotFound: 6001,
+  /** Agent is not active */
+  AgentNotActive: 6002,
+  /** Agent has insufficient capabilities */
+  InsufficientCapabilities: 6003,
+  /** Agent has reached maximum active tasks */
+  MaxActiveTasksReached: 6004,
+  /** Agent has active tasks and cannot be deregistered */
+  AgentHasActiveTasks: 6005,
+  /** Only the agent authority can perform this action */
+  UnauthorizedAgent: 6006,
+  /** Agent registration required to create tasks */
+  AgentRegistrationRequired: 6007,
+
+  // Task errors (6008-6023)
+  /** Task not found */
+  TaskNotFound: 6008,
+  /** Task is not open for claims */
+  TaskNotOpen: 6009,
+  /** Task has reached maximum workers */
+  TaskFullyClaimed: 6010,
+  /** Task has expired */
+  TaskExpired: 6011,
+  /** Task deadline has not passed */
+  TaskNotExpired: 6012,
+  /** Task deadline has passed */
+  DeadlinePassed: 6013,
+  /** Task is not in progress */
+  TaskNotInProgress: 6014,
+  /** Task is already completed */
+  TaskAlreadyCompleted: 6015,
+  /** Task cannot be cancelled */
+  TaskCannotBeCancelled: 6016,
+  /** Only the task creator can perform this action */
+  UnauthorizedTaskAction: 6017,
+  /** Invalid creator */
+  InvalidCreator: 6018,
+  /** Invalid task type */
+  InvalidTaskType: 6019,
+  /** Competitive task already completed by another worker */
+  CompetitiveTaskAlreadyWon: 6020,
+  /** Task has no workers */
+  NoWorkers: 6021,
+  /** Proof constraint hash does not match task's stored constraint hash */
+  ConstraintHashMismatch: 6022,
+  /** Task is not a private task (no constraint hash set) */
+  NotPrivateTask: 6023,
+
+  // Claim errors (6024-6032)
+  /** Worker has already claimed this task */
+  AlreadyClaimed: 6024,
+  /** Worker has not claimed this task */
+  NotClaimed: 6025,
+  /** Claim has already been completed */
+  ClaimAlreadyCompleted: 6026,
+  /** Claim has not expired yet */
+  ClaimNotExpired: 6027,
+  /** Invalid proof of work */
+  InvalidProof: 6028,
+  /** ZK proof verification failed */
+  ZkVerificationFailed: 6029,
+  /** Invalid proof size - expected 388 bytes for Groth16 */
+  InvalidProofSize: 6030,
+  /** Invalid proof binding: expected_binding cannot be all zeros */
+  InvalidProofBinding: 6031,
+  /** Invalid output commitment: output_commitment cannot be all zeros */
+  InvalidOutputCommitment: 6032,
+
+  // Dispute errors (6033-6047)
+  /** Dispute is not active */
+  DisputeNotActive: 6033,
+  /** Voting period has ended */
+  VotingEnded: 6034,
+  /** Voting period has not ended */
+  VotingNotEnded: 6035,
+  /** Already voted on this dispute */
+  AlreadyVoted: 6036,
+  /** Not authorized to vote (not an arbiter) */
+  NotArbiter: 6037,
+  /** Insufficient votes to resolve */
+  InsufficientVotes: 6038,
+  /** Dispute has already been resolved */
+  DisputeAlreadyResolved: 6039,
+  /** Only protocol authority or dispute initiator can resolve disputes */
+  UnauthorizedResolver: 6040,
+  /** Agent has active dispute votes pending resolution */
+  ActiveDisputeVotes: 6041,
+  /** Agent must wait 24 hours after voting before deregistering */
+  RecentVoteActivity: 6042,
+  /** Insufficient dispute evidence provided */
+  InsufficientEvidence: 6043,
+  /** Dispute evidence exceeds maximum allowed length */
+  EvidenceTooLong: 6044,
+  /** Dispute has not expired */
+  DisputeNotExpired: 6045,
+  /** Dispute slashing already applied */
+  SlashAlreadyApplied: 6046,
+  /** Dispute has not been resolved */
+  DisputeNotResolved: 6047,
+
+  // State errors (6048-6050)
+  /** State version mismatch (concurrent modification) */
+  VersionMismatch: 6048,
+  /** State key already exists */
+  StateKeyExists: 6049,
+  /** State not found */
+  StateNotFound: 6050,
+
+  // Protocol errors (6051-6061)
+  /** Protocol is already initialized */
+  ProtocolAlreadyInitialized: 6051,
+  /** Protocol is not initialized */
+  ProtocolNotInitialized: 6052,
+  /** Invalid protocol fee (must be <= 1000 bps) */
+  InvalidProtocolFee: 6053,
+  /** Invalid dispute threshold */
+  InvalidDisputeThreshold: 6054,
+  /** Insufficient stake for arbiter registration */
+  InsufficientStake: 6055,
+  /** Invalid multisig threshold */
+  MultisigInvalidThreshold: 6056,
+  /** Invalid multisig signer configuration */
+  MultisigInvalidSigners: 6057,
+  /** Not enough multisig signers */
+  MultisigNotEnoughSigners: 6058,
+  /** Duplicate multisig signer provided */
+  MultisigDuplicateSigner: 6059,
+  /** Multisig signer cannot be default pubkey */
+  MultisigDefaultSigner: 6060,
+  /** Multisig signer account not owned by System Program */
+  MultisigSignerNotSystemOwned: 6061,
+
+  // General errors (6062-6068)
+  /** Invalid input parameter */
+  InvalidInput: 6062,
+  /** Arithmetic overflow */
+  ArithmeticOverflow: 6063,
+  /** Vote count overflow */
+  VoteOverflow: 6064,
+  /** Insufficient funds */
+  InsufficientFunds: 6065,
+  /** Account data is corrupted */
+  CorruptedData: 6066,
+  /** String too long */
+  StringTooLong: 6067,
+  /** Account owner validation failed: account not owned by this program */
+  InvalidAccountOwner: 6068,
+
+  // Rate limiting errors (6069-6071)
+  /** Rate limit exceeded: maximum actions per 24h window reached */
+  RateLimitExceeded: 6069,
+  /** Cooldown period has not elapsed since last action */
+  CooldownNotElapsed: 6070,
+  /** Insufficient stake to initiate dispute */
+  InsufficientStakeForDispute: 6071,
+
+  // Version/upgrade errors (6072-6077)
+  /** Protocol version mismatch: account version incompatible with current program */
+  VersionMismatchProtocol: 6072,
+  /** Account version too old: migration required */
+  AccountVersionTooOld: 6073,
+  /** Account version too new: program upgrade required */
+  AccountVersionTooNew: 6074,
+  /** Migration not allowed: invalid source version */
+  InvalidMigrationSource: 6075,
+  /** Migration not allowed: invalid target version */
+  InvalidMigrationTarget: 6076,
+  /** Only upgrade authority can perform this action */
+  UnauthorizedUpgrade: 6077,
+} as const;
+
+/** Union type of all Anchor error code values */
+export type AnchorErrorCode = (typeof AnchorErrorCodes)[keyof typeof AnchorErrorCodes];
+
+/** Union type of all Anchor error names */
+export type AnchorErrorName = keyof typeof AnchorErrorCodes;
+
+// ============================================================================
+// Error Messages Mapping
+// ============================================================================
+
+/** Human-readable messages for each Anchor error code */
+const AnchorErrorMessages: Record<AnchorErrorCode, string> = {
+  6000: 'Agent is already registered',
+  6001: 'Agent not found',
+  6002: 'Agent is not active',
+  6003: 'Agent has insufficient capabilities',
+  6004: 'Agent has reached maximum active tasks',
+  6005: 'Agent has active tasks and cannot be deregistered',
+  6006: 'Only the agent authority can perform this action',
+  6007: 'Agent registration required to create tasks',
+  6008: 'Task not found',
+  6009: 'Task is not open for claims',
+  6010: 'Task has reached maximum workers',
+  6011: 'Task has expired',
+  6012: 'Task deadline has not passed',
+  6013: 'Task deadline has passed',
+  6014: 'Task is not in progress',
+  6015: 'Task is already completed',
+  6016: 'Task cannot be cancelled',
+  6017: 'Only the task creator can perform this action',
+  6018: 'Invalid creator',
+  6019: 'Invalid task type',
+  6020: 'Competitive task already completed by another worker',
+  6021: 'Task has no workers',
+  6022: "Proof constraint hash does not match task's stored constraint hash",
+  6023: 'Task is not a private task (no constraint hash set)',
+  6024: 'Worker has already claimed this task',
+  6025: 'Worker has not claimed this task',
+  6026: 'Claim has already been completed',
+  6027: 'Claim has not expired yet',
+  6028: 'Invalid proof of work',
+  6029: 'ZK proof verification failed',
+  6030: 'Invalid proof size - expected 388 bytes for Groth16',
+  6031: 'Invalid proof binding: expected_binding cannot be all zeros',
+  6032: 'Invalid output commitment: output_commitment cannot be all zeros',
+  6033: 'Dispute is not active',
+  6034: 'Voting period has ended',
+  6035: 'Voting period has not ended',
+  6036: 'Already voted on this dispute',
+  6037: 'Not authorized to vote (not an arbiter)',
+  6038: 'Insufficient votes to resolve',
+  6039: 'Dispute has already been resolved',
+  6040: 'Only protocol authority or dispute initiator can resolve disputes',
+  6041: 'Agent has active dispute votes pending resolution',
+  6042: 'Agent must wait 24 hours after voting before deregistering',
+  6043: 'Insufficient dispute evidence provided',
+  6044: 'Dispute evidence exceeds maximum allowed length',
+  6045: 'Dispute has not expired',
+  6046: 'Dispute slashing already applied',
+  6047: 'Dispute has not been resolved',
+  6048: 'State version mismatch (concurrent modification)',
+  6049: 'State key already exists',
+  6050: 'State not found',
+  6051: 'Protocol is already initialized',
+  6052: 'Protocol is not initialized',
+  6053: 'Invalid protocol fee (must be <= 1000 bps)',
+  6054: 'Invalid dispute threshold',
+  6055: 'Insufficient stake for arbiter registration',
+  6056: 'Invalid multisig threshold',
+  6057: 'Invalid multisig signer configuration',
+  6058: 'Not enough multisig signers',
+  6059: 'Duplicate multisig signer provided',
+  6060: 'Multisig signer cannot be default pubkey',
+  6061: 'Multisig signer account not owned by System Program',
+  6062: 'Invalid input parameter',
+  6063: 'Arithmetic overflow',
+  6064: 'Vote count overflow',
+  6065: 'Insufficient funds',
+  6066: 'Account data is corrupted',
+  6067: 'String too long',
+  6068: 'Account owner validation failed: account not owned by this program',
+  6069: 'Rate limit exceeded: maximum actions per 24h window reached',
+  6070: 'Cooldown period has not elapsed since last action',
+  6071: 'Insufficient stake to initiate dispute',
+  6072: 'Protocol version mismatch: account version incompatible with current program',
+  6073: 'Account version too old: migration required',
+  6074: 'Account version too new: program upgrade required',
+  6075: 'Migration not allowed: invalid source version',
+  6076: 'Migration not allowed: invalid target version',
+  6077: 'Only upgrade authority can perform this action',
+};
+
+// ============================================================================
+// Base Runtime Error Class
+// ============================================================================
+
+/**
+ * Base class for all runtime errors.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await runtime.registerAgent(config);
+ * } catch (err) {
+ *   if (err instanceof RuntimeError) {
+ *     console.log(`Runtime error: ${err.code} - ${err.message}`);
+ *   }
+ * }
+ * ```
+ */
+export class RuntimeError extends Error {
+  /** The error code identifying this error type */
+  public readonly code: RuntimeErrorCode;
+
+  constructor(message: string, code: RuntimeErrorCode) {
+    super(message);
+    this.name = 'RuntimeError';
+    this.code = code;
+    // Maintain proper stack trace in V8 environments
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, RuntimeError);
+    }
+  }
+}
+
+// ============================================================================
+// Specific Runtime Error Classes
+// ============================================================================
+
+/**
+ * Error thrown when an agent is not registered in the protocol.
+ *
+ * @example
+ * ```typescript
+ * if (!agent.isRegistered) {
+ *   throw new AgentNotRegisteredError();
+ * }
+ * ```
+ */
+export class AgentNotRegisteredError extends RuntimeError {
+  constructor() {
+    super('Agent is not registered in the protocol', RuntimeErrorCodes.AGENT_NOT_REGISTERED);
+    this.name = 'AgentNotRegisteredError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AgentNotRegisteredError);
+    }
+  }
+}
+
+/**
+ * Error thrown when attempting to register an agent that already exists.
+ *
+ * @example
+ * ```typescript
+ * const existing = await getAgent(agentId);
+ * if (existing) {
+ *   throw new AgentAlreadyRegisteredError(agentId);
+ * }
+ * ```
+ */
+export class AgentAlreadyRegisteredError extends RuntimeError {
+  /** The ID of the agent that is already registered */
+  public readonly agentId: string;
+
+  constructor(agentId: string) {
+    super(`Agent "${agentId}" is already registered`, RuntimeErrorCodes.AGENT_ALREADY_REGISTERED);
+    this.name = 'AgentAlreadyRegisteredError';
+    this.agentId = agentId;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, AgentAlreadyRegisteredError);
+    }
+  }
+}
+
+/**
+ * Error thrown when input validation fails.
+ *
+ * @example
+ * ```typescript
+ * if (!isValidEndpoint(endpoint)) {
+ *   throw new ValidationError('Invalid endpoint URL format');
+ * }
+ * ```
+ */
+export class ValidationError extends RuntimeError {
+  constructor(message: string) {
+    super(message, RuntimeErrorCodes.VALIDATION_ERROR);
+    this.name = 'ValidationError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ValidationError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a rate limit is exceeded.
+ *
+ * @example
+ * ```typescript
+ * if (taskCount >= maxTasksPer24h) {
+ *   throw new RateLimitError('task_creation', cooldownEnd);
+ * }
+ * ```
+ */
+export class RateLimitError extends RuntimeError {
+  /** The type of rate limit that was exceeded */
+  public readonly limitType: string;
+  /** When the cooldown period ends */
+  public readonly cooldownEnds: Date;
+
+  constructor(limitType: string, cooldownEnds: Date) {
+    super(
+      `Rate limit exceeded for "${limitType}". Cooldown ends at ${cooldownEnds.toISOString()}`,
+      RuntimeErrorCodes.RATE_LIMIT_ERROR
+    );
+    this.name = 'RateLimitError';
+    this.limitType = limitType;
+    this.cooldownEnds = cooldownEnds;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, RateLimitError);
+    }
+  }
+}
+
+/**
+ * Error thrown when an agent has insufficient stake for an operation.
+ *
+ * @example
+ * ```typescript
+ * if (currentStake < requiredStake) {
+ *   throw new InsufficientStakeError(requiredStake, currentStake);
+ * }
+ * ```
+ */
+export class InsufficientStakeError extends RuntimeError {
+  /** The required stake amount in lamports */
+  public readonly required: bigint;
+  /** The available stake amount in lamports */
+  public readonly available: bigint;
+
+  constructor(required: bigint, available: bigint) {
+    super(
+      `Insufficient stake: required ${required} lamports, available ${available} lamports`,
+      RuntimeErrorCodes.INSUFFICIENT_STAKE
+    );
+    this.name = 'InsufficientStakeError';
+    this.required = required;
+    this.available = available;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InsufficientStakeError);
+    }
+  }
+}
+
+/**
+ * Error thrown when an agent has active tasks preventing an operation.
+ *
+ * @example
+ * ```typescript
+ * if (agent.activeTasks > 0) {
+ *   throw new ActiveTasksError(agent.activeTasks);
+ * }
+ * ```
+ */
+export class ActiveTasksError extends RuntimeError {
+  /** The number of active tasks */
+  public readonly activeTaskCount: number;
+
+  constructor(activeTaskCount: number) {
+    super(
+      `Agent has ${activeTaskCount} active ${activeTaskCount === 1 ? 'task' : 'tasks'} and cannot perform this operation`,
+      RuntimeErrorCodes.ACTIVE_TASKS_ERROR
+    );
+    this.name = 'ActiveTasksError';
+    this.activeTaskCount = activeTaskCount;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ActiveTasksError);
+    }
+  }
+}
+
+/**
+ * Error thrown when an agent has pending dispute votes.
+ *
+ * @example
+ * ```typescript
+ * if (pendingVotes > 0) {
+ *   throw new PendingDisputeVotesError(pendingVotes);
+ * }
+ * ```
+ */
+export class PendingDisputeVotesError extends RuntimeError {
+  /** The number of pending dispute votes */
+  public readonly voteCount: number;
+
+  constructor(voteCount: number) {
+    super(
+      `Agent has ${voteCount} pending dispute ${voteCount === 1 ? 'vote' : 'votes'} that must be resolved first`,
+      RuntimeErrorCodes.PENDING_DISPUTE_VOTES
+    );
+    this.name = 'PendingDisputeVotesError';
+    this.voteCount = voteCount;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PendingDisputeVotesError);
+    }
+  }
+}
+
+/**
+ * Error thrown when an agent has recent vote activity.
+ *
+ * @example
+ * ```typescript
+ * const waitPeriod = 24 * 60 * 60 * 1000; // 24 hours
+ * if (Date.now() - lastVote.getTime() < waitPeriod) {
+ *   throw new RecentVoteActivityError(lastVote);
+ * }
+ * ```
+ */
+export class RecentVoteActivityError extends RuntimeError {
+  /** The timestamp of the last vote */
+  public readonly lastVoteTimestamp: Date;
+
+  constructor(lastVoteTimestamp: Date) {
+    super(
+      `Agent must wait 24 hours after voting before performing this operation. Last vote: ${lastVoteTimestamp.toISOString()}`,
+      RuntimeErrorCodes.RECENT_VOTE_ACTIVITY
+    );
+    this.name = 'RecentVoteActivityError';
+    this.lastVoteTimestamp = lastVoteTimestamp;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, RecentVoteActivityError);
+    }
+  }
+}
+
+// ============================================================================
+// Parsed Anchor Error Type
+// ============================================================================
+
+/**
+ * Structured representation of a parsed Anchor error.
+ */
+export interface ParsedAnchorError {
+  /** The numeric error code */
+  code: AnchorErrorCode;
+  /** The error name (e.g., 'AgentNotFound') */
+  name: AnchorErrorName;
+  /** Human-readable error message */
+  message: string;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/** Reverse lookup map from code to name */
+const codeToNameMap: Map<number, AnchorErrorName> = new Map(
+  (Object.entries(AnchorErrorCodes) as [AnchorErrorName, number][]).map(([name, code]) => [
+    code,
+    name,
+  ])
+);
+
+/**
+ * Check if an error matches a specific Anchor error code.
+ *
+ * Handles multiple error formats:
+ * - Direct error code property
+ * - Nested errorCode object
+ * - Transaction logs containing error code
+ * - Error message containing error code
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await program.methods.claimTask().rpc();
+ * } catch (err) {
+ *   if (isAnchorError(err, AnchorErrorCodes.AlreadyClaimed)) {
+ *     console.log('Task already claimed by this worker');
+ *   } else if (isAnchorError(err, AnchorErrorCodes.TaskNotOpen)) {
+ *     console.log('Task is not open for claims');
+ *   }
+ * }
+ * ```
+ *
+ * @param error - The error to check
+ * @param code - The Anchor error code to match
+ * @returns True if the error matches the specified code
+ */
+export function isAnchorError(error: unknown, code: AnchorErrorCode): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const err = error as Record<string, unknown>;
+
+  // Check direct code property
+  if ('code' in err && err.code === code) {
+    return true;
+  }
+
+  // Check Anchor SDK errorCode format: { errorCode: { code: string, number: number } }
+  if ('errorCode' in err && typeof err.errorCode === 'object' && err.errorCode !== null) {
+    const errorCode = err.errorCode as Record<string, unknown>;
+    if ('number' in errorCode && errorCode.number === code) {
+      return true;
+    }
+  }
+
+  // Check for error.error format (nested error object)
+  if ('error' in err && typeof err.error === 'object' && err.error !== null) {
+    const innerError = err.error as Record<string, unknown>;
+    if ('errorCode' in innerError && typeof innerError.errorCode === 'object') {
+      const errorCode = innerError.errorCode as Record<string, unknown>;
+      if ('number' in errorCode && errorCode.number === code) {
+        return true;
+      }
+    }
+  }
+
+  // Check transaction logs for error code pattern
+  if ('logs' in err && Array.isArray(err.logs)) {
+    const errorPattern = new RegExp(`Error Code: \\w+\\. Error Number: ${code}\\.`);
+    for (const log of err.logs) {
+      if (typeof log === 'string' && errorPattern.test(log)) {
+        return true;
+      }
+    }
+  }
+
+  // Check error message for error code
+  if ('message' in err && typeof err.message === 'string') {
+    // Match patterns like "custom program error: 0x1770" (hex) or "Error Number: 6000"
+    const hexCode = `0x${code.toString(16)}`;
+    if (
+      err.message.includes(`custom program error: ${hexCode}`) ||
+      err.message.includes(`Error Number: ${code}`)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Parse an error into a structured Anchor error format.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await program.methods.registerAgent().rpc();
+ * } catch (err) {
+ *   const parsed = parseAnchorError(err);
+ *   if (parsed) {
+ *     console.log(`Error ${parsed.code}: ${parsed.name} - ${parsed.message}`);
+ *   }
+ * }
+ * ```
+ *
+ * @param error - The error to parse
+ * @returns Parsed error object if it's an Anchor error, null otherwise
+ */
+export function parseAnchorError(error: unknown): ParsedAnchorError | null {
+  if (!error || typeof error !== 'object') {
+    return null;
+  }
+
+  const err = error as Record<string, unknown>;
+  let code: number | undefined;
+  let name: AnchorErrorName | undefined;
+
+  // Try to extract code from various formats
+
+  // Format 1: Direct code property
+  if ('code' in err && typeof err.code === 'number') {
+    code = err.code;
+  }
+
+  // Format 2: Anchor SDK errorCode format
+  if ('errorCode' in err && typeof err.errorCode === 'object' && err.errorCode !== null) {
+    const errorCode = err.errorCode as Record<string, unknown>;
+    if ('number' in errorCode && typeof errorCode.number === 'number') {
+      code = errorCode.number;
+    }
+    if ('code' in errorCode && typeof errorCode.code === 'string') {
+      name = errorCode.code as AnchorErrorName;
+    }
+  }
+
+  // Format 3: Nested error.error format
+  if (!code && 'error' in err && typeof err.error === 'object' && err.error !== null) {
+    const innerError = err.error as Record<string, unknown>;
+    if ('errorCode' in innerError && typeof innerError.errorCode === 'object') {
+      const errorCode = innerError.errorCode as Record<string, unknown>;
+      if ('number' in errorCode && typeof errorCode.number === 'number') {
+        code = errorCode.number;
+      }
+      if ('code' in errorCode && typeof errorCode.code === 'string') {
+        name = errorCode.code as AnchorErrorName;
+      }
+    }
+  }
+
+  // Format 4: Extract from logs
+  if (!code && 'logs' in err && Array.isArray(err.logs)) {
+    const errorPattern = /Error Code: (\w+)\. Error Number: (\d+)\./;
+    for (const log of err.logs) {
+      if (typeof log === 'string') {
+        const match = log.match(errorPattern);
+        if (match) {
+          name = match[1] as AnchorErrorName;
+          code = parseInt(match[2], 10);
+          break;
+        }
+      }
+    }
+  }
+
+  // Format 5: Extract from error message
+  if (!code && 'message' in err && typeof err.message === 'string') {
+    // Match hex pattern: "custom program error: 0x1770"
+    const hexMatch = err.message.match(/custom program error: 0x([0-9a-fA-F]+)/);
+    if (hexMatch) {
+      code = parseInt(hexMatch[1], 16);
+    }
+
+    // Match decimal pattern: "Error Number: 6000"
+    if (!code) {
+      const decMatch = err.message.match(/Error Number: (\d+)/);
+      if (decMatch) {
+        code = parseInt(decMatch[1], 10);
+      }
+    }
+  }
+
+  // Validate code is in our known range
+  if (code === undefined || code < 6000 || code > 6077) {
+    return null;
+  }
+
+  // Look up name if not already found
+  if (!name) {
+    name = codeToNameMap.get(code);
+  }
+
+  // Final validation
+  if (!name || !(name in AnchorErrorCodes)) {
+    return null;
+  }
+
+  return {
+    code: code as AnchorErrorCode,
+    name,
+    message: AnchorErrorMessages[code as AnchorErrorCode],
+  };
+}
+
+/**
+ * Get the error name for a given Anchor error code.
+ *
+ * @example
+ * ```typescript
+ * const name = getAnchorErrorName(6000);
+ * console.log(name); // 'AgentAlreadyRegistered'
+ * ```
+ *
+ * @param code - The error code to look up
+ * @returns The error name, or undefined if not found
+ */
+export function getAnchorErrorName(code: number): AnchorErrorName | undefined {
+  return codeToNameMap.get(code);
+}
+
+/**
+ * Get the error message for a given Anchor error code.
+ *
+ * @example
+ * ```typescript
+ * const message = getAnchorErrorMessage(6000);
+ * console.log(message); // 'Agent is already registered'
+ * ```
+ *
+ * @param code - The error code to look up
+ * @returns The error message, or undefined if not found
+ */
+export function getAnchorErrorMessage(code: AnchorErrorCode): string {
+  return AnchorErrorMessages[code];
+}
+
+/**
+ * Type guard to check if an error is a RuntimeError.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await runtime.doSomething();
+ * } catch (err) {
+ *   if (isRuntimeError(err)) {
+ *     console.log(`Runtime error code: ${err.code}`);
+ *   }
+ * }
+ * ```
+ *
+ * @param error - The error to check
+ * @returns True if the error is a RuntimeError instance
+ */
+export function isRuntimeError(error: unknown): error is RuntimeError {
+  return error instanceof RuntimeError;
+}

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Type definitions for @agenc/runtime
+ * @packageDocumentation
+ */
+
+// Error types, constants, and helpers
+export {
+  // Constants
+  RuntimeErrorCodes,
+  AnchorErrorCodes,
+  // Types
+  RuntimeErrorCode,
+  AnchorErrorCode,
+  AnchorErrorName,
+  ParsedAnchorError,
+  // Base error class
+  RuntimeError,
+  // Specific error classes
+  AgentNotRegisteredError,
+  AgentAlreadyRegisteredError,
+  ValidationError,
+  RateLimitError,
+  InsufficientStakeError,
+  ActiveTasksError,
+  PendingDisputeVotesError,
+  RecentVoteActivityError,
+  // Helper functions
+  isAnchorError,
+  parseAnchorError,
+  getAnchorErrorName,
+  getAnchorErrorMessage,
+  isRuntimeError,
+} from './errors.js';


### PR DESCRIPTION
## Summary

Implements Issue #116 - Runtime Error Types for `@agenc/runtime`.

- Add `RuntimeError` base class with 8 specific error subclasses
- Map all 78 Anchor error codes (6000-6077) matching `errors.rs`
- Add helper functions for error handling
- Include 67 unit tests with full coverage

## Changes

| File | Purpose |
|------|---------|
| `runtime/src/types/errors.ts` | Main error implementation (833 lines) |
| `runtime/src/types/errors.test.ts` | Unit tests (657 lines) |
| `runtime/src/types/index.ts` | Barrel export |
| `runtime/src/index.ts` | Add error exports |

## Error Classes

- `RuntimeError` - Base class with `code` property
- `AgentNotRegisteredError`
- `AgentAlreadyRegisteredError(agentId)`
- `ValidationError(message)`
- `RateLimitError(limitType, cooldownEnds)`
- `InsufficientStakeError(required, available)` - uses `bigint`
- `ActiveTasksError(activeTaskCount)`
- `PendingDisputeVotesError(voteCount)`
- `RecentVoteActivityError(lastVoteTimestamp)`

## Helper Functions

- `isAnchorError(error, code)` - Check if error matches specific Anchor code
- `parseAnchorError(error)` - Parse to structured `ParsedAnchorError`
- `getAnchorErrorName(code)` - Get error name from code
- `getAnchorErrorMessage(code)` - Get error message from code
- `isRuntimeError(error)` - Type guard

## Test Plan

- [x] All 67 unit tests pass
- [x] Build succeeds (ESM + CJS + types)
- [x] All 78 error codes verified against `errors.rs`
- [x] Runtime verification of exports

Closes #116