### PR TITLE
fix: prevent workers with completed claims from initiating disputes

### DIFF
--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -106,8 +106,13 @@ pub fn handler(
         CoordinationError::NotTaskParticipant
     );
 
-    // If initiator has a claim, verify it hasn't expired
+    // If initiator has a claim, verify it's still valid for dispute
     if let Some(claim) = &ctx.accounts.initiator_claim {
+        // Workers with completed claims cannot dispute - they already got paid
+        require!(
+            !claim.is_completed,
+            CoordinationError::ClaimAlreadyCompleted
+        );
         require!(
             claim.expires_at > clock.unix_timestamp,
             CoordinationError::ClaimExpired


### PR DESCRIPTION
## Summary
Workers who have already completed their claim and received payment should not be able to initiate disputes. This prevents potential abuse where a worker collects payment then tries to dispute.

## Changes
- Added `ClaimAlreadyCompleted` check in `initiate_dispute.rs` before the `expires_at` check
- Reuses existing `CoordinationError::ClaimAlreadyCompleted` error (already defined in errors.rs)

## Testing
- `cargo check` passes

Fixes #577