### PR TITLE
fix: require multisig threshold < owners count

### DIFF
--- a/programs/agenc-coordination/src/instructions/initialize_protocol.rs
+++ b/programs/agenc-coordination/src/instructions/initialize_protocol.rs
@@ -90,7 +90,9 @@ pub fn handler(
         CoordinationError::MultisigInvalidSigners
     );
     require!(
-        multisig_threshold > 0 && (multisig_threshold as usize) <= multisig_owners.len(),
+    // Fix #505: Require threshold < owners count to ensure protocol remains
+    // operational even if one key is lost. This prevents lockout scenarios.
+        multisig_threshold > 0 && (multisig_threshold as usize) < multisig_owners.len(),
         CoordinationError::MultisigInvalidThreshold
     );
 


### PR DESCRIPTION
Changes multisig threshold validation from `<=` to `<` to ensure at least one owner can be absent without causing protocol lockout.

## Changes
- Updated validation in `initialize_protocol.rs` to require `threshold < owners.len()`
- Added comment explaining the fix rationale

Fixes #505