### PR TITLE
feat(runtime): Phase 3 Wave 3 — TaskDiscovery and extended tests (#211, #218)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -199,6 +199,12 @@ export {
   defaultTaskScorer,
   rankTasks,
   filterAndRank,
+  // TaskDiscovery class
+  TaskDiscovery,
+  type TaskDiscoveryOptions,
+  type TaskDiscoveryResult,
+  type TaskDiscoveryListener,
+  type TaskDiscoveryMode,
 } from './task/index.js';
 
 // Logger utilities

--- a/runtime/src/task/discovery.test.ts
+++ b/runtime/src/task/discovery.test.ts
@@ -1,0 +1,825 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
+import { TaskDiscovery, type TaskDiscoveryOptions, type TaskDiscoveryResult } from './discovery.js';
+import { TaskOperations } from './operations.js';
+import { OnChainTaskStatus, type OnChainTask, type TaskFilterConfig } from './types.js';
+import { TaskType } from '../events/types.js';
+import { silentLogger } from '../utils/logger.js';
+import { PROGRAM_ID } from '@agenc/sdk';
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../types/agenc_coordination.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const COMPUTE = 1n << 0n;
+const INFERENCE = 1n << 1n;
+
+function createTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
+  return {
+    taskId: new Uint8Array(32),
+    creator: Keypair.generate().publicKey,
+    requiredCapabilities: COMPUTE,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    rewardAmount: 1_000_000n,
+    maxWorkers: 5,
+    currentWorkers: 0,
+    status: OnChainTaskStatus.Open,
+    taskType: TaskType.Exclusive,
+    createdAt: 1700000000,
+    deadline: Math.floor(Date.now() / 1000) + 3600,
+    completedAt: 0,
+    escrow: Keypair.generate().publicKey,
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a mock Anchor program with event listener support for TaskCreated.
+ */
+function createMockProgram() {
+  const eventCallbacks = new Map<number, { eventName: string; callback: Function }>();
+  let nextListenerId = 1;
+
+  const mockProgram = {
+    programId: PROGRAM_ID,
+    addEventListener: vi.fn((eventName: string, callback: Function) => {
+      const id = nextListenerId++;
+      eventCallbacks.set(id, { eventName, callback });
+      return id;
+    }),
+    removeEventListener: vi.fn(async (_id: number) => {
+      eventCallbacks.delete(_id);
+    }),
+    _emit: (eventName: string, rawEvent: unknown, slot: number, signature: string) => {
+      for (const { eventName: name, callback } of eventCallbacks.values()) {
+        if (name === eventName) {
+          callback(rawEvent, slot, signature);
+        }
+      }
+    },
+    _getCallbackCount: () => eventCallbacks.size,
+  };
+
+  return mockProgram as unknown as Program<AgencCoordination> & {
+    _emit: typeof mockProgram._emit;
+    _getCallbackCount: typeof mockProgram._getCallbackCount;
+  };
+}
+
+/**
+ * Creates a mock TaskOperations instance.
+ */
+function createMockOperations() {
+  return {
+    fetchClaimableTasks: vi.fn().mockResolvedValue([]),
+    fetchTask: vi.fn().mockResolvedValue(null),
+    fetchAllTasks: vi.fn().mockResolvedValue([]),
+    fetchClaim: vi.fn().mockResolvedValue(null),
+    fetchActiveClaims: vi.fn().mockResolvedValue([]),
+    claimTask: vi.fn(),
+    completeTask: vi.fn(),
+    completeTaskPrivate: vi.fn(),
+    fetchTaskByIds: vi.fn().mockResolvedValue(null),
+  } as unknown as TaskOperations & {
+    fetchClaimableTasks: ReturnType<typeof vi.fn>;
+    fetchTask: ReturnType<typeof vi.fn>;
+  };
+}
+
+function mockBN(value: bigint | number): { toNumber: () => number; toString: () => string } {
+  const bigValue = BigInt(value);
+  return {
+    toNumber: () => Number(bigValue),
+    toString: () => bigValue.toString(),
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TaskDiscovery', () => {
+  let mockProgram: ReturnType<typeof createMockProgram>;
+  let mockOps: ReturnType<typeof createMockOperations>;
+  let discovery: TaskDiscovery;
+
+  const defaultConfig = (): TaskDiscoveryOptions => ({
+    program: mockProgram,
+    operations: mockOps as unknown as TaskOperations,
+    filter: {},
+    mode: 'poll',
+    pollIntervalMs: 100,
+    logger: silentLogger,
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockProgram = createMockProgram();
+    mockOps = createMockOperations();
+  });
+
+  afterEach(async () => {
+    if (discovery?.isRunning()) {
+      await discovery.stop();
+    }
+    vi.useRealTimers();
+  });
+
+  // ==========================================================================
+  // Poll Mode Tests
+  // ==========================================================================
+
+  describe('Poll Mode', () => {
+    it('discovers tasks on interval', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      // Flush the initial poll microtask
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].pda).toBe(taskPda);
+      expect(listener.mock.calls[0][0].source).toBe('poll');
+    });
+
+    it('deduplicates: same task not discovered twice', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // First poll should discover
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // Second poll should not re-discover
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('filters tasks by agent capabilities', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask({ requiredCapabilities: COMPUTE | INFERENCE });
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener);
+
+      // Agent only has COMPUTE, but task requires COMPUTE | INFERENCE
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('continues polling after fetch error', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValue([{ task, taskPda }]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+      // First poll fails — no discovery
+      expect(listener).not.toHaveBeenCalled();
+
+      // Second poll succeeds
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies filter config', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask({ rewardAmount: 500_000n });
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.filter = { minRewardLamports: 1_000_000n };
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // Event Mode Tests
+  // ==========================================================================
+
+  describe('Event Mode', () => {
+    it('discovers tasks via TaskCreated events', async () => {
+      const creator = Keypair.generate().publicKey;
+      const taskId = new Uint8Array(32).fill(1);
+      const task = createTask({ taskId, creator });
+
+      // Derive the expected PDA
+      const [expectedPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from('task'), creator.toBuffer(), Buffer.from(taskId)],
+        PROGRAM_ID,
+      );
+      (mockOps.fetchTask as ReturnType<typeof vi.fn>).mockResolvedValue(task);
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.mode = 'event';
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+
+      // Simulate TaskCreated event
+      mockProgram._emit(
+        'taskCreated',
+        {
+          taskId: Array.from(taskId),
+          creator,
+          requiredCapabilities: mockBN(COMPUTE),
+          rewardAmount: mockBN(1_000_000n),
+          taskType: 0,
+          deadline: mockBN(0),
+          timestamp: mockBN(Date.now()),
+        },
+        100,
+        'sig-event-1',
+      );
+
+      // Wait for async fetchTask
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].source).toBe('event');
+      expect(listener.mock.calls[0][0].pda.equals(expectedPda)).toBe(true);
+    });
+
+    it('deduplicates: same task from event not discovered twice', async () => {
+      const creator = Keypair.generate().publicKey;
+      const taskId = new Uint8Array(32).fill(2);
+      const task = createTask({ taskId, creator });
+      (mockOps.fetchTask as ReturnType<typeof vi.fn>).mockResolvedValue(task);
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.mode = 'event';
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+
+      const rawEvent = {
+        taskId: Array.from(taskId),
+        creator,
+        requiredCapabilities: mockBN(COMPUTE),
+        rewardAmount: mockBN(1_000_000n),
+        taskType: 0,
+        deadline: mockBN(0),
+        timestamp: mockBN(Date.now()),
+      };
+
+      // Emit twice
+      mockProgram._emit('taskCreated', rawEvent, 100, 'sig1');
+      await vi.advanceTimersByTimeAsync(0);
+
+      mockProgram._emit('taskCreated', rawEvent, 101, 'sig2');
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('filters events by capabilities', async () => {
+      const creator = Keypair.generate().publicKey;
+      const taskId = new Uint8Array(32).fill(3);
+      // Task requires INFERENCE but agent only has COMPUTE
+      const task = createTask({
+        taskId,
+        creator,
+        requiredCapabilities: INFERENCE,
+      });
+      (mockOps.fetchTask as ReturnType<typeof vi.fn>).mockResolvedValue(task);
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.mode = 'event';
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+
+      mockProgram._emit(
+        'taskCreated',
+        {
+          taskId: Array.from(taskId),
+          creator,
+          requiredCapabilities: mockBN(INFERENCE),
+          rewardAmount: mockBN(1_000_000n),
+          taskType: 0,
+          deadline: mockBN(0),
+          timestamp: mockBN(Date.now()),
+        },
+        100,
+        'sig-filter',
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('handles fetch failure gracefully', async () => {
+      const creator = Keypair.generate().publicKey;
+      const taskId = new Uint8Array(32).fill(4);
+      (mockOps.fetchTask as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('fetch error'));
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.mode = 'event';
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+
+      mockProgram._emit(
+        'taskCreated',
+        {
+          taskId: Array.from(taskId),
+          creator,
+          requiredCapabilities: mockBN(COMPUTE),
+          rewardAmount: mockBN(1_000_000n),
+          taskType: 0,
+          deadline: mockBN(0),
+          timestamp: mockBN(Date.now()),
+        },
+        100,
+        'sig-fail',
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Listener should NOT be called since fetch failed
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('handles null task from fetchTask', async () => {
+      const creator = Keypair.generate().publicKey;
+      const taskId = new Uint8Array(32).fill(5);
+      (mockOps.fetchTask as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.mode = 'event';
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+
+      mockProgram._emit(
+        'taskCreated',
+        {
+          taskId: Array.from(taskId),
+          creator,
+          requiredCapabilities: mockBN(COMPUTE),
+          rewardAmount: mockBN(1_000_000n),
+          taskType: 0,
+          deadline: mockBN(0),
+          timestamp: mockBN(Date.now()),
+        },
+        100,
+        'sig-null',
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // Hybrid Mode Tests
+  // ==========================================================================
+
+  describe('Hybrid Mode', () => {
+    it('runs both poll and event sources', async () => {
+      const pollPda = Keypair.generate().publicKey;
+      const pollTask = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task: pollTask, taskPda: pollPda },
+      ]);
+
+      const eventCreator = Keypair.generate().publicKey;
+      const eventTaskId = new Uint8Array(32).fill(10);
+      const eventTask = createTask({ taskId: eventTaskId, creator: eventCreator });
+      (mockOps.fetchTask as ReturnType<typeof vi.fn>).mockResolvedValue(eventTask);
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.mode = 'hybrid';
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Poll finds one
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].source).toBe('poll');
+
+      // Event finds another
+      mockProgram._emit(
+        'taskCreated',
+        {
+          taskId: Array.from(eventTaskId),
+          creator: eventCreator,
+          requiredCapabilities: mockBN(COMPUTE),
+          rewardAmount: mockBN(1_000_000n),
+          taskType: 0,
+          deadline: mockBN(0),
+          timestamp: mockBN(Date.now()),
+        },
+        100,
+        'sig-hybrid',
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener.mock.calls[1][0].source).toBe('event');
+    });
+
+    it('cross-source deduplication: poll-discovered task not rediscovered via event', async () => {
+      const creator = Keypair.generate().publicKey;
+      const taskId = new Uint8Array(32).fill(20);
+      const task = createTask({ taskId, creator });
+
+      // Derive expected PDA
+      const [expectedPda] = PublicKey.findProgramAddressSync(
+        [Buffer.from('task'), creator.toBuffer(), Buffer.from(taskId)],
+        PROGRAM_ID,
+      );
+
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda: expectedPda },
+      ]);
+      (mockOps.fetchTask as ReturnType<typeof vi.fn>).mockResolvedValue(task);
+
+      const listener = vi.fn();
+      const config = defaultConfig();
+      config.mode = 'hybrid';
+      discovery = new TaskDiscovery(config);
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Poll discovers first
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // Same task emitted as event — should be deduplicated
+      mockProgram._emit(
+        'taskCreated',
+        {
+          taskId: Array.from(taskId),
+          creator,
+          requiredCapabilities: mockBN(COMPUTE),
+          rewardAmount: mockBN(1_000_000n),
+          taskType: 0,
+          deadline: mockBN(0),
+          timestamp: mockBN(Date.now()),
+        },
+        200,
+        'sig-dedup',
+      );
+
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Still only 1 notification
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ==========================================================================
+  // Listener Tests
+  // ==========================================================================
+
+  describe('Listeners', () => {
+    it('multiple listeners all notified', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener1);
+      discovery.onTaskDiscovered(listener2);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+
+    it('exception in one listener does not break others', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const throwingListener = vi.fn(() => {
+        throw new Error('Listener error');
+      });
+      const goodListener = vi.fn();
+
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(throwingListener);
+      discovery.onTaskDiscovered(goodListener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(throwingListener).toHaveBeenCalledTimes(1);
+      expect(goodListener).toHaveBeenCalledTimes(1);
+    });
+
+    it('unsubscribe removes listener', async () => {
+      const taskPda1 = Keypair.generate().publicKey;
+      const taskPda2 = Keypair.generate().publicKey;
+      const task1 = createTask();
+      const task2 = createTask();
+
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce([{ task: task1, taskPda: taskPda1 }])
+        .mockResolvedValueOnce([{ task: task2, taskPda: taskPda2 }]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      const unsub = discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      // Unsubscribe
+      unsub();
+
+      // Next poll
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Should still be 1 (not 2)
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ==========================================================================
+  // Lifecycle Tests
+  // ==========================================================================
+
+  describe('Lifecycle', () => {
+    it('start() is idempotent', async () => {
+      discovery = new TaskDiscovery(defaultConfig());
+
+      await discovery.start(COMPUTE);
+      await discovery.start(COMPUTE); // no-op
+
+      expect(discovery.isRunning()).toBe(true);
+    });
+
+    it('stop() is idempotent', async () => {
+      discovery = new TaskDiscovery(defaultConfig());
+
+      await discovery.start(COMPUTE);
+      await discovery.stop();
+      await discovery.stop(); // no-op
+
+      expect(discovery.isRunning()).toBe(false);
+    });
+
+    it('stop() cleans up timer and subscriptions', async () => {
+      const config = defaultConfig();
+      config.mode = 'hybrid';
+      discovery = new TaskDiscovery(config);
+
+      await discovery.start(COMPUTE);
+      expect(discovery.isRunning()).toBe(true);
+      expect(mockProgram.addEventListener).toHaveBeenCalled();
+
+      await discovery.stop();
+      expect(discovery.isRunning()).toBe(false);
+      expect(mockProgram.removeEventListener).toHaveBeenCalled();
+    });
+
+    it('isRunning() reflects state', async () => {
+      discovery = new TaskDiscovery(defaultConfig());
+
+      expect(discovery.isRunning()).toBe(false);
+
+      await discovery.start(COMPUTE);
+      expect(discovery.isRunning()).toBe(true);
+
+      await discovery.stop();
+      expect(discovery.isRunning()).toBe(false);
+    });
+
+    it('can restart after stop', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      await discovery.stop();
+
+      // Clear seen so the same task can be re-discovered
+      discovery.clearSeen();
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ==========================================================================
+  // Monitoring Tests
+  // ==========================================================================
+
+  describe('Monitoring', () => {
+    it('getDiscoveredCount() is accurate', async () => {
+      const taskPda1 = Keypair.generate().publicKey;
+      const taskPda2 = Keypair.generate().publicKey;
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+        { task: createTask(), taskPda: taskPda1 },
+        { task: createTask(), taskPda: taskPda2 },
+      ]);
+
+      discovery = new TaskDiscovery(defaultConfig());
+
+      expect(discovery.getDiscoveredCount()).toBe(0);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(discovery.getDiscoveredCount()).toBe(2);
+    });
+
+    it('clearSeen() resets deduplication', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.start(COMPUTE);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(discovery.getDiscoveredCount()).toBe(1);
+
+      // Clear seen
+      discovery.clearSeen();
+      expect(discovery.getDiscoveredCount()).toBe(0);
+
+      // Next poll should rediscover the same task
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(discovery.getDiscoveredCount()).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // Manual Poll Tests
+  // ==========================================================================
+
+  describe('Manual poll()', () => {
+    it('returns discovered tasks', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      discovery = new TaskDiscovery(defaultConfig());
+      const results = await discovery.poll(COMPUTE);
+
+      expect(results.length).toBe(1);
+      expect(results[0].pda).toBe(taskPda);
+      expect(results[0].source).toBe('poll');
+    });
+
+    it('deduplicates with previously seen tasks', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      discovery = new TaskDiscovery(defaultConfig());
+
+      const first = await discovery.poll(COMPUTE);
+      expect(first.length).toBe(1);
+
+      const second = await discovery.poll(COMPUTE);
+      expect(second.length).toBe(0);
+    });
+
+    it('applies filters', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask({ rewardAmount: 500_000n });
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const config = defaultConfig();
+      config.filter = { minRewardLamports: 1_000_000n };
+      discovery = new TaskDiscovery(config);
+
+      const results = await discovery.poll(COMPUTE);
+      expect(results.length).toBe(0);
+    });
+
+    it('notifies listeners during manual poll', async () => {
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockResolvedValue([
+        { task, taskPda },
+      ]);
+
+      const listener = vi.fn();
+      discovery = new TaskDiscovery(defaultConfig());
+      discovery.onTaskDiscovered(listener);
+
+      await discovery.poll(COMPUTE);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty on error', async () => {
+      (mockOps.fetchClaimableTasks as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error('network'),
+      );
+
+      discovery = new TaskDiscovery(defaultConfig());
+      const results = await discovery.poll(COMPUTE);
+
+      expect(results.length).toBe(0);
+    });
+  });
+});

--- a/runtime/src/task/discovery.ts
+++ b/runtime/src/task/discovery.ts
@@ -1,0 +1,358 @@
+/**
+ * TaskDiscovery — flexible task discovery system supporting poll, event, and hybrid modes.
+ *
+ * Agents use TaskDiscovery to find available tasks matching their capabilities.
+ * Three modes are available:
+ * - **poll**: Timer-based periodic discovery via fetchClaimableTasks
+ * - **event**: Reactive discovery via TaskCreated on-chain events
+ * - **hybrid**: Both modes with cross-source deduplication
+ *
+ * @module
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../types/agenc_coordination.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import type { EventSubscription, TaskCreatedEvent } from '../events/types.js';
+import { subscribeToTaskCreated } from '../events/task.js';
+import type { TaskOperations } from './operations.js';
+import type { OnChainTask } from './types.js';
+import { matchesFilter } from './filters.js';
+import type { TaskFilterConfig } from './types.js';
+import { deriveTaskPda } from './pda.js';
+
+// ============================================================================
+// Configuration & Interfaces
+// ============================================================================
+
+/**
+ * Discovery mode: how tasks are found.
+ */
+export type TaskDiscoveryMode = 'poll' | 'event' | 'hybrid';
+
+/**
+ * Configuration for TaskDiscovery.
+ */
+export interface TaskDiscoveryOptions {
+  /** Anchor program instance */
+  program: Program<AgencCoordination>;
+  /** TaskOperations instance for querying tasks */
+  operations: TaskOperations;
+  /** Filter configuration for task matching */
+  filter: TaskFilterConfig;
+  /** Discovery mode */
+  mode: TaskDiscoveryMode;
+  /** Poll interval in milliseconds (default 5000) */
+  pollIntervalMs?: number;
+  /** Logger instance (defaults to silent logger) */
+  logger?: Logger;
+}
+
+/**
+ * A task discovered by the TaskDiscovery system.
+ */
+export interface TaskDiscoveryResult {
+  /** Task account PDA */
+  pda: PublicKey;
+  /** Parsed on-chain task data */
+  task: OnChainTask;
+  /** Timestamp when the task was discovered */
+  discoveredAt: number;
+  /** Which discovery source found it */
+  source: 'poll' | 'event';
+}
+
+/**
+ * Callback for discovered tasks.
+ */
+export type TaskDiscoveryListener = (task: TaskDiscoveryResult) => void;
+
+// ============================================================================
+// TaskDiscovery Class
+// ============================================================================
+
+/**
+ * Flexible task discovery system supporting poll, event, and hybrid modes.
+ *
+ * @example
+ * ```typescript
+ * const discovery = new TaskDiscovery({
+ *   program,
+ *   operations,
+ *   filter: { minRewardLamports: 1_000_000n },
+ *   mode: 'hybrid',
+ * });
+ *
+ * discovery.onTaskDiscovered((task) => {
+ *   console.log(`Found task: ${task.pda.toBase58()}`);
+ * });
+ *
+ * await discovery.start(AgentCapabilities.COMPUTE);
+ * ```
+ */
+export class TaskDiscovery {
+  private readonly program: Program<AgencCoordination>;
+  private readonly operations: TaskOperations;
+  private readonly filter: TaskFilterConfig;
+  private readonly mode: TaskDiscoveryMode;
+  private readonly pollIntervalMs: number;
+  private readonly logger: Logger;
+
+  private readonly listeners: Set<TaskDiscoveryListener> = new Set();
+  private readonly seenTaskPdas: Set<string> = new Set();
+  private running = false;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private eventSubscription: EventSubscription | null = null;
+  private agentCapabilities: bigint = 0n;
+
+  constructor(config: TaskDiscoveryOptions) {
+    this.program = config.program;
+    this.operations = config.operations;
+    this.filter = config.filter;
+    this.mode = config.mode;
+    this.pollIntervalMs = config.pollIntervalMs ?? 5000;
+    this.logger = config.logger ?? silentLogger;
+  }
+
+  // ==========================================================================
+  // Listener Registration
+  // ==========================================================================
+
+  /**
+   * Register a listener for discovered tasks.
+   * Returns an unsubscribe function.
+   */
+  onTaskDiscovered(callback: TaskDiscoveryListener): () => void {
+    this.listeners.add(callback);
+    return () => {
+      this.listeners.delete(callback);
+    };
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  /**
+   * Start discovering tasks for the given agent capabilities.
+   * Idempotent — calling when already started is a no-op.
+   */
+  async start(agentCapabilities: bigint): Promise<void> {
+    if (this.running) {
+      return;
+    }
+
+    this.running = true;
+    this.agentCapabilities = agentCapabilities;
+
+    if (this.mode === 'poll' || this.mode === 'hybrid') {
+      // Run an initial poll immediately, then set up the interval
+      void this.executePollCycle();
+      this.pollTimer = setInterval(
+        () => void this.executePollCycle(),
+        this.pollIntervalMs,
+      );
+    }
+
+    if (this.mode === 'event' || this.mode === 'hybrid') {
+      this.setupEventDiscovery();
+    }
+
+    this.logger.info(`TaskDiscovery started in ${this.mode} mode`);
+  }
+
+  /**
+   * Stop discovering tasks.
+   * Idempotent — calling when already stopped is a no-op.
+   */
+  async stop(): Promise<void> {
+    if (!this.running) {
+      return;
+    }
+
+    this.running = false;
+
+    if (this.pollTimer !== null) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+
+    if (this.eventSubscription) {
+      await this.eventSubscription.unsubscribe();
+      this.eventSubscription = null;
+    }
+
+    this.logger.info('TaskDiscovery stopped');
+  }
+
+  /**
+   * Check if discovery is currently running.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // ==========================================================================
+  // Manual Poll
+  // ==========================================================================
+
+  /**
+   * Manually trigger a poll cycle for tasks matching the given capabilities.
+   * Returns newly discovered tasks (not previously seen).
+   */
+  async poll(agentCapabilities: bigint): Promise<TaskDiscoveryResult[]> {
+    const discovered: TaskDiscoveryResult[] = [];
+    try {
+      const claimable = await this.operations.fetchClaimableTasks();
+
+      for (const { task, taskPda } of claimable) {
+        if (this.isDuplicate(taskPda)) {
+          continue;
+        }
+
+        if (!matchesFilter(task, agentCapabilities, this.filter)) {
+          continue;
+        }
+
+        const result: TaskDiscoveryResult = {
+          pda: taskPda,
+          task,
+          discoveredAt: Date.now(),
+          source: 'poll',
+        };
+
+        this.seenTaskPdas.add(taskPda.toBase58());
+        discovered.push(result);
+        this.notifyListeners(result);
+      }
+    } catch (error) {
+      this.logger.error(`Manual poll failed: ${error}`);
+    }
+
+    return discovered;
+  }
+
+  // ==========================================================================
+  // Monitoring
+  // ==========================================================================
+
+  /**
+   * Get the count of unique tasks discovered so far.
+   */
+  getDiscoveredCount(): number {
+    return this.seenTaskPdas.size;
+  }
+
+  /**
+   * Clear the seen task set. Useful for testing or resetting discovery state.
+   */
+  clearSeen(): void {
+    this.seenTaskPdas.clear();
+  }
+
+  // ==========================================================================
+  // Private Implementation
+  // ==========================================================================
+
+  /**
+   * Execute a poll cycle, fetching and filtering tasks.
+   */
+  private async executePollCycle(): Promise<void> {
+    try {
+      const claimable = await this.operations.fetchClaimableTasks();
+
+      for (const { task, taskPda } of claimable) {
+        if (this.isDuplicate(taskPda)) {
+          continue;
+        }
+
+        if (!matchesFilter(task, this.agentCapabilities, this.filter)) {
+          continue;
+        }
+
+        const result: TaskDiscoveryResult = {
+          pda: taskPda,
+          task,
+          discoveredAt: Date.now(),
+          source: 'poll',
+        };
+
+        this.seenTaskPdas.add(taskPda.toBase58());
+        this.notifyListeners(result);
+      }
+    } catch (error) {
+      this.logger.error(`Poll cycle failed: ${error}`);
+    }
+  }
+
+  /**
+   * Set up event-based discovery via TaskCreated subscription.
+   */
+  private setupEventDiscovery(): void {
+    this.eventSubscription = subscribeToTaskCreated(
+      this.program,
+      (event: TaskCreatedEvent) => {
+        // Derive the task PDA from the event data
+        const { address: taskPda } = deriveTaskPda(
+          event.creator,
+          event.taskId,
+          this.program.programId,
+        );
+
+        if (this.isDuplicate(taskPda)) {
+          return;
+        }
+
+        // Fetch the full task account to apply filters
+        this.operations
+          .fetchTask(taskPda)
+          .then((task: OnChainTask | null) => {
+            if (!task) {
+              this.logger.warn(`Event-discovered task not found on-chain: ${taskPda.toBase58()}`);
+              return;
+            }
+
+            if (!matchesFilter(task, this.agentCapabilities, this.filter)) {
+              return;
+            }
+
+            const result: TaskDiscoveryResult = {
+              pda: taskPda,
+              task,
+              discoveredAt: Date.now(),
+              source: 'event',
+            };
+
+            this.seenTaskPdas.add(taskPda.toBase58());
+            this.notifyListeners(result);
+          })
+          .catch((error: unknown) => {
+            this.logger.warn(`Failed to fetch event-discovered task: ${error}`);
+          });
+      },
+    );
+  }
+
+  /**
+   * Check if a task PDA has already been seen.
+   */
+  private isDuplicate(taskPda: PublicKey): boolean {
+    return this.seenTaskPdas.has(taskPda.toBase58());
+  }
+
+  /**
+   * Notify all listeners of a discovered task.
+   * Exception isolation: one listener failure doesn't affect others.
+   */
+  private notifyListeners(task: TaskDiscoveryResult): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(task);
+      } catch (error) {
+        this.logger.error(`Listener threw exception: ${error}`);
+      }
+    }
+  }
+}

--- a/runtime/src/task/filters.test.ts
+++ b/runtime/src/task/filters.test.ts
@@ -70,6 +70,19 @@ describe('hasRequiredCapabilities', () => {
     expect(hasRequiredCapabilities(COMPUTE, 0n)).toBe(true);
     expect(hasRequiredCapabilities(0n, 0n)).toBe(true);
   });
+
+  it('returns true when agent has superset of required capabilities', () => {
+    const agentCaps = COMPUTE | INFERENCE | STORAGE;
+    expect(hasRequiredCapabilities(agentCaps, COMPUTE)).toBe(true);
+    expect(hasRequiredCapabilities(agentCaps, COMPUTE | INFERENCE)).toBe(true);
+  });
+
+  it('handles full bitmask (all capabilities set)', () => {
+    const allCaps = (1n << 10n) - 1n; // All 10 capabilities
+    expect(hasRequiredCapabilities(allCaps, COMPUTE)).toBe(true);
+    expect(hasRequiredCapabilities(allCaps, allCaps)).toBe(true);
+    expect(hasRequiredCapabilities(COMPUTE, allCaps)).toBe(false);
+  });
 });
 
 describe('matchesFilter', () => {
@@ -315,6 +328,20 @@ describe('rankTasks', () => {
 
     expect(ranked[0].task.maxWorkers).toBe(10);
     expect(ranked[1].task.maxWorkers).toBe(1);
+  });
+
+  it('handles empty array', () => {
+    const ranked = rankTasks([]);
+    expect(ranked).toEqual([]);
+  });
+
+  it('handles single task', () => {
+    const tasks: DiscoveredTask[] = [
+      toDiscoveredTask(createTask({ rewardAmount: 5_000n })),
+    ];
+    const ranked = rankTasks(tasks);
+    expect(ranked.length).toBe(1);
+    expect(ranked[0].relevanceScore).toBeGreaterThan(0);
   });
 });
 

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -7,3 +7,4 @@ export * from './pda.js';
 export * from './types.js';
 export * from './filters.js';
 export * from './operations.js';
+export * from './discovery.js';


### PR DESCRIPTION
- **#211** — TaskDiscovery class with poll/event/hybrid modes, deduplication, listener pattern
- **#218** — Discovery + filter/operations test extensions

780 tests passing, typecheck clean.