### PR TITLE
feat(runtime): add configurable retry with exponential backoff (#226)

### DIFF
--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -722,6 +722,24 @@ export interface CompleteResult {
 }
 
 // ============================================================================
+// Retry Policy Types
+// ============================================================================
+
+/**
+ * Configuration for retry behavior with exponential backoff.
+ */
+export interface RetryPolicy {
+  /** Maximum number of attempts (including the initial attempt). Default: 3 */
+  maxAttempts: number;
+  /** Base delay in milliseconds before the first retry. Default: 1000 */
+  baseDelayMs: number;
+  /** Maximum delay in milliseconds between retries. Default: 30000 */
+  maxDelayMs: number;
+  /** Whether to apply full jitter (random between 0 and computed delay). Default: true */
+  jitter: boolean;
+}
+
+// ============================================================================
 // Task Executor Types
 // ============================================================================
 
@@ -766,6 +784,8 @@ export interface TaskExecutorConfig {
   batchTasks?: BatchTaskItem[];
   /** Per-task execution timeout in milliseconds (default: 300_000 = 5 min). Set to 0 to disable. */
   taskTimeoutMs?: number;
+  /** Retry policy for pipeline stages. Applies to claim and submit steps (NOT execute). */
+  retryPolicy?: Partial<RetryPolicy>;
 }
 
 /**
@@ -790,6 +810,10 @@ export interface TaskExecutorStatus {
   claimsFailed: number;
   /** Total submit failures */
   submitsFailed: number;
+  /** Total claim retry attempts */
+  claimRetries: number;
+  /** Total submit retry attempts */
+  submitRetries: number;
   /** Timestamp when the executor was started (null if not started) */
   startedAt: number | null;
   /** Milliseconds the executor has been running */

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -166,6 +166,7 @@ export {
   type OperatingMode,
   type BatchTaskItem,
   type TaskExecutorStatus,
+  type RetryPolicy,
 } from '../task/index.js';
 
 // Event monitoring types (Phase 2)


### PR DESCRIPTION
Closes #226

Adds configurable retry policies with exponential backoff and jitter to TaskExecutor pipeline stages.

- `RetryPolicy` interface: maxAttempts, baseDelayMs, maxDelayMs, jitter
- AWS-style full jitter: `random(0, min(base * 2^attempt, maxDelay))`
- Retries claim and submit failures (transient RPC/tx errors)
- Does NOT retry handler execution failures (application bugs)
- Respects abort signal during retry waits
- Logs each retry attempt
- 842 tests pass (new retry tests added)