### PR TITLE
fix: Set default min_stake_for_dispute to 0.1 SOL

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -298,7 +298,7 @@ impl Default for ProtocolConfig {
             max_tasks_per_24h: 50,      // 50 tasks per 24h window
             dispute_initiation_cooldown: 300, // 5 minutes between disputes
             max_disputes_per_24h: 10,   // 10 disputes per 24h window
-            min_stake_for_dispute: 0,   // No stake required by default
+            min_stake_for_dispute: 100_000_000, // 0.1 SOL default for anti-griefing
             slash_percentage: ProtocolConfig::DEFAULT_SLASH_PERCENTAGE,
             // Versioning
             protocol_version: CURRENT_PROTOCOL_VERSION,


### PR DESCRIPTION
## Summary

Sets the default `min_stake_for_dispute` to 0.1 SOL (100,000,000 lamports) to prevent free dispute griefing.

## Changes

- Updated `ProtocolConfig::default()` to set `min_stake_for_dispute: 100_000_000` (0.1 SOL)

## Context

The previous default of 0 allowed zero-stake agents to spam disputes at near-zero cost (only transaction fees). While `initialize_protocol` already requires this value to be > 0 (from #499), having a reasonable default makes the code more self-documenting and provides a sensible fallback.

Closes #478