### PR TITLE
Add timestamp field to bond events

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -192,6 +192,7 @@ pub struct BondDeposited {
     pub agent: Pubkey,
     pub amount: u64,
     pub new_total: u64,
+    pub timestamp: i64,
 }
 
 /// Emitted when bond is locked for a commitment
@@ -200,6 +201,7 @@ pub struct BondLocked {
     pub agent: Pubkey,
     pub commitment: Pubkey,
     pub amount: u64,
+    pub timestamp: i64,
 }
 
 #[event]
@@ -228,6 +230,7 @@ pub struct BondReleased {
     pub agent: Pubkey,
     pub commitment: Pubkey,
     pub amount: u64,
+    pub timestamp: i64,
 }
 
 /// Emitted when arbiter votes are cleaned up during dispute expiration


### PR DESCRIPTION
Adds `timestamp: i64` field to bond-related events for consistency with other protocol events:

- `BondDeposited`
- `BondLocked`
- `BondReleased`

Fixes #473