### PR TITLE
fix: prevent zombie task attack in expire_claim (#138)

### DIFF
--- a/programs/agenc-coordination/src/instructions/expire_claim.rs
+++ b/programs/agenc-coordination/src/instructions/expire_claim.rs
@@ -60,8 +60,9 @@ pub fn handler(ctx: Context<ExpireClaim>) -> Result<()> {
         .checked_sub(1)
         .ok_or(CoordinationError::ArithmeticOverflow)?;
 
-    // Reopen task if no workers left
-    if task.current_workers == 0 {
+    // Reopen task if no workers left AND task is still in progress
+    // (Don't reopen cancelled/completed/disputed tasks - prevents zombie task attack)
+    if task.current_workers == 0 && task.status == TaskStatus::InProgress {
         task.status = TaskStatus::Open;
     }
 


### PR DESCRIPTION
## Summary

- Fix HIGH severity security vulnerability where `expire_claim` could reset a cancelled task's status to `Open`, creating zombie tasks with empty escrows that trap workers
- Add status validation `task.status == TaskStatus::InProgress` before reopening task

## Test Plan

- [x] Added regression test: "Does not reopen cancelled task when claim expires (zombie task fix #138)"
- [x] All 135 tests pass
- [x] Manual verification: create task, claim it, cancel it, expire the claim → status remains `Cancelled`

Fixes #138