### PR TITLE
feat(runtime): Phase 3 Wave 4 — TaskExecutor, exports, tests (#215, #210, #219)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -147,9 +147,6 @@ export {
   TASK_ID_LENGTH,
   // Task enums
   OnChainTaskStatus,
-  DiscoveryMode,
-  OperatingMode,
-  TaskExecutorStatus,
   // Task functions
   taskStatusToString,
   taskTypeToString,
@@ -186,6 +183,9 @@ export {
   type CompleteResult,
   type TaskExecutorConfig,
   type TaskExecutorEvents,
+  type OperatingMode,
+  type BatchTaskItem,
+  type TaskExecutorStatus,
 } from './types/index.js';
 
 // Task module (Phase 3)
@@ -205,6 +205,8 @@ export {
   type TaskDiscoveryResult,
   type TaskDiscoveryListener,
   type TaskDiscoveryMode,
+  // TaskExecutor class
+  TaskExecutor,
 } from './task/index.js';
 
 // Logger utilities

--- a/runtime/src/task/executor.test.ts
+++ b/runtime/src/task/executor.test.ts
@@ -1,0 +1,1140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
+import { TaskExecutor } from './executor.js';
+import type { TaskOperations } from './operations.js';
+import type { TaskDiscovery, TaskDiscoveryResult, TaskDiscoveryListener } from './discovery.js';
+import type {
+  OnChainTask,
+  TaskExecutionContext,
+  TaskExecutionResult,
+  PrivateTaskExecutionResult,
+  TaskExecutorConfig,
+  TaskExecutorEvents,
+  ClaimResult,
+  CompleteResult,
+} from './types.js';
+import { OnChainTaskStatus, isPrivateExecutionResult } from './types.js';
+import { TaskType } from '../events/types.js';
+import { silentLogger } from '../utils/logger.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const COMPUTE = 1n << 0n;
+
+function createTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
+  return {
+    taskId: new Uint8Array(32),
+    creator: Keypair.generate().publicKey,
+    requiredCapabilities: COMPUTE,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    rewardAmount: 1_000_000n,
+    maxWorkers: 5,
+    currentWorkers: 0,
+    status: OnChainTaskStatus.Open,
+    taskType: TaskType.Exclusive,
+    createdAt: 1700000000,
+    deadline: Math.floor(Date.now() / 1000) + 3600,
+    completedAt: 0,
+    escrow: Keypair.generate().publicKey,
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+function createDiscoveryResult(overrides: Partial<TaskDiscoveryResult> = {}): TaskDiscoveryResult {
+  return {
+    pda: Keypair.generate().publicKey,
+    task: createTask(),
+    discoveredAt: Date.now(),
+    source: 'poll',
+    ...overrides,
+  };
+}
+
+function createMockOperations(): TaskOperations & {
+  claimTask: ReturnType<typeof vi.fn>;
+  completeTask: ReturnType<typeof vi.fn>;
+  completeTaskPrivate: ReturnType<typeof vi.fn>;
+  fetchTask: ReturnType<typeof vi.fn>;
+  fetchTaskByIds: ReturnType<typeof vi.fn>;
+} {
+  const claimPda = Keypair.generate().publicKey;
+  return {
+    fetchClaimableTasks: vi.fn().mockResolvedValue([]),
+    fetchTask: vi.fn().mockResolvedValue(null),
+    fetchAllTasks: vi.fn().mockResolvedValue([]),
+    fetchClaim: vi.fn().mockResolvedValue(null),
+    fetchActiveClaims: vi.fn().mockResolvedValue([]),
+    fetchTaskByIds: vi.fn().mockResolvedValue(null),
+    claimTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      claimPda,
+      transactionSignature: 'claim-sig',
+    } satisfies ClaimResult),
+    completeTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      isPrivate: false,
+      transactionSignature: 'complete-sig',
+    } satisfies CompleteResult),
+    completeTaskPrivate: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      isPrivate: true,
+      transactionSignature: 'private-complete-sig',
+    } satisfies CompleteResult),
+  } as unknown as TaskOperations & {
+    claimTask: ReturnType<typeof vi.fn>;
+    completeTask: ReturnType<typeof vi.fn>;
+    completeTaskPrivate: ReturnType<typeof vi.fn>;
+    fetchTask: ReturnType<typeof vi.fn>;
+    fetchTaskByIds: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockDiscovery(): TaskDiscovery & {
+  onTaskDiscovered: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  _emitTask: (task: TaskDiscoveryResult) => void;
+} {
+  let listener: TaskDiscoveryListener | null = null;
+
+  const mock = {
+    onTaskDiscovered: vi.fn((cb: TaskDiscoveryListener) => {
+      listener = cb;
+      return () => { listener = null; };
+    }),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    isRunning: vi.fn().mockReturnValue(false),
+    getDiscoveredCount: vi.fn().mockReturnValue(0),
+    clearSeen: vi.fn(),
+    poll: vi.fn().mockResolvedValue([]),
+    _emitTask: (task: TaskDiscoveryResult) => {
+      listener?.(task);
+    },
+  };
+
+  return mock as unknown as TaskDiscovery & {
+    onTaskDiscovered: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    _emitTask: (task: TaskDiscoveryResult) => void;
+  };
+}
+
+const agentId = new Uint8Array(32).fill(42);
+const agentPda = Keypair.generate().publicKey;
+
+const defaultHandler = async (_ctx: TaskExecutionContext): Promise<TaskExecutionResult> => ({
+  proofHash: new Uint8Array(32).fill(1),
+});
+
+function createExecutorConfig(overrides: Partial<TaskExecutorConfig> = {}): TaskExecutorConfig {
+  return {
+    operations: createMockOperations(),
+    handler: defaultHandler,
+    agentId,
+    agentPda,
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 10,
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timeout');
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('TaskExecutor', () => {
+  // ==========================================================================
+  // Autonomous Mode
+  // ==========================================================================
+
+  describe('autonomous mode', () => {
+    it('starts discovery and enters processing loop', async () => {
+      const mockDiscovery = createMockDiscovery();
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+
+      // Start in background (autonomous mode loops)
+      const startPromise = executor.start();
+
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+      expect(mockDiscovery.onTaskDiscovered).toHaveBeenCalled();
+      expect(mockDiscovery.start).toHaveBeenCalled();
+      expect(executor.isRunning()).toBe(true);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('full pipeline: discover → claim → execute → submit', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const handlerCalled = vi.fn();
+
+      const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+        handlerCalled(ctx);
+        return { proofHash: new Uint8Array(32).fill(1) };
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+
+      const startPromise = executor.start();
+
+      // Wait for discovery to start
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      // Inject a task
+      const task = createDiscoveryResult();
+      mockDiscovery._emitTask(task);
+
+      // Wait for pipeline to complete
+      await waitFor(() => mockOps.completeTask.mock.calls.length > 0);
+
+      expect(mockOps.claimTask).toHaveBeenCalledWith(task.pda, task.task);
+      expect(handlerCalled).toHaveBeenCalledTimes(1);
+      expect(mockOps.completeTask).toHaveBeenCalledTimes(1);
+
+      const status = executor.getStatus();
+      expect(status.tasksDiscovered).toBe(1);
+      expect(status.tasksClaimed).toBe(1);
+      expect(status.tasksCompleted).toBe(1);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('provides correct TaskExecutionContext to handler', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      let capturedContext: TaskExecutionContext | null = null;
+
+      const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+        capturedContext = ctx;
+        return { proofHash: new Uint8Array(32).fill(1) };
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      const task = createDiscoveryResult();
+      mockDiscovery._emitTask(task);
+      await waitFor(() => capturedContext !== null);
+
+      expect(capturedContext!.task).toBe(task.task);
+      expect(capturedContext!.taskPda).toBe(task.pda);
+      expect(capturedContext!.agentPda).toBe(agentPda);
+      expect(capturedContext!.agentId).toEqual(agentId);
+      expect(capturedContext!.logger).toBeDefined();
+      expect(capturedContext!.signal).toBeInstanceOf(AbortSignal);
+      // claimPda should be the one from the claim result
+      expect(capturedContext!.claimPda).toBeInstanceOf(PublicKey);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('throws if discovery is not provided for autonomous mode', async () => {
+      const config = createExecutorConfig({ mode: 'autonomous' });
+      const executor = new TaskExecutor(config);
+
+      await expect(executor.start()).rejects.toThrow('TaskDiscovery is required');
+    });
+
+    it('throws if already running', async () => {
+      const mockDiscovery = createMockDiscovery();
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+
+      await waitFor(() => executor.isRunning());
+
+      await expect(executor.start()).rejects.toThrow('already running');
+
+      await executor.stop();
+      await startPromise;
+    });
+  });
+
+  // ==========================================================================
+  // Batch Mode
+  // ==========================================================================
+
+  describe('batch mode', () => {
+    it('processes all specified batch tasks', async () => {
+      const mockOps = createMockOperations();
+      const taskPda = Keypair.generate().publicKey;
+      const task = createTask();
+      mockOps.fetchTask.mockResolvedValue(task);
+
+      const config = createExecutorConfig({
+        mode: 'batch',
+        operations: mockOps,
+        batchTasks: [{ taskPda }],
+      });
+      const executor = new TaskExecutor(config);
+      await executor.start();
+
+      expect(mockOps.claimTask).toHaveBeenCalledTimes(1);
+      expect(mockOps.completeTask).toHaveBeenCalledTimes(1);
+
+      const status = executor.getStatus();
+      expect(status.tasksDiscovered).toBe(1);
+      expect(status.tasksCompleted).toBe(1);
+    });
+
+    it('resolves start() promise when batch is complete', async () => {
+      const mockOps = createMockOperations();
+      const taskPda = Keypair.generate().publicKey;
+      mockOps.fetchTask.mockResolvedValue(createTask());
+
+      const config = createExecutorConfig({
+        mode: 'batch',
+        operations: mockOps,
+        batchTasks: [{ taskPda }],
+      });
+      const executor = new TaskExecutor(config);
+
+      // Should resolve after processing
+      await executor.start();
+
+      // After batch completes, status reflects
+      expect(executor.getStatus().tasksCompleted).toBe(1);
+    });
+
+    it('handles mix of taskPda and creator+taskId batch items', async () => {
+      const mockOps = createMockOperations();
+      const taskPda1 = Keypair.generate().publicKey;
+      const creator = Keypair.generate().publicKey;
+      const taskIdBytes = new Uint8Array(32).fill(5);
+
+      const task1 = createTask();
+      const task2 = createTask({ creator, taskId: taskIdBytes });
+
+      mockOps.fetchTask.mockResolvedValueOnce(task1).mockResolvedValueOnce(task2);
+
+      const config = createExecutorConfig({
+        mode: 'batch',
+        operations: mockOps,
+        batchTasks: [
+          { taskPda: taskPda1 },
+          { creator, taskId: taskIdBytes },
+        ],
+      });
+      const executor = new TaskExecutor(config);
+      await executor.start();
+
+      expect(mockOps.claimTask).toHaveBeenCalledTimes(2);
+      expect(mockOps.completeTask).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles empty batch gracefully', async () => {
+      const config = createExecutorConfig({
+        mode: 'batch',
+        batchTasks: [],
+      });
+      const executor = new TaskExecutor(config);
+      await executor.start();
+
+      expect(executor.getStatus().tasksDiscovered).toBe(0);
+    });
+
+    it('handles batch task not found on-chain', async () => {
+      const mockOps = createMockOperations();
+      mockOps.fetchTask.mockResolvedValue(null);
+
+      const config = createExecutorConfig({
+        mode: 'batch',
+        operations: mockOps,
+        batchTasks: [{ taskPda: Keypair.generate().publicKey }],
+      });
+      const executor = new TaskExecutor(config);
+      await executor.start();
+
+      expect(mockOps.claimTask).not.toHaveBeenCalled();
+      expect(executor.getStatus().tasksDiscovered).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // Error Handling
+  // ==========================================================================
+
+  describe('error handling', () => {
+    it('continues processing on claim failure', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      mockOps.claimTask
+        .mockRejectedValueOnce(new Error('TaskFullyClaimed'))
+        .mockResolvedValueOnce({
+          success: true,
+          taskId: new Uint8Array(32),
+          claimPda: Keypair.generate().publicKey,
+          transactionSignature: 'sig',
+        } satisfies ClaimResult);
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      // First task: claim fails
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => mockOps.claimTask.mock.calls.length >= 1);
+      await flushAsync();
+
+      // Second task: succeeds
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => mockOps.completeTask.mock.calls.length >= 1);
+
+      const status = executor.getStatus();
+      expect(status.claimsFailed).toBe(1);
+      expect(status.tasksCompleted).toBe(1);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('increments tasksFailed on handler failure', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+
+      const handler = async (): Promise<TaskExecutionResult> => {
+        throw new Error('Handler error');
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => executor.getStatus().tasksFailed >= 1);
+
+      expect(executor.getStatus().tasksFailed).toBe(1);
+      // Should not attempt to submit
+      expect(mockOps.completeTask).not.toHaveBeenCalled();
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('increments submitsFailed on submit failure', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      mockOps.completeTask.mockRejectedValueOnce(new Error('Submit failed'));
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => executor.getStatus().submitsFailed >= 1);
+
+      expect(executor.getStatus().submitsFailed).toBe(1);
+
+      await executor.stop();
+      await startPromise;
+    });
+  });
+
+  // ==========================================================================
+  // Status & Metrics
+  // ==========================================================================
+
+  describe('status and metrics', () => {
+    it('getStatus() returns correct initial state', () => {
+      const config = createExecutorConfig({ mode: 'batch' });
+      const executor = new TaskExecutor(config);
+
+      const status = executor.getStatus();
+      expect(status.running).toBe(false);
+      expect(status.mode).toBe('batch');
+      expect(status.tasksDiscovered).toBe(0);
+      expect(status.tasksClaimed).toBe(0);
+      expect(status.tasksCompleted).toBe(0);
+      expect(status.tasksFailed).toBe(0);
+      expect(status.tasksInProgress).toBe(0);
+      expect(status.claimsFailed).toBe(0);
+      expect(status.submitsFailed).toBe(0);
+      expect(status.startedAt).toBeNull();
+      expect(status.uptimeMs).toBe(0);
+    });
+
+    it('isRunning() reflects state correctly', async () => {
+      const mockDiscovery = createMockDiscovery();
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+
+      expect(executor.isRunning()).toBe(false);
+
+      const startPromise = executor.start();
+      await waitFor(() => executor.isRunning());
+
+      expect(executor.isRunning()).toBe(true);
+
+      await executor.stop();
+      await startPromise;
+
+      expect(executor.isRunning()).toBe(false);
+    });
+
+    it('getStatus() computes uptimeMs from startedAt', async () => {
+      const mockDiscovery = createMockDiscovery();
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+
+      await waitFor(() => executor.isRunning());
+
+      // Allow some time to pass
+      await new Promise((r) => setTimeout(r, 50));
+
+      const status = executor.getStatus();
+      expect(status.startedAt).toBeTypeOf('number');
+      expect(status.uptimeMs).toBeGreaterThan(0);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('tracks metrics across multiple tasks', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      // Inject 3 tasks
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => executor.getStatus().tasksCompleted >= 1);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => executor.getStatus().tasksCompleted >= 2);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => executor.getStatus().tasksCompleted >= 3);
+
+      const status = executor.getStatus();
+      expect(status.tasksDiscovered).toBe(3);
+      expect(status.tasksClaimed).toBe(3);
+      expect(status.tasksCompleted).toBe(3);
+
+      await executor.stop();
+      await startPromise;
+    });
+  });
+
+  // ==========================================================================
+  // Event Callbacks
+  // ==========================================================================
+
+  describe('event callbacks', () => {
+    it('emits onTaskDiscovered when task enters pipeline', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onTaskDiscovered = vi.fn();
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onTaskDiscovered });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      const task = createDiscoveryResult();
+      mockDiscovery._emitTask(task);
+
+      await waitFor(() => onTaskDiscovered.mock.calls.length > 0);
+      expect(onTaskDiscovered).toHaveBeenCalledWith(task);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('emits onTaskClaimed after successful claim', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onTaskClaimed = vi.fn();
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onTaskClaimed });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => onTaskClaimed.mock.calls.length > 0);
+
+      expect(onTaskClaimed).toHaveBeenCalledTimes(1);
+      expect(onTaskClaimed.mock.calls[0][0].success).toBe(true);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('emits onTaskExecutionStarted when handler begins', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onTaskExecutionStarted = vi.fn();
+
+      const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+        return { proofHash: new Uint8Array(32).fill(1) };
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onTaskExecutionStarted });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => onTaskExecutionStarted.mock.calls.length > 0);
+
+      expect(onTaskExecutionStarted).toHaveBeenCalledTimes(1);
+      const ctx = onTaskExecutionStarted.mock.calls[0][0] as TaskExecutionContext;
+      expect(ctx.signal).toBeInstanceOf(AbortSignal);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('emits onTaskCompleted after successful submission', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onTaskCompleted = vi.fn();
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onTaskCompleted });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => onTaskCompleted.mock.calls.length > 0);
+
+      expect(onTaskCompleted).toHaveBeenCalledTimes(1);
+      expect(onTaskCompleted.mock.calls[0][0].success).toBe(true);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('emits onClaimFailed when claim fails', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onClaimFailed = vi.fn();
+      mockOps.claimTask.mockRejectedValueOnce(new Error('claim error'));
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onClaimFailed });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      const task = createDiscoveryResult();
+      mockDiscovery._emitTask(task);
+      await waitFor(() => onClaimFailed.mock.calls.length > 0);
+
+      expect(onClaimFailed).toHaveBeenCalledTimes(1);
+      expect(onClaimFailed.mock.calls[0][0]).toBeInstanceOf(Error);
+      expect(onClaimFailed.mock.calls[0][1]).toBe(task.pda);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('emits onTaskFailed when handler throws', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onTaskFailed = vi.fn();
+
+      const handler = async (): Promise<TaskExecutionResult> => {
+        throw new Error('handler boom');
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onTaskFailed });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      const task = createDiscoveryResult();
+      mockDiscovery._emitTask(task);
+      await waitFor(() => onTaskFailed.mock.calls.length > 0);
+
+      expect(onTaskFailed).toHaveBeenCalledTimes(1);
+      expect(onTaskFailed.mock.calls[0][0].message).toBe('handler boom');
+      expect(onTaskFailed.mock.calls[0][1]).toBe(task.pda);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('emits onSubmitFailed when submit fails', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onSubmitFailed = vi.fn();
+      mockOps.completeTask.mockRejectedValueOnce(new Error('submit error'));
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onSubmitFailed });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      const task = createDiscoveryResult();
+      mockDiscovery._emitTask(task);
+      await waitFor(() => onSubmitFailed.mock.calls.length > 0);
+
+      expect(onSubmitFailed).toHaveBeenCalledTimes(1);
+      expect(onSubmitFailed.mock.calls[0][0].message).toBe('submit error');
+      expect(onSubmitFailed.mock.calls[0][1]).toBe(task.pda);
+
+      await executor.stop();
+      await startPromise;
+    });
+  });
+
+  // ==========================================================================
+  // Concurrency
+  // ==========================================================================
+
+  describe('concurrency', () => {
+    it('handler receives AbortSignal in context', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      let capturedSignal: AbortSignal | null = null;
+
+      const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+        capturedSignal = ctx.signal;
+        return { proofHash: new Uint8Array(32).fill(1) };
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => capturedSignal !== null);
+
+      expect(capturedSignal).toBeInstanceOf(AbortSignal);
+      expect(capturedSignal!.aborted).toBe(false);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('AbortSignal fires on stop()', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      let capturedSignal: AbortSignal | null = null;
+      let handlerResolve: (() => void) | null = null;
+
+      const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+        capturedSignal = ctx.signal;
+        // Hold the handler open until we resolve
+        await new Promise<void>((resolve) => {
+          handlerResolve = resolve;
+        });
+        return { proofHash: new Uint8Array(32).fill(1) };
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => capturedSignal !== null);
+
+      expect(capturedSignal!.aborted).toBe(false);
+
+      // Stop aborts controllers synchronously before async cleanup
+      const stopPromise = executor.stop();
+      expect(capturedSignal!.aborted).toBe(true);
+
+      // Resolve the handler so cleanup completes
+      handlerResolve?.();
+      await stopPromise;
+      await startPromise;
+    });
+
+    it('respects maxConcurrentTasks limit', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      let activeCount = 0;
+      let maxActive = 0;
+      const resolvers: (() => void)[] = [];
+
+      const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+        activeCount++;
+        maxActive = Math.max(maxActive, activeCount);
+        await new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        });
+        activeCount--;
+        return { proofHash: new Uint8Array(32).fill(1) };
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+        maxConcurrentTasks: 2,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      // Inject 4 tasks
+      for (let i = 0; i < 4; i++) {
+        mockDiscovery._emitTask(createDiscoveryResult());
+      }
+
+      // Wait for 2 handlers to start
+      await waitFor(() => activeCount === 2, 2000);
+
+      // Only 2 should be active at once
+      expect(activeCount).toBe(2);
+      expect(maxActive).toBe(2);
+
+      // Complete tasks one at a time, verifying concurrency never exceeds 2
+      // Resolve task 1 — should allow queued task 3 to start
+      resolvers[0]();
+      await waitFor(() => resolvers.length >= 3, 2000);
+      expect(activeCount).toBeLessThanOrEqual(2);
+
+      // Resolve task 2 — should allow queued task 4 to start
+      resolvers[1]();
+      await waitFor(() => resolvers.length >= 4, 2000);
+      expect(activeCount).toBeLessThanOrEqual(2);
+
+      // Resolve remaining tasks
+      resolvers[2]();
+      resolvers[3]();
+
+      await waitFor(() => executor.getStatus().tasksCompleted >= 4, 5000);
+      expect(executor.getStatus().tasksCompleted).toBe(4);
+      expect(maxActive).toBe(2);
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('queues tasks beyond limit (not dropped)', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const resolvers: (() => void)[] = [];
+
+      const handler = async (_ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+        await new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        });
+        return { proofHash: new Uint8Array(32).fill(1) };
+      };
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+        maxConcurrentTasks: 1,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      // Inject 3 tasks
+      mockDiscovery._emitTask(createDiscoveryResult());
+      mockDiscovery._emitTask(createDiscoveryResult());
+      mockDiscovery._emitTask(createDiscoveryResult());
+
+      // Wait for first handler to start
+      await waitFor(() => resolvers.length >= 1);
+
+      // All 3 discovered
+      expect(executor.getStatus().tasksDiscovered).toBe(3);
+
+      // Only 1 active
+      expect(executor.getStatus().tasksInProgress).toBe(1);
+
+      // Complete tasks one by one
+      resolvers[0]();
+      await waitFor(() => resolvers.length >= 2);
+
+      resolvers[1]();
+      await waitFor(() => resolvers.length >= 3);
+
+      resolvers[2]();
+      await waitFor(() => executor.getStatus().tasksCompleted >= 3, 5000);
+
+      expect(executor.getStatus().tasksCompleted).toBe(3);
+
+      await executor.stop();
+      await startPromise;
+    });
+  });
+
+  // ==========================================================================
+  // Private Tasks
+  // ==========================================================================
+
+  describe('private tasks', () => {
+    it('calls completeTaskPrivate for PrivateTaskExecutionResult', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+
+      const handler = async (): Promise<PrivateTaskExecutionResult> => ({
+        proof: new Uint8Array(388),
+        constraintHash: new Uint8Array(32).fill(1),
+        outputCommitment: new Uint8Array(32).fill(2),
+        expectedBinding: new Uint8Array(32).fill(3),
+      });
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => mockOps.completeTaskPrivate.mock.calls.length > 0);
+
+      expect(mockOps.completeTaskPrivate).toHaveBeenCalledTimes(1);
+      expect(mockOps.completeTask).not.toHaveBeenCalled();
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('calls completeTask for TaskExecutionResult', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+
+      const handler = async (): Promise<TaskExecutionResult> => ({
+        proofHash: new Uint8Array(32).fill(1),
+        resultData: new Uint8Array(64).fill(2),
+      });
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+        handler,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => mockOps.completeTask.mock.calls.length > 0);
+
+      expect(mockOps.completeTask).toHaveBeenCalledTimes(1);
+      expect(mockOps.completeTaskPrivate).not.toHaveBeenCalled();
+
+      await executor.stop();
+      await startPromise;
+    });
+
+    it('isPrivateExecutionResult correctly routes result type', () => {
+      const publicResult: TaskExecutionResult = {
+        proofHash: new Uint8Array(32),
+      };
+
+      const privateResult: PrivateTaskExecutionResult = {
+        proof: new Uint8Array(388),
+        constraintHash: new Uint8Array(32),
+        outputCommitment: new Uint8Array(32),
+        expectedBinding: new Uint8Array(32),
+      };
+
+      expect(isPrivateExecutionResult(publicResult)).toBe(false);
+      expect(isPrivateExecutionResult(privateResult)).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  describe('lifecycle', () => {
+    it('stop() is idempotent when not running', async () => {
+      const config = createExecutorConfig({ mode: 'batch' });
+      const executor = new TaskExecutor(config);
+
+      // Should not throw
+      await executor.stop();
+      await executor.stop();
+    });
+
+    it('stop() clears queue and stops discovery', async () => {
+      const mockDiscovery = createMockDiscovery();
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      const startPromise = executor.start();
+      await waitFor(() => executor.isRunning());
+
+      await executor.stop();
+      await startPromise;
+
+      expect(mockDiscovery.stop).toHaveBeenCalled();
+      expect(executor.isRunning()).toBe(false);
+    });
+
+    it('on() registers multiple event callback sets', async () => {
+      const mockOps = createMockOperations();
+      const mockDiscovery = createMockDiscovery();
+      const onDiscovered1 = vi.fn();
+      const onCompleted2 = vi.fn();
+
+      const config = createExecutorConfig({
+        mode: 'autonomous',
+        operations: mockOps,
+        discovery: mockDiscovery,
+      });
+      const executor = new TaskExecutor(config);
+      executor.on({ onTaskDiscovered: onDiscovered1 });
+      executor.on({ onTaskCompleted: onCompleted2 });
+
+      const startPromise = executor.start();
+      await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+      mockDiscovery._emitTask(createDiscoveryResult());
+      await waitFor(() => onCompleted2.mock.calls.length > 0);
+
+      expect(onDiscovered1).toHaveBeenCalled();
+      expect(onCompleted2).toHaveBeenCalled();
+
+      await executor.stop();
+      await startPromise;
+    });
+  });
+});

--- a/runtime/src/task/executor.ts
+++ b/runtime/src/task/executor.ts
@@ -1,0 +1,478 @@
+/**
+ * TaskExecutor — main orchestration class for the Discovery → Claim → Execute → Submit pipeline.
+ *
+ * Supports two operating modes:
+ * - **autonomous**: Continuously discover tasks via TaskDiscovery, claim, execute, and submit results.
+ * - **batch**: Process a pre-selected list of tasks, then resolve.
+ *
+ * Features:
+ * - Concurrency control with configurable maxConcurrentTasks and task queue
+ * - Separate execution paths for private (ZK) vs public tasks
+ * - AbortController per active task for graceful cancellation
+ * - 7 event callbacks emitted at correct pipeline stages
+ * - 6-counter metrics tracking
+ *
+ * @module
+ */
+
+import type { PublicKey } from '@solana/web3.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import type { TaskOperations } from './operations.js';
+import type { TaskDiscovery, TaskDiscoveryResult } from './discovery.js';
+import type {
+  TaskExecutionContext,
+  TaskExecutionResult,
+  PrivateTaskExecutionResult,
+  TaskHandler,
+  ClaimResult,
+  CompleteResult,
+  TaskExecutorConfig,
+  TaskExecutorStatus,
+  TaskExecutorEvents,
+  OperatingMode,
+  BatchTaskItem,
+} from './types.js';
+import { isPrivateExecutionResult } from './types.js';
+import { deriveTaskPda } from './pda.js';
+
+// ============================================================================
+// TaskExecutor Class
+// ============================================================================
+
+/**
+ * Main orchestration class that ties together the complete task execution pipeline:
+ * Discovery → Claim → Execute → Submit.
+ *
+ * @example
+ * ```typescript
+ * const executor = new TaskExecutor({
+ *   operations,
+ *   handler: async (ctx) => {
+ *     // ... process task ...
+ *     return { proofHash: new Uint8Array(32).fill(1) };
+ *   },
+ *   discovery,
+ *   agentId: myAgentId,
+ *   agentPda: myAgentPda,
+ *   mode: 'autonomous',
+ *   maxConcurrentTasks: 3,
+ * });
+ *
+ * executor.on({
+ *   onTaskCompleted: (result) => console.log('Completed:', result.taskId),
+ *   onTaskFailed: (err) => console.error('Failed:', err),
+ * });
+ *
+ * await executor.start();
+ * ```
+ */
+export class TaskExecutor {
+  private readonly operations: TaskOperations;
+  private readonly handler: TaskHandler;
+  private readonly mode: OperatingMode;
+  private readonly maxConcurrentTasks: number;
+  private readonly logger: Logger;
+  private readonly discovery: TaskDiscovery | null;
+  private readonly agentId: Uint8Array;
+  private readonly agentPda: PublicKey;
+  private readonly batchTasks: BatchTaskItem[];
+
+  // Runtime state
+  private running = false;
+  private startedAt: number | null = null;
+  private activeTasks: Map<string, AbortController> = new Map();
+  private taskQueue: TaskDiscoveryResult[] = [];
+  private events: TaskExecutorEvents = {};
+  private discoveryUnsubscribe: (() => void) | null = null;
+
+  // Metrics
+  private metrics = {
+    tasksDiscovered: 0,
+    tasksClaimed: 0,
+    tasksCompleted: 0,
+    tasksFailed: 0,
+    claimsFailed: 0,
+    submitsFailed: 0,
+  };
+
+  constructor(config: TaskExecutorConfig) {
+    this.operations = config.operations;
+    this.handler = config.handler;
+    this.mode = config.mode ?? 'autonomous';
+    this.maxConcurrentTasks = config.maxConcurrentTasks ?? 1;
+    this.logger = config.logger ?? silentLogger;
+    this.discovery = config.discovery ?? null;
+    this.agentId = new Uint8Array(config.agentId);
+    this.agentPda = config.agentPda;
+    this.batchTasks = config.batchTasks ?? [];
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  /**
+   * Start the executor.
+   *
+   * In autonomous mode, sets up discovery and enters the processing loop.
+   * In batch mode, processes all batch tasks and resolves when complete.
+   *
+   * @throws Error if already running
+   * @throws Error if autonomous mode lacks a discovery instance
+   */
+  async start(): Promise<void> {
+    if (this.running) {
+      throw new Error('TaskExecutor is already running');
+    }
+
+    this.running = true;
+    this.startedAt = Date.now();
+    this.logger.info(`TaskExecutor starting in ${this.mode} mode`);
+
+    if (this.mode === 'autonomous') {
+      await this.autonomousLoop();
+    } else {
+      await this.batchLoop();
+    }
+  }
+
+  /**
+   * Stop the executor gracefully.
+   *
+   * Stops discovery, aborts all in-progress task handlers, waits for active tasks,
+   * and clears the queue. Does NOT cancel on-chain claims (they expire naturally).
+   */
+  async stop(): Promise<void> {
+    if (!this.running) {
+      return;
+    }
+
+    this.running = false;
+    this.logger.info('TaskExecutor stopping');
+
+    // Stop discovery listener first (synchronous)
+    if (this.discoveryUnsubscribe) {
+      this.discoveryUnsubscribe();
+      this.discoveryUnsubscribe = null;
+    }
+
+    // Abort all in-progress handlers immediately
+    for (const controller of this.activeTasks.values()) {
+      controller.abort();
+    }
+
+    // Stop discovery (async)
+    if (this.discovery) {
+      await this.discovery.stop();
+    }
+
+    // Wait for active tasks to finish/abort
+    if (this.activeTasks.size > 0) {
+      await new Promise<void>((resolve) => {
+        const checkDone = () => {
+          if (this.activeTasks.size === 0) {
+            resolve();
+          } else {
+            setTimeout(checkDone, 50);
+          }
+        };
+        // Timeout safety: resolve after 5 seconds regardless
+        setTimeout(resolve, 5000);
+        checkDone();
+      });
+    }
+
+    // Clear queue
+    this.taskQueue = [];
+    this.startedAt = null;
+
+    this.logger.info('TaskExecutor stopped');
+  }
+
+  /**
+   * Check if the executor is currently running.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  // ==========================================================================
+  // Status & Metrics
+  // ==========================================================================
+
+  /**
+   * Get a snapshot of the executor's current status and metrics.
+   */
+  getStatus(): TaskExecutorStatus {
+    return {
+      running: this.running,
+      mode: this.mode,
+      tasksDiscovered: this.metrics.tasksDiscovered,
+      tasksClaimed: this.metrics.tasksClaimed,
+      tasksInProgress: this.activeTasks.size,
+      tasksCompleted: this.metrics.tasksCompleted,
+      tasksFailed: this.metrics.tasksFailed,
+      claimsFailed: this.metrics.claimsFailed,
+      submitsFailed: this.metrics.submitsFailed,
+      startedAt: this.startedAt,
+      uptimeMs: this.startedAt ? Date.now() - this.startedAt : 0,
+    };
+  }
+
+  // ==========================================================================
+  // Event Registration
+  // ==========================================================================
+
+  /**
+   * Register event callbacks for pipeline stage notifications.
+   * Replaces any previously registered callbacks.
+   */
+  on(events: TaskExecutorEvents): void {
+    this.events = { ...this.events, ...events };
+  }
+
+  // ==========================================================================
+  // Autonomous Mode
+  // ==========================================================================
+
+  private async autonomousLoop(): Promise<void> {
+    if (!this.discovery) {
+      throw new Error('TaskDiscovery is required for autonomous mode');
+    }
+
+    // Register discovery callback
+    this.discoveryUnsubscribe = this.discovery.onTaskDiscovered((task: TaskDiscoveryResult) => {
+      this.metrics.tasksDiscovered++;
+      this.events.onTaskDiscovered?.(task);
+      this.handleDiscoveredTask(task);
+    });
+
+    // Start discovery (pass agent capabilities of 0n; the filter config handles matching)
+    await this.discovery.start(0n);
+
+    // Keep running until stopped — discovery callbacks drive task processing
+    while (this.running) {
+      this.drainQueue();
+      await sleep(100);
+    }
+  }
+
+  // ==========================================================================
+  // Batch Mode
+  // ==========================================================================
+
+  private async batchLoop(): Promise<void> {
+    const results: TaskDiscoveryResult[] = [];
+
+    for (const item of this.batchTasks) {
+      if (!this.running) break;
+
+      try {
+        const resolved = await this.resolveBatchItem(item);
+        if (resolved) {
+          results.push(resolved);
+        }
+      } catch (err) {
+        this.logger.warn(`Failed to resolve batch task: ${err}`);
+      }
+    }
+
+    // Process all resolved batch tasks
+    for (const task of results) {
+      if (!this.running) break;
+
+      this.metrics.tasksDiscovered++;
+      this.events.onTaskDiscovered?.(task);
+
+      if (this.activeTasks.size < this.maxConcurrentTasks) {
+        this.launchTask(task);
+      } else {
+        this.taskQueue.push(task);
+      }
+    }
+
+    // Drain remaining queued tasks
+    this.drainQueue();
+
+    // Wait for all active tasks to complete
+    while (this.activeTasks.size > 0 || this.taskQueue.length > 0) {
+      await sleep(50);
+    }
+  }
+
+  private async resolveBatchItem(item: BatchTaskItem): Promise<TaskDiscoveryResult | null> {
+    let taskPda: PublicKey | undefined = item.taskPda;
+
+    // Derive PDA from creator + taskId if not directly provided
+    if (!taskPda && item.creator && item.taskId) {
+      const { address } = deriveTaskPda(item.creator, item.taskId);
+      taskPda = address;
+    }
+
+    if (!taskPda) {
+      this.logger.warn('Batch item missing taskPda or creator+taskId');
+      return null;
+    }
+
+    const task = await this.operations.fetchTask(taskPda);
+    if (!task) {
+      this.logger.warn(`Batch task not found: ${taskPda.toBase58()}`);
+      return null;
+    }
+
+    return {
+      pda: taskPda,
+      task,
+      discoveredAt: Date.now(),
+      source: 'poll',
+    };
+  }
+
+  // ==========================================================================
+  // Concurrency Management
+  // ==========================================================================
+
+  private handleDiscoveredTask(task: TaskDiscoveryResult): void {
+    if (this.activeTasks.size < this.maxConcurrentTasks && this.taskQueue.length === 0) {
+      this.launchTask(task);
+    } else {
+      this.taskQueue.push(task);
+    }
+  }
+
+  private drainQueue(): void {
+    while (
+      this.running &&
+      this.activeTasks.size < this.maxConcurrentTasks &&
+      this.taskQueue.length > 0
+    ) {
+      const task = this.taskQueue.shift()!;
+      this.launchTask(task);
+    }
+  }
+
+  /**
+   * Register a task in activeTasks synchronously, then fire processTask asynchronously.
+   * This ensures the concurrency counter is accurate before the next handleDiscoveredTask call.
+   */
+  private launchTask(task: TaskDiscoveryResult): void {
+    const pda = task.pda.toBase58();
+    const controller = new AbortController();
+    this.activeTasks.set(pda, controller);
+    void this.processTask(task, pda, controller);
+  }
+
+  // ==========================================================================
+  // Pipeline: Claim → Execute → Submit
+  // ==========================================================================
+
+  private async processTask(
+    task: TaskDiscoveryResult,
+    pda: string,
+    controller: AbortController,
+  ): Promise<void> {
+
+    try {
+      // Step 1: Claim
+      const claimResult = await this.claimTaskStep(task);
+
+      // Step 2: Execute handler
+      const result = await this.executeTaskStep(task, claimResult, controller.signal);
+
+      // Step 3: Submit result on-chain
+      await this.submitTaskStep(task, result);
+    } catch (err) {
+      // Check if aborted (graceful shutdown)
+      if (controller.signal.aborted) {
+        this.logger.debug(`Task ${pda} aborted`);
+      }
+      // Error already handled in individual steps; just ensure metrics are right
+    } finally {
+      this.activeTasks.delete(pda);
+      this.drainQueue();
+    }
+  }
+
+  private async claimTaskStep(task: TaskDiscoveryResult): Promise<ClaimResult> {
+    try {
+      const result = await this.operations.claimTask(task.pda, task.task);
+      this.metrics.tasksClaimed++;
+      this.events.onTaskClaimed?.(result);
+      return result;
+    } catch (err) {
+      this.metrics.claimsFailed++;
+      this.events.onClaimFailed?.(err instanceof Error ? err : new Error(String(err)), task.pda);
+      throw err;
+    }
+  }
+
+  private async executeTaskStep(
+    task: TaskDiscoveryResult,
+    claimResult: ClaimResult,
+    signal: AbortSignal,
+  ): Promise<TaskExecutionResult | PrivateTaskExecutionResult> {
+    const context: TaskExecutionContext = {
+      task: task.task,
+      taskPda: task.pda,
+      claimPda: claimResult.claimPda,
+      agentId: new Uint8Array(this.agentId),
+      agentPda: this.agentPda,
+      logger: this.logger,
+      signal,
+    };
+
+    this.events.onTaskExecutionStarted?.(context);
+
+    try {
+      return await this.handler(context);
+    } catch (err) {
+      this.metrics.tasksFailed++;
+      this.events.onTaskFailed?.(err instanceof Error ? err : new Error(String(err)), task.pda);
+      throw err;
+    }
+  }
+
+  private async submitTaskStep(
+    task: TaskDiscoveryResult,
+    result: TaskExecutionResult | PrivateTaskExecutionResult,
+  ): Promise<CompleteResult> {
+    try {
+      let completeResult: CompleteResult;
+
+      if (isPrivateExecutionResult(result)) {
+        completeResult = await this.operations.completeTaskPrivate(
+          task.pda,
+          task.task,
+          result.proof,
+          result.constraintHash,
+          result.outputCommitment,
+          result.expectedBinding,
+        );
+      } else {
+        completeResult = await this.operations.completeTask(
+          task.pda,
+          task.task,
+          result.proofHash,
+          result.resultData ?? null,
+        );
+      }
+
+      this.metrics.tasksCompleted++;
+      this.events.onTaskCompleted?.(completeResult);
+      return completeResult;
+    } catch (err) {
+      this.metrics.submitsFailed++;
+      this.events.onSubmitFailed?.(err instanceof Error ? err : new Error(String(err)), task.pda);
+      throw err;
+    }
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -1,5 +1,5 @@
 /**
- * Task management utilities (PDA derivation, types, parsing, filters)
+ * Task management utilities (PDA derivation, types, parsing, filters, operations, discovery, executor)
  * @module
  */
 
@@ -8,3 +8,4 @@ export * from './types.js';
 export * from './filters.js';
 export * from './operations.js';
 export * from './discovery.js';
+export * from './executor.js';

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -243,6 +243,7 @@ export class TaskOperations {
       return {
         success: true,
         taskId: task.taskId,
+        claimPda,
         transactionSignature: signature,
       };
     } catch (err) {

--- a/runtime/src/task/types.test.ts
+++ b/runtime/src/task/types.test.ts
@@ -429,21 +429,12 @@ describe('isTaskClaimable', () => {
 });
 
 describe('isPrivateExecutionResult', () => {
-  it('identifies PrivateTaskExecutionResult by presence of proof field', () => {
+  it('identifies PrivateTaskExecutionResult by presence of proof and constraintHash fields', () => {
     const result: PrivateTaskExecutionResult = {
-      success: true,
-      transactionSignature: null,
       proof: new Uint8Array(256),
-    };
-
-    expect(isPrivateExecutionResult(result)).toBe(true);
-  });
-
-  it('identifies PrivateTaskExecutionResult by presence of proofHash field', () => {
-    const result: PrivateTaskExecutionResult = {
-      success: true,
-      transactionSignature: null,
-      proofHash: new Uint8Array(32),
+      constraintHash: new Uint8Array(32),
+      outputCommitment: new Uint8Array(32),
+      expectedBinding: new Uint8Array(32),
     };
 
     expect(isPrivateExecutionResult(result)).toBe(true);
@@ -451,9 +442,17 @@ describe('isPrivateExecutionResult', () => {
 
   it('identifies TaskExecutionResult as non-private', () => {
     const result: TaskExecutionResult = {
-      success: true,
-      transactionSignature: null,
+      proofHash: new Uint8Array(32),
     };
+
+    expect(isPrivateExecutionResult(result)).toBe(false);
+  });
+
+  it('does not match object with only proof (missing constraintHash)', () => {
+    const result = {
+      proof: new Uint8Array(256),
+      proofHash: new Uint8Array(32),
+    } as TaskExecutionResult;
 
     expect(isPrivateExecutionResult(result)).toBe(false);
   });

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -120,9 +120,6 @@ export {
   TASK_ID_LENGTH,
   // Enums
   OnChainTaskStatus,
-  DiscoveryMode,
-  OperatingMode,
-  TaskExecutorStatus,
   // Functions
   taskStatusToString,
   taskTypeToString,
@@ -165,6 +162,9 @@ export {
   type CompleteResult,
   type TaskExecutorConfig,
   type TaskExecutorEvents,
+  type OperatingMode,
+  type BatchTaskItem,
+  type TaskExecutorStatus,
 } from '../task/index.js';
 
 // Event monitoring types (Phase 2)


### PR DESCRIPTION
## Summary
- **TaskExecutor class** (`runtime/src/task/executor.ts`): Main orchestration class implementing the Discovery → Claim → Execute → Submit pipeline with autonomous and batch operating modes, concurrency control via Map + maxConcurrentTasks semaphore, AbortController per active task, private vs public result routing via `isPrivateExecutionResult`, and 7 event callbacks with 6-counter metrics (#215)
- **Exports** (`task/index.ts`, `types/index.ts`, `index.ts`): Updated barrel exports to include executor.ts and new types (OperatingMode, BatchTaskItem, TaskExecutorStatus) (#210)
- **Tests** (`runtime/src/task/executor.test.ts`): 34 tests covering autonomous mode, batch mode, full pipeline, concurrency limits, AbortSignal on stop, private/public routing, error handling, event callbacks, metrics, and lifecycle (#219)
- **Type refinements**: Updated `TaskExecutionContext`, `TaskExecutionResult`, `PrivateTaskExecutionResult`, `TaskHandler`, `TaskExecutorConfig`, `TaskExecutorStatus`, `TaskExecutorEvents`, and `isPrivateExecutionResult` to match executor requirements; added `claimPda` to `ClaimResult` in operations.ts

## Test plan
- [x] `npm run typecheck` passes
- [x] 814 unit tests pass (34 new executor tests + 780 existing)
- [x] Integration tests skipped (require local validator, not a regression)