### PR TITLE
fix(program): require task participant for dispute initiation

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -158,6 +158,9 @@ pub enum CoordinationError {
     #[msg("Dispute has not been resolved")]
     DisputeNotResolved,
 
+    #[msg("Only task creator or workers can initiate disputes")]
+    NotTaskParticipant,
+
     // State errors (6400-6499)
     #[msg("State version mismatch (concurrent modification)")]
     VersionMismatch,

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -249,6 +249,13 @@ pub mod agenc_coordination {
         instructions::apply_dispute_slash::handler(ctx)
     }
 
+    /// Apply slashing to a dispute initiator when their dispute is rejected.
+    /// This provides symmetric slashing: workers are slashed for bad work,
+    /// initiators are slashed for frivolous disputes.
+    pub fn apply_creator_slash(ctx: Context<ApplyCreatorSlash>) -> Result<()> {
+        instructions::apply_creator_slash::handler(ctx)
+    }
+
     /// Expire a dispute after the maximum duration has passed.
     pub fn expire_dispute(ctx: Context<ExpireDispute>) -> Result<()> {
         instructions::expire_dispute::handler(ctx)

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -579,6 +579,9 @@ impl Dispute {
         8 +  // voting_deadline
         8 +  // expires_at
         1 +  // slash_applied
+        1 +  // initiator_slash_applied
+        8 +  // initiator_bond
+        1 +  // bond_released
         1; // bump
 }
 

--- a/tests/coordination-security.ts
+++ b/tests/coordination-security.ts
@@ -806,7 +806,8 @@ describe("coordination-security", () => {
             protocolConfig: protocolPda,
             resolver: provider.wallet.publicKey,
             creator: creator.publicKey,
-            worker: null,
+            workerAgent: null,
+            workerAuthority: null,
           })
           .remainingAccounts([
             { pubkey: votePda1, isSigner: false, isWritable: false },


### PR DESCRIPTION
## Security Fix

**Severity:** HIGH

**Issue:** Anyone could initiate disputes on any task, enabling griefing attacks.

**Fix:** 
- Add `initiator_claim` optional account to verify worker relationship
- Check that initiator is either task creator OR has a valid TaskClaim
- Add `NotTaskParticipant` error code

**Testing:** Added test verifying unauthorized agents cannot dispute.

Closes #294