### PR TITLE
feat(zk): add nullifier mechanism to prevent proof/knowledge reuse

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -265,4 +265,11 @@ pub enum CoordinationError {
 
     #[msg("Invalid dependency type")]
     InvalidDependencyType,
+
+    // Nullifier errors (7000-7099)
+    #[msg("Nullifier has already been spent - proof/knowledge reuse detected")]
+    NullifierAlreadySpent,
+
+    #[msg("Invalid nullifier: nullifier value cannot be all zeros")]
+    InvalidNullifier,
 }

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -699,3 +699,31 @@ pub struct SpeculativeCommitment {
 impl SpeculativeCommitment {
     pub const SIZE: usize = 8 + 32 + 32 + 32 + 1 + 8 + 8 + 8 + 1; // 130 bytes
 }
+
+/// Nullifier account to prevent proof/knowledge reuse across tasks.
+/// Once a nullifier is "spent" (account exists), the same proof/knowledge
+/// combination cannot be used again.
+/// PDA seeds: ["nullifier", nullifier_value]
+#[account]
+#[derive(Default)]
+pub struct Nullifier {
+    /// The nullifier value (derived from constraint_hash + agent_secret in ZK circuit)
+    pub nullifier_value: [u8; 32],
+    /// The task where this nullifier was first used
+    pub task: Pubkey,
+    /// The agent who spent this nullifier
+    pub agent: Pubkey,
+    /// Timestamp when nullifier was spent
+    pub spent_at: i64,
+    /// Bump seed for PDA
+    pub bump: u8,
+}
+
+impl Nullifier {
+    pub const SIZE: usize = 8 +  // discriminator
+        32 + // nullifier_value
+        32 + // task
+        32 + // agent
+        8 +  // spent_at
+        1;   // bump
+}


### PR DESCRIPTION
## Summary

Implements a nullifier mechanism for the ZK proof system to prevent proof/knowledge reuse across tasks.

## Problem

The ZK proof system lacked a nullifier mechanism. This meant that if two tasks had the same `constraint_hash` (expecting the same output), an agent could potentially reuse a proof from one task to complete another task they hadn't actually worked on.

## Solution

### Circuit Changes (`circuits-circom/task_completion/circuit.circom`)

- Added `signal input agent_secret` (private input) - a secret known only to the agent
- Added `signal output nullifier` - the nullifier value exposed as public output
- Computes: `nullifier = Poseidon(constraint_hash, agent_secret)`

### On-chain Changes (`programs/agenc-coordination/`)

**state.rs:**
- Added `Nullifier` account type with PDA seeds `["nullifier", nullifier_value]`
- Stores: nullifier_value, task, agent, spent_at timestamp, bump

**complete_task_private.rs:**
- Updated `PrivateCompletionProof` struct to include `nullifier` field
- Updated `PUBLIC_INPUTS_COUNT` from 67 to 68
- Added nullifier to `build_public_inputs()` function
- Added `nullifier_account` to `CompleteTaskPrivate` context with `init` constraint
- Initializes nullifier account on successful proof verification
- Added validation to reject zero-value nullifiers

**errors.rs:**
- Added `InvalidNullifier` error code

## Security Model

1. The nullifier is derived from `constraint_hash + agent_secret` inside the ZK circuit
2. Each unique (constraint, agent_secret) pair produces a unique nullifier
3. Anchor's `init` constraint automatically rejects if the PDA already exists
4. This prevents proof replay even when multiple tasks share the same `constraint_hash`

## Testing

- [x] `cargo check` passes

## Note on Verifying Key

After circuit changes are compiled with `circom`, the verifying key will need to be regenerated and updated in `verifying_key.rs`. This PR implements the on-chain infrastructure to be ready when the circuit is compiled.

Fixes #336