### PR TITLE
fix: add 1-hour buffer to claim expiration past deadline

### DIFF
--- a/programs/agenc-coordination/src/instructions/claim_task.rs
+++ b/programs/agenc-coordination/src/instructions/claim_task.rs
@@ -92,8 +92,12 @@ pub fn handler(ctx: Context<ClaimTask>) -> Result<()> {
     );
 
     // Calculate claim expiration
+    // Add buffer past deadline so workers can complete and submit proof
+    const COMPLETION_BUFFER: i64 = 3600; // 1 hour buffer
     let expires_at = if task.deadline > 0 {
         task.deadline
+            .checked_add(COMPLETION_BUFFER)
+            .ok_or(CoordinationError::ArithmeticOverflow)?
     } else {
         clock
             .unix_timestamp


### PR DESCRIPTION
Fixes #562

Workers need time to complete and submit proof after the task deadline.
This adds a COMPLETION_BUFFER constant (3600 seconds = 1 hour) that extends claim expiration past the task deadline.

## Changes
- Added `COMPLETION_BUFFER` constant (3600 seconds = 1 hour)
- Modified claim expiration calculation to add buffer when task has a deadline
- Uses `checked_add` for safe arithmetic