### PR TITLE
Add zero evidence_hash validation to initiate_dispute

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -179,6 +179,9 @@ pub enum CoordinationError {
     #[msg("Only task creator or workers can initiate disputes")]
     NotTaskParticipant,
 
+    #[msg("Invalid evidence hash: cannot be all zeros")]
+    InvalidEvidenceHash,
+
     // State errors (6400-6499)
     #[msg("State version mismatch (concurrent modification)")]
     VersionMismatch,

--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -103,6 +103,12 @@ pub fn handler(
     // Validate resolution type
     require!(resolution_type <= 2, CoordinationError::InvalidInput);
 
+    // Validate evidence hash is not zero
+    require!(
+        evidence_hash != [0u8; 32],
+        CoordinationError::InvalidEvidenceHash
+    );
+
     let evidence_len = evidence.len();
     require!(evidence_len >= 50, CoordinationError::InsufficientEvidence);
     require!(evidence_len <= 1000, CoordinationError::EvidenceTooLong);


### PR DESCRIPTION
## Summary

Adds validation to reject disputes with zero evidence hash (all zeros).

## Changes

- Added `InvalidEvidenceHash` error variant to `CoordinationError` enum in `errors.rs`
- Added validation in `initiate_dispute.rs` handler:
  ```rust
  require!(
      evidence_hash != [0u8; 32],
      CoordinationError::InvalidEvidenceHash
  );
  ```

## Testing

- `cargo check` passes

Fixes #378