### PR TITLE
docs: add permissionless design documentation to expiration instructions

### DIFF
--- a/programs/agenc-coordination/src/instructions/expire_claim.rs
+++ b/programs/agenc-coordination/src/instructions/expire_claim.rs
@@ -1,4 +1,10 @@
-//! Expire a stale claim to free task slot
+//! Expires a stale claim after its deadline passes.
+//!
+//! # Permissionless Design
+//! This instruction can be called by anyone. This is intentional:
+//! - Prevents claims from blocking task slots indefinitely
+//! - Allows third-party cleanup services
+//! - No economic risk since only valid expirations succeed
 
 use crate::errors::CoordinationError;
 use crate::state::{AgentRegistration, Task, TaskClaim, TaskStatus};

--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -1,4 +1,10 @@
-//! Expire a dispute after the maximum duration
+//! Expires a dispute after voting period ends.
+//!
+//! # Permissionless Design
+//! This instruction can be called by anyone. This is intentional:
+//! - Prevents disputes from being permanently stuck
+//! - Allows third-party cleanup services
+//! - No economic risk since only valid expirations succeed
 
 use std::collections::HashSet;
 


### PR DESCRIPTION
Add module-level documentation explaining the permissionless design pattern for `expire_dispute.rs` and `expire_claim.rs` instructions.

## Changes
- Updated `expire_dispute.rs` with module-level documentation explaining the permissionless design
- Updated `expire_claim.rs` with similar documentation

## Permissionless Design
These instructions can be called by anyone, which is intentional:
- Prevents disputes/claims from being permanently stuck
- Allows third-party cleanup services  
- No economic risk since only valid expirations succeed

Fixes #514