### PR TITLE
docs: document stake/rent mixing in agent PDA

### DIFF
--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -30,6 +30,9 @@ pub struct RegisterAgent<'info> {
 
     pub system_program: Program<'info, System>,
 }
+/// Note: The agent PDA account holds both rent-exempt balance and staked funds.
+/// On deregister, stake is returned but rent remains with the account.
+/// The `stake` field in AgentRegistration tracks only the staked portion.
 
 /// Note: The agent PDA account holds both rent-exempt balance and staked funds.
 /// On deregister, stake is returned but rent remains with the account.


### PR DESCRIPTION
Add documentation explaining that agent PDA accounts hold both rent-exempt balance and staked funds.

On deregister, stake is returned but rent remains with the account. The `stake` field in AgentRegistration tracks only the staked portion.

Fixes #555