### PR TITLE
feat: add test runner, ZK circuit, and account inspector MCP tools

### DIFF
--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -5,6 +5,9 @@ import { registerTaskTools } from './tools/tasks.js';
 import { registerProtocolTools } from './tools/protocol.js';
 import { registerDisputeTools } from './tools/disputes.js';
 import { registerConnectionTools } from './tools/connection.js';
+import { registerTestingTools } from './tools/testing.js';
+import { registerCircuitTools } from './tools/circuits.js';
+import { registerInspectorTools } from './tools/inspector.js';
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -18,6 +21,9 @@ export function createServer(): McpServer {
   registerTaskTools(server);
   registerProtocolTools(server);
   registerDisputeTools(server);
+  registerTestingTools(server);
+  registerCircuitTools(server);
+  registerInspectorTools(server);
 
   // Register MCP resources
   registerResources(server);

--- a/mcp/src/tools/circuits.ts
+++ b/mcp/src/tools/circuits.ts
@@ -1,0 +1,591 @@
+/**
+ * ZK Circuit MCP Tools
+ *
+ * Wraps circom and snarkjs CLI tools for compiling, proving, and verifying
+ * Circom ZK circuits with structured output parsing.
+ */
+
+import { execFile } from 'child_process';
+import { stat, readFile } from 'fs/promises';
+import path from 'path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+/** Root of the AgenC repository.
+ *  When bundled into dist/index.cjs, __dirname is mcp/dist/ (2 up).
+ *  When running from source, __dirname is mcp/src/tools/ (4 up). */
+function findProjectRoot(): string {
+  const { existsSync } = require('fs');
+  const bundled = path.resolve(__dirname, '..', '..');
+  if (existsSync(path.join(bundled, 'Anchor.toml'))) return bundled;
+  const source = path.resolve(__dirname, '..', '..', '..', '..');
+  if (existsSync(path.join(source, 'Anchor.toml'))) return source;
+  return process.cwd();
+}
+const PROJECT_ROOT = findProjectRoot();
+
+/** Default circuit directory */
+const DEFAULT_CIRCUIT_DIR = path.join(PROJECT_ROOT, 'circuits-circom', 'task_completion');
+
+/**
+ * Validate a circuit path to prevent directory traversal and injection.
+ */
+function validatePath(inputPath: string | undefined, defaultDir: string): string {
+  if (!inputPath) return defaultDir;
+
+  // Reject path traversal
+  if (inputPath.includes('..')) {
+    throw new Error('Path traversal not allowed');
+  }
+
+  // Reject shell metacharacters
+  const dangerousChars = /[;&|`$(){}[\]<>!]/;
+  if (dangerousChars.test(inputPath)) {
+    throw new Error('Invalid characters in path');
+  }
+
+  // Resolve relative to project root
+  if (path.isAbsolute(inputPath)) {
+    return inputPath;
+  }
+  return path.resolve(PROJECT_ROOT, inputPath);
+}
+
+/**
+ * Run a command and capture output.
+ */
+function runCommand(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const proc = execFile(cmd, args, {
+      cwd,
+      timeout: timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+    }, (error, stdout, stderr) => {
+      resolve({
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        exitCode: error
+          ? (error as NodeJS.ErrnoException & { code?: number | string }).code === 'ETIMEDOUT'
+            ? 124
+            : (proc.exitCode ?? 1)
+          : 0,
+      });
+    });
+  });
+}
+
+/**
+ * Check if a file or directory exists.
+ */
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get file size in bytes.
+ */
+async function getFileSize(p: string): Promise<number> {
+  try {
+    const s = await stat(p);
+    return s.size;
+  } catch {
+    return 0;
+  }
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
+}
+
+export function registerCircuitTools(server: McpServer): void {
+  server.tool(
+    'agenc_compile_circuit',
+    'Compile a Circom circuit to R1CS + WASM, parsing constraint and signal counts',
+    {
+      circuit_path: z.string().optional().describe('Path to circuit directory (default: circuits-circom/task_completion/)'),
+    },
+    async ({ circuit_path }) => {
+      try {
+        const circuitDir = validatePath(circuit_path, DEFAULT_CIRCUIT_DIR);
+
+        // Find the .circom file
+        const circomFile = path.join(circuitDir, 'circuit.circom');
+        if (!(await fileExists(circomFile))) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Error: circuit file not found at ' + circomFile + '\nLooking for circuit.circom in ' + circuitDir,
+            }],
+          };
+        }
+
+        const targetDir = path.join(circuitDir, 'target');
+
+        const { stdout, stderr, exitCode } = await runCommand(
+          'circom',
+          [circomFile, '--r1cs', '--wasm', '--sym', '-o', targetDir],
+          circuitDir,
+          120_000,
+        );
+
+        const combined = stdout + '\n' + stderr;
+
+        if (exitCode !== 0) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Compilation FAILED (exit ' + exitCode + ')\n\n' + combined.slice(-3000),
+            }],
+          };
+        }
+
+        // Parse output for constraint and signal counts
+        const constraintMatch = /non-linear constraints:\s*(\d+)/i.exec(combined)
+          ?? /constraints:\s*(\d+)/i.exec(combined);
+        const signalMatch = /private inputs:\s*(\d+)/i.exec(combined)
+          ?? /signals:\s*(\d+)/i.exec(combined);
+        const publicMatch = /public inputs:\s*(\d+)/i.exec(combined);
+        const outputMatch = /outputs:\s*(\d+)/i.exec(combined);
+
+        const lines = [
+          'Compilation SUCCESS',
+          '',
+          '--- Circuit Stats ---',
+        ];
+
+        if (constraintMatch) lines.push('Constraints: ' + constraintMatch[1]);
+        if (publicMatch) lines.push('Public Inputs: ' + publicMatch[1]);
+        if (signalMatch) lines.push('Private Inputs: ' + signalMatch[1]);
+        if (outputMatch) lines.push('Outputs: ' + outputMatch[1]);
+
+        // Check output files
+        const r1csPath = path.join(targetDir, 'circuit.r1cs');
+        const wasmDir = path.join(targetDir, 'circuit_js');
+
+        lines.push('');
+        lines.push('--- Output Files ---');
+        if (await fileExists(r1csPath)) {
+          lines.push('R1CS: ' + r1csPath + ' (' + formatFileSize(await getFileSize(r1csPath)) + ')');
+        }
+        if (await fileExists(wasmDir)) {
+          lines.push('WASM: ' + wasmDir + '/');
+        }
+        if (await fileExists(path.join(targetDir, 'circuit.sym'))) {
+          lines.push('Symbols: ' + path.join(targetDir, 'circuit.sym'));
+        }
+
+        if (!constraintMatch && !signalMatch) {
+          lines.push('', '--- Raw Output ---', combined.slice(0, 2000));
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_generate_witness',
+    'Generate a witness from input signals using snarkjs',
+    {
+      input_json: z.string().describe('JSON string with input signals (e.g. {"task_id": "1", "agent_pubkey": "..."})'),
+      circuit_path: z.string().optional().describe('Path to circuit directory (default: circuits-circom/task_completion/)'),
+    },
+    async ({ input_json, circuit_path }) => {
+      try {
+        const circuitDir = validatePath(circuit_path, DEFAULT_CIRCUIT_DIR);
+        const targetDir = path.join(circuitDir, 'target');
+        const wasmPath = path.join(targetDir, 'circuit_js', 'circuit.wasm');
+        const witnessPath = path.join(targetDir, 'witness.wtns');
+
+        if (!(await fileExists(wasmPath))) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Error: compiled WASM not found at ' + wasmPath + '\nRun agenc_compile_circuit first.',
+            }],
+          };
+        }
+
+        // Validate JSON
+        try {
+          JSON.parse(input_json);
+        } catch {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: invalid JSON input' }],
+          };
+        }
+
+        // Write input to temp file
+        const inputPath = path.join(targetDir, 'input.json');
+        const { writeFile } = await import('fs/promises');
+        await writeFile(inputPath, input_json);
+
+        const { stdout, stderr, exitCode } = await runCommand(
+          'npx',
+          ['snarkjs', 'wtns', 'calculate', wasmPath, inputPath, witnessPath],
+          circuitDir,
+          60_000,
+        );
+
+        if (exitCode !== 0) {
+          const combined = stdout + '\n' + stderr;
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Witness generation FAILED (exit ' + exitCode + ')\n\n' + combined.slice(-2000),
+            }],
+          };
+        }
+
+        const witnessSize = await getFileSize(witnessPath);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: [
+              'Witness generation SUCCESS',
+              'Output: ' + witnessPath + ' (' + formatFileSize(witnessSize) + ')',
+            ].join('\n'),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_generate_proof',
+    'Generate a Groth16 proof from a witness using snarkjs',
+    {
+      witness_path: z.string().optional().describe('Path to witness file (default: target/witness.wtns in circuit dir)'),
+      circuit_path: z.string().optional().describe('Path to circuit directory (default: circuits-circom/task_completion/)'),
+    },
+    async ({ witness_path, circuit_path }) => {
+      try {
+        const circuitDir = validatePath(circuit_path, DEFAULT_CIRCUIT_DIR);
+        const targetDir = path.join(circuitDir, 'target');
+
+        const witnessFile = witness_path
+          ? validatePath(witness_path, targetDir)
+          : path.join(targetDir, 'witness.wtns');
+        const zkeyPath = path.join(targetDir, 'circuit_final.zkey');
+        const proofPath = path.join(targetDir, 'proof.json');
+        const publicPath = path.join(targetDir, 'public.json');
+
+        if (!(await fileExists(witnessFile))) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Error: witness file not found at ' + witnessFile + '\nRun agenc_generate_witness first.',
+            }],
+          };
+        }
+
+        if (!(await fileExists(zkeyPath))) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Error: proving key not found at ' + zkeyPath + '\nRun trusted setup (powers of tau + phase 2) first.',
+            }],
+          };
+        }
+
+        const { stdout, stderr, exitCode } = await runCommand(
+          'npx',
+          ['snarkjs', 'groth16', 'prove', zkeyPath, witnessFile, proofPath, publicPath],
+          circuitDir,
+          120_000,
+        );
+
+        if (exitCode !== 0) {
+          const combined = stdout + '\n' + stderr;
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Proof generation FAILED (exit ' + exitCode + ')\n\n' + combined.slice(-2000),
+            }],
+          };
+        }
+
+        const proofSize = await getFileSize(proofPath);
+        const publicSize = await getFileSize(publicPath);
+
+        const lines = [
+          'Proof generation SUCCESS',
+          '',
+          'Proof: ' + proofPath + ' (' + formatFileSize(proofSize) + ')',
+          'Public inputs: ' + publicPath + ' (' + formatFileSize(publicSize) + ')',
+        ];
+
+        // Show public inputs count
+        try {
+          const publicData = JSON.parse(await readFile(publicPath, 'utf-8'));
+          if (Array.isArray(publicData)) {
+            lines.push('Public input count: ' + publicData.length);
+          }
+        } catch {
+          // Skip if can't parse
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_verify_proof',
+    'Verify a Groth16 proof locally using snarkjs',
+    {
+      proof_path: z.string().optional().describe('Path to proof.json (default: target/proof.json in circuit dir)'),
+      public_path: z.string().optional().describe('Path to public.json (default: target/public.json in circuit dir)'),
+      circuit_path: z.string().optional().describe('Path to circuit directory (default: circuits-circom/task_completion/)'),
+    },
+    async ({ proof_path, public_path, circuit_path }) => {
+      try {
+        const circuitDir = validatePath(circuit_path, DEFAULT_CIRCUIT_DIR);
+        const targetDir = path.join(circuitDir, 'target');
+
+        const proofFile = proof_path
+          ? validatePath(proof_path, targetDir)
+          : path.join(targetDir, 'proof.json');
+        const publicFile = public_path
+          ? validatePath(public_path, targetDir)
+          : path.join(targetDir, 'public.json');
+        const vkPath = path.join(targetDir, 'verification_key.json');
+
+        if (!(await fileExists(proofFile))) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Error: proof file not found at ' + proofFile,
+            }],
+          };
+        }
+
+        if (!(await fileExists(publicFile))) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Error: public inputs file not found at ' + publicFile,
+            }],
+          };
+        }
+
+        if (!(await fileExists(vkPath))) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Error: verification key not found at ' + vkPath,
+            }],
+          };
+        }
+
+        const { stdout, stderr, exitCode } = await runCommand(
+          'npx',
+          ['snarkjs', 'groth16', 'verify', vkPath, publicFile, proofFile],
+          circuitDir,
+          60_000,
+        );
+
+        const combined = (stdout + '\n' + stderr).trim();
+        const isValid = exitCode === 0 && /OK|valid/i.test(combined);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: [
+              'Verification: ' + (isValid ? 'VALID' : 'INVALID'),
+              '',
+              'Proof: ' + proofFile,
+              'Public inputs: ' + publicFile,
+              'Verification key: ' + vkPath,
+              '',
+              combined.length > 0 ? combined.slice(0, 1000) : '(no output)',
+            ].join('\n'),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_get_circuit_info',
+    'Get circuit metadata: file existence, compiled artifacts, constraint counts',
+    {
+      circuit_path: z.string().optional().describe('Path to circuit directory (default: circuits-circom/task_completion/)'),
+    },
+    async ({ circuit_path }) => {
+      try {
+        const circuitDir = validatePath(circuit_path, DEFAULT_CIRCUIT_DIR);
+        const targetDir = path.join(circuitDir, 'target');
+
+        const lines = ['Circuit directory: ' + circuitDir, ''];
+
+        // Check source files
+        const circomFile = path.join(circuitDir, 'circuit.circom');
+        const inputExample = path.join(circuitDir, 'input.example.json');
+
+        lines.push('--- Source Files ---');
+        lines.push('circuit.circom: ' + (await fileExists(circomFile) ? 'exists (' + formatFileSize(await getFileSize(circomFile)) + ')' : 'NOT FOUND'));
+        lines.push('input.example.json: ' + (await fileExists(inputExample) ? 'exists' : 'not found'));
+
+        // Check compiled artifacts
+        const r1csPath = path.join(targetDir, 'circuit.r1cs');
+        const wasmDir = path.join(targetDir, 'circuit_js');
+        const symPath = path.join(targetDir, 'circuit.sym');
+        const zkeyPath = path.join(targetDir, 'circuit_final.zkey');
+        const vkPath = path.join(targetDir, 'verification_key.json');
+        const proofPath = path.join(targetDir, 'proof.json');
+        const publicPath = path.join(targetDir, 'public.json');
+
+        lines.push('');
+        lines.push('--- Compiled Artifacts ---');
+        lines.push('R1CS: ' + (await fileExists(r1csPath) ? formatFileSize(await getFileSize(r1csPath)) : 'not compiled'));
+        lines.push('WASM: ' + (await fileExists(wasmDir) ? 'exists' : 'not compiled'));
+        lines.push('Symbols: ' + (await fileExists(symPath) ? 'exists' : 'not compiled'));
+
+        lines.push('');
+        lines.push('--- Proving Setup ---');
+        lines.push('Proving key (zkey): ' + (await fileExists(zkeyPath) ? formatFileSize(await getFileSize(zkeyPath)) : 'not generated'));
+        lines.push('Verification key: ' + (await fileExists(vkPath) ? 'exists' : 'not generated'));
+
+        lines.push('');
+        lines.push('--- Proof Artifacts ---');
+        lines.push('proof.json: ' + (await fileExists(proofPath) ? formatFileSize(await getFileSize(proofPath)) : 'none'));
+        lines.push('public.json: ' + (await fileExists(publicPath) ? formatFileSize(await getFileSize(publicPath)) : 'none'));
+
+        // If R1CS exists, try to get info via snarkjs
+        if (await fileExists(r1csPath)) {
+          const { stdout, stderr } = await runCommand(
+            'npx',
+            ['snarkjs', 'r1cs', 'info', r1csPath],
+            circuitDir,
+            30_000,
+          );
+          const info = (stdout + '\n' + stderr).trim();
+          if (info.length > 0) {
+            lines.push('');
+            lines.push('--- R1CS Info ---');
+            lines.push(info.slice(0, 1500));
+          }
+        }
+
+        // Show verification key protocol if available
+        if (await fileExists(vkPath)) {
+          try {
+            const vk = JSON.parse(await readFile(vkPath, 'utf-8'));
+            if (vk.protocol) {
+              lines.push('');
+              lines.push('Proving system: ' + vk.protocol);
+            }
+            if (vk.nPublic !== undefined) {
+              lines.push('Public inputs (from VK): ' + vk.nPublic);
+            }
+          } catch {
+            // Skip parse errors
+          }
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_get_proving_key_info',
+    'Check proving key existence and size for the ZK circuit',
+    {
+      circuit_path: z.string().optional().describe('Path to circuit directory (default: circuits-circom/task_completion/)'),
+    },
+    async ({ circuit_path }) => {
+      try {
+        const circuitDir = validatePath(circuit_path, DEFAULT_CIRCUIT_DIR);
+        const targetDir = path.join(circuitDir, 'target');
+        const zkeyPath = path.join(targetDir, 'circuit_final.zkey');
+        const vkPath = path.join(targetDir, 'verification_key.json');
+
+        const lines = ['Circuit: ' + circuitDir, ''];
+
+        if (await fileExists(zkeyPath)) {
+          const size = await getFileSize(zkeyPath);
+          lines.push('Proving key: ' + zkeyPath);
+          lines.push('Size: ' + formatFileSize(size));
+
+          // Try to export VK info
+          if (await fileExists(vkPath)) {
+            try {
+              const vk = JSON.parse(await readFile(vkPath, 'utf-8'));
+              lines.push('');
+              lines.push('--- Verification Key ---');
+              lines.push('Protocol: ' + (vk.protocol ?? 'unknown'));
+              lines.push('Curve: ' + (vk.curve ?? 'unknown'));
+              if (vk.nPublic !== undefined) lines.push('Public inputs: ' + vk.nPublic);
+            } catch {
+              // Skip
+            }
+          }
+
+          lines.push('');
+          lines.push('Status: Ready for proof generation');
+        } else {
+          lines.push('Proving key: NOT FOUND');
+          lines.push('Expected at: ' + zkeyPath);
+          lines.push('');
+          lines.push('To generate a proving key, run the trusted setup:');
+          lines.push('  1. npx snarkjs powersoftau new bn128 <power> pot_0000.ptau');
+          lines.push('  2. npx snarkjs powersoftau contribute pot_0000.ptau pot_0001.ptau');
+          lines.push('  3. npx snarkjs powersoftau prepare phase2 pot_0001.ptau pot_final.ptau');
+          lines.push('  4. npx snarkjs groth16 setup circuit.r1cs pot_final.ptau circuit_0000.zkey');
+          lines.push('  5. npx snarkjs zkey contribute circuit_0000.zkey circuit_final.zkey');
+          lines.push('  6. npx snarkjs zkey export verificationkey circuit_final.zkey verification_key.json');
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+}

--- a/mcp/src/tools/inspector.ts
+++ b/mcp/src/tools/inspector.ts
@@ -1,0 +1,670 @@
+/**
+ * Program Account Inspector MCP Tools
+ *
+ * Fetches and decodes on-chain AgenC accounts into human-readable JSON
+ * using the program IDL. Supports agent, task, escrow, dispute, and
+ * transaction inspection.
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import { BorshCoder } from '@coral-xyz/anchor';
+import { SEEDS } from '@agenc/sdk';
+import { getCapabilityNames, hexToBytes, IDL } from '@agenc/runtime';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import {
+  getConnection,
+  getReadOnlyProgram,
+  getCurrentProgramId,
+} from '../utils/connection.js';
+import {
+  formatSol,
+  formatTimestamp,
+  formatStatus,
+  formatTaskStatus,
+  formatTaskType,
+  formatDisputeStatus,
+  formatResolutionType,
+  formatBytes,
+} from '../utils/formatting.js';
+
+/** Known account type names from IDL */
+// Known account types: agentRegistration, task, taskEscrow, taskClaim,
+// dispute, disputeVote, authorityDisputeVote, protocolConfig, coordinationState
+
+/**
+ * Format any decoded account into readable text.
+ */
+function formatDecodedAccount(
+  data: Record<string, unknown>,
+  accountType: string,
+  pubkey: PublicKey,
+): string {
+  const lines: string[] = ['Account: ' + pubkey.toBase58(), 'Type: ' + accountType, ''];
+
+  for (const [key, value] of Object.entries(data)) {
+    lines.push(formatField(key, value));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a single field with type-aware rendering.
+ */
+function formatField(key: string, value: unknown, indent = ''): string {
+  // PublicKey
+  if (value instanceof PublicKey) {
+    return indent + key + ': ' + value.toBase58();
+  }
+
+  // BN from Anchor
+  if (value !== null && typeof value === 'object' && 'toNumber' in (value as Record<string, unknown>)) {
+    const bn = value as { toNumber: () => number; toString: () => string };
+    const num = bn.toNumber();
+
+    // Detect timestamps (reasonable Unix timestamp range)
+    if (isTimestampField(key) && num > 1_000_000_000 && num < 10_000_000_000) {
+      return indent + key + ': ' + formatTimestamp(num);
+    }
+
+    // Detect lamport amounts
+    if (isLamportField(key)) {
+      return indent + key + ': ' + formatSol(num) + ' (' + num + ' lamports)';
+    }
+
+    // Capabilities bitmask
+    if (key === 'capabilities' || key === 'requiredCapabilities') {
+      const bigVal = BigInt(bn.toString());
+      const names = getCapabilityNames(bigVal);
+      return indent + key + ': ' + (names.length > 0 ? names.join(', ') : 'None') + ' (bitmask: ' + bigVal + ')';
+    }
+
+    return indent + key + ': ' + num;
+  }
+
+  // Byte arrays (agent IDs, hashes)
+  if (value instanceof Uint8Array || (Array.isArray(value) && value.length > 0 && typeof value[0] === 'number')) {
+    const bytes = value instanceof Uint8Array ? value : new Uint8Array(value as number[]);
+    if (bytes.length === 32) {
+      // Could be a pubkey or hash
+      if (isIdField(key)) {
+        return indent + key + ': ' + Buffer.from(bytes).toString('hex');
+      }
+      try {
+        const pk = new PublicKey(bytes);
+        return indent + key + ': ' + pk.toBase58() + ' (pubkey)';
+      } catch {
+        return indent + key + ': ' + Buffer.from(bytes).toString('hex');
+      }
+    }
+    return indent + key + ': ' + formatBytes(bytes);
+  }
+
+  // Anchor enum: { active: {} }
+  if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+    const keys = Object.keys(value as Record<string, unknown>);
+    if (keys.length === 1 && typeof (value as Record<string, unknown>)[keys[0]] === 'object') {
+      const inner = (value as Record<string, Record<string, unknown>>)[keys[0]];
+      if (inner !== null && Object.keys(inner).length === 0) {
+        // Format enums nicely
+        if (key === 'status') {
+          if (isTaskStatusField(key, keys[0])) return indent + key + ': ' + formatTaskStatus(value as Record<string, unknown>);
+          if (isDisputeStatusField(keys[0])) return indent + key + ': ' + formatDisputeStatus(value as Record<string, unknown>);
+          return indent + key + ': ' + formatStatus(value as Record<string, unknown>);
+        }
+        if (key === 'taskType') return indent + key + ': ' + formatTaskType(value as Record<string, unknown>);
+        if (key === 'resolutionType') return indent + key + ': ' + formatResolutionType(value as Record<string, unknown>);
+        return indent + key + ': ' + keys[0].charAt(0).toUpperCase() + keys[0].slice(1);
+      }
+    }
+  }
+
+  // null
+  if (value === null || value === undefined) {
+    return indent + key + ': null';
+  }
+
+  // Primitives
+  return indent + key + ': ' + String(value);
+}
+
+function isTimestampField(key: string): boolean {
+  const tsFields = ['registeredAt', 'lastActive', 'createdAt', 'updatedAt', 'deadline', 'votingDeadline', 'resolvedAt', 'claimedAt', 'completedAt', 'lastTaskCreated', 'lastDisputeInitiated', 'rateLimitWindowStart'];
+  return tsFields.includes(key);
+}
+
+function isLamportField(key: string): boolean {
+  const lamportFields = ['rewardAmount', 'stake', 'totalEarned', 'totalValueDistributed', 'minAgentStake', 'minArbiterStake', 'minStakeForDispute', 'balance', 'amount', 'refundAmount'];
+  return lamportFields.includes(key);
+}
+
+function isIdField(key: string): boolean {
+  return key.endsWith('Id') || key === 'agentId' || key === 'taskId' || key === 'disputeId';
+}
+
+function isTaskStatusField(_key: string, enumValue: string): boolean {
+  return ['open', 'inProgress', 'pendingValidation', 'completed', 'cancelled', 'disputed'].includes(enumValue);
+}
+
+function isDisputeStatusField(enumValue: string): boolean {
+  return ['active', 'resolved', 'expired'].includes(enumValue);
+}
+
+export function registerInspectorTools(server: McpServer): void {
+  server.tool(
+    'agenc_inspect_account',
+    'Fetch and decode any AgenC account by pubkey using the IDL',
+    {
+      pubkey: z.string().describe('Account public key (base58)'),
+    },
+    async ({ pubkey }) => {
+      try {
+        const connection = getConnection();
+        const pk = new PublicKey(pubkey);
+        const accountInfo = await connection.getAccountInfo(pk);
+
+        if (!accountInfo) {
+          return {
+            content: [{ type: 'text' as const, text: 'Account not found: ' + pubkey }],
+          };
+        }
+
+        const programId = getCurrentProgramId();
+
+        // Check if it's owned by the AgenC program
+        if (!accountInfo.owner.equals(programId)) {
+          const lines = [
+            'Account: ' + pubkey,
+            'Owner: ' + accountInfo.owner.toBase58(),
+            'Note: This account is NOT owned by AgenC program (' + programId.toBase58() + ')',
+            'Data length: ' + accountInfo.data.length + ' bytes',
+            'Lamports: ' + accountInfo.lamports + ' (' + formatSol(accountInfo.lamports) + ')',
+            'Executable: ' + accountInfo.executable,
+          ];
+          return {
+            content: [{ type: 'text' as const, text: lines.join('\n') }],
+          };
+        }
+
+        // Try to decode using IDL
+        const coder = new BorshCoder(IDL);
+        const decoded = coder.accounts.decodeAny(accountInfo.data);
+
+        if (!decoded) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: [
+                'Account: ' + pubkey,
+                'Owner: ' + accountInfo.owner.toBase58() + ' (AgenC program)',
+                'Data length: ' + accountInfo.data.length + ' bytes',
+                'Could not decode account data with IDL. The discriminator may not match any known account type.',
+              ].join('\n'),
+            }],
+          };
+        }
+
+        const data = decoded as Record<string, unknown>;
+        // Try to identify the account type from the discriminator
+        let accountType = 'Unknown';
+        for (const acct of IDL.accounts ?? []) {
+          try {
+            const testDecode = coder.accounts.decode(acct.name, accountInfo.data);
+            if (testDecode) {
+              accountType = acct.name;
+              break;
+            }
+          } catch {
+            // Not this type
+          }
+        }
+
+        const text = formatDecodedAccount(data, accountType, pk);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: text + '\n\nLamports: ' + accountInfo.lamports + ' (' + formatSol(accountInfo.lamports) + ')\nData length: ' + accountInfo.data.length + ' bytes',
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_inspect_agent',
+    'Inspect an agent account (derives PDA from agent_id or fetches by pubkey)',
+    {
+      agent_id: z.string().optional().describe('Agent ID (64-char hex string)'),
+      pubkey: z.string().optional().describe('Agent PDA address (base58)'),
+    },
+    async ({ agent_id, pubkey }) => {
+      try {
+        const program = getReadOnlyProgram();
+        const programId = getCurrentProgramId();
+        let pda: PublicKey;
+
+        if (pubkey) {
+          pda = new PublicKey(pubkey);
+        } else if (agent_id) {
+          const idBytes = hexToBytes(agent_id);
+          [pda] = PublicKey.findProgramAddressSync(
+            [SEEDS.AGENT, Buffer.from(idBytes)],
+            programId,
+          );
+        } else {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: provide either agent_id or pubkey' }],
+          };
+        }
+
+        const account = await program.account.agentRegistration.fetch(pda);
+        const acc = account as unknown as Record<string, unknown>;
+        const text = formatDecodedAccount(acc, 'AgentRegistration', pda);
+
+        return {
+          content: [{ type: 'text' as const, text: text }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_inspect_task',
+    'Inspect a task account (derives PDA from creator + task_id, or fetches by pubkey)',
+    {
+      creator: z.string().optional().describe('Task creator pubkey (base58)'),
+      task_id: z.string().optional().describe('Task ID (64-char hex string)'),
+      pubkey: z.string().optional().describe('Task PDA address (base58)'),
+    },
+    async ({ creator, task_id, pubkey }) => {
+      try {
+        const program = getReadOnlyProgram();
+        const programId = getCurrentProgramId();
+        let pda: PublicKey;
+
+        if (pubkey) {
+          pda = new PublicKey(pubkey);
+        } else if (creator && task_id) {
+          const creatorPk = new PublicKey(creator);
+          const idBytes = hexToBytes(task_id);
+          [pda] = PublicKey.findProgramAddressSync(
+            [SEEDS.TASK, creatorPk.toBuffer(), Buffer.from(idBytes)],
+            programId,
+          );
+        } else {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: provide either pubkey, or both creator and task_id' }],
+          };
+        }
+
+        const account = await program.account.task.fetch(pda);
+        const acc = account as unknown as Record<string, unknown>;
+
+        // Also derive escrow PDA for context
+        const [escrowPda] = PublicKey.findProgramAddressSync(
+          [SEEDS.ESCROW, pda.toBuffer()],
+          programId,
+        );
+
+        const text = formatDecodedAccount(acc, 'Task', pda);
+        const escrowBalance = await getConnection().getBalance(escrowPda).catch(() => 0);
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: text + '\n\n--- Escrow ---\nEscrow PDA: ' + escrowPda.toBase58() + '\nEscrow Balance: ' + formatSol(escrowBalance),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_inspect_escrow',
+    'Inspect an escrow account for a task (derives PDA from task or fetches by pubkey)',
+    {
+      task_pda: z.string().optional().describe('Task PDA (base58) to derive escrow from'),
+      pubkey: z.string().optional().describe('Escrow PDA address (base58) directly'),
+    },
+    async ({ task_pda, pubkey }) => {
+      try {
+        const connection = getConnection();
+        const programId = getCurrentProgramId();
+        let escrowAddr: PublicKey;
+        let taskAddr: PublicKey | null = null;
+
+        if (pubkey) {
+          escrowAddr = new PublicKey(pubkey);
+        } else if (task_pda) {
+          taskAddr = new PublicKey(task_pda);
+          [escrowAddr] = PublicKey.findProgramAddressSync(
+            [SEEDS.ESCROW, taskAddr.toBuffer()],
+            programId,
+          );
+        } else {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: provide either task_pda or pubkey' }],
+          };
+        }
+
+        const accountInfo = await connection.getAccountInfo(escrowAddr);
+
+        if (!accountInfo) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: 'Escrow account not found: ' + escrowAddr.toBase58() + (taskAddr ? '\nDerived from task: ' + taskAddr.toBase58() : ''),
+            }],
+          };
+        }
+
+        const lines = [
+          'Escrow PDA: ' + escrowAddr.toBase58(),
+        ];
+        if (taskAddr) lines.push('Task PDA: ' + taskAddr.toBase58());
+        lines.push(
+          'Owner: ' + accountInfo.owner.toBase58(),
+          'Balance: ' + formatSol(accountInfo.lamports) + ' (' + accountInfo.lamports + ' lamports)',
+          'Data length: ' + accountInfo.data.length + ' bytes',
+        );
+
+        // Fetch task for context
+        if (taskAddr) {
+          try {
+            const program = getReadOnlyProgram();
+            const task = await program.account.task.fetch(taskAddr) as unknown as Record<string, unknown>;
+            lines.push(
+              '',
+              '--- Task Context ---',
+              'Status: ' + formatTaskStatus(task.status as number | Record<string, unknown>),
+              'Type: ' + formatTaskType(task.taskType as number | Record<string, unknown>),
+              'Reward: ' + formatSol(Number(task.rewardAmount ?? 0)),
+              'Completions: ' + (task.completions ?? 0),
+              'Workers: ' + (task.currentWorkers ?? 0) + '/' + (task.maxWorkers ?? 1),
+            );
+          } catch {
+            // Task may not exist
+          }
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_inspect_dispute',
+    'Inspect a dispute account (derives PDA from dispute_id or fetches by pubkey)',
+    {
+      dispute_id: z.string().optional().describe('Dispute ID (64-char hex string)'),
+      pubkey: z.string().optional().describe('Dispute PDA address (base58)'),
+    },
+    async ({ dispute_id, pubkey }) => {
+      try {
+        const program = getReadOnlyProgram();
+        const programId = getCurrentProgramId();
+        let pda: PublicKey;
+
+        if (pubkey) {
+          pda = new PublicKey(pubkey);
+        } else if (dispute_id) {
+          const idBytes = hexToBytes(dispute_id);
+          [pda] = PublicKey.findProgramAddressSync(
+            [SEEDS.DISPUTE, Buffer.from(idBytes)],
+            programId,
+          );
+        } else {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: provide either dispute_id or pubkey' }],
+          };
+        }
+
+        const account = await program.account.dispute.fetch(pda);
+        const acc = account as unknown as Record<string, unknown>;
+        const text = formatDecodedAccount(acc, 'Dispute', pda);
+
+        return {
+          content: [{ type: 'text' as const, text: text }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_list_program_accounts',
+    'List all AgenC accounts of a given type using getProgramAccounts',
+    {
+      account_type: z.enum(['agent', 'task', 'escrow', 'dispute', 'claim', 'vote', 'protocol', 'state']).describe('Account type to list'),
+      limit: z.number().int().positive().optional().describe('Maximum number of accounts to return (default: 20)'),
+    },
+    async ({ account_type, limit }) => {
+      try {
+        const program = getReadOnlyProgram();
+        const maxResults = limit ?? 20;
+
+        // Map type to Anchor account accessor
+        const accessorMap: Record<string, string> = {
+          agent: 'agentRegistration',
+          task: 'task',
+          escrow: 'taskEscrow',
+          dispute: 'dispute',
+          claim: 'taskClaim',
+          vote: 'disputeVote',
+          protocol: 'protocolConfig',
+          state: 'coordinationState',
+        };
+
+        const accessor = accessorMap[account_type];
+        if (!accessor) {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: unknown account type "' + account_type + '"' }],
+          };
+        }
+
+        // Use dynamic access to program.account
+        const accountAccessor = (program.account as Record<string, { all: () => Promise<Array<{ publicKey: PublicKey; account: unknown }>> }>)[accessor];
+        if (!accountAccessor) {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: account accessor "' + accessor + '" not found in program' }],
+          };
+        }
+
+        const accounts = await accountAccessor.all();
+
+        if (accounts.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'No ' + account_type + ' accounts found' }],
+          };
+        }
+
+        const displayed = accounts.slice(0, maxResults);
+        const lines: string[] = [
+          'Found ' + accounts.length + ' ' + account_type + ' account(s)' + (accounts.length > maxResults ? ' (showing first ' + maxResults + ')' : '') + ':',
+          '',
+        ];
+
+        for (let i = 0; i < displayed.length; i++) {
+          const a = displayed[i];
+          const acc = a.account as Record<string, unknown>;
+
+          lines.push('[' + (i + 1) + '] ' + a.publicKey.toBase58());
+
+          // Show summary fields based on type
+          switch (account_type) {
+            case 'agent': {
+              const agentId = acc.agentId as Uint8Array | number[];
+              const idBytes = agentId instanceof Uint8Array ? agentId : new Uint8Array(agentId);
+              lines.push('    ID: ' + Buffer.from(idBytes).toString('hex').slice(0, 16) + '...');
+              lines.push('    Status: ' + formatStatus(acc.status as number | Record<string, unknown>));
+              lines.push('    Active Tasks: ' + (acc.activeTasks ?? 0));
+              break;
+            }
+            case 'task': {
+              lines.push('    Status: ' + formatTaskStatus(acc.status as number | Record<string, unknown>));
+              lines.push('    Type: ' + formatTaskType(acc.taskType as number | Record<string, unknown>));
+              lines.push('    Reward: ' + formatSol(Number(acc.rewardAmount ?? 0)));
+              break;
+            }
+            case 'dispute': {
+              lines.push('    Status: ' + formatDisputeStatus(acc.status as number | Record<string, unknown>));
+              lines.push('    Votes: ' + (acc.votesFor ?? 0) + ' for / ' + (acc.votesAgainst ?? 0) + ' against');
+              break;
+            }
+            default:
+              // Generic: show first few fields
+              for (const [key, value] of Object.entries(acc).slice(0, 3)) {
+                lines.push('    ' + formatField(key, value, ''));
+              }
+          }
+          lines.push('');
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_inspect_transaction',
+    'Fetch and decode a transaction with AgenC instruction details',
+    {
+      signature: z.string().describe('Transaction signature (base58)'),
+    },
+    async ({ signature }) => {
+      try {
+        const connection = getConnection();
+        const tx = await connection.getTransaction(signature, {
+          maxSupportedTransactionVersion: 0,
+          commitment: 'confirmed',
+        });
+
+        if (!tx) {
+          return {
+            content: [{ type: 'text' as const, text: 'Transaction not found: ' + signature }],
+          };
+        }
+
+        const lines = [
+          'Transaction: ' + signature,
+          'Slot: ' + tx.slot,
+          'Block Time: ' + (tx.blockTime ? formatTimestamp(tx.blockTime) : 'unknown'),
+          'Status: ' + (tx.meta?.err ? 'FAILED' : 'SUCCESS'),
+        ];
+
+        if (tx.meta?.err) {
+          lines.push('Error: ' + JSON.stringify(tx.meta.err));
+        }
+
+        lines.push(
+          'Fee: ' + formatSol(tx.meta?.fee ?? 0),
+          'Compute Units: ' + (tx.meta?.computeUnitsConsumed ?? 'unknown'),
+        );
+
+        // List accounts involved
+        const accountKeys = tx.transaction.message.staticAccountKeys
+          ?? (tx.transaction.message as unknown as { accountKeys: PublicKey[] }).accountKeys
+          ?? [];
+        const programId = getCurrentProgramId();
+
+        lines.push('', '--- Accounts (' + accountKeys.length + ') ---');
+        for (let i = 0; i < Math.min(accountKeys.length, 15); i++) {
+          const key = accountKeys[i];
+          const isProgram = key.equals(programId);
+          lines.push('  [' + i + '] ' + key.toBase58() + (isProgram ? ' (AgenC program)' : ''));
+        }
+        if (accountKeys.length > 15) {
+          lines.push('  ... and ' + (accountKeys.length - 15) + ' more');
+        }
+
+        // Try to decode AgenC instructions
+        const coder = new BorshCoder(IDL);
+        const compiledInstructions = tx.transaction.message.compiledInstructions
+          ?? (tx.transaction.message as unknown as { instructions: Array<{ programIdIndex: number; data: Buffer | Uint8Array }> }).instructions
+          ?? [];
+
+        lines.push('', '--- Instructions ---');
+        let ixIndex = 0;
+        for (const ix of compiledInstructions) {
+          const progIndex = 'programIdIndex' in ix ? ix.programIdIndex : (ix as unknown as { programIdIndex: number }).programIdIndex;
+          const progKey = accountKeys[progIndex];
+
+          if (progKey && progKey.equals(programId)) {
+            try {
+              const ixData = 'data' in ix
+                ? (ix.data instanceof Uint8Array ? Buffer.from(ix.data) : Buffer.from(ix.data as string, 'base64'))
+                : Buffer.alloc(0);
+              const decoded = coder.instruction.decode(ixData);
+              if (decoded) {
+                lines.push('[' + ixIndex + '] AgenC: ' + decoded.name);
+                // Show decoded args
+                const args = decoded.data as Record<string, unknown>;
+                if (args && typeof args === 'object') {
+                  for (const [key, value] of Object.entries(args)) {
+                    lines.push('     ' + formatField(key, value, ''));
+                  }
+                }
+              } else {
+                lines.push('[' + ixIndex + '] AgenC: (could not decode)');
+              }
+            } catch {
+              lines.push('[' + ixIndex + '] AgenC: (decode error)');
+            }
+          } else {
+            lines.push('[' + ixIndex + '] Program: ' + (progKey ? progKey.toBase58() : 'unknown'));
+          }
+          ixIndex++;
+        }
+
+        // Show log messages
+        if (tx.meta?.logMessages && tx.meta.logMessages.length > 0) {
+          lines.push('', '--- Logs ---');
+          const logs = tx.meta.logMessages;
+          for (const log of logs.slice(0, 30)) {
+            lines.push('  ' + log);
+          }
+          if (logs.length > 30) {
+            lines.push('  ... and ' + (logs.length - 30) + ' more log lines');
+          }
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+}

--- a/mcp/src/tools/testing.ts
+++ b/mcp/src/tools/testing.ts
@@ -1,0 +1,506 @@
+/**
+ * Anchor Test Runner MCP Tools
+ *
+ * Wraps ts-mocha and anchor test with structured output parsing.
+ */
+
+import { execFile } from 'child_process';
+import { readdir } from 'fs/promises';
+import path from 'path';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+/** Root of the AgenC repository (parent of mcp/).
+ *  When bundled into dist/index.cjs, __dirname is mcp/dist/ (2 up).
+ *  When running from source, __dirname is mcp/src/tools/ (4 up).
+ *  We detect by checking if Anchor.toml exists at the resolved path. */
+function findProjectRoot(): string {
+  const { existsSync } = require('fs');
+  // Try bundled path first (mcp/dist/ -> 2 up)
+  const bundled = path.resolve(__dirname, '..', '..');
+  if (existsSync(path.join(bundled, 'Anchor.toml'))) return bundled;
+  // Try source path (mcp/src/tools/ -> 4 up)
+  const source = path.resolve(__dirname, '..', '..', '..', '..');
+  if (existsSync(path.join(source, 'Anchor.toml'))) return source;
+  // Fallback to cwd
+  return process.cwd();
+}
+const PROJECT_ROOT = findProjectRoot();
+
+/** Directory containing test files */
+const TESTS_DIR = path.join(PROJECT_ROOT, 'tests');
+
+/** Known test suites mapped to file globs */
+const TEST_SUITES: Record<string, { files: string[]; description: string }> = {
+  smoke: {
+    files: ['smoke.ts'],
+    description: 'Devnet smoke tests',
+  },
+  integration: {
+    files: ['integration.ts', 'test_1.ts'],
+    description: 'Main integration test suite',
+  },
+  security: {
+    files: ['coordination-security.ts', 'audit-high-severity.ts', 'sybil-attack.ts'],
+    description: 'Security-focused tests',
+  },
+  zk: {
+    files: ['complete_task_private.ts', 'zk-proof-lifecycle.ts', 'sdk-proof-generation.ts'],
+    description: 'ZK proof and private completion tests',
+  },
+  fuzz: {
+    files: [],
+    description: 'Rust fuzz tests (run via cargo fuzz)',
+  },
+};
+
+/** Test result for a single test case */
+interface TestCaseResult {
+  name: string;
+  status: 'passed' | 'failed' | 'pending';
+  duration_ms?: number;
+  error?: string;
+}
+
+/** Aggregated test run result */
+interface TestRunResult {
+  file: string;
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  duration_ms: number;
+  tests: TestCaseResult[];
+  raw_output: string;
+}
+
+/** Cached last result */
+let lastResults: TestRunResult[] | null = null;
+
+/**
+ * Parse mocha spec output into structured results.
+ */
+function parseMochaOutput(stdout: string, stderr: string, file: string): TestRunResult {
+  const combined = stdout + '\n' + stderr;
+  const tests: TestCaseResult[] = [];
+
+  // Match passing tests: lines with checkmark and timing
+  const passRegex = /^\s*[^\S\n]*[✓✔]\s+(.+?)(?:\s+\((\d+)ms\))?\s*$/gm;
+  let match;
+  while ((match = passRegex.exec(combined)) !== null) {
+    tests.push({
+      name: match[1].trim(),
+      status: 'passed',
+      duration_ms: match[2] ? parseInt(match[2], 10) : undefined,
+    });
+  }
+
+  // Match failing tests: numbered failures
+  const failRegex = /^\s*\d+\)\s+(.+)\s*$/gm;
+  const failNames = new Set<string>();
+  while ((match = failRegex.exec(combined)) !== null) {
+    const name = match[1].trim();
+    // Avoid duplicates from error detail sections
+    if (!failNames.has(name)) {
+      failNames.add(name);
+      tests.push({ name, status: 'failed' });
+    }
+  }
+
+  // Try to extract error messages for failed tests
+  const errorBlockRegex = /^\s*\d+\)\s+(.+?)\n([\s\S]*?)(?=\n\s*\d+\)|\n\s*\d+ passing|\n\s*$)/gm;
+  while ((match = errorBlockRegex.exec(combined)) !== null) {
+    const name = match[1].trim();
+    const errorBody = match[2].trim();
+    const existing = tests.find((t) => t.name === name && t.status === 'failed');
+    if (existing) {
+      // Extract first meaningful error line
+      const errLines = errorBody.split('\n').map((l) => l.trim()).filter(Boolean);
+      existing.error = errLines.slice(0, 5).join('\n');
+    }
+  }
+
+  // Match pending tests
+  const pendingRegex = /^\s*-\s+(.+)\s*$/gm;
+  while ((match = pendingRegex.exec(combined)) !== null) {
+    tests.push({ name: match[1].trim(), status: 'pending' });
+  }
+
+  // Parse summary line: "N passing (Xs)" and "N failing"
+  const passingMatch = /(\d+)\s+passing\s+\(([^)]+)\)/.exec(combined);
+  const failingMatch = /(\d+)\s+failing/.exec(combined);
+  const pendingMatch = /(\d+)\s+pending/.exec(combined);
+
+  const passed = passingMatch ? parseInt(passingMatch[1], 10) : tests.filter((t) => t.status === 'passed').length;
+  const failed = failingMatch ? parseInt(failingMatch[1], 10) : tests.filter((t) => t.status === 'failed').length;
+  const pending = pendingMatch ? parseInt(pendingMatch[1], 10) : tests.filter((t) => t.status === 'pending').length;
+
+  // Parse duration
+  let durationMs = 0;
+  if (passingMatch && passingMatch[2]) {
+    const durStr = passingMatch[2];
+    const secMatch = /(\d+)s/.exec(durStr);
+    const msMatch = /(\d+)ms/.exec(durStr);
+    const minMatch = /(\d+)m/.exec(durStr);
+    if (minMatch) durationMs += parseInt(minMatch[1], 10) * 60_000;
+    if (secMatch) durationMs += parseInt(secMatch[1], 10) * 1000;
+    if (msMatch) durationMs += parseInt(msMatch[1], 10);
+    if (!secMatch && !msMatch && !minMatch) {
+      // Try plain number as ms
+      const plain = parseInt(durStr, 10);
+      if (!isNaN(plain)) durationMs = plain;
+    }
+  }
+
+  return {
+    file,
+    total: passed + failed + pending,
+    passed,
+    failed,
+    pending,
+    duration_ms: durationMs,
+    tests,
+    raw_output: combined.length > 5000 ? combined.slice(0, 5000) + '\n... (truncated)' : combined,
+  };
+}
+
+/**
+ * Run a command and capture output.
+ */
+function runCommand(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve) => {
+    const proc = execFile(cmd, args, {
+      cwd,
+      timeout: timeoutMs,
+      maxBuffer: 10 * 1024 * 1024,
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+    }, (error, stdout, stderr) => {
+      resolve({
+        stdout: stdout ?? '',
+        stderr: stderr ?? '',
+        exitCode: error ? (error as NodeJS.ErrnoException & { code?: number | string }).code === 'ETIMEDOUT' ? 124 : (proc.exitCode ?? 1) : 0,
+      });
+    });
+  });
+}
+
+function formatTestResults(results: TestRunResult[]): string {
+  const lines: string[] = [];
+
+  for (const r of results) {
+    lines.push('=== ' + r.file + ' ===');
+    lines.push('Total: ' + r.total + '  Passed: ' + r.passed + '  Failed: ' + r.failed + '  Pending: ' + r.pending);
+    if (r.duration_ms > 0) {
+      lines.push('Duration: ' + (r.duration_ms / 1000).toFixed(1) + 's');
+    }
+    lines.push('');
+
+    for (const t of r.tests) {
+      const icon = t.status === 'passed' ? '[PASS]' : t.status === 'failed' ? '[FAIL]' : '[SKIP]';
+      const dur = t.duration_ms !== undefined ? ' (' + t.duration_ms + 'ms)' : '';
+      lines.push('  ' + icon + ' ' + t.name + dur);
+      if (t.error) {
+        lines.push('       ' + t.error.split('\n').join('\n       '));
+      }
+    }
+    lines.push('');
+  }
+
+  const totalPassed = results.reduce((s, r) => s + r.passed, 0);
+  const totalFailed = results.reduce((s, r) => s + r.failed, 0);
+  const totalPending = results.reduce((s, r) => s + r.pending, 0);
+  lines.push('--- Summary ---');
+  lines.push('Files: ' + results.length + '  Passed: ' + totalPassed + '  Failed: ' + totalFailed + '  Pending: ' + totalPending);
+  lines.push('Result: ' + (totalFailed === 0 ? 'ALL PASSED' : 'FAILURES DETECTED'));
+
+  return lines.join('\n');
+}
+
+export function registerTestingTools(server: McpServer): void {
+  server.tool(
+    'agenc_run_tests',
+    'Run AgenC tests via ts-mocha with structured result parsing',
+    {
+      file: z.string().optional().describe('Specific test file name (e.g. "smoke.ts"). Runs all if omitted.'),
+      grep: z.string().optional().describe('Mocha --grep pattern to filter test names'),
+      timeout: z.number().int().positive().optional().describe('Test timeout in ms (default: 120000)'),
+    },
+    async ({ file, grep, timeout }) => {
+      try {
+        const timeoutMs = timeout ?? 120_000;
+        const filesToRun: string[] = [];
+
+        if (file) {
+          // Validate filename to prevent path traversal
+          const basename = path.basename(file);
+          if (basename !== file || file.includes('..')) {
+            return {
+              content: [{ type: 'text' as const, text: 'Error: invalid test file name' }],
+            };
+          }
+          filesToRun.push(file);
+        } else {
+          // Discover all .ts test files
+          try {
+            const entries = await readdir(TESTS_DIR);
+            for (const e of entries) {
+              if (e.endsWith('.ts')) filesToRun.push(e);
+            }
+          } catch {
+            return {
+              content: [{ type: 'text' as const, text: 'Error: could not read tests directory at ' + TESTS_DIR }],
+            };
+          }
+        }
+
+        if (filesToRun.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'No test files found' }],
+          };
+        }
+
+        const results: TestRunResult[] = [];
+        for (const f of filesToRun) {
+          const args = [
+            'ts-mocha',
+            '-p', './tsconfig.json',
+            '-t', String(timeoutMs),
+            'tests/' + f,
+          ];
+          if (grep) {
+            args.push('--grep', grep);
+          }
+
+          const { stdout, stderr, exitCode } = await runCommand(
+            'npx', args, PROJECT_ROOT, timeoutMs + 30_000,
+          );
+
+          const result = parseMochaOutput(stdout, stderr, f);
+          if (exitCode === 124) {
+            result.tests.push({ name: '(timeout)', status: 'failed', error: 'Test run timed out after ' + timeoutMs + 'ms' });
+            result.failed += 1;
+            result.total += 1;
+          }
+          results.push(result);
+        }
+
+        lastResults = results;
+
+        return {
+          content: [{ type: 'text' as const, text: formatTestResults(results) }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_run_test_suite',
+    'Run a named test suite (smoke, integration, security, zk, fuzz)',
+    {
+      suite: z.enum(['smoke', 'integration', 'security', 'zk', 'fuzz']).describe('Test suite to run'),
+      timeout: z.number().int().positive().optional().describe('Test timeout in ms (default: 120000)'),
+    },
+    async ({ suite, timeout }) => {
+      try {
+        const suiteConfig = TEST_SUITES[suite];
+        if (!suiteConfig) {
+          return {
+            content: [{ type: 'text' as const, text: 'Error: unknown suite "' + suite + '"' }],
+          };
+        }
+
+        if (suite === 'fuzz') {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: [
+                'Fuzz tests run via cargo fuzz, not ts-mocha.',
+                'Available fuzz targets:',
+                '  cargo fuzz run claim_task',
+                '  cargo fuzz run complete_task',
+                '  cargo fuzz run vote_dispute',
+                '  cargo fuzz run resolve_dispute',
+                '',
+                'Run from: programs/agenc-coordination/',
+              ].join('\n'),
+            }],
+          };
+        }
+
+        if (suiteConfig.files.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'Suite "' + suite + '" has no TypeScript test files.' }],
+          };
+        }
+
+        const timeoutMs = timeout ?? 120_000;
+        const results: TestRunResult[] = [];
+
+        for (const f of suiteConfig.files) {
+          const args = [
+            'ts-mocha',
+            '-p', './tsconfig.json',
+            '-t', String(timeoutMs),
+            'tests/' + f,
+          ];
+
+          const { stdout, stderr, exitCode } = await runCommand(
+            'npx', args, PROJECT_ROOT, timeoutMs + 30_000,
+          );
+
+          const result = parseMochaOutput(stdout, stderr, f);
+          if (exitCode === 124) {
+            result.tests.push({ name: '(timeout)', status: 'failed', error: 'Test run timed out' });
+            result.failed += 1;
+            result.total += 1;
+          }
+          results.push(result);
+        }
+
+        lastResults = results;
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: 'Suite: ' + suite + ' (' + suiteConfig.description + ')\n\n' + formatTestResults(results),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_get_test_files',
+    'List available test files with descriptions',
+    {},
+    async () => {
+      try {
+        const entries = await readdir(TESTS_DIR);
+        const testFiles = entries.filter((e) => e.endsWith('.ts')).sort();
+
+        const descriptions: Record<string, string> = {
+          'test_1.ts': 'Main integration test suite',
+          'smoke.ts': 'Devnet smoke tests',
+          'coordination-security.ts': 'Security-focused tests',
+          'audit-high-severity.ts': 'Audit finding tests',
+          'rate-limiting.ts': 'Rate limiting behavior tests',
+          'upgrades.ts': 'Protocol upgrade tests',
+          'complete_task_private.ts': 'ZK private completion tests',
+          'integration.ts': 'Anchor 0.32 lifecycle tests',
+          'minimal.ts': 'Minimal debugging tests',
+          'zk-proof-lifecycle.ts': 'ZK proof lifecycle tests',
+          'sdk-proof-generation.ts': 'SDK proof generation tests',
+          'sybil-attack.ts': 'Sybil attack resistance tests',
+          'dispute-slash-logic.ts': 'Dispute slashing logic tests',
+        };
+
+        const lines = testFiles.map((f) => {
+          const desc = descriptions[f] ?? 'Test file';
+          return '  ' + f + ' - ' + desc;
+        });
+
+        const suiteLines = Object.entries(TEST_SUITES).map(([name, cfg]) => {
+          return '  ' + name + ': ' + cfg.description + ' (' + (cfg.files.length > 0 ? cfg.files.join(', ') : 'cargo fuzz') + ')';
+        });
+
+        return {
+          content: [{
+            type: 'text' as const,
+            text: [
+              'Test files (' + testFiles.length + '):',
+              ...lines,
+              '',
+              'Named suites:',
+              ...suiteLines,
+            ].join('\n'),
+          }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+
+  server.tool(
+    'agenc_get_last_results',
+    'Get results from the last test run',
+    {},
+    async () => {
+      if (!lastResults) {
+        return {
+          content: [{ type: 'text' as const, text: 'No test results cached. Run agenc_run_tests or agenc_run_test_suite first.' }],
+        };
+      }
+
+      return {
+        content: [{ type: 'text' as const, text: formatTestResults(lastResults) }],
+      };
+    },
+  );
+
+  server.tool(
+    'agenc_run_anchor_test',
+    'Run full anchor test with parsed output (builds program + runs all tests)',
+    {
+      skip_build: z.boolean().optional().describe('Skip anchor build step (default: false)'),
+      skip_deploy: z.boolean().optional().describe('Skip anchor deploy step (default: false)'),
+      timeout: z.number().int().positive().optional().describe('Timeout in ms (default: 300000)'),
+    },
+    async ({ skip_build, skip_deploy, timeout }) => {
+      try {
+        const timeoutMs = timeout ?? 300_000;
+        const args = ['test'];
+        if (skip_build) args.push('--skip-build');
+        if (skip_deploy) args.push('--skip-deploy');
+
+        const { stdout, stderr, exitCode } = await runCommand(
+          'anchor', args, PROJECT_ROOT, timeoutMs,
+        );
+
+        const result = parseMochaOutput(stdout, stderr, 'anchor test');
+        if (exitCode === 124) {
+          result.tests.push({ name: '(timeout)', status: 'failed', error: 'anchor test timed out after ' + timeoutMs + 'ms' });
+          result.failed += 1;
+          result.total += 1;
+        }
+
+        lastResults = [result];
+
+        const lines = [
+          'anchor test ' + (exitCode === 0 ? 'PASSED' : 'FAILED (exit ' + exitCode + ')'),
+          '',
+          formatTestResults([result]),
+        ];
+
+        // Include raw output if no tests were parsed (build failure, etc.)
+        if (result.total === 0 && (stdout + stderr).length > 0) {
+          const raw = (stdout + stderr).slice(-3000);
+          lines.push('', '--- Raw Output (last 3000 chars) ---', raw);
+        }
+
+        return {
+          content: [{ type: 'text' as const, text: lines.join('\n') }],
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: ' + (error as Error).message }],
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
Implements #183, #184, #185. Adds 18 new MCP tools to `@agenc/mcp` (40 total).

## New Tools

### Test Runner (#183) — `src/tools/testing.ts` (506 lines)
- `agenc_run_tests` — Run all tests or specific file with parsed Mocha output
- `agenc_run_test_suite` — Run named suite (smoke, integration, security, zk, fuzz)
- `agenc_get_test_files` — List all 13 test files with descriptions
- `agenc_get_last_results` — Cached results from last run
- `agenc_run_anchor_test` — Full `anchor test` with parsed output

### ZK Circuits (#184) — `src/tools/circuits.ts` (591 lines)
- `agenc_compile_circuit` — Compile circom → R1CS + WASM
- `agenc_generate_witness` — Generate witness from input signals
- `agenc_generate_proof` — Groth16 proof generation
- `agenc_verify_proof` — Local proof verification
- `agenc_get_circuit_info` — Circuit metadata (constraints, signals, artifacts)
- `agenc_get_proving_key_info` — Proving key existence and size

### Account Inspector (#185) — `src/tools/inspector.ts` (670 lines)
- `agenc_inspect_account` — Fetch + IDL decode any account by pubkey
- `agenc_inspect_agent` — Derive agent PDA, fetch and decode
- `agenc_inspect_task` — Derive task PDA, fetch and decode
- `agenc_inspect_escrow` — Derive escrow PDA, fetch and decode
- `agenc_inspect_dispute` — Derive dispute PDA, fetch and decode
- `agenc_list_program_accounts` — List all accounts of a given type
- `agenc_inspect_transaction` — Fetch + decode tx with AgenC instructions

## Verified
- Typecheck clean (`npx tsc --noEmit`)
- Build succeeds (`npm run build` → 8MB CJS bundle)
- Server initializes with all 40 tools
- `agenc_get_test_files` → lists 13 test files
- `agenc_get_circuit_info` → shows circuit status, VK with 67 public inputs
- `agenc_inspect_account` → decodes on-chain account data with owner detection