### PR TITLE
Fix #568: Validate escrow balance before reward transfer

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -337,4 +337,8 @@ pub enum CoordinationError {
     // Duplicate account errors (7200-7299)
     #[msg("Duplicate arbiter provided in remaining_accounts")]
     DuplicateArbiter,
+
+    // Escrow errors (7300-7399)
+    #[msg("Escrow has insufficient balance for reward transfer")]
+    InsufficientEscrowBalance,
 }


### PR DESCRIPTION
## Summary
Adds a safety check to verify the escrow account has sufficient balance before attempting reward transfers in `complete_task`.

## Changes
- Added `InsufficientEscrowBalance` error variant to `errors.rs`
- Added balance validation before `transfer_rewards()` in `complete_task.rs`

The check uses safe arithmetic (`checked_add`) to calculate the total transfer amount (worker reward + protocol fee) and verifies the escrow has enough lamports.

Fixes #568