### PR TITLE
Require worker accounts when cancelling task with workers

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -374,6 +374,9 @@ pub enum CoordinationError {
     #[msg("All worker accounts must be provided when cancelling a task with active claims")]
     IncompleteWorkerAccounts,
 
+    #[msg("Worker accounts required when task has active workers")]
+    WorkerAccountsRequired,
+
     // Duplicate account errors (7200-7299)
     #[msg("Duplicate arbiter provided in remaining_accounts")]
     DuplicateArbiter,

--- a/programs/agenc-coordination/src/instructions/cancel_task.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_task.rs
@@ -54,6 +54,14 @@ pub fn handler(ctx: Context<CancelTask>) -> Result<()> {
 
     require!(can_cancel, CoordinationError::TaskCannotBeCancelled);
 
+    // If task has workers, require accounts
+    if task.current_workers > 0 {
+        require!(
+            !ctx.remaining_accounts.is_empty(),
+            CoordinationError::WorkerAccountsRequired
+        );
+    }
+
     // Calculate refund (total minus any distributed)
     let refund_amount = escrow
         .amount


### PR DESCRIPTION
Adds early validation that `remaining_accounts` is not empty when `task.current_workers > 0`, ensuring proper cleanup of worker state.

## Changes
- Added check in `cancel_task.rs` to require `remaining_accounts` when task has active workers
- Added `WorkerAccountsRequired` error variant

Fixes #456