### PR TITLE
feat(runtime): add RollbackController for cascade rollbacks

### DIFF
--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -17,3 +17,4 @@ export * from './dependency-graph.js';
 export * from './proof-pipeline.js';
 export * from './speculative-executor.js';
 export * from './commitment-ledger.js';
+export * from './rollback-controller.js';

--- a/runtime/src/task/rollback-controller.test.ts
+++ b/runtime/src/task/rollback-controller.test.ts
@@ -1,0 +1,644 @@
+/**
+ * RollbackController tests
+ * @module
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { randomBytes } from 'crypto';
+import { RollbackController, type RollbackEvents, type RollbackReason } from './rollback-controller.js';
+import { DependencyGraph } from './dependency-graph.js';
+import { CommitmentLedger } from './commitment-ledger.js';
+import type { OnChainTask } from './types.js';
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+/**
+ * Creates a mock OnChainTask with the given task ID.
+ */
+function createMockTask(taskIdBytes?: Uint8Array): OnChainTask {
+  const taskId = taskIdBytes ?? randomBytes(32);
+  return {
+    taskId,
+    status: 0,
+    constraintHash: randomBytes(32),
+    reward: 100_000_000n,
+    deadline: BigInt(Date.now() + 3600000),
+    claimDeadline: 0n,
+    requiredCapabilities: 0n,
+    outputHash: null,
+    claimedBy: null,
+    completedBy: null,
+    proofUri: null,
+  } as unknown as OnChainTask;
+}
+
+/**
+ * Creates a Keypair and returns its public key.
+ */
+function createTaskPda(): PublicKey {
+  return Keypair.generate().publicKey;
+}
+
+// ============================================================================
+// Test Suite
+// ============================================================================
+
+describe('RollbackController', () => {
+  let dependencyGraph: DependencyGraph;
+  let commitmentLedger: CommitmentLedger;
+  let controller: RollbackController;
+  let events: RollbackEvents;
+
+  beforeEach(() => {
+    dependencyGraph = new DependencyGraph();
+    commitmentLedger = new CommitmentLedger({ maxCommitments: 1000 });
+    events = {
+      onRollbackStarted: vi.fn(),
+      onTaskRolledBack: vi.fn(),
+      onRollbackCompleted: vi.fn(),
+      onRetryScheduled: vi.fn(),
+    };
+    controller = new RollbackController(
+      { enableEvents: true },
+      dependencyGraph,
+      commitmentLedger,
+      events
+    );
+  });
+
+  describe('constructor', () => {
+    it('should create with default config', () => {
+      const ctrl = new RollbackController({}, dependencyGraph, commitmentLedger);
+      expect(ctrl).toBeDefined();
+    });
+
+    it('should accept partial config', () => {
+      const ctrl = new RollbackController(
+        { allowRetry: true, maxRetries: 3 },
+        dependencyGraph,
+        commitmentLedger
+      );
+      expect(ctrl).toBeDefined();
+    });
+  });
+
+  describe('registerActiveTask / unregisterActiveTask', () => {
+    it('should register and unregister active tasks', () => {
+      const taskPda = createTaskPda();
+      const abortController = new AbortController();
+
+      controller.registerActiveTask(taskPda, abortController);
+      expect(controller.isRolledBack(taskPda)).toBe(false);
+
+      controller.unregisterActiveTask(taskPda);
+    });
+
+    it('should track commitment ID when provided', () => {
+      const taskPda = createTaskPda();
+      const abortController = new AbortController();
+      const commitmentId = 'test-commitment-id';
+
+      controller.registerActiveTask(taskPda, abortController, commitmentId);
+      controller.unregisterActiveTask(taskPda);
+    });
+  });
+
+  describe('isRolledBack', () => {
+    it('should return false for tasks not rolled back', () => {
+      const taskPda = createTaskPda();
+      expect(controller.isRolledBack(taskPda)).toBe(false);
+    });
+
+    it('should return true after rollback', async () => {
+      const rootPda = createTaskPda();
+      const rootTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+
+      await controller.rollback(rootPda, 'proof_failed');
+
+      expect(controller.isRolledBack(rootPda)).toBe(true);
+    });
+  });
+
+  describe('rollback - single task', () => {
+    it('should rollback a single root task with no descendants', async () => {
+      const rootPda = createTaskPda();
+      const rootTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      expect(result.rootTaskPda.equals(rootPda)).toBe(true);
+      expect(result.reason).toBe('proof_failed');
+      expect(result.rolledBackTasks).toHaveLength(0); // No descendants
+      expect(result.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('should update dependency graph status on rollback', async () => {
+      const rootPda = createTaskPda();
+      const rootTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+
+      await controller.rollback(rootPda, 'proof_failed');
+
+      const node = dependencyGraph.getNode(rootPda);
+      expect(node?.status).toBe('failed');
+    });
+
+    it('should emit events during rollback', async () => {
+      const rootPda = createTaskPda();
+      const rootTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+
+      await controller.rollback(rootPda, 'manual');
+
+      expect(events.onRollbackStarted).toHaveBeenCalledWith(rootPda, 0);
+      expect(events.onRollbackCompleted).toHaveBeenCalled();
+    });
+  });
+
+  describe('rollback - cascade (chain)', () => {
+    it('should rollback all tasks in a linear chain', async () => {
+      // Create chain: A -> B -> C
+      const pdaA = createTaskPda();
+      const pdaB = createTaskPda();
+      const pdaC = createTaskPda();
+
+      const taskA = createMockTask();
+      const taskB = createMockTask();
+      const taskC = createMockTask();
+
+      dependencyGraph.addTask(taskA, pdaA);
+      dependencyGraph.addTaskWithParent(taskB, pdaB, pdaA);
+      dependencyGraph.addTaskWithParent(taskC, pdaC, pdaB);
+
+      // Create commitments
+      const producerAgent = createTaskPda();
+      commitmentLedger.createCommitment(pdaB, taskB.taskId, randomBytes(32), producerAgent, 1000n);
+      commitmentLedger.createCommitment(pdaC, taskC.taskId, randomBytes(32), producerAgent, 2000n);
+
+      // Rollback from A (root failure)
+      const result = await controller.rollback(pdaA, 'proof_failed');
+
+      expect(result.rolledBackTasks).toHaveLength(2);
+      expect(controller.isRolledBack(pdaA)).toBe(true);
+      expect(controller.isRolledBack(pdaB)).toBe(true);
+      expect(controller.isRolledBack(pdaC)).toBe(true);
+
+      // Verify stake calculation
+      expect(result.stakeAtRisk).toBe(3000n);
+    });
+
+    it('should abort executing tasks in chain', async () => {
+      // Create chain: A -> B
+      const pdaA = createTaskPda();
+      const pdaB = createTaskPda();
+
+      const taskA = createMockTask();
+      const taskB = createMockTask();
+
+      dependencyGraph.addTask(taskA, pdaA);
+      dependencyGraph.addTaskWithParent(taskB, pdaB, pdaA);
+
+      // Register B as actively executing
+      const abortController = new AbortController();
+      controller.registerActiveTask(pdaB, abortController);
+
+      // Rollback from A
+      await controller.rollback(pdaA, 'proof_failed');
+
+      // Verify abort was called
+      expect(abortController.signal.aborted).toBe(true);
+
+      // Verify B was recorded as aborted
+      const result = controller.getRollbackHistory()[0];
+      const rolledBackB = result.rolledBackTasks.find(t => t.taskPda.equals(pdaB));
+      expect(rolledBackB?.action).toBe('aborted');
+      expect(rolledBackB?.state).toBe('executing');
+    });
+  });
+
+  describe('rollback - cascade (DAG)', () => {
+    it('should rollback all branches in a DAG', async () => {
+      // Create DAG:
+      //     A
+      //    / \
+      //   B   C
+      //    \ /
+      //     D
+      const pdaA = createTaskPda();
+      const pdaB = createTaskPda();
+      const pdaC = createTaskPda();
+      const pdaD = createTaskPda();
+
+      const taskA = createMockTask();
+      const taskB = createMockTask();
+      const taskC = createMockTask();
+      const taskD = createMockTask();
+
+      dependencyGraph.addTask(taskA, pdaA);
+      dependencyGraph.addTaskWithParent(taskB, pdaB, pdaA);
+      dependencyGraph.addTaskWithParent(taskC, pdaC, pdaA);
+      // Note: DependencyGraph only supports single parent, so D depends on B only
+      dependencyGraph.addTaskWithParent(taskD, pdaD, pdaB);
+
+      // Rollback from A
+      const result = await controller.rollback(pdaA, 'proof_failed');
+
+      // Should rollback B, C, D (3 descendants)
+      expect(result.rolledBackTasks).toHaveLength(3);
+      expect(controller.isRolledBack(pdaA)).toBe(true);
+      expect(controller.isRolledBack(pdaB)).toBe(true);
+      expect(controller.isRolledBack(pdaC)).toBe(true);
+      expect(controller.isRolledBack(pdaD)).toBe(true);
+    });
+
+    it('should rollback partial DAG from middle node', async () => {
+      // Create chain: A -> B -> C
+      const pdaA = createTaskPda();
+      const pdaB = createTaskPda();
+      const pdaC = createTaskPda();
+
+      const taskA = createMockTask();
+      const taskB = createMockTask();
+      const taskC = createMockTask();
+
+      dependencyGraph.addTask(taskA, pdaA);
+      dependencyGraph.addTaskWithParent(taskB, pdaB, pdaA);
+      dependencyGraph.addTaskWithParent(taskC, pdaC, pdaB);
+
+      // Rollback from B (middle)
+      const result = await controller.rollback(pdaB, 'proof_timeout');
+
+      // Should only rollback C (B's descendant)
+      expect(result.rolledBackTasks).toHaveLength(1);
+      expect(controller.isRolledBack(pdaA)).toBe(false); // A is ancestor, not affected
+      expect(controller.isRolledBack(pdaB)).toBe(true);
+      expect(controller.isRolledBack(pdaC)).toBe(true);
+    });
+  });
+
+  describe('rollback - idempotency', () => {
+    it('should return cached result on repeated rollback', async () => {
+      const rootPda = createTaskPda();
+      const rootTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+
+      const result1 = await controller.rollback(rootPda, 'proof_failed');
+      const result2 = await controller.rollback(rootPda, 'proof_failed');
+
+      // Same object should be returned
+      expect(result1).toBe(result2);
+
+      // Events should only fire once
+      expect(events.onRollbackCompleted).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle idempotent rollback with different reasons', async () => {
+      const rootPda = createTaskPda();
+      const rootTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+
+      const result1 = await controller.rollback(rootPda, 'proof_failed');
+      const result2 = await controller.rollback(rootPda, 'manual');
+
+      // First result should be cached regardless of different reason
+      expect(result1).toBe(result2);
+      expect(result2.reason).toBe('proof_failed'); // Original reason preserved
+    });
+  });
+
+  describe('rollback - commitment status updates', () => {
+    it('should update commitment status to rolled_back', async () => {
+      const pdaA = createTaskPda();
+      const pdaB = createTaskPda();
+
+      const taskA = createMockTask();
+      const taskB = createMockTask();
+
+      dependencyGraph.addTask(taskA, pdaA);
+      dependencyGraph.addTaskWithParent(taskB, pdaB, pdaA);
+
+      // Create commitment for B
+      const producerAgent = createTaskPda();
+      commitmentLedger.createCommitment(pdaB, taskB.taskId, randomBytes(32), producerAgent, 1000n);
+
+      // Rollback from A
+      await controller.rollback(pdaA, 'proof_failed');
+
+      // Verify commitment status
+      const commitment = commitmentLedger.getByTask(pdaB);
+      expect(commitment?.status).toBe('rolled_back');
+    });
+
+    it('should handle tasks without commitments gracefully', async () => {
+      const rootPda = createTaskPda();
+      const childPda = createTaskPda();
+
+      const rootTask = createMockTask();
+      const childTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+      dependencyGraph.addTaskWithParent(childTask, childPda, rootPda);
+
+      // No commitments created - should not throw
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      expect(result.rolledBackTasks).toHaveLength(1);
+    });
+  });
+
+  describe('rollback - different states', () => {
+    it('should handle task in pending state', async () => {
+      const rootPda = createTaskPda();
+      const childPda = createTaskPda();
+
+      const rootTask = createMockTask();
+      const childTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+      dependencyGraph.addTaskWithParent(childTask, childPda, rootPda);
+
+      const producerAgent = createTaskPda();
+      const commitment = commitmentLedger.createCommitment(
+        childPda, childTask.taskId, randomBytes(32), producerAgent, 1000n
+      );
+      expect(commitment.status).toBe('pending');
+
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      const rolledBack = result.rolledBackTasks.find(t => t.taskPda.equals(childPda));
+      expect(rolledBack?.state).toBe('executing');
+    });
+
+    it('should handle task in proof_generating state', async () => {
+      const rootPda = createTaskPda();
+      const childPda = createTaskPda();
+
+      const rootTask = createMockTask();
+      const childTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+      dependencyGraph.addTaskWithParent(childTask, childPda, rootPda);
+
+      const producerAgent = createTaskPda();
+      commitmentLedger.createCommitment(childPda, childTask.taskId, randomBytes(32), producerAgent, 1000n);
+      commitmentLedger.updateStatus(childPda, 'proof_generating');
+
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      const rolledBack = result.rolledBackTasks.find(t => t.taskPda.equals(childPda));
+      expect(rolledBack?.state).toBe('proof_generating');
+      expect(rolledBack?.action).toBe('cancelled');
+    });
+
+    it('should handle task in proof_generated state', async () => {
+      const rootPda = createTaskPda();
+      const childPda = createTaskPda();
+
+      const rootTask = createMockTask();
+      const childTask = createMockTask();
+
+      dependencyGraph.addTask(rootTask, rootPda);
+      dependencyGraph.addTaskWithParent(childTask, childPda, rootPda);
+
+      const producerAgent = createTaskPda();
+      commitmentLedger.createCommitment(childPda, childTask.taskId, randomBytes(32), producerAgent, 1000n);
+      commitmentLedger.updateStatus(childPda, 'proof_generated');
+
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      const rolledBack = result.rolledBackTasks.find(t => t.taskPda.equals(childPda));
+      expect(rolledBack?.state).toBe('proof_generated');
+      expect(rolledBack?.action).toBe('cancelled');
+    });
+  });
+
+  describe('getRollbackHistory', () => {
+    it('should return empty array initially', () => {
+      const history = controller.getRollbackHistory();
+      expect(history).toHaveLength(0);
+    });
+
+    it('should return history in newest-first order', async () => {
+      const pda1 = createTaskPda();
+      const pda2 = createTaskPda();
+
+      dependencyGraph.addTask(createMockTask(), pda1);
+      dependencyGraph.addTask(createMockTask(), pda2);
+
+      await controller.rollback(pda1, 'proof_failed');
+      await controller.rollback(pda2, 'proof_timeout');
+
+      const history = controller.getRollbackHistory();
+
+      expect(history).toHaveLength(2);
+      expect(history[0].rootTaskPda.equals(pda2)).toBe(true); // Newest first
+      expect(history[1].rootTaskPda.equals(pda1)).toBe(true);
+    });
+
+    it('should respect limit parameter', async () => {
+      const pdas = [createTaskPda(), createTaskPda(), createTaskPda()];
+
+      for (const pda of pdas) {
+        dependencyGraph.addTask(createMockTask(), pda);
+        await controller.rollback(pda, 'proof_failed');
+      }
+
+      const history = controller.getRollbackHistory(2);
+      expect(history).toHaveLength(2);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return zero stats initially', () => {
+      const stats = controller.getStats();
+
+      expect(stats.totalRollbacks).toBe(0);
+      expect(stats.totalTasksRolledBack).toBe(0);
+      expect(stats.totalWastedComputeMs).toBe(0);
+      expect(stats.totalStakeLost).toBe(0n);
+    });
+
+    it('should track cumulative statistics', async () => {
+      // Create two chains
+      const pda1 = createTaskPda();
+      const pda1Child = createTaskPda();
+      const pda2 = createTaskPda();
+
+      dependencyGraph.addTask(createMockTask(), pda1);
+      dependencyGraph.addTaskWithParent(createMockTask(), pda1Child, pda1);
+      dependencyGraph.addTask(createMockTask(), pda2);
+
+      // Create commitments
+      const producer = createTaskPda();
+      const task1Child = createMockTask();
+      commitmentLedger.createCommitment(pda1Child, task1Child.taskId, randomBytes(32), producer, 1000n);
+
+      await controller.rollback(pda1, 'proof_failed');
+      await controller.rollback(pda2, 'proof_timeout');
+
+      const stats = controller.getStats();
+
+      expect(stats.totalRollbacks).toBe(2);
+      expect(stats.totalTasksRolledBack).toBe(1); // Only pda1Child was a descendant
+      expect(stats.totalStakeLost).toBe(1000n);
+      expect(stats.rollbacksByReason.proof_failed).toBe(1);
+      expect(stats.rollbacksByReason.proof_timeout).toBe(1);
+    });
+  });
+
+  describe('clear', () => {
+    it('should reset all state', async () => {
+      const pda = createTaskPda();
+      dependencyGraph.addTask(createMockTask(), pda);
+
+      await controller.rollback(pda, 'proof_failed');
+
+      expect(controller.isRolledBack(pda)).toBe(true);
+      expect(controller.getStats().totalRollbacks).toBe(1);
+
+      controller.clear();
+
+      expect(controller.isRolledBack(pda)).toBe(false);
+      expect(controller.getStats().totalRollbacks).toBe(0);
+      expect(controller.getRollbackHistory()).toHaveLength(0);
+    });
+  });
+
+  describe('rollback - events disabled', () => {
+    it('should not emit events when disabled', async () => {
+      const noEventsController = new RollbackController(
+        { enableEvents: false },
+        dependencyGraph,
+        commitmentLedger,
+        events
+      );
+
+      const pda = createTaskPda();
+      dependencyGraph.addTask(createMockTask(), pda);
+
+      await noEventsController.rollback(pda, 'proof_failed');
+
+      expect(events.onRollbackStarted).not.toHaveBeenCalled();
+      expect(events.onRollbackCompleted).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rollback - all reasons', () => {
+    const reasons: RollbackReason[] = ['proof_failed', 'proof_timeout', 'ancestor_failed', 'manual'];
+
+    for (const reason of reasons) {
+      it(`should handle reason: ${reason}`, async () => {
+        const pda = createTaskPda();
+        dependencyGraph.addTask(createMockTask(), pda);
+
+        const result = await controller.rollback(pda, reason);
+
+        expect(result.reason).toBe(reason);
+      });
+    }
+  });
+
+  describe('rollback - wasted compute calculation', () => {
+    it('should calculate compute time for active tasks', async () => {
+      const rootPda = createTaskPda();
+      const childPda = createTaskPda();
+
+      dependencyGraph.addTask(createMockTask(), rootPda);
+      dependencyGraph.addTaskWithParent(createMockTask(), childPda, rootPda);
+
+      // Register child as actively executing
+      const abortController = new AbortController();
+      controller.registerActiveTask(childPda, abortController);
+
+      // Wait a bit to accumulate compute time
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      // Should have some wasted compute time
+      expect(result.wastedComputeMs).toBeGreaterThan(0);
+    });
+
+    it('should calculate compute time from commitment creation', async () => {
+      const rootPda = createTaskPda();
+      const childPda = createTaskPda();
+
+      const childTask = createMockTask();
+
+      dependencyGraph.addTask(createMockTask(), rootPda);
+      dependencyGraph.addTaskWithParent(childTask, childPda, rootPda);
+
+      // Create commitment
+      const producer = createTaskPda();
+      commitmentLedger.createCommitment(childPda, childTask.taskId, randomBytes(32), producer, 1000n);
+
+      // Wait a bit
+      await new Promise(resolve => setTimeout(resolve, 10));
+
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      // Should have compute time from commitment age
+      const childRolledBack = result.rolledBackTasks.find(t => t.taskPda.equals(childPda));
+      expect(childRolledBack?.computeTimeMs).toBeGreaterThan(0);
+    });
+  });
+
+  describe('integration - large cascade', () => {
+    it('should handle deep dependency chains', async () => {
+      // Create chain of depth 10
+      const pdas: PublicKey[] = [];
+      const tasks: OnChainTask[] = [];
+
+      for (let i = 0; i < 10; i++) {
+        pdas.push(createTaskPda());
+        tasks.push(createMockTask());
+      }
+
+      // Build chain
+      dependencyGraph.addTask(tasks[0], pdas[0]);
+      for (let i = 1; i < 10; i++) {
+        dependencyGraph.addTaskWithParent(tasks[i], pdas[i], pdas[i - 1]);
+      }
+
+      // Rollback from root
+      const result = await controller.rollback(pdas[0], 'proof_failed');
+
+      // Should rollback all 9 descendants
+      expect(result.rolledBackTasks).toHaveLength(9);
+
+      // All should be marked as rolled back
+      for (const pda of pdas) {
+        expect(controller.isRolledBack(pda)).toBe(true);
+      }
+    });
+
+    it('should handle wide branching factor', async () => {
+      // Create root with 20 children
+      const rootPda = createTaskPda();
+      const rootTask = createMockTask();
+      dependencyGraph.addTask(rootTask, rootPda);
+
+      const childPdas: PublicKey[] = [];
+      for (let i = 0; i < 20; i++) {
+        const childPda = createTaskPda();
+        childPdas.push(childPda);
+        dependencyGraph.addTaskWithParent(createMockTask(), childPda, rootPda);
+      }
+
+      const result = await controller.rollback(rootPda, 'proof_failed');
+
+      expect(result.rolledBackTasks).toHaveLength(20);
+    });
+  });
+});

--- a/runtime/src/task/rollback-controller.ts
+++ b/runtime/src/task/rollback-controller.ts
@@ -1,0 +1,561 @@
+/**
+ * RollbackController - Cascade rollback handling for speculative execution
+ *
+ * When an optimistically deferred proof fails, all speculative work built on
+ * that result must be unwound. This controller handles:
+ * - BFS traversal through DependencyGraph to find affected tasks
+ * - Aborting executing tasks via AbortController
+ * - Canceling pending proofs
+ * - Marking commitments as failed
+ * - Tracking rollback metrics (wasted compute, stake lost)
+ *
+ * @module
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import { DependencyGraph, type TaskNode } from './dependency-graph.js';
+import { CommitmentLedger } from './commitment-ledger.js';
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Reason for triggering a rollback.
+ */
+export type RollbackReason =
+  | 'proof_failed' // Proof verification failed on-chain
+  | 'proof_timeout' // Proof generation timed out
+  | 'ancestor_failed' // Ancestor task proof failed (cascade)
+  | 'manual'; // Manual rollback requested
+
+/**
+ * State of a task when it was rolled back.
+ */
+export type RolledBackTaskState =
+  | 'executing' // Task was still executing
+  | 'executed' // Task execution completed, no proof yet
+  | 'proof_generating' // Proof generation was in progress
+  | 'proof_generated'; // Proof was ready but not submitted
+
+/**
+ * Action taken to roll back a task.
+ */
+export type RolledBackTaskAction =
+  | 'aborted' // Execution was aborted via AbortController
+  | 'discarded' // Result was discarded (no abort needed)
+  | 'cancelled'; // Pending proof was cancelled
+
+/**
+ * Configuration for the RollbackController.
+ */
+export interface RollbackConfig {
+  /** Allow retrying the failed task after rollback */
+  allowRetry: boolean;
+
+  /** Maximum retry attempts for failed tasks */
+  maxRetries: number;
+
+  /** Delay before retry (ms) */
+  retryDelayMs: number;
+
+  /** Whether to emit events for observability */
+  enableEvents: boolean;
+}
+
+/**
+ * Information about a task that was rolled back.
+ */
+export interface RolledBackTask {
+  /** Task account PDA */
+  taskPda: PublicKey;
+
+  /** Unique 32-byte task identifier */
+  taskId: Uint8Array;
+
+  /** State the task was in when rolled back */
+  state: RolledBackTaskState;
+
+  /** Action taken to roll back the task */
+  action: RolledBackTaskAction;
+
+  /** Compute time wasted (ms) */
+  computeTimeMs: number;
+
+  /** Stake that was at risk */
+  stakeAtRisk: bigint;
+}
+
+/**
+ * Result of a rollback operation.
+ */
+export interface RollbackResult {
+  /** Task that triggered the rollback */
+  rootTaskPda: PublicKey;
+
+  /** Reason for rollback */
+  reason: RollbackReason;
+
+  /** All tasks that were rolled back (not including root) */
+  rolledBackTasks: RolledBackTask[];
+
+  /** Total compute time wasted (ms) */
+  wastedComputeMs: number;
+
+  /** Total stake that was at risk */
+  stakeAtRisk: bigint;
+
+  /** Timestamp when rollback was executed */
+  timestamp: number;
+}
+
+/**
+ * Event callbacks for rollback operations.
+ */
+export interface RollbackEvents {
+  /** Called when a rollback operation starts */
+  onRollbackStarted?: (rootTaskPda: PublicKey, affectedCount: number) => void;
+
+  /** Called for each task that is rolled back */
+  onTaskRolledBack?: (task: RolledBackTask) => void;
+
+  /** Called when a rollback operation completes */
+  onRollbackCompleted?: (result: RollbackResult) => void;
+
+  /** Called when a retry is scheduled */
+  onRetryScheduled?: (
+    taskPda: PublicKey,
+    retryCount: number,
+    delayMs: number
+  ) => void;
+}
+
+/**
+ * Internal tracking for active task execution.
+ */
+interface ActiveTaskEntry {
+  /** AbortController to abort execution */
+  abortController: AbortController;
+
+  /** Timestamp when execution started */
+  startedAt: number;
+
+  /** Associated commitment ID (if any) */
+  commitmentId?: string;
+}
+
+/**
+ * Statistics about rollback operations.
+ */
+export interface RollbackStats {
+  /** Total number of rollbacks executed */
+  totalRollbacks: number;
+
+  /** Total number of tasks rolled back across all operations */
+  totalTasksRolledBack: number;
+
+  /** Total compute time wasted across all rollbacks (ms) */
+  totalWastedComputeMs: number;
+
+  /** Total stake that was at risk across all rollbacks */
+  totalStakeLost: bigint;
+
+  /** Number of rollbacks by reason */
+  rollbacksByReason: Record<RollbackReason, number>;
+}
+
+// ============================================================================
+// Default Configuration
+// ============================================================================
+
+const DEFAULT_CONFIG: RollbackConfig = {
+  allowRetry: false,
+  maxRetries: 0,
+  retryDelayMs: 1000,
+  enableEvents: true,
+};
+
+// ============================================================================
+// RollbackController Implementation
+// ============================================================================
+
+/**
+ * Handles cascade rollback of speculative execution when proofs fail.
+ *
+ * Uses BFS traversal through the DependencyGraph to find all affected
+ * downstream tasks, then aborts executing tasks, cancels pending proofs,
+ * and marks commitments as failed.
+ *
+ * Rollbacks are idempotent - rolling back an already-rolled-back task
+ * returns the cached result.
+ *
+ * @example
+ * ```typescript
+ * const controller = new RollbackController(
+ *   { allowRetry: true, maxRetries: 3, retryDelayMs: 1000, enableEvents: true },
+ *   dependencyGraph,
+ *   commitmentLedger
+ * );
+ *
+ * // Register active task
+ * const abortController = new AbortController();
+ * controller.registerActiveTask(taskPda, abortController);
+ *
+ * // Later, if proof fails
+ * const result = await controller.rollback(taskPda, 'proof_failed');
+ * console.log(`Rolled back ${result.rolledBackTasks.length} tasks`);
+ * ```
+ */
+export class RollbackController {
+  private readonly config: RollbackConfig;
+  private readonly dependencyGraph: DependencyGraph;
+  private readonly commitmentLedger: CommitmentLedger;
+  private readonly events: RollbackEvents;
+
+  /** Map from task PDA (base58) to active task entry */
+  private activeTasks: Map<string, ActiveTaskEntry> = new Map();
+
+  /** Set of task PDAs (base58) that have been rolled back */
+  private rolledBackTasks: Set<string> = new Set();
+
+  /** Map from root task PDA (base58) to rollback result */
+  private rollbackResults: Map<string, RollbackResult> = new Map();
+
+  /** History of rollback results (newest first) */
+  private rollbackHistory: RollbackResult[] = [];
+
+  /** Maximum history entries to keep */
+  private readonly maxHistorySize: number = 1000;
+
+  /** Cumulative statistics */
+  private stats: RollbackStats = {
+    totalRollbacks: 0,
+    totalTasksRolledBack: 0,
+    totalWastedComputeMs: 0,
+    totalStakeLost: 0n,
+    rollbacksByReason: {
+      proof_failed: 0,
+      proof_timeout: 0,
+      ancestor_failed: 0,
+      manual: 0,
+    },
+  };
+
+  /**
+   * Creates a new RollbackController instance.
+   *
+   * @param config - Configuration options (uses defaults for missing values)
+   * @param dependencyGraph - The dependency graph for task relationships
+   * @param commitmentLedger - The commitment ledger for tracking speculative results
+   * @param events - Optional event callbacks for observability
+   */
+  constructor(
+    config: Partial<RollbackConfig>,
+    dependencyGraph: DependencyGraph,
+    commitmentLedger: CommitmentLedger,
+    events: RollbackEvents = {}
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.dependencyGraph = dependencyGraph;
+    this.commitmentLedger = commitmentLedger;
+    this.events = events;
+  }
+
+  /**
+   * Registers an active task's AbortController for potential cancellation.
+   *
+   * Call this when a task begins executing speculatively so that the
+   * RollbackController can abort it if needed.
+   *
+   * @param taskPda - Task account PDA
+   * @param abortController - AbortController for the task's execution
+   * @param commitmentId - Optional commitment ID associated with this task
+   */
+  registerActiveTask(
+    taskPda: PublicKey,
+    abortController: AbortController,
+    commitmentId?: string
+  ): void {
+    const key = taskPda.toBase58();
+    this.activeTasks.set(key, {
+      abortController,
+      startedAt: Date.now(),
+      commitmentId,
+    });
+  }
+
+  /**
+   * Unregisters a completed task.
+   *
+   * Call this when a task completes execution (successfully or not).
+   *
+   * @param taskPda - Task account PDA
+   */
+  unregisterActiveTask(taskPda: PublicKey): void {
+    this.activeTasks.delete(taskPda.toBase58());
+  }
+
+  /**
+   * Checks if a task has been rolled back.
+   *
+   * @param taskPda - Task account PDA
+   * @returns True if the task has been rolled back
+   */
+  isRolledBack(taskPda: PublicKey): boolean {
+    return this.rolledBackTasks.has(taskPda.toBase58());
+  }
+
+  /**
+   * Executes a cascade rollback from a failed task.
+   *
+   * Idempotent: rolling back an already-rolled-back task returns
+   * the cached result from the original rollback.
+   *
+   * @param rootTaskPda - Task PDA that triggered the rollback
+   * @param reason - Reason for the rollback
+   * @returns RollbackResult with all affected tasks
+   */
+  async rollback(
+    rootTaskPda: PublicKey,
+    reason: RollbackReason
+  ): Promise<RollbackResult> {
+    const rootKey = rootTaskPda.toBase58();
+
+    // Idempotency check - return cached result if already rolled back
+    const existingResult = this.rollbackResults.get(rootKey);
+    if (existingResult) {
+      return existingResult;
+    }
+
+    // Get all affected tasks via BFS through dependency graph
+    const affectedNodes = this.getAffectedTasks(rootTaskPda);
+
+    // Emit start event
+    if (this.config.enableEvents && this.events.onRollbackStarted) {
+      this.events.onRollbackStarted(rootTaskPda, affectedNodes.length);
+    }
+
+    // Process each affected task
+    const rolledBackTasks: RolledBackTask[] = [];
+
+    for (const node of affectedNodes) {
+      const rolledBack = await this.rollbackTask(node, reason);
+      if (rolledBack) {
+        rolledBackTasks.push(rolledBack);
+
+        // Emit per-task event
+        if (this.config.enableEvents && this.events.onTaskRolledBack) {
+          this.events.onTaskRolledBack(rolledBack);
+        }
+      }
+    }
+
+    // Mark the root task as rolled back too
+    this.rolledBackTasks.add(rootKey);
+
+    // Mark root commitment as failed
+    try {
+      this.commitmentLedger.markFailed(rootTaskPda);
+    } catch {
+      // Commitment may not exist for root task
+    }
+
+    // Update root task status in graph
+    this.dependencyGraph.updateStatus(rootTaskPda, 'failed');
+
+    // Calculate totals
+    const wastedComputeMs = rolledBackTasks.reduce(
+      (sum, t) => sum + t.computeTimeMs,
+      0
+    );
+    const stakeAtRisk = rolledBackTasks.reduce(
+      (sum, t) => sum + t.stakeAtRisk,
+      0n
+    );
+
+    // Build result
+    const result: RollbackResult = {
+      rootTaskPda,
+      reason,
+      rolledBackTasks,
+      wastedComputeMs,
+      stakeAtRisk,
+      timestamp: Date.now(),
+    };
+
+    // Cache result for idempotency
+    this.rollbackResults.set(rootKey, result);
+
+    // Add to history
+    this.rollbackHistory.unshift(result);
+    if (this.rollbackHistory.length > this.maxHistorySize) {
+      this.rollbackHistory.pop();
+    }
+
+    // Update stats
+    this.stats.totalRollbacks++;
+    this.stats.totalTasksRolledBack += rolledBackTasks.length;
+    this.stats.totalWastedComputeMs += wastedComputeMs;
+    this.stats.totalStakeLost += stakeAtRisk;
+    this.stats.rollbacksByReason[reason]++;
+
+    // Emit completion event
+    if (this.config.enableEvents && this.events.onRollbackCompleted) {
+      this.events.onRollbackCompleted(result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Gets the rollback history.
+   *
+   * @param limit - Maximum number of entries to return (default: 100)
+   * @returns Array of RollbackResults, newest first
+   */
+  getRollbackHistory(limit: number = 100): RollbackResult[] {
+    return this.rollbackHistory.slice(0, limit);
+  }
+
+  /**
+   * Gets cumulative statistics about rollback operations.
+   *
+   * @returns RollbackStats object
+   */
+  getStats(): RollbackStats {
+    return { ...this.stats };
+  }
+
+  /**
+   * Clears all state (for testing).
+   */
+  clear(): void {
+    this.activeTasks.clear();
+    this.rolledBackTasks.clear();
+    this.rollbackResults.clear();
+    this.rollbackHistory = [];
+    this.stats = {
+      totalRollbacks: 0,
+      totalTasksRolledBack: 0,
+      totalWastedComputeMs: 0,
+      totalStakeLost: 0n,
+      rollbacksByReason: {
+        proof_failed: 0,
+        proof_timeout: 0,
+        ancestor_failed: 0,
+        manual: 0,
+      },
+    };
+  }
+
+  /**
+   * Gets all tasks affected by a failure, using BFS traversal.
+   *
+   * @param rootTaskPda - The task that failed
+   * @returns Array of affected TaskNodes (excluding the root)
+   */
+  private getAffectedTasks(rootTaskPda: PublicKey): TaskNode[] {
+    // Use DependencyGraph's getDescendants which does BFS
+    return this.dependencyGraph.getDescendants(rootTaskPda);
+  }
+
+  /**
+   * Rolls back a single task.
+   *
+   * @param node - The task node to roll back
+   * @param reason - Reason for the rollback
+   * @returns RolledBackTask info or null if task already rolled back
+   */
+  private async rollbackTask(
+    node: TaskNode,
+    _reason: RollbackReason
+  ): Promise<RolledBackTask | null> {
+    const key = node.taskPda.toBase58();
+
+    // Skip if already rolled back
+    if (this.rolledBackTasks.has(key)) {
+      return null;
+    }
+
+    // Mark as rolled back
+    this.rolledBackTasks.add(key);
+
+    // Get commitment info
+    const commitment = this.commitmentLedger.getByTask(node.taskPda);
+
+    // Determine state and action
+    let state: RolledBackTaskState;
+    let action: RolledBackTaskAction;
+    let computeTimeMs = 0;
+    let stakeAtRisk = 0n;
+
+    // Check if task is actively executing
+    const activeEntry = this.activeTasks.get(key);
+
+    if (activeEntry) {
+      // Task is actively executing - abort it
+      state = 'executing';
+      action = 'aborted';
+      computeTimeMs = Date.now() - activeEntry.startedAt;
+      activeEntry.abortController.abort();
+      this.activeTasks.delete(key);
+    } else if (commitment) {
+      // Task has a commitment - determine state from commitment status
+      switch (commitment.status) {
+        case 'pending':
+        case 'executing':
+          state = 'executing';
+          action = 'aborted';
+          break;
+        case 'executed':
+          state = 'executed';
+          action = 'discarded';
+          break;
+        case 'proof_generating':
+          state = 'proof_generating';
+          action = 'cancelled';
+          break;
+        case 'proof_generated':
+          state = 'proof_generated';
+          action = 'cancelled';
+          break;
+        default:
+          state = 'executed';
+          action = 'discarded';
+      }
+
+      // Get stake from commitment
+      stakeAtRisk = commitment.stakeAtRisk;
+
+      // Calculate compute time from commitment creation
+      computeTimeMs = Date.now() - commitment.createdAt;
+    } else {
+      // No commitment - task was pending but not started
+      state = 'executing';
+      action = 'discarded';
+    }
+
+    // Update commitment status to rolled_back
+    if (commitment) {
+      try {
+        // Mark the commitment as rolled back by marking its source as failed
+        // This will cascade to dependents via markFailed
+        this.commitmentLedger.updateStatus(node.taskPda, 'rolled_back');
+      } catch {
+        // May already be in a terminal state
+      }
+    }
+
+    // Update task status in dependency graph
+    this.dependencyGraph.updateStatus(node.taskPda, 'failed');
+
+    return {
+      taskPda: node.taskPda,
+      taskId: node.taskId,
+      state,
+      action,
+      computeTimeMs,
+      stakeAtRisk,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Implements `RollbackController` to handle cascade rollbacks when speculative proofs fail.

## Changes

- **`runtime/src/task/rollback-controller.ts`**: New RollbackController class that:
  - Uses BFS traversal through DependencyGraph to find all affected downstream tasks
  - Aborts executing tasks via registered AbortControllers
  - Cancels pending proofs by updating CommitmentLedger status
  - Tracks rollback metrics (wasted compute time, stake at risk)
  - Provides idempotent rollback operations (repeated calls return cached result)
  - Emits events for observability (onRollbackStarted, onTaskRolledBack, onRollbackCompleted)
  - Maintains rollback history and cumulative statistics

- **`runtime/src/task/rollback-controller.test.ts`**: Comprehensive test suite (35 tests) covering:
  - Single task rollback
  - Cascade rollback (linear chains)
  - Cascade rollback (DAG structures)
  - Idempotency
  - Commitment status updates
  - Different task states (executing, proof_generating, etc.)
  - History and statistics tracking
  - Large cascades (deep chains, wide branching)

## API

```typescript
export class RollbackController {
  constructor(config, dependencyGraph, commitmentLedger, events?);
  
  // Register/unregister active tasks for abort capability
  registerActiveTask(taskPda, abortController, commitmentId?): void;
  unregisterActiveTask(taskPda): void;
  
  // Execute cascade rollback
  rollback(rootTaskPda, reason): Promise<RollbackResult>;
  
  // Query state
  isRolledBack(taskPda): boolean;
  getRollbackHistory(limit?): RollbackResult[];
  getStats(): RollbackStats;
}
```

## Testing

All 35 tests pass:
```
npm test -- --run src/task/rollback-controller.test.ts
```

Closes #274
Part of epic #291