### PR TITLE
docs: remove Sunspot references, update to groth16-solana (#162)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <p align="center">
   <img src="https://img.shields.io/badge/Solana-1.18+-14F195?style=flat-square&logo=solana" alt="Solana">
   <img src="https://img.shields.io/badge/Rust-Anchor-orange?style=flat-square&logo=rust" alt="Rust">
-  <img src="https://img.shields.io/badge/Noir-ZK%20Circuits-black?style=flat-square" alt="Noir">
-  <img src="https://img.shields.io/badge/Sunspot-Verifier-blueviolet?style=flat-square" alt="Sunspot">
+  <img src="https://img.shields.io/badge/Circom-ZK%20Circuits-black?style=flat-square" alt="Circom">
+  <img src="https://img.shields.io/badge/groth16--solana-Verifier-blueviolet?style=flat-square" alt="groth16-solana">
   <img src="https://img.shields.io/badge/Privacy-E2E-red?style=flat-square" alt="E2E Privacy">
   <img src="https://img.shields.io/badge/Built%20by-Tetsuo-white?style=flat-square" alt="Tetsuo">
 </p>
@@ -48,7 +48,7 @@
 
 - **On-chain Agent Registry** - Agents register with verifiable capabilities and endpoints
 - **Task Marketplace** - Create, claim, and complete tasks with automatic escrow payments
-- **Private Task Completion** - ZK proofs verify work without revealing outputs (Noir + Sunspot)
+- **Private Task Completion** - ZK proofs verify work without revealing outputs (Circom + groth16-solana)
 - **Privacy-Preserving Payments** - Private deposits/withdrawals via Privacy Cash SDK
 - **Dispute Resolution** - Multisig governance for conflict resolution
 - **Rate Limiting** - Configurable throttles prevent spam
@@ -74,7 +74,7 @@
 │  │  AgenC Coordination Program (Rust/Anchor)                │   │
 │  │  • Agent Registry      • Task Marketplace                │   │
 │  │  • Escrow Management   • Dispute Resolution              │   │
-│  │  • ZK Proof Verification (Sunspot)                       │   │
+│  │  • ZK Proof Verification (groth16-solana)                │   │
 │  └─────────────────────────────────────────────────────────┘   │
 │  ┌─────────────────────────────────────────────────────────┐   │
 │  │  Program Derived Addresses (PDAs)                        │   │
@@ -85,12 +85,12 @@
                               │
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
-│                   Noir ZK Circuits                               │
+│                   Circom ZK Circuits                             │
 │  ┌─────────────────────────────────────────────────────────┐   │
 │  │  task_completion circuit                                 │   │
 │  │  • Proves output satisfies constraint (without reveal)   │   │
 │  │  • Binds proof to task_id and agent_pubkey               │   │
-│  │  • Poseidon2 hash (Sunspot compatible)                   │   │
+│  │  • Poseidon hash (circomlib compatible)                  │   │
 │  └─────────────────────────────────────────────────────────┘   │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -107,7 +107,7 @@ AgenC/
 │       ├── events.rs              # Event definitions
 │       └── instructions/          # 20 instruction handlers
 ├── sdk/privacy-cash-sdk/          # TypeScript SDK for private payments
-├── circuits/task_completion/      # Noir ZK circuit for private completion
+├── circuits-circom/task_completion/ # Circom ZK circuit for private completion
 ├── tests/                         # Integration & security tests
 ├── demo/                          # Demo scripts
 ├── docs/                          # Documentation
@@ -122,7 +122,7 @@ AgenC/
 - Solana CLI 1.18+
 - Anchor 0.32+
 - Node.js 18+
-- nargo (for ZK circuits)
+- circom + snarkjs (for ZK circuits)
 
 ### Install Dependencies
 
@@ -133,9 +133,8 @@ cargo install --git https://github.com/coral-xyz/anchor anchor-cli
 # Install Node dependencies
 yarn install
 
-# Install nargo for ZK circuits (optional)
-curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-noirup
+# Install circom for ZK circuits (optional)
+npm install -g circom snarkjs
 ```
 
 ### Build
@@ -204,7 +203,7 @@ Tasks can be completed privately using zero-knowledge proofs:
 1. **Task Creator** sets a `constraint_hash` (hash of expected output)
 2. **Agent** completes work off-chain, generates ZK proof
 3. **Proof** verifies output matches constraint without revealing it
-4. **On-chain** verification via Sunspot verifier
+4. **On-chain** verification via groth16-solana verifier
 5. **Payment** released privately via Privacy Cash SDK
 
 ```typescript
@@ -269,29 +268,27 @@ Agents register with capability flags (bitmask):
 
 ## ZK Circuits
 
-The ZK proof system uses Noir circuits compiled to Groth16 via Sunspot.
+The ZK proof system uses Circom circuits with Groth16 proofs verified via groth16-solana.
 
 | Component | Description |
 |-----------|-------------|
-| `circuits/task_completion` | Main circuit proving task completion |
-| `circuits/hash_helper` | Helper circuit for SDK hash computation |
+| `circuits-circom/task_completion` | Main circuit proving task completion |
 
 ### Quick Start
 
 ```bash
-# Install nargo
-curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-noirup
+# Install circom and snarkjs
+npm install -g circom snarkjs
 
-# Compile and test
-cd circuits/task_completion
-nargo compile && nargo test
+# Compile circuit
+cd circuits-circom/task_completion
+circom circuit.circom --r1cs --wasm --sym
 
-# Run demo (requires sunspot)
-./circuits/demo.sh
+# Generate proof (via SDK)
+npx ts-node examples/generate-proof.ts
 ```
 
-See [circuits/README.md](circuits/README.md) for full setup instructions including sunspot installation.
+See [circuits-circom/README.md](circuits-circom/README.md) for full setup instructions including trusted setup.
 
 ### Examples
 

--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -31,7 +31,7 @@ AgenC is a privacy-preserving multi-agent coordination protocol on Solana. It en
 
 - **Task Marketplace**: Creators post tasks with escrowed rewards
 - **Agent Registry**: Workers register with capabilities and stake
-- **ZK Task Verification**: Private task completion via Noir circuits + Sunspot verifier
+- **ZK Task Verification**: Private task completion via Circom circuits + groth16-solana verifier
 - **Shielded Payments**: Unlinkable payments via Privacy Cash integration
 - **Dispute Resolution**: Decentralized arbitration with staked arbiters
 
@@ -72,7 +72,7 @@ AgenC is a privacy-preserving multi-agent coordination protocol on Solana. It en
                          |
                          v
 +------------------+     +------------------+     +------------------+
-|   Agent/Worker   |---->|   Noir Circuit   |---->| Sunspot Verifier |
+|   Agent/Worker   |---->|  Circom Circuit  |---->| groth16-solana   |
 +------------------+     +------------------+     +------------------+
                                                         |
                                                         v
@@ -388,9 +388,9 @@ min_stake_for_dispute: configurable
 
 ### 6.3 ZK Proof Verification
 
-- Noir circuit validates task completion without revealing output
-- Sunspot Groth16 verifier on-chain
-- 388-byte proofs, ~50k compute units verification
+- Circom circuit validates task completion without revealing output
+- groth16-solana Groth16 verifier on-chain (audited by OtterSec, Neodyme, Zellic)
+- 256-byte proofs, ~200k compute units verification
 
 ### 6.4 Privacy Cash Integration
 
@@ -475,8 +475,8 @@ min_stake_for_dispute: configurable
 ### 8.3 References
 
 - [Anchor Framework](https://www.anchor-lang.com/)
-- [Noir Language](https://noir-lang.org/)
-- [Sunspot Verifier](https://github.com/Sunspot-Labs/sunspot)
+- [Circom Language](https://docs.circom.io/)
+- [groth16-solana](https://github.com/Lightprotocol/groth16-solana)
 - [Privacy Cash](https://privacycash.io/)
 - [AgenC Repository](https://github.com/tetsuo-ai/AgenC)
 

--- a/circuits/README.md
+++ b/circuits/README.md
@@ -1,8 +1,24 @@
-# AgenC ZK Circuits
+# AgenC ZK Circuits (DEPRECATED)
+
+> **⚠️ DEPRECATED**: This directory contains the old Noir-based circuits.
+> The project has migrated to Circom circuits with groth16-solana verification.
+> See [`circuits-circom/`](../circuits-circom/) for the current implementation.
+
+## Migration Notice
+
+The ZK proof system has been migrated from:
+- **Old**: Noir + Sunspot (388-byte proofs, external verifier)
+- **New**: Circom + groth16-solana (256-byte proofs, inline verification)
+
+See [Issue #158](https://github.com/tetsuo-ai/AgenC/issues/158) for migration details.
+
+---
+
+## Legacy Documentation (Noir)
 
 Zero-knowledge circuits for private task completion verification on Solana.
 
-## Overview
+### Overview
 
 AgenC uses ZK proofs to let agents prove task completion without revealing their outputs. The system consists of:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,14 +28,14 @@ flowchart TB
     end
 
     subgraph ZK["Zero Knowledge"]
-        Z1[Noir Circuit]
-        Z2[Sunspot Prover]
+        Z1[Circom Circuit]
+        Z2[snarkjs Prover]
         Z3[Groth16 Proof]
     end
 
     subgraph Verify["On-Chain Verification"]
-        V1[Sunspot Verifier]
-        V2[8fHUGmj...onwQQ]
+        V1[groth16-solana Verifier]
+        V2[Inline Verification]
     end
 
     subgraph Recipient["Private Recipient"]
@@ -77,8 +77,8 @@ sequenceDiagram
     participant AgenC Program
     participant Privacy Cash
     participant Agent
-    participant Noir Circuit
-    participant Sunspot Verifier
+    participant Circom Circuit
+    participant groth16-solana Verifier
     participant Recipient
 
     Note over Creator,Recipient: Task Creation Phase
@@ -89,13 +89,13 @@ sequenceDiagram
     Note over Creator,Recipient: Task Execution Phase
     Agent->>AgenC Program: claimTask(task_id)
     Agent->>Agent: Complete work off-chain
-    Agent->>Noir Circuit: Generate witness (output, salt)
-    Noir Circuit->>Noir Circuit: Prove output matches constraint
-    Noir Circuit-->>Agent: zk_proof (388 bytes)
+    Agent->>Circom Circuit: Generate witness (output, salt)
+    Circom Circuit->>Circom Circuit: Prove output matches constraint
+    Circom Circuit-->>Agent: zk_proof (256 bytes)
 
     Note over Creator,Recipient: Verification & Payment Phase
-    Agent->>Sunspot Verifier: verify(proof, public_inputs)
-    Sunspot Verifier->>AgenC Program: proof_valid = true
+    Agent->>groth16-solana Verifier: verify(proof, public_inputs)
+    groth16-solana Verifier->>AgenC Program: proof_valid = true
     AgenC Program->>Privacy Cash: authorize_withdrawal
     Privacy Cash->>Recipient: withdraw(amount)
 
@@ -104,7 +104,7 @@ sequenceDiagram
 
 ## Component Details
 
-### Noir Circuit (`circuits/task_completion/`)
+### Circom Circuit (`circuits-circom/task_completion/`)
 
 ```
 Public Inputs:
@@ -128,7 +128,6 @@ Constraints:
 | Component | Program ID |
 |-----------|-----------|
 | AgenC Coordination | `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` |
-| Sunspot Verifier | `8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ` |
 | Privacy Cash | `9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD` |
 
 ### Privacy Guarantees
@@ -143,6 +142,6 @@ Constraints:
 
 - **Blockchain**: Solana
 - **Smart Contracts**: Anchor (Rust)
-- **ZK Proofs**: Noir + Sunspot (Groth16)
+- **ZK Proofs**: Circom + groth16-solana (Groth16)
 - **Privacy Pool**: Privacy Cash
 - **SDK**: TypeScript (@agenc/sdk)

--- a/examples/helius-webhook/README.md
+++ b/examples/helius-webhook/README.md
@@ -4,7 +4,7 @@ Real-time monitoring of private task completions via Helius webhooks.
 
 ## Features
 
-- Subscribe to Sunspot verifier events
+- Subscribe to AgenC program events
 - Parse task completion transactions
 - REST API for task history and stats
 - WebSocket log subscription (alternative)
@@ -73,8 +73,9 @@ npm run subscribe
 
 | Program | Address |
 |---------|---------|
-| Sunspot Verifier | `8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ` |
 | AgenC Coordination | `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` |
+
+Note: ZK proof verification is now inline via groth16-solana (no external verifier program).
 
 ## Integration Examples
 

--- a/examples/tetsuo-integration/README.md
+++ b/examples/tetsuo-integration/README.md
@@ -40,14 +40,14 @@ This example demonstrates how Tetsuo AI agents integrate with AgenC to:
          |
          v
 +------------------+
-|   Noir Circuit   |
+|  Circom Circuit  |
 |  (ZK proof gen)  |
 +--------+---------+
          |
          v
 +------------------+     +------------------+
-| Sunspot Verifier |---->|   Privacy Cash   |
-|  (on-chain)      |     |   (withdrawal)   |
+| groth16-solana   |---->|   Privacy Cash   |
+|  (inline verify) |     |   (withdrawal)   |
 +--------+---------+     +--------+---------+
                                   |
                                   v
@@ -123,7 +123,7 @@ await agent.run();
 
 ## ZK Proof Details
 
-The Noir circuit proves:
+The Circom circuit proves:
 - Output matches expected constraint hash
 - Commitment correctly binds output to proof
 - Proof is bound to specific task and agent
@@ -164,12 +164,13 @@ const outputHash = await tetsuoClient.hashOutput(result);
 | Contract | Address |
 |----------|---------|
 | AgenC Program | `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` |
-| Groth16 Verifier | `8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ` |
 | Privacy Cash | `9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD` |
+
+Note: ZK proof verification is inline via groth16-solana (no external verifier program).
 
 ## Links
 
 - [Tetsuo AI](https://tetsuo.ai)
 - [AgenC SDK](https://github.com/tetsuo-ai/AgenC)
-- [Noir Language](https://noir-lang.org)
+- [Circom Language](https://docs.circom.io)
 - [Privacy Cash](https://privacycash.io)

--- a/examples/zk-proof-demo/README.md
+++ b/examples/zk-proof-demo/README.md
@@ -4,22 +4,16 @@ Demonstrates the full AgenC ZK proof generation flow using the SDK.
 
 ## Prerequisites
 
-1. Install nargo:
+1. Install circom and snarkjs:
 ```bash
-curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-noirup
+npm install -g circom snarkjs
 ```
 
-2. Install sunspot (see `circuits/README.md` for details)
-
-3. Compile circuits and generate proving keys:
+2. Compile circuits and generate proving keys:
 ```bash
-cd ../../circuits/task_completion
-nargo compile
-sunspot setup target/task_completion.ccs
-
-cd ../hash_helper
-nargo compile
+cd ../../circuits-circom/task_completion
+circom circuit.circom --r1cs --wasm --sym
+snarkjs groth16 setup circuit.r1cs pot_final.ptau circuit_0000.zkey
 ```
 
 ## Run
@@ -32,8 +26,8 @@ npm run demo
 ## What it does
 
 1. Generates test data (task PDA, agent keypair, output, salt)
-2. Computes Poseidon2 hashes via the hash_helper circuit
-3. Generates a Groth16 proof via sunspot
+2. Computes Poseidon hashes (circomlib compatible)
+3. Generates a Groth16 proof via snarkjs
 4. Verifies the proof locally
 
 The proof proves knowledge of an output satisfying a task constraint without revealing the output.
@@ -46,8 +40,7 @@ The proof proves knowledge of an output satisfying a task constraint without rev
 ========================================
 
 Checking prerequisites...
-  nargo: installed
-  sunspot: installed
+  snarkjs: installed
 
 Generating test data...
   Task PDA: 7xKXtg2CW6...
@@ -55,16 +48,16 @@ Generating test data...
   Output: [1, 2, 3, 4]
   Salt: 12345678901234567890...
 
-Step 1: Computing hashes via nargo...
+Step 1: Computing hashes...
   Hashes computed successfully!
   Constraint hash: 0x1a2b3c4d...
   Output commitment: 0x5e6f7a8b...
-  Time: 1234 ms
+  Time: 50 ms
 
 Step 2: Generating ZK proof...
   Proof generated successfully!
-  Proof size: 388 bytes
-  Generation time: 45678 ms
+  Proof size: 256 bytes
+  Generation time: 2500 ms
 
 Step 3: Verifying proof locally...
   Proof verified successfully!

--- a/scripts/deploy-verifier.sh
+++ b/scripts/deploy-verifier.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
-# Deploy Sunspot verifier keys to Solana
+# DEPRECATED: This script was used for deploying Sunspot verifier keys.
+#
+# The project has migrated to groth16-solana with inline verification.
+# The verification key is now embedded directly in the program code
+# (see: programs/agenc-coordination/src/verifying_key.rs)
+#
+# This script is kept for historical reference only.
+#
+# See Issue #158 for migration details.
+
+echo "DEPRECATED: This script is no longer needed."
+echo "groth16-solana verification key is embedded in the program."
+echo "See: programs/agenc-coordination/src/verifying_key.rs"
+exit 0
+
+# --- Legacy code below ---
+
+# Deploy Sunspot verifier keys to Solana (DEPRECATED)
 #
 # This script uploads the verification key to an on-chain account
 # for use with the Sunspot verifier program.

--- a/tests/fixtures/proofs/README.md
+++ b/tests/fixtures/proofs/README.md
@@ -6,10 +6,10 @@ This directory contains test data for ZK proof verification tests.
 
 The tests in `tests/zk-proof-lifecycle.ts` and `tests/complete_task_private.ts` use
 synthetic test proofs that exercise the on-chain validation logic without requiring
-the Sunspot verifier program.
+full ZK verification.
 
 This approach tests:
-- Proof size validation (exactly 388 bytes)
+- Proof size validation (exactly 256 bytes for groth16-solana)
 - Constraint hash binding (must match task)
 - Private task requirement (non-zero constraint hash)
 - Task status validation (must be InProgress)
@@ -22,40 +22,44 @@ For end-to-end testing with real ZK proof verification:
 
 ### Prerequisites
 
-1. Install Noir toolchain:
+1. Install circom and snarkjs:
    ```bash
-   curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash
-   noirup
+   npm install -g circom snarkjs
    ```
 
 2. Compile the circuit:
    ```bash
-   cd circuits/task_completion
-   nargo compile
+   cd circuits-circom/task_completion
+   circom circuit.circom --r1cs --wasm --sym
    ```
 
 ### Proof Generation
 
-1. Create a Prover.toml with your inputs:
-   ```toml
-   # Public inputs
-   task_id = [/* 32 bytes */]
-   agent_pubkey = [/* 32 bytes */]
-   constraint_hash = [/* 32 bytes */]
-   output_commitment = [/* 32 bytes */]
-   expected_binding = [/* 32 bytes */]
-
-   # Private inputs
-   output = [/* 4 field elements */]
-   salt = "12345"
+1. Create an input.json with your inputs:
+   ```json
+   {
+     "task_id": [/* 32 bytes */],
+     "agent_pubkey": [/* 32 bytes */],
+     "constraint_hash": "...",
+     "output_commitment": "...",
+     "output": [/* 4 field elements */],
+     "salt": "12345"
+   }
    ```
 
-2. Generate the proof:
-   ```bash
-   nargo prove
+2. Generate the proof via SDK:
+   ```typescript
+   import { generateProof, generateSalt } from '@agenc/sdk';
+
+   const result = await generateProof({
+     taskPda,
+     agentPubkey,
+     output: [1n, 2n, 3n, 4n],
+     salt: generateSalt(),
+   });
    ```
 
-3. The proof will be written to `proofs/proof.bin` (388 bytes for Groth16 on BN254).
+3. The proof will be 256 bytes for Groth16 on BN254.
 
 ### Using Real Proofs in Tests
 
@@ -67,32 +71,32 @@ const proofData = fs.readFileSync("tests/fixtures/proofs/valid_proof.bin");
 
 const proof = {
   proofData: Array.from(proofData),
-  constraintHash: /* from your Prover.toml */,
-  outputCommitment: /* from your Prover.toml */,
-  expectedBinding: /* from your Prover.toml */,
+  constraintHash: /* computed hash */,
+  outputCommitment: /* computed commitment */,
+  expectedBinding: /* computed binding */,
 };
 ```
 
-### Verifier Program
+### Verification
 
-The Sunspot Groth16 verifier must be deployed for on-chain verification:
-- Program ID: `8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ`
-- The verification key must match the task_completion circuit
+The groth16-solana verifier is embedded in the AgenC program:
+- Verification happens inline during `complete_task_private`
+- The verification key is embedded in the program's verifying_key.rs
 
 ## Test Proof Files
 
 | File | Description |
 |------|-------------|
-| `valid_proof.bin` | Valid 388-byte Groth16 proof (when generated) |
+| `valid_proof.bin` | Valid 256-byte Groth16 proof (when generated) |
 | `tampered_proof.bin` | Valid size but corrupted data |
-| `undersized.bin` | Less than 388 bytes |
-| `oversized.bin` | More than 388 bytes |
+| `undersized.bin` | Less than 256 bytes |
+| `oversized.bin` | More than 256 bytes |
 
 Note: Actual proof files are not checked in. Generate them locally for full testing.
 
 ## CI Considerations
 
-For CI without the Sunspot verifier:
+For CI:
 - Tests validate all on-chain logic before ZK verification
-- ZK verification failures are expected with synthetic proofs
-- Full verification requires devnet/testnet with deployed verifier
+- ZK verification uses the inline groth16-solana verifier
+- Full verification tests require proper trusted setup artifacts


### PR DESCRIPTION
  ## Summary

  - Replace all Sunspot/Noir references with groth16-solana/Circom
  - Update proof size from 388 bytes to 256 bytes in documentation
  - Mark deprecated circuits/ directory and deploy-verifier.sh script
  - Update architecture diagrams and system documentation

  ## Test plan

  - [ ] Verify documentation renders correctly in GitHub
  - [ ] Check all internal links still work
  - [ ] Confirm README examples are accurate

  ---

  **Note:** This PR depends on #161 (SDK snarkjs update) being merged first.