### PR TITLE
feat(runtime): add OpenTelemetry-compatible metrics and tracing (#240)

### DIFF
--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -11,3 +11,4 @@ export * from './discovery.js';
 export * from './executor.js';
 export * from './dlq.js';
 export * from './checkpoint.js';
+export * from './metrics.js';

--- a/runtime/src/task/metrics.test.ts
+++ b/runtime/src/task/metrics.test.ts
@@ -1,0 +1,781 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Keypair } from '@solana/web3.js';
+import { TaskExecutor } from './executor.js';
+import type { TaskOperations } from './operations.js';
+import type { TaskDiscovery, TaskDiscoveryResult, TaskDiscoveryListener } from './discovery.js';
+import type {
+  OnChainTask,
+  TaskExecutionContext,
+  TaskExecutionResult,
+  TaskExecutorConfig,
+  ClaimResult,
+  CompleteResult,
+  MetricsProvider,
+  TracingProvider,
+  Span,
+} from './types.js';
+import { OnChainTaskStatus } from './types.js';
+import { TaskType } from '../events/types.js';
+import { silentLogger } from '../utils/logger.js';
+import {
+  DefaultMetricsCollector,
+  NoopMetrics,
+  NoopTracing,
+  NoopSpan,
+  METRIC_NAMES,
+} from './metrics.js';
+import type { MetricsSnapshot } from './metrics.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const COMPUTE = 1n << 0n;
+
+function createTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
+  return {
+    taskId: new Uint8Array(32),
+    creator: Keypair.generate().publicKey,
+    requiredCapabilities: COMPUTE,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    rewardAmount: 1_000_000n,
+    maxWorkers: 5,
+    currentWorkers: 0,
+    status: OnChainTaskStatus.Open,
+    taskType: TaskType.Exclusive,
+    createdAt: 1700000000,
+    deadline: Math.floor(Date.now() / 1000) + 3600,
+    completedAt: 0,
+    escrow: Keypair.generate().publicKey,
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+function createDiscoveryResult(overrides: Partial<TaskDiscoveryResult> = {}): TaskDiscoveryResult {
+  return {
+    pda: Keypair.generate().publicKey,
+    task: createTask(),
+    discoveredAt: Date.now(),
+    source: 'poll',
+    ...overrides,
+  };
+}
+
+function createMockOperations(): TaskOperations & {
+  claimTask: ReturnType<typeof vi.fn>;
+  completeTask: ReturnType<typeof vi.fn>;
+  completeTaskPrivate: ReturnType<typeof vi.fn>;
+  fetchTask: ReturnType<typeof vi.fn>;
+  fetchTaskByIds: ReturnType<typeof vi.fn>;
+  fetchClaim: ReturnType<typeof vi.fn>;
+} {
+  const claimPda = Keypair.generate().publicKey;
+  return {
+    fetchClaimableTasks: vi.fn().mockResolvedValue([]),
+    fetchTask: vi.fn().mockResolvedValue(null),
+    fetchAllTasks: vi.fn().mockResolvedValue([]),
+    fetchClaim: vi.fn().mockResolvedValue(null),
+    fetchActiveClaims: vi.fn().mockResolvedValue([]),
+    fetchTaskByIds: vi.fn().mockResolvedValue(null),
+    claimTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      claimPda,
+      transactionSignature: 'claim-sig',
+    } satisfies ClaimResult),
+    completeTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      isPrivate: false,
+      transactionSignature: 'complete-sig',
+    } satisfies CompleteResult),
+    completeTaskPrivate: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: new Uint8Array(32),
+      isPrivate: true,
+      transactionSignature: 'private-complete-sig',
+    } satisfies CompleteResult),
+  } as unknown as TaskOperations & {
+    claimTask: ReturnType<typeof vi.fn>;
+    completeTask: ReturnType<typeof vi.fn>;
+    completeTaskPrivate: ReturnType<typeof vi.fn>;
+    fetchTask: ReturnType<typeof vi.fn>;
+    fetchTaskByIds: ReturnType<typeof vi.fn>;
+    fetchClaim: ReturnType<typeof vi.fn>;
+  };
+}
+
+function createMockDiscovery(): TaskDiscovery & {
+  onTaskDiscovered: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  resume: ReturnType<typeof vi.fn>;
+  _emitTask: (task: TaskDiscoveryResult) => void;
+} {
+  let listener: TaskDiscoveryListener | null = null;
+
+  const mock = {
+    onTaskDiscovered: vi.fn((cb: TaskDiscoveryListener) => {
+      listener = cb;
+      return () => { listener = null; };
+    }),
+    start: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn().mockResolvedValue(undefined),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    isRunning: vi.fn().mockReturnValue(false),
+    isPaused: vi.fn().mockReturnValue(false),
+    getDiscoveredCount: vi.fn().mockReturnValue(0),
+    clearSeen: vi.fn(),
+    poll: vi.fn().mockResolvedValue([]),
+    _emitTask: (task: TaskDiscoveryResult) => {
+      listener?.(task);
+    },
+  };
+
+  return mock as unknown as TaskDiscovery & {
+    onTaskDiscovered: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    pause: ReturnType<typeof vi.fn>;
+    resume: ReturnType<typeof vi.fn>;
+    _emitTask: (task: TaskDiscoveryResult) => void;
+  };
+}
+
+const agentId = new Uint8Array(32).fill(42);
+const agentPda = Keypair.generate().publicKey;
+
+const defaultHandler = async (_ctx: TaskExecutionContext): Promise<TaskExecutionResult> => ({
+  proofHash: new Uint8Array(32).fill(1),
+});
+
+function createExecutorConfig(overrides: Partial<TaskExecutorConfig> = {}): TaskExecutorConfig {
+  return {
+    operations: createMockOperations(),
+    handler: defaultHandler,
+    agentId,
+    agentPda,
+    logger: silentLogger,
+    ...overrides,
+  };
+}
+
+async function waitFor(
+  condition: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 10,
+): Promise<void> {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timeout');
+    }
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+// ============================================================================
+// DefaultMetricsCollector Tests
+// ============================================================================
+
+describe('DefaultMetricsCollector', () => {
+  let collector: DefaultMetricsCollector;
+
+  beforeEach(() => {
+    collector = new DefaultMetricsCollector();
+  });
+
+  describe('counter()', () => {
+    it('should increment by 1 by default', () => {
+      collector.counter('test.count');
+      collector.counter('test.count');
+      collector.counter('test.count');
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.counters['test.count']).toBe(3);
+    });
+
+    it('should increment by custom value', () => {
+      collector.counter('test.count', 5);
+      collector.counter('test.count', 3);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.counters['test.count']).toBe(8);
+    });
+
+    it('should support multiple counter names', () => {
+      collector.counter('a');
+      collector.counter('b', 2);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.counters['a']).toBe(1);
+      expect(snapshot.counters['b']).toBe(2);
+    });
+  });
+
+  describe('histogram()', () => {
+    it('should record histogram values', () => {
+      collector.histogram('latency', 42);
+      collector.histogram('latency', 58);
+      collector.histogram('latency', 100);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.histograms['latency']).toHaveLength(3);
+      expect(snapshot.histograms['latency'][0].value).toBe(42);
+      expect(snapshot.histograms['latency'][1].value).toBe(58);
+      expect(snapshot.histograms['latency'][2].value).toBe(100);
+    });
+
+    it('should record timestamps on entries', () => {
+      const before = Date.now();
+      collector.histogram('latency', 10);
+      const after = Date.now();
+      const snapshot = collector.getSnapshot();
+      const entry = snapshot.histograms['latency'][0];
+      expect(entry.timestamp).toBeGreaterThanOrEqual(before);
+      expect(entry.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('should store labels on histogram entries', () => {
+      collector.histogram('latency', 50, { taskPda: 'abc123' });
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.histograms['latency'][0].labels).toEqual({ taskPda: 'abc123' });
+    });
+  });
+
+  describe('gauge()', () => {
+    it('should set gauge value', () => {
+      collector.gauge('queue.size', 10);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.gauges['queue.size']).toBe(10);
+    });
+
+    it('should overwrite gauge value', () => {
+      collector.gauge('queue.size', 10);
+      collector.gauge('queue.size', 5);
+      collector.gauge('queue.size', 0);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.gauges['queue.size']).toBe(0);
+    });
+  });
+
+  describe('recordTaskDuration()', () => {
+    it('should record duration in agenc.task.<stage>.duration_ms histogram', () => {
+      collector.recordTaskDuration('claim', 42);
+      collector.recordTaskDuration('execute', 150);
+      collector.recordTaskDuration('submit', 88);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.histograms['agenc.task.claim.duration_ms']).toHaveLength(1);
+      expect(snapshot.histograms['agenc.task.claim.duration_ms'][0].value).toBe(42);
+      expect(snapshot.histograms['agenc.task.execute.duration_ms'][0].value).toBe(150);
+      expect(snapshot.histograms['agenc.task.submit.duration_ms'][0].value).toBe(88);
+    });
+  });
+
+  describe('incrementCounter()', () => {
+    it('should increment counter via incrementCounter alias', () => {
+      collector.incrementCounter('x');
+      collector.incrementCounter('x', 4);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.counters['x']).toBe(5);
+    });
+  });
+
+  describe('recordHistogram()', () => {
+    it('should record histogram via recordHistogram alias', () => {
+      collector.recordHistogram('y', 99);
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.histograms['y']).toHaveLength(1);
+      expect(snapshot.histograms['y'][0].value).toBe(99);
+    });
+  });
+
+  describe('getSnapshot()', () => {
+    it('should return a point-in-time snapshot with timestamp', () => {
+      const before = Date.now();
+      const snapshot = collector.getSnapshot();
+      const after = Date.now();
+      expect(snapshot.timestamp).toBeGreaterThanOrEqual(before);
+      expect(snapshot.timestamp).toBeLessThanOrEqual(after);
+    });
+
+    it('should return empty collections when no data recorded', () => {
+      const snapshot = collector.getSnapshot();
+      expect(snapshot.counters).toEqual({});
+      expect(snapshot.gauges).toEqual({});
+      expect(snapshot.histograms).toEqual({});
+    });
+
+    it('should return copies (not references) of internal data', () => {
+      collector.counter('c', 1);
+      collector.gauge('g', 10);
+      collector.histogram('h', 5);
+      const snap1 = collector.getSnapshot();
+
+      // Mutate snapshot
+      snap1.counters['c'] = 999;
+      snap1.gauges['g'] = 999;
+      snap1.histograms['h'].push({ value: 999, timestamp: 0 });
+
+      // Verify collector is unchanged
+      const snap2 = collector.getSnapshot();
+      expect(snap2.counters['c']).toBe(1);
+      expect(snap2.gauges['g']).toBe(10);
+      expect(snap2.histograms['h']).toHaveLength(1);
+    });
+  });
+});
+
+// ============================================================================
+// NoopMetrics Tests
+// ============================================================================
+
+describe('NoopMetrics', () => {
+  it('should not throw on any method call', () => {
+    const noop = new NoopMetrics();
+    expect(() => noop.counter('test')).not.toThrow();
+    expect(() => noop.counter('test', 5, { label: 'value' })).not.toThrow();
+    expect(() => noop.histogram('test', 10)).not.toThrow();
+    expect(() => noop.histogram('test', 10, { label: 'value' })).not.toThrow();
+    expect(() => noop.gauge('test', 5)).not.toThrow();
+    expect(() => noop.gauge('test', 5, { label: 'value' })).not.toThrow();
+  });
+});
+
+// ============================================================================
+// NoopTracing / NoopSpan Tests
+// ============================================================================
+
+describe('NoopTracing', () => {
+  it('should return a NoopSpan', () => {
+    const noop = new NoopTracing();
+    const span = noop.startSpan('test');
+    expect(span).toBeInstanceOf(NoopSpan);
+  });
+
+  it('should return a span that does not throw on any method', () => {
+    const noop = new NoopTracing();
+    const span = noop.startSpan('test', { key: 'value' });
+    expect(() => span.setAttribute('k', 'v')).not.toThrow();
+    expect(() => span.setAttribute('k', 42)).not.toThrow();
+    expect(() => span.setStatus('ok')).not.toThrow();
+    expect(() => span.setStatus('error', 'msg')).not.toThrow();
+    expect(() => span.end()).not.toThrow();
+  });
+});
+
+// ============================================================================
+// METRIC_NAMES Constants Tests
+// ============================================================================
+
+describe('METRIC_NAMES', () => {
+  it('should have agenc.task.* prefix on all names', () => {
+    for (const value of Object.values(METRIC_NAMES)) {
+      expect(value).toMatch(/^agenc\.task\./);
+    }
+  });
+
+  it('should include all expected metric names', () => {
+    expect(METRIC_NAMES.CLAIM_DURATION).toBe('agenc.task.claim.duration_ms');
+    expect(METRIC_NAMES.EXECUTE_DURATION).toBe('agenc.task.execute.duration_ms');
+    expect(METRIC_NAMES.SUBMIT_DURATION).toBe('agenc.task.submit.duration_ms');
+    expect(METRIC_NAMES.PIPELINE_DURATION).toBe('agenc.task.pipeline.duration_ms');
+    expect(METRIC_NAMES.QUEUE_SIZE).toBe('agenc.task.queue.size');
+    expect(METRIC_NAMES.ACTIVE_COUNT).toBe('agenc.task.active.count');
+    expect(METRIC_NAMES.TASKS_DISCOVERED).toBe('agenc.task.discovered.count');
+    expect(METRIC_NAMES.TASKS_CLAIMED).toBe('agenc.task.claimed.count');
+    expect(METRIC_NAMES.TASKS_COMPLETED).toBe('agenc.task.completed.count');
+    expect(METRIC_NAMES.TASKS_FAILED).toBe('agenc.task.failed.count');
+    expect(METRIC_NAMES.CLAIMS_FAILED).toBe('agenc.task.claims_failed.count');
+    expect(METRIC_NAMES.SUBMITS_FAILED).toBe('agenc.task.submits_failed.count');
+    expect(METRIC_NAMES.CLAIMS_EXPIRED).toBe('agenc.task.claims_expired.count');
+    expect(METRIC_NAMES.CLAIM_RETRIES).toBe('agenc.task.claim_retries.count');
+    expect(METRIC_NAMES.SUBMIT_RETRIES).toBe('agenc.task.submit_retries.count');
+  });
+});
+
+// ============================================================================
+// TaskExecutor Pipeline Metrics Integration Tests
+// ============================================================================
+
+describe('TaskExecutor metrics integration', () => {
+  let executor: TaskExecutor;
+  let discovery: ReturnType<typeof createMockDiscovery>;
+  let operations: ReturnType<typeof createMockOperations>;
+  let metricsCollector: DefaultMetricsCollector;
+
+  beforeEach(() => {
+    operations = createMockOperations();
+    discovery = createMockDiscovery();
+    metricsCollector = new DefaultMetricsCollector();
+  });
+
+  afterEach(async () => {
+    if (executor?.isRunning()) {
+      await executor.stop();
+    }
+  });
+
+  it('should record pipeline stage durations on successful task', async () => {
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      metrics: metricsCollector,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => operations.completeTask.mock.calls.length > 0);
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    const snapshot = metricsCollector.getSnapshot();
+
+    // Verify stage durations were recorded
+    expect(snapshot.histograms[METRIC_NAMES.CLAIM_DURATION]).toBeDefined();
+    expect(snapshot.histograms[METRIC_NAMES.CLAIM_DURATION].length).toBeGreaterThanOrEqual(1);
+
+    expect(snapshot.histograms[METRIC_NAMES.EXECUTE_DURATION]).toBeDefined();
+    expect(snapshot.histograms[METRIC_NAMES.EXECUTE_DURATION].length).toBeGreaterThanOrEqual(1);
+
+    expect(snapshot.histograms[METRIC_NAMES.SUBMIT_DURATION]).toBeDefined();
+    expect(snapshot.histograms[METRIC_NAMES.SUBMIT_DURATION].length).toBeGreaterThanOrEqual(1);
+
+    expect(snapshot.histograms[METRIC_NAMES.PIPELINE_DURATION]).toBeDefined();
+    expect(snapshot.histograms[METRIC_NAMES.PIPELINE_DURATION].length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should emit counter metrics for discovered/claimed/completed', async () => {
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      metrics: metricsCollector,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => operations.completeTask.mock.calls.length > 0);
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    const snapshot = metricsCollector.getSnapshot();
+    expect(snapshot.counters[METRIC_NAMES.TASKS_DISCOVERED]).toBe(1);
+    expect(snapshot.counters[METRIC_NAMES.TASKS_CLAIMED]).toBe(1);
+    expect(snapshot.counters[METRIC_NAMES.TASKS_COMPLETED]).toBe(1);
+  });
+
+  it('should emit failure counter on handler error', async () => {
+    const failHandler = async (_ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+      throw new Error('handler exploded');
+    };
+
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      handler: failHandler,
+      metrics: metricsCollector,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => {
+      const s = metricsCollector.getSnapshot();
+      return (s.counters[METRIC_NAMES.TASKS_FAILED] ?? 0) >= 1;
+    });
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    const snapshot = metricsCollector.getSnapshot();
+    expect(snapshot.counters[METRIC_NAMES.TASKS_FAILED]).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should update queue size and active count gauges', async () => {
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      metrics: metricsCollector,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => operations.completeTask.mock.calls.length > 0);
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    const snapshot = metricsCollector.getSnapshot();
+    // After completion, active count should be 0
+    expect(snapshot.gauges[METRIC_NAMES.ACTIVE_COUNT]).toBe(0);
+    expect(snapshot.gauges[METRIC_NAMES.QUEUE_SIZE]).toBeDefined();
+  });
+
+  it('should call tracing provider with span lifecycle', async () => {
+    const setAttributeCalls: Array<{ key: string; value: string | number }> = [];
+    const setStatusCalls: Array<{ status: string; message?: string }> = [];
+    let spanEnded = false;
+
+    const mockSpan: Span = {
+      setAttribute(key: string, value: string | number) {
+        setAttributeCalls.push({ key, value });
+      },
+      setStatus(status: 'ok' | 'error', message?: string) {
+        setStatusCalls.push({ status, message });
+      },
+      end() {
+        spanEnded = true;
+      },
+    };
+
+    const mockTracing: TracingProvider = {
+      startSpan: vi.fn().mockReturnValue(mockSpan),
+    };
+
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      tracing: mockTracing,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => operations.completeTask.mock.calls.length > 0);
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    // Verify span was created with correct name
+    expect(mockTracing.startSpan).toHaveBeenCalledWith(
+      'agenc.task.pipeline',
+      expect.objectContaining({ taskPda: expect.any(String) }),
+    );
+
+    // Verify attributes were set for stage durations
+    const attrKeys = setAttributeCalls.map(c => c.key);
+    expect(attrKeys).toContain('claim.duration_ms');
+    expect(attrKeys).toContain('execute.duration_ms');
+    expect(attrKeys).toContain('submit.duration_ms');
+
+    // Verify span status was set to ok
+    expect(setStatusCalls).toContainEqual({ status: 'ok' });
+
+    // Verify span was ended
+    expect(spanEnded).toBe(true);
+  });
+
+  it('should set span error status on failure', async () => {
+    const setStatusCalls: Array<{ status: string; message?: string }> = [];
+    let spanEnded = false;
+
+    const mockSpan: Span = {
+      setAttribute() {},
+      setStatus(status: 'ok' | 'error', message?: string) {
+        setStatusCalls.push({ status, message });
+      },
+      end() {
+        spanEnded = true;
+      },
+    };
+
+    const mockTracing: TracingProvider = {
+      startSpan: vi.fn().mockReturnValue(mockSpan),
+    };
+
+    const failHandler = async (_ctx: TaskExecutionContext): Promise<TaskExecutionResult> => {
+      throw new Error('boom');
+    };
+
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      handler: failHandler,
+      tracing: mockTracing,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => spanEnded);
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    expect(setStatusCalls.some(c => c.status === 'error')).toBe(true);
+    expect(spanEnded).toBe(true);
+  });
+
+  it('should return metrics snapshot via getMetricsSnapshot()', async () => {
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      metrics: metricsCollector,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => operations.completeTask.mock.calls.length > 0);
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    const snapshot = executor.getMetricsSnapshot();
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.counters[METRIC_NAMES.TASKS_COMPLETED]).toBe(1);
+    expect(snapshot!.histograms[METRIC_NAMES.PIPELINE_DURATION]).toBeDefined();
+    expect(snapshot!.timestamp).toBeGreaterThan(0);
+  });
+
+  it('should return null from getMetricsSnapshot() when using NoopMetrics', () => {
+    executor = new TaskExecutor(createExecutorConfig({
+      mode: 'batch',
+      batchTasks: [],
+    }));
+
+    const snapshot = executor.getMetricsSnapshot();
+    expect(snapshot).toBeNull();
+  });
+
+  it('should work with custom MetricsProvider implementation', async () => {
+    const counterCalls: Array<{ name: string; value?: number }> = [];
+    const histogramCalls: Array<{ name: string; value: number }> = [];
+    const gaugeCalls: Array<{ name: string; value: number }> = [];
+
+    const customProvider: MetricsProvider = {
+      counter(name, value) { counterCalls.push({ name, value }); },
+      histogram(name, value) { histogramCalls.push({ name, value }); },
+      gauge(name, value) { gaugeCalls.push({ name, value }); },
+    };
+
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      metrics: customProvider,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => operations.completeTask.mock.calls.length > 0);
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    // Verify custom provider was called
+    expect(counterCalls.length).toBeGreaterThan(0);
+    expect(histogramCalls.length).toBeGreaterThan(0);
+    expect(gaugeCalls.length).toBeGreaterThan(0);
+
+    // Verify OpenTelemetry-compatible naming
+    const counterNames = counterCalls.map(c => c.name);
+    expect(counterNames).toContain(METRIC_NAMES.TASKS_DISCOVERED);
+    expect(counterNames).toContain(METRIC_NAMES.TASKS_CLAIMED);
+    expect(counterNames).toContain(METRIC_NAMES.TASKS_COMPLETED);
+
+    const histogramNames = histogramCalls.map(h => h.name);
+    expect(histogramNames).toContain(METRIC_NAMES.CLAIM_DURATION);
+    expect(histogramNames).toContain(METRIC_NAMES.EXECUTE_DURATION);
+    expect(histogramNames).toContain(METRIC_NAMES.SUBMIT_DURATION);
+    expect(histogramNames).toContain(METRIC_NAMES.PIPELINE_DURATION);
+  });
+
+  it('should record submit failure counter on submit error', async () => {
+    operations.completeTask.mockRejectedValue(new Error('submit failed'));
+
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      metrics: metricsCollector,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+      retryPolicy: { maxAttempts: 1 },
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => {
+      const s = metricsCollector.getSnapshot();
+      return (s.counters[METRIC_NAMES.SUBMITS_FAILED] ?? 0) >= 1;
+    });
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    const snapshot = metricsCollector.getSnapshot();
+    expect(snapshot.counters[METRIC_NAMES.SUBMITS_FAILED]).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should record claim failure counter on claim error', async () => {
+    operations.claimTask.mockRejectedValue(new Error('claim failed'));
+
+    executor = new TaskExecutor(createExecutorConfig({
+      operations,
+      discovery,
+      mode: 'autonomous',
+      metrics: metricsCollector,
+      taskTimeoutMs: 0,
+      claimExpiryBufferMs: 0,
+      retryPolicy: { maxAttempts: 1 },
+    }));
+
+    const startPromise = executor.start();
+    await waitFor(() => discovery.start.mock.calls.length > 0);
+    const task = createDiscoveryResult();
+    discovery._emitTask(task);
+
+    await waitFor(() => {
+      const s = metricsCollector.getSnapshot();
+      return (s.counters[METRIC_NAMES.CLAIMS_FAILED] ?? 0) >= 1;
+    });
+    await executor.stop();
+    await startPromise.catch(() => {});
+
+    const snapshot = metricsCollector.getSnapshot();
+    expect(snapshot.counters[METRIC_NAMES.CLAIMS_FAILED]).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/runtime/src/task/metrics.ts
+++ b/runtime/src/task/metrics.ts
@@ -1,0 +1,223 @@
+/**
+ * OpenTelemetry-compatible metrics and tracing implementations for the TaskExecutor pipeline.
+ *
+ * Provides:
+ * - {@link DefaultMetricsCollector}: In-memory metrics collector with counter, histogram, and gauge support
+ * - {@link NoopMetrics}: No-op metrics provider (default when no provider is configured)
+ * - {@link NoopTracing}: No-op tracing provider (default when no provider is configured)
+ * - {@link NoopSpan}: No-op span implementation
+ *
+ * All metric names follow the OpenTelemetry `agenc.task.*` naming convention.
+ *
+ * @module
+ */
+
+import type { MetricsProvider, TracingProvider, Span } from './types.js';
+
+// ============================================================================
+// Metric name constants (OpenTelemetry-compatible, agenc.task.* prefix)
+// ============================================================================
+
+export const METRIC_NAMES = {
+  CLAIM_DURATION: 'agenc.task.claim.duration_ms',
+  EXECUTE_DURATION: 'agenc.task.execute.duration_ms',
+  SUBMIT_DURATION: 'agenc.task.submit.duration_ms',
+  PIPELINE_DURATION: 'agenc.task.pipeline.duration_ms',
+  QUEUE_SIZE: 'agenc.task.queue.size',
+  ACTIVE_COUNT: 'agenc.task.active.count',
+  TASKS_DISCOVERED: 'agenc.task.discovered.count',
+  TASKS_CLAIMED: 'agenc.task.claimed.count',
+  TASKS_COMPLETED: 'agenc.task.completed.count',
+  TASKS_FAILED: 'agenc.task.failed.count',
+  CLAIMS_FAILED: 'agenc.task.claims_failed.count',
+  SUBMITS_FAILED: 'agenc.task.submits_failed.count',
+  CLAIMS_EXPIRED: 'agenc.task.claims_expired.count',
+  CLAIM_RETRIES: 'agenc.task.claim_retries.count',
+  SUBMIT_RETRIES: 'agenc.task.submit_retries.count',
+} as const;
+
+// ============================================================================
+// Histogram data structure
+// ============================================================================
+
+/**
+ * A single histogram entry with value, timestamp, and labels.
+ */
+export interface HistogramEntry {
+  value: number;
+  timestamp: number;
+  labels?: Record<string, string>;
+}
+
+// ============================================================================
+// Metrics snapshot
+// ============================================================================
+
+/**
+ * A snapshot of all collected metrics at a point in time.
+ */
+export interface MetricsSnapshot {
+  /** Counter values keyed by metric name. */
+  counters: Record<string, number>;
+  /** Gauge values keyed by metric name. */
+  gauges: Record<string, number>;
+  /** Histogram entries keyed by metric name. */
+  histograms: Record<string, HistogramEntry[]>;
+  /** Timestamp when the snapshot was taken. */
+  timestamp: number;
+}
+
+// ============================================================================
+// MetricsCollector interface
+// ============================================================================
+
+/**
+ * Extended metrics collector with snapshot and query capabilities.
+ * Builds on {@link MetricsProvider} to add introspection for testing and export.
+ */
+export interface MetricsCollector extends MetricsProvider {
+  /** Record a task duration for a specific pipeline stage. */
+  recordTaskDuration(stage: string, durationMs: number, labels?: Record<string, string>): void;
+  /** Increment a named counter by an optional amount (default 1). */
+  incrementCounter(name: string, value?: number, labels?: Record<string, string>): void;
+  /** Record a histogram value for distribution tracking. */
+  recordHistogram(name: string, value: number, labels?: Record<string, string>): void;
+  /** Get a point-in-time snapshot of all collected metrics. */
+  getSnapshot(): MetricsSnapshot;
+}
+
+// ============================================================================
+// DefaultMetricsCollector
+// ============================================================================
+
+/**
+ * In-memory metrics collector implementing the {@link MetricsCollector} interface.
+ *
+ * Stores counters, gauges, and histograms in memory for export or inspection.
+ * Suitable for testing and as the default collector when no external provider
+ * (e.g., Prometheus, DataDog) is configured.
+ *
+ * @example
+ * ```typescript
+ * const collector = new DefaultMetricsCollector();
+ * collector.counter('agenc.task.discovered.count');
+ * collector.histogram('agenc.task.claim.duration_ms', 42);
+ * collector.gauge('agenc.task.queue.size', 5);
+ *
+ * const snapshot = collector.getSnapshot();
+ * console.log(snapshot.counters['agenc.task.discovered.count']); // 1
+ * console.log(snapshot.histograms['agenc.task.claim.duration_ms']); // [{ value: 42, ... }]
+ * ```
+ */
+export class DefaultMetricsCollector implements MetricsCollector {
+  private counters: Map<string, number> = new Map();
+  private gauges: Map<string, number> = new Map();
+  private histograms: Map<string, HistogramEntry[]> = new Map();
+
+  counter(name: string, value = 1, _labels?: Record<string, string>): void {
+    const current = this.counters.get(name) ?? 0;
+    this.counters.set(name, current + value);
+  }
+
+  histogram(name: string, value: number, labels?: Record<string, string>): void {
+    let entries = this.histograms.get(name);
+    if (!entries) {
+      entries = [];
+      this.histograms.set(name, entries);
+    }
+    entries.push({ value, timestamp: Date.now(), labels });
+  }
+
+  gauge(name: string, value: number, _labels?: Record<string, string>): void {
+    this.gauges.set(name, value);
+  }
+
+  recordTaskDuration(stage: string, durationMs: number, labels?: Record<string, string>): void {
+    this.histogram(`agenc.task.${stage}.duration_ms`, durationMs, labels);
+  }
+
+  incrementCounter(name: string, value = 1, labels?: Record<string, string>): void {
+    this.counter(name, value, labels);
+  }
+
+  recordHistogram(name: string, value: number, labels?: Record<string, string>): void {
+    this.histogram(name, value, labels);
+  }
+
+  getSnapshot(): MetricsSnapshot {
+    const counters: Record<string, number> = {};
+    for (const [key, val] of this.counters) {
+      counters[key] = val;
+    }
+
+    const gauges: Record<string, number> = {};
+    for (const [key, val] of this.gauges) {
+      gauges[key] = val;
+    }
+
+    const histograms: Record<string, HistogramEntry[]> = {};
+    for (const [key, val] of this.histograms) {
+      histograms[key] = [...val];
+    }
+
+    return {
+      counters,
+      gauges,
+      histograms,
+      timestamp: Date.now(),
+    };
+  }
+}
+
+// ============================================================================
+// NoopMetrics
+// ============================================================================
+
+/**
+ * No-op metrics provider. All operations are silently ignored.
+ * Used as the default when no metrics provider is configured.
+ */
+export class NoopMetrics implements MetricsProvider {
+  counter(_name: string, _value?: number, _labels?: Record<string, string>): void {
+    // noop
+  }
+  histogram(_name: string, _value: number, _labels?: Record<string, string>): void {
+    // noop
+  }
+  gauge(_name: string, _value: number, _labels?: Record<string, string>): void {
+    // noop
+  }
+}
+
+// ============================================================================
+// NoopSpan
+// ============================================================================
+
+/**
+ * No-op span implementation. All operations are silently ignored.
+ */
+export class NoopSpan implements Span {
+  setAttribute(_key: string, _value: string | number): void {
+    // noop
+  }
+  setStatus(_status: 'ok' | 'error', _message?: string): void {
+    // noop
+  }
+  end(): void {
+    // noop
+  }
+}
+
+// ============================================================================
+// NoopTracing
+// ============================================================================
+
+/**
+ * No-op tracing provider. Returns NoopSpan instances.
+ * Used as the default when no tracing provider is configured.
+ */
+export class NoopTracing implements TracingProvider {
+  startSpan(_name: string, _attributes?: Record<string, string>): Span {
+    return new NoopSpan();
+  }
+}

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -850,6 +850,44 @@ export interface CheckpointStore {
 }
 
 // ============================================================================
+// Metrics & Tracing Types
+// ============================================================================
+
+/**
+ * OpenTelemetry-compatible metrics provider.
+ * Supports counter, histogram, and gauge metric types with optional labels.
+ */
+export interface MetricsProvider {
+  /** Increment a counter metric. */
+  counter(name: string, value?: number, labels?: Record<string, string>): void;
+  /** Record a histogram observation (e.g. latency). */
+  histogram(name: string, value: number, labels?: Record<string, string>): void;
+  /** Set a gauge metric to an absolute value. */
+  gauge(name: string, value: number, labels?: Record<string, string>): void;
+}
+
+/**
+ * OpenTelemetry-compatible tracing provider.
+ * Creates spans for distributed tracing of pipeline stages.
+ */
+export interface TracingProvider {
+  /** Start a new trace span with optional attributes. */
+  startSpan(name: string, attributes?: Record<string, string>): Span;
+}
+
+/**
+ * A single trace span representing a unit of work.
+ */
+export interface Span {
+  /** Set an attribute on the span. */
+  setAttribute(key: string, value: string | number): void;
+  /** Set the span status. */
+  setStatus(status: 'ok' | 'error', message?: string): void;
+  /** End the span, recording its duration. */
+  end(): void;
+}
+
+// ============================================================================
 // Task Executor Types
 // ============================================================================
 
@@ -904,6 +942,10 @@ export interface TaskExecutorConfig {
   deadLetterQueue?: Partial<DeadLetterQueueConfig>;
   /** Checkpoint store for durable execution. When provided, pipeline progress is persisted and recovered on restart. */
   checkpointStore?: CheckpointStore;
+  /** Optional metrics provider for OpenTelemetry-compatible instrumentation. */
+  metrics?: MetricsProvider;
+  /** Optional tracing provider for distributed trace spans. */
+  tracing?: TracingProvider;
 }
 
 /**


### PR DESCRIPTION
Closes #240

Adds structured observability to the TaskExecutor pipeline.

- MetricsCollector interface with counters, histograms, gauges
- DefaultMetricsCollector in-memory implementation
- Pipeline stage timing: claim, execute, submit durations
- Trace spans with attributes and status per processTask call
- getMetricsSnapshot() for export
- OpenTelemetry-compatible naming: agenc.task.* prefix
- 928 tests pass