### PR TITLE
feat(runtime): add dead letter queue for failed tasks (#232)

### DIFF
--- a/runtime/src/task/dlq.test.ts
+++ b/runtime/src/task/dlq.test.ts
@@ -1,0 +1,726 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Keypair } from '@solana/web3.js';
+import { DeadLetterQueue } from './dlq.js';
+import { TaskExecutor } from './executor.js';
+import type { TaskOperations } from './operations.js';
+import type { TaskDiscovery, TaskDiscoveryResult, TaskDiscoveryListener } from './discovery.js';
+import type {
+  OnChainTask,
+  OnChainTaskClaim,
+  TaskExecutionContext,
+  TaskExecutionResult,
+  TaskExecutorConfig,
+  DeadLetterEntry,
+  ClaimResult,
+  CompleteResult,
+} from './types.js';
+import { OnChainTaskStatus } from './types.js';
+import { TaskType } from '../events/types.js';
+import { silentLogger } from '../utils/logger.js';
+
+// ============================================================================
+// Helpers (match executor.test.ts patterns)
+// ============================================================================
+
+const COMPUTE = 1n << 0n;
+
+function createTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
+  return {
+    taskId: new Uint8Array(32),
+    creator: Keypair.generate().publicKey,
+    requiredCapabilities: COMPUTE,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    rewardAmount: 1_000_000n,
+    maxWorkers: 5,
+    currentWorkers: 0,
+    status: OnChainTaskStatus.Open,
+    taskType: TaskType.Exclusive,
+    createdAt: 1700000000,
+    deadline: Math.floor(Date.now() / 1000) + 3600,
+    completedAt: 0,
+    escrow: Keypair.generate().publicKey,
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+function createDiscoveryResult(overrides: Partial<TaskDiscoveryResult> = {}): TaskDiscoveryResult {
+  return {
+    pda: Keypair.generate().publicKey,
+    task: createTask(),
+    discoveredAt: Date.now(),
+    source: 'poll',
+    ...overrides,
+  };
+}
+
+function createEntry(overrides: Partial<DeadLetterEntry> = {}): DeadLetterEntry {
+  return {
+    taskPda: Keypair.generate().publicKey.toBase58(),
+    task: createTask(),
+    error: 'test error',
+    failedAt: Date.now(),
+    stage: 'claim',
+    attempts: 3,
+    retryable: true,
+    ...overrides,
+  };
+}
+
+function createMockOperations(): TaskOperations & {
+  claimTask: ReturnType<typeof vi.fn>;
+  completeTask: ReturnType<typeof vi.fn>;
+  completeTaskPrivate: ReturnType<typeof vi.fn>;
+  fetchTask: ReturnType<typeof vi.fn>;
+  fetchTaskByIds: ReturnType<typeof vi.fn>;
+  fetchClaim: ReturnType<typeof vi.fn>;
+} {
+  const claimPda = Keypair.generate().publicKey;
+  return {
+    fetchClaimableTasks: vi.fn().mockResolvedValue([]),
+    fetchTask: vi.fn().mockResolvedValue(null),
+    fetchAllTasks: vi.fn().mockResolvedValue([]),
+    fetchClaim: vi.fn().mockResolvedValue(null),
+    fetchActiveClaims: vi.fn().mockResolvedValue([]),
+    fetchTaskByIds: vi.fn().mockResolvedValue(null),
+    claimTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      claimPda,
+      transactionSignature: 'claim-sig',
+    } satisfies ClaimResult),
+    completeTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      isPrivate: false,
+      transactionSignature: 'complete-sig',
+    } satisfies CompleteResult),
+    completeTaskPrivate: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      isPrivate: true,
+      transactionSignature: 'private-complete-sig',
+    } satisfies CompleteResult),
+  } as unknown as TaskOperations & {
+    claimTask: ReturnType<typeof vi.fn>;
+    completeTask: ReturnType<typeof vi.fn>;
+    completeTaskPrivate: ReturnType<typeof vi.fn>;
+    fetchTask: ReturnType<typeof vi.fn>;
+    fetchTaskByIds: ReturnType<typeof vi.fn>;
+    fetchClaim: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockDiscovery(): TaskDiscovery & {
+  onTaskDiscovered: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  _emitTask: (task: TaskDiscoveryResult) => void;
+} {
+  let listener: TaskDiscoveryListener | null = null;
+
+  const mock = {
+    onTaskDiscovered: vi.fn((cb: TaskDiscoveryListener) => {
+      listener = cb;
+      return () => { listener = null; };
+    }),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    isRunning: vi.fn().mockReturnValue(false),
+    isPaused: vi.fn().mockReturnValue(false),
+    getDiscoveredCount: vi.fn().mockReturnValue(0),
+    clearSeen: vi.fn(),
+    poll: vi.fn().mockResolvedValue([]),
+    _emitTask: (task: TaskDiscoveryResult) => {
+      listener?.(task);
+    },
+  };
+
+  return mock as unknown as TaskDiscovery & {
+    onTaskDiscovered: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    _emitTask: (task: TaskDiscoveryResult) => void;
+  };
+}
+
+const agentId = new Uint8Array(32).fill(42);
+const agentPda = Keypair.generate().publicKey;
+
+const defaultHandler = async (_ctx: TaskExecutionContext): Promise<TaskExecutionResult> => ({
+  proofHash: new Uint8Array(32).fill(1),
+});
+
+function createExecutorConfig(overrides: Partial<TaskExecutorConfig> = {}): TaskExecutorConfig {
+  return {
+    operations: createMockOperations(),
+    handler: defaultHandler,
+    agentId,
+    agentPda,
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 10,
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timeout');
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+// ============================================================================
+// DeadLetterQueue Unit Tests
+// ============================================================================
+
+describe('DeadLetterQueue', () => {
+  let dlq: DeadLetterQueue;
+
+  beforeEach(() => {
+    dlq = new DeadLetterQueue();
+  });
+
+  describe('add()', () => {
+    it('adds an entry to the queue', () => {
+      const entry = createEntry();
+      dlq.add(entry);
+      expect(dlq.size()).toBe(1);
+    });
+
+    it('preserves insertion order', () => {
+      const e1 = createEntry({ error: 'first' });
+      const e2 = createEntry({ error: 'second' });
+      const e3 = createEntry({ error: 'third' });
+      dlq.add(e1);
+      dlq.add(e2);
+      dlq.add(e3);
+
+      const all = dlq.getAll();
+      expect(all[0].error).toBe('first');
+      expect(all[1].error).toBe('second');
+      expect(all[2].error).toBe('third');
+    });
+  });
+
+  describe('getAll()', () => {
+    it('returns empty array when queue is empty', () => {
+      expect(dlq.getAll()).toEqual([]);
+    });
+
+    it('returns a copy (not the internal array)', () => {
+      dlq.add(createEntry());
+      const all = dlq.getAll();
+      all.push(createEntry());
+      expect(dlq.size()).toBe(1);
+    });
+
+    it('returns all entries ordered oldest to newest', () => {
+      for (let i = 0; i < 5; i++) {
+        dlq.add(createEntry({ error: `error-${i}` }));
+      }
+      const all = dlq.getAll();
+      expect(all).toHaveLength(5);
+      expect(all[0].error).toBe('error-0');
+      expect(all[4].error).toBe('error-4');
+    });
+  });
+
+  describe('getByTaskId()', () => {
+    it('returns matching entry', () => {
+      const entry = createEntry({ taskPda: 'abc123' });
+      dlq.add(entry);
+      expect(dlq.getByTaskId('abc123')).toBe(entry);
+    });
+
+    it('returns undefined for non-existent entry', () => {
+      dlq.add(createEntry());
+      expect(dlq.getByTaskId('nonexistent')).toBeUndefined();
+    });
+
+    it('returns undefined when queue is empty', () => {
+      expect(dlq.getByTaskId('anything')).toBeUndefined();
+    });
+  });
+
+  describe('retry()', () => {
+    it('removes and returns entry by taskPda', () => {
+      const entry = createEntry({ taskPda: 'abc123' });
+      dlq.add(entry);
+
+      const result = dlq.retry('abc123');
+      expect(result).toBe(entry);
+      expect(dlq.size()).toBe(0);
+    });
+
+    it('returns undefined for non-existent entry', () => {
+      dlq.add(createEntry());
+      expect(dlq.retry('nonexistent')).toBeUndefined();
+      expect(dlq.size()).toBe(1);
+    });
+
+    it('only removes the matching entry', () => {
+      dlq.add(createEntry({ taskPda: 'a' }));
+      dlq.add(createEntry({ taskPda: 'b' }));
+      dlq.add(createEntry({ taskPda: 'c' }));
+
+      dlq.retry('b');
+      expect(dlq.size()).toBe(2);
+      expect(dlq.getByTaskId('a')).toBeDefined();
+      expect(dlq.getByTaskId('b')).toBeUndefined();
+      expect(dlq.getByTaskId('c')).toBeDefined();
+    });
+  });
+
+  describe('remove()', () => {
+    it('removes entry and returns true', () => {
+      dlq.add(createEntry({ taskPda: 'abc123' }));
+      expect(dlq.remove('abc123')).toBe(true);
+      expect(dlq.size()).toBe(0);
+    });
+
+    it('returns false for non-existent entry', () => {
+      expect(dlq.remove('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('size()', () => {
+    it('returns 0 for empty queue', () => {
+      expect(dlq.size()).toBe(0);
+    });
+
+    it('tracks additions', () => {
+      dlq.add(createEntry());
+      dlq.add(createEntry());
+      expect(dlq.size()).toBe(2);
+    });
+
+    it('tracks removals', () => {
+      dlq.add(createEntry({ taskPda: 'a' }));
+      dlq.add(createEntry({ taskPda: 'b' }));
+      dlq.remove('a');
+      expect(dlq.size()).toBe(1);
+    });
+  });
+
+  describe('clear()', () => {
+    it('removes all entries', () => {
+      for (let i = 0; i < 10; i++) {
+        dlq.add(createEntry());
+      }
+      dlq.clear();
+      expect(dlq.size()).toBe(0);
+      expect(dlq.getAll()).toEqual([]);
+    });
+  });
+
+  describe('maxSize eviction (FIFO)', () => {
+    it('evicts oldest entry when at capacity', () => {
+      const small = new DeadLetterQueue({ maxSize: 3 });
+      small.add(createEntry({ error: 'e1' }));
+      small.add(createEntry({ error: 'e2' }));
+      small.add(createEntry({ error: 'e3' }));
+      expect(small.size()).toBe(3);
+
+      small.add(createEntry({ error: 'e4' }));
+      expect(small.size()).toBe(3);
+
+      const all = small.getAll();
+      expect(all[0].error).toBe('e2');
+      expect(all[1].error).toBe('e3');
+      expect(all[2].error).toBe('e4');
+    });
+
+    it('evicts multiple oldest entries as needed', () => {
+      const small = new DeadLetterQueue({ maxSize: 2 });
+      small.add(createEntry({ error: 'e1' }));
+      small.add(createEntry({ error: 'e2' }));
+      small.add(createEntry({ error: 'e3' }));
+      small.add(createEntry({ error: 'e4' }));
+
+      expect(small.size()).toBe(2);
+      const all = small.getAll();
+      expect(all[0].error).toBe('e3');
+      expect(all[1].error).toBe('e4');
+    });
+
+    it('defaults to maxSize 1000', () => {
+      const defaultDlq = new DeadLetterQueue();
+      for (let i = 0; i < 1001; i++) {
+        defaultDlq.add(createEntry({ error: `e-${i}` }));
+      }
+      expect(defaultDlq.size()).toBe(1000);
+      // Oldest (e-0) should have been evicted
+      const all = defaultDlq.getAll();
+      expect(all[0].error).toBe('e-1');
+      expect(all[999].error).toBe('e-1000');
+    });
+
+    it('respects custom maxSize', () => {
+      const custom = new DeadLetterQueue({ maxSize: 5 });
+      for (let i = 0; i < 10; i++) {
+        custom.add(createEntry({ error: `e-${i}` }));
+      }
+      expect(custom.size()).toBe(5);
+      const all = custom.getAll();
+      expect(all[0].error).toBe('e-5');
+      expect(all[4].error).toBe('e-9');
+    });
+  });
+});
+
+// ============================================================================
+// Executor DLQ Integration Tests
+// ============================================================================
+
+describe('TaskExecutor DLQ integration', () => {
+  it('exposes DLQ via getDeadLetterQueue()', () => {
+    const config = createExecutorConfig({ mode: 'batch' });
+    const executor = new TaskExecutor(config);
+    const dlq = executor.getDeadLetterQueue();
+
+    expect(dlq).toBeInstanceOf(DeadLetterQueue);
+    expect(dlq.size()).toBe(0);
+  });
+
+  it('sends handler failure to DLQ', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+    const onDeadLettered = vi.fn();
+
+    const handler = async (): Promise<TaskExecutionResult> => {
+      throw new Error('handler crash');
+    };
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      handler,
+    });
+    const executor = new TaskExecutor(config);
+    executor.on({ onDeadLettered });
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    const task = createDiscoveryResult();
+    mockDiscovery._emitTask(task);
+
+    await waitFor(() => executor.getStatus().tasksFailed >= 1, 3000);
+    // Allow DLQ write to settle
+    await new Promise((r) => setTimeout(r, 50));
+
+    const dlq = executor.getDeadLetterQueue();
+    expect(dlq.size()).toBe(1);
+
+    const entry = dlq.getAll()[0];
+    expect(entry.taskPda).toBe(task.pda.toBase58());
+    expect(entry.error).toBe('handler crash');
+    expect(entry.stage).toBe('execute');
+    expect(entry.attempts).toBe(1);
+    expect(entry.retryable).toBe(false);
+    expect(entry.failedAt).toBeGreaterThan(0);
+
+    // onDeadLettered callback fired
+    expect(onDeadLettered).toHaveBeenCalledTimes(1);
+    expect(onDeadLettered.mock.calls[0][0].taskPda).toBe(task.pda.toBase58());
+
+    await executor.stop();
+    await startPromise;
+  });
+
+  it('sends claim retry exhaustion to DLQ with stage=claim', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+    const onDeadLettered = vi.fn();
+
+    mockOps.claimTask.mockRejectedValue(new Error('persistent RPC failure'));
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      retryPolicy: { maxAttempts: 2, baseDelayMs: 10, maxDelayMs: 50, jitter: false },
+    });
+    const executor = new TaskExecutor(config);
+    executor.on({ onDeadLettered });
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    const task = createDiscoveryResult();
+    mockDiscovery._emitTask(task);
+
+    await waitFor(() => mockOps.claimTask.mock.calls.length >= 2, 5000);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const dlq = executor.getDeadLetterQueue();
+    expect(dlq.size()).toBe(1);
+
+    const entry = dlq.getAll()[0];
+    expect(entry.stage).toBe('claim');
+    expect(entry.attempts).toBe(2);
+    expect(entry.retryable).toBe(true);
+
+    expect(onDeadLettered).toHaveBeenCalledTimes(1);
+
+    await executor.stop();
+    await startPromise;
+  });
+
+  it('sends submit retry exhaustion to DLQ with stage=submit', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+    const onDeadLettered = vi.fn();
+
+    mockOps.completeTask.mockRejectedValue(new Error('persistent submit failure'));
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      retryPolicy: { maxAttempts: 2, baseDelayMs: 10, maxDelayMs: 50, jitter: false },
+    });
+    const executor = new TaskExecutor(config);
+    executor.on({ onDeadLettered });
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    const task = createDiscoveryResult();
+    mockDiscovery._emitTask(task);
+
+    await waitFor(() => mockOps.completeTask.mock.calls.length >= 2, 5000);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const dlq = executor.getDeadLetterQueue();
+    expect(dlq.size()).toBe(1);
+
+    const entry = dlq.getAll()[0];
+    expect(entry.stage).toBe('submit');
+    expect(entry.attempts).toBe(2);
+    expect(entry.retryable).toBe(true);
+
+    expect(onDeadLettered).toHaveBeenCalledTimes(1);
+
+    await executor.stop();
+    await startPromise;
+  });
+
+  it('sends timeout failure to DLQ with stage=execute', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+    const onDeadLettered = vi.fn();
+
+    const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+      await new Promise<void>((_, reject) => {
+        ctx.signal.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+      return { proofHash: new Uint8Array(32).fill(1) };
+    };
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      handler,
+      taskTimeoutMs: 50,
+    });
+    const executor = new TaskExecutor(config);
+    executor.on({ onDeadLettered });
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    mockDiscovery._emitTask(createDiscoveryResult());
+    await waitFor(() => executor.getStatus().tasksFailed >= 1, 3000);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const dlq = executor.getDeadLetterQueue();
+    expect(dlq.size()).toBe(1);
+
+    const entry = dlq.getAll()[0];
+    expect(entry.stage).toBe('execute');
+    expect(entry.error).toContain('timed out');
+
+    expect(onDeadLettered).toHaveBeenCalledTimes(1);
+
+    await executor.stop();
+    await startPromise;
+  });
+
+  it('does not send to DLQ on graceful shutdown abort', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+    const onDeadLettered = vi.fn();
+    let handlerResolve: (() => void) | null = null;
+
+    const handler = async (ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+      await new Promise<void>((resolve, reject) => {
+        handlerResolve = resolve;
+        ctx.signal.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+      return { proofHash: new Uint8Array(32).fill(1) };
+    };
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      handler,
+      taskTimeoutMs: 0,
+    });
+    const executor = new TaskExecutor(config);
+    executor.on({ onDeadLettered });
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    mockDiscovery._emitTask(createDiscoveryResult());
+    await waitFor(() => handlerResolve !== null);
+
+    // Stop executor (graceful shutdown aborts signal)
+    await executor.stop();
+    await startPromise;
+
+    // DLQ should be empty — graceful shutdown is not a failure
+    expect(executor.getDeadLetterQueue().size()).toBe(0);
+    expect(onDeadLettered).not.toHaveBeenCalled();
+  });
+
+  it('respects deadLetterQueue.maxSize config', () => {
+    const config = createExecutorConfig({
+      mode: 'batch',
+      deadLetterQueue: { maxSize: 5 },
+    });
+    const executor = new TaskExecutor(config);
+    const dlq = executor.getDeadLetterQueue();
+
+    // Manually verify by adding entries directly — we access DLQ through public API
+    for (let i = 0; i < 10; i++) {
+      dlq.add(createEntry({ error: `e-${i}` }));
+    }
+    expect(dlq.size()).toBe(5);
+    expect(dlq.getAll()[0].error).toBe('e-5');
+  });
+
+  it('accumulates multiple failures in DLQ', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+    const onDeadLettered = vi.fn();
+
+    const handler = async (): Promise<TaskExecutionResult> => {
+      throw new Error('handler crash');
+    };
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      handler,
+      maxConcurrentTasks: 3,
+    });
+    const executor = new TaskExecutor(config);
+    executor.on({ onDeadLettered });
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    // Emit 3 tasks that will all fail
+    mockDiscovery._emitTask(createDiscoveryResult());
+    mockDiscovery._emitTask(createDiscoveryResult());
+    mockDiscovery._emitTask(createDiscoveryResult());
+
+    await waitFor(() => executor.getStatus().tasksFailed >= 3, 5000);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(executor.getDeadLetterQueue().size()).toBe(3);
+    expect(onDeadLettered).toHaveBeenCalledTimes(3);
+
+    await executor.stop();
+    await startPromise;
+  });
+
+  it('includes errorCode from RuntimeError in DLQ entry', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+
+    // Create an error with a code property
+    const codedError = new Error('handler failed');
+    (codedError as Record<string, unknown>).code = 'TASK_EXECUTION_FAILED';
+
+    const handler = async (): Promise<TaskExecutionResult> => {
+      throw codedError;
+    };
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      handler,
+    });
+    const executor = new TaskExecutor(config);
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    mockDiscovery._emitTask(createDiscoveryResult());
+    await waitFor(() => executor.getStatus().tasksFailed >= 1, 3000);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const entry = executor.getDeadLetterQueue().getAll()[0];
+    expect(entry.errorCode).toBe('TASK_EXECUTION_FAILED');
+
+    await executor.stop();
+    await startPromise;
+  });
+
+  it('DLQ entry includes task context from discovery result', async () => {
+    const mockOps = createMockOperations();
+    const mockDiscovery = createMockDiscovery();
+
+    const handler = async (): Promise<TaskExecutionResult> => {
+      throw new Error('fail');
+    };
+
+    const config = createExecutorConfig({
+      mode: 'autonomous',
+      operations: mockOps,
+      discovery: mockDiscovery,
+      handler,
+    });
+    const executor = new TaskExecutor(config);
+
+    const startPromise = executor.start();
+    await waitFor(() => mockDiscovery.start.mock.calls.length > 0);
+
+    const task = createDiscoveryResult();
+    mockDiscovery._emitTask(task);
+    await waitFor(() => executor.getStatus().tasksFailed >= 1, 3000);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const entry = executor.getDeadLetterQueue().getAll()[0];
+    expect(entry.task).toBe(task.task);
+    expect(entry.taskPda).toBe(task.pda.toBase58());
+
+    await executor.stop();
+    await startPromise;
+  });
+});

--- a/runtime/src/task/dlq.ts
+++ b/runtime/src/task/dlq.ts
@@ -1,0 +1,118 @@
+/**
+ * DeadLetterQueue — in-memory queue for capturing failed tasks with full context.
+ *
+ * Tasks that fail after retry exhaustion are placed in the DLQ for inspection,
+ * manual retry, and alerting. The queue has a configurable max size and evicts
+ * the oldest entries (FIFO) when full.
+ *
+ * @module
+ */
+
+import type { DeadLetterEntry, DeadLetterQueueConfig } from './types.js';
+
+// ============================================================================
+// Defaults
+// ============================================================================
+
+const DEFAULT_DLQ_CONFIG: DeadLetterQueueConfig = {
+  maxSize: 1000,
+};
+
+// ============================================================================
+// DeadLetterQueue Class
+// ============================================================================
+
+/**
+ * In-memory dead letter queue for failed tasks.
+ *
+ * @example
+ * ```typescript
+ * const dlq = new DeadLetterQueue({ maxSize: 500 });
+ *
+ * dlq.add({
+ *   taskPda: 'abc123...',
+ *   task: onChainTask,
+ *   error: 'RPC timeout',
+ *   failedAt: Date.now(),
+ *   stage: 'claim',
+ *   attempts: 3,
+ *   retryable: true,
+ * });
+ *
+ * console.log(dlq.size()); // 1
+ * const entries = dlq.getAll();
+ * ```
+ */
+export class DeadLetterQueue {
+  private readonly maxSize: number;
+  private readonly entries: DeadLetterEntry[] = [];
+
+  constructor(config?: Partial<DeadLetterQueueConfig>) {
+    this.maxSize = config?.maxSize ?? DEFAULT_DLQ_CONFIG.maxSize;
+  }
+
+  /**
+   * Add a failed task entry to the DLQ.
+   * If the queue is at max capacity, the oldest entry is evicted (FIFO).
+   */
+  add(entry: DeadLetterEntry): void {
+    if (this.entries.length >= this.maxSize) {
+      this.entries.shift();
+    }
+    this.entries.push(entry);
+  }
+
+  /**
+   * Get all entries in the DLQ, ordered from oldest to newest.
+   */
+  getAll(): DeadLetterEntry[] {
+    return [...this.entries];
+  }
+
+  /**
+   * Get a specific entry by task PDA (base58 string).
+   * Returns undefined if not found.
+   */
+  getByTaskId(taskPda: string): DeadLetterEntry | undefined {
+    return this.entries.find((e) => e.taskPda === taskPda);
+  }
+
+  /**
+   * Remove and return an entry by task PDA for retry.
+   * Returns the entry if found and removed, undefined otherwise.
+   */
+  retry(taskPda: string): DeadLetterEntry | undefined {
+    const index = this.entries.findIndex((e) => e.taskPda === taskPda);
+    if (index === -1) {
+      return undefined;
+    }
+    return this.entries.splice(index, 1)[0];
+  }
+
+  /**
+   * Remove an entry by task PDA without returning it.
+   * Returns true if the entry was found and removed.
+   */
+  remove(taskPda: string): boolean {
+    const index = this.entries.findIndex((e) => e.taskPda === taskPda);
+    if (index === -1) {
+      return false;
+    }
+    this.entries.splice(index, 1);
+    return true;
+  }
+
+  /**
+   * Get the current number of entries in the DLQ.
+   */
+  size(): number {
+    return this.entries.length;
+  }
+
+  /**
+   * Remove all entries from the DLQ.
+   */
+  clear(): void {
+    this.entries.length = 0;
+  }
+}

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -9,3 +9,4 @@ export * from './filters.js';
 export * from './operations.js';
 export * from './discovery.js';
 export * from './executor.js';
+export * from './dlq.js';


### PR DESCRIPTION
Closes #232

Adds DLQ to capture failed tasks with full context.

- DeadLetterQueue class: add, getAll, getByTaskId, retry, remove, size, clear
- DLQ entry: taskPda, error, stage, retryCount, metadata, errorCode
- FIFO eviction at maxSize (default: 1000)
- Executor integration: routes to DLQ after retry exhaustion
- onDeadLettered event
- 898 tests pass