### PR TITLE
fix: prevent duplicate arbiters in remaining_accounts

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -309,4 +309,8 @@ pub enum CoordinationError {
     // Cancel task errors (7100-7199)
     #[msg("All worker accounts must be provided when cancelling a task with active claims")]
     IncompleteWorkerAccounts,
+
+    // Duplicate account errors (7200-7299)
+    #[msg("Duplicate arbiter provided in remaining_accounts")]
+    DuplicateArbiter,
 }


### PR DESCRIPTION
## Summary
Fixes #583

## Problem
The same arbiter could be included multiple times in `remaining_accounts` in `resolve_dispute.rs` and `expire_dispute.rs`. This could incorrectly decrement their `active_dispute_votes` counter multiple times, corrupting arbiter state.

## Solution
- Added `DuplicateArbiter` error variant to `errors.rs`
- Added `HashSet`-based duplicate detection in both handlers before processing arbiters
- The check runs before any arbiter processing, rejecting the transaction if duplicates are detected

## Changes
- `programs/agenc-coordination/src/errors.rs`: Added `DuplicateArbiter` error
- `programs/agenc-coordination/src/instructions/resolve_dispute.rs`: Added HashSet import and duplicate arbiter check  
- `programs/agenc-coordination/src/instructions/expire_dispute.rs`: Added HashSet import and duplicate arbiter check

## Testing
- `cargo check` passes