### PR TITLE
feat(runtime): add per-task execution timeout to TaskExecutor (#230)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -71,6 +71,7 @@ export {
   TaskExecutionError,
   TaskSubmissionError,
   ExecutorStateError,
+  TaskTimeoutError,
   // Error helper functions
   isAnchorError,
   parseAnchorError,

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -764,6 +764,8 @@ export interface TaskExecutorConfig {
   logger?: Logger;
   /** Batch tasks (for batch mode) */
   batchTasks?: BatchTaskItem[];
+  /** Per-task execution timeout in milliseconds (default: 300_000 = 5 min). Set to 0 to disable. */
+  taskTimeoutMs?: number;
 }
 
 /**
@@ -812,4 +814,6 @@ export interface TaskExecutorEvents {
   onClaimFailed?: (error: Error, taskPda: PublicKey) => void;
   /** Called when a submit attempt fails */
   onSubmitFailed?: (error: Error, taskPda: PublicKey) => void;
+  /** Called when a task execution times out */
+  onTaskTimeout?: (error: Error, taskPda: PublicKey) => void;
 }

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -39,8 +39,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY).toBe('RECENT_VOTE_ACTIVITY');
   });
 
-  it('has exactly 13 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(13);
+  it('has exactly 14 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(14);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -42,6 +42,8 @@ export const RuntimeErrorCodes = {
   TASK_SUBMISSION_FAILED: 'TASK_SUBMISSION_FAILED',
   /** Executor state machine is in an invalid state */
   EXECUTOR_STATE_ERROR: 'EXECUTOR_STATE_ERROR',
+  /** Task execution timed out */
+  TASK_TIMEOUT: 'TASK_TIMEOUT',
 } as const;
 
 /** Union type of all runtime error code values */
@@ -678,6 +680,35 @@ export class ExecutorStateError extends RuntimeError {
     this.name = 'ExecutorStateError';
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ExecutorStateError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a task handler exceeds its execution timeout.
+ *
+ * @example
+ * ```typescript
+ * executor.on({
+ *   onTaskTimeout: (error, taskPda) => {
+ *     console.log(`Task ${taskPda.toBase58()} timed out after ${error.timeoutMs}ms`);
+ *   },
+ * });
+ * ```
+ */
+export class TaskTimeoutError extends RuntimeError {
+  /** The timeout duration in milliseconds that was exceeded */
+  public readonly timeoutMs: number;
+
+  constructor(timeoutMs: number) {
+    super(
+      `Task execution timed out after ${timeoutMs}ms`,
+      RuntimeErrorCodes.TASK_TIMEOUT,
+    );
+    this.name = 'TaskTimeoutError';
+    this.timeoutMs = timeoutMs;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, TaskTimeoutError);
     }
   }
 }

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -36,6 +36,7 @@ export {
   TaskExecutionError,
   TaskSubmissionError,
   ExecutorStateError,
+  TaskTimeoutError,
   // Helper functions
   isAnchorError,
   parseAnchorError,


### PR DESCRIPTION
Closes #230

Adds configurable per-task execution timeouts so hung handlers don't permanently consume concurrency slots.

- `taskTimeoutMs` config option (default: 300,000ms = 5 min)
- `TaskTimeoutError` with timeout metadata
- `onTaskTimeout` event callback
- AbortSignal.timeout combined with stop signal
- 6 new executor tests, all 828 tests pass