### PR TITLE
fix: validate rent_recipient is worker authority in expire_claim

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -109,6 +109,9 @@ pub enum CoordinationError {
     #[msg("Invalid output commitment: output_commitment cannot be all zeros")]
     InvalidOutputCommitment,
 
+    #[msg("Invalid rent recipient: must be worker authority")]
+    InvalidRentRecipient,
+
     // Dispute errors (6300-6399)
     #[msg("Dispute is not active")]
     DisputeNotActive,

--- a/programs/agenc-coordination/src/instructions/expire_claim.rs
+++ b/programs/agenc-coordination/src/instructions/expire_claim.rs
@@ -29,8 +29,11 @@ pub struct ExpireClaim<'info> {
     )]
     pub worker: Account<'info, AgentRegistration>,
 
-    /// CHECK: Receives rent from closed claim account
-    #[account(mut)]
+    /// CHECK: Receives rent from closed claim account - validated to be worker authority
+    #[account(
+        mut,
+        constraint = rent_recipient.key() == worker.authority @ CoordinationError::InvalidRentRecipient
+    )]
     pub rent_recipient: UncheckedAccount<'info>,
 
     pub system_program: Program<'info, System>,


### PR DESCRIPTION
## Summary

Fixes #331

The `rent_recipient` in `expire_claim.rs` was an `UncheckedAccount` with no validation, allowing anyone to direct rent refunds to any account.

## Changes

1. Added constraint to validate `rent_recipient.key() == worker.authority`
2. Added `InvalidRentRecipient` error code to `CoordinationError` enum

## Security Impact

This prevents unauthorized parties from stealing rent refunds when claims expire. The rent from closed claim accounts will now only go to the worker's authority wallet.