### PR TITLE
fix(resolve_dispute): add minimum quorum for dispute resolution

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -188,6 +188,9 @@ pub enum CoordinationError {
     #[msg("Arbiter cannot vote on disputes they are a participant in")]
     ArbiterIsDisputeParticipant,
 
+    #[msg("Insufficient quorum: minimum number of voters not reached")]
+    InsufficientQuorum,
+
     // State errors (6400-6499)
     #[msg("State version mismatch (concurrent modification)")]
     VersionMismatch,

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -125,6 +125,14 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         .checked_add(dispute.votes_against)
         .ok_or(CoordinationError::ArithmeticOverflow)?;
 
+    // Require minimum quorum for dispute resolution (fix #546)
+    // A single arbiter should not be able to unilaterally decide outcomes
+    const MIN_VOTERS_FOR_RESOLUTION: u8 = 3;
+    require!(
+        dispute.total_voters >= MIN_VOTERS_FOR_RESOLUTION,
+        CoordinationError::InsufficientQuorum
+    );
+
     // Determine outcome: if no votes, treat as rejected (refund to creator)
     // This prevents tasks from being stuck between voting_deadline and expires_at
     let approved = if total_votes == 0 {


### PR DESCRIPTION
## Summary
A single arbiter should not be able to unilaterally decide dispute outcomes. This adds a minimum voter requirement before a dispute can be resolved.

## Changes
- Added `InsufficientQuorum` error to `errors.rs`
- Added minimum quorum check (3 voters) in `resolve_dispute.rs` before processing resolution

## Testing
- `cargo check` passes

Closes #546