### PR TITLE
docs: document capability bitmask in Task.required_capabilities

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -398,7 +398,11 @@ pub struct Task {
     pub task_id: [u8; 32],
     /// Task creator (paying party)
     pub creator: Pubkey,
-    /// Required capability bitmask
+    /// Required capability bitmask (u64).
+    ///
+    /// Specifies which capabilities an agent must have to claim this task.
+    /// See [`capability`] module for defined bits. An agent can claim this
+    /// task only if: `(agent.capabilities & required_capabilities) == required_capabilities`
     pub required_capabilities: u64,
     /// Task description or instruction hash
     pub description: [u8; 64],


### PR DESCRIPTION
## Summary

Adds documentation to the `required_capabilities` field in the Task struct explaining its relationship with the capability bitmask system.

## Changes

- Enhanced `Task.required_capabilities` field documentation to:
  - Explain it's a u64 bitmask
  - Reference the `capability` module for defined bits
  - Document the matching formula: `(agent.capabilities & required_capabilities) == required_capabilities`

## Note

The capability module documentation was already present in main (added in commit 076c5a9). This PR completes the documentation by adding the missing field-level docs for `Task.required_capabilities`.

Fixes #580