### PR TITLE
docs: document immutable authority field

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -211,6 +211,7 @@ pub const MIN_SUPPORTED_VERSION: u8 = 1;
 #[account]
 pub struct ProtocolConfig {
     /// Protocol authority
+    /// Note: Cannot be updated after initialization.
     pub authority: Pubkey,
     /// Treasury for protocol fees
     pub treasury: Pubkey,


### PR DESCRIPTION
Clarify that the `authority` field in `ProtocolConfig` cannot be updated after initialization.

Fixes #452