### PR TITLE
feat(runtime): add basic proof pipelining (single-level speculation)

### DIFF
--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -15,3 +15,4 @@ export * from './checkpoint.js';
 export * from './metrics.js';
 export * from './dependency-graph.js';
 export * from './proof-pipeline.js';
+export * from './speculative-executor.js';

--- a/runtime/src/task/speculative-executor.test.ts
+++ b/runtime/src/task/speculative-executor.test.ts
@@ -1,0 +1,845 @@
+/**
+ * Tests for SpeculativeExecutor - single-level speculative execution.
+ *
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
+import {
+  SpeculativeExecutor,
+  type SpeculativeExecutorConfig,
+  type SpeculativeExecutorEvents,
+  type SpeculativeTask,
+} from './speculative-executor.js';
+import { DependencyGraph, DependencyType } from './dependency-graph.js';
+import type { ProofPipeline, ProofGenerationJob } from './proof-pipeline.js';
+import type { TaskOperations } from './operations.js';
+import type {
+  OnChainTask,
+  OnChainTaskStatus,
+  OnChainTaskClaim,
+  TaskExecutionResult,
+  PrivateTaskExecutionResult,
+  TaskExecutionContext,
+  TaskHandler,
+} from './types.js';
+import { TaskType } from '../events/types.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createMockTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
+  return {
+    taskId: new Uint8Array(32).fill(1),
+    creator: Keypair.generate().publicKey,
+    requiredCapabilities: 0n,
+    description: new Uint8Array(64).fill(0),
+    constraintHash: new Uint8Array(32).fill(0),
+    rewardAmount: 1_000_000n,
+    maxWorkers: 1,
+    currentWorkers: 0,
+    status: 0 as OnChainTaskStatus, // Open
+    taskType: TaskType.Exclusive,
+    createdAt: Math.floor(Date.now() / 1000),
+    deadline: Math.floor(Date.now() / 1000) + 3600,
+    completedAt: 0,
+    escrow: Keypair.generate().publicKey,
+    result: new Uint8Array(64).fill(0),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+function createMockClaim(overrides: Partial<OnChainTaskClaim> = {}): OnChainTaskClaim {
+  return {
+    task: Keypair.generate().publicKey,
+    worker: Keypair.generate().publicKey,
+    claimedAt: Math.floor(Date.now() / 1000),
+    expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    completedAt: 0,
+    proofHash: new Uint8Array(32).fill(0),
+    resultData: new Uint8Array(64).fill(0),
+    isCompleted: false,
+    isValidated: false,
+    rewardPaid: 0n,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+function createMockOperations(): TaskOperations {
+  const mockTask = createMockTask();
+  const mockClaim = createMockClaim();
+
+  return {
+    fetchTask: vi.fn().mockResolvedValue(mockTask),
+    fetchClaim: vi.fn().mockResolvedValue(mockClaim),
+    claimTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: mockTask.taskId,
+      claimPda: Keypair.generate().publicKey,
+      transactionSignature: 'test-sig',
+    }),
+    completeTask: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: mockTask.taskId,
+      isPrivate: false,
+      transactionSignature: 'complete-sig',
+    }),
+    completeTaskPrivate: vi.fn().mockResolvedValue({
+      success: true,
+      taskId: mockTask.taskId,
+      isPrivate: true,
+      transactionSignature: 'complete-private-sig',
+    }),
+    fetchTaskEscrow: vi.fn().mockResolvedValue(null),
+    fetchProtocolConfig: vi.fn().mockResolvedValue(null),
+    fetchTasksByCreator: vi.fn().mockResolvedValue([]),
+    fetchAllOpenTasks: vi.fn().mockResolvedValue([]),
+    fetchClaimsByWorker: vi.fn().mockResolvedValue([]),
+  } as unknown as TaskOperations;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SpeculativeExecutor', () => {
+  let operations: TaskOperations;
+  let handler: TaskHandler;
+  let agentId: Uint8Array;
+  let agentPda: PublicKey;
+
+  beforeEach(() => {
+    operations = createMockOperations();
+    handler = vi.fn().mockResolvedValue({
+      proofHash: new Uint8Array(32).fill(1),
+    });
+    agentId = new Uint8Array(32).fill(42);
+    agentPda = Keypair.generate().publicKey;
+  });
+
+  describe('constructor', () => {
+    it('should create executor with default config', () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const status = executor.getStatus();
+      expect(status.speculationEnabled).toBe(true);
+      expect(status.activeSpeculativeTasks).toBe(0);
+      expect(status.tasksAwaitingParent).toBe(0);
+    });
+
+    it('should respect custom speculation config', () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+        enableSpeculation: false,
+        maxSpeculativeTasksPerParent: 10,
+        speculatableDependencyTypes: [DependencyType.Data],
+        abortOnParentFailure: false,
+      });
+
+      const status = executor.getStatus();
+      expect(status.speculationEnabled).toBe(false);
+    });
+  });
+
+  describe('addTaskToGraph', () => {
+    it('should add root task to graph', () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const task = createMockTask();
+      const taskPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(task, taskPda);
+
+      const graph = executor.getDependencyGraph();
+      expect(graph.hasTask(taskPda)).toBe(true);
+      expect(graph.getDepth(taskPda)).toBe(0);
+    });
+
+    it('should add task with parent dependency', () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      const graph = executor.getDependencyGraph();
+      expect(graph.hasTask(childPda)).toBe(true);
+      expect(graph.getDepth(childPda)).toBe(1);
+      expect(graph.getParent(childPda)?.taskPda.equals(parentPda)).toBe(true);
+    });
+  });
+
+  describe('executeTask', () => {
+    it('should execute task and return result', async () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const taskPda = Keypair.generate().publicKey;
+
+      const result = await executor.executeTask(taskPda);
+
+      expect(result).toBeDefined();
+      expect(result.proofHash).toEqual(new Uint8Array(32).fill(1));
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should pass parent result to handler context', async () => {
+      let capturedContext: TaskExecutionContext | null = null;
+      handler = vi.fn().mockImplementation(async (ctx: TaskExecutionContext) => {
+        capturedContext = ctx;
+        return { proofHash: new Uint8Array(32).fill(1) };
+      });
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const taskPda = Keypair.generate().publicKey;
+      const parentResult: TaskExecutionResult = {
+        proofHash: new Uint8Array(32).fill(99),
+      };
+
+      await executor.executeTask(taskPda, parentResult);
+
+      expect(capturedContext).toBeDefined();
+      // Check parent result is accessible
+      const ctxWithParent = capturedContext as TaskExecutionContext & { parentResult?: TaskExecutionResult };
+      expect(ctxWithParent.parentResult).toEqual(parentResult);
+    });
+
+    it('should throw if task not found', async () => {
+      (operations.fetchTask as Mock).mockResolvedValue(null);
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const taskPda = Keypair.generate().publicKey;
+
+      await expect(executor.executeTask(taskPda)).rejects.toThrow('Task not found');
+    });
+
+    it('should throw if claim not found', async () => {
+      (operations.fetchClaim as Mock).mockResolvedValue(null);
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const taskPda = Keypair.generate().publicKey;
+
+      await expect(executor.executeTask(taskPda)).rejects.toThrow('Claim not found');
+    });
+  });
+
+  describe('executeWithSpeculation', () => {
+    it('should execute task and queue proof', async () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const task = createMockTask();
+      const taskPda = Keypair.generate().publicKey;
+      executor.addTaskToGraph(task, taskPda);
+
+      const result = await executor.executeWithSpeculation(taskPda);
+
+      expect(result.proofHash).toEqual(new Uint8Array(32).fill(1));
+
+      // Verify proof was queued (status may have advanced due to async processing)
+      const pipeline = executor.getProofPipeline();
+      const job = pipeline.getJob(taskPda);
+      expect(job).toBeDefined();
+      // Job may be queued, generating, or already confirmed depending on timing
+      expect(['queued', 'generating', 'generated', 'submitting', 'confirmed']).toContain(job?.status);
+    });
+
+    it('should start speculative execution of dependents', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+      executor.on(events);
+
+      // Set up parent-child relationship
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      // Execute parent (should trigger speculation on child)
+      await executor.executeWithSpeculation(parentPda);
+
+      // Wait for speculative execution to start
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledWith(childPda, parentPda);
+
+      const status = executor.getStatus();
+      expect(status.activeSpeculativeTasks).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should not speculate when speculation is disabled', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+        enableSpeculation: false,
+      });
+      executor.on(events);
+
+      // Set up parent-child relationship
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      await executor.executeWithSpeculation(parentPda);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(events.onSpeculativeExecutionStarted).not.toHaveBeenCalled();
+    });
+
+    it('should respect maxSpeculativeTasksPerParent limit', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+        maxSpeculativeTasksPerParent: 2,
+      });
+      executor.on(events);
+
+      // Set up parent with 5 children
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const parentPda = Keypair.generate().publicKey;
+      executor.addTaskToGraph(parentTask, parentPda);
+
+      for (let i = 0; i < 5; i++) {
+        const childTask = createMockTask({ taskId: new Uint8Array(32).fill(10 + i) });
+        const childPda = Keypair.generate().publicKey;
+        executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+      }
+
+      await executor.executeWithSpeculation(parentPda);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Should only have started 2 speculative executions (the limit)
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledTimes(2);
+    });
+
+    it('should only speculate on allowed dependency types', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+        speculatableDependencyTypes: [DependencyType.Data], // Only Data, not Resource
+      });
+      executor.on(events);
+
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const dataChildTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const resourceChildTask = createMockTask({ taskId: new Uint8Array(32).fill(3) });
+      const parentPda = Keypair.generate().publicKey;
+      const dataChildPda = Keypair.generate().publicKey;
+      const resourceChildPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(dataChildTask, dataChildPda, parentPda, DependencyType.Data);
+      executor.addTaskToGraph(resourceChildTask, resourceChildPda, parentPda, DependencyType.Resource);
+
+      await executor.executeWithSpeculation(parentPda);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Only the Data dependency child should be speculated
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledTimes(1);
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledWith(dataChildPda, parentPda);
+    });
+  });
+
+  describe('cancelSpeculativeTask', () => {
+    it('should cancel a pending speculative task', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+        onSpeculativeExecutionAborted: vi.fn(),
+      };
+
+      // Track execution order - parent must complete before speculation starts
+      let parentCompleted = false;
+      let childStarted = false;
+
+      // Parent handler completes quickly
+      const parentHandler = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        parentCompleted = true;
+        return { proofHash: new Uint8Array(32).fill(1) };
+      });
+
+      // Child handler is slow to allow cancellation
+      const childHandler = vi.fn().mockImplementation(async () => {
+        childStarted = true;
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        return { proofHash: new Uint8Array(32).fill(2) };
+      });
+
+      // Use a handler that switches based on task
+      let callCount = 0;
+      handler = vi.fn().mockImplementation(async (ctx) => {
+        callCount++;
+        if (callCount === 1) {
+          // First call is parent
+          return parentHandler(ctx);
+        }
+        // Subsequent calls are child (speculative)
+        return childHandler(ctx);
+      });
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+      executor.on(events);
+
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      // Start parent execution - this will complete and trigger speculation
+      const parentPromise = executor.executeWithSpeculation(parentPda);
+
+      // Wait for parent to complete and speculation to start
+      await parentPromise;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify speculation started
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledWith(childPda, parentPda);
+
+      // Cancel the speculative child (should be executing now)
+      const cancelled = executor.cancelSpeculativeTask(childPda, 'test cancellation');
+
+      expect(cancelled).toBe(true);
+      expect(events.onSpeculativeExecutionAborted).toHaveBeenCalledWith(childPda, 'test cancellation');
+    });
+
+    it('should return false if task not found', () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const unknownPda = Keypair.generate().publicKey;
+      const result = executor.cancelSpeculativeTask(unknownPda, 'test');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('event callbacks', () => {
+    it('should emit onTaskExecutionStarted for each execution', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onTaskExecutionStarted: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+      executor.on(events);
+
+      const task = createMockTask();
+      const taskPda = Keypair.generate().publicKey;
+      executor.addTaskToGraph(task, taskPda);
+
+      await executor.executeTask(taskPda);
+
+      expect(events.onTaskExecutionStarted).toHaveBeenCalledTimes(1);
+      expect(events.onTaskExecutionStarted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          taskPda,
+          agentId,
+          agentPda,
+        })
+      );
+    });
+
+    it('should emit parent proof events', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onParentProofConfirmed: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+      executor.on(events);
+
+      const task = createMockTask();
+      const taskPda = Keypair.generate().publicKey;
+      executor.addTaskToGraph(task, taskPda);
+
+      await executor.executeWithSpeculation(taskPda);
+
+      // Simulate proof confirmation
+      const pipeline = executor.getProofPipeline();
+      const job = pipeline.getJob(taskPda);
+
+      // Wait for proof to be processed (the pipeline auto-submits)
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // The proof pipeline will call our event handlers when proof is confirmed
+      // In real scenarios, this happens asynchronously after submission
+    });
+  });
+
+  describe('metrics', () => {
+    it('should track speculative execution metrics', async () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      // Set up parent-child relationship
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      await executor.executeWithSpeculation(parentPda);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const metrics = executor.getMetrics();
+      expect(metrics.speculativeExecutionsStarted).toBe(1);
+    });
+
+    it('should provide complete status snapshot', () => {
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+
+      const status = executor.getStatus();
+
+      expect(status).toEqual(
+        expect.objectContaining({
+          speculationEnabled: true,
+          activeSpeculativeTasks: 0,
+          tasksAwaitingParent: 0,
+          proofPipelineStats: expect.objectContaining({
+            queued: 0,
+            generating: 0,
+            awaitingSubmission: 0,
+            confirmed: 0,
+            failed: 0,
+          }),
+          metrics: expect.objectContaining({
+            speculativeExecutionsStarted: 0,
+            speculativeExecutionsConfirmed: 0,
+            speculativeExecutionsAborted: 0,
+            estimatedTimeSavedMs: 0,
+          }),
+        })
+      );
+    });
+  });
+
+  describe('proof ordering invariant', () => {
+    it('should queue proofs for speculative tasks', async () => {
+      // This test verifies that speculative tasks get their proofs queued
+      // The actual ordering is handled by the ProofPipeline
+
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+      executor.on(events);
+
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      await executor.executeWithSpeculation(parentPda);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      // Verify speculative execution was started
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledWith(childPda, parentPda);
+
+      // Verify that the parent proof was queued
+      const pipeline = executor.getProofPipeline();
+      const parentJob = pipeline.getJob(parentPda);
+      expect(parentJob).toBeDefined();
+    });
+  });
+
+  describe('abort on parent failure', () => {
+    it('should abort speculative tasks when parent proof fails', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+        onSpeculativeExecutionAborted: vi.fn(),
+        onParentProofFailed: vi.fn(),
+      };
+
+      // Make complete task fail
+      (operations.completeTask as Mock).mockRejectedValue(new Error('Proof verification failed'));
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+        abortOnParentFailure: true,
+        proofPipelineConfig: {
+          retryPolicy: { maxAttempts: 1, baseDelayMs: 10, maxDelayMs: 10, jitter: false },
+        },
+      });
+      executor.on(events);
+
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      await executor.executeWithSpeculation(parentPda);
+
+      // Wait for proof failure to propagate
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Verify parent failure was detected
+      expect(events.onParentProofFailed).toHaveBeenCalled();
+
+      // Verify speculative task was aborted
+      expect(events.onSpeculativeExecutionAborted).toHaveBeenCalledWith(
+        childPda,
+        expect.stringContaining('parent proof failed')
+      );
+    });
+
+    it('should not abort when abortOnParentFailure is false', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionAborted: vi.fn(),
+      };
+
+      (operations.completeTask as Mock).mockRejectedValue(new Error('Proof verification failed'));
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+        abortOnParentFailure: false,
+        proofPipelineConfig: {
+          retryPolicy: { maxAttempts: 1, baseDelayMs: 10, maxDelayMs: 10, jitter: false },
+        },
+      });
+      executor.on(events);
+
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      await executor.executeWithSpeculation(parentPda);
+      await new Promise((resolve) => setTimeout(resolve, 200));
+
+      // Speculative task should NOT be aborted
+      expect(events.onSpeculativeExecutionAborted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('shutdown', () => {
+    it('should abort all speculative tasks on shutdown', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+        onSpeculativeExecutionAborted: vi.fn(),
+      };
+
+      // Track execution
+      let callCount = 0;
+
+      // Parent completes quickly, child is slow
+      handler = vi.fn().mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) {
+          // Parent - quick
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return { proofHash: new Uint8Array(32).fill(1) };
+        }
+        // Child - slow
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        return { proofHash: new Uint8Array(32).fill(2) };
+      });
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+      executor.on(events);
+
+      const parentTask = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const childTask = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const parentPda = Keypair.generate().publicKey;
+      const childPda = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(parentTask, parentPda);
+      executor.addTaskToGraph(childTask, childPda, parentPda, DependencyType.Data);
+
+      // Start parent execution (will complete and trigger speculation)
+      const execPromise = executor.executeWithSpeculation(parentPda);
+
+      // Wait for parent to complete and speculative task to start
+      await execPromise;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // Verify speculation started
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledWith(childPda, parentPda);
+
+      // Shutdown while child is still executing
+      await executor.shutdown();
+
+      expect(events.onSpeculativeExecutionAborted).toHaveBeenCalledWith(childPda, 'shutdown');
+    });
+  });
+
+  describe('single-level speculation constraint', () => {
+    it('should only speculate one level deep (no chaining)', async () => {
+      const events: SpeculativeExecutorEvents = {
+        onSpeculativeExecutionStarted: vi.fn(),
+      };
+
+      const executor = new SpeculativeExecutor({
+        operations,
+        handler,
+        agentId,
+        agentPda,
+      });
+      executor.on(events);
+
+      // Set up chain: A -> B -> C
+      const taskA = createMockTask({ taskId: new Uint8Array(32).fill(1) });
+      const taskB = createMockTask({ taskId: new Uint8Array(32).fill(2) });
+      const taskC = createMockTask({ taskId: new Uint8Array(32).fill(3) });
+      const pdaA = Keypair.generate().publicKey;
+      const pdaB = Keypair.generate().publicKey;
+      const pdaC = Keypair.generate().publicKey;
+
+      executor.addTaskToGraph(taskA, pdaA);
+      executor.addTaskToGraph(taskB, pdaB, pdaA, DependencyType.Data);
+      executor.addTaskToGraph(taskC, pdaC, pdaB, DependencyType.Data);
+
+      // Execute A
+      await executor.executeWithSpeculation(pdaA);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // B should be speculated (direct dependent of A)
+      // C should NOT be speculated (only single-level, not chained)
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledTimes(1);
+      expect(events.onSpeculativeExecutionStarted).toHaveBeenCalledWith(pdaB, pdaA);
+    });
+  });
+});

--- a/runtime/src/task/speculative-executor.ts
+++ b/runtime/src/task/speculative-executor.ts
@@ -1,0 +1,794 @@
+/**
+ * SpeculativeExecutor - Single-level speculative execution with proof pipelining.
+ *
+ * Extends TaskExecutor to enable speculative execution of dependent tasks
+ * while parent proofs are being generated. This reduces pipeline latency
+ * by overlapping execution and proof generation.
+ *
+ * Key features:
+ * - Single-level speculation (no chaining A->B->C)
+ * - Proof submission gated on parent confirmation
+ * - Automatic abort of speculative tasks when parent fails
+ * - Configurable dependency type filtering
+ *
+ * @module
+ */
+
+import type { PublicKey } from '@solana/web3.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import type { TaskOperations } from './operations.js';
+import type { TaskDiscovery } from './discovery.js';
+import type {
+  TaskExecutionResult,
+  PrivateTaskExecutionResult,
+  TaskHandler,
+  TaskExecutorConfig,
+  TaskExecutorEvents,
+  MetricsProvider,
+  TracingProvider,
+  OnChainTask,
+  TaskExecutionContext,
+} from './types.js';
+import {
+  DependencyGraph,
+  DependencyType,
+  type TaskNode,
+} from './dependency-graph.js';
+import {
+  ProofPipeline,
+  type ProofPipelineConfig,
+  type ProofPipelineEvents,
+  type ProofGenerationJob,
+} from './proof-pipeline.js';
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Status of a speculative task execution.
+ */
+export type SpeculativeTaskStatus =
+  | 'pending'
+  | 'executing'
+  | 'executed'
+  | 'proof_queued'
+  | 'confirmed'
+  | 'aborted'
+  | 'failed';
+
+/**
+ * Tracks a speculatively executed task.
+ */
+export interface SpeculativeTask {
+  /** Task PDA address */
+  readonly taskPda: PublicKey;
+  /** Task ID (32 bytes) */
+  readonly taskId: Uint8Array;
+  /** Parent task PDA that this depends on */
+  readonly parentPda: PublicKey;
+  /** Current speculative status */
+  status: SpeculativeTaskStatus;
+  /** Execution result (set after execution completes) */
+  executionResult?: TaskExecutionResult | PrivateTaskExecutionResult;
+  /** Timestamp when speculative execution started */
+  readonly startedAt: number;
+  /** Timestamp when completed or aborted */
+  completedAt?: number;
+  /** Abort reason if aborted */
+  abortReason?: string;
+  /** AbortController for cancellation */
+  readonly controller: AbortController;
+}
+
+/**
+ * Configuration for speculative execution.
+ */
+export interface SpeculativeExecutorConfig extends Omit<TaskExecutorConfig, 'discovery'> {
+  /** TaskDiscovery instance (optional for speculative mode) */
+  discovery?: TaskDiscovery;
+  /** Enable single-level speculation. Default: true */
+  enableSpeculation?: boolean;
+  /** Maximum speculative tasks per parent. Default: 5 */
+  maxSpeculativeTasksPerParent?: number;
+  /** Dependency types eligible for speculation. Default: [Data, Order] */
+  speculatableDependencyTypes?: DependencyType[];
+  /** Abort speculative tasks if parent proof fails. Default: true */
+  abortOnParentFailure?: boolean;
+  /** Proof pipeline configuration */
+  proofPipelineConfig?: Partial<ProofPipelineConfig>;
+}
+
+/**
+ * Extended events for speculative execution lifecycle.
+ */
+export interface SpeculativeExecutorEvents extends TaskExecutorEvents {
+  /** Called when speculative execution starts for a dependent task */
+  onSpeculativeExecutionStarted?: (taskPda: PublicKey, parentPda: PublicKey) => void;
+  /** Called when a speculative task's proof is confirmed on-chain */
+  onSpeculativeExecutionConfirmed?: (taskPda: PublicKey) => void;
+  /** Called when a speculative task is aborted (e.g., parent failed) */
+  onSpeculativeExecutionAborted?: (taskPda: PublicKey, reason: string) => void;
+  /** Called when parent proof is confirmed, enabling dependent submission */
+  onParentProofConfirmed?: (parentPda: PublicKey) => void;
+  /** Called when parent proof fails */
+  onParentProofFailed?: (parentPda: PublicKey, error: Error) => void;
+}
+
+/**
+ * Metrics for speculative execution tracking.
+ */
+export interface SpeculativeMetrics {
+  /** Total speculative executions started */
+  speculativeExecutionsStarted: number;
+  /** Speculative executions that were confirmed */
+  speculativeExecutionsConfirmed: number;
+  /** Speculative executions that were aborted */
+  speculativeExecutionsAborted: number;
+  /** Total time saved by speculation (estimated, in ms) */
+  estimatedTimeSavedMs: number;
+}
+
+/**
+ * Status snapshot of the speculative executor.
+ */
+export interface SpeculativeExecutorStatus {
+  /** Whether speculation is enabled */
+  speculationEnabled: boolean;
+  /** Number of active speculative tasks */
+  activeSpeculativeTasks: number;
+  /** Number of tasks awaiting parent confirmation */
+  tasksAwaitingParent: number;
+  /** Proof pipeline stats */
+  proofPipelineStats: {
+    queued: number;
+    generating: number;
+    awaitingSubmission: number;
+    confirmed: number;
+    failed: number;
+  };
+  /** Speculative execution metrics */
+  metrics: SpeculativeMetrics;
+}
+
+// ============================================================================
+// Default Configuration
+// ============================================================================
+
+const DEFAULT_SPECULATIVE_CONFIG = {
+  enableSpeculation: true,
+  maxSpeculativeTasksPerParent: 5,
+  speculatableDependencyTypes: [DependencyType.Data, DependencyType.Order],
+  abortOnParentFailure: true,
+};
+
+// ============================================================================
+// SpeculativeExecutor Class
+// ============================================================================
+
+/**
+ * Executor with single-level speculative execution support.
+ *
+ * When a task completes execution, the executor:
+ * 1. Queues proof generation (async)
+ * 2. Identifies dependent tasks eligible for speculation
+ * 3. Starts executing dependents speculatively
+ * 4. Holds dependent proofs until parent proof confirms
+ * 5. Aborts dependents if parent proof fails
+ *
+ * @example
+ * ```typescript
+ * const executor = new SpeculativeExecutor({
+ *   operations,
+ *   handler: async (ctx) => ({ proofHash: new Uint8Array(32).fill(1) }),
+ *   agentId: myAgentId,
+ *   agentPda: myAgentPda,
+ *   enableSpeculation: true,
+ *   maxSpeculativeTasksPerParent: 3,
+ * });
+ *
+ * executor.on({
+ *   onSpeculativeExecutionStarted: (taskPda, parentPda) => {
+ *     console.log(`Speculating ${taskPda} based on ${parentPda}`);
+ *   },
+ * });
+ *
+ * // Execute a task and its dependents speculatively
+ * await executor.executeWithSpeculation(taskPda, parentResult);
+ * ```
+ */
+export class SpeculativeExecutor {
+  private readonly operations: TaskOperations;
+  private readonly handler: TaskHandler;
+  private readonly agentId: Uint8Array;
+  private readonly agentPda: PublicKey;
+  private readonly logger: Logger;
+  private readonly metricsProvider?: MetricsProvider;
+  private readonly tracingProvider?: TracingProvider;
+
+  // Speculation configuration
+  private readonly speculationEnabled: boolean;
+  private readonly maxSpeculativeTasksPerParent: number;
+  private readonly speculatableDependencyTypes: Set<DependencyType>;
+  private readonly abortOnParentFailure: boolean;
+
+  // Core components
+  private readonly dependencyGraph: DependencyGraph;
+  private readonly proofPipeline: ProofPipeline;
+
+  // Runtime state
+  private readonly speculativeTasks: Map<string, SpeculativeTask> = new Map();
+  private readonly parentToSpeculativeTasks: Map<string, Set<string>> = new Map();
+  private events: SpeculativeExecutorEvents = {};
+
+  // Metrics
+  private metrics: SpeculativeMetrics = {
+    speculativeExecutionsStarted: 0,
+    speculativeExecutionsConfirmed: 0,
+    speculativeExecutionsAborted: 0,
+    estimatedTimeSavedMs: 0,
+  };
+
+  constructor(config: SpeculativeExecutorConfig) {
+    this.operations = config.operations;
+    this.handler = config.handler;
+    this.agentId = new Uint8Array(config.agentId);
+    this.agentPda = config.agentPda;
+    this.logger = config.logger ?? silentLogger;
+    this.metricsProvider = config.metrics;
+    this.tracingProvider = config.tracing;
+
+    // Speculation config with defaults
+    this.speculationEnabled = config.enableSpeculation ?? DEFAULT_SPECULATIVE_CONFIG.enableSpeculation;
+    this.maxSpeculativeTasksPerParent = config.maxSpeculativeTasksPerParent ?? DEFAULT_SPECULATIVE_CONFIG.maxSpeculativeTasksPerParent;
+    this.speculatableDependencyTypes = new Set(
+      config.speculatableDependencyTypes ?? DEFAULT_SPECULATIVE_CONFIG.speculatableDependencyTypes
+    );
+    this.abortOnParentFailure = config.abortOnParentFailure ?? DEFAULT_SPECULATIVE_CONFIG.abortOnParentFailure;
+
+    // Initialize dependency graph
+    this.dependencyGraph = new DependencyGraph();
+
+    // Initialize proof pipeline with event handlers
+    const pipelineEvents: ProofPipelineEvents = {
+      onProofQueued: (job) => this.handleProofQueued(job),
+      onProofGenerated: (job) => this.handleProofGenerated(job),
+      onProofConfirmed: (job) => this.handleProofConfirmed(job),
+      onProofFailed: (job, error) => this.handleProofFailed(job, error),
+    };
+
+    this.proofPipeline = new ProofPipeline(
+      config.proofPipelineConfig ?? {},
+      pipelineEvents,
+      this.operations,
+    );
+  }
+
+  // ==========================================================================
+  // Public API
+  // ==========================================================================
+
+  /**
+   * Register event callbacks for speculative execution lifecycle.
+   */
+  on(events: SpeculativeExecutorEvents): void {
+    this.events = { ...this.events, ...events };
+  }
+
+  /**
+   * Get the dependency graph for external inspection or manipulation.
+   */
+  getDependencyGraph(): DependencyGraph {
+    return this.dependencyGraph;
+  }
+
+  /**
+   * Get the proof pipeline for external inspection.
+   */
+  getProofPipeline(): ProofPipeline {
+    return this.proofPipeline;
+  }
+
+  /**
+   * Get current speculative executor status.
+   */
+  getStatus(): SpeculativeExecutorStatus {
+    let tasksAwaitingParent = 0;
+    for (const task of this.speculativeTasks.values()) {
+      if (task.status === 'proof_queued') {
+        tasksAwaitingParent++;
+      }
+    }
+
+    return {
+      speculationEnabled: this.speculationEnabled,
+      activeSpeculativeTasks: this.speculativeTasks.size,
+      tasksAwaitingParent,
+      proofPipelineStats: this.proofPipeline.getStats(),
+      metrics: { ...this.metrics },
+    };
+  }
+
+  /**
+   * Get speculative metrics snapshot.
+   */
+  getMetrics(): SpeculativeMetrics {
+    return { ...this.metrics };
+  }
+
+  /**
+   * Add a task to the dependency graph.
+   * Must be called before executing tasks that have dependencies.
+   *
+   * @param task - The on-chain task data
+   * @param taskPda - Task account PDA
+   * @param parentPda - Parent task PDA (null for root tasks)
+   * @param dependencyType - Type of dependency
+   */
+  addTaskToGraph(
+    task: OnChainTask,
+    taskPda: PublicKey,
+    parentPda: PublicKey | null = null,
+    dependencyType: DependencyType = DependencyType.Data,
+  ): void {
+    if (parentPda) {
+      this.dependencyGraph.addTaskWithParent(task, taskPda, parentPda, dependencyType);
+    } else {
+      this.dependencyGraph.addTask(task, taskPda);
+    }
+  }
+
+  /**
+   * Execute a task with speculative execution of dependents.
+   *
+   * When the task completes execution:
+   * 1. Queues proof generation (async)
+   * 2. Finds eligible dependent tasks
+   * 3. Starts speculative execution of dependents
+   *
+   * @param taskPda - Task account PDA
+   * @param parentResult - Optional parent execution result for data dependencies
+   * @returns Execution result
+   */
+  async executeWithSpeculation(
+    taskPda: PublicKey,
+    parentResult?: TaskExecutionResult | PrivateTaskExecutionResult,
+  ): Promise<TaskExecutionResult | PrivateTaskExecutionResult> {
+    const pdaKey = taskPda.toBase58();
+    this.logger.info(`Starting execution with speculation: ${pdaKey}`);
+
+    // Mark task as executing in the graph
+    this.dependencyGraph.updateStatus(taskPda, 'executing');
+
+    // Execute the task
+    const result = await this.executeTask(taskPda, parentResult);
+
+    // Mark as completed in graph
+    this.dependencyGraph.updateStatus(taskPda, 'completed');
+
+    // Queue proof generation
+    const task = await this.operations.fetchTask(taskPda);
+    if (!task) {
+      throw new Error(`Task not found: ${pdaKey}`);
+    }
+
+    this.proofPipeline.enqueue(taskPda, task.taskId, result);
+
+    // Start speculative execution of dependents if enabled
+    if (this.speculationEnabled) {
+      await this.startSpeculativeExecutions(taskPda, result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Execute a task without speculation.
+   * Used for root tasks or when speculation is disabled.
+   *
+   * @param taskPda - Task account PDA
+   * @param parentResult - Optional parent execution result
+   * @returns Execution result
+   */
+  async executeTask(
+    taskPda: PublicKey,
+    parentResult?: TaskExecutionResult | PrivateTaskExecutionResult,
+  ): Promise<TaskExecutionResult | PrivateTaskExecutionResult> {
+    const pdaKey = taskPda.toBase58();
+    this.logger.debug(`Executing task: ${pdaKey}`);
+
+    // Fetch task data
+    const task = await this.operations.fetchTask(taskPda);
+    if (!task) {
+      throw new Error(`Task not found: ${pdaKey}`);
+    }
+
+    // Fetch claim data
+    const claim = await this.operations.fetchClaim(taskPda);
+    if (!claim) {
+      throw new Error(`Claim not found for task: ${pdaKey}`);
+    }
+
+    // Create execution context
+    const controller = new AbortController();
+    const context: TaskExecutionContext = {
+      task,
+      taskPda,
+      claimPda: taskPda, // Claim PDA is derived from task PDA
+      agentId: this.agentId,
+      agentPda: this.agentPda,
+      logger: this.logger,
+      signal: controller.signal,
+    };
+
+    // Add parent result to context if available (as custom property)
+    if (parentResult) {
+      (context as TaskExecutionContext & { parentResult?: typeof parentResult }).parentResult = parentResult;
+    }
+
+    // Start tracing span
+    const span = this.tracingProvider?.startSpan('task.execute', {
+      taskPda: pdaKey,
+    });
+
+    try {
+      this.events.onTaskExecutionStarted?.(context);
+
+      // Execute the handler
+      const result = await this.handler(context);
+
+      span?.setStatus('ok');
+      this.logger.debug(`Task execution completed: ${pdaKey}`);
+
+      return result;
+    } catch (error) {
+      span?.setStatus('error', error instanceof Error ? error.message : String(error));
+      throw error;
+    } finally {
+      span?.end();
+    }
+  }
+
+  /**
+   * Wait for a task's proof to be confirmed.
+   *
+   * @param taskPda - Task account PDA
+   * @param timeoutMs - Timeout in milliseconds
+   */
+  async waitForProofConfirmation(taskPda: PublicKey, timeoutMs?: number): Promise<ProofGenerationJob> {
+    return this.proofPipeline.waitForConfirmation(taskPda, timeoutMs);
+  }
+
+  /**
+   * Cancel a speculative task.
+   *
+   * @param taskPda - Task account PDA
+   * @param reason - Cancellation reason
+   */
+  cancelSpeculativeTask(taskPda: PublicKey, reason: string): boolean {
+    const pdaKey = taskPda.toBase58();
+    const specTask = this.speculativeTasks.get(pdaKey);
+
+    if (!specTask) {
+      return false;
+    }
+
+    this.abortSpeculativeTask(specTask, reason);
+    return true;
+  }
+
+  /**
+   * Graceful shutdown - wait for in-flight proofs.
+   */
+  async shutdown(): Promise<void> {
+    this.logger.info('SpeculativeExecutor shutting down...');
+
+    // Abort all speculative tasks
+    for (const specTask of this.speculativeTasks.values()) {
+      if (specTask.status === 'executing' || specTask.status === 'pending') {
+        this.abortSpeculativeTask(specTask, 'shutdown');
+      }
+    }
+
+    // Shutdown proof pipeline
+    await this.proofPipeline.shutdown();
+
+    this.logger.info('SpeculativeExecutor shutdown complete');
+  }
+
+  // ==========================================================================
+  // Speculative Execution
+  // ==========================================================================
+
+  /**
+   * Start speculative execution of dependent tasks.
+   * Only speculates ONE level deep (direct dependents only).
+   */
+  private async startSpeculativeExecutions(
+    parentPda: PublicKey,
+    parentResult: TaskExecutionResult | PrivateTaskExecutionResult,
+  ): Promise<void> {
+    const parentKey = parentPda.toBase58();
+
+    // Get direct dependents from the graph
+    const dependents = this.dependencyGraph.getDependents(parentPda);
+
+    if (dependents.length === 0) {
+      this.logger.debug(`No dependents found for ${parentKey}`);
+      return;
+    }
+
+    // Filter to speculatable dependency types
+    const speculatable = dependents.filter((dep) =>
+      this.speculatableDependencyTypes.has(dep.dependencyType)
+    );
+
+    if (speculatable.length === 0) {
+      this.logger.debug(`No speculatable dependents for ${parentKey}`);
+      return;
+    }
+
+    // Get existing speculative tasks for this parent
+    const existingCount = this.parentToSpeculativeTasks.get(parentKey)?.size ?? 0;
+    const remainingSlots = this.maxSpeculativeTasksPerParent - existingCount;
+
+    if (remainingSlots <= 0) {
+      this.logger.debug(`Max speculative tasks reached for parent ${parentKey}`);
+      return;
+    }
+
+    // Take only up to remaining slots
+    const toSpeculate = speculatable.slice(0, remainingSlots);
+
+    this.logger.info(
+      `Starting ${toSpeculate.length} speculative execution(s) for parent ${parentKey}`
+    );
+
+    // Start speculative execution for each eligible dependent
+    for (const dependent of toSpeculate) {
+      await this.startSpeculativeTask(dependent, parentPda, parentResult);
+    }
+  }
+
+  /**
+   * Start speculative execution of a single dependent task.
+   */
+  private async startSpeculativeTask(
+    taskNode: TaskNode,
+    parentPda: PublicKey,
+    parentResult: TaskExecutionResult | PrivateTaskExecutionResult,
+  ): Promise<void> {
+    const pdaKey = taskNode.taskPda.toBase58();
+    const parentKey = parentPda.toBase58();
+
+    // Check if already speculating
+    if (this.speculativeTasks.has(pdaKey)) {
+      this.logger.debug(`Task ${pdaKey} already speculating`);
+      return;
+    }
+
+    // Create speculative task tracker
+    const controller = new AbortController();
+    const specTask: SpeculativeTask = {
+      taskPda: taskNode.taskPda,
+      taskId: taskNode.taskId,
+      parentPda,
+      status: 'pending',
+      startedAt: Date.now(),
+      controller,
+    };
+
+    // Register in tracking maps
+    this.speculativeTasks.set(pdaKey, specTask);
+    if (!this.parentToSpeculativeTasks.has(parentKey)) {
+      this.parentToSpeculativeTasks.set(parentKey, new Set());
+    }
+    this.parentToSpeculativeTasks.get(parentKey)!.add(pdaKey);
+
+    // Update metrics
+    this.metrics.speculativeExecutionsStarted++;
+    this.metricsProvider?.counter('speculative_executions_started', 1);
+
+    // Emit event
+    this.events.onSpeculativeExecutionStarted?.(taskNode.taskPda, parentPda);
+
+    // Execute speculatively (don't await - fire and forget)
+    this.executeSpeculativeTask(specTask, parentResult).catch((error) => {
+      this.logger.error(`Speculative execution failed for ${pdaKey}: ${error}`);
+      specTask.status = 'failed';
+      specTask.completedAt = Date.now();
+      specTask.abortReason = error instanceof Error ? error.message : String(error);
+    });
+  }
+
+  /**
+   * Execute a speculative task and queue its proof.
+   */
+  private async executeSpeculativeTask(
+    specTask: SpeculativeTask,
+    parentResult: TaskExecutionResult | PrivateTaskExecutionResult,
+  ): Promise<void> {
+    const pdaKey = specTask.taskPda.toBase58();
+
+    try {
+      specTask.status = 'executing';
+
+      // Check if aborted before starting
+      if (specTask.controller.signal.aborted) {
+        throw new Error('Aborted before execution');
+      }
+
+      // Update graph status
+      this.dependencyGraph.updateStatus(specTask.taskPda, 'executing');
+
+      // Execute the task with parent result context
+      const result = await this.executeTask(specTask.taskPda, parentResult);
+
+      // Check if aborted during execution
+      if (specTask.controller.signal.aborted) {
+        throw new Error('Aborted during execution');
+      }
+
+      // Store result
+      specTask.executionResult = result;
+      specTask.status = 'executed';
+
+      // Update graph status
+      this.dependencyGraph.updateStatus(specTask.taskPda, 'completed');
+
+      // Fetch task data for proof pipeline
+      const task = await this.operations.fetchTask(specTask.taskPda);
+      if (!task) {
+        throw new Error(`Task not found: ${pdaKey}`);
+      }
+
+      // Queue proof generation
+      // The proof will NOT be submitted until parent is confirmed
+      this.proofPipeline.enqueue(specTask.taskPda, task.taskId, result);
+      specTask.status = 'proof_queued';
+
+      this.logger.debug(`Speculative task ${pdaKey} executed, proof queued`);
+    } catch (error) {
+      if (specTask.controller.signal.aborted) {
+        this.logger.debug(`Speculative task ${pdaKey} was aborted`);
+        // Status already set by abortSpeculativeTask
+      } else {
+        specTask.status = 'failed';
+        specTask.completedAt = Date.now();
+        specTask.abortReason = error instanceof Error ? error.message : String(error);
+        this.dependencyGraph.updateStatus(specTask.taskPda, 'failed');
+        this.logger.error(`Speculative execution failed: ${pdaKey} - ${specTask.abortReason}`);
+      }
+    }
+  }
+
+  /**
+   * Abort a speculative task.
+   */
+  private abortSpeculativeTask(specTask: SpeculativeTask, reason: string): void {
+    const pdaKey = specTask.taskPda.toBase58();
+
+    if (specTask.status === 'confirmed' || specTask.status === 'aborted') {
+      return; // Already finalized
+    }
+
+    // Signal abort
+    specTask.controller.abort();
+
+    // Update state
+    specTask.status = 'aborted';
+    specTask.completedAt = Date.now();
+    specTask.abortReason = reason;
+
+    // Update graph
+    this.dependencyGraph.updateStatus(specTask.taskPda, 'failed');
+
+    // Cancel proof job if queued
+    this.proofPipeline.cancel(specTask.taskPda);
+
+    // Update metrics
+    this.metrics.speculativeExecutionsAborted++;
+    this.metricsProvider?.counter('speculative_executions_aborted', 1);
+
+    // Emit event
+    this.events.onSpeculativeExecutionAborted?.(specTask.taskPda, reason);
+
+    this.logger.info(`Speculative task aborted: ${pdaKey} - ${reason}`);
+  }
+
+  // ==========================================================================
+  // Proof Pipeline Event Handlers
+  // ==========================================================================
+
+  /**
+   * Handle proof job queued event.
+   */
+  private handleProofQueued(job: ProofGenerationJob): void {
+    this.logger.debug(`Proof queued: ${job.taskPda.toBase58()}`);
+  }
+
+  /**
+   * Handle proof generated event.
+   */
+  private handleProofGenerated(job: ProofGenerationJob): void {
+    this.logger.debug(`Proof generated: ${job.taskPda.toBase58()}`);
+  }
+
+  /**
+   * Handle proof confirmed event.
+   * When a parent proof is confirmed, check for speculative dependents
+   * that can now have their proofs submitted.
+   */
+  private handleProofConfirmed(job: ProofGenerationJob): void {
+    const pdaKey = job.taskPda.toBase58();
+    this.logger.info(`Proof confirmed: ${pdaKey}`);
+
+    // Check if this is a speculative task
+    const specTask = this.speculativeTasks.get(pdaKey);
+    if (specTask) {
+      specTask.status = 'confirmed';
+      specTask.completedAt = Date.now();
+
+      // Calculate estimated time saved
+      const timeSaved = specTask.startedAt ? Date.now() - specTask.startedAt : 0;
+      this.metrics.estimatedTimeSavedMs += timeSaved;
+
+      this.metrics.speculativeExecutionsConfirmed++;
+      this.metricsProvider?.counter('speculative_executions_confirmed', 1);
+
+      this.events.onSpeculativeExecutionConfirmed?.(job.taskPda);
+    }
+
+    // Emit parent confirmation event
+    this.events.onParentProofConfirmed?.(job.taskPda);
+
+    // Check if there are speculative dependents waiting for this parent
+    const dependentKeys = this.parentToSpeculativeTasks.get(pdaKey);
+    if (dependentKeys && dependentKeys.size > 0) {
+      this.logger.debug(
+        `Parent ${pdaKey} confirmed, ${dependentKeys.size} dependent(s) can now submit proofs`
+      );
+
+      // The proof pipeline will automatically submit queued proofs
+      // when ancestors are confirmed (handled by ProofPipeline internals)
+    }
+  }
+
+  /**
+   * Handle proof failed event.
+   * When a parent proof fails, abort all speculative dependents.
+   */
+  private handleProofFailed(job: ProofGenerationJob, error: Error): void {
+    const pdaKey = job.taskPda.toBase58();
+    this.logger.error(`Proof failed: ${pdaKey} - ${error.message}`);
+
+    // Emit parent failure event
+    this.events.onParentProofFailed?.(job.taskPda, error);
+
+    // Check if this is a speculative task that failed
+    const specTask = this.speculativeTasks.get(pdaKey);
+    if (specTask && specTask.status !== 'confirmed' && specTask.status !== 'aborted') {
+      specTask.status = 'failed';
+      specTask.completedAt = Date.now();
+      specTask.abortReason = `proof failed: ${error.message}`;
+    }
+
+    // If abort on parent failure is enabled, abort all speculative dependents
+    if (this.abortOnParentFailure) {
+      const dependentKeys = this.parentToSpeculativeTasks.get(pdaKey);
+      if (dependentKeys && dependentKeys.size > 0) {
+        this.logger.info(
+          `Parent ${pdaKey} proof failed, aborting ${dependentKeys.size} speculative dependent(s)`
+        );
+
+        for (const depKey of dependentKeys) {
+          const depTask = this.speculativeTasks.get(depKey);
+          if (depTask) {
+            this.abortSpeculativeTask(depTask, `parent proof failed: ${error.message}`);
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements single-level speculative execution for the AgenC runtime. When a task completes execution, dependent tasks can begin executing speculatively while the parent's proof generates in the background.

## Changes

- **SpeculativeExecutor class** - Extends task execution with speculation support
  - Single-level speculation (one level deep, no chaining)
  - Proof submission gated on parent confirmation
  - Automatic abort of speculative tasks when parent proof fails
  - Configurable dependency type filtering
  - Comprehensive event callbacks for monitoring

- **Configuration options**:
  - `enableSpeculation` - Toggle speculation on/off
  - `maxSpeculativeTasksPerParent` - Limit concurrent speculative tasks (default: 5)
  - `speculatableDependencyTypes` - Filter which dependency types can be speculated
  - `abortOnParentFailure` - Auto-abort dependents on parent failure

- **24 unit tests** covering:
  - Basic execution flow
  - Speculative execution triggering
  - Dependency type filtering
  - Cancel/abort functionality
  - Shutdown behavior
  - Parent failure cascading
  - Metrics tracking

## Expected Latency Improvement

Current pipeline (sequential):
```
Task A: execute(10s) -> proof(20s) -> submit(2s) = 32s
Task B: [wait for A]  -> execute(10s) -> proof(20s) -> submit(2s) = 32s
Total: 64s
```

With single-level speculation:
```
Task A: execute(10s) -> [proof(20s) + submit(2s)]
Task B:              execute(10s) -> proof(20s) -> [wait for A] -> submit(2s)
Total: ~42s (34% faster)
```

## Dependencies

- Requires #265 (DependencyGraph) - merged
- Requires #267 (ProofPipeline) - merged

Closes #268.
Part of epic #291.