### PR TITLE
fix: require all worker accounts when cancelling task

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -302,4 +302,8 @@ pub enum CoordinationError {
 
     #[msg("Invalid nullifier: nullifier value cannot be all zeros")]
     InvalidNullifier,
+
+    // Cancel task errors (7100-7199)
+    #[msg("All worker accounts must be provided when cancelling a task with active claims")]
+    IncompleteWorkerAccounts,
 }

--- a/programs/agenc-coordination/src/instructions/cancel_task.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_task.rs
@@ -108,5 +108,11 @@ pub fn handler(ctx: Context<CancelTask>) -> Result<()> {
         worker.try_serialize(&mut &mut worker_data[8..])?;
     }
 
+    // Validate all workers were provided
+    require!(
+        num_pairs == task.current_workers as usize,
+        CoordinationError::IncompleteWorkerAccounts
+    );
+
     Ok(())
 }


### PR DESCRIPTION
## Summary
Adds validation that all worker accounts are provided when cancelling a task with active claims.

## Changes
- Added `IncompleteWorkerAccounts` error to errors.rs
- Added validation in `cancel_task` that `num_pairs == task.current_workers`

This prevents partial worker processing which could leave some workers' `active_tasks` counters inconsistent.

Fixes #397