### PR TITLE
fix: validate state_value not all zeros

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -230,6 +230,9 @@ pub enum CoordinationError {
     #[msg("State not found")]
     StateNotFound,
 
+    #[msg("Invalid state value: state_value cannot be all zeros")]
+    InvalidStateValue,
+
     // Protocol errors (6500-6599)
     #[msg("Protocol is already initialized")]
     ProtocolAlreadyInitialized,

--- a/programs/agenc-coordination/src/instructions/update_state.rs
+++ b/programs/agenc-coordination/src/instructions/update_state.rs
@@ -54,6 +54,12 @@ pub fn handler(
         }
     }
 
+    // Validate state_value is not all zeros
+    require!(
+        state_value.iter().any(|&b| b != 0),
+        CoordinationError::InvalidStateValue
+    );
+
     // Check version for optimistic locking (if state already exists)
     if state.version > 0 {
         require!(


### PR DESCRIPTION
Adds validation to update_state instruction requiring state_value to have at least one non-zero byte, preventing meaningless all-zero state updates.

Fixes #444