### PR TITLE
fix: add owner to CoordinationState PDA seeds to prevent collisions

### DIFF
--- a/programs/agenc-coordination/src/instructions/update_state.rs
+++ b/programs/agenc-coordination/src/instructions/update_state.rs
@@ -12,7 +12,7 @@ pub struct UpdateState<'info> {
         init_if_needed,
         payer = authority,
         space = CoordinationState::SIZE,
-        seeds = [b"state", state_key.as_ref()],
+        seeds = [b"state", authority.key().as_ref(), state_key.as_ref()],
         bump
     )]
     pub state: Account<'info, CoordinationState>,
@@ -63,6 +63,7 @@ pub fn handler(
     }
 
     // Update state
+    state.owner = ctx.accounts.authority.key();
     state.state_key = state_key;
     state.state_value = state_value;
     state.last_updater = agent.key();

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -608,9 +608,11 @@ impl TaskClaim {
 }
 
 /// Shared coordination state
-/// PDA seeds: ["state", state_key]
+/// PDA seeds: ["state", owner, state_key]
 #[account]
 pub struct CoordinationState {
+    /// Owner authority - namespaces state to prevent cross-user collisions
+    pub owner: Pubkey,
     /// State key
     pub state_key: [u8; 32],
     /// State value
@@ -628,6 +630,7 @@ pub struct CoordinationState {
 impl Default for CoordinationState {
     fn default() -> Self {
         Self {
+            owner: Pubkey::default(),
             state_key: [0u8; 32],
             state_value: [0u8; 64],
             last_updater: Pubkey::default(),
@@ -640,6 +643,7 @@ impl Default for CoordinationState {
 
 impl CoordinationState {
     pub const SIZE: usize = 8 + // discriminator
+        32 + // owner
         32 + // state_key
         64 + // state_value
         32 + // last_updater


### PR DESCRIPTION
## Summary
Fixes #519

Adds an `owner` field to the CoordinationState PDA seeds to prevent cross-user collisions.

## Changes
- Add `owner: Pubkey` field to `CoordinationState` struct
- Update PDA seeds from `["state", state_key]` to `["state", owner, state_key]`
- Update `SIZE` constant to account for new owner field (32 bytes)
- Set owner field in `update_state` handler

## Problem
Previously, if two different task creators or agents wanted to use the same logical state key name (e.g., hash of "task_progress"), they would derive the same PDA address and collide.

## Solution
By adding the authority (owner) to the PDA seeds, each user now has their own namespace for coordination state. This follows the pattern used by other PDAs like `Task` which includes the creator in its seeds.

## Breaking Change
⚠️ This is a breaking change for any existing CoordinationState accounts. The account size increases by 32 bytes and existing PDAs will need migration.