### PR TITLE
fix: reset current_workers to 0 on task cancel

### DIFF
--- a/programs/agenc-coordination/src/instructions/cancel_task.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_task.rs
@@ -114,5 +114,8 @@ pub fn handler(ctx: Context<CancelTask>) -> Result<()> {
         CoordinationError::IncompleteWorkerAccounts
     );
 
+    // Reset current_workers since all workers are removed on cancel
+    task.current_workers = 0;
+
     Ok(())
 }


### PR DESCRIPTION
After processing all worker claims during cancellation, the task's current_workers counter was not being reset. This could cause stale data if the task account was queried after cancellation.

Fixes #422