### PR TITLE
docs(errors): simplify error code range note

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -4,9 +4,8 @@ use anchor_lang::prelude::*;
 
 /// Protocol error codes
 ///
-/// Note: Error code comments (e.g., "6100-6199") are informational only.
-/// Anchor assigns codes sequentially starting at 6000.
-/// The comments help organize errors by category but are not enforced.
+/// Note: Error code range comments (e.g., 6100-6199) are organizational
+/// and may become stale. Anchor assigns codes sequentially.
 #[error_code]
 pub enum CoordinationError {
     // Agent errors (6000-6099)


### PR DESCRIPTION
Simplify the error code range note to be more concise.

**Changes:**
- Updated the documentation comment on `CoordinationError` to clarify that error code range comments are organizational and may become stale

Closes #451