### PR TITLE
feat(runtime): implement agent capabilities module

### DIFF
--- a/runtime/src/agent/capabilities.test.ts
+++ b/runtime/src/agent/capabilities.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest';
+import {
+  Capability,
+  ALL_CAPABILITIES,
+  ALL_CAPABILITY_NAMES,
+  combineCapabilities,
+  hasCapability,
+  hasAllCapabilities,
+  hasAnyCapability,
+  getCapabilityNames,
+  parseCapabilities,
+  formatCapabilities,
+  countCapabilities,
+  type CapabilityName,
+} from './capabilities.js';
+
+describe('Capability Constants', () => {
+  it('matches on-chain state.rs values (lines 16-27)', () => {
+    // These values must match programs/agenc-coordination/src/state.rs
+    expect(Capability.COMPUTE).toBe(1n << 0n);
+    expect(Capability.INFERENCE).toBe(1n << 1n);
+    expect(Capability.STORAGE).toBe(1n << 2n);
+    expect(Capability.NETWORK).toBe(1n << 3n);
+    expect(Capability.SENSOR).toBe(1n << 4n);
+    expect(Capability.ACTUATOR).toBe(1n << 5n);
+    expect(Capability.COORDINATOR).toBe(1n << 6n);
+    expect(Capability.ARBITER).toBe(1n << 7n);
+    expect(Capability.VALIDATOR).toBe(1n << 8n);
+    expect(Capability.AGGREGATOR).toBe(1n << 9n);
+  });
+
+  it('has exactly 10 capabilities', () => {
+    expect(ALL_CAPABILITIES.length).toBe(10);
+    expect(ALL_CAPABILITY_NAMES.length).toBe(10);
+  });
+
+  it('ALL_CAPABILITIES contains all values', () => {
+    expect(ALL_CAPABILITIES).toContain(Capability.COMPUTE);
+    expect(ALL_CAPABILITIES).toContain(Capability.INFERENCE);
+    expect(ALL_CAPABILITIES).toContain(Capability.STORAGE);
+    expect(ALL_CAPABILITIES).toContain(Capability.NETWORK);
+    expect(ALL_CAPABILITIES).toContain(Capability.SENSOR);
+    expect(ALL_CAPABILITIES).toContain(Capability.ACTUATOR);
+    expect(ALL_CAPABILITIES).toContain(Capability.COORDINATOR);
+    expect(ALL_CAPABILITIES).toContain(Capability.ARBITER);
+    expect(ALL_CAPABILITIES).toContain(Capability.VALIDATOR);
+    expect(ALL_CAPABILITIES).toContain(Capability.AGGREGATOR);
+  });
+
+  it('ALL_CAPABILITY_NAMES contains all names', () => {
+    expect(ALL_CAPABILITY_NAMES).toContain('COMPUTE');
+    expect(ALL_CAPABILITY_NAMES).toContain('INFERENCE');
+    expect(ALL_CAPABILITY_NAMES).toContain('STORAGE');
+    expect(ALL_CAPABILITY_NAMES).toContain('NETWORK');
+    expect(ALL_CAPABILITY_NAMES).toContain('SENSOR');
+    expect(ALL_CAPABILITY_NAMES).toContain('ACTUATOR');
+    expect(ALL_CAPABILITY_NAMES).toContain('COORDINATOR');
+    expect(ALL_CAPABILITY_NAMES).toContain('ARBITER');
+    expect(ALL_CAPABILITY_NAMES).toContain('VALIDATOR');
+    expect(ALL_CAPABILITY_NAMES).toContain('AGGREGATOR');
+  });
+});
+
+describe('combineCapabilities', () => {
+  it('combines multiple capabilities with bitwise OR', () => {
+    const caps = combineCapabilities(Capability.COMPUTE, Capability.INFERENCE);
+    expect(caps).toBe(3n);
+  });
+
+  it('returns 0n for no capabilities', () => {
+    expect(combineCapabilities()).toBe(0n);
+  });
+
+  it('handles single capability', () => {
+    expect(combineCapabilities(Capability.STORAGE)).toBe(4n);
+  });
+
+  it('combines all capabilities', () => {
+    const all = combineCapabilities(...ALL_CAPABILITIES);
+    // 2^10 - 1 = 1023 (all 10 bits set)
+    expect(all).toBe(1023n);
+  });
+});
+
+describe('hasCapability', () => {
+  it('returns true for set capability', () => {
+    const caps = combineCapabilities(Capability.COMPUTE, Capability.INFERENCE);
+    expect(hasCapability(caps, Capability.COMPUTE)).toBe(true);
+    expect(hasCapability(caps, Capability.INFERENCE)).toBe(true);
+  });
+
+  it('returns false for unset capability', () => {
+    const caps = combineCapabilities(Capability.COMPUTE, Capability.INFERENCE);
+    expect(hasCapability(caps, Capability.STORAGE)).toBe(false);
+  });
+
+  it('handles zero capabilities', () => {
+    expect(hasCapability(0n, Capability.COMPUTE)).toBe(false);
+  });
+});
+
+describe('hasAllCapabilities', () => {
+  it('returns true when all required capabilities are present', () => {
+    const caps = combineCapabilities(
+      Capability.COMPUTE,
+      Capability.INFERENCE,
+      Capability.STORAGE
+    );
+    expect(
+      hasAllCapabilities(caps, [Capability.COMPUTE, Capability.INFERENCE])
+    ).toBe(true);
+  });
+
+  it('returns false when any required capability is missing', () => {
+    const caps = combineCapabilities(Capability.COMPUTE, Capability.INFERENCE);
+    expect(
+      hasAllCapabilities(caps, [Capability.COMPUTE, Capability.NETWORK])
+    ).toBe(false);
+  });
+
+  it('returns true for empty requirements', () => {
+    expect(hasAllCapabilities(0n, [])).toBe(true);
+  });
+});
+
+describe('hasAnyCapability', () => {
+  it('returns true when any capability matches', () => {
+    const caps = combineCapabilities(Capability.COMPUTE);
+    expect(
+      hasAnyCapability(caps, [Capability.COMPUTE, Capability.INFERENCE])
+    ).toBe(true);
+  });
+
+  it('returns false when no capability matches', () => {
+    const caps = combineCapabilities(Capability.COMPUTE);
+    expect(
+      hasAnyCapability(caps, [Capability.STORAGE, Capability.NETWORK])
+    ).toBe(false);
+  });
+
+  it('returns false for empty list', () => {
+    const caps = combineCapabilities(Capability.COMPUTE);
+    expect(hasAnyCapability(caps, [])).toBe(false);
+  });
+});
+
+describe('getCapabilityNames', () => {
+  it('returns correct names for bitmask', () => {
+    const caps = combineCapabilities(Capability.COMPUTE, Capability.INFERENCE);
+    const names = getCapabilityNames(caps);
+    expect(names).toContain('COMPUTE');
+    expect(names).toContain('INFERENCE');
+    expect(names.length).toBe(2);
+  });
+
+  it('returns empty array for zero', () => {
+    expect(getCapabilityNames(0n)).toEqual([]);
+  });
+
+  it('returns all names for all capabilities', () => {
+    const all = combineCapabilities(...ALL_CAPABILITIES);
+    const names = getCapabilityNames(all);
+    expect(names.length).toBe(10);
+  });
+});
+
+describe('parseCapabilities', () => {
+  it('converts names to bitmask', () => {
+    const caps = parseCapabilities(['COMPUTE', 'INFERENCE']);
+    expect(caps).toBe(3n);
+  });
+
+  it('handles empty array', () => {
+    expect(parseCapabilities([])).toBe(0n);
+  });
+
+  it('round-trips with getCapabilityNames', () => {
+    const original: CapabilityName[] = ['COMPUTE', 'STORAGE', 'ARBITER'];
+    const caps = parseCapabilities(original);
+    const names = getCapabilityNames(caps);
+    expect(names.sort()).toEqual(original.sort());
+  });
+});
+
+describe('formatCapabilities', () => {
+  it('formats as comma-separated string', () => {
+    const caps = combineCapabilities(Capability.COMPUTE, Capability.INFERENCE);
+    expect(formatCapabilities(caps)).toBe('COMPUTE, INFERENCE');
+  });
+
+  it('returns "None" for zero', () => {
+    expect(formatCapabilities(0n)).toBe('None');
+  });
+
+  it('handles single capability', () => {
+    expect(formatCapabilities(Capability.ARBITER)).toBe('ARBITER');
+  });
+});
+
+describe('countCapabilities', () => {
+  it('counts set bits correctly', () => {
+    const caps = combineCapabilities(
+      Capability.COMPUTE,
+      Capability.INFERENCE,
+      Capability.STORAGE
+    );
+    expect(countCapabilities(caps)).toBe(3);
+  });
+
+  it('returns 0 for no capabilities', () => {
+    expect(countCapabilities(0n)).toBe(0);
+  });
+
+  it('returns 10 for all capabilities', () => {
+    const all = combineCapabilities(...ALL_CAPABILITIES);
+    expect(countCapabilities(all)).toBe(10);
+  });
+});

--- a/runtime/src/agent/capabilities.ts
+++ b/runtime/src/agent/capabilities.ts
@@ -1,0 +1,99 @@
+/**
+ * Capability bitmask constants matching on-chain values
+ * From: programs/agenc-coordination/src/state.rs (lines 16-27)
+ */
+export const Capability = {
+  COMPUTE: 1n << 0n, // General computation
+  INFERENCE: 1n << 1n, // ML inference
+  STORAGE: 1n << 2n, // Data storage
+  NETWORK: 1n << 3n, // Network relay
+  SENSOR: 1n << 4n, // Sensor data collection
+  ACTUATOR: 1n << 5n, // Physical actuation
+  COORDINATOR: 1n << 6n, // Task coordination
+  ARBITER: 1n << 7n, // Dispute resolution
+  VALIDATOR: 1n << 8n, // Result validation
+  AGGREGATOR: 1n << 9n, // Data aggregation
+} as const;
+
+export type CapabilityName = keyof typeof Capability;
+
+/**
+ * All capability values as an array
+ */
+export const ALL_CAPABILITIES = Object.values(Capability);
+
+/**
+ * All capability names as an array
+ */
+export const ALL_CAPABILITY_NAMES = Object.keys(Capability) as CapabilityName[];
+
+/**
+ * Combine multiple capabilities into a single bitmask
+ * @example
+ * const caps = combineCapabilities(Capability.COMPUTE, Capability.INFERENCE);
+ */
+export function combineCapabilities(...caps: bigint[]): bigint {
+  return caps.reduce((acc, cap) => acc | cap, 0n);
+}
+
+/**
+ * Check if agent has a specific capability
+ */
+export function hasCapability(agentCaps: bigint, required: bigint): boolean {
+  return (agentCaps & required) === required;
+}
+
+/**
+ * Check if agent has ALL required capabilities
+ */
+export function hasAllCapabilities(
+  agentCaps: bigint,
+  required: bigint[]
+): boolean {
+  return required.every((cap) => hasCapability(agentCaps, cap));
+}
+
+/**
+ * Check if agent has ANY of the specified capabilities
+ */
+export function hasAnyCapability(agentCaps: bigint, caps: bigint[]): boolean {
+  return caps.some((cap) => hasCapability(agentCaps, cap));
+}
+
+/**
+ * Get list of capability names from bitmask
+ */
+export function getCapabilityNames(caps: bigint): CapabilityName[] {
+  const names: CapabilityName[] = [];
+  for (const [name, value] of Object.entries(Capability)) {
+    if (hasCapability(caps, value)) {
+      names.push(name as CapabilityName);
+    }
+  }
+  return names;
+}
+
+/**
+ * Parse capability names to bitmask
+ * @example
+ * const caps = parseCapabilities(['COMPUTE', 'INFERENCE']);
+ */
+export function parseCapabilities(names: CapabilityName[]): bigint {
+  return combineCapabilities(...names.map((n) => Capability[n]));
+}
+
+/**
+ * Format capabilities as human-readable string
+ * @example
+ * formatCapabilities(3n) // "COMPUTE, INFERENCE"
+ */
+export function formatCapabilities(caps: bigint): string {
+  return getCapabilityNames(caps).join(', ') || 'None';
+}
+
+/**
+ * Count number of capabilities in bitmask
+ */
+export function countCapabilities(caps: bigint): number {
+  return getCapabilityNames(caps).length;
+}

--- a/runtime/src/agent/index.ts
+++ b/runtime/src/agent/index.ts
@@ -3,6 +3,22 @@
  * @packageDocumentation
  */
 
+// Re-export capabilities module (canonical source for capability constants)
+export {
+  Capability,
+  ALL_CAPABILITIES,
+  ALL_CAPABILITY_NAMES,
+  combineCapabilities,
+  hasCapability,
+  hasAllCapabilities,
+  hasAnyCapability,
+  getCapabilityNames,
+  parseCapabilities,
+  formatCapabilities,
+  countCapabilities,
+  type CapabilityName,
+} from './capabilities.js';
+
 export {
   // Constants
   AgentCapabilities,
@@ -20,15 +36,12 @@ export {
   // Functions
   agentStatusToString,
   isValidAgentStatus,
-  hasCapability,
-  getCapabilityNames,
   createCapabilityMask,
   parseAgentState,
   computeRateLimitState,
 
   // Types
   type AgentCapability,
-  type CapabilityName,
   type AgentState,
   type AgentRegistrationParams,
   type AgentUpdateParams,


### PR DESCRIPTION
## Summary

Implements Phase 1 Section 7 - Agent Capabilities module for `@agenc/runtime`.

- Add `capabilities.ts` as canonical source for capability constants and utilities
- All 10 capability constants match on-chain `state.rs` (lines 16-27)
- Refactor `types.ts` to import from `capabilities.ts` (eliminates duplicate code)
- Backwards compatible: `AgentCapabilities`, `CAPABILITY_NAMES`, `createCapabilityMask` still work

### New Exports

| Export | Description |
|--------|-------------|
| `Capability` | Capability constants object |
| `CapabilityName` | Type for capability names |
| `ALL_CAPABILITIES` | Array of all capability values |
| `ALL_CAPABILITY_NAMES` | Array of all capability names |
| `combineCapabilities()` | Combine capabilities with bitwise OR |
| `hasCapability()` | Check if capability is set |
| `hasAllCapabilities()` | Check all required capabilities |
| `hasAnyCapability()` | Check any matching capability |
| `getCapabilityNames()` | Convert bitmask to name array |
| `parseCapabilities()` | Convert names to bitmask |
| `formatCapabilities()` | Human-readable string |
| `countCapabilities()` | Count set capabilities |

## Test Plan

- [x] All 10 capability constants verified against on-chain values
- [x] 29 new tests for capabilities module
- [x] 88 existing types.test.ts tests still pass
- [x] TypeScript compilation passes
- [x] Total: 277 tests passing

Closes #117