### PR TITLE
fix(program): track protocol fee in escrow accounting

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -130,7 +130,7 @@ pub fn handler(
     )?;
 
     // Update states
-    update_claim_state(claim, escrow, worker_reward, task.reward_amount)?;
+    update_claim_state(claim, escrow, worker_reward, protocol_fee)?;
     let task_completed =
         update_task_state(task, clock.unix_timestamp, escrow, Some(claim_result_data))?;
     update_worker_state(worker, worker_reward, clock.unix_timestamp)?;

--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -203,7 +203,7 @@ pub fn complete_task_private(
         protocol_fee,
     )?;
 
-    update_claim_state(claim, escrow, worker_reward, task.reward_amount)?;
+    update_claim_state(claim, escrow, worker_reward, protocol_fee)?;
     // Pass None for result_data to preserve privacy
     let task_completed = update_task_state(task, clock.unix_timestamp, escrow, None)?;
     update_worker_state(worker, worker_reward, clock.unix_timestamp)?;


### PR DESCRIPTION
## Summary

CRITICAL fix for escrow accounting.

## Problem

`update_claim_state()` only adds `worker_reward` to `escrow.distributed`, but `transfer_rewards()` withdraws BOTH `worker_reward` AND `protocol_fee`. This causes `remaining_funds` to be overestimated in disputes.

## Solution

Modified `update_claim_state` to accept `protocol_fee` parameter and track total withdrawn (worker_reward + protocol_fee) in `escrow.distributed`.

## Changes

- `completion_helpers.rs`: Updated `update_claim_state` to track total withdrawn amount
- `complete_task.rs`: Pass `protocol_fee` instead of `task.reward_amount`
- `complete_task_private.rs`: Pass `protocol_fee` instead of `task.reward_amount`

Closes #337