### PR TITLE
docs: document immutable multisig design choice

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -90,7 +90,6 @@ pub struct TaskCancelled {
 pub struct StateUpdated {
     pub state_key: [u8; 32],
     pub state_value: [u8; 64],
-    pub state_value: [u8; 64],
     pub updater: Pubkey,
     pub version: u64,
     pub timestamp: i64,

--- a/programs/agenc-coordination/src/instructions/initialize_protocol.rs
+++ b/programs/agenc-coordination/src/instructions/initialize_protocol.rs
@@ -172,6 +172,8 @@ pub fn handler(
     config.protocol_version = CURRENT_PROTOCOL_VERSION;
     config.min_supported_version = MIN_SUPPORTED_VERSION;
     config._padding = [0u8; 2];
+    // Fix #497: Explicitly zero all slots before populating to ensure no data leakage.
+    // This is the ONLY place multisig_owners can be set (immutable after init).
     config.multisig_owners = [Pubkey::default(); ProtocolConfig::MAX_MULTISIG_OWNERS];
     for (index, owner) in multisig_owners.iter().enumerate() {
         config.multisig_owners[index] = *owner;

--- a/programs/agenc-coordination/src/instructions/update_state.rs
+++ b/programs/agenc-coordination/src/instructions/update_state.rs
@@ -81,7 +81,6 @@ pub fn handler(
     emit!(StateUpdated {
         state_key,
         state_value,
-        state_value,
         updater: agent.key(),
         version: state.version,
         timestamp: clock.unix_timestamp,

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -260,7 +260,17 @@ pub struct ProtocolConfig {
     pub min_supported_version: u8,
     /// Padding for alignment/future use
     pub _padding: [u8; 2],
-    /// Multisig owners (fixed-size)
+    /// Multisig owners (fixed-size).
+    ///
+    /// # Design Note (see #497)
+    /// Multisig configuration is **immutable** after protocol initialization.
+    /// This is intentional for security reasons:
+    /// - Prevents hostile takeover via multisig reconfiguration
+    /// - Ensures governance changes require protocol redeployment with proper ceremony
+    /// - The array is fully zeroed before population in `initialize_protocol`
+    ///
+    /// Only the first `multisig_owners_len` entries are valid; remaining slots
+    /// are always `Pubkey::default()`.
     pub multisig_owners: [Pubkey; ProtocolConfig::MAX_MULTISIG_OWNERS],
 }
 
@@ -339,8 +349,6 @@ impl ProtocolConfig {
         self.min_supported_version <= self.protocol_version
             && self.protocol_version <= CURRENT_PROTOCOL_VERSION
             // Program can read configs at or above program's min
-            && self.protocol_version >= MIN_SUPPORTED_VERSION
-    }
             && self.protocol_version >= MIN_SUPPORTED_VERSION
     }
 }


### PR DESCRIPTION
## Summary
Closes #497

Documents that the multisig_owners array is intentionally **immutable** after protocol initialization.

## Changes
1. Added documentation to `state.rs` explaining the immutable design
2. Added inline comment in `initialize_protocol.rs` referencing #497
3. Fixed duplicate line merge artifacts

## Testing
- `cargo check` passes