### PR TITLE
fix: prevent initiator from resolving their own dispute

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -219,6 +219,9 @@ pub enum CoordinationError {
     #[msg("Worker was not involved in this dispute")]
     WorkerNotInDispute,
 
+    #[msg("Dispute initiator cannot resolve their own dispute")]
+    InitiatorCannotResolve,
+
     // State errors (6400-6499)
     #[msg("State version mismatch (concurrent modification)")]
     VersionMismatch,

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -96,6 +96,12 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         CoordinationError::DisputeNotActive
     );
 
+    // Prevent initiator from resolving their own dispute (fix #458)
+    require!(
+        ctx.accounts.resolver.key() != dispute.initiator_authority,
+        CoordinationError::InitiatorCannotResolve
+    );
+
     // Verify voting period has ended
     require!(
         clock.unix_timestamp >= dispute.voting_deadline,


### PR DESCRIPTION
Adds a check in `resolve_dispute.rs` to prevent the dispute initiator from resolving their own dispute.

## Changes
- Added `InitiatorCannotResolve` error variant
- Added require! check in handler to reject resolution if resolver is the initiator

Closes #458