### PR TITLE
fix: Prevent arbiter from voting on own dispute

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -185,6 +185,9 @@ pub enum CoordinationError {
     #[msg("Invalid evidence hash: cannot be all zeros")]
     InvalidEvidenceHash,
 
+    #[msg("Arbiter cannot vote on disputes they are a participant in")]
+    ArbiterIsDisputeParticipant,
+
     // State errors (6400-6499)
     #[msg("State version mismatch (concurrent modification)")]
     VersionMismatch,

--- a/programs/agenc-coordination/src/instructions/vote_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/vote_dispute.rs
@@ -67,6 +67,12 @@ pub fn handler(ctx: Context<VoteDispute>, approve: bool) -> Result<()> {
 
     check_version_compatible(config)?;
 
+    // Verify arbiter is not a dispute participant (fix #391)
+    require!(
+        dispute.initiator != arbiter.key(),
+        CoordinationError::ArbiterIsDisputeParticipant
+    );
+
     // Verify dispute is active
     require!(
         dispute.status == DisputeStatus::Active,


### PR DESCRIPTION
## Summary
Fixes #391

Adds a check in `vote_dispute` handler to ensure the arbiter is not the dispute initiator. This prevents conflicts of interest where someone could vote on disputes they initiated.

## Changes
- Added `ArbiterIsDisputeParticipant` error variant to `errors.rs`
- Added check in `vote_dispute.rs` that `dispute.initiator != arbiter.key()`

## Testing
- `cargo check` passes