### PR TITLE
Prevent expired claim from initiating dispute

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -109,6 +109,9 @@ pub enum CoordinationError {
     #[msg("Claim has not expired yet")]
     ClaimNotExpired,
 
+    #[msg("Claim has expired")]
+    ClaimExpired,
+
     #[msg("Invalid proof of work")]
     InvalidProof,
 

--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -100,6 +100,14 @@ pub fn handler(
         CoordinationError::NotTaskParticipant
     );
 
+    // If initiator has a claim, verify it hasn't expired
+    if let Some(claim) = &ctx.accounts.initiator_claim {
+        require!(
+            claim.expires_at > clock.unix_timestamp,
+            CoordinationError::ClaimExpired
+        );
+    }
+
     // Validate resolution type
     require!(resolution_type <= 2, CoordinationError::InvalidInput);
 


### PR DESCRIPTION
## Summary
Add validation check to reject dispute initiation when the initiator's claim has expired. Workers with expired claims should not be able to initiate disputes.

## Changes
- Add `ClaimExpired` error to `CoordinationError` enum
- Add `expires_at` validation in `initiate_dispute` handler after verifying initiator has a claim

## Testing
- `cargo check` passes

Fixes #527