### PR TITLE
fix: enforce proof dependency verification before task completion

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -302,6 +302,12 @@ pub enum CoordinationError {
     #[msg("Invalid dependency type")]
     InvalidDependencyType,
 
+    #[msg("Parent task must be completed before completing a proof-dependent task")]
+    ParentTaskNotCompleted,
+
+    #[msg("Parent task account required for proof-dependent task completion")]
+    ParentTaskAccountRequired,
+
     // Nullifier errors (7000-7099)
     #[msg("Nullifier has already been spent - proof/knowledge reuse detected")]
     NullifierAlreadySpent,


### PR DESCRIPTION
## Summary
For tasks with `DependencyType::Proof`, require the parent task to be completed before allowing completion. This prevents workers from completing dependent tasks speculatively when on-chain proof is required.

## Changes
- Add `ParentTaskNotCompleted` and `ParentTaskAccountRequired` errors to `CoordinationError`
- Add parent task verification in `complete_task` handler:
  - Check if task has `DependencyType::Proof`
  - Require parent task account in `remaining_accounts`
  - Validate parent account key matches `task.depends_on`
  - Validate parent account is owned by the program
  - Deserialize parent task and verify `status == TaskStatus::Completed`

## Testing
- `cargo check` passes

Closes #536