### PR TITLE
fix(dispute): allow expire when voting_deadline passed

### DIFF
--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -74,8 +74,13 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
         dispute.status == DisputeStatus::Active,
         CoordinationError::DisputeNotActive
     );
+
+    // Fix #574: Allow expiration when EITHER expires_at OR voting_deadline has passed.
+    // This closes the gap between voting_deadline and expires_at where disputes
+    // could get stuck with funds locked if no one called resolve_dispute.
     require!(
-        clock.unix_timestamp > dispute.expires_at,
+        clock.unix_timestamp > dispute.expires_at
+            || clock.unix_timestamp >= dispute.voting_deadline,
         CoordinationError::DisputeNotExpired
     );
 


### PR DESCRIPTION
## Summary

Fixes #574

## Problem

There's a gap between `voting_deadline` and `expires_at` where disputes can be stuck. If voting ends but nobody calls `resolve_dispute`, funds remain locked until `expires_at` because `expire_dispute` only checked `expires_at`.

## Solution

Modified the expiration check in `expire_dispute.rs` to allow expiration when EITHER:
- `expires_at` has passed (existing behavior), OR  
- `voting_deadline` has passed

This ensures that once voting ends, the dispute can always be finalized (via either `resolve_dispute` or `expire_dispute`), preventing funds from being stuck in the gap window.

## Changes

- `programs/agenc-coordination/src/instructions/expire_dispute.rs`: Updated timestamp check to use OR condition with `voting_deadline`

## Testing

- `cargo check` passes