### PR TITLE
Add missing RateLimitTooHigh and CooldownTooLong error variants

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -299,6 +299,12 @@ pub enum CoordinationError {
     #[msg("Cooldown value exceeds maximum (24 hours)")]
     CooldownTooLarge,
 
+    #[msg("Rate limit value exceeds maximum allowed (1000)")]
+    RateLimitTooHigh,
+
+    #[msg("Cooldown value exceeds maximum allowed (1 week)")]
+    CooldownTooLong,
+
     #[msg("Insufficient stake to initiate dispute")]
     InsufficientStakeForDispute,
 


### PR DESCRIPTION
## Summary
Add missing error variants that the rate limit validation code depends on, fixing the build failure on main.

## Changes
- Add `RateLimitTooHigh` error variant for rate limit upper bound validation
- Add `CooldownTooLong` error variant for cooldown upper bound validation

## Context
The rate limit validation logic was merged in #641 but the error variants it uses were missing, causing `cargo check` to fail on main.

## Testing
- `cargo check` now passes

Fixes #526