### PR TITLE
docs(state): document total_voters u8 limit

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -691,7 +691,8 @@ pub struct Dispute {
     pub votes_for: u64,
     /// Votes against
     pub votes_against: u64,
-    /// Total eligible voters
+    /// Total arbiters who voted (max 255 due to u8)
+    /// Note: Increase to u16 if more arbiters needed
     pub total_voters: u8,
     /// Voting deadline - after this, no new votes accepted
     /// voting_deadline = created_at + voting_period


### PR DESCRIPTION
Clarifies that `total_voters` is limited to 255 due to `u8` type. Adds note about increasing to `u16` if more arbiters are needed.

## Changes
- Updated documentation for `total_voters` field in `DisputeState` struct
- Added max value note (255) and suggestion for future scaling

Fixes #462