### PR TITLE
feat(runtime): add robust protocol config caching to AgentManager

### DIFF
--- a/runtime/src/agent/index.ts
+++ b/runtime/src/agent/index.ts
@@ -73,4 +73,9 @@ export {
 } from './events.js';
 
 // AgentManager class
-export { AgentManager, type AgentManagerConfig } from './manager.js';
+export {
+  AgentManager,
+  type AgentManagerConfig,
+  type ProtocolConfigCacheOptions,
+  type GetProtocolConfigOptions,
+} from './manager.js';

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -124,6 +124,8 @@ export {
   type EventSubscriptionOptions,
   // AgentManager types
   type AgentManagerConfig,
+  type ProtocolConfigCacheOptions,
+  type GetProtocolConfigOptions,
 } from './types/index.js';
 
 // Wallet types and helpers

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -88,4 +88,6 @@ export {
   type AgentEventCallbacks,
   type EventSubscriptionOptions,
   type AgentManagerConfig,
+  type ProtocolConfigCacheOptions,
+  type GetProtocolConfigOptions,
 } from '../agent/index.js';


### PR DESCRIPTION
## Summary

- Adds intelligent caching for `getProtocolConfig()` with configurable TTL (default 5 minutes)
- Implements promise deduplication to prevent thundering herd on concurrent calls
- Uses generation counter to prevent stale data from in-flight fetches after cache invalidation
- Adds optional stale-while-revalidate fallback via `returnStaleOnError` option

## New APIs

```typescript
// Configuration
interface ProtocolConfigCacheOptions {
  ttlMs?: number;              // Default: 300000 (5 min), 0 = disabled, Infinity = forever
  returnStaleOnError?: boolean; // Default: false
}

// Usage
const manager = new AgentManager({
  connection,
  wallet,
  protocolConfigCache: { ttlMs: 60000, returnStaleOnError: true },
});

// Methods
await manager.getProtocolConfig();                      // Uses cache
await manager.getProtocolConfig({ forceRefresh: true }); // Bypasses cache
manager.invalidateProtocolConfigCache();                // Manual invalidation
manager.getCachedProtocolConfig();                      // Sync access
manager.isProtocolConfigCacheFresh();                   // Check freshness
```

## Implementation Details

- **TTL validation**: Rejects negative and NaN values, accepts 0 (disabled) and Infinity (forever)
- **Promise deduplication**: Concurrent callers share single RPC request
- **Generation counter**: Prevents stale data caching after invalidation during fetch
- **Conditional promise cleanup**: Avoids clobbering newer fetch's promise in finally handler

## Test Plan

- [x] All 479 existing tests pass
- [x] New tests for cache configuration validation
- [x] New tests for cache accessor methods
- [x] TypeScript typecheck passes
- [x] Build succeeds