### PR TITLE
fix(vote_dispute): update arbiter last_active on voting

### DIFF
--- a/programs/agenc-coordination/src/instructions/vote_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/vote_dispute.rs
@@ -139,6 +139,7 @@ pub fn handler(ctx: Context<VoteDispute>, approve: bool) -> Result<()> {
         .checked_add(1)
         .ok_or(CoordinationError::ArithmeticOverflow)?;
     arbiter.last_vote_timestamp = clock.unix_timestamp;
+    arbiter.last_active = clock.unix_timestamp;
 
     emit!(DisputeVoteCast {
         dispute_id: dispute.dispute_id,


### PR DESCRIPTION
## Summary
Updates `arbiter.last_active` timestamp when an arbiter casts a vote on a dispute, ensuring activity tracking remains accurate.

## Changes
- Added `arbiter.last_active = clock.unix_timestamp;` after updating `last_vote_timestamp` in vote_dispute handler

## Testing
- `cargo check` passes

Fixes #576