### PR TITLE
fix(cancel_task): use checked_add for lamport addition

### DIFF
--- a/programs/agenc-coordination/src/instructions/cancel_task.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_task.rs
@@ -57,11 +57,11 @@ pub fn handler(ctx: Context<CancelTask>) -> Result<()> {
     // Transfer refund to creator
     if refund_amount > 0 {
         **escrow.to_account_info().try_borrow_mut_lamports()? -= refund_amount;
-        **ctx
-            .accounts
-            .creator
-            .to_account_info()
-            .try_borrow_mut_lamports()? += refund_amount;
+        let creator_info = ctx.accounts.creator.to_account_info();
+        **creator_info.try_borrow_mut_lamports()? = creator_info
+            .lamports()
+            .checked_add(refund_amount)
+            .ok_or(CoordinationError::ArithmeticOverflow)?;
     }
 
     // Update task status


### PR DESCRIPTION
## Summary
Replace unchecked `+=` lamport addition with `checked_add` in cancel_task.rs to prevent potential arithmetic overflow.

## Changes
- Use `checked_add` instead of `+=` for adding refund amount to creator's lamports
- Return `CoordinationError::ArithmeticOverflow` if addition would overflow

## Testing
- `cargo check` passes

Fixes #370