### PR TITLE
fix(protocol): require min_stake_for_dispute > 0

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -382,6 +382,9 @@ pub enum CoordinationError {
     #[msg("Stake value is below minimum required (0.001 SOL)")]
     StakeTooLow,
 
+    #[msg("min_stake_for_dispute must be greater than zero")]
+    InvalidMinStake,
+
     // Speculation Bond errors (7500-7599)
     #[msg("Bond amount too low")]
     BondAmountTooLow,

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -268,6 +268,7 @@ pub mod agenc_coordination {
         dispute_threshold: u8,
         protocol_fee_bps: u16,
         min_stake: u64,
+        min_stake_for_dispute: u64,
         multisig_threshold: u8,
         multisig_owners: Vec<Pubkey>,
     ) -> Result<()> {
@@ -276,6 +277,7 @@ pub mod agenc_coordination {
             dispute_threshold,
             protocol_fee_bps,
             min_stake,
+            min_stake_for_dispute,
             multisig_threshold,
             multisig_owners,
         )


### PR DESCRIPTION
## Summary
Adds validation that `min_stake_for_dispute` must be greater than zero during protocol initialization. This prevents the protocol from being initialized with a zero dispute stake requirement.

## Changes
- Add `InvalidMinStake` error variant to `CoordinationError`
- Add `min_stake_for_dispute` parameter to `initialize_protocol` instruction
- Add `require!()` validation for `min_stake_for_dispute > 0`
- Update config assignment to use the parameter value

## Testing
- `cargo check` passes

Fixes #499