### PR TITLE
feat(runtime): add speculation metrics

### DIFF
--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -2675,6 +2675,58 @@
       ]
     },
     {
+      "name": "BondDeposited",
+      "discriminator": [
+        210,
+        149,
+        47,
+        232,
+        72,
+        128,
+        248,
+        153
+      ]
+    },
+    {
+      "name": "BondLocked",
+      "discriminator": [
+        89,
+        45,
+        139,
+        7,
+        22,
+        105,
+        232,
+        59
+      ]
+    },
+    {
+      "name": "BondReleased",
+      "discriminator": [
+        191,
+        161,
+        250,
+        29,
+        188,
+        146,
+        120,
+        251
+      ]
+    },
+    {
+      "name": "BondSlashed",
+      "discriminator": [
+        59,
+        7,
+        252,
+        195,
+        234,
+        156,
+        42,
+        54
+      ]
+    },
+    {
       "name": "DependentTaskCreated",
       "discriminator": [
         82,
@@ -2802,6 +2854,19 @@
         162,
         10,
         30
+      ]
+    },
+    {
+      "name": "SpeculativeCommitmentCreated",
+      "discriminator": [
+        72,
+        69,
+        96,
+        30,
+        161,
+        244,
+        6,
+        183
       ]
     },
     {
@@ -3641,6 +3706,106 @@
               "Bump seed"
             ],
             "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondDeposited",
+      "docs": [
+        "Emitted when bond is deposited to speculation bond account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "new_total",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondLocked",
+      "docs": [
+        "Emitted when bond is locked for a commitment"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondReleased",
+      "docs": [
+        "Emitted when bond is released back to agent after successful proof"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondSlashed",
+      "docs": [
+        "Emitted when an agent's bond is slashed due to failed speculation"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "reason",
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4553,6 +4718,39 @@
           },
           {
             "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpeculativeCommitmentCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "task",
+            "type": "pubkey"
+          },
+          {
+            "name": "producer",
+            "type": "pubkey"
+          },
+          {
+            "name": "result_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "bonded_stake",
+            "type": "u64"
+          },
+          {
+            "name": "expires_at",
             "type": "i64"
           }
         ]

--- a/runtime/src/task/index.ts
+++ b/runtime/src/task/index.ts
@@ -21,3 +21,4 @@ export * from './rollback-controller.js';
 export * from './proof-deferral.js';
 export * from './speculative-scheduler.js';
 export * from './proof-time-estimator.js';
+export * from './speculation-metrics.js';

--- a/runtime/src/task/speculation-metrics.test.ts
+++ b/runtime/src/task/speculation-metrics.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  SpeculationMetricsCollector,
+  SPECULATION_METRIC_NAMES,
+  type SpeculationObservabilityMetrics,
+} from './speculation-metrics.js';
+
+describe('SpeculationMetricsCollector', () => {
+  let collector: SpeculationMetricsCollector;
+
+  beforeEach(() => {
+    collector = new SpeculationMetricsCollector();
+  });
+
+  describe('initial state', () => {
+    it('should initialize with zero values', () => {
+      const metrics = collector.getMetrics();
+
+      expect(metrics.speculationExecutionsTotal).toBe(0);
+      expect(metrics.speculationHitsTotal).toBe(0);
+      expect(metrics.speculationMissesTotal).toBe(0);
+      expect(metrics.speculationRollbacksTotal).toBe(0);
+      expect(metrics.activeSpeculations).toBe(0);
+      expect(metrics.currentMaxDepth).toBe(0);
+      expect(metrics.stakeAtRiskLamports).toBe(0n);
+    });
+
+    it('should return 0 hit rate when no speculations have resolved', () => {
+      expect(collector.getHitRate()).toBe(0);
+    });
+  });
+
+  describe('recordSpeculationStarted', () => {
+    it('should increment executions total and active count', () => {
+      collector.recordSpeculationStarted();
+
+      const metrics = collector.getMetrics();
+      expect(metrics.speculationExecutionsTotal).toBe(1);
+      expect(metrics.activeSpeculations).toBe(1);
+    });
+
+    it('should track multiple started speculations', () => {
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationStarted();
+
+      const metrics = collector.getMetrics();
+      expect(metrics.speculationExecutionsTotal).toBe(3);
+      expect(metrics.activeSpeculations).toBe(3);
+    });
+  });
+
+  describe('recordSpeculationHit', () => {
+    it('should increment hits and decrement active count', () => {
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationHit();
+
+      const metrics = collector.getMetrics();
+      expect(metrics.speculationHitsTotal).toBe(1);
+      expect(metrics.activeSpeculations).toBe(0);
+    });
+  });
+
+  describe('recordSpeculationMiss', () => {
+    it('should increment misses and decrement active count', () => {
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationMiss();
+
+      const metrics = collector.getMetrics();
+      expect(metrics.speculationMissesTotal).toBe(1);
+      expect(metrics.activeSpeculations).toBe(0);
+    });
+  });
+
+  describe('recordRollback', () => {
+    it('should increment rollback counter', () => {
+      collector.recordRollback();
+      collector.recordRollback();
+
+      const metrics = collector.getMetrics();
+      expect(metrics.speculationRollbacksTotal).toBe(2);
+    });
+  });
+
+  describe('updateDepth', () => {
+    it('should track maximum depth', () => {
+      collector.updateDepth(1);
+      expect(collector.getMetrics().currentMaxDepth).toBe(1);
+
+      collector.updateDepth(3);
+      expect(collector.getMetrics().currentMaxDepth).toBe(3);
+
+      collector.updateDepth(2);
+      expect(collector.getMetrics().currentMaxDepth).toBe(3); // Still 3
+    });
+  });
+
+  describe('updateStake', () => {
+    it('should update stake at risk', () => {
+      collector.updateStake(1_000_000n);
+      expect(collector.getMetrics().stakeAtRiskLamports).toBe(1_000_000n);
+
+      collector.updateStake(500_000n);
+      expect(collector.getMetrics().stakeAtRiskLamports).toBe(500_000n);
+    });
+
+    it('should handle large stake values', () => {
+      const largeStake = 1_000_000_000_000_000n; // 1 quadrillion lamports
+      collector.updateStake(largeStake);
+      expect(collector.getMetrics().stakeAtRiskLamports).toBe(largeStake);
+    });
+  });
+
+  describe('getHitRate', () => {
+    it('should calculate hit rate correctly', () => {
+      // 3 hits, 1 miss = 75% hit rate
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationHit();
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationHit();
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationHit();
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationMiss();
+
+      expect(collector.getHitRate()).toBe(0.75);
+    });
+
+    it('should return 1.0 when all speculations hit', () => {
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationHit();
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationHit();
+
+      expect(collector.getHitRate()).toBe(1);
+    });
+
+    it('should return 0 when all speculations miss', () => {
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationMiss();
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationMiss();
+
+      expect(collector.getHitRate()).toBe(0);
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('should return a copy of metrics', () => {
+      collector.recordSpeculationStarted();
+      const metrics1 = collector.getMetrics();
+      const metrics2 = collector.getMetrics();
+
+      expect(metrics1).not.toBe(metrics2); // Different objects
+      expect(metrics1).toEqual(metrics2); // Same values
+    });
+  });
+
+  describe('reset', () => {
+    it('should reset all metrics to initial values', () => {
+      // Populate some metrics
+      collector.recordSpeculationStarted();
+      collector.recordSpeculationHit();
+      collector.recordRollback();
+      collector.updateDepth(5);
+      collector.updateStake(1_000_000n);
+
+      // Reset
+      collector.reset();
+
+      // Verify all zeroed
+      const metrics = collector.getMetrics();
+      expect(metrics.speculationExecutionsTotal).toBe(0);
+      expect(metrics.speculationHitsTotal).toBe(0);
+      expect(metrics.speculationMissesTotal).toBe(0);
+      expect(metrics.speculationRollbacksTotal).toBe(0);
+      expect(metrics.activeSpeculations).toBe(0);
+      expect(metrics.currentMaxDepth).toBe(0);
+      expect(metrics.stakeAtRiskLamports).toBe(0n);
+    });
+  });
+
+  describe('full lifecycle', () => {
+    it('should track a realistic speculation workflow', () => {
+      // Start 5 speculations
+      for (let i = 0; i < 5; i++) {
+        collector.recordSpeculationStarted();
+      }
+      collector.updateDepth(3);
+      collector.updateStake(5_000_000n);
+
+      let metrics = collector.getMetrics();
+      expect(metrics.speculationExecutionsTotal).toBe(5);
+      expect(metrics.activeSpeculations).toBe(5);
+
+      // 3 hit, 2 miss
+      collector.recordSpeculationHit();
+      collector.recordSpeculationHit();
+      collector.recordSpeculationHit();
+      collector.recordSpeculationMiss();
+      collector.recordRollback();
+      collector.recordSpeculationMiss();
+      collector.recordRollback();
+
+      collector.updateStake(0n);
+
+      metrics = collector.getMetrics();
+      expect(metrics.speculationHitsTotal).toBe(3);
+      expect(metrics.speculationMissesTotal).toBe(2);
+      expect(metrics.speculationRollbacksTotal).toBe(2);
+      expect(metrics.activeSpeculations).toBe(0);
+      expect(metrics.currentMaxDepth).toBe(3);
+      expect(metrics.stakeAtRiskLamports).toBe(0n);
+      expect(collector.getHitRate()).toBe(0.6);
+    });
+  });
+});
+
+describe('SPECULATION_METRIC_NAMES', () => {
+  it('should have OpenTelemetry-compatible metric names', () => {
+    expect(SPECULATION_METRIC_NAMES.EXECUTIONS_TOTAL).toBe('agenc.speculation.executions.total');
+    expect(SPECULATION_METRIC_NAMES.HITS_TOTAL).toBe('agenc.speculation.hits.total');
+    expect(SPECULATION_METRIC_NAMES.MISSES_TOTAL).toBe('agenc.speculation.misses.total');
+    expect(SPECULATION_METRIC_NAMES.ROLLBACKS_TOTAL).toBe('agenc.speculation.rollbacks.total');
+    expect(SPECULATION_METRIC_NAMES.ACTIVE_COUNT).toBe('agenc.speculation.active.count');
+    expect(SPECULATION_METRIC_NAMES.MAX_DEPTH).toBe('agenc.speculation.max_depth');
+    expect(SPECULATION_METRIC_NAMES.STAKE_AT_RISK).toBe('agenc.speculation.stake_at_risk_lamports');
+    expect(SPECULATION_METRIC_NAMES.HIT_RATE).toBe('agenc.speculation.hit_rate');
+  });
+});

--- a/runtime/src/task/speculation-metrics.ts
+++ b/runtime/src/task/speculation-metrics.ts
@@ -1,0 +1,188 @@
+/**
+ * Speculation-specific metrics for observability of speculative execution.
+ *
+ * Provides:
+ * - {@link SpeculationObservabilityMetrics}: Interface defining all speculation-related metrics
+ * - {@link SpeculationMetricsCollector}: Collector for tracking speculation performance
+ *
+ * All metric names follow the OpenTelemetry `agenc.speculation.*` naming convention.
+ *
+ * @module
+ */
+
+// ============================================================================
+// Metric name constants (OpenTelemetry-compatible, agenc.speculation.* prefix)
+// ============================================================================
+
+export const SPECULATION_METRIC_NAMES = {
+  EXECUTIONS_TOTAL: 'agenc.speculation.executions.total',
+  HITS_TOTAL: 'agenc.speculation.hits.total',
+  MISSES_TOTAL: 'agenc.speculation.misses.total',
+  ROLLBACKS_TOTAL: 'agenc.speculation.rollbacks.total',
+  ACTIVE_COUNT: 'agenc.speculation.active.count',
+  MAX_DEPTH: 'agenc.speculation.max_depth',
+  STAKE_AT_RISK: 'agenc.speculation.stake_at_risk_lamports',
+  HIT_RATE: 'agenc.speculation.hit_rate',
+} as const;
+
+// ============================================================================
+// SpeculationObservabilityMetrics interface
+// ============================================================================
+
+/**
+ * Metrics interface for speculative execution observability.
+ *
+ * Captures key performance indicators for speculation:
+ * - Execution counts (total, hits, misses, rollbacks)
+ * - Active speculation gauge
+ * - Depth tracking for nested speculation
+ * - Stake exposure monitoring
+ *
+ * This interface is designed for OpenTelemetry integration and external
+ * observability systems, complementing the internal SpeculationMetrics
+ * used by SpeculativeTaskScheduler.
+ */
+export interface SpeculationObservabilityMetrics {
+  /** Total number of speculative executions started. */
+  speculationExecutionsTotal: number;
+  /** Number of speculations that were confirmed (predicted correctly). */
+  speculationHitsTotal: number;
+  /** Number of speculations that were invalidated (predicted incorrectly). */
+  speculationMissesTotal: number;
+  /** Number of rollback operations performed due to speculation failures. */
+  speculationRollbacksTotal: number;
+  /** Current number of active (in-flight) speculations. */
+  activeSpeculations: number;
+  /** Maximum speculation depth observed (for nested speculative execution). */
+  currentMaxDepth: number;
+  /** Total stake at risk across all active speculations (in lamports). */
+  stakeAtRiskLamports: bigint;
+}
+
+// ============================================================================
+// SpeculationMetricsCollector
+// ============================================================================
+
+/**
+ * Collector for speculation-related metrics.
+ *
+ * Tracks speculative execution performance including hit/miss rates,
+ * rollback frequency, speculation depth, and stake exposure.
+ *
+ * @example
+ * ```typescript
+ * const collector = new SpeculationMetricsCollector();
+ *
+ * // Track a speculation lifecycle
+ * collector.recordSpeculationStarted();
+ * collector.updateDepth(2);
+ * collector.updateStake(1_000_000n);
+ *
+ * // Speculation confirmed
+ * collector.recordSpeculationHit();
+ *
+ * // Check performance
+ * console.log(collector.getHitRate()); // 1.0
+ * console.log(collector.getMetrics());
+ * ```
+ */
+export class SpeculationMetricsCollector {
+  private metrics: SpeculationObservabilityMetrics = {
+    speculationExecutionsTotal: 0,
+    speculationHitsTotal: 0,
+    speculationMissesTotal: 0,
+    speculationRollbacksTotal: 0,
+    activeSpeculations: 0,
+    currentMaxDepth: 0,
+    stakeAtRiskLamports: 0n,
+  };
+
+  /**
+   * Record that a new speculation has started.
+   * Increments both the total executions counter and active speculation gauge.
+   */
+  recordSpeculationStarted(): void {
+    this.metrics.speculationExecutionsTotal++;
+    this.metrics.activeSpeculations++;
+  }
+
+  /**
+   * Record that a speculation was confirmed (hit).
+   * Increments the hit counter and decrements the active speculation gauge.
+   */
+  recordSpeculationHit(): void {
+    this.metrics.speculationHitsTotal++;
+    this.metrics.activeSpeculations--;
+  }
+
+  /**
+   * Record that a speculation was invalidated (miss).
+   * Increments the miss counter and decrements the active speculation gauge.
+   */
+  recordSpeculationMiss(): void {
+    this.metrics.speculationMissesTotal++;
+    this.metrics.activeSpeculations--;
+  }
+
+  /**
+   * Record that a rollback operation was performed.
+   * This is typically called when a speculation miss requires state reversal.
+   */
+  recordRollback(): void {
+    this.metrics.speculationRollbacksTotal++;
+  }
+
+  /**
+   * Update the maximum observed speculation depth.
+   * Only updates if the new depth exceeds the current maximum.
+   *
+   * @param depth - The current speculation depth
+   */
+  updateDepth(depth: number): void {
+    this.metrics.currentMaxDepth = Math.max(this.metrics.currentMaxDepth, depth);
+  }
+
+  /**
+   * Update the current stake at risk across all active speculations.
+   *
+   * @param stake - Total stake at risk in lamports
+   */
+  updateStake(stake: bigint): void {
+    this.metrics.stakeAtRiskLamports = stake;
+  }
+
+  /**
+   * Get a snapshot of all current metrics.
+   *
+   * @returns A copy of the current metrics state
+   */
+  getMetrics(): SpeculationObservabilityMetrics {
+    return { ...this.metrics };
+  }
+
+  /**
+   * Calculate the speculation hit rate.
+   *
+   * @returns The ratio of hits to total resolved speculations (0-1), or 0 if no speculations have resolved
+   */
+  getHitRate(): number {
+    const total = this.metrics.speculationHitsTotal + this.metrics.speculationMissesTotal;
+    return total > 0 ? this.metrics.speculationHitsTotal / total : 0;
+  }
+
+  /**
+   * Reset all metrics to their initial values.
+   * Useful for testing or periodic metric resets.
+   */
+  reset(): void {
+    this.metrics = {
+      speculationExecutionsTotal: 0,
+      speculationHitsTotal: 0,
+      speculationMissesTotal: 0,
+      speculationRollbacksTotal: 0,
+      activeSpeculations: 0,
+      currentMaxDepth: 0,
+      stakeAtRiskLamports: 0n,
+    };
+  }
+}

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -2687,6 +2687,58 @@ export type AgencCoordination = {
       ]
     },
     {
+      "name": "bondDeposited",
+      "discriminator": [
+        210,
+        149,
+        47,
+        232,
+        72,
+        128,
+        248,
+        153
+      ]
+    },
+    {
+      "name": "bondLocked",
+      "discriminator": [
+        89,
+        45,
+        139,
+        7,
+        22,
+        105,
+        232,
+        59
+      ]
+    },
+    {
+      "name": "bondReleased",
+      "discriminator": [
+        191,
+        161,
+        250,
+        29,
+        188,
+        146,
+        120,
+        251
+      ]
+    },
+    {
+      "name": "bondSlashed",
+      "discriminator": [
+        59,
+        7,
+        252,
+        195,
+        234,
+        156,
+        42,
+        54
+      ]
+    },
+    {
       "name": "dependentTaskCreated",
       "discriminator": [
         82,
@@ -2814,6 +2866,19 @@ export type AgencCoordination = {
         162,
         10,
         30
+      ]
+    },
+    {
+      "name": "speculativeCommitmentCreated",
+      "discriminator": [
+        72,
+        69,
+        96,
+        30,
+        161,
+        244,
+        6,
+        183
       ]
     },
     {
@@ -3653,6 +3718,106 @@ export type AgencCoordination = {
               "Bump seed"
             ],
             "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "bondDeposited",
+      "docs": [
+        "Emitted when bond is deposited to speculation bond account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "newTotal",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "bondLocked",
+      "docs": [
+        "Emitted when bond is locked for a commitment"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "bondReleased",
+      "docs": [
+        "Emitted when bond is released back to agent after successful proof"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "bondSlashed",
+      "docs": [
+        "Emitted when an agent's bond is slashed due to failed speculation"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "reason",
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4565,6 +4730,39 @@ export type AgencCoordination = {
           },
           {
             "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "speculativeCommitmentCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "task",
+            "type": "pubkey"
+          },
+          {
+            "name": "producer",
+            "type": "pubkey"
+          },
+          {
+            "name": "resultHash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "bondedStake",
+            "type": "u64"
+          },
+          {
+            "name": "expiresAt",
             "type": "i64"
           }
         ]


### PR DESCRIPTION
Adds SpeculationMetricsCollector for observability.

## Changes
- New `SpeculationObservabilityMetrics` interface with OpenTelemetry-compatible metric names
- New `SpeculationMetricsCollector` class for tracking:
  - Speculation execution counts (total, hits, misses, rollbacks)
  - Active speculation gauge
  - Maximum speculation depth
  - Stake at risk tracking
  - Hit rate calculation
- 17 unit tests covering all functionality
- Exported from task module index

Closes #286