### PR TITLE
feat(runtime): add configurable retry with exponential backoff (#226)

### DIFF
--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -722,6 +722,27 @@ export interface CompleteResult {
 }
 
 // ============================================================================
+// Retry Policy Types
+// ============================================================================
+
+/**
+ * Configuration for retry behavior with exponential backoff.
+ *
+ * Delay formula: `min(baseDelayMs * 2^attempt, maxDelayMs)`
+ * With jitter (AWS full jitter): `random(0, delay)`
+ */
+export interface RetryPolicy {
+  /** Maximum number of attempts (including the initial attempt). Default: 3 */
+  maxAttempts: number;
+  /** Base delay in milliseconds for exponential backoff. Default: 1000 */
+  baseDelayMs: number;
+  /** Maximum delay cap in milliseconds. Default: 30000 */
+  maxDelayMs: number;
+  /** Whether to apply full jitter (random(0, delay)). Default: true */
+  jitter: boolean;
+}
+
+// ============================================================================
 // Task Executor Types
 // ============================================================================
 
@@ -768,6 +789,8 @@ export interface TaskExecutorConfig {
   taskTimeoutMs?: number;
   /** Buffer in milliseconds before claim deadline to trigger abort (default: 30_000 = 30s). Set to 0 to disable. */
   claimExpiryBufferMs?: number;
+  /** Retry policy for transient failures in claim and submit stages. Handler execution is NOT retried. */
+  retryPolicy?: Partial<RetryPolicy>;
 }
 
 /**
@@ -792,6 +815,10 @@ export interface TaskExecutorStatus {
   claimsFailed: number;
   /** Total submit failures */
   submitsFailed: number;
+  /** Total claim retry attempts */
+  claimRetries: number;
+  /** Total submit retry attempts */
+  submitRetries: number;
   /** Timestamp when the executor was started (null if not started) */
   startedAt: number | null;
   /** Milliseconds the executor has been running */

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -39,8 +39,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY).toBe('RECENT_VOTE_ACTIVITY');
   });
 
-  it('has exactly 15 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(15);
+  it('has exactly 16 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(16);
   });
 });
 

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -37,6 +37,7 @@ export {
   TaskSubmissionError,
   ExecutorStateError,
   TaskTimeoutError,
+  RetryExhaustedError,
   // Helper functions
   isAnchorError,
   parseAnchorError,
@@ -166,6 +167,7 @@ export {
   type OperatingMode,
   type BatchTaskItem,
   type TaskExecutorStatus,
+  type RetryPolicy,
 } from '../task/index.js';
 
 // Event monitoring types (Phase 2)


### PR DESCRIPTION
Closes #226

Adds retry policies with exponential backoff and jitter to TaskExecutor pipeline.

- RetryPolicy config: maxAttempts, baseDelayMs, maxDelayMs, jitter
- AWS-style full jitter: random(0, min(base * 2^attempt, maxDelay))
- Retries claim and submit failures (transient RPC/tx errors)
- Does NOT retry handler execution failures
- Respects abort signal during retry waits
- 851 tests pass