### PR TITLE
fix(dispute): compare task.creator with authority wallet, not agent PDA

### DIFF
--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -91,7 +91,8 @@ pub fn handler(
     );
 
     // Verify initiator is task participant (creator or has claim)
-    let is_creator = task.creator == agent.key();
+    // Compare task.creator (wallet) with authority (signer's wallet), not agent PDA
+    let is_creator = task.creator == ctx.accounts.authority.key();
     let has_claim = ctx.accounts.initiator_claim.is_some();
 
     require!(


### PR DESCRIPTION
## Summary

The `is_creator` check in `initiate_dispute.rs` was comparing `task.creator` (a wallet pubkey) against `agent.key()` (a PDA), which could **never** match. This made it impossible for task creators to initiate disputes on their own tasks.

## Changes

Fixed by comparing `task.creator` with `ctx.accounts.authority.key()` (the signer's wallet address), matching the pattern used in `cancel_task.rs`.

## Testing

- `cargo check` passes

Fixes #368