### PR TITLE
fix: SDK anchor CJS interop and MCP server runtime

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -2,7 +2,7 @@
   "name": "@agenc/mcp",
   "version": "0.1.0",
   "description": "Model Context Protocol server for AgenC development — exposes protocol operations as MCP tools",
-  "main": "dist/index.js",
+  "main": "dist/index.cjs",
   "types": "dist/index.d.ts",
   "bin": {
     "agenc-mcp": "./dist/index.js"
@@ -58,10 +58,15 @@
     "@solana/web3.js": ">=1.90.0"
   },
   "peerDependenciesMeta": {
-    "@coral-xyz/anchor": { "optional": true },
-    "@solana/web3.js": { "optional": true }
+    "@coral-xyz/anchor": {
+      "optional": true
+    },
+    "@solana/web3.js": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=18.0.0"
-  }
+  },
+  "type": "module"
 }

--- a/mcp/tsup.config.ts
+++ b/mcp/tsup.config.ts
@@ -8,23 +8,17 @@ export default defineConfig({
   clean: true,
   platform: 'node',
   target: 'node18',
-  // Bundle these dependencies into the output to avoid ESM/CJS interop
-  // issues at runtime. @coral-xyz/anchor is CJS-only and causes failures
-  // when consumed as an external dependency in both CJS and ESM contexts.
-  noExternal: [
-    '@coral-xyz/anchor',
-    '@solana/web3.js',
-    '@agenc/runtime',
-    '@agenc/sdk',
-  ],
+  // Bundle everything - resolving anchor interop at build time
+  noExternal: [/.*/],
   esbuildOptions(options) {
-    // Force CJS resolution throughout the dependency tree.
-    // esbuild's export map resolution picks .mjs files from @agenc/sdk
-    // and @agenc/runtime, which triggers broken ESM interop with
-    // @coral-xyz/anchor. Alias to CJS entry points directly.
+    // Force resolution to CJS entry points.
+    // The SDK/Runtime .mjs files have broken anchor interop,
+    // so we resolve to .js (CJS) entries where require() works.
     options.alias = {
       '@agenc/sdk': path.resolve(__dirname, '../sdk/dist/index.js'),
       '@agenc/runtime': path.resolve(__dirname, '../runtime/dist/index.js'),
     };
+    // Mark native Node modules as external
+    options.external = ['fs', 'path', 'os', 'crypto', 'http', 'https', 'net', 'tls', 'stream', 'url', 'zlib', 'events', 'util', 'buffer', 'assert', 'child_process', 'worker_threads', 'node:*'];
   },
 });

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -6,7 +6,7 @@
 
 import { Connection, PublicKey, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js';
 import type { Idl } from '@coral-xyz/anchor';
-import anchor from '@coral-xyz/anchor';
+import * as anchor from '@coral-xyz/anchor';
 const { Program, AnchorProvider, Wallet } = anchor;
 type Program = InstanceType<typeof Program>;
 type AnchorProvider = InstanceType<typeof AnchorProvider>;

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -13,7 +13,7 @@ import {
   LAMPORTS_PER_SOL,
 } from '@solana/web3.js';
 import type { Program } from '@coral-xyz/anchor';
-import anchor from '@coral-xyz/anchor';
+import * as anchor from '@coral-xyz/anchor';
 const { BN } = anchor;
 type BN = InstanceType<typeof BN>;
 import { PROGRAM_ID, SEEDS, TaskState, U64_SIZE, DISCRIMINATOR_SIZE, PERCENT_BASE, DEFAULT_FEE_PERCENT } from './constants';


### PR DESCRIPTION
Fixes the MCP server runtime crash from #179/#180.

## Root Cause
SDK used `import anchor from "@coral-xyz/anchor"` (default import) but anchor has no default export. tsup converted this to `.default` access in CJS output → `undefined` → crash.

## Fix
- **SDK**: `import anchor from` → `import * as anchor from` in `client.ts` and `tasks.ts`
- **MCP**: Bundle all deps via `noExternal`, alias SDK/runtime to CJS entries

## Tested
```
$ echo initialize | node dist/index.cjs
→ {"result":{"serverInfo":{"name":"AgenC Protocol Tools","version":"0.1.0"},...}}

$ tools/list → 21 tools registered
$ agenc_decode_error(6000) → "AgentAlreadyRegistered"  
$ agenc_decode_capabilities("7") → "COMPUTE, INFERENCE, STORAGE"
$ resources/read(agenc://error-codes) → Full 79-code reference
```