### PR TITLE
Add validation for task creation parameters

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -69,6 +69,15 @@ pub enum CoordinationError {
     #[msg("Invalid creator")]
     InvalidCreator,
 
+    #[msg("Invalid task ID: cannot be zero")]
+    InvalidTaskId,
+
+    #[msg("Invalid description: cannot be empty")]
+    InvalidDescription,
+
+    #[msg("Invalid max workers: must be between 1 and 100")]
+    InvalidMaxWorkers,
+
     #[msg("Invalid task type")]
     InvalidTaskType,
 

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -78,7 +78,12 @@ pub fn handler(
     constraint_hash: Option<[u8; 32]>,
     dependency_type: u8,
 ) -> Result<()> {
-    require!(max_workers > 0, CoordinationError::InvalidInput);
+    // Validate task_id is not zero (#367)
+    require!(task_id != [0u8; 32], CoordinationError::InvalidTaskId);
+    // Validate description is not empty (#369)
+    require!(description != [0u8; 64], CoordinationError::InvalidDescription);
+    // Validate max_workers bounds (#412)
+    require!(max_workers > 0 && max_workers <= 100, CoordinationError::InvalidMaxWorkers);
     require!(task_type <= 2, CoordinationError::InvalidTaskType);
     require!(
         dependency_type >= 1 && dependency_type <= 3,

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -68,7 +68,12 @@ pub fn handler(
     task_type: u8,
     constraint_hash: Option<[u8; 32]>,
 ) -> Result<()> {
-    require!(max_workers > 0, CoordinationError::InvalidInput);
+    // Validate task_id is not zero (#367)
+    require!(task_id != [0u8; 32], CoordinationError::InvalidTaskId);
+    // Validate description is not empty (#369)
+    require!(description != [0u8; 64], CoordinationError::InvalidDescription);
+    // Validate max_workers bounds (#412)
+    require!(max_workers > 0 && max_workers <= 100, CoordinationError::InvalidMaxWorkers);
     require!(task_type <= 2, CoordinationError::InvalidTaskType);
 
     let clock = Clock::get()?;


### PR DESCRIPTION
## Summary
Adds missing validation to task creation instructions to reject invalid inputs.

## Changes
- Reject zero `task_id` in both `create_task` and `create_dependent_task`
- Reject empty `description` (all zeros)
- Enforce `max_workers` upper bound of 100

## New Error Codes
- `InvalidTaskId` - Task ID cannot be all zeros
- `InvalidDescription` - Description cannot be empty
- `InvalidMaxWorkers` - Max workers must be between 1 and 100

## Issues Fixed
Fixes #367
Fixes #369
Fixes #412

## Testing
- `cargo check` passes