### PR TITLE
fix(slash): transfer lamports to treasury on slash

### DIFF
--- a/programs/agenc-coordination/src/instructions/apply_initiator_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_initiator_slash.rs
@@ -27,6 +27,13 @@ pub struct ApplyInitiatorSlash<'info> {
         bump = protocol_config.bump
     )]
     pub protocol_config: Account<'info, ProtocolConfig>,
+
+    /// CHECK: Treasury account to receive slashed lamports
+    #[account(
+        mut,
+        constraint = treasury.key() == protocol_config.treasury @ CoordinationError::InvalidInput
+    )]
+    pub treasury: UncheckedAccount<'info>,
 }
 
 pub fn handler(ctx: Context<ApplyInitiatorSlash>) -> Result<()> {
@@ -83,6 +90,20 @@ pub fn handler(ctx: Context<ApplyInitiatorSlash>) -> Result<()> {
         initiator_agent.stake = initiator_agent
             .stake
             .checked_sub(slash_amount)
+            .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+        // Fix #374: Actually transfer lamports to treasury
+        let initiator_agent_info = ctx.accounts.initiator_agent.to_account_info();
+        let treasury_info = ctx.accounts.treasury.to_account_info();
+
+        **initiator_agent_info.try_borrow_mut_lamports()? = initiator_agent_info
+            .lamports()
+            .checked_sub(slash_amount)
+            .ok_or(CoordinationError::InsufficientFunds)?;
+
+        **treasury_info.try_borrow_mut_lamports()? = treasury_info
+            .lamports()
+            .checked_add(slash_amount)
             .ok_or(CoordinationError::ArithmeticOverflow)?;
     }
 


### PR DESCRIPTION
## Summary
Fixes #374

The slashing mechanism was broken - it only decremented the `agent.stake` field but never transferred actual lamports. This meant slashed agents could recover all their lamports on deregister.

## The Bug
- `apply_dispute_slash` and `apply_initiator_slash` only decremented `agent.stake`
- No lamports were transferred from the agent account to the treasury
- On deregister, agent could withdraw ALL lamports including the "slashed" amount

## The Fix
- Added `treasury` account (mutable, validated against `protocol_config.treasury`) to both slash instructions
- After decrementing stake, actually transfer the lamports from agent account to treasury

## Changes
- `apply_dispute_slash.rs`: Added treasury account + lamport transfer
- `apply_initiator_slash.rs`: Added treasury account + lamport transfer

## Testing
- `cargo check` passes