### PR TITLE
feat: add 3D character assets with Git LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,5 @@
 *.yaml text eol=lf
 *.js text eol=lf
 *.ts text eol=lf
+assets/3d/*.zip filter=lfs diff=lfs merge=lfs -text
+assets/3d/*.rar filter=lfs diff=lfs merge=lfs -text

--- a/assets/3d/uploads_files_2829013_Tory_Rigged_Woman_002.2.zip
+++ b/assets/3d/uploads_files_2829013_Tory_Rigged_Woman_002.2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c1021c360645089d3b4e14c2035ef293bed854d294891ed1aaa5fad7ac9c8cd
+size 1782471038

--- a/assets/3d/uploads_files_2829013_Tory_Rigged_Woman_002.5.zip
+++ b/assets/3d/uploads_files_2829013_Tory_Rigged_Woman_002.5.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:013c34021a6a5197487bcc4ee767144d2c0a9863990e4cce00de3b119dc3ba2a
+size 1777297629

--- a/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_Marmoset_4.06_Scene.rar
+++ b/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_Marmoset_4.06_Scene.rar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61df592dd6fd58ef2e75737076b8e5af9c0f94d94a6f870d812bacc4bf2d940f
+size 1302499630

--- a/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_Maya2022.4_Project.rar
+++ b/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_Maya2022.4_Project.rar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd8adad7e4cba8c8a7ac14d5347e0fe34f7f7588487661fcf7bf9a95f096ade9
+size 9283254

--- a/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_Skeleton_Meshes(FBX_Files).rar
+++ b/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_Skeleton_Meshes(FBX_Files).rar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00fa6993db3c0bb778fdc81ffd04f88910312b203f1e86dfd792583e7c7a3f15
+size 18087289

--- a/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_UE4_4.27.2_Project.rar
+++ b/assets/3d/uploads_files_6189326_Perfect_Female_Curvy_Body_UE4_4.27.2_Project.rar
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7f946cfb7097fcd0bbdd30c37b752802c4dd04ec7c3025b9251ebacac22998d
+size 1215913641


### PR DESCRIPTION
## Summary
- Add 3D character model assets to `assets/3d/`
- Configure Git LFS tracking for `.zip` and `.rar` files in assets/3d
- Total assets: ~6.1 GB (stored via LFS)

## Files Added
- Tory Rigged Woman models (2 versions)
- Perfect Female Curvy Body assets (Marmoset, Maya, FBX, UE4)

## Test plan
- [x] Verify Git LFS is tracking files correctly (`git lfs status`)
- [ ] Confirm LFS storage quota sufficient (10 GB available)