### PR TITLE
Fix: Add validation to prevent zero agent_id registration

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -26,6 +26,9 @@ pub enum CoordinationError {
     #[msg("Only the agent authority can perform this action")]
     UnauthorizedAgent,
 
+    #[msg("Invalid agent ID: agent_id cannot be all zeros")]
+    InvalidAgentId,
+
     #[msg("Agent registration required to create tasks")]
     AgentRegistrationRequired,
 

--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -39,6 +39,11 @@ pub fn handler(
     metadata_uri: Option<String>,
     stake_amount: u64,
 ) -> Result<()> {
+    require!(
+        agent_id != [0u8; 32],
+        CoordinationError::InvalidAgentId
+    );
+
     require!(endpoint.len() <= 128, CoordinationError::StringTooLong);
 
     let metadata = metadata_uri.unwrap_or_default();


### PR DESCRIPTION
## Summary
Adds validation to prevent agents from registering with `agent_id = [0u8; 32]` which could cause PDA collision issues.

## Changes
- Added `InvalidAgentId` error variant to `errors.rs`
- Added `require!` check in `register_agent.rs` handler to reject zero agent_id

## Testing
- `cargo check` passes

Fixes #360