### PR TITLE
Add stake_amount field to AgentRegistered event

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -12,6 +12,7 @@ pub struct AgentRegistered {
     pub authority: Pubkey,
     pub capabilities: u64,
     pub endpoint: String,
+    pub stake_amount: u64,
     pub timestamp: i64,
 }
 

--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -106,6 +106,7 @@ pub fn handler(
         authority: agent.authority,
         capabilities,
         endpoint,
+        stake_amount,
         timestamp: clock.unix_timestamp,
     });
 


### PR DESCRIPTION
Adds `stake_amount` field to the `AgentRegistered` event so off-chain listeners can see the initial stake amount when an agent registers.

## Changes
- Added `stake_amount: u64` field to `AgentRegistered` event struct in `events.rs`
- Updated `emit!()" call in `register_agent.rs` to include the stake amount

## Testing
- `cargo check` passes

Closes #487