### PR TITLE
fix: add timestamp field to SpeculativeCommitmentCreated event

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -206,6 +206,7 @@ pub struct SpeculativeCommitmentCreated {
     pub result_hash: [u8; 32],
     pub bonded_stake: u64,
     pub expires_at: i64,
+    pub timestamp: i64,
 }
 
 /// Emitted when an agent's bond is slashed due to failed speculation


### PR DESCRIPTION
Adds missing `timestamp: i64` field to `SpeculativeCommitmentCreated` event to match the pattern used by other events (TaskCreated, DisputeInitiated, BondSlashed, etc.).

Fixes #584