### PR TITLE
fix(errors): add missing error variants from PR #612

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -197,6 +197,12 @@ pub enum CoordinationError {
     #[msg("Agent has active disputes as defendant and cannot deregister")]
     ActiveDisputesExist,
 
+    #[msg("Worker agent account required when creator initiates dispute")]
+    WorkerAgentRequired,
+
+    #[msg("Worker claim account required when creator initiates dispute")]
+    WorkerClaimRequired,
+
     // State errors (6400-6499)
     #[msg("State version mismatch (concurrent modification)")]
     VersionMismatch,


### PR DESCRIPTION
Hotfix: PR #612 used WorkerAgentRequired and WorkerClaimRequired error variants but didn't define them. This restores main to a compilable state.