### PR TITLE
fix(initiate_dispute): require current_workers > 0 before dispute

### DIFF
--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -105,6 +105,12 @@ pub fn handler(
         CoordinationError::InvalidStatusTransition
     );
 
+    // Verify task has workers to dispute (fix #502)
+    require!(
+        task.current_workers > 0,
+        CoordinationError::NoWorkers
+    );
+
     // Verify initiator is task participant (creator or has claim)
     // Compare task.creator (wallet) with authority (signer's wallet), not agent PDA
     let is_creator = task.creator == ctx.accounts.authority.key();


### PR DESCRIPTION
## Summary
Adds a validation check to require `task.current_workers > 0` before allowing dispute initiation.

## Changes
- Added `require!` check in `initiate_dispute.rs` after status validation
- Uses existing `CoordinationError::NoWorkers` error

## Why
Prevents disputes on tasks with no workers assigned, which would:
- Waste protocol resources
- Create invalid dispute states (no one to dispute against)

Fixes #502