### PR TITLE
fix(complete_task_private): add deadline enforcement

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -166,6 +166,12 @@ pub fn complete_task_private(
     let nullifier_account = &mut ctx.accounts.nullifier_account;
     let clock = Clock::get()?;
 
+    // Deadline check (issue #384)
+    require!(
+        task.deadline == 0 || clock.unix_timestamp <= task.deadline,
+        CoordinationError::DeadlinePassed
+    );
+
     check_version_compatible(&ctx.accounts.protocol_config)?;
 
     require!(


### PR DESCRIPTION
## Summary

Adds deadline enforcement to `complete_task_private.rs`, matching the existing check in `complete_task.rs`.

## Changes

- Added deadline check after getting clock in the handler function:
  - Tasks with `deadline == 0` are allowed (no deadline)
  - Tasks with a deadline are rejected if `clock.unix_timestamp > task.deadline`

## Testing

- `cargo check` passes

Fixes #384