### PR TITLE
Add close constraint to escrow in dispute resolution

### DIFF
--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -28,6 +28,7 @@ pub struct ExpireDispute<'info> {
 
     #[account(
         mut,
+        close = creator,
         seeds = [b"escrow", task.key().as_ref()],
         bump = escrow.bump
     )]

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -29,6 +29,7 @@ pub struct ResolveDispute<'info> {
 
     #[account(
         mut,
+        close = creator,
         seeds = [b"escrow", task.key().as_ref()],
         bump = escrow.bump
     )]


### PR DESCRIPTION
## Summary
Adds `close = creator` constraint to escrow accounts in:
- `resolve_dispute.rs`
- `expire_dispute.rs`

This ensures the escrow PDA is closed after dispute resolution (whether resolved or expired), returning rent lamports to the task creator.

## Changes
- Added `close = creator` to escrow account constraint in `ResolveDispute`
- Added `close = creator` to escrow account constraint in `ExpireDispute`

Fixes #372