### PR TITLE
Add minimum stake validation in initialize_protocol

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -341,4 +341,8 @@ pub enum CoordinationError {
     // Escrow errors (7300-7399)
     #[msg("Escrow has insufficient balance for reward transfer")]
     InsufficientEscrowBalance,
+
+    // Stake validation errors (7400-7499)
+    #[msg("Stake value is below minimum required (0.001 SOL)")]
+    StakeTooLow,
 }

--- a/programs/agenc-coordination/src/instructions/initialize_protocol.rs
+++ b/programs/agenc-coordination/src/instructions/initialize_protocol.rs
@@ -27,6 +27,9 @@ pub struct InitializeProtocol<'info> {
     pub system_program: Program<'info, System>,
 }
 
+/// Minimum reasonable stake value (0.001 SOL in lamports)
+const MIN_REASONABLE_STAKE: u64 = 1_000_000;
+
 pub fn handler(
     ctx: Context<InitializeProtocol>,
     dispute_threshold: u8,
@@ -43,6 +46,11 @@ pub fn handler(
     require!(
         protocol_fee_bps <= MAX_PROTOCOL_FEE_BPS,
         CoordinationError::InvalidProtocolFee
+    );
+    // Ensure minimum stake is sensible (fixes #586)
+    require!(
+        min_stake >= MIN_REASONABLE_STAKE,
+        CoordinationError::StakeTooLow
     );
     require!(
         !multisig_owners.is_empty(),


### PR DESCRIPTION
## Summary
Validates that min_stake >= 0.001 SOL (1,000,000 lamports) to prevent protocol initialization with unreasonably low or zero stake requirements.

## Changes
- Added `MIN_REASONABLE_STAKE` constant (1,000,000 lamports = 0.001 SOL)
- Added validation to reject min_stake values below this threshold  
- Added `StakeTooLow` error variant to CoordinationError enum

## Testing
- cargo check passes

Fixes #586