### PR TITLE
feat: add ProtocolConfig types and fix clippy/test issues (#115)

### DIFF
--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -56,6 +56,7 @@ pub struct CreateTask<'info> {
     pub system_program: Program<'info, System>,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn handler(
     ctx: Context<CreateTask>,
     task_id: [u8; 32],

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -107,10 +107,11 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
     require!(total_votes > 0, CoordinationError::InsufficientVotes);
 
     // Calculate approval percentage
-    let approval_pct = (dispute.votes_for as u64)
+    let approval_pct = dispute
+        .votes_for
         .checked_mul(PERCENT_BASE)
         .ok_or(CoordinationError::ArithmeticOverflow)?
-        .checked_div(total_votes as u64)
+        .checked_div(total_votes)
         .ok_or(CoordinationError::ArithmeticOverflow)? as u8;
 
     // Determine outcome based on threshold

--- a/programs/agenc-coordination/src/instructions/update_agent.rs
+++ b/programs/agenc-coordination/src/instructions/update_agent.rs
@@ -50,7 +50,7 @@ pub fn handler(
             3 => {
                 let protocol_config_info = ctx
                     .remaining_accounts
-                    .get(0)
+                    .first()
                     .ok_or(CoordinationError::UnauthorizedAgent)?;
                 let (expected_pda, _) =
                     Pubkey::find_program_address(&[b"protocol"], ctx.program_id);

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unexpected_cfgs)]
+#![allow(clippy::too_many_arguments)]
 //! AgenC Coordination Protocol
 //!
 //! A decentralized multi-agent coordination layer for the AgenC framework.
@@ -79,6 +80,7 @@ pub mod agenc_coordination {
     /// * `deadline` - Unix timestamp deadline (0 = no deadline)
     /// * `task_type` - 0=exclusive (single worker), 1=collaborative (multi-worker)
     /// * `constraint_hash` - For private tasks: hash of expected output (None for non-private)
+    #[allow(clippy::too_many_arguments)]
     pub fn create_task(
         ctx: Context<CreateTask>,
         task_id: [u8; 32],

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -36,8 +36,12 @@ export class AgentRuntime {
   }
 }
 
-// Error types, constants, and helpers
+// Types (protocol and errors)
 export {
+  // Protocol types
+  ProtocolConfig,
+  parseProtocolConfig,
+  MAX_MULTISIG_OWNERS,
   // Error constants
   RuntimeErrorCodes,
   AnchorErrorCodes,

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -3,6 +3,13 @@
  * @packageDocumentation
  */
 
+// Protocol configuration types
+export {
+  ProtocolConfig,
+  parseProtocolConfig,
+  MAX_MULTISIG_OWNERS,
+} from './protocol.js';
+
 // Error types, constants, and helpers
 export {
   // Constants

--- a/runtime/src/types/protocol.test.ts
+++ b/runtime/src/types/protocol.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect } from 'vitest';
+import { PublicKey } from '@solana/web3.js';
+import { MAX_MULTISIG_OWNERS, parseProtocolConfig, ProtocolConfig } from './protocol';
+
+/**
+ * Mock BN-like object for testing
+ */
+function mockBN(value: bigint | number): { toNumber: () => number; toString: () => string } {
+  const bigValue = BigInt(value);
+  return {
+    toNumber: () => Number(bigValue),
+    toString: () => bigValue.toString(),
+  };
+}
+
+// Well-known valid Solana addresses for testing (NOT actual program IDs)
+const TEST_PUBKEY_1 = '11111111111111111111111111111111';
+const TEST_PUBKEY_2 = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+const TEST_PUBKEY_3 = 'MemoSq4gqABAXKb96qnH8TysNcWxMyWCqXgDLGmfcHr';
+const TEST_PUBKEY_4 = 'SysvarRent111111111111111111111111111111111';
+const TEST_PUBKEY_5 = 'SysvarC1ock11111111111111111111111111111111';
+const TEST_PUBKEY_6 = 'SysvarStakeHistory1111111111111111111111111';
+const TEST_PUBKEY_7 = 'SysvarS1otHashes111111111111111111111111111';
+
+/**
+ * Creates valid mock protocol config data
+ */
+function createValidMockData() {
+  return {
+    authority: new PublicKey(TEST_PUBKEY_1),
+    treasury: new PublicKey(TEST_PUBKEY_2),
+    disputeThreshold: 51,
+    protocolFeeBps: 100,
+    minArbiterStake: mockBN(1_000_000_000n),
+    minAgentStake: mockBN(100_000_000n),
+    maxClaimDuration: mockBN(86400),
+    maxDisputeDuration: mockBN(172800),
+    totalAgents: mockBN(10n),
+    totalTasks: mockBN(100n),
+    completedTasks: mockBN(50n),
+    totalValueDistributed: mockBN(10_000_000_000n),
+    bump: 255,
+    multisigThreshold: 2,
+    multisigOwnersLen: 3,
+    taskCreationCooldown: mockBN(60),
+    maxTasksPer24h: 10,
+    disputeInitiationCooldown: mockBN(300),
+    maxDisputesPer24h: 5,
+    minStakeForDispute: mockBN(500_000_000n),
+    slashPercentage: 10,
+    protocolVersion: 1,
+    minSupportedVersion: 1,
+    multisigOwners: [
+      new PublicKey(TEST_PUBKEY_3),
+      new PublicKey(TEST_PUBKEY_4),
+      new PublicKey(TEST_PUBKEY_5),
+      new PublicKey(TEST_PUBKEY_6),
+      new PublicKey(TEST_PUBKEY_7),
+    ],
+  };
+}
+
+describe('MAX_MULTISIG_OWNERS', () => {
+  it('equals 5', () => {
+    expect(MAX_MULTISIG_OWNERS).toBe(5);
+  });
+});
+
+describe('ProtocolConfig interface', () => {
+  it('accepts valid structure', () => {
+    // This test verifies the interface is correctly typed
+    const config: ProtocolConfig = {
+      authority: new PublicKey(TEST_PUBKEY_1),
+      treasury: new PublicKey(TEST_PUBKEY_2),
+      disputeThreshold: 51,
+      protocolFeeBps: 100,
+      minArbiterStake: 1_000_000_000n,
+      minAgentStake: 100_000_000n,
+      maxClaimDuration: 86400,
+      maxDisputeDuration: 172800,
+      totalAgents: 10n,
+      totalTasks: 100n,
+      completedTasks: 50n,
+      totalValueDistributed: 10_000_000_000n,
+      bump: 255,
+      multisigThreshold: 2,
+      multisigOwnersLen: 3,
+      taskCreationCooldown: 60,
+      maxTasksPer24h: 10,
+      disputeInitiationCooldown: 300,
+      maxDisputesPer24h: 5,
+      minStakeForDispute: 500_000_000n,
+      slashPercentage: 10,
+      protocolVersion: 1,
+      minSupportedVersion: 1,
+      multisigOwners: [new PublicKey(TEST_PUBKEY_3)],
+    };
+
+    expect(config.authority).toBeInstanceOf(PublicKey);
+    expect(typeof config.disputeThreshold).toBe('number');
+    expect(typeof config.minArbiterStake).toBe('bigint');
+  });
+});
+
+describe('parseProtocolConfig', () => {
+  describe('success cases', () => {
+    it('parses valid mock data', () => {
+      const mockData = createValidMockData();
+      const config = parseProtocolConfig(mockData);
+
+      expect(config.authority).toBeInstanceOf(PublicKey);
+      expect(config.treasury).toBeInstanceOf(PublicKey);
+      expect(config.disputeThreshold).toBe(51);
+      expect(config.protocolFeeBps).toBe(100);
+      expect(config.minArbiterStake).toBe(1_000_000_000n);
+      expect(config.minAgentStake).toBe(100_000_000n);
+      expect(config.maxClaimDuration).toBe(86400);
+      expect(config.maxDisputeDuration).toBe(172800);
+      expect(config.totalAgents).toBe(10n);
+      expect(config.totalTasks).toBe(100n);
+      expect(config.completedTasks).toBe(50n);
+      expect(config.totalValueDistributed).toBe(10_000_000_000n);
+      expect(config.bump).toBe(255);
+      expect(config.multisigThreshold).toBe(2);
+      expect(config.multisigOwnersLen).toBe(3);
+      expect(config.taskCreationCooldown).toBe(60);
+      expect(config.maxTasksPer24h).toBe(10);
+      expect(config.disputeInitiationCooldown).toBe(300);
+      expect(config.maxDisputesPer24h).toBe(5);
+      expect(config.minStakeForDispute).toBe(500_000_000n);
+      expect(config.slashPercentage).toBe(10);
+      expect(config.protocolVersion).toBe(1);
+      expect(config.minSupportedVersion).toBe(1);
+    });
+
+    it('correctly converts u64 fields to bigint', () => {
+      const mockData = createValidMockData();
+      mockData.minArbiterStake = mockBN(9_007_199_254_740_993n); // > MAX_SAFE_INTEGER
+      mockData.totalValueDistributed = mockBN(18_446_744_073_709_551_615n); // u64 max
+
+      const config = parseProtocolConfig(mockData);
+
+      expect(config.minArbiterStake).toBe(9_007_199_254_740_993n);
+      expect(config.totalValueDistributed).toBe(18_446_744_073_709_551_615n);
+    });
+
+    it('correctly converts i64 duration fields to number', () => {
+      const mockData = createValidMockData();
+      mockData.maxClaimDuration = mockBN(604800); // 1 week in seconds
+      mockData.maxDisputeDuration = mockBN(1209600); // 2 weeks
+
+      const config = parseProtocolConfig(mockData);
+
+      expect(config.maxClaimDuration).toBe(604800);
+      expect(config.maxDisputeDuration).toBe(1209600);
+      expect(typeof config.maxClaimDuration).toBe('number');
+    });
+
+    it('correctly slices multisigOwners to actual length', () => {
+      const mockData = createValidMockData();
+      mockData.multisigOwnersLen = 2;
+      mockData.multisigOwners = [
+        new PublicKey(TEST_PUBKEY_3),
+        new PublicKey(TEST_PUBKEY_4),
+        new PublicKey(TEST_PUBKEY_5),
+        new PublicKey(TEST_PUBKEY_6),
+        new PublicKey(TEST_PUBKEY_7),
+      ];
+
+      const config = parseProtocolConfig(mockData);
+
+      expect(config.multisigOwners).toHaveLength(2);
+      expect(config.multisigOwners[0].toBase58()).toBe(TEST_PUBKEY_3);
+    });
+
+    it('handles empty multisig owners (length 0)', () => {
+      const mockData = createValidMockData();
+      mockData.multisigOwnersLen = 0;
+
+      const config = parseProtocolConfig(mockData);
+
+      expect(config.multisigOwners).toHaveLength(0);
+    });
+  });
+
+  describe('error cases - missing required fields', () => {
+    it('throws on null input', () => {
+      expect(() => parseProtocolConfig(null)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws on undefined input', () => {
+      expect(() => parseProtocolConfig(undefined)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws on empty object', () => {
+      expect(() => parseProtocolConfig({})).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when authority is missing', () => {
+      const mockData = createValidMockData();
+      const { authority: _, ...dataWithoutAuthority } = mockData;
+
+      expect(() => parseProtocolConfig(dataWithoutAuthority)).toThrow(
+        'Invalid protocol config data'
+      );
+    });
+
+    it('throws when authority is not a PublicKey', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).authority = 'not a pubkey';
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when treasury is missing', () => {
+      const mockData = createValidMockData();
+      const { treasury: _, ...dataWithoutTreasury } = mockData;
+
+      expect(() => parseProtocolConfig(dataWithoutTreasury)).toThrow(
+        'Invalid protocol config data'
+      );
+    });
+
+    it('throws when disputeThreshold is not a number', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).disputeThreshold = 'not a number';
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when protocolFeeBps is not a number', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).protocolFeeBps = null;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when bump is not a number', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).bump = undefined;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when multisigThreshold is not a number', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).multisigThreshold = 'two';
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when multisigOwnersLen is not a number', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).multisigOwnersLen = null;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when BN fields are missing toNumber/toString', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).minArbiterStake = 123; // number instead of BN-like
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when multisigOwners is not an array', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).multisigOwners = 'not an array';
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+
+    it('throws when multisigOwners contains non-PublicKey elements', () => {
+      const mockData = createValidMockData();
+      (mockData as Record<string, unknown>).multisigOwners = [
+        'not a pubkey',
+        new PublicKey(TEST_PUBKEY_1),
+      ];
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocol config data');
+    });
+  });
+
+  describe('error cases - range validation', () => {
+    it('throws when disputeThreshold is 0', () => {
+      const mockData = createValidMockData();
+      mockData.disputeThreshold = 0;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid disputeThreshold');
+      expect(() => parseProtocolConfig(mockData)).toThrow('must be 1-100');
+    });
+
+    it('throws when disputeThreshold exceeds 100', () => {
+      const mockData = createValidMockData();
+      mockData.disputeThreshold = 101;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid disputeThreshold: 101');
+      expect(() => parseProtocolConfig(mockData)).toThrow('must be 1-100');
+    });
+
+    it('throws when protocolFeeBps exceeds 10000', () => {
+      const mockData = createValidMockData();
+      mockData.protocolFeeBps = 10001;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid protocolFeeBps: 10001');
+      expect(() => parseProtocolConfig(mockData)).toThrow('must be <= 10000');
+    });
+
+    it('allows protocolFeeBps at max (10000 = 100%)', () => {
+      const mockData = createValidMockData();
+      mockData.protocolFeeBps = 10000;
+
+      const config = parseProtocolConfig(mockData);
+      expect(config.protocolFeeBps).toBe(10000);
+    });
+
+    it('throws when slashPercentage exceeds 100', () => {
+      const mockData = createValidMockData();
+      mockData.slashPercentage = 101;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid slashPercentage: 101');
+      expect(() => parseProtocolConfig(mockData)).toThrow('must be 0-100');
+    });
+
+    it('allows slashPercentage at boundary values (0 and 100)', () => {
+      const mockData = createValidMockData();
+
+      mockData.slashPercentage = 0;
+      let config = parseProtocolConfig(mockData);
+      expect(config.slashPercentage).toBe(0);
+
+      mockData.slashPercentage = 100;
+      config = parseProtocolConfig(mockData);
+      expect(config.slashPercentage).toBe(100);
+    });
+
+    it('throws when multisigOwnersLen exceeds MAX_MULTISIG_OWNERS', () => {
+      const mockData = createValidMockData();
+      mockData.multisigOwnersLen = 6;
+
+      expect(() => parseProtocolConfig(mockData)).toThrow('Invalid multisigOwnersLen: 6');
+      expect(() => parseProtocolConfig(mockData)).toThrow('exceeds maximum 5');
+    });
+
+    it('allows multisigOwnersLen at MAX_MULTISIG_OWNERS', () => {
+      const mockData = createValidMockData();
+      mockData.multisigOwnersLen = 5;
+
+      const config = parseProtocolConfig(mockData);
+      expect(config.multisigOwnersLen).toBe(5);
+      expect(config.multisigOwners).toHaveLength(5);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles zero values for optional fields', () => {
+      const mockData = createValidMockData();
+      mockData.taskCreationCooldown = mockBN(0);
+      mockData.maxTasksPer24h = 0;
+      mockData.disputeInitiationCooldown = mockBN(0);
+      mockData.maxDisputesPer24h = 0;
+
+      const config = parseProtocolConfig(mockData);
+
+      expect(config.taskCreationCooldown).toBe(0);
+      expect(config.maxTasksPer24h).toBe(0);
+      expect(config.disputeInitiationCooldown).toBe(0);
+      expect(config.maxDisputesPer24h).toBe(0);
+    });
+
+    it('handles maximum u8 values', () => {
+      const mockData = createValidMockData();
+      mockData.bump = 255;
+      mockData.maxTasksPer24h = 255;
+      mockData.maxDisputesPer24h = 255;
+      mockData.disputeThreshold = 100; // max valid
+
+      const config = parseProtocolConfig(mockData);
+
+      expect(config.bump).toBe(255);
+      expect(config.maxTasksPer24h).toBe(255);
+      expect(config.maxDisputesPer24h).toBe(255);
+      expect(config.disputeThreshold).toBe(100);
+    });
+
+    it('handles minimum valid disputeThreshold (1)', () => {
+      const mockData = createValidMockData();
+      mockData.disputeThreshold = 1;
+
+      const config = parseProtocolConfig(mockData);
+      expect(config.disputeThreshold).toBe(1);
+    });
+  });
+});

--- a/runtime/src/types/protocol.ts
+++ b/runtime/src/types/protocol.ts
@@ -1,0 +1,285 @@
+import { PublicKey } from '@solana/web3.js';
+
+/** Maximum number of multisig owners */
+export const MAX_MULTISIG_OWNERS = 5;
+
+/**
+ * Protocol configuration account data.
+ * Mirrors the on-chain ProtocolConfig account structure (excluding internal padding).
+ * PDA seeds: ["protocol"]
+ */
+export interface ProtocolConfig {
+  /** Protocol authority */
+  authority: PublicKey;
+
+  /** Treasury for protocol fees */
+  treasury: PublicKey;
+
+  /** Minimum votes needed to resolve dispute (percentage, 1-100) */
+  disputeThreshold: number;
+
+  /** Protocol fee in basis points (1/100th of a percent) */
+  protocolFeeBps: number;
+
+  /** Minimum stake required to register as arbiter (lamports) */
+  minArbiterStake: bigint;
+
+  /** Minimum stake required to register as agent (lamports) */
+  minAgentStake: bigint;
+
+  /** Max duration (seconds) a claim can stay active without completion */
+  maxClaimDuration: number;
+
+  /** Max duration (seconds) a dispute can remain active */
+  maxDisputeDuration: number;
+
+  /** Total registered agents */
+  totalAgents: bigint;
+
+  /** Total tasks created */
+  totalTasks: bigint;
+
+  /** Total tasks completed */
+  completedTasks: bigint;
+
+  /** Total value distributed (lamports) */
+  totalValueDistributed: bigint;
+
+  /** Bump seed for PDA */
+  bump: number;
+
+  /** Multisig threshold */
+  multisigThreshold: number;
+
+  /** Length of configured multisig owners */
+  multisigOwnersLen: number;
+
+  /** Minimum cooldown between task creations (seconds, 0 = disabled) */
+  taskCreationCooldown: number;
+
+  /** Maximum tasks an agent can create per 24h window (0 = unlimited) */
+  maxTasksPer24h: number;
+
+  /** Minimum cooldown between dispute initiations (seconds, 0 = disabled) */
+  disputeInitiationCooldown: number;
+
+  /** Maximum disputes an agent can initiate per 24h window (0 = unlimited) */
+  maxDisputesPer24h: number;
+
+  /** Minimum stake required to initiate a dispute (griefing resistance, lamports) */
+  minStakeForDispute: bigint;
+
+  /** Percentage of stake slashed on losing dispute (0-100) */
+  slashPercentage: number;
+
+  /** Current protocol version (for upgrades) */
+  protocolVersion: number;
+
+  /** Minimum supported version for backward compatibility */
+  minSupportedVersion: number;
+
+  /** Multisig owners (sliced to actual length) */
+  multisigOwners: PublicKey[];
+}
+
+/**
+ * Raw account data shape from Anchor.
+ * BN fields will be converted to number/bigint.
+ */
+interface RawProtocolConfigData {
+  authority: PublicKey;
+  treasury: PublicKey;
+  disputeThreshold: number;
+  protocolFeeBps: number;
+  minArbiterStake: { toNumber?: () => number; toString: () => string };
+  minAgentStake: { toNumber?: () => number; toString: () => string };
+  maxClaimDuration: { toNumber: () => number };
+  maxDisputeDuration: { toNumber: () => number };
+  totalAgents: { toNumber?: () => number; toString: () => string };
+  totalTasks: { toNumber?: () => number; toString: () => string };
+  completedTasks: { toNumber?: () => number; toString: () => string };
+  totalValueDistributed: { toNumber?: () => number; toString: () => string };
+  bump: number;
+  multisigThreshold: number;
+  multisigOwnersLen: number;
+  taskCreationCooldown: { toNumber: () => number };
+  maxTasksPer24h: number;
+  disputeInitiationCooldown: { toNumber: () => number };
+  maxDisputesPer24h: number;
+  minStakeForDispute: { toNumber?: () => number; toString: () => string };
+  slashPercentage: number;
+  protocolVersion: number;
+  minSupportedVersion: number;
+  multisigOwners: PublicKey[];
+}
+
+/**
+ * Checks if a value is a BN-like object with toString method
+ */
+function isBNLike(value: unknown): value is { toString: () => string } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).toString === 'function'
+  );
+}
+
+/**
+ * Checks if a value is a BN-like object with toNumber method (for i64 fields)
+ */
+function isBNLikeWithToNumber(value: unknown): value is { toNumber: () => number } {
+  return (
+    isBNLike(value) && typeof (value as Record<string, unknown>).toNumber === 'function'
+  );
+}
+
+/**
+ * Type guard to check if a value has the shape of raw protocol config data.
+ * Validates all required fields used by parseProtocolConfig.
+ */
+function isRawProtocolConfigData(data: unknown): data is RawProtocolConfigData {
+  if (typeof data !== 'object' || data === null) {
+    return false;
+  }
+  const obj = data as Record<string, unknown>;
+
+  // Validate PublicKey fields
+  if (!(obj.authority instanceof PublicKey)) return false;
+  if (!(obj.treasury instanceof PublicKey)) return false;
+
+  // Validate number fields (u8, u16)
+  if (typeof obj.disputeThreshold !== 'number') return false;
+  if (typeof obj.protocolFeeBps !== 'number') return false;
+  if (typeof obj.bump !== 'number') return false;
+  if (typeof obj.multisigThreshold !== 'number') return false;
+  if (typeof obj.multisigOwnersLen !== 'number') return false;
+  if (typeof obj.maxTasksPer24h !== 'number') return false;
+  if (typeof obj.maxDisputesPer24h !== 'number') return false;
+  if (typeof obj.slashPercentage !== 'number') return false;
+  if (typeof obj.protocolVersion !== 'number') return false;
+  if (typeof obj.minSupportedVersion !== 'number') return false;
+
+  // Validate BN-like fields (u64 - need toString for bigint conversion)
+  if (!isBNLike(obj.minArbiterStake)) return false;
+  if (!isBNLike(obj.minAgentStake)) return false;
+  if (!isBNLike(obj.totalAgents)) return false;
+  if (!isBNLike(obj.totalTasks)) return false;
+  if (!isBNLike(obj.completedTasks)) return false;
+  if (!isBNLike(obj.totalValueDistributed)) return false;
+  if (!isBNLike(obj.minStakeForDispute)) return false;
+
+  // Validate BN-like fields (i64 - need toNumber for duration conversion)
+  if (!isBNLikeWithToNumber(obj.maxClaimDuration)) return false;
+  if (!isBNLikeWithToNumber(obj.maxDisputeDuration)) return false;
+  if (!isBNLikeWithToNumber(obj.taskCreationCooldown)) return false;
+  if (!isBNLikeWithToNumber(obj.disputeInitiationCooldown)) return false;
+
+  // Validate array field and its contents
+  if (!Array.isArray(obj.multisigOwners)) return false;
+  if (!obj.multisigOwners.every((pk) => pk instanceof PublicKey)) return false;
+
+  return true;
+}
+
+/**
+ * Safely converts a BN-like value to bigint.
+ * Handles Anchor's BN type which has toString() method.
+ */
+function toBigInt(value: { toString: () => string }): bigint {
+  return BigInt(value.toString());
+}
+
+/**
+ * Parses raw Anchor account data into a typed ProtocolConfig.
+ *
+ * @param data - Raw account data from Anchor program.account.protocolConfig.fetch()
+ * @returns Parsed ProtocolConfig with proper TypeScript types
+ * @throws Error if required fields are missing or invalid
+ *
+ * @example
+ * ```typescript
+ * const rawData = await program.account.protocolConfig.fetch(protocolPda);
+ * const config = parseProtocolConfig(rawData);
+ * console.log(`Protocol fee: ${config.protocolFeeBps} bps`);
+ * ```
+ */
+export function parseProtocolConfig(data: unknown): ProtocolConfig {
+  if (!isRawProtocolConfigData(data)) {
+    throw new Error('Invalid protocol config data: missing required fields');
+  }
+
+  // Range validation for protocol fields
+  if (data.disputeThreshold < 1 || data.disputeThreshold > 100) {
+    throw new Error(
+      `Invalid disputeThreshold: ${data.disputeThreshold} (must be 1-100)`
+    );
+  }
+
+  if (data.protocolFeeBps > 10000) {
+    throw new Error(
+      `Invalid protocolFeeBps: ${data.protocolFeeBps} (must be <= 10000)`
+    );
+  }
+
+  if (data.slashPercentage > 100) {
+    throw new Error(
+      `Invalid slashPercentage: ${data.slashPercentage} (must be 0-100)`
+    );
+  }
+
+  const multisigOwnersLen = data.multisigOwnersLen;
+
+  // Validate multisigOwnersLen is within bounds
+  if (multisigOwnersLen > MAX_MULTISIG_OWNERS) {
+    throw new Error(
+      `Invalid multisigOwnersLen: ${multisigOwnersLen} exceeds maximum ${MAX_MULTISIG_OWNERS}`
+    );
+  }
+
+  // Slice multisig owners to actual length
+  const multisigOwners = data.multisigOwners.slice(0, multisigOwnersLen);
+
+  return {
+    // Authority & Treasury
+    authority: data.authority,
+    treasury: data.treasury,
+
+    // Dispute Settings
+    disputeThreshold: data.disputeThreshold,
+    protocolFeeBps: data.protocolFeeBps,
+
+    // Stake Requirements (u64 -> bigint)
+    minArbiterStake: toBigInt(data.minArbiterStake),
+    minAgentStake: toBigInt(data.minAgentStake),
+
+    // Duration Limits (i64 -> number, safe for seconds values)
+    maxClaimDuration: data.maxClaimDuration.toNumber(),
+    maxDisputeDuration: data.maxDisputeDuration.toNumber(),
+
+    // Statistics (u64 -> bigint for large values)
+    totalAgents: toBigInt(data.totalAgents),
+    totalTasks: toBigInt(data.totalTasks),
+    completedTasks: toBigInt(data.completedTasks),
+    totalValueDistributed: toBigInt(data.totalValueDistributed),
+
+    // PDA
+    bump: data.bump,
+
+    // Multisig
+    multisigThreshold: data.multisigThreshold,
+    multisigOwnersLen: multisigOwnersLen,
+    multisigOwners: multisigOwners,
+
+    // Rate Limiting
+    taskCreationCooldown: data.taskCreationCooldown.toNumber(),
+    maxTasksPer24h: data.maxTasksPer24h,
+    disputeInitiationCooldown: data.disputeInitiationCooldown.toNumber(),
+    maxDisputesPer24h: data.maxDisputesPer24h,
+    minStakeForDispute: toBigInt(data.minStakeForDispute),
+    slashPercentage: data.slashPercentage,
+
+    // Versioning
+    protocolVersion: data.protocolVersion,
+    minSupportedVersion: data.minSupportedVersion,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `ProtocolConfig` TypeScript interface and `parseProtocolConfig()` function to `@agenc/runtime` package
- Fix all clippy warnings in Rust code
- Fix flaky test failures caused by agents not being registered

## Changes

### Protocol Types (`runtime/src/types/protocol.ts`)
- `ProtocolConfig` interface mirroring on-chain Rust struct (24 fields)
- `parseProtocolConfig()` function to convert raw Anchor account data
- `MAX_MULTISIG_OWNERS` constant
- Proper type conversions: `u64` → `bigint`, `i64` → `number`, `Pubkey` → `PublicKey`

### Clippy Fixes
- `resolve_dispute.rs`: Remove unnecessary `as u64` casts
- `update_agent.rs`: Use `.first()` instead of `.get(0)`
- `create_task.rs`, `lib.rs`: Add `#[allow(clippy::too_many_arguments)]`

### Test Reliability (`tests/test_1.ts`)
- Enhanced `beforeEach` hook to register agents on-demand if they don't exist
- Fixes 18 previously failing tests caused by agents not being initialized

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Runtime tests pass (91 tests)
- [x] Anchor tests pass (134 tests, previously 116 passing)