### PR TITLE
feat(program): add SpeculativeCommitment account

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -182,3 +182,12 @@ pub struct ProtocolVersionUpdated {
     pub min_supported_version: u8,
     pub timestamp: i64,
 }
+
+#[event]
+pub struct SpeculativeCommitmentCreated {
+    pub task: Pubkey,
+    pub producer: Pubkey,
+    pub result_hash: [u8; 32],
+    pub bonded_stake: u64,
+    pub expires_at: i64,
+}

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -651,3 +651,20 @@ impl TaskEscrow {
         1 +  // is_closed
         1; // bump
 }
+
+/// On-chain record of a speculative commitment
+#[account]
+pub struct SpeculativeCommitment {
+    pub task: Pubkey,
+    pub producer: Pubkey,
+    pub result_hash: [u8; 32],
+    pub confirmed: bool,
+    pub expires_at: i64,
+    pub bonded_stake: u64,
+    pub created_at: i64,
+    pub bump: u8,
+}
+
+impl SpeculativeCommitment {
+    pub const SIZE: usize = 8 + 32 + 32 + 32 + 1 + 8 + 8 + 8 + 1; // 130 bytes
+}


### PR DESCRIPTION
Adds on-chain SpeculativeCommitment account for tracking speculative commitments.

## Changes
- Added `SpeculativeCommitment` account struct to `state.rs`
- Added `SpeculativeCommitmentCreated` event to `events.rs`

Closes #281