### PR TITLE
fix: escrow distributed counter uses worker_reward for correct accounting

### DIFF
--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -81,16 +81,20 @@ pub fn transfer_rewards<'info>(
 }
 
 /// Update claim state after completion.
+///
+/// Note: `reward_amount` is kept for API compatibility but `worker_reward`
+/// (the actual amount paid) is used for the distributed counter to maintain
+/// invariant E3: `distributed <= amount`.
 pub fn update_claim_state(
     claim: &mut Account<TaskClaim>,
     escrow: &mut Account<TaskEscrow>,
     worker_reward: u64,
-    reward_amount: u64,
+    _reward_amount: u64,
 ) -> Result<()> {
     claim.reward_paid = worker_reward;
     escrow.distributed = escrow
         .distributed
-        .checked_add(reward_amount)
+        .checked_add(worker_reward)
         .ok_or(CoordinationError::ArithmeticOverflow)?;
     Ok(())
 }


### PR DESCRIPTION
Fixes #100

The `update_claim_state` function was using `reward_amount` (full task reward) instead of `worker_reward` (actual amount paid to worker) when updating the escrow's `distributed` counter. For collaborative tasks with multiple workers, this caused `distributed` to be inflated (e.g., 3x for a 3-worker task), violating invariant E3: `distributed <= amount`.

**Fix:** Changed the `checked_add` call to use `worker_reward` instead of `reward_amount`. The `reward_amount` parameter is kept (as `_reward_amount`) for API compatibility.