### PR TITLE
 feat(sdk): migrate from Sunspot/nargo to snarkjs for proof generation (#161)

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -31,7 +31,8 @@
     "privacy",
     "zk",
     "zero-knowledge",
-    "noir",
+    "circom",
+    "groth16",
     "agents",
     "coordination",
     "escrow",
@@ -50,11 +51,11 @@
   "dependencies": {
     "@coral-xyz/anchor": ">=0.29.0",
     "@solana/web3.js": ">=1.90.0",
-    "@zkpassport/poseidon2": "^0.6.2",
     "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "ora": "^5.4.1",
-    "poseidon-lite": "^0.3.0"
+    "poseidon-lite": "^0.3.0",
+    "snarkjs": "^0.7.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -8,7 +8,7 @@ import { Connection, PublicKey, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.j
 import { Program, AnchorProvider, Wallet, Idl } from '@coral-xyz/anchor';
 import * as path from 'path';
 import { AgenCPrivacyClient } from './privacy';
-import { PROGRAM_ID, VERIFIER_PROGRAM_ID, DEVNET_RPC, MAINNET_RPC } from './constants';
+import { PROGRAM_ID, DEVNET_RPC, MAINNET_RPC } from './constants';
 
 /**
  * Validates a circuit path to prevent path traversal attacks.

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -11,9 +11,6 @@ import { PublicKey } from '@solana/web3.js';
 /** AgenC Coordination Program ID */
 export const PROGRAM_ID = new PublicKey('EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ');
 
-/** Sunspot Groth16 Verifier Program ID */
-export const VERIFIER_PROGRAM_ID = new PublicKey('8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ');
-
 /** Privacy Cash Program ID */
 export const PRIVACY_CASH_PROGRAM_ID = new PublicKey('9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD');
 
@@ -50,8 +47,8 @@ export const OUTPUT_FIELD_COUNT = 4;
 // ZK Proof Constants
 // ============================================================================
 
-/** Proof size in bytes (Groth16) */
-export const PROOF_SIZE_BYTES = 388;
+/** Proof size in bytes (Groth16 via groth16-solana) */
+export const PROOF_SIZE_BYTES = 256;
 
 /** Approximate verification compute units */
 export const VERIFICATION_COMPUTE_UNITS = 50_000;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -4,7 +4,7 @@
  * AgenC enables agents to complete tasks and receive payments with full privacy:
  * - ZK proofs verify task completion without revealing outputs
  * - Privacy Cash breaks payment linkability via shielded pools
- * - Sunspot on-chain verifier validates Noir circuit proofs
+ * - Inline groth16-solana verifier validates Circom circuit proofs
  */
 
 // Privacy exports available when privacycash is installed
@@ -18,21 +18,21 @@ export {
 export {
   generateProof,
   verifyProofLocally,
-  computeHashesViaNargo,
+  computeHashes,
   generateSalt,
   checkToolsAvailable,
   requireTools,
   pubkeyToField,
   FIELD_MODULUS,
+  // Hash computation functions
+  computeExpectedBinding,
+  computeConstraintHash,
+  computeCommitment,
   // Types
   ProofGenerationParams,
   ProofResult,
   HashResult,
   ToolsStatus,
-  // Legacy (deprecated - use computeHashesViaNargo instead)
-  computeExpectedBinding,
-  computeConstraintHash,
-  computeCommitment,
 } from './proofs';
 
 export {
@@ -55,7 +55,6 @@ export {
 
 export {
   PROGRAM_ID,
-  VERIFIER_PROGRAM_ID,
   PRIVACY_CASH_PROGRAM_ID,
   DEVNET_RPC,
   MAINNET_RPC,

--- a/sdk/src/privacy.ts
+++ b/sdk/src/privacy.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
 import type { PrivacyCash, PrivacyCashConfig } from 'privacycash';
-import { HASH_SIZE, VERIFIER_PROGRAM_ID } from './constants';
+import { HASH_SIZE } from './constants';
 
 /**
  * Validates a circuit path to prevent path traversal and command injection.
@@ -320,10 +320,7 @@ export class AgenCPrivacyClient {
             this.program.programId
         );
 
-        // Get verifier program ID (deployed via Sunspot)
-        const verifierProgramId = await this.getVerifierProgramId();
-
-        // Build instruction - simplified to just verify ZK proof
+        // Build instruction - ZK proof verified inline via groth16-solana
         // Privacy Cash withdrawal happens separately via their SDK
         const ix = await this.program.methods
             .completeTaskPrivate(taskId, {
@@ -334,7 +331,6 @@ export class AgenCPrivacyClient {
                 worker,
                 task: taskPda,
                 taskClaim: claimPda,
-                zkVerifier: verifierProgramId,
                 systemProgram: PublicKey.default,
             })
             .instruction();
@@ -401,10 +397,6 @@ salt = "${params.salt}"
         return await accounts['task'].fetch(taskPda) as { constraintHash: Buffer };
     }
     
-    private async getVerifierProgramId(): Promise<PublicKey> {
-        // Return the Sunspot Groth16 verifier program ID from constants
-        return VERIFIER_PROGRAM_ID;
-    }
 }
 
 /**

--- a/sdk/src/proofs.ts
+++ b/sdk/src/proofs.ts
@@ -1,9 +1,8 @@
 /**
  * ZK Proof Generation for AgenC
  *
- * Uses nargo to compute Poseidon2 hashes, ensuring exact compatibility with
- * Noir's poseidon2_permutation. The hash_helper circuit computes all hashes
- * needed for proof generation.
+ * Uses snarkjs with Circom circuits for Groth16 proof generation.
+ * Hash computation uses poseidon-lite for exact circomlib compatibility.
  *
  * ## Security Notes
  *
@@ -14,15 +13,19 @@
  * - Store salts securely if you need to verify commitments later
  *
  * ### Hash Computation
- * - All hashes are computed via nargo using the hash_helper circuit
+ * - All hashes are computed via poseidon-lite (circomlib compatible)
  * - This guarantees exact compatibility with the task_completion circuit
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
 import { PublicKey } from '@solana/web3.js';
-import { HASH_SIZE, OUTPUT_FIELD_COUNT } from './constants';
+import { poseidon2, poseidon4 } from 'poseidon-lite';
+import { HASH_SIZE, OUTPUT_FIELD_COUNT, PROOF_SIZE_BYTES } from './constants';
+
+// snarkjs is a CommonJS module
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const snarkjs = require('snarkjs');
 
 /**
  * Validates a circuit path to prevent path traversal and command injection.
@@ -46,15 +49,13 @@ function validateCircuitPath(circuitPath: string): void {
 /** BN254 scalar field modulus */
 export const FIELD_MODULUS = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 
-const FIELD_HEX_LENGTH = HASH_SIZE * 2;
-const DEFAULT_CIRCUIT_PATH = './circuits/task_completion';
-const DEFAULT_HASH_HELPER_PATH = './circuits/hash_helper';
+const DEFAULT_CIRCUIT_PATH = './circuits-circom/task_completion';
 
 /** Bits per byte for bit shifting */
 const BITS_PER_BYTE = 8n;
 
 /**
- * Result from computing hashes via the hash_helper circuit
+ * Result from computing hashes
  */
 export interface HashResult {
   constraintHash: bigint;
@@ -63,7 +64,7 @@ export interface HashResult {
 }
 
 /**
- * Parameters for proof generation (simplified interface)
+ * Parameters for proof generation
  */
 export interface ProofGenerationParams {
   taskPda: PublicKey;
@@ -71,12 +72,10 @@ export interface ProofGenerationParams {
   output: bigint[];
   salt: bigint;
   circuitPath?: string;
-  hashHelperPath?: string;
 }
 
 export interface ProofResult {
   proof: Buffer;
-  publicWitness: Buffer;
   constraintHash: Buffer;
   outputCommitment: Buffer;
   expectedBinding: Buffer;
@@ -103,256 +102,6 @@ export function generateSalt(): bigint {
 }
 
 /**
- * Compute hashes using the hash_helper Noir circuit via nargo.
- * This ensures exact compatibility with the task_completion circuit.
- *
- * @param taskPda - Task PDA (used as task_id)
- * @param agentPubkey - Agent's public key
- * @param output - Task output (4 field elements)
- * @param salt - Random salt for commitment
- * @param hashHelperPath - Path to hash_helper circuit (default: ./circuits/hash_helper)
- * @returns Computed hashes (constraintHash, outputCommitment, expectedBinding)
- */
-export async function computeHashesViaNargo(
-  taskPda: PublicKey,
-  agentPubkey: PublicKey,
-  output: bigint[],
-  salt: bigint,
-  hashHelperPath: string = DEFAULT_HASH_HELPER_PATH
-): Promise<HashResult> {
-  validateCircuitPath(hashHelperPath);
-
-  if (output.length !== OUTPUT_FIELD_COUNT) {
-    throw new Error(`Output must be exactly ${OUTPUT_FIELD_COUNT} field elements`);
-  }
-
-  const taskBytes = Array.from(taskPda.toBytes());
-  const agentBytes = Array.from(agentPubkey.toBytes());
-
-  const proverToml = `task_id = [${taskBytes.join(', ')}]
-agent_pubkey = [${agentBytes.join(', ')}]
-output = [${output.map((o) => `"${o.toString()}"`).join(', ')}]
-salt = "${salt.toString()}"
-`;
-
-  const proverTomlPath = path.join(hashHelperPath, 'Prover.toml');
-  fs.writeFileSync(proverTomlPath, proverToml);
-
-  try {
-    const result = execSync('nargo execute', {
-      cwd: hashHelperPath,
-      encoding: 'utf-8',
-      timeout: 60000,
-    });
-
-    // Parse output: "Circuit output: (0x..., 0x..., 0x...)"
-    const outputMatch = result.match(/Circuit output: \((0x[0-9a-fA-F]+), (0x[0-9a-fA-F]+), (0x[0-9a-fA-F]+)\)/);
-    if (!outputMatch) {
-      throw new Error(`Failed to parse hash_helper output: ${result}`);
-    }
-
-    return {
-      constraintHash: BigInt(outputMatch[1]),
-      outputCommitment: BigInt(outputMatch[2]),
-      expectedBinding: BigInt(outputMatch[3]),
-    };
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Hash computation failed: ${message}`);
-  }
-}
-
-function generateProverToml(
-  taskPda: PublicKey,
-  agentPubkey: PublicKey,
-  output: bigint[],
-  salt: bigint,
-  hashes: HashResult
-): string {
-  const taskBytes = Array.from(taskPda.toBytes());
-  const agentBytes = Array.from(agentPubkey.toBytes());
-
-  return `task_id = [${taskBytes.join(', ')}]
-agent_pubkey = [${agentBytes.join(', ')}]
-constraint_hash = "0x${hashes.constraintHash.toString(16).padStart(FIELD_HEX_LENGTH, '0')}"
-output_commitment = "0x${hashes.outputCommitment.toString(16).padStart(FIELD_HEX_LENGTH, '0')}"
-expected_binding = "0x${hashes.expectedBinding.toString(16).padStart(FIELD_HEX_LENGTH, '0')}"
-output = [${output.map((o) => `"${o.toString()}"`).join(', ')}]
-salt = "${salt.toString()}"
-`;
-}
-
-function bigintToBytes32(value: bigint): Buffer {
-  const hex = value.toString(16).padStart(FIELD_HEX_LENGTH, '0');
-  return Buffer.from(hex, 'hex');
-}
-
-/**
- * Generate a ZK proof for private task completion.
- *
- * This function:
- * 1. Computes all necessary hashes via the hash_helper circuit (nargo)
- * 2. Generates the witness for the task_completion circuit
- * 3. Creates the Groth16 proof via sunspot
- *
- * @param params - Proof generation parameters
- * @returns Proof result including proof bytes and public inputs
- */
-export async function generateProof(params: ProofGenerationParams): Promise<ProofResult> {
-  const circuitPath = params.circuitPath || DEFAULT_CIRCUIT_PATH;
-  const hashHelperPath = params.hashHelperPath || DEFAULT_HASH_HELPER_PATH;
-
-  validateCircuitPath(circuitPath);
-  validateCircuitPath(hashHelperPath);
-
-  const startTime = Date.now();
-
-  // Step 1: Compute hashes using the hash_helper circuit
-  const hashes = await computeHashesViaNargo(
-    params.taskPda,
-    params.agentPubkey,
-    params.output,
-    params.salt,
-    hashHelperPath
-  );
-
-  // Step 2: Write Prover.toml for task_completion circuit
-  const proverTomlPath = path.join(circuitPath, 'Prover.toml');
-  const targetDir = path.join(circuitPath, 'target');
-  if (!fs.existsSync(targetDir)) {
-    fs.mkdirSync(targetDir, { recursive: true });
-  }
-
-  fs.writeFileSync(
-    proverTomlPath,
-    generateProverToml(params.taskPda, params.agentPubkey, params.output, params.salt, hashes)
-  );
-
-  // Step 3: Execute circuit and generate proof
-  const proofOutputPath = path.join(circuitPath, 'target/task_completion.proof');
-  const witnessPath = path.join(circuitPath, 'target/task_completion.gz');
-
-  try {
-    execSync('nargo execute', { cwd: circuitPath, stdio: 'pipe', timeout: 120000 });
-    execSync(
-      'sunspot prove target/task_completion.ccs target/task_completion.pk target/task_completion.gz -o target/task_completion.proof',
-      { cwd: circuitPath, stdio: 'pipe', timeout: 300000 }
-    );
-
-    const proof = fs.readFileSync(proofOutputPath);
-    const publicWitness = fs.readFileSync(witnessPath);
-
-    return {
-      proof,
-      publicWitness,
-      constraintHash: bigintToBytes32(hashes.constraintHash),
-      outputCommitment: bigintToBytes32(hashes.outputCommitment),
-      expectedBinding: bigintToBytes32(hashes.expectedBinding),
-      proofSize: proof.length,
-      generationTime: Date.now() - startTime,
-    };
-  } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`Proof generation failed: ${message}`);
-  }
-}
-
-export async function verifyProofLocally(
-  proof: Buffer,
-  publicWitness: Buffer,
-  circuitPath: string = DEFAULT_CIRCUIT_PATH
-): Promise<boolean> {
-  validateCircuitPath(circuitPath);
-
-  const uniqueSuffix = `${Date.now()}_${Math.random().toString(36).substring(2, 10)}`;
-  const proofPath = path.join(circuitPath, `target/verify_test_${uniqueSuffix}.proof`);
-  const witnessPath = path.join(circuitPath, `target/verify_test_${uniqueSuffix}.pw`);
-  const relativeProofPath = `target/verify_test_${uniqueSuffix}.proof`;
-  const relativeWitnessPath = `target/verify_test_${uniqueSuffix}.pw`;
-
-  fs.writeFileSync(proofPath, proof);
-  fs.writeFileSync(witnessPath, publicWitness);
-
-  try {
-    execSync(
-      `sunspot verify target/task_completion.ccs target/task_completion.vk ${relativeProofPath} ${relativeWitnessPath}`,
-      { cwd: circuitPath, stdio: 'pipe', timeout: 60000 }
-    );
-    return true;
-  } catch {
-    return false;
-  } finally {
-    try { fs.unlinkSync(proofPath); } catch { /* file may not exist */ }
-    try { fs.unlinkSync(witnessPath); } catch { /* file may not exist */ }
-  }
-}
-
-export interface ToolsStatus {
-  nargo: boolean;
-  sunspot: boolean;
-  nargoVersion?: string;
-  sunspotVersion?: string;
-}
-
-/**
- * Check if required tools (nargo, sunspot) are available.
- * @returns Status of each tool including version if available
- */
-export function checkToolsAvailable(): ToolsStatus {
-  const result: ToolsStatus = { nargo: false, sunspot: false };
-
-  try {
-    const nargoOutput = execSync('nargo --version', { stdio: 'pipe', encoding: 'utf-8' });
-    result.nargo = true;
-    result.nargoVersion = nargoOutput.trim();
-  } catch {}
-
-  try {
-    const sunspotOutput = execSync('sunspot --version', { stdio: 'pipe', encoding: 'utf-8' });
-    result.sunspot = true;
-    result.sunspotVersion = sunspotOutput.trim();
-  } catch {}
-
-  return result;
-}
-
-/**
- * Throws an error with installation instructions if required tools are missing.
- * @param requireSunspot - Whether sunspot is required (default: true)
- */
-export function requireTools(requireSunspot: boolean = true): void {
-  const tools = checkToolsAvailable();
-
-  if (!tools.nargo) {
-    throw new Error(
-      'nargo not found. Install with:\n' +
-      '  curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash\n' +
-      '  noirup\n\n' +
-      'See: https://noir-lang.org/docs/getting_started/installation'
-    );
-  }
-
-  if (requireSunspot && !tools.sunspot) {
-    throw new Error(
-      'sunspot not found. Install with:\n' +
-      '  1. Install Go 1.21+\n' +
-      '  2. git clone https://github.com/Sunspot-Network/sunspot\n' +
-      '  3. cd sunspot/go && go build -o sunspot\n' +
-      '  4. Add to PATH\n\n' +
-      'See: circuits/README.md for detailed instructions'
-    );
-  }
-}
-
-// Legacy exports for backwards compatibility (these use JS hashes which may not match circuit)
-// DEPRECATED: Use computeHashesViaNargo instead
-
-import { poseidon2Hash } from '@zkpassport/poseidon2';
-
-/** Base for byte-to-field conversion */
-const BYTE_BASE = 256n;
-
-/**
  * Convert a PublicKey to a field element.
  *
  * Interprets the 32-byte public key as a big-endian integer and reduces
@@ -364,36 +113,304 @@ const BYTE_BASE = 256n;
 export function pubkeyToField(pubkey: PublicKey): bigint {
   const bytes = pubkey.toBytes();
   let field = 0n;
+  const BYTE_BASE = 256n;
   for (const byte of bytes) {
     field = (field * BYTE_BASE + BigInt(byte)) % FIELD_MODULUS;
   }
   return field;
 }
 
-/** @deprecated Use computeHashesViaNargo instead - JS hash may not match circuit */
+/**
+ * Compute the constraint hash from output values.
+ * Uses Poseidon hash matching the circomlib implementation.
+ *
+ * @param output - Task output (4 field elements)
+ * @returns The constraint hash
+ */
 export function computeConstraintHash(output: bigint[]): bigint {
-  console.warn('DEPRECATED: computeConstraintHash uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.');
   if (output.length !== OUTPUT_FIELD_COUNT) {
     throw new Error(`Output must be exactly ${OUTPUT_FIELD_COUNT} field elements`);
   }
-  return poseidon2Hash(output.map((x) => x % FIELD_MODULUS));
+  // Reduce each element modulo field to handle overflow
+  const reduced = output.map((x) => ((x % FIELD_MODULUS) + FIELD_MODULUS) % FIELD_MODULUS);
+  return poseidon4(reduced);
 }
 
-/** @deprecated Use computeHashesViaNargo instead - JS hash may not match circuit */
+/**
+ * Compute the output commitment from constraint hash and salt.
+ * Uses Poseidon hash matching the circomlib implementation.
+ *
+ * @param constraintHash - The constraint hash
+ * @param salt - Random salt
+ * @returns The output commitment
+ */
 export function computeCommitment(constraintHash: bigint, salt: bigint): bigint {
-  console.warn('DEPRECATED: computeCommitment uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.');
-  return poseidon2Hash([constraintHash % FIELD_MODULUS, salt % FIELD_MODULUS, 0n, 0n]);
+  // Reduce inputs modulo field
+  const ch = ((constraintHash % FIELD_MODULUS) + FIELD_MODULUS) % FIELD_MODULUS;
+  const s = ((salt % FIELD_MODULUS) + FIELD_MODULUS) % FIELD_MODULUS;
+  return poseidon2([ch, s]);
 }
 
-/** @deprecated Use computeHashesViaNargo instead - JS hash may not match circuit */
+/**
+ * Compute the expected binding for proof verification.
+ * Binding = hash(hash(task_id, agent_pubkey), output_commitment)
+ *
+ * @param taskPda - Task PDA
+ * @param agentPubkey - Agent's public key
+ * @param outputCommitment - The output commitment
+ * @returns The expected binding
+ */
 export function computeExpectedBinding(
   taskPda: PublicKey,
   agentPubkey: PublicKey,
   outputCommitment: bigint
 ): bigint {
-  console.warn('DEPRECATED: computeExpectedBinding uses JS Poseidon2 which may not match circuit. Use computeHashesViaNargo instead.');
   const taskField = pubkeyToField(taskPda);
   const agentField = pubkeyToField(agentPubkey);
-  const binding = poseidon2Hash([taskField, agentField, 0n, 0n]);
-  return poseidon2Hash([binding, outputCommitment % FIELD_MODULUS, 0n, 0n]);
+  const binding = poseidon2([taskField, agentField]);
+  const commitment = ((outputCommitment % FIELD_MODULUS) + FIELD_MODULUS) % FIELD_MODULUS;
+  return poseidon2([binding, commitment]);
+}
+
+/**
+ * Compute all hashes needed for proof generation.
+ *
+ * @param taskPda - Task PDA (used as task_id)
+ * @param agentPubkey - Agent's public key
+ * @param output - Task output (4 field elements)
+ * @param salt - Random salt for commitment
+ * @returns Computed hashes (constraintHash, outputCommitment, expectedBinding)
+ */
+export function computeHashes(
+  taskPda: PublicKey,
+  agentPubkey: PublicKey,
+  output: bigint[],
+  salt: bigint
+): HashResult {
+  const constraintHash = computeConstraintHash(output);
+  const outputCommitment = computeCommitment(constraintHash, salt);
+  const expectedBinding = computeExpectedBinding(taskPda, agentPubkey, outputCommitment);
+
+  return {
+    constraintHash,
+    outputCommitment,
+    expectedBinding,
+  };
+}
+
+function bigintToBytes32(value: bigint): Buffer {
+  const hex = value.toString(16).padStart(HASH_SIZE * 2, '0');
+  return Buffer.from(hex, 'hex');
+}
+
+/**
+ * Build witness input for the Circom circuit.
+ */
+function buildWitnessInput(
+  taskPda: PublicKey,
+  agentPubkey: PublicKey,
+  output: bigint[],
+  salt: bigint,
+  hashes: HashResult
+): Record<string, string | string[]> {
+  const taskBytes = Array.from(taskPda.toBytes()).map((b) => b.toString());
+  const agentBytes = Array.from(agentPubkey.toBytes()).map((b) => b.toString());
+
+  return {
+    task_id: taskBytes,
+    agent_pubkey: agentBytes,
+    constraint_hash: hashes.constraintHash.toString(),
+    output_commitment: hashes.outputCommitment.toString(),
+    expected_binding: hashes.expectedBinding.toString(),
+    output: output.map((o) => o.toString()),
+    salt: salt.toString(),
+  };
+}
+
+/**
+ * Convert snarkjs proof to groth16-solana format (256 bytes).
+ *
+ * groth16-solana expects: proof_a (64 bytes G1) + proof_b (128 bytes G2) + proof_c (64 bytes G1)
+ * snarkjs outputs proof points as decimal strings that need to be converted.
+ */
+function convertProofToSolanaFormat(proof: {
+  pi_a: string[];
+  pi_b: string[][];
+  pi_c: string[];
+}): Buffer {
+  // Helper to convert a decimal string to 32-byte big-endian buffer
+  const toBe32 = (val: string): Buffer => {
+    const bi = BigInt(val);
+    const hex = bi.toString(16).padStart(64, '0');
+    return Buffer.from(hex, 'hex');
+  };
+
+  // proof_a: G1 point (2 coordinates, 32 bytes each = 64 bytes)
+  const proofA = Buffer.concat([toBe32(proof.pi_a[0]), toBe32(proof.pi_a[1])]);
+
+  // proof_b: G2 point (2x2 coordinates, 32 bytes each = 128 bytes)
+  // Note: G2 point in snarkjs is [[x0, x1], [y0, y1]] but groth16-solana expects
+  // different ordering. The standard is: x1, x0, y1, y0 (reversed within pairs)
+  const proofB = Buffer.concat([
+    toBe32(proof.pi_b[0][1]),
+    toBe32(proof.pi_b[0][0]),
+    toBe32(proof.pi_b[1][1]),
+    toBe32(proof.pi_b[1][0]),
+  ]);
+
+  // proof_c: G1 point (2 coordinates, 32 bytes each = 64 bytes)
+  const proofC = Buffer.concat([toBe32(proof.pi_c[0]), toBe32(proof.pi_c[1])]);
+
+  return Buffer.concat([proofA, proofB, proofC]);
+}
+
+/**
+ * Generate a ZK proof for private task completion.
+ *
+ * This function:
+ * 1. Computes all necessary hashes using poseidon-lite (circomlib compatible)
+ * 2. Generates the witness for the task_completion circuit
+ * 3. Creates the Groth16 proof via snarkjs
+ *
+ * @param params - Proof generation parameters
+ * @returns Proof result including proof bytes and public inputs
+ */
+export async function generateProof(params: ProofGenerationParams): Promise<ProofResult> {
+  const circuitPath = params.circuitPath || DEFAULT_CIRCUIT_PATH;
+  validateCircuitPath(circuitPath);
+
+  const startTime = Date.now();
+
+  // Step 1: Compute hashes using poseidon-lite
+  const hashes = computeHashes(params.taskPda, params.agentPubkey, params.output, params.salt);
+
+  // Step 2: Build witness input
+  const witnessInput = buildWitnessInput(
+    params.taskPda,
+    params.agentPubkey,
+    params.output,
+    params.salt,
+    hashes
+  );
+
+  // Step 3: Locate circuit files
+  const wasmPath = path.join(circuitPath, 'target/circuit_js/circuit.wasm');
+  const zkeyPath = path.join(circuitPath, 'target/circuit.zkey');
+
+  if (!fs.existsSync(wasmPath)) {
+    throw new Error(`Circuit WASM not found at ${wasmPath}. Run 'npm run build' in circuits-circom/task_completion first.`);
+  }
+  if (!fs.existsSync(zkeyPath)) {
+    throw new Error(`Circuit zkey not found at ${zkeyPath}. Run 'npm run build' in circuits-circom/task_completion first.`);
+  }
+
+  // Step 4: Generate proof using snarkjs
+  const { proof } = await snarkjs.groth16.fullProve(witnessInput, wasmPath, zkeyPath);
+
+  // Step 5: Convert proof to groth16-solana format
+  const proofBuffer = convertProofToSolanaFormat(proof);
+
+  if (proofBuffer.length !== PROOF_SIZE_BYTES) {
+    throw new Error(`Proof size mismatch: expected ${PROOF_SIZE_BYTES}, got ${proofBuffer.length}`);
+  }
+
+  return {
+    proof: proofBuffer,
+    constraintHash: bigintToBytes32(hashes.constraintHash),
+    outputCommitment: bigintToBytes32(hashes.outputCommitment),
+    expectedBinding: bigintToBytes32(hashes.expectedBinding),
+    proofSize: proofBuffer.length,
+    generationTime: Date.now() - startTime,
+  };
+}
+
+/**
+ * Verify a proof locally using snarkjs.
+ *
+ * @param proof - The proof buffer (256 bytes in groth16-solana format)
+ * @param publicSignals - Array of public signals
+ * @param circuitPath - Path to circuit directory
+ * @returns True if proof is valid
+ */
+export async function verifyProofLocally(
+  proof: Buffer,
+  publicSignals: bigint[],
+  circuitPath: string = DEFAULT_CIRCUIT_PATH
+): Promise<boolean> {
+  validateCircuitPath(circuitPath);
+
+  const vkeyPath = path.join(circuitPath, 'target/verification_key.json');
+
+  if (!fs.existsSync(vkeyPath)) {
+    throw new Error(`Verification key not found at ${vkeyPath}. Run trusted setup first.`);
+  }
+
+  const vkey = JSON.parse(fs.readFileSync(vkeyPath, 'utf-8'));
+
+  // Convert proof buffer back to snarkjs format
+  // This is the reverse of convertProofToSolanaFormat
+  const readBe32 = (buf: Buffer, offset: number): string => {
+    const slice = buf.slice(offset, offset + 32);
+    return BigInt('0x' + slice.toString('hex')).toString();
+  };
+
+  const snarkjsProof = {
+    pi_a: [readBe32(proof, 0), readBe32(proof, 32), '1'],
+    pi_b: [
+      [readBe32(proof, 96), readBe32(proof, 64)],
+      [readBe32(proof, 160), readBe32(proof, 128)],
+      ['1', '0'],
+    ],
+    pi_c: [readBe32(proof, 192), readBe32(proof, 224), '1'],
+    protocol: 'groth16',
+    curve: 'bn128',
+  };
+
+  const signals = publicSignals.map((s) => s.toString());
+
+  try {
+    return await snarkjs.groth16.verify(vkey, signals, snarkjsProof);
+  } catch {
+    return false;
+  }
+}
+
+export interface ToolsStatus {
+  snarkjs: boolean;
+  snarkjsVersion?: string;
+}
+
+/**
+ * Check if required tools (snarkjs) are available.
+ * Note: circom is only needed for circuit compilation, not proof generation.
+ * @returns Status of snarkjs including version if available
+ */
+export function checkToolsAvailable(): ToolsStatus {
+  const result: ToolsStatus = { snarkjs: false };
+
+  // snarkjs is a node module, check if it's importable
+  try {
+    const snarkjsPkg = require('snarkjs/package.json');
+    result.snarkjs = true;
+    result.snarkjsVersion = snarkjsPkg.version;
+  } catch {
+    // snarkjs not available
+  }
+
+  return result;
+}
+
+/**
+ * Throws an error with installation instructions if required tools are missing.
+ */
+export function requireTools(): void {
+  const tools = checkToolsAvailable();
+
+  if (!tools.snarkjs) {
+    throw new Error(
+      'snarkjs not found. Install with:\n' +
+        '  npm install snarkjs\n\n' +
+        'See: https://github.com/iden3/snarkjs'
+    );
+  }
 }


### PR DESCRIPTION
 ## Summary

  - Migrate SDK proof generation from Sunspot/nargo to snarkjs/Circom
  - Replace @zkpassport/poseidon2 with poseidon-lite (circomlib compatible)
  - Remove VERIFIER_PROGRAM_ID constant (verification is now inline via groth16-solana)
  - Update proof size from 388 bytes to 256 bytes (groth16-solana format)
  - Update privacy client to work with new inline verification

  ## Test plan

  - [x] All 57 SDK unit tests passing
  - [x] TypeScript typecheck passes
  - [x] SDK build succeeds
  - [ ] Integration test with actual proof generation (requires circuit build artifacts)

  ## Breaking Changes

  - `computeHashesViaNargo` removed, use `computeHashes` instead
  - `VERIFIER_PROGRAM_ID` export removed (no longer needed)
  - Proof size changed from 388 to 256 bytes
  - Hash outputs differ (poseidon-lite vs @zkpassport/poseidon2)