### PR TITLE
docs: add documentation to SlashReason enum

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -147,12 +147,18 @@ pub enum DisputeStatus {
     Expired = 2,
 }
 
-/// Reason for slashing an agent's bond
+/// Reason for slashing an agent's stake
+///
+/// These correspond to verification failures where slashing applies as a penalty
+/// for submitting invalid or incomplete work.
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum SlashReason {
+    /// Proof verification failed (cryptographic proof invalid)
     ProofFailed = 0,
+    /// Proof was not submitted within the required timeframe
     ProofTimeout = 1,
+    /// Result data failed validation checks
     InvalidResult = 2,
 }
 


### PR DESCRIPTION
Add documentation to SlashReason enum variants explaining what each reason represents.

- Changed top-level doc comment from 'bond' to 'stake' for consistency
- Added module-level description explaining verification failure penalties
- Documented each variant:
  - ProofFailed: cryptographic proof invalid
  - ProofTimeout: proof not submitted in time
  - InvalidResult: result data failed validation

Fixes #578