### PR TITLE
fix: correct TaskState enum values to match on-chain TaskStatus

### DIFF
--- a/sdk/dist/index.js
+++ b/sdk/dist/index.js
@@ -104,10 +104,11 @@ var PERCENT_BASE = 100;
 var DEFAULT_FEE_PERCENT = 1;
 var TaskState = /* @__PURE__ */ ((TaskState2) => {
   TaskState2[TaskState2["Open"] = 0] = "Open";
-  TaskState2[TaskState2["Claimed"] = 1] = "Claimed";
-  TaskState2[TaskState2["Completed"] = 2] = "Completed";
-  TaskState2[TaskState2["Disputed"] = 3] = "Disputed";
+  TaskState2[TaskState2["InProgress"] = 1] = "InProgress";
+  TaskState2[TaskState2["PendingValidation"] = 2] = "PendingValidation";
+  TaskState2[TaskState2["Completed"] = 3] = "Completed";
   TaskState2[TaskState2["Cancelled"] = 4] = "Cancelled";
+  TaskState2[TaskState2["Disputed"] = 5] = "Disputed";
   return TaskState2;
 })(TaskState || {});
 var SEEDS = {
@@ -949,12 +950,13 @@ async function getTasksByCreator(connection, program, creator) {
 function formatTaskState(state) {
   const states = {
     [0 /* Open */]: "Open",
-    [1 /* Claimed */]: "Claimed",
-    [2 /* Completed */]: "Completed",
-    [3 /* Disputed */]: "Disputed",
-    [4 /* Cancelled */]: "Cancelled"
+    [1 /* InProgress */]: "In Progress",
+    [2 /* PendingValidation */]: "Pending Validation",
+    [3 /* Completed */]: "Completed",
+    [4 /* Cancelled */]: "Cancelled",
+    [5 /* Disputed */]: "Disputed"
   };
-  return states[state] || "Unknown";
+  return states[state] ?? "Unknown";
 }
 function calculateEscrowFee(escrowLamports, feePercentage = DEFAULT_FEE_PERCENT) {
   if (escrowLamports < 0 || !Number.isFinite(escrowLamports)) {

--- a/sdk/dist/index.mjs
+++ b/sdk/dist/index.mjs
@@ -28,10 +28,11 @@ var PERCENT_BASE = 100;
 var DEFAULT_FEE_PERCENT = 1;
 var TaskState = /* @__PURE__ */ ((TaskState2) => {
   TaskState2[TaskState2["Open"] = 0] = "Open";
-  TaskState2[TaskState2["Claimed"] = 1] = "Claimed";
-  TaskState2[TaskState2["Completed"] = 2] = "Completed";
-  TaskState2[TaskState2["Disputed"] = 3] = "Disputed";
+  TaskState2[TaskState2["InProgress"] = 1] = "InProgress";
+  TaskState2[TaskState2["PendingValidation"] = 2] = "PendingValidation";
+  TaskState2[TaskState2["Completed"] = 3] = "Completed";
   TaskState2[TaskState2["Cancelled"] = 4] = "Cancelled";
+  TaskState2[TaskState2["Disputed"] = 5] = "Disputed";
   return TaskState2;
 })(TaskState || {});
 var SEEDS = {
@@ -876,12 +877,13 @@ async function getTasksByCreator(connection, program, creator) {
 function formatTaskState(state) {
   const states = {
     [0 /* Open */]: "Open",
-    [1 /* Claimed */]: "Claimed",
-    [2 /* Completed */]: "Completed",
-    [3 /* Disputed */]: "Disputed",
-    [4 /* Cancelled */]: "Cancelled"
+    [1 /* InProgress */]: "In Progress",
+    [2 /* PendingValidation */]: "Pending Validation",
+    [3 /* Completed */]: "Completed",
+    [4 /* Cancelled */]: "Cancelled",
+    [5 /* Disputed */]: "Disputed"
   };
-  return states[state] || "Unknown";
+  return states[state] ?? "Unknown";
 }
 function calculateEscrowFee(escrowLamports, feePercentage = DEFAULT_FEE_PERCENT) {
   if (escrowLamports < 0 || !Number.isFinite(escrowLamports)) {

--- a/sdk/src/__tests__/tasks.test.ts
+++ b/sdk/src/__tests__/tasks.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for TaskState enum and task helper functions.
+ *
+ * These tests verify:
+ * 1. TaskState enum values match on-chain TaskStatus
+ * 2. formatTaskState() returns correct human-readable strings
+ * 3. Edge cases are handled correctly
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TaskState, formatTaskState } from '../tasks';
+
+describe('TaskState enum', () => {
+  describe('enum values match on-chain TaskStatus', () => {
+    // Values MUST match programs/agenc-coordination/src/state.rs:TaskStatus
+    it('Open equals 0', () => {
+      expect(TaskState.Open).toBe(0);
+    });
+
+    it('InProgress equals 1', () => {
+      expect(TaskState.InProgress).toBe(1);
+    });
+
+    it('PendingValidation equals 2', () => {
+      expect(TaskState.PendingValidation).toBe(2);
+    });
+
+    it('Completed equals 3', () => {
+      expect(TaskState.Completed).toBe(3);
+    });
+
+    it('Cancelled equals 4', () => {
+      expect(TaskState.Cancelled).toBe(4);
+    });
+
+    it('Disputed equals 5', () => {
+      expect(TaskState.Disputed).toBe(5);
+    });
+  });
+
+  describe('enum completeness', () => {
+    it('has exactly 6 states', () => {
+      // Get numeric enum values (filter out reverse mappings)
+      const numericValues = Object.values(TaskState).filter(
+        (v): v is number => typeof v === 'number'
+      );
+      expect(numericValues).toHaveLength(6);
+    });
+
+    it('has all expected state names', () => {
+      const expectedNames = [
+        'Open',
+        'InProgress',
+        'PendingValidation',
+        'Completed',
+        'Cancelled',
+        'Disputed',
+      ];
+
+      for (const name of expectedNames) {
+        expect(TaskState[name as keyof typeof TaskState]).toBeDefined();
+      }
+    });
+
+    it('values are sequential from 0 to 5', () => {
+      const numericValues = Object.values(TaskState)
+        .filter((v): v is number => typeof v === 'number')
+        .sort((a, b) => a - b);
+
+      expect(numericValues).toEqual([0, 1, 2, 3, 4, 5]);
+    });
+  });
+
+  describe('on-chain compatibility', () => {
+    it('numeric values work with on-chain data (simulated)', () => {
+      // Simulate reading state from on-chain account
+      const onChainState = 1; // InProgress
+      const taskState = onChainState as TaskState;
+
+      expect(taskState).toBe(TaskState.InProgress);
+    });
+
+    it('handles all on-chain values correctly', () => {
+      const onChainToExpected: Array<[number, TaskState]> = [
+        [0, TaskState.Open],
+        [1, TaskState.InProgress],
+        [2, TaskState.PendingValidation],
+        [3, TaskState.Completed],
+        [4, TaskState.Cancelled],
+        [5, TaskState.Disputed],
+      ];
+
+      for (const [onChain, expected] of onChainToExpected) {
+        expect(onChain as TaskState).toBe(expected);
+      }
+    });
+  });
+});
+
+describe('formatTaskState', () => {
+  describe('returns correct strings for all states', () => {
+    it('formats Open correctly', () => {
+      expect(formatTaskState(TaskState.Open)).toBe('Open');
+    });
+
+    it('formats InProgress correctly', () => {
+      expect(formatTaskState(TaskState.InProgress)).toBe('In Progress');
+    });
+
+    it('formats PendingValidation correctly', () => {
+      expect(formatTaskState(TaskState.PendingValidation)).toBe('Pending Validation');
+    });
+
+    it('formats Completed correctly', () => {
+      expect(formatTaskState(TaskState.Completed)).toBe('Completed');
+    });
+
+    it('formats Cancelled correctly', () => {
+      expect(formatTaskState(TaskState.Cancelled)).toBe('Cancelled');
+    });
+
+    it('formats Disputed correctly', () => {
+      expect(formatTaskState(TaskState.Disputed)).toBe('Disputed');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns Unknown for invalid state value', () => {
+      expect(formatTaskState(99 as TaskState)).toBe('Unknown');
+    });
+
+    it('returns Unknown for negative state value', () => {
+      expect(formatTaskState(-1 as TaskState)).toBe('Unknown');
+    });
+
+    it('handles numeric zero correctly (Open)', () => {
+      expect(formatTaskState(0 as TaskState)).toBe('Open');
+    });
+  });
+
+  describe('type safety', () => {
+    it('accepts TaskState enum values', () => {
+      // This verifies TypeScript type compatibility at compile time
+      const state: TaskState = TaskState.Completed;
+      const formatted: string = formatTaskState(state);
+      expect(formatted).toBe('Completed');
+    });
+
+    it('formats all states without throwing', () => {
+      const allStates = [
+        TaskState.Open,
+        TaskState.InProgress,
+        TaskState.PendingValidation,
+        TaskState.Completed,
+        TaskState.Cancelled,
+        TaskState.Disputed,
+      ];
+
+      for (const state of allStates) {
+        expect(() => formatTaskState(state)).not.toThrow();
+        expect(formatTaskState(state)).not.toBe('Unknown');
+      }
+    });
+  });
+});

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -69,13 +69,23 @@ export const PERCENT_BASE = 100;
 /** Default protocol fee percentage */
 export const DEFAULT_FEE_PERCENT = 1;
 
-/** Task states */
+/**
+ * Task states matching on-chain TaskStatus enum.
+ * Values MUST match programs/agenc-coordination/src/state.rs:TaskStatus
+ */
 export enum TaskState {
+  /** Task is open for claims */
   Open = 0,
-  Claimed = 1,
-  Completed = 2,
-  Disputed = 3,
+  /** Task has been claimed and is being worked on */
+  InProgress = 1,
+  /** Task is awaiting validation */
+  PendingValidation = 2,
+  /** Task has been completed successfully */
+  Completed = 3,
+  /** Task has been cancelled by creator */
   Cancelled = 4,
+  /** Task is in dispute resolution */
+  Disputed = 5,
 }
 
 /** PDA seeds */

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -434,12 +434,13 @@ export async function getTasksByCreator(
 export function formatTaskState(state: TaskState): string {
   const states: Record<TaskState, string> = {
     [TaskState.Open]: 'Open',
-    [TaskState.Claimed]: 'Claimed',
+    [TaskState.InProgress]: 'In Progress',
+    [TaskState.PendingValidation]: 'Pending Validation',
     [TaskState.Completed]: 'Completed',
-    [TaskState.Disputed]: 'Disputed',
     [TaskState.Cancelled]: 'Cancelled',
+    [TaskState.Disputed]: 'Disputed',
   };
-  return states[state] || 'Unknown';
+  return states[state] ?? 'Unknown';
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes TaskState enum values to match on-chain TaskStatus in `state.rs`
- Adds missing `PendingValidation` state
- Updates `formatTaskState()` to handle all 6 states
- Adds comprehensive unit tests (22 new tests)

## Changes

| State | On-Chain | SDK (Before) | SDK (After) |
|-------|----------|--------------|-------------|
| Open | 0 | 0 | 0 |
| InProgress | 1 | 1 (named "Claimed") | 1 |
| PendingValidation | 2 | **Missing** | 2 |
| Completed | 3 | **2** | 3 |
| Cancelled | 4 | 4 | 4 |
| Disputed | 5 | **3** | 5 |

## Breaking Changes

This is a clean break with no deprecated aliases:
- `TaskState.Claimed` renamed to `TaskState.InProgress`
- `TaskState.Completed` value: 2 → 3
- `TaskState.Disputed` value: 3 → 5
- New state: `TaskState.PendingValidation = 2`

## Test Plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (55 tests, 22 new)
- [x] `npm run build` succeeds

Fixes #102