### PR TITLE
docs: clarify error code comments are informational only

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -2,6 +2,11 @@
 
 use anchor_lang::prelude::*;
 
+/// Protocol error codes
+///
+/// Note: Error code comments (e.g., "6100-6199") are informational only.
+/// Anchor assigns codes sequentially starting at 6000.
+/// The comments help organize errors by category but are not enforced.
 #[error_code]
 pub enum CoordinationError {
     // Agent errors (6000-6099)


### PR DESCRIPTION
Adds documentation to the `CoordinationError` enum explaining that error code range comments (e.g., "6100-6199") are informational only.

Anchor assigns codes sequentially starting at 6000, so the comments help organize errors by category but are not enforced.

Fixes #541