### PR TITLE
feat(events): add result_data field to TaskCompleted event

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -71,6 +71,7 @@ pub struct TaskCompleted {
     pub task_id: [u8; 32],
     pub worker: Pubkey,
     pub proof_hash: [u8; 32],
+    pub result_data: [u8; 64],
     pub reward_paid: u64,
     pub timestamp: i64,
 }

--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -204,6 +204,7 @@ pub fn handler(
         task_id: task.task_id,
         worker: worker.key(),
         proof_hash,
+        result_data: claim_result_data,
         reward_paid: worker_reward,
         timestamp: clock.unix_timestamp,
     });

--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -270,6 +270,7 @@ pub fn complete_task_private(
         task_id: task.task_id,
         worker: worker.key(),
         proof_hash: proof.output_commitment,
+        result_data: [0u8; 64], // Zeroed for privacy
         reward_paid: worker_reward,
         timestamp: clock.unix_timestamp,
     });


### PR DESCRIPTION
## Summary
Adds a 64-byte `result_data` field to the `TaskCompleted` event to include task output in completion events.

## Changes
- **events.rs**: Added `result_data: [u8; 64]` field to `TaskCompleted` struct
- **complete_task.rs**: Updated `emit!(TaskCompleted {...})` to include `result_data: claim_result_data`
- **complete_task_private.rs**: Updated emit to use zeroed `result_data` for privacy preservation

## Testing
- `cargo check` passes

Fixes #481