### PR TITLE
fix: improve error message for missing protocol config when suspending agent

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -333,6 +333,9 @@ pub enum CoordinationError {
     #[msg("Minimum version cannot exceed current protocol version")]
     InvalidMinVersion,
 
+    #[msg("Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts")]
+    ProtocolConfigRequired,
+
     // Dependency errors (6900-6999)
     #[msg("Parent task has been cancelled")]
     ParentTaskCancelled,

--- a/programs/agenc-coordination/src/instructions/update_agent.rs
+++ b/programs/agenc-coordination/src/instructions/update_agent.rs
@@ -62,7 +62,7 @@ pub fn handler(
                 let protocol_config_info = ctx
                     .remaining_accounts
                     .first()
-                    .ok_or(CoordinationError::UnauthorizedAgent)?;
+                    .ok_or(CoordinationError::ProtocolConfigRequired)?;
                 let (expected_pda, _) =
                     Pubkey::find_program_address(&[b"protocol"], ctx.program_id);
                 require!(


### PR DESCRIPTION
## Summary
Improves the error message when attempting to suspend an agent without providing the protocol config PDA in remaining_accounts.

## Changes
- Added new `ProtocolConfigRequired` error variant with descriptive message
- Updated `update_agent` to use the new error instead of generic `UnauthorizedAgent`

## Before
```
Only the agent authority can perform this action
```

## After
```
Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts
```

Fixes #491