### PR TITLE
Add rate limiting for agent updates

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -296,6 +296,9 @@ pub enum CoordinationError {
     #[msg("Cooldown period has not elapsed since last action")]
     CooldownNotElapsed,
 
+    #[msg("Agent update too frequent: must wait cooldown period")]
+    UpdateTooFrequent,
+
     #[msg("Cooldown value cannot be negative")]
     InvalidCooldown,
 


### PR DESCRIPTION
## Summary
Adds a 60-second cooldown check between agent updates to prevent spam.

## Changes
- Add `UPDATE_COOLDOWN` constant (60 seconds)
- Add cooldown check at start of `update_agent` handler
- Add `UpdateTooFrequent` error for rate limit violations
- Update `last_state_update` timestamp on successful updates

## Testing
- `cargo check` passes

Fixes #490