### PR TITLE
Prevent setting status to Active while having active tasks

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -38,6 +38,9 @@ pub enum CoordinationError {
     #[msg("Agent is suspended and cannot change status")]
     AgentSuspended,
 
+    #[msg("Agent cannot set status to Active while having active tasks")]
+    AgentBusyWithTasks,
+
     // Task errors (6100-6199)
     #[msg("Task not found")]
     TaskNotFound,

--- a/programs/agenc-coordination/src/instructions/update_agent.rs
+++ b/programs/agenc-coordination/src/instructions/update_agent.rs
@@ -48,6 +48,12 @@ pub fn handler(
             return Err(CoordinationError::AgentSuspended.into());
         }
 
+        // Prevent setting status to Active while agent has active tasks
+        // Agents with pending work should remain Busy, not advertise as available
+        if s == 1 && agent.active_tasks > 0 {
+            return Err(CoordinationError::AgentBusyWithTasks.into());
+        }
+
         agent.status = match s {
             0 => AgentStatus::Inactive,
             1 => AgentStatus::Active,


### PR DESCRIPTION
Adds validation in `update_agent` to reject Active status (`s == 1`) when `agent.active_tasks > 0`. Agents with pending work should remain Busy, not advertise as available.

## Changes
- Added `AgentBusyWithTasks` error variant in errors.rs
- Added check in `update_agent` handler before status match

Fixes #557