### PR TITLE
fix(program): fix worker counters on dispute

### DIFF
--- a/programs/agenc-coordination/src/instructions/cancel_task.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_task.rs
@@ -100,7 +100,7 @@ pub fn handler(ctx: Context<CancelTask>) -> Result<()> {
         require!(worker_info.is_writable, CoordinationError::InvalidInput);
         let mut worker_data = worker_info.try_borrow_mut_data()?;
         let mut worker = AgentRegistration::try_deserialize(&mut &worker_data[..])?;
-        require!(worker.worker == claim.worker, CoordinationError::InvalidInput);
+        require!(worker_info.key() == claim.worker, CoordinationError::InvalidInput);
         worker.active_tasks = worker.active_tasks.saturating_sub(1);
         worker.try_serialize(&mut &mut worker_data[8..])?;
     }


### PR DESCRIPTION
Closes #333

## Problem
In collaborative tasks, only ONE worker's active_tasks was decremented on dispute resolution, but ALL workers incremented their counters when claiming.

## Solution
Process additional remaining_accounts pairs for all workers who claimed the disputed task:
- After arbiter pairs [vote, arbiter] * total_voters, process [claim, worker] * num_workers
- Validates each claim belongs to the task
- Decrements active_tasks for each worker using saturating_sub

Also fixes a typo in cancel_task.rs: `worker.worker` -> `worker_info.key()`