### PR TITLE
docs: document _reserved field deserialization behavior

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -403,7 +403,9 @@ pub struct AgentRegistration {
     pub last_state_update: i64,
     /// Active disputes where this agent is a defendant (can be slashed)
     pub disputes_as_defendant: u8,
-    /// Reserved for future use
+    /// Reserved bytes for future use.
+    /// Note: Not validated on deserialization - may contain arbitrary data
+    /// from previous versions. New fields should handle this gracefully.
     pub _reserved: [u8; 5],
 }
 


### PR DESCRIPTION
Clarify that `_reserved` bytes in `AgentRegistration` are not validated on deserialization and may contain arbitrary data from previous protocol versions. New fields added to the struct should handle this gracefully.

Fixes #498