### PR TITLE
fix(program): handle zero-vote dispute resolution

### DIFF
--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -118,23 +118,25 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         drop(worker_data);
     }
 
-    // Calculate total votes and check threshold
+    // Calculate total votes
     let total_votes = dispute
         .votes_for
         .checked_add(dispute.votes_against)
         .ok_or(CoordinationError::ArithmeticOverflow)?;
-    require!(total_votes > 0, CoordinationError::InsufficientVotes);
 
-    // Calculate approval percentage
-    let approval_pct = dispute
-        .votes_for
-        .checked_mul(PERCENT_BASE)
-        .ok_or(CoordinationError::ArithmeticOverflow)?
-        .checked_div(total_votes)
-        .ok_or(CoordinationError::ArithmeticOverflow)? as u8;
-
-    // Determine outcome based on threshold
-    let approved = approval_pct >= config.dispute_threshold;
+    // Determine outcome: if no votes, treat as rejected (refund to creator)
+    // This prevents tasks from being stuck between voting_deadline and expires_at
+    let approved = if total_votes == 0 {
+        false // No votes = dispute rejected
+    } else {
+        let approval_pct = dispute
+            .votes_for
+            .checked_mul(PERCENT_BASE)
+            .ok_or(CoordinationError::ArithmeticOverflow)?
+            .checked_div(total_votes)
+            .ok_or(CoordinationError::ArithmeticOverflow)? as u8;
+        approval_pct >= config.dispute_threshold
+    };
 
     // Calculate remaining escrow funds
     let remaining_funds = escrow


### PR DESCRIPTION
## Summary
When the voting_deadline passes with zero votes, neither `resolve_dispute` (requires votes > 0) nor `expire_dispute` (requires expires_at passed) can execute, leaving tasks stuck in disputed state.

## Changes
- Remove the `require!(total_votes > 0, ...)` check
- Default to rejected (refund to creator) when no arbiters vote
- This prevents tasks from being stuck between voting_deadline and expires_at

## Testing
- `cargo check` passes
- `anchor build` passes

Closes #332