### PR TITLE
fix(sdk): use named imports from @coral-xyz/anchor for CJS compat

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -5,12 +5,7 @@
  */
 
 import { Connection, PublicKey, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js';
-import type { Idl } from '@coral-xyz/anchor';
-import * as anchor from '@coral-xyz/anchor';
-const { Program, AnchorProvider, Wallet } = anchor;
-type Program = InstanceType<typeof Program>;
-type AnchorProvider = InstanceType<typeof AnchorProvider>;
-type Wallet = InstanceType<typeof Wallet>;
+import { type Idl, Program, AnchorProvider, Wallet } from '@coral-xyz/anchor';
 import * as path from 'path';
 import { AgenCPrivacyClient } from './privacy';
 import { PROGRAM_ID, DEVNET_RPC, MAINNET_RPC } from './constants';

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -12,10 +12,7 @@ import {
   SystemProgram,
   LAMPORTS_PER_SOL,
 } from '@solana/web3.js';
-import type { Program } from '@coral-xyz/anchor';
-import * as anchor from '@coral-xyz/anchor';
-const { BN } = anchor;
-type BN = InstanceType<typeof BN>;
+import { type Program, BN } from '@coral-xyz/anchor';
 import { PROGRAM_ID, SEEDS, TaskState, U64_SIZE, DISCRIMINATOR_SIZE, PERCENT_BASE, DEFAULT_FEE_PERCENT } from './constants';
 
 export { TaskState };


### PR DESCRIPTION
## Summary

Fixes the ESM/CJS interop bug that crashes the MCP server on startup.

### Root Cause

`sdk/src/client.ts` and `sdk/src/tasks.ts` used:
```ts
import * as anchor from '@coral-xyz/anchor';
const { Program, AnchorProvider, Wallet } = anchor;
```

When tsup/esbuild compiles this to CJS, it produces:
```js
var import_anchor = __toESM(require('@coral-xyz/anchor'));
var { Program, AnchorProvider, Wallet } = import_anchor.default;
```

But `@coral-xyz/anchor` sets `__esModule: true` with **no default export**, so `import_anchor.default` is `undefined` → `TypeError: Cannot destructure property 'Program' of 'import_anchor3.default' as it is undefined`.

### Fix

Switch to named imports (industry standard for Anchor/Solana projects):
```ts
import { type Idl, Program, AnchorProvider, Wallet } from '@coral-xyz/anchor';
import { type Program, BN } from '@coral-xyz/anchor';
```

Named imports compile cleanly to both ESM and CJS — no `__toESM` wrapper, no `.default` ambiguity.

### Verified
- ✅ SDK builds (CJS + ESM)
- ✅ SDK typecheck passes (`tsc --noEmit`)
- ✅ MCP builds
- ✅ MCP server starts without crash
- ✅ No `import_anchor.default` in compiled output

Refs #179