### PR TITLE
fix(program): decrement active_tasks for all workers on dispute resolution

### DIFF
--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -123,19 +123,28 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
     }
 
     // Decrement active_dispute_votes for each arbiter who voted (fix #328)
-    if dispute.total_voters > 0 {
-        let expected = dispute
-            .total_voters
-            .checked_mul(2)
-            .ok_or(CoordinationError::ArithmeticOverflow)? as usize;
-        require!(
-            ctx.remaining_accounts.len() == expected,
-            CoordinationError::InvalidInput
-        );
+    // remaining_accounts format (fix #333):
+    // - First: (vote, arbiter) pairs for total_voters
+    // - Then: optional (claim, worker) pairs for additional workers on collaborative tasks
+    let arbiter_accounts = dispute
+        .total_voters
+        .checked_mul(2)
+        .ok_or(CoordinationError::ArithmeticOverflow)? as usize;
 
-        for i in (0..expected).step_by(2) {
-            let vote_info = &ctx.remaining_accounts[i];
-            let arbiter_info = &ctx.remaining_accounts[i + 1];
+    // Validate we have at least enough accounts for arbiters
+    require!(
+        ctx.remaining_accounts.len() >= arbiter_accounts,
+        CoordinationError::InvalidInput
+    );
+
+    // Additional accounts must come in pairs (claim, worker)
+    let extra_accounts = ctx.remaining_accounts.len() - arbiter_accounts;
+    require!(extra_accounts % 2 == 0, CoordinationError::InvalidInput);
+
+    // Process arbiter (vote, arbiter) pairs
+    for i in (0..arbiter_accounts).step_by(2) {
+        let vote_info = &ctx.remaining_accounts[i];
+        let arbiter_info = &ctx.remaining_accounts[i + 1];
 
             require!(
                 vote_info.owner == &crate::ID,
@@ -164,6 +173,42 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
             arbiter.active_dispute_votes = arbiter.active_dispute_votes.saturating_sub(1);
             arbiter.try_serialize(&mut &mut arbiter_data[8..])?;
         }
+
+    // Process additional worker (claim, worker) pairs to decrement active_tasks (fix #333)
+    // This handles collaborative tasks where multiple workers claimed the task
+    for i in (arbiter_accounts..ctx.remaining_accounts.len()).step_by(2) {
+        let claim_info = &ctx.remaining_accounts[i];
+        let worker_info = &ctx.remaining_accounts[i + 1];
+
+        // Validate account ownership
+        require!(
+            claim_info.owner == &crate::ID,
+            CoordinationError::InvalidAccountOwner
+        );
+        require!(
+            worker_info.owner == &crate::ID,
+            CoordinationError::InvalidAccountOwner
+        );
+
+        // Validate claim belongs to this task
+        let claim_data = claim_info.try_borrow_data()?;
+        let claim = TaskClaim::try_deserialize(&mut &**claim_data)?;
+        require!(
+            claim.task == task.key(),
+            CoordinationError::InvalidInput
+        );
+        require!(
+            claim.worker == worker_info.key(),
+            CoordinationError::InvalidInput
+        );
+        drop(claim_data);
+
+        // Decrement worker's active_tasks
+        require!(worker_info.is_writable, CoordinationError::InvalidInput);
+        let mut worker_data = worker_info.try_borrow_mut_data()?;
+        let mut worker_reg = AgentRegistration::try_deserialize(&mut &**worker_data)?;
+        worker_reg.active_tasks = worker_reg.active_tasks.saturating_sub(1);
+        worker_reg.try_serialize(&mut &mut worker_data[8..])?;
     }
 
     task.status = TaskStatus::Cancelled;


### PR DESCRIPTION
## Summary
Fixes #333 - Worker active_tasks counter corrupted on disputed tasks

## Problem
When resolving/expiring disputes on collaborative tasks, only ONE worker's `active_tasks` counter was decremented, but ALL workers who claimed the task had their counters incremented. This led to workers eventually hitting the `MaxActiveTasksReached` limit (10) and being unable to claim new tasks.

## Solution
Extended `remaining_accounts` format in both `resolve_dispute.rs` and `expire_dispute.rs` to support additional (claim, worker) pairs after the arbiter pairs:

```
remaining_accounts format:
- First: (vote, arbiter) pairs for total_voters
- Then: optional (claim, worker) pairs for additional workers
```

For each additional worker pair:
1. Validate account ownership (must be owned by this program)
2. Validate claim belongs to this task
3. Validate claim.worker matches worker account
4. Decrement worker's `active_tasks` using `saturating_sub(1)`

## Testing
- `cargo check` passes
- Logic mirrors existing arbiter pair processing pattern