### PR TITLE
fix: add close constraint to claim in complete_task_private

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -96,6 +96,7 @@ pub struct CompleteTaskPrivate<'info> {
 
     #[account(
         mut,
+        close = authority,
         seeds = [b"claim", task.key().as_ref(), worker.key().as_ref()],
         bump = claim.bump,
         constraint = claim.task == task.key() @ CoordinationError::NotClaimed


### PR DESCRIPTION
## Summary
Add `close = authority` constraint to the claim account in `complete_task_private` instruction.

## Changes
- Add `close = authority` to close the claim PDA when task completion is processed
- Returns rent lamports to the authority when the claim account is closed

## Testing
- `cargo check` passes

Fixes #403