### PR TITLE
fix(dispute): store initiator wallet for resolver constraint

### DIFF
--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -179,6 +179,7 @@ pub fn handler(
     dispute.dispute_id = dispute_id;
     dispute.task = task.key();
     dispute.initiator = agent.key();
+    dispute.initiator_authority = ctx.accounts.authority.key();
     dispute.evidence_hash = evidence_hash;
     dispute.resolution_type = match resolution_type {
         0 => ResolutionType::Refund,

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -42,7 +42,7 @@ pub struct ResolveDispute<'info> {
 
     #[account(
         constraint = resolver.key() == protocol_config.authority
-            || resolver.key() == dispute.initiator
+            || resolver.key() == dispute.initiator_authority
             @ CoordinationError::UnauthorizedResolver
     )]
     pub resolver: Signer<'info>,

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -535,8 +535,10 @@ pub struct Dispute {
     pub dispute_id: [u8; 32],
     /// Related task
     pub task: Pubkey,
-    /// Initiator
+    /// Initiator (agent PDA)
     pub initiator: Pubkey,
+    /// Initiator's authority wallet (for resolver constraint)
+    pub initiator_authority: Pubkey,
     /// Evidence hash
     pub evidence_hash: [u8; 32],
     /// Proposed resolution type
@@ -570,6 +572,7 @@ impl Dispute {
         32 + // dispute_id
         32 + // task
         32 + // initiator
+        32 + // initiator_authority
         32 + // evidence_hash
         1 +  // resolution_type
         1 +  // status


### PR DESCRIPTION
## Summary
The resolver constraint in `resolve_dispute.rs` was comparing a wallet signer against an agent PDA (`dispute.initiator`), which could never match since PDAs cannot sign transactions.

## Changes
- Add `initiator_authority` field to `Dispute` struct to store the wallet pubkey
- Set `initiator_authority` from `authority.key()` in `initiate_dispute`
- Update resolver constraint to check `initiator_authority` instead of `initiator`
- Update `Dispute::SIZE` constant for the new field (+32 bytes)

## Testing
- `cargo check` passes

Fixes #340