### PR TITLE
feat(sdk): add dependency query support with memcmp filters

### DIFF
--- a/sdk/src/__tests__/queries.test.ts
+++ b/sdk/src/__tests__/queries.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Unit tests for dependency query helpers.
+ *
+ * These tests verify:
+ * 1. TASK_FIELD_OFFSETS match the on-chain Task struct layout
+ * 2. Query functions build correct memcmp filters
+ * 3. Data parsing handles account data correctly
+ *
+ * @see https://github.com/tetsuo-ai/AgenC/issues/262
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PublicKey, Connection, Keypair } from '@solana/web3.js';
+import * as queries from '../queries';
+import { PROGRAM_ID } from '../constants';
+import { TaskState } from '../tasks';
+
+const {
+  TASK_FIELD_OFFSETS,
+  getTasksByDependency,
+  getDependentTaskCount,
+  hasDependents,
+} = queries;
+
+// Generate valid test pubkeys
+const makeTestPubkey = (seed: number): PublicKey => {
+  const bytes = new Uint8Array(32);
+  bytes.fill(seed);
+  return new PublicKey(bytes);
+};
+
+describe('TASK_FIELD_OFFSETS', () => {
+  describe('offset values match on-chain Task struct', () => {
+    // Values MUST match programs/agenc-coordination/src/state.rs:Task
+    it('DISCRIMINATOR offset is 0', () => {
+      expect(TASK_FIELD_OFFSETS.DISCRIMINATOR).toBe(0);
+    });
+
+    it('TASK_ID offset is 8 (after 8-byte discriminator)', () => {
+      expect(TASK_FIELD_OFFSETS.TASK_ID).toBe(8);
+    });
+
+    it('CREATOR offset is 40 (after task_id)', () => {
+      // discriminator(8) + task_id(32) = 40
+      expect(TASK_FIELD_OFFSETS.CREATOR).toBe(40);
+    });
+
+    it('DEPENDS_ON offset is 311', () => {
+      // This is the critical offset for memcmp filtering
+      // Calculated from the Task struct layout:
+      // discriminator(8) + task_id(32) + creator(32) + required_capabilities(8) +
+      // description(64) + constraint_hash(32) + reward_amount(8) + max_workers(1) +
+      // current_workers(1) + status(1) + task_type(1) + created_at(8) + deadline(8) +
+      // completed_at(8) + escrow(32) + result(64) + completions(1) +
+      // required_completions(1) + bump(1) = 311
+      expect(TASK_FIELD_OFFSETS.DEPENDS_ON).toBe(311);
+    });
+
+    it('DEPENDS_ON_PUBKEY offset is 312 (after Option discriminator)', () => {
+      // The Pubkey value is 1 byte after the Option discriminator
+      expect(TASK_FIELD_OFFSETS.DEPENDS_ON_PUBKEY).toBe(312);
+    });
+
+    it('DEPENDENCY_TYPE offset is 344 (after depends_on)', () => {
+      // DEPENDS_ON(311) + Option<Pubkey>(33) = 344
+      expect(TASK_FIELD_OFFSETS.DEPENDENCY_TYPE).toBe(344);
+    });
+  });
+
+  describe('offset calculation verification', () => {
+    it('offsets are in ascending order', () => {
+      const offsets = [
+        TASK_FIELD_OFFSETS.DISCRIMINATOR,
+        TASK_FIELD_OFFSETS.TASK_ID,
+        TASK_FIELD_OFFSETS.CREATOR,
+        TASK_FIELD_OFFSETS.REQUIRED_CAPABILITIES,
+        TASK_FIELD_OFFSETS.DESCRIPTION,
+        TASK_FIELD_OFFSETS.CONSTRAINT_HASH,
+        TASK_FIELD_OFFSETS.REWARD_AMOUNT,
+        TASK_FIELD_OFFSETS.MAX_WORKERS,
+        TASK_FIELD_OFFSETS.CURRENT_WORKERS,
+        TASK_FIELD_OFFSETS.STATUS,
+        TASK_FIELD_OFFSETS.TASK_TYPE,
+        TASK_FIELD_OFFSETS.CREATED_AT,
+        TASK_FIELD_OFFSETS.DEADLINE,
+        TASK_FIELD_OFFSETS.COMPLETED_AT,
+        TASK_FIELD_OFFSETS.ESCROW,
+        TASK_FIELD_OFFSETS.RESULT,
+        TASK_FIELD_OFFSETS.COMPLETIONS,
+        TASK_FIELD_OFFSETS.REQUIRED_COMPLETIONS,
+        TASK_FIELD_OFFSETS.BUMP,
+        TASK_FIELD_OFFSETS.DEPENDS_ON,
+        TASK_FIELD_OFFSETS.DEPENDENCY_TYPE,
+      ];
+
+      for (let i = 1; i < offsets.length; i++) {
+        expect(offsets[i]).toBeGreaterThan(offsets[i - 1]);
+      }
+    });
+
+    it('field sizes are correct', () => {
+      // Verify key field size calculations
+      expect(TASK_FIELD_OFFSETS.TASK_ID - TASK_FIELD_OFFSETS.DISCRIMINATOR).toBe(8); // discriminator size
+      expect(TASK_FIELD_OFFSETS.CREATOR - TASK_FIELD_OFFSETS.TASK_ID).toBe(32); // task_id size
+      expect(TASK_FIELD_OFFSETS.REQUIRED_CAPABILITIES - TASK_FIELD_OFFSETS.CREATOR).toBe(32); // creator (pubkey) size
+      expect(TASK_FIELD_OFFSETS.DEPENDS_ON_PUBKEY - TASK_FIELD_OFFSETS.DEPENDS_ON).toBe(1); // Option discriminator size
+    });
+  });
+});
+
+describe('getTasksByDependency', () => {
+  let mockConnection: Connection;
+  let parentTaskPda: PublicKey;
+
+  beforeEach(() => {
+    parentTaskPda = makeTestPubkey(1);
+    mockConnection = {
+      getProgramAccounts: vi.fn(),
+    } as unknown as Connection;
+  });
+
+  it('calls getProgramAccounts with correct memcmp filter', async () => {
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([]);
+
+    await getTasksByDependency(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    expect(mockConnection.getProgramAccounts).toHaveBeenCalledWith(
+      PROGRAM_ID,
+      expect.objectContaining({
+        filters: expect.arrayContaining([
+          expect.objectContaining({
+            memcmp: expect.objectContaining({
+              offset: TASK_FIELD_OFFSETS.DEPENDS_ON,
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('builds correct filter bytes for Some(Pubkey)', async () => {
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([]);
+
+    await getTasksByDependency(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    const call = vi.mocked(mockConnection.getProgramAccounts).mock.calls[0];
+    const filter = (call[1] as { filters: Array<{ memcmp: { bytes: string } }> }).filters[0];
+    const bytes = Buffer.from(filter.memcmp.bytes, 'base64');
+
+    // First byte should be 1 (Some discriminator)
+    expect(bytes[0]).toBe(1);
+    // Remaining 32 bytes should be the pubkey
+    expect(bytes.subarray(1).toString('hex')).toBe(parentTaskPda.toBuffer().toString('hex'));
+  });
+
+  it('returns empty array when no tasks found', async () => {
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([]);
+
+    const result = await getTasksByDependency(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    expect(result).toEqual([]);
+  });
+
+  it('parses task data correctly', async () => {
+    // Create mock task account data
+    const taskPda = makeTestPubkey(2);
+    const creator = makeTestPubkey(3);
+    const taskData = createMockTaskData({
+      taskId: Buffer.alloc(32, 0x01),
+      creator,
+      dependsOn: parentTaskPda,
+      status: TaskState.InProgress,
+      rewardAmount: BigInt(1000000),
+      createdAt: BigInt(1700000000),
+      deadline: BigInt(1700100000),
+    });
+
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([
+      { pubkey: taskPda, account: { data: taskData, executable: false, lamports: 0, owner: PROGRAM_ID } },
+    ]);
+
+    const result = await getTasksByDependency(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].publicKey.equals(taskPda)).toBe(true);
+    expect(result[0].creator.equals(creator)).toBe(true);
+    expect(result[0].dependsOn.equals(parentTaskPda)).toBe(true);
+    expect(result[0].status).toBe(TaskState.InProgress);
+    expect(result[0].rewardAmount).toBe(BigInt(1000000));
+    expect(result[0].createdAt).toBe(1700000000);
+    expect(result[0].deadline).toBe(1700100000);
+  });
+
+  it('handles multiple dependent tasks', async () => {
+    const taskPda1 = makeTestPubkey(2);
+    const taskPda2 = makeTestPubkey(4);
+    const creator = makeTestPubkey(3);
+
+    const taskData1 = createMockTaskData({ creator, dependsOn: parentTaskPda });
+    const taskData2 = createMockTaskData({ creator, dependsOn: parentTaskPda });
+
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([
+      { pubkey: taskPda1, account: { data: taskData1, executable: false, lamports: 0, owner: PROGRAM_ID } },
+      { pubkey: taskPda2, account: { data: taskData2, executable: false, lamports: 0, owner: PROGRAM_ID } },
+    ]);
+
+    const result = await getTasksByDependency(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('getDependentTaskCount', () => {
+  let mockConnection: Connection;
+  let parentTaskPda: PublicKey;
+
+  beforeEach(() => {
+    parentTaskPda = makeTestPubkey(1);
+    mockConnection = {
+      getProgramAccounts: vi.fn(),
+    } as unknown as Connection;
+  });
+
+  it('calls getProgramAccounts with dataSlice for efficiency', async () => {
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([]);
+
+    await getDependentTaskCount(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    expect(mockConnection.getProgramAccounts).toHaveBeenCalledWith(
+      PROGRAM_ID,
+      expect.objectContaining({
+        dataSlice: { offset: 0, length: 0 },
+      })
+    );
+  });
+
+  it('returns 0 when no tasks found', async () => {
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([]);
+
+    const count = await getDependentTaskCount(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    expect(count).toBe(0);
+  });
+
+  it('returns correct count for multiple tasks', async () => {
+    // Mock returns accounts with empty data (due to dataSlice)
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([
+      { pubkey: makeTestPubkey(1), account: { data: Buffer.alloc(0), executable: false, lamports: 0, owner: PROGRAM_ID } },
+      { pubkey: makeTestPubkey(2), account: { data: Buffer.alloc(0), executable: false, lamports: 0, owner: PROGRAM_ID } },
+      { pubkey: makeTestPubkey(3), account: { data: Buffer.alloc(0), executable: false, lamports: 0, owner: PROGRAM_ID } },
+    ]);
+
+    const count = await getDependentTaskCount(mockConnection, PROGRAM_ID, parentTaskPda);
+
+    expect(count).toBe(3);
+  });
+});
+
+describe('hasDependents', () => {
+  let mockConnection: Connection;
+  let taskPda: PublicKey;
+
+  beforeEach(() => {
+    taskPda = makeTestPubkey(1);
+    mockConnection = {
+      getProgramAccounts: vi.fn(),
+    } as unknown as Connection;
+  });
+
+  it('returns false when task has no dependents', async () => {
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([]);
+
+    const result = await hasDependents(mockConnection, PROGRAM_ID, taskPda);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true when task has at least one dependent', async () => {
+    vi.mocked(mockConnection.getProgramAccounts).mockResolvedValue([
+      { pubkey: makeTestPubkey(2), account: { data: Buffer.alloc(0), executable: false, lamports: 0, owner: PROGRAM_ID } },
+    ]);
+
+    const result = await hasDependents(mockConnection, PROGRAM_ID, taskPda);
+
+    expect(result).toBe(true);
+  });
+});
+
+/**
+ * Helper to create mock Task account data for testing.
+ */
+function createMockTaskData(params: {
+  taskId?: Buffer;
+  creator?: PublicKey;
+  dependsOn?: PublicKey;
+  status?: TaskState;
+  rewardAmount?: bigint;
+  createdAt?: bigint;
+  deadline?: bigint;
+}): Buffer {
+  const data = Buffer.alloc(400); // Large enough for Task account
+
+  // Write discriminator (8 bytes) - use placeholder
+  data.fill(0xaa, 0, 8);
+
+  // Write task_id (32 bytes at offset 8)
+  if (params.taskId) {
+    params.taskId.copy(data, TASK_FIELD_OFFSETS.TASK_ID);
+  }
+
+  // Write creator (32 bytes at offset 40)
+  if (params.creator) {
+    params.creator.toBuffer().copy(data, TASK_FIELD_OFFSETS.CREATOR);
+  }
+
+  // Write reward_amount (8 bytes at offset 176)
+  if (params.rewardAmount !== undefined) {
+    data.writeBigUInt64LE(params.rewardAmount, TASK_FIELD_OFFSETS.REWARD_AMOUNT);
+  }
+
+  // Write status (1 byte at offset 186)
+  if (params.status !== undefined) {
+    data.writeUInt8(params.status, TASK_FIELD_OFFSETS.STATUS);
+  }
+
+  // Write created_at (8 bytes at offset 188)
+  if (params.createdAt !== undefined) {
+    data.writeBigInt64LE(params.createdAt, TASK_FIELD_OFFSETS.CREATED_AT);
+  }
+
+  // Write deadline (8 bytes at offset 196)
+  if (params.deadline !== undefined) {
+    data.writeBigInt64LE(params.deadline, TASK_FIELD_OFFSETS.DEADLINE);
+  }
+
+  // Write depends_on (Option<Pubkey> at offset 311)
+  if (params.dependsOn) {
+    data.writeUInt8(1, TASK_FIELD_OFFSETS.DEPENDS_ON); // Some discriminator
+    params.dependsOn.toBuffer().copy(data, TASK_FIELD_OFFSETS.DEPENDS_ON_PUBKEY);
+  } else {
+    data.writeUInt8(0, TASK_FIELD_OFFSETS.DEPENDS_ON); // None discriminator
+  }
+
+  return data;
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -75,5 +75,17 @@ export {
   SEEDS,
 } from './constants';
 
+export {
+  // Query functions
+  getTasksByDependency,
+  getDependentTaskCount,
+  getTasksByDependencyWithProgram,
+  hasDependents,
+  // Field offsets for memcmp filtering (for custom queries)
+  TASK_FIELD_OFFSETS,
+  // Types
+  DependentTask,
+} from './queries';
+
 // Version info
 export const VERSION = '1.0.0';

--- a/sdk/src/queries.ts
+++ b/sdk/src/queries.ts
@@ -1,0 +1,462 @@
+/**
+ * Query Helpers for AgenC
+ *
+ * Efficient on-chain queries using Solana's memcmp filters
+ */
+
+import { Connection, PublicKey, GetProgramAccountsFilter } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import { PROGRAM_ID, DISCRIMINATOR_SIZE } from './constants';
+
+// ============================================================================
+// Task Account Field Offsets
+// ============================================================================
+
+/**
+ * Byte offsets for all fields in the Task account.
+ *
+ * Task account layout:
+ *   discriminator:          8 bytes  (offset 0)
+ *   task_id:               32 bytes  (offset 8)
+ *   creator:               32 bytes  (offset 40)
+ *   required_capabilities:  8 bytes  (offset 72)
+ *   description:           64 bytes  (offset 80)
+ *   constraint_hash:       32 bytes  (offset 144)
+ *   reward_amount:          8 bytes  (offset 176)
+ *   max_workers:            1 byte   (offset 184)
+ *   current_workers:        1 byte   (offset 185)
+ *   status:                 1 byte   (offset 186)
+ *   task_type:              1 byte   (offset 187)
+ *   created_at:             8 bytes  (offset 188)
+ *   deadline:               8 bytes  (offset 196)
+ *   completed_at:           8 bytes  (offset 204)
+ *   escrow:                32 bytes  (offset 212)
+ *   result:                64 bytes  (offset 244)
+ *   completions:            1 byte   (offset 308)
+ *   required_completions:   1 byte   (offset 309)
+ *   bump:                   1 byte   (offset 310)
+ *   depends_on:            33 bytes  (offset 311) - Option<Pubkey>: 1 byte discriminator + 32 bytes
+ *   dependency_type:        1 byte   (offset 344)
+ *   _reserved:             32 bytes  (offset 345)
+ *
+ * For Option<Pubkey>:
+ *   - Byte 0 (offset 311): discriminator (0 = None, 1 = Some)
+ *   - Bytes 1-32 (offset 312-343): Pubkey data (when Some)
+ */
+export const TASK_FIELD_OFFSETS = {
+  /** Anchor account discriminator (8 bytes) */
+  DISCRIMINATOR: 0,
+  /** Unique task identifier (32 bytes) */
+  TASK_ID: 8,
+  /** Task creator pubkey (32 bytes) */
+  CREATOR: 40,
+  /** Required capability bitmask (8 bytes) */
+  REQUIRED_CAPABILITIES: 72,
+  /** Task description or instruction hash (64 bytes) */
+  DESCRIPTION: 80,
+  /** Constraint hash for private task verification (32 bytes) */
+  CONSTRAINT_HASH: 144,
+  /** Reward amount in lamports (8 bytes) */
+  REWARD_AMOUNT: 176,
+  /** Maximum workers allowed (1 byte) */
+  MAX_WORKERS: 184,
+  /** Current worker count (1 byte) */
+  CURRENT_WORKERS: 185,
+  /** Task status enum (1 byte) */
+  STATUS: 186,
+  /** Task type enum (1 byte) */
+  TASK_TYPE: 187,
+  /** Creation timestamp (8 bytes) */
+  CREATED_AT: 188,
+  /** Deadline timestamp (8 bytes) */
+  DEADLINE: 196,
+  /** Completion timestamp (8 bytes) */
+  COMPLETED_AT: 204,
+  /** Escrow account pubkey (32 bytes) */
+  ESCROW: 212,
+  /** Result data or pointer (64 bytes) */
+  RESULT: 244,
+  /** Number of completions (1 byte) */
+  COMPLETIONS: 308,
+  /** Required completions (1 byte) */
+  REQUIRED_COMPLETIONS: 309,
+  /** PDA bump seed (1 byte) */
+  BUMP: 310,
+  /** Optional parent task dependency - Option<Pubkey> discriminator byte (1 + 32 bytes) */
+  DEPENDS_ON: 311,
+  /** The actual Pubkey bytes within depends_on (after Option discriminator) */
+  DEPENDS_ON_PUBKEY: 312,
+  /** Type of dependency relationship (1 byte) */
+  DEPENDENCY_TYPE: 344,
+} as const;
+
+// ============================================================================
+// Result Types
+// ============================================================================
+
+/**
+ * Parsed task data returned from dependency queries.
+ */
+export interface DependentTask {
+  /** Task account public key */
+  publicKey: PublicKey;
+  /** Task ID bytes */
+  taskId: Uint8Array;
+  /** Task creator */
+  creator: PublicKey;
+  /** Required capability bitmask */
+  requiredCapabilities: bigint;
+  /** Task description/instruction hash */
+  description: Uint8Array;
+  /** Constraint hash for private verification */
+  constraintHash: Uint8Array;
+  /** Reward amount in lamports */
+  rewardAmount: bigint;
+  /** Maximum workers allowed */
+  maxWorkers: number;
+  /** Current worker count */
+  currentWorkers: number;
+  /** Task status */
+  status: number;
+  /** Task type */
+  taskType: number;
+  /** Creation timestamp (unix seconds) */
+  createdAt: number;
+  /** Deadline timestamp (unix seconds, 0 = no deadline) */
+  deadline: number;
+  /** Completion timestamp (unix seconds, 0 = not completed) */
+  completedAt: number;
+  /** Escrow account pubkey */
+  escrow: PublicKey;
+  /** Result data or pointer */
+  result: Uint8Array;
+  /** Number of completions */
+  completions: number;
+  /** Required completions */
+  requiredCompletions: number;
+  /** PDA bump seed */
+  bump: number;
+  /** Parent task this depends on (null if no dependency) */
+  dependsOn: PublicKey | null;
+  /** Type of dependency relationship */
+  dependencyType: number;
+}
+
+// ============================================================================
+// Helper Types
+// ============================================================================
+
+/**
+ * Helper type for dynamic account access on Anchor programs.
+ */
+type AccountFetcher = {
+  fetch: (key: PublicKey) => Promise<unknown>;
+  all: (
+    filters?: Array<{ memcmp: { offset: number; bytes: string } }>
+  ) => Promise<Array<{ account: unknown; publicKey: PublicKey }>>;
+};
+
+function getAccount(program: Program, name: string): AccountFetcher {
+  const accounts = program.account as Record<string, AccountFetcher | undefined>;
+  const account = accounts[name];
+  if (!account) {
+    throw new Error(
+      `Account "${name}" not found in program. ` +
+        `Available accounts: ${Object.keys(accounts).join(', ') || 'none'}`
+    );
+  }
+  return account;
+}
+
+// ============================================================================
+// Dependency Query Functions
+// ============================================================================
+
+/**
+ * Get all tasks that depend on a given parent task.
+ *
+ * Uses memcmp filters on the `depends_on` field for efficient on-chain filtering.
+ * Only fetches tasks where depends_on is Some(parentTaskPda).
+ *
+ * @param connection - Solana RPC connection
+ * @param programId - AgenC program ID (defaults to PROGRAM_ID)
+ * @param parentTaskPda - The parent task PDA to query dependents for
+ * @returns Array of parsed task data that depend on the parent
+ *
+ * @example
+ * ```typescript
+ * const parentTask = deriveTaskPda(parentTaskId);
+ * const dependents = await getTasksByDependency(connection, PROGRAM_ID, parentTask);
+ * console.log(`Found ${dependents.length} dependent tasks`);
+ * for (const task of dependents) {
+ *   console.log(`Task ${task.publicKey.toBase58()} depends on parent`);
+ * }
+ * ```
+ */
+export async function getTasksByDependency(
+  connection: Connection,
+  programId: PublicKey,
+  parentTaskPda: PublicKey
+): Promise<DependentTask[]> {
+  // Build the memcmp bytes: Option discriminator (1 = Some) + Pubkey bytes
+  const filterBytes = Buffer.alloc(33);
+  filterBytes[0] = 1; // Some discriminator
+  parentTaskPda.toBuffer().copy(filterBytes, 1);
+
+  const filters: GetProgramAccountsFilter[] = [
+    {
+      memcmp: {
+        offset: TASK_FIELD_OFFSETS.DEPENDS_ON,
+        bytes: filterBytes.toString('base64'),
+        encoding: 'base64',
+      },
+    },
+  ];
+
+  const accounts = await connection.getProgramAccounts(programId, {
+    filters,
+  });
+
+  return accounts.map(({ pubkey, account }) =>
+    deserializeTaskAccount(pubkey, account.data as Buffer)
+  );
+}
+
+/**
+ * Get the count of tasks that depend on a given parent task.
+ *
+ * Uses dataSlice to minimize bandwidth - only fetches account keys, not full data.
+ * This is more efficient than getTasksByDependency when you only need the count.
+ *
+ * @param connection - Solana RPC connection
+ * @param programId - AgenC program ID (defaults to PROGRAM_ID)
+ * @param parentTaskPda - The parent task PDA to count dependents for
+ * @returns Number of tasks that depend on the parent
+ *
+ * @example
+ * ```typescript
+ * const parentTask = deriveTaskPda(parentTaskId);
+ * const count = await getDependentTaskCount(connection, PROGRAM_ID, parentTask);
+ * if (count > 0) {
+ *   console.log(`Cannot delete task: ${count} tasks depend on it`);
+ * }
+ * ```
+ */
+export async function getDependentTaskCount(
+  connection: Connection,
+  programId: PublicKey,
+  parentTaskPda: PublicKey
+): Promise<number> {
+  // Build the memcmp bytes: Option discriminator (1 = Some) + Pubkey bytes
+  const filterBytes = Buffer.alloc(33);
+  filterBytes[0] = 1; // Some discriminator
+  parentTaskPda.toBuffer().copy(filterBytes, 1);
+
+  const filters: GetProgramAccountsFilter[] = [
+    {
+      memcmp: {
+        offset: TASK_FIELD_OFFSETS.DEPENDS_ON,
+        bytes: filterBytes.toString('base64'),
+        encoding: 'base64',
+      },
+    },
+  ];
+
+  // Use dataSlice to fetch only 0 bytes of data - we just need the count
+  const accounts = await connection.getProgramAccounts(programId, {
+    filters,
+    dataSlice: { offset: 0, length: 0 },
+  });
+
+  return accounts.length;
+}
+
+/**
+ * Check if a task has any dependents (child tasks).
+ *
+ * This is a convenience wrapper around getDependentTaskCount.
+ *
+ * @param connection - Solana RPC connection
+ * @param programId - AgenC program ID
+ * @param taskPda - The task PDA to check
+ * @returns True if the task has at least one dependent
+ *
+ * @example
+ * ```typescript
+ * if (await hasDependents(connection, PROGRAM_ID, taskPda)) {
+ *   console.log('Task has dependent tasks');
+ * }
+ * ```
+ */
+export async function hasDependents(
+  connection: Connection,
+  programId: PublicKey,
+  taskPda: PublicKey
+): Promise<boolean> {
+  const count = await getDependentTaskCount(connection, programId, taskPda);
+  return count > 0;
+}
+
+/**
+ * Get all tasks that depend on a parent, using an Anchor program instance.
+ *
+ * This is a convenience wrapper that uses Anchor's account fetching
+ * which provides automatic deserialization.
+ *
+ * @param program - Anchor program instance
+ * @param parentTaskPda - The parent task PDA to query dependents for
+ * @returns Array of deserialized task accounts
+ */
+export async function getTasksByDependencyWithProgram(
+  program: Program,
+  parentTaskPda: PublicKey
+): Promise<Array<{ publicKey: PublicKey; account: unknown }>> {
+  // Build the memcmp bytes: Option discriminator (1 = Some) + Pubkey bytes
+  const filterBytes = Buffer.alloc(33);
+  filterBytes[0] = 1; // Some discriminator
+  parentTaskPda.toBuffer().copy(filterBytes, 1);
+
+  const tasks = await getAccount(program, 'task').all([
+    {
+      memcmp: {
+        offset: TASK_FIELD_OFFSETS.DEPENDS_ON,
+        bytes: filterBytes.toString('base64'),
+      },
+    },
+  ]);
+
+  return tasks.map((t) => ({
+    publicKey: t.publicKey,
+    account: t.account,
+  }));
+}
+
+/**
+ * Get all root tasks (tasks with no dependencies).
+ *
+ * Uses memcmp filter to find tasks where depends_on is None.
+ *
+ * @param connection - Solana RPC connection
+ * @param programId - AgenC program ID
+ * @returns Array of root task data
+ */
+export async function getRootTasks(
+  connection: Connection,
+  programId: PublicKey
+): Promise<DependentTask[]> {
+  // For None, the Option discriminator byte is 0
+  const filterBytes = Buffer.alloc(1);
+  filterBytes[0] = 0; // None discriminator
+
+  const filters: GetProgramAccountsFilter[] = [
+    {
+      memcmp: {
+        offset: TASK_FIELD_OFFSETS.DEPENDS_ON,
+        bytes: filterBytes.toString('base64'),
+        encoding: 'base64',
+      },
+    },
+  ];
+
+  const accounts = await connection.getProgramAccounts(programId, {
+    filters,
+  });
+
+  return accounts.map(({ pubkey, account }) =>
+    deserializeTaskAccount(pubkey, account.data as Buffer)
+  );
+}
+
+// ============================================================================
+// Task Deserialization
+// ============================================================================
+
+/**
+ * Deserialize raw Task account data into a DependentTask object.
+ */
+function deserializeTaskAccount(publicKey: PublicKey, data: Buffer): DependentTask {
+  const taskId = data.subarray(
+    TASK_FIELD_OFFSETS.TASK_ID,
+    TASK_FIELD_OFFSETS.TASK_ID + 32
+  );
+
+  const creator = new PublicKey(
+    data.subarray(TASK_FIELD_OFFSETS.CREATOR, TASK_FIELD_OFFSETS.CREATOR + 32)
+  );
+
+  const requiredCapabilities = data.readBigUInt64LE(
+    TASK_FIELD_OFFSETS.REQUIRED_CAPABILITIES
+  );
+
+  const description = data.subarray(
+    TASK_FIELD_OFFSETS.DESCRIPTION,
+    TASK_FIELD_OFFSETS.DESCRIPTION + 64
+  );
+
+  const constraintHash = data.subarray(
+    TASK_FIELD_OFFSETS.CONSTRAINT_HASH,
+    TASK_FIELD_OFFSETS.CONSTRAINT_HASH + 32
+  );
+
+  const rewardAmount = data.readBigUInt64LE(TASK_FIELD_OFFSETS.REWARD_AMOUNT);
+
+  const maxWorkers = data.readUInt8(TASK_FIELD_OFFSETS.MAX_WORKERS);
+  const currentWorkers = data.readUInt8(TASK_FIELD_OFFSETS.CURRENT_WORKERS);
+  const status = data.readUInt8(TASK_FIELD_OFFSETS.STATUS);
+  const taskType = data.readUInt8(TASK_FIELD_OFFSETS.TASK_TYPE);
+
+  const createdAt = Number(data.readBigInt64LE(TASK_FIELD_OFFSETS.CREATED_AT));
+  const deadline = Number(data.readBigInt64LE(TASK_FIELD_OFFSETS.DEADLINE));
+  const completedAt = Number(data.readBigInt64LE(TASK_FIELD_OFFSETS.COMPLETED_AT));
+
+  const escrow = new PublicKey(
+    data.subarray(TASK_FIELD_OFFSETS.ESCROW, TASK_FIELD_OFFSETS.ESCROW + 32)
+  );
+
+  const result = data.subarray(
+    TASK_FIELD_OFFSETS.RESULT,
+    TASK_FIELD_OFFSETS.RESULT + 64
+  );
+
+  const completions = data.readUInt8(TASK_FIELD_OFFSETS.COMPLETIONS);
+  const requiredCompletions = data.readUInt8(TASK_FIELD_OFFSETS.REQUIRED_COMPLETIONS);
+  const bump = data.readUInt8(TASK_FIELD_OFFSETS.BUMP);
+
+  // Parse Option<Pubkey> for depends_on
+  const dependsOnDiscriminator = data.readUInt8(TASK_FIELD_OFFSETS.DEPENDS_ON);
+  let dependsOn: PublicKey | null = null;
+  if (dependsOnDiscriminator === 1) {
+    dependsOn = new PublicKey(
+      data.subarray(
+        TASK_FIELD_OFFSETS.DEPENDS_ON_PUBKEY,
+        TASK_FIELD_OFFSETS.DEPENDS_ON_PUBKEY + 32
+      )
+    );
+  }
+
+  const dependencyType = data.readUInt8(TASK_FIELD_OFFSETS.DEPENDENCY_TYPE);
+
+  return {
+    publicKey,
+    taskId,
+    creator,
+    requiredCapabilities,
+    description,
+    constraintHash,
+    rewardAmount,
+    maxWorkers,
+    currentWorkers,
+    status,
+    taskType,
+    createdAt,
+    deadline,
+    completedAt,
+    escrow,
+    result,
+    completions,
+    requiredCompletions,
+    bump,
+    dependsOn,
+    dependencyType,
+  };
+}


### PR DESCRIPTION
## Summary

Adds SDK query helpers to find tasks by their dependency relationships using Solana memcmp filters.

## Changes

- Add `getTasksByDependency()` to find all tasks depending on a parent task
- Add `getDependentTaskCount()` for lightweight counting (uses dataSlice for efficiency)
- Add `hasDependents()` convenience function
- Add `getTasksByDependencyWithProgram()` for Anchor program integration
- Document field offsets for memcmp filtering (`TASK_FIELD_OFFSETS`)
- Export `DependentTask` type for query results

## Implementation Details

The `depends_on` field in the Task account is at byte offset 311. It's serialized as an `Option<Pubkey>`:
- 1 byte discriminator (0 = None, 1 = Some)
- 32 bytes Pubkey value (when Some)

The memcmp filter matches both the discriminator byte and the pubkey to find tasks depending on a specific parent.

## Testing

- Build passes
- Unit tests pass (18 new tests)
- Verified field offset calculations match on-chain Task struct

Closes #262
Part of epic #291