### PR TITLE
fix: validate result_data not all zeros

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -146,6 +146,9 @@ pub enum CoordinationError {
     #[msg("Invalid proof hash: proof_hash cannot be all zeros")]
     InvalidProofHash,
 
+    #[msg("Invalid result data: result_data cannot be all zeros when provided")]
+    InvalidResultData,
+
     // Dispute errors (6300-6399)
     #[msg("Dispute is not active")]
     DisputeNotActive,

--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -126,6 +126,14 @@ pub fn handler(
         CoordinationError::InvalidProofHash
     );
 
+    // Validate result_data is not all zeros (when provided)
+    if let Some(ref data) = result_data {
+        require!(
+            data.iter().any(|&b| b != 0),
+            CoordinationError::InvalidResultData
+        );
+    }
+
     // Validate task state
     require!(
         task.status == TaskStatus::InProgress,


### PR DESCRIPTION
## Summary

Adds validation in `complete_task` to reject `result_data` when all bytes are zero.

## Changes

- Added `InvalidResultData` error variant in `errors.rs`
- Added validation in `complete_task.rs` that checks if provided `result_data` contains at least one non-zero byte

## Testing

- `cargo check` passes

Closes #447