### PR TITLE
docs(state): document reputation score range

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -330,7 +330,9 @@ pub struct AgentRegistration {
     pub tasks_completed: u64,
     /// Total rewards earned
     pub total_earned: u64,
-    /// Reputation score (0-10000)
+    /// Reputation score (0-10000 logical range, stored as u16)
+    /// Note: Type allows 0-65535 but protocol uses 0-10000 scale
+    /// where 0 = worst, 10000 = perfect
     pub reputation: u16,
     /// Active task count
     pub active_tasks: u8,


### PR DESCRIPTION
## Summary
Expands documentation for the `reputation` field in `AgentRegistration` to clarify that:
- The logical range is 0-10000 (protocol-enforced scale)
- The u16 type allows 0-65535 but the protocol only uses 0-10000
- 0 = worst reputation, 10000 = perfect reputation

## Changes
- Updated doc comment for `pub reputation: u16` in `state.rs`

## Testing
- `cargo check` passes

Fixes #530