### PR TITLE
fix(apply_dispute_slash): validate worker involvement in dispute

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -203,6 +203,9 @@ pub enum CoordinationError {
     #[msg("Worker claim account required when creator initiates dispute")]
     WorkerClaimRequired,
 
+    #[msg("Worker was not involved in this dispute")]
+    WorkerNotInDispute,
+
     // State errors (6400-6499)
     #[msg("State version mismatch (concurrent modification)")]
     VersionMismatch,

--- a/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
@@ -59,6 +59,14 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
 
     check_version_compatible(config)?;
 
+    // Verify the worker was actually part of this disputed task
+    // Check that worker has/had a claim on the task
+    require!(
+        ctx.accounts.worker_claim.task == dispute.task
+            && ctx.accounts.worker_claim.worker == worker_agent.key(),
+        CoordinationError::WorkerNotInDispute
+    );
+
     require!(
         dispute.status == DisputeStatus::Resolved,
         CoordinationError::DisputeNotResolved


### PR DESCRIPTION
## Summary
Add validation that the worker being slashed was actually involved in the disputed task.

## Changes
- Add check in `apply_dispute_slash` that verifies:
  - The worker's claim is for the disputed task (`worker_claim.task == dispute.task`)
  - The worker agent matches the claim's worker (`worker_claim.worker == worker_agent.key()`)
- Add `WorkerNotInDispute` error variant for when the validation fails

## Why
Without this validation, it was theoretically possible to pass in a worker_claim for a worker who wasn't actually involved in the dispute, potentially allowing slashing of the wrong worker.

Fixes #569