### PR TITLE
feat(runtime): add SpeculativeTaskScheduler orchestrator

### DIFF
--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -19,3 +19,4 @@ export * from './speculative-executor.js';
 export * from './commitment-ledger.js';
 export * from './rollback-controller.js';
 export * from './proof-deferral.js';
+export * from './speculative-scheduler.js';

--- a/runtime/src/task/speculative-scheduler.test.ts
+++ b/runtime/src/task/speculative-scheduler.test.ts
@@ -1,0 +1,843 @@
+/**
+ * Tests for SpeculativeTaskScheduler
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import {
+  SpeculativeTaskScheduler,
+  type SpeculativeSchedulerConfig,
+  type SpeculativeSchedulerEvents,
+} from './speculative-scheduler.js';
+import { DependencyGraph, DependencyType } from './dependency-graph.js';
+import type { ProofPipeline } from './proof-pipeline.js';
+import type { OnChainTask } from './types.js';
+import { OnChainTaskStatus, TaskType } from './types.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function randomPda(): PublicKey {
+  return Keypair.generate().publicKey;
+}
+
+function createMockTask(): OnChainTask {
+  return {
+    taskId: new Uint8Array(32).fill(Math.floor(Math.random() * 256)),
+    creator: randomPda(),
+    requiredCapabilities: 0n,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    rewardAmount: 1_000_000n,
+    maxWorkers: 1,
+    currentWorkers: 0,
+    status: OnChainTaskStatus.Open,
+    taskType: TaskType.Exclusive,
+    createdAt: Math.floor(Date.now() / 1000),
+    deadline: 0,
+    completedAt: 0,
+    escrow: randomPda(),
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+  };
+}
+
+function createMockProofPipeline(): ProofPipeline {
+  return {
+    queueProofGeneration: vi.fn(),
+    submitProof: vi.fn().mockResolvedValue('mock-signature'),
+    getQueuedJobs: vi.fn().mockReturnValue([]),
+    getActiveJobs: vi.fn().mockReturnValue([]),
+    getCompletedJobs: vi.fn().mockReturnValue([]),
+    getFailedJobs: vi.fn().mockReturnValue([]),
+    getStats: vi.fn().mockReturnValue({
+      queued: 0,
+      generating: 0,
+      generated: 0,
+      submitting: 0,
+      confirmed: 0,
+      failed: 0,
+      totalProcessed: 0,
+      averageGenerationTimeMs: 0,
+      averageSubmissionTimeMs: 0,
+    }),
+    stop: vi.fn().mockResolvedValue(undefined),
+    start: vi.fn(),
+    isShuttingDown: vi.fn().mockReturnValue(false),
+    cancel: vi.fn(),
+  } as unknown as ProofPipeline;
+}
+
+function createScheduler(
+  configOverrides: Partial<SpeculativeSchedulerConfig> = {},
+  events: SpeculativeSchedulerEvents = {},
+  dependencyGraph?: DependencyGraph
+): {
+  scheduler: SpeculativeTaskScheduler;
+  graph: DependencyGraph;
+  pipeline: ProofPipeline;
+} {
+  const graph = dependencyGraph ?? new DependencyGraph();
+  const pipeline = createMockProofPipeline();
+
+  const scheduler = new SpeculativeTaskScheduler(
+    {
+      maxSpeculationDepth: 3,
+      maxSpeculativeStake: 10_000_000_000n,
+      enableSpeculation: true,
+      ...configOverrides,
+    },
+    events,
+    graph,
+    pipeline
+  );
+
+  return { scheduler, graph, pipeline };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SpeculativeTaskScheduler', () => {
+  describe('constructor', () => {
+    it('should create scheduler with default config', () => {
+      const { scheduler } = createScheduler();
+
+      const status = scheduler.getStatus();
+      expect(status.running).toBe(false);
+      expect(status.speculationEnabled).toBe(true);
+      expect(status.activeSpeculations).toBe(0);
+    });
+
+    it('should respect enableSpeculation config', () => {
+      const { scheduler } = createScheduler({ enableSpeculation: false });
+
+      const status = scheduler.getStatus();
+      expect(status.speculationEnabled).toBe(false);
+    });
+
+    it('should wire up component accessors', () => {
+      const { scheduler, graph } = createScheduler();
+
+      expect(scheduler.getDependencyGraph()).toBe(graph);
+      expect(scheduler.getCommitmentLedger()).toBeDefined();
+      expect(scheduler.getProofDeferralManager()).toBeDefined();
+      expect(scheduler.getRollbackController()).toBeDefined();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('should start and stop correctly', () => {
+      const { scheduler } = createScheduler();
+
+      expect(scheduler.getStatus().running).toBe(false);
+
+      scheduler.start();
+      expect(scheduler.getStatus().running).toBe(true);
+
+      scheduler.stop();
+      expect(scheduler.getStatus().running).toBe(false);
+    });
+
+    it('should handle multiple start calls gracefully', () => {
+      const { scheduler } = createScheduler();
+
+      scheduler.start();
+      scheduler.start(); // Should not throw
+      expect(scheduler.getStatus().running).toBe(true);
+    });
+
+    it('should handle multiple stop calls gracefully', () => {
+      const { scheduler } = createScheduler();
+
+      scheduler.start();
+      scheduler.stop();
+      scheduler.stop(); // Should not throw
+      expect(scheduler.getStatus().running).toBe(false);
+    });
+  });
+
+  describe('shouldSpeculate - global enable', () => {
+    it('should allow speculation when enabled', () => {
+      const { scheduler, graph } = createScheduler({ enableSpeculation: true });
+
+      const taskPda = randomPda();
+      const task = createMockTask();
+      graph.addTask(task, taskPda);
+
+      const decision = scheduler.shouldSpeculate(taskPda);
+      expect(decision.allowed).toBe(true);
+    });
+
+    it('should deny speculation when disabled', () => {
+      const { scheduler, graph } = createScheduler({ enableSpeculation: false });
+
+      const taskPda = randomPda();
+      const task = createMockTask();
+      graph.addTask(task, taskPda);
+
+      const decision = scheduler.shouldSpeculate(taskPda);
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('disabled');
+    });
+
+    it('should deny when task not found in graph', () => {
+      const { scheduler } = createScheduler();
+
+      const taskPda = randomPda();
+      const decision = scheduler.shouldSpeculate(taskPda);
+
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('task_not_found');
+    });
+  });
+
+  describe('shouldSpeculate - depth limiting', () => {
+    it('should allow speculation within depth limit', () => {
+      const { scheduler, graph } = createScheduler({ maxSpeculationDepth: 3 });
+
+      // Create chain: root -> child1 -> child2 (depth 2)
+      const rootPda = randomPda();
+      const child1Pda = randomPda();
+      const child2Pda = randomPda();
+
+      graph.addTask(createMockTask(), rootPda);
+      graph.addTaskWithParent(createMockTask(), child1Pda, rootPda);
+      graph.addTaskWithParent(createMockTask(), child2Pda, child1Pda);
+
+      // Depth 2 should be allowed (limit is 3)
+      const decision = scheduler.shouldSpeculate(child2Pda);
+      expect(decision.allowed).toBe(true);
+    });
+
+    it('should deny speculation when at depth limit', () => {
+      const { scheduler, graph } = createScheduler({ maxSpeculationDepth: 2 });
+
+      // Create chain: root -> child1 -> child2 (depth 2)
+      const rootPda = randomPda();
+      const child1Pda = randomPda();
+      const child2Pda = randomPda();
+
+      graph.addTask(createMockTask(), rootPda);
+      graph.addTaskWithParent(createMockTask(), child1Pda, rootPda);
+      graph.addTaskWithParent(createMockTask(), child2Pda, child1Pda);
+
+      // Depth 2 == limit of 2, should be denied
+      const decision = scheduler.shouldSpeculate(child2Pda);
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('depth_limit');
+    });
+
+    it('should fire onDepthLimitReached event', () => {
+      const onDepthLimitReached = vi.fn();
+
+      const { scheduler, graph } = createScheduler(
+        { maxSpeculationDepth: 1 },
+        { onDepthLimitReached }
+      );
+
+      const rootPda = randomPda();
+      const childPda = randomPda();
+
+      graph.addTask(createMockTask(), rootPda);
+      graph.addTaskWithParent(createMockTask(), childPda, rootPda);
+
+      scheduler.shouldSpeculate(childPda);
+
+      expect(onDepthLimitReached).toHaveBeenCalledWith(childPda, 1);
+    });
+  });
+
+  describe('shouldSpeculate - stake limiting', () => {
+    it('should deny speculation when stake limit reached', () => {
+      const { scheduler, graph } = createScheduler({
+        maxSpeculativeStake: 1_000_000n, // 0.001 SOL
+      });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      // Create commitments to exceed stake limit
+      const ledger = scheduler.getCommitmentLedger();
+      const task1Pda = randomPda();
+      ledger.createCommitment(
+        task1Pda,
+        new Uint8Array(32),
+        new Uint8Array(32),
+        randomPda(),
+        2_000_000n // Exceeds limit
+      );
+
+      const decision = scheduler.shouldSpeculate(taskPda);
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('stake_limit');
+    });
+
+    it('should fire onStakeLimitReached event', () => {
+      const onStakeLimitReached = vi.fn();
+
+      const { scheduler, graph } = createScheduler(
+        { maxSpeculativeStake: 1_000_000n },
+        { onStakeLimitReached }
+      );
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      // Exceed stake limit
+      const ledger = scheduler.getCommitmentLedger();
+      ledger.createCommitment(
+        randomPda(),
+        new Uint8Array(32),
+        new Uint8Array(32),
+        randomPda(),
+        2_000_000n
+      );
+
+      scheduler.shouldSpeculate(taskPda);
+
+      expect(onStakeLimitReached).toHaveBeenCalledWith(2_000_000n, 1_000_000n);
+    });
+  });
+
+  describe('shouldSpeculate - dependency type filtering', () => {
+    it('should allow speculation for allowed dependency types', () => {
+      const { scheduler, graph } = createScheduler({
+        speculatableDependencyTypes: [DependencyType.Data],
+      });
+
+      const rootPda = randomPda();
+      const childPda = randomPda();
+
+      graph.addTask(createMockTask(), rootPda);
+      graph.addTaskWithParent(createMockTask(), childPda, rootPda, DependencyType.Data);
+
+      const decision = scheduler.shouldSpeculate(childPda);
+      expect(decision.allowed).toBe(true);
+    });
+
+    it('should deny speculation for disallowed dependency types', () => {
+      const { scheduler, graph } = createScheduler({
+        speculatableDependencyTypes: [DependencyType.Data], // Only Data
+      });
+
+      const rootPda = randomPda();
+      const childPda = randomPda();
+
+      graph.addTask(createMockTask(), rootPda);
+      graph.addTaskWithParent(createMockTask(), childPda, rootPda, DependencyType.Resource);
+
+      const decision = scheduler.shouldSpeculate(childPda);
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('dependency_type_not_speculatable');
+    });
+  });
+
+  describe('shouldSpeculate - private task policy', () => {
+    it('should deny private speculation when disabled', () => {
+      const { scheduler, graph } = createScheduler({
+        allowPrivateSpeculation: false,
+      });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      const decision = scheduler.shouldSpeculate(taskPda, undefined, true);
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('private_speculation_disabled');
+    });
+
+    it('should allow private speculation when enabled', () => {
+      const { scheduler, graph } = createScheduler({
+        allowPrivateSpeculation: true,
+      });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      const decision = scheduler.shouldSpeculate(taskPda, undefined, true);
+      expect(decision.allowed).toBe(true);
+    });
+  });
+
+  describe('shouldSpeculate - reputation threshold', () => {
+    it('should deny speculation for low reputation agents', () => {
+      const { scheduler, graph } = createScheduler({
+        minReputationForSpeculation: 500,
+      });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      const decision = scheduler.shouldSpeculate(taskPda, undefined, false, 400);
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('low_reputation');
+    });
+
+    it('should allow speculation for high reputation agents', () => {
+      const { scheduler, graph } = createScheduler({
+        minReputationForSpeculation: 500,
+      });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      const decision = scheduler.shouldSpeculate(taskPda, undefined, false, 600);
+      expect(decision.allowed).toBe(true);
+    });
+
+    it('should allow speculation at exact threshold', () => {
+      const { scheduler, graph } = createScheduler({
+        minReputationForSpeculation: 500,
+      });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      const decision = scheduler.shouldSpeculate(taskPda, undefined, false, 500);
+      expect(decision.allowed).toBe(true);
+    });
+  });
+
+  describe('speculation enable/disable', () => {
+    it('should enable speculation via method', () => {
+      const { scheduler } = createScheduler({ enableSpeculation: false });
+
+      expect(scheduler.isSpeculationEnabled()).toBe(false);
+
+      scheduler.enableSpeculation();
+      expect(scheduler.isSpeculationEnabled()).toBe(true);
+    });
+
+    it('should disable speculation via method', () => {
+      const { scheduler } = createScheduler({ enableSpeculation: true });
+
+      expect(scheduler.isSpeculationEnabled()).toBe(true);
+
+      scheduler.disableSpeculation('test_reason');
+      expect(scheduler.isSpeculationEnabled()).toBe(false);
+    });
+
+    it('should fire onSpeculationDisabled event', () => {
+      const onSpeculationDisabled = vi.fn();
+
+      const { scheduler } = createScheduler(
+        { enableSpeculation: true },
+        { onSpeculationDisabled }
+      );
+
+      scheduler.disableSpeculation('manual_disable');
+
+      expect(onSpeculationDisabled).toHaveBeenCalledWith('manual_disable');
+    });
+
+    it('should fire onSpeculationEnabled event', () => {
+      const onSpeculationEnabled = vi.fn();
+
+      const { scheduler } = createScheduler(
+        { enableSpeculation: false },
+        { onSpeculationEnabled }
+      );
+
+      scheduler.enableSpeculation();
+
+      expect(onSpeculationEnabled).toHaveBeenCalled();
+    });
+  });
+
+  describe('registerSpeculationStart', () => {
+    it('should track active speculations', () => {
+      const { scheduler, graph } = createScheduler();
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      scheduler.registerSpeculationStart(taskPda, 1);
+
+      const status = scheduler.getStatus();
+      expect(status.activeSpeculations).toBe(1);
+    });
+
+    it('should increment speculativeExecutions metric', () => {
+      const { scheduler, graph } = createScheduler();
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      const metricsBefore = scheduler.getMetrics();
+      expect(metricsBefore.speculativeExecutions).toBe(0);
+
+      scheduler.registerSpeculationStart(taskPda, 1);
+
+      const metricsAfter = scheduler.getMetrics();
+      expect(metricsAfter.speculativeExecutions).toBe(1);
+    });
+
+    it('should fire onSpeculationStarted event', () => {
+      const onSpeculationStarted = vi.fn();
+
+      const { scheduler, graph } = createScheduler({}, { onSpeculationStarted });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      scheduler.registerSpeculationStart(taskPda, 2);
+
+      expect(onSpeculationStarted).toHaveBeenCalledWith(taskPda, 2);
+    });
+  });
+
+  describe('onProofConfirmed', () => {
+    it('should update metrics on confirmation', () => {
+      const { scheduler, graph } = createScheduler();
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      // Start speculation
+      scheduler.registerSpeculationStart(taskPda, 1);
+
+      // Confirm proof
+      scheduler.onProofConfirmed(taskPda);
+
+      const metrics = scheduler.getMetrics();
+      expect(metrics.speculativeHits).toBe(1);
+      expect(metrics.hitRate).toBe(100);
+    });
+
+    it('should fire onSpeculationConfirmed event', () => {
+      const onSpeculationConfirmed = vi.fn();
+
+      const { scheduler, graph } = createScheduler({}, { onSpeculationConfirmed });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      scheduler.registerSpeculationStart(taskPda, 1);
+      scheduler.onProofConfirmed(taskPda);
+
+      expect(onSpeculationConfirmed).toHaveBeenCalledWith(taskPda);
+    });
+
+    it('should remove from active speculations', () => {
+      const { scheduler, graph } = createScheduler();
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      scheduler.registerSpeculationStart(taskPda, 1);
+      expect(scheduler.getStatus().activeSpeculations).toBe(1);
+
+      scheduler.onProofConfirmed(taskPda);
+      expect(scheduler.getStatus().activeSpeculations).toBe(0);
+    });
+  });
+
+  describe('onProofFailed', () => {
+    it('should update metrics on failure', () => {
+      const { scheduler, graph } = createScheduler();
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      // Start speculation
+      scheduler.registerSpeculationStart(taskPda, 1);
+
+      // Fail proof
+      scheduler.onProofFailed(taskPda, 'test_failure');
+
+      const metrics = scheduler.getMetrics();
+      expect(metrics.speculativeMisses).toBe(1);
+      expect(metrics.hitRate).toBe(0);
+    });
+
+    it('should fire onSpeculationFailed event', () => {
+      const onSpeculationFailed = vi.fn();
+
+      const { scheduler, graph } = createScheduler({}, { onSpeculationFailed });
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      scheduler.registerSpeculationStart(taskPda, 1);
+      scheduler.onProofFailed(taskPda, 'verification_failed');
+
+      expect(onSpeculationFailed).toHaveBeenCalledWith(taskPda, 'verification_failed');
+    });
+
+    it('should calculate rollback rate correctly', () => {
+      const { scheduler, graph } = createScheduler();
+
+      // Register multiple speculations
+      const taskPdas = [randomPda(), randomPda(), randomPda(), randomPda()];
+      for (const pda of taskPdas) {
+        graph.addTask(createMockTask(), pda);
+        scheduler.registerSpeculationStart(pda, 0);
+      }
+
+      // 2 succeed, 2 fail
+      scheduler.onProofConfirmed(taskPdas[0]);
+      scheduler.onProofConfirmed(taskPdas[1]);
+      scheduler.onProofFailed(taskPdas[2]);
+      scheduler.onProofFailed(taskPdas[3]);
+
+      const metrics = scheduler.getMetrics();
+      expect(metrics.speculativeExecutions).toBe(4);
+      expect(metrics.speculativeHits).toBe(2);
+      expect(metrics.speculativeMisses).toBe(2);
+      expect(metrics.hitRate).toBe(50);
+      expect(metrics.rollbackRate).toBe(50);
+    });
+  });
+
+  describe('rollback rate auto-disable', () => {
+    it('should auto-disable speculation when rollback rate exceeds threshold', () => {
+      const onSpeculationDisabled = vi.fn();
+
+      const { scheduler, graph } = createScheduler(
+        { maxRollbackRatePercent: 30 }, // 30% threshold
+        { onSpeculationDisabled }
+      );
+
+      // Create 10 speculations
+      const taskPdas: PublicKey[] = [];
+      for (let i = 0; i < 10; i++) {
+        const pda = randomPda();
+        taskPdas.push(pda);
+        graph.addTask(createMockTask(), pda);
+        scheduler.registerSpeculationStart(pda, 0);
+      }
+
+      // Fail 4 of them (40% > 30% threshold)
+      scheduler.onProofConfirmed(taskPdas[0]);
+      scheduler.onProofConfirmed(taskPdas[1]);
+      scheduler.onProofConfirmed(taskPdas[2]);
+      scheduler.onProofConfirmed(taskPdas[3]);
+      scheduler.onProofConfirmed(taskPdas[4]);
+      scheduler.onProofConfirmed(taskPdas[5]);
+      scheduler.onProofFailed(taskPdas[6]);
+      scheduler.onProofFailed(taskPdas[7]);
+      scheduler.onProofFailed(taskPdas[8]);
+      scheduler.onProofFailed(taskPdas[9]);
+
+      // Rollback rate is now 40%, next shouldSpeculate should disable
+      const newTaskPda = randomPda();
+      graph.addTask(createMockTask(), newTaskPda);
+
+      const decision = scheduler.shouldSpeculate(newTaskPda);
+      expect(decision.allowed).toBe(false);
+      expect(decision.reason).toBe('rollback_rate_exceeded');
+      expect(onSpeculationDisabled).toHaveBeenCalled();
+      expect(scheduler.isSpeculationEnabled()).toBe(false);
+    });
+  });
+
+  describe('metrics', () => {
+    it('should return correct metrics structure', () => {
+      const { scheduler } = createScheduler();
+
+      const metrics = scheduler.getMetrics();
+
+      expect(typeof metrics.speculativeExecutions).toBe('number');
+      expect(typeof metrics.speculativeHits).toBe('number');
+      expect(typeof metrics.speculativeMisses).toBe('number');
+      expect(typeof metrics.hitRate).toBe('number');
+      expect(typeof metrics.estimatedTimeSaved).toBe('number');
+      expect(typeof metrics.timeWastedOnRollbacks).toBe('number');
+      expect(typeof metrics.rollbackRate).toBe('number');
+    });
+
+    it('should return defensive copy of metrics', () => {
+      const { scheduler } = createScheduler();
+
+      const metrics1 = scheduler.getMetrics();
+      metrics1.speculativeExecutions = 999;
+
+      const metrics2 = scheduler.getMetrics();
+      expect(metrics2.speculativeExecutions).toBe(0);
+    });
+  });
+
+  describe('status', () => {
+    it('should return correct status structure', () => {
+      const { scheduler } = createScheduler({ maxSpeculationDepth: 5 });
+
+      const status = scheduler.getStatus();
+
+      expect(typeof status.running).toBe('boolean');
+      expect(typeof status.speculationEnabled).toBe('boolean');
+      expect(typeof status.activeSpeculations).toBe('number');
+      expect(typeof status.maxDepthReached).toBe('number');
+      expect(status.currentMaxDepth).toBe(5);
+      expect(typeof status.totalStakeAtRisk).toBe('bigint');
+      expect(typeof status.pendingProofs).toBe('number');
+      expect(typeof status.awaitingAncestors).toBe('number');
+    });
+  });
+
+  describe('forceRollback', () => {
+    it('should trigger rollback via controller', async () => {
+      const { scheduler, graph } = createScheduler();
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      const result = await scheduler.forceRollback(taskPda, 'manual');
+
+      expect(result).toBeDefined();
+      expect(result.reason).toBe('manual');
+      expect(result.rootTaskPda).toEqual(taskPda);
+    });
+  });
+
+  describe('addDependency', () => {
+    it('should warn when downstream task not in graph', () => {
+      const { scheduler, graph } = createScheduler();
+
+      const upstreamPda = randomPda();
+      const downstreamPda = randomPda();
+
+      // Add upstream first
+      graph.addTask(createMockTask(), upstreamPda);
+
+      // Add dependency via scheduler - should not throw
+      scheduler.addDependency(upstreamPda, downstreamPda, DependencyType.Data);
+
+      // Downstream should NOT be in graph (scheduler warns but doesn't add)
+      const node = graph.getNode(downstreamPda);
+      expect(node).toBeUndefined();
+    });
+
+    it('should be no-op when downstream already exists', () => {
+      const { scheduler, graph } = createScheduler();
+
+      const upstreamPda = randomPda();
+      const downstreamPda = randomPda();
+
+      // Add both tasks
+      graph.addTask(createMockTask(), upstreamPda);
+      graph.addTaskWithParent(createMockTask(), downstreamPda, upstreamPda);
+
+      // addDependency should be no-op since downstream exists
+      scheduler.addDependency(upstreamPda, downstreamPda, DependencyType.Data);
+
+      // Check downstream still exists with original parent
+      const node = graph.getNode(downstreamPda);
+      expect(node).toBeDefined();
+      expect(node?.dependsOn).toEqual(upstreamPda);
+    });
+  });
+
+  describe('component accessors', () => {
+    it('should return all components', () => {
+      const { scheduler, graph } = createScheduler();
+
+      expect(scheduler.getDependencyGraph()).toBe(graph);
+      expect(scheduler.getCommitmentLedger()).toBeDefined();
+      expect(scheduler.getProofDeferralManager()).toBeDefined();
+      expect(scheduler.getRollbackController()).toBeDefined();
+    });
+
+    it('should return active commitments from ledger', () => {
+      const { scheduler } = createScheduler();
+
+      const commitments = scheduler.getActiveCommitments();
+      expect(Array.isArray(commitments)).toBe(true);
+    });
+
+    it('should return blocked proofs from deferral manager', () => {
+      const { scheduler } = createScheduler();
+
+      const blocked = scheduler.getBlockedProofs();
+      expect(Array.isArray(blocked)).toBe(true);
+    });
+  });
+
+  describe('integration scenarios', () => {
+    it('should handle complete speculation lifecycle', () => {
+      const onSpeculationStarted = vi.fn();
+      const onSpeculationConfirmed = vi.fn();
+
+      const { scheduler, graph } = createScheduler(
+        {},
+        { onSpeculationStarted, onSpeculationConfirmed }
+      );
+
+      scheduler.start();
+
+      const taskPda = randomPda();
+      graph.addTask(createMockTask(), taskPda);
+
+      // Check policy
+      const decision = scheduler.shouldSpeculate(taskPda);
+      expect(decision.allowed).toBe(true);
+
+      // Start speculation
+      scheduler.registerSpeculationStart(taskPda, 0);
+      expect(onSpeculationStarted).toHaveBeenCalled();
+
+      // Confirm
+      scheduler.onProofConfirmed(taskPda);
+      expect(onSpeculationConfirmed).toHaveBeenCalled();
+
+      const metrics = scheduler.getMetrics();
+      expect(metrics.speculativeExecutions).toBe(1);
+      expect(metrics.speculativeHits).toBe(1);
+      expect(metrics.hitRate).toBe(100);
+
+      scheduler.stop();
+    });
+
+    it('should handle multi-level speculation chain', () => {
+      const { scheduler, graph } = createScheduler({ maxSpeculationDepth: 5 });
+
+      // Create chain: root -> child1 -> child2 -> child3
+      const rootPda = randomPda();
+      const child1Pda = randomPda();
+      const child2Pda = randomPda();
+      const child3Pda = randomPda();
+
+      graph.addTask(createMockTask(), rootPda);
+      graph.addTaskWithParent(createMockTask(), child1Pda, rootPda);
+      graph.addTaskWithParent(createMockTask(), child2Pda, child1Pda);
+      graph.addTaskWithParent(createMockTask(), child3Pda, child2Pda);
+
+      // All should be allowed (depth 3 < 5)
+      expect(scheduler.shouldSpeculate(rootPda).allowed).toBe(true);
+      expect(scheduler.shouldSpeculate(child1Pda).allowed).toBe(true);
+      expect(scheduler.shouldSpeculate(child2Pda).allowed).toBe(true);
+      expect(scheduler.shouldSpeculate(child3Pda).allowed).toBe(true);
+    });
+
+    it('should handle mixed success/failure scenarios', () => {
+      const { scheduler, graph } = createScheduler();
+
+      // Create multiple speculative executions
+      const taskPdas: PublicKey[] = [];
+      for (let i = 0; i < 5; i++) {
+        const pda = randomPda();
+        taskPdas.push(pda);
+        graph.addTask(createMockTask(), pda);
+        scheduler.registerSpeculationStart(pda, 0);
+      }
+
+      // 3 succeed, 2 fail
+      scheduler.onProofConfirmed(taskPdas[0]);
+      scheduler.onProofConfirmed(taskPdas[1]);
+      scheduler.onProofFailed(taskPdas[2], 'verification_failed');
+      scheduler.onProofConfirmed(taskPdas[3]);
+      scheduler.onProofFailed(taskPdas[4], 'timeout');
+
+      const metrics = scheduler.getMetrics();
+      expect(metrics.speculativeExecutions).toBe(5);
+      expect(metrics.speculativeHits).toBe(3);
+      expect(metrics.speculativeMisses).toBe(2);
+      expect(metrics.hitRate).toBe(60);
+      expect(metrics.rollbackRate).toBe(40);
+    });
+  });
+});

--- a/runtime/src/task/speculative-scheduler.ts
+++ b/runtime/src/task/speculative-scheduler.ts
@@ -1,0 +1,741 @@
+/**
+ * SpeculativeTaskScheduler - Central orchestrator for speculative execution
+ *
+ * Ties together DependencyGraph, CommitmentLedger, ProofDeferralManager, and
+ * RollbackController to enable multi-level speculative execution with safety
+ * invariants.
+ *
+ * @module
+ */
+
+import type { PublicKey } from '@solana/web3.js';
+import {
+  DependencyGraph,
+  DependencyType,
+  type TaskNode,
+} from './dependency-graph.js';
+import {
+  CommitmentLedger,
+  type CommitmentLedgerConfig,
+  type SpeculativeCommitment,
+} from './commitment-ledger.js';
+import {
+  ProofDeferralManager,
+  type ProofDeferralConfig,
+  type DeferredProof,
+} from './proof-deferral.js';
+import {
+  RollbackController,
+  type RollbackConfig,
+  type RollbackResult,
+  type RollbackReason,
+} from './rollback-controller.js';
+import type { ProofPipeline } from './proof-pipeline.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+
+// ============================================================================
+// Type Definitions
+// ============================================================================
+
+/**
+ * Configuration for the SpeculativeTaskScheduler.
+ */
+export interface SpeculativeSchedulerConfig {
+  /** Maximum depth of unconfirmed proof ancestors (default: 3) */
+  maxSpeculationDepth: number;
+
+  /** Maximum total stake at risk from speculative execution (lamports) */
+  maxSpeculativeStake: bigint;
+
+  /** Allow speculative execution of private (ZK) tasks */
+  allowPrivateSpeculation: boolean;
+
+  /** Minimum reputation score to trust speculative results (0-1000) */
+  minReputationForSpeculation: number;
+
+  /** Time budget: max ms to wait for proof before force-voiding */
+  proofTimeoutMs: number;
+
+  /** Strategy for ordering speculative execution */
+  schedulingStrategy: 'fifo' | 'priority' | 'reward-weighted';
+
+  /** Only speculate on these dependency types */
+  speculatableDependencyTypes: DependencyType[];
+
+  /** Auto-disable speculation if rollback rate exceeds threshold (0-100) */
+  maxRollbackRatePercent: number;
+
+  /** Global enable/disable for speculation */
+  enableSpeculation: boolean;
+
+  /** CommitmentLedger configuration */
+  commitmentLedger: Partial<CommitmentLedgerConfig>;
+
+  /** ProofDeferralManager configuration */
+  proofDeferral: Partial<ProofDeferralConfig>;
+
+  /** RollbackController configuration */
+  rollback: Partial<RollbackConfig>;
+
+  /** Logger instance */
+  logger?: Logger;
+}
+
+/**
+ * Decision about whether to speculate on a task.
+ */
+export interface SpeculationDecision {
+  /** Whether speculation is allowed */
+  allowed: boolean;
+  /** Reason if not allowed */
+  reason?: SpeculationDenialReason;
+}
+
+/**
+ * Reasons speculation may be denied.
+ */
+export type SpeculationDenialReason =
+  | 'disabled' // Speculation globally disabled
+  | 'dependency_type_not_speculatable' // Dependency type not in allowed list
+  | 'depth_limit' // Max speculation depth reached
+  | 'stake_limit' // Max stake at risk reached
+  | 'private_speculation_disabled' // Private task speculation not allowed
+  | 'low_reputation' // Agent reputation too low
+  | 'rollback_rate_exceeded' // Auto-disabled due to high rollback rate
+  | 'task_not_found'; // Task not in dependency graph
+
+/**
+ * Event callbacks for the speculative scheduler.
+ */
+export interface SpeculativeSchedulerEvents {
+  /** Called when speculation starts for a task */
+  onSpeculationStarted?: (taskPda: PublicKey, depth: number) => void;
+  /** Called when a speculative result is confirmed */
+  onSpeculationConfirmed?: (taskPda: PublicKey) => void;
+  /** Called when speculation fails (proof rejected) */
+  onSpeculationFailed?: (taskPda: PublicKey, reason: string) => void;
+  /** Called when rollback begins */
+  onRollbackStarted?: (rootTaskPda: PublicKey, affectedCount: number) => void;
+  /** Called when rollback completes */
+  onRollbackCompleted?: (result: RollbackResult) => void;
+  /** Called when depth limit blocks speculation */
+  onDepthLimitReached?: (taskPda: PublicKey, currentDepth: number) => void;
+  /** Called when stake limit blocks speculation */
+  onStakeLimitReached?: (totalAtRisk: bigint, limit: bigint) => void;
+  /** Called when speculation is auto-disabled */
+  onSpeculationDisabled?: (reason: string) => void;
+  /** Called when speculation is re-enabled */
+  onSpeculationEnabled?: () => void;
+}
+
+/**
+ * Current status of the speculative scheduler.
+ */
+export interface SpeculativeSchedulerStatus {
+  /** Whether the scheduler is running */
+  running: boolean;
+  /** Whether speculation is currently enabled */
+  speculationEnabled: boolean;
+  /** Number of active speculative executions */
+  activeSpeculations: number;
+  /** Maximum depth currently reached */
+  maxDepthReached: number;
+  /** Configured max depth limit */
+  currentMaxDepth: number;
+  /** Total stake at risk from speculative executions */
+  totalStakeAtRisk: bigint;
+  /** Number of proofs pending submission */
+  pendingProofs: number;
+  /** Number of proofs awaiting ancestor confirmation */
+  awaitingAncestors: number;
+}
+
+/**
+ * Metrics about speculative execution performance.
+ */
+export interface SpeculationMetrics {
+  /** Total tasks executed speculatively */
+  speculativeExecutions: number;
+  /** Tasks where speculation was correct (proof passed) */
+  speculativeHits: number;
+  /** Tasks rolled back due to proof failure */
+  speculativeMisses: number;
+  /** Hit rate percentage (0-100) */
+  hitRate: number;
+  /** Total compute time saved by speculation (estimated ms) */
+  estimatedTimeSaved: number;
+  /** Total compute time wasted on rollbacks (ms) */
+  timeWastedOnRollbacks: number;
+  /** Rollback rate (0-100) for auto-disable check */
+  rollbackRate: number;
+}
+
+// ============================================================================
+// Default Configuration
+// ============================================================================
+
+const DEFAULT_CONFIG: SpeculativeSchedulerConfig = {
+  maxSpeculationDepth: 3,
+  maxSpeculativeStake: 10_000_000_000n, // 10 SOL
+  allowPrivateSpeculation: false,
+  minReputationForSpeculation: 500,
+  proofTimeoutMs: 300_000, // 5 minutes
+  schedulingStrategy: 'fifo',
+  speculatableDependencyTypes: [DependencyType.Data, DependencyType.Order],
+  maxRollbackRatePercent: 20,
+  enableSpeculation: true,
+  commitmentLedger: {},
+  proofDeferral: {},
+  rollback: {},
+};
+
+// ============================================================================
+// SpeculativeTaskScheduler Implementation
+// ============================================================================
+
+/**
+ * Central orchestrator for speculative execution.
+ *
+ * Coordinates DependencyGraph, CommitmentLedger, ProofDeferralManager, and
+ * RollbackController to enable safe multi-level speculation with:
+ * - Depth limiting (max unconfirmed ancestors)
+ * - Stake limiting (max economic risk)
+ * - Auto-disable on high rollback rate
+ * - Private task speculation policy
+ * - Reputation-based gating
+ *
+ * @example
+ * ```typescript
+ * const scheduler = new SpeculativeTaskScheduler(
+ *   { maxSpeculationDepth: 3, maxSpeculativeStake: 10_000_000_000n },
+ *   events,
+ *   dependencyGraph,
+ *   proofPipeline
+ * );
+ *
+ * scheduler.start();
+ *
+ * // Check if task can speculate
+ * const decision = scheduler.shouldSpeculate(taskPda);
+ * if (decision.allowed) {
+ *   // Execute speculatively...
+ * }
+ *
+ * // When proof confirmed
+ * scheduler.onProofConfirmed(taskPda);
+ *
+ * // When proof failed
+ * scheduler.onProofFailed(taskPda);
+ *
+ * scheduler.stop();
+ * ```
+ */
+export class SpeculativeTaskScheduler {
+  private readonly config: SpeculativeSchedulerConfig;
+  private readonly events: SpeculativeSchedulerEvents;
+  private readonly logger: Logger;
+
+  // Core components
+  private readonly dependencyGraph: DependencyGraph;
+  private readonly commitmentLedger: CommitmentLedger;
+  private readonly proofDeferralManager: ProofDeferralManager;
+  private readonly rollbackController: RollbackController;
+
+  // State
+  private running: boolean = false;
+  private speculationEnabled: boolean;
+
+  // Metrics
+  private metrics: SpeculationMetrics = {
+    speculativeExecutions: 0,
+    speculativeHits: 0,
+    speculativeMisses: 0,
+    hitRate: 0,
+    estimatedTimeSaved: 0,
+    timeWastedOnRollbacks: 0,
+    rollbackRate: 0,
+  };
+
+  // Tracking for active speculations
+  private activeSpeculations: Map<string, { startedAt: number; depth: number }> =
+    new Map();
+
+  /**
+   * Creates a new SpeculativeTaskScheduler instance.
+   *
+   * @param config - Configuration options
+   * @param events - Event callbacks for observability
+   * @param dependencyGraph - Pre-existing DependencyGraph instance
+   * @param proofPipeline - ProofPipeline for proof generation/submission
+   */
+  constructor(
+    config: Partial<SpeculativeSchedulerConfig>,
+    events: SpeculativeSchedulerEvents,
+    dependencyGraph: DependencyGraph,
+    proofPipeline: ProofPipeline
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.events = events;
+    this.logger = config.logger ?? silentLogger;
+    this.speculationEnabled = this.config.enableSpeculation;
+
+    // Use provided dependency graph
+    this.dependencyGraph = dependencyGraph;
+
+    // Create commitment ledger
+    this.commitmentLedger = new CommitmentLedger(this.config.commitmentLedger);
+
+    // Create proof deferral manager with wired events
+    this.proofDeferralManager = new ProofDeferralManager(
+      {
+        ...this.config.proofDeferral,
+        ancestorTimeoutMs: this.config.proofTimeoutMs,
+        logger: this.logger,
+      },
+      {
+        onProofConfirmed: (taskPda, _sig) => this.handleProofConfirmed(taskPda),
+        onProofFailed: (taskPda, error, _stage) =>
+          this.handleProofFailed(taskPda, error.message),
+        onProofTimedOut: (taskPda, _stage) =>
+          this.handleProofFailed(taskPda, 'timeout'),
+        onProofCancelled: (taskPda, _ancestorPda) =>
+          this.handleProofFailed(taskPda, 'ancestor_failed'),
+      },
+      this.commitmentLedger,
+      this.dependencyGraph,
+      proofPipeline
+    );
+
+    // Create rollback controller with wired events
+    this.rollbackController = new RollbackController(
+      {
+        ...this.config.rollback,
+        enableEvents: true,
+      },
+      this.dependencyGraph,
+      this.commitmentLedger,
+      {
+        onRollbackStarted: (rootTaskPda, affectedCount) => {
+          this.events.onRollbackStarted?.(rootTaskPda, affectedCount);
+        },
+        onRollbackCompleted: (result) => {
+          this.updateMetricsOnRollback(result);
+          this.events.onRollbackCompleted?.(result);
+        },
+      }
+    );
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  /**
+   * Starts the speculative scheduler.
+   */
+  start(): void {
+    if (this.running) {
+      this.logger.warn('Scheduler already running');
+      return;
+    }
+
+    this.running = true;
+    this.logger.info('SpeculativeTaskScheduler started');
+  }
+
+  /**
+   * Stops the scheduler gracefully.
+   *
+   * Does not accept new speculative executions but allows pending proofs
+   * to complete.
+   */
+  stop(): void {
+    if (!this.running) {
+      this.logger.warn('Scheduler not running');
+      return;
+    }
+
+    this.running = false;
+    this.logger.info('SpeculativeTaskScheduler stopped');
+  }
+
+  // ==========================================================================
+  // Speculation Policy
+  // ==========================================================================
+
+  /**
+   * Determines whether a task should be executed speculatively.
+   *
+   * Checks all policy constraints:
+   * 1. Global speculation enabled
+   * 2. Dependency type allowed
+   * 3. Depth limit
+   * 4. Stake limit
+   * 5. Private task policy
+   * 6. Reputation threshold
+   * 7. Rollback rate threshold
+   *
+   * @param taskPda - Task account PDA
+   * @param taskNode - Optional task node (fetched if not provided)
+   * @param isPrivate - Whether this is a private (ZK) task
+   * @param agentReputation - Agent's reputation score (0-1000)
+   * @returns Decision about whether to speculate
+   */
+  shouldSpeculate(
+    taskPda: PublicKey,
+    taskNode?: TaskNode,
+    isPrivate: boolean = false,
+    agentReputation: number = 1000
+  ): SpeculationDecision {
+    // 1. Check global enable
+    if (!this.speculationEnabled) {
+      return { allowed: false, reason: 'disabled' };
+    }
+
+    // Get task node if not provided
+    const node = taskNode ?? this.dependencyGraph.getNode(taskPda);
+    if (!node) {
+      return { allowed: false, reason: 'task_not_found' };
+    }
+
+    // 2. Check dependency type
+    if (
+      !this.config.speculatableDependencyTypes.includes(node.dependencyType)
+    ) {
+      return { allowed: false, reason: 'dependency_type_not_speculatable' };
+    }
+
+    // 3. Check depth limit
+    const depth = this.dependencyGraph.getDepth(taskPda);
+    if (depth >= this.config.maxSpeculationDepth) {
+      this.events.onDepthLimitReached?.(taskPda, depth);
+      return { allowed: false, reason: 'depth_limit' };
+    }
+
+    // 4. Check stake limit
+    const currentStake = this.commitmentLedger.getTotalStakeAtRisk();
+    if (currentStake >= this.config.maxSpeculativeStake) {
+      this.events.onStakeLimitReached?.(
+        currentStake,
+        this.config.maxSpeculativeStake
+      );
+      return { allowed: false, reason: 'stake_limit' };
+    }
+
+    // 5. Check private task policy
+    if (isPrivate && !this.config.allowPrivateSpeculation) {
+      return { allowed: false, reason: 'private_speculation_disabled' };
+    }
+
+    // 6. Check reputation threshold
+    if (agentReputation < this.config.minReputationForSpeculation) {
+      return { allowed: false, reason: 'low_reputation' };
+    }
+
+    // 7. Check rollback rate (auto-disable)
+    if (this.metrics.rollbackRate > this.config.maxRollbackRatePercent) {
+      this.disableSpeculation('rollback_rate_exceeded');
+      return { allowed: false, reason: 'rollback_rate_exceeded' };
+    }
+
+    return { allowed: true };
+  }
+
+  /**
+   * Registers the start of a speculative execution.
+   *
+   * Call this when beginning speculative execution of a task.
+   *
+   * @param taskPda - Task account PDA
+   * @param depth - Speculation depth
+   */
+  registerSpeculationStart(taskPda: PublicKey, depth: number): void {
+    const pdaKey = taskPda.toBase58();
+
+    this.activeSpeculations.set(pdaKey, {
+      startedAt: Date.now(),
+      depth,
+    });
+
+    this.metrics.speculativeExecutions++;
+    this.events.onSpeculationStarted?.(taskPda, depth);
+
+    this.logger.debug(`Speculation started for ${pdaKey} at depth ${depth}`);
+  }
+
+  // ==========================================================================
+  // Dependency Management
+  // ==========================================================================
+
+  /**
+   * Adds a dependency between tasks.
+   *
+   * Note: This method assumes both tasks already exist in the graph.
+   * Use the DependencyGraph directly for more control.
+   *
+   * @param _upstream - Parent task PDA (unused, for API consistency)
+   * @param downstream - Child task PDA
+   * @param _type - Type of dependency (unused, for API consistency)
+   */
+  addDependency(
+    _upstream: PublicKey,
+    downstream: PublicKey,
+    _type: DependencyType
+  ): void {
+    // Check if downstream already exists
+    const existingNode = this.dependencyGraph.getNode(downstream);
+    if (existingNode) {
+      // Task already exists in graph
+      return;
+    }
+
+    // Add edge via graph's edge API if available, or log warning
+    this.logger.warn(
+      `addDependency: downstream task ${downstream.toBase58()} not in graph. ` +
+      `Add it via DependencyGraph.addTaskWithParent() first.`
+    );
+  }
+
+  // ==========================================================================
+  // Proof Lifecycle Handlers
+  // ==========================================================================
+
+  /**
+   * Called when a proof is confirmed on-chain.
+   *
+   * Updates metrics and triggers downstream proof submissions.
+   *
+   * @param taskPda - Task account PDA
+   */
+  onProofConfirmed(taskPda: PublicKey): void {
+    this.handleProofConfirmed(taskPda);
+  }
+
+  /**
+   * Called when a proof fails (verification failed, timeout, etc).
+   *
+   * Triggers rollback of all dependent speculative work.
+   *
+   * @param taskPda - Task account PDA
+   * @param reason - Optional reason for failure
+   */
+  onProofFailed(taskPda: PublicKey, reason?: string): void {
+    this.handleProofFailed(taskPda, reason ?? 'proof_failed');
+  }
+
+  /**
+   * Force rollback a specific task.
+   *
+   * @param taskPda - Task account PDA to roll back
+   * @param reason - Reason for rollback
+   * @returns Rollback result
+   */
+  async forceRollback(
+    taskPda: PublicKey,
+    reason: RollbackReason = 'manual'
+  ): Promise<RollbackResult> {
+    return this.rollbackController.rollback(taskPda, reason);
+  }
+
+  // ==========================================================================
+  // Status and Metrics
+  // ==========================================================================
+
+  /**
+   * Gets the current scheduler status.
+   */
+  getStatus(): SpeculativeSchedulerStatus {
+    const stats = this.commitmentLedger.getStats();
+    const deferralStats = this.proofDeferralManager.getStats();
+
+    return {
+      running: this.running,
+      speculationEnabled: this.speculationEnabled,
+      activeSpeculations: this.activeSpeculations.size,
+      maxDepthReached: this.commitmentLedger.getMaxDepth(),
+      currentMaxDepth: this.config.maxSpeculationDepth,
+      totalStakeAtRisk: stats.totalStakeAtRisk,
+      pendingProofs: deferralStats.queued + deferralStats.generating,
+      awaitingAncestors: deferralStats.awaitingAncestors,
+    };
+  }
+
+  /**
+   * Gets speculation metrics.
+   */
+  getMetrics(): SpeculationMetrics {
+    return { ...this.metrics };
+  }
+
+  /**
+   * Gets all active speculative commitments.
+   *
+   * Returns commitments that are not yet confirmed, failed, or rolled back.
+   */
+  getActiveCommitments(): SpeculativeCommitment[] {
+    return this.commitmentLedger.getAllCommitments().filter(
+      (c) =>
+        c.status !== 'confirmed' &&
+        c.status !== 'failed' &&
+        c.status !== 'rolled_back'
+    );
+  }
+
+  /**
+   * Gets all proofs awaiting ancestor confirmation.
+   */
+  getBlockedProofs(): DeferredProof[] {
+    return this.proofDeferralManager.getBlockedProofs();
+  }
+
+  // ==========================================================================
+  // Speculation Control
+  // ==========================================================================
+
+  /**
+   * Enables speculation (if previously disabled).
+   */
+  enableSpeculation(): void {
+    if (!this.speculationEnabled) {
+      this.speculationEnabled = true;
+      this.events.onSpeculationEnabled?.();
+      this.logger.info('Speculation enabled');
+    }
+  }
+
+  /**
+   * Disables speculation.
+   *
+   * @param reason - Reason for disabling
+   */
+  disableSpeculation(reason: string): void {
+    if (this.speculationEnabled) {
+      this.speculationEnabled = false;
+      this.events.onSpeculationDisabled?.(reason);
+      this.logger.warn(`Speculation disabled: ${reason}`);
+    }
+  }
+
+  /**
+   * Checks if speculation is currently enabled.
+   */
+  isSpeculationEnabled(): boolean {
+    return this.speculationEnabled;
+  }
+
+  // ==========================================================================
+  // Component Accessors
+  // ==========================================================================
+
+  /**
+   * Gets the dependency graph.
+   */
+  getDependencyGraph(): DependencyGraph {
+    return this.dependencyGraph;
+  }
+
+  /**
+   * Gets the commitment ledger.
+   */
+  getCommitmentLedger(): CommitmentLedger {
+    return this.commitmentLedger;
+  }
+
+  /**
+   * Gets the proof deferral manager.
+   */
+  getProofDeferralManager(): ProofDeferralManager {
+    return this.proofDeferralManager;
+  }
+
+  /**
+   * Gets the rollback controller.
+   */
+  getRollbackController(): RollbackController {
+    return this.rollbackController;
+  }
+
+  // ==========================================================================
+  // Internal Handlers
+  // ==========================================================================
+
+  private handleProofConfirmed(taskPda: PublicKey): void {
+    const pdaKey = taskPda.toBase58();
+
+    // Update speculation tracking
+    const speculation = this.activeSpeculations.get(pdaKey);
+    if (speculation) {
+      // Calculate time saved (estimated as time from start to now)
+      const timeTaken = Date.now() - speculation.startedAt;
+      this.metrics.estimatedTimeSaved += timeTaken;
+      this.metrics.speculativeHits++;
+
+      this.activeSpeculations.delete(pdaKey);
+    }
+
+    // Update commitment ledger
+    try {
+      this.commitmentLedger.markConfirmed(taskPda);
+    } catch {
+      // Commitment may not exist if task wasn't speculative
+    }
+
+    // Update dependency graph
+    this.dependencyGraph.updateStatus(taskPda, 'completed');
+
+    // Recalculate hit rate
+    this.updateHitRate();
+
+    // Fire event
+    this.events.onSpeculationConfirmed?.(taskPda);
+
+    this.logger.debug(`Proof confirmed for ${pdaKey}`);
+
+    // Notify proof deferral manager to unblock waiting proofs
+    this.proofDeferralManager.onAncestorConfirmed(taskPda);
+  }
+
+  private handleProofFailed(taskPda: PublicKey, reason: string): void {
+    const pdaKey = taskPda.toBase58();
+
+    // Update speculation tracking
+    const speculation = this.activeSpeculations.get(pdaKey);
+    if (speculation) {
+      this.metrics.speculativeMisses++;
+      this.activeSpeculations.delete(pdaKey);
+    }
+
+    // Trigger rollback of all dependents
+    this.rollbackController.rollback(taskPda, 'proof_failed');
+
+    // Notify proof deferral manager to cancel waiting proofs
+    this.proofDeferralManager.onAncestorFailed(taskPda);
+
+    // Recalculate metrics
+    this.updateHitRate();
+    this.updateRollbackRate();
+
+    // Fire event
+    this.events.onSpeculationFailed?.(taskPda, reason);
+
+    this.logger.warn(`Proof failed for ${pdaKey}: ${reason}`);
+  }
+
+  private updateMetricsOnRollback(result: RollbackResult): void {
+    this.metrics.timeWastedOnRollbacks += result.wastedComputeMs;
+    this.updateRollbackRate();
+  }
+
+  private updateHitRate(): void {
+    const total = this.metrics.speculativeHits + this.metrics.speculativeMisses;
+    this.metrics.hitRate =
+      total > 0 ? (this.metrics.speculativeHits / total) * 100 : 0;
+  }
+
+  private updateRollbackRate(): void {
+    const total = this.metrics.speculativeExecutions;
+    this.metrics.rollbackRate =
+      total > 0 ? (this.metrics.speculativeMisses / total) * 100 : 0;
+  }
+}


### PR DESCRIPTION
## Summary
Main orchestrator for speculative execution that ties together all speculation components.

## Changes
- Add `SpeculativeTaskScheduler` class that integrates:
  - DependencyGraph
  - CommitmentLedger
  - ProofDeferralManager
  - RollbackController

- Implement speculation decision policy with:
  - Global enable/disable
  - Dependency type filtering
  - Depth limiting (configurable max speculation depth)
  - Stake limiting (configurable max stake at risk)
  - Private task speculation policy
  - Reputation-based gating
  - Rollback rate auto-disable (circuit breaker)

- Track speculation metrics:
  - Speculative executions count
  - Hits (successful speculations)
  - Misses (rollbacks)
  - Hit rate and rollback rate
  - Estimated time saved / time wasted

- Add comprehensive test suite (47 tests)

## Testing
```bash
npm test -- -t "SpeculativeTaskScheduler"
```

Closes #276
Part of epic #291