### PR TITLE
fix: use voting_deadline for dispute expiration check

### DIFF
--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -74,8 +74,10 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
         dispute.status == DisputeStatus::Active,
         CoordinationError::DisputeNotActive
     );
+    // Allow expiration after voting deadline to close gap where funds are stuck
+    // (voting_deadline < current_time < expires_at). Fixes #574
     require!(
-        clock.unix_timestamp > dispute.expires_at,
+        clock.unix_timestamp > dispute.voting_deadline,
         CoordinationError::DisputeNotExpired
     );
 


### PR DESCRIPTION
## Summary
Fixes #574: Dispute deadline gap vulnerability

## Problem
There was a gap between `voting_deadline` and `expires_at` where neither vote nor expire works:
- If `voting_deadline < current_time < expires_at`, users can't vote (deadline passed) and can't expire (not yet expired)
- This caused funds to be stuck

## Solution
Changed the expiration check in `expire_dispute.rs` to use `voting_deadline` instead of `expires_at`:
```rust
// Old: require!(clock.unix_timestamp > dispute.expires_at, ...)
// New: allow expiration after voting deadline
require!(
    clock.unix_timestamp > dispute.voting_deadline,
    CoordinationError::DisputeNotExpired
);
```

This allows expiration to occur as soon as the voting deadline passes, closing the gap.

## Testing
- `cargo check` passes