### PR TITLE
Add treasury validation in initialize_protocol

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -242,6 +242,9 @@ pub enum CoordinationError {
     #[msg("Invalid protocol fee (must be <= 1000 bps)")]
     InvalidProtocolFee,
 
+    #[msg("Invalid treasury: treasury account cannot be default pubkey")]
+    InvalidTreasury,
+
     #[msg("Invalid dispute threshold: must be 1-100 (percentage of votes required)")]
     InvalidDisputeThreshold,
 

--- a/programs/agenc-coordination/src/instructions/initialize_protocol.rs
+++ b/programs/agenc-coordination/src/instructions/initialize_protocol.rs
@@ -146,6 +146,12 @@ pub fn handler(
         CoordinationError::MultisigNotEnoughSigners
     );
 
+    // Fix #448: Validate treasury is not the default pubkey
+    require!(
+        ctx.accounts.treasury.key() != Pubkey::default(),
+        CoordinationError::InvalidTreasury
+    );
+
     // Now safe to write config
     let config = &mut ctx.accounts.protocol_config;
     config.authority = ctx.accounts.authority.key();


### PR DESCRIPTION
## Summary

Adds validation to reject default pubkey for treasury account during protocol initialization.

## Changes

- Added `InvalidTreasury` error variant in `errors.rs`
- Added treasury validation in `initialize_protocol.rs` handler

## Validation

```rust
require!(
    ctx.accounts.treasury.key() != Pubkey::default(),
    CoordinationError::InvalidTreasury
);
```

This prevents initializing the protocol with an invalid treasury destination that could cause funds to be lost.

Fixes #448