### PR TITLE
feat(runtime): add createEventMonitor() to AgentRuntime (#190)

### DIFF
--- a/runtime/src/runtime.ts
+++ b/runtime/src/runtime.ts
@@ -11,6 +11,7 @@ import { Connection, PublicKey } from '@solana/web3.js';
 import { PROGRAM_ID } from '@agenc/sdk';
 import { AgentManager } from './agent/manager.js';
 import { AgentState, AgentStatus, AgentRegistrationParams, AGENT_ID_LENGTH } from './agent/types.js';
+import { EventMonitor } from './events/index.js';
 import { AgentRuntimeConfig, isKeypair } from './types/config.js';
 import type { Wallet } from './types/wallet.js';
 import { keypairToWallet } from './types/wallet.js';
@@ -381,5 +382,29 @@ export class AgentRuntime {
    */
   isStarted(): boolean {
     return this.started;
+  }
+
+  /**
+   * Create an EventMonitor instance configured with this runtime's program and logger.
+   *
+   * The returned EventMonitor can subscribe to task, dispute, protocol, and agent
+   * events with transparent metrics tracking.
+   *
+   * @returns A new EventMonitor instance
+   *
+   * @example
+   * ```typescript
+   * const monitor = runtime.createEventMonitor();
+   * monitor.subscribeToTaskEvents({
+   *   onTaskCreated: (event) => console.log('Task created:', event.taskId),
+   * });
+   * monitor.start();
+   * ```
+   */
+  createEventMonitor(): EventMonitor {
+    return new EventMonitor({
+      program: this.agentManager.getProgram(),
+      logger: this.logger,
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Adds `createEventMonitor()` method to `AgentRuntime` class that creates an `EventMonitor` instance configured with the runtime's Anchor program and logger
- Adds 4 unit tests verifying the method returns proper `EventMonitor` instances with correct initial state

Closes #190

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (615 tests pass, 8 skipped integration tests requiring local validator)
- [ ] Verify `createEventMonitor()` returns a working `EventMonitor` in integration environment