### PR TITLE
Remove unused require_version_compatible macro

### DIFF
--- a/programs/agenc-coordination/src/instructions/migrate.rs
+++ b/programs/agenc-coordination/src/instructions/migrate.rs
@@ -155,15 +155,3 @@ pub fn update_min_version_handler(
 
     Ok(())
 }
-
-/// Check version compatibility before critical operations
-/// Use this macro in instructions that require version checks
-#[macro_export]
-macro_rules! require_version_compatible {
-    ($config:expr) => {
-        require!(
-            $config.is_version_compatible(),
-            CoordinationError::VersionMismatchProtocol
-        );
-    };
-}


### PR DESCRIPTION
Fixes #525

Removes the unused `require_version_compatible!` macro from `migrate.rs`. This macro was defined but never used anywhere in the codebase.