### PR TITLE
docs: document suspended agent task behavior

### DIFF
--- a/programs/agenc-coordination/src/instructions/update_agent.rs
+++ b/programs/agenc-coordination/src/instructions/update_agent.rs
@@ -1,4 +1,8 @@
 //! Update an existing agent's registration
+//!
+//! Note: Suspending an agent does not automatically cancel their active tasks.
+//! Tasks may become frozen if workers cannot complete them.
+//! Consider canceling or reassigning tasks before suspension.
 
 use crate::errors::CoordinationError;
 use crate::events::AgentUpdated;


### PR DESCRIPTION
Add documentation warning that suspending an agent does not automatically cancel their active tasks, which may cause tasks to become frozen.

## Changes
- Added module-level documentation to `update_agent.rs` explaining suspension behavior:
  - Suspending an agent does not automatically cancel their active tasks
  - Tasks may become frozen if workers cannot complete them
  - Consider canceling or reassigning tasks before suspension

Fixes #465