### PR TITLE
Add SIZE constant tests for all account structs

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -887,3 +887,79 @@ impl Nullifier {
         8 +  // spent_at
         1;   // bump
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: SIZE should equal struct size + 8-byte discriminator
+    macro_rules! test_size_constant {
+        ($struct:ty) => {
+            assert_eq!(
+                <$struct>::SIZE,
+                std::mem::size_of::<$struct>() + 8,
+                concat!(stringify!($struct), "::SIZE mismatch")
+            );
+        };
+    }
+
+    #[test]
+    fn test_protocol_config_size() {
+        test_size_constant!(ProtocolConfig);
+    }
+
+    #[test]
+    fn test_agent_registration_size() {
+        test_size_constant!(AgentRegistration);
+    }
+
+    #[test]
+    fn test_task_size() {
+        test_size_constant!(Task);
+    }
+
+    #[test]
+    fn test_task_claim_size() {
+        test_size_constant!(TaskClaim);
+    }
+
+    #[test]
+    fn test_coordination_state_size() {
+        test_size_constant!(CoordinationState);
+    }
+
+    #[test]
+    fn test_dispute_size() {
+        test_size_constant!(Dispute);
+    }
+
+    #[test]
+    fn test_dispute_vote_size() {
+        test_size_constant!(DisputeVote);
+    }
+
+    #[test]
+    fn test_authority_dispute_vote_size() {
+        test_size_constant!(AuthorityDisputeVote);
+    }
+
+    #[test]
+    fn test_task_escrow_size() {
+        test_size_constant!(TaskEscrow);
+    }
+
+    #[test]
+    fn test_speculation_bond_size() {
+        test_size_constant!(SpeculationBond);
+    }
+
+    #[test]
+    fn test_speculative_commitment_size() {
+        test_size_constant!(SpeculativeCommitment);
+    }
+
+    #[test]
+    fn test_nullifier_size() {
+        test_size_constant!(Nullifier);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a test module to  that verifies SIZE constants match actual struct sizes (+ 8-byte discriminator) for all 12 account types.

## Changes

- Adds `#[cfg(test)] mod tests` block at end of state.rs
- Uses a macro `test_size_constant!` to DRY up the assertions
- Tests all structs with SIZE constants:
  - ProtocolConfig
  - AgentRegistration
  - Task
  - TaskClaim
  - CoordinationState
  - Dispute
  - DisputeVote
  - AuthorityDisputeVote
  - TaskEscrow
  - SpeculationBond
  - SpeculativeCommitment
  - Nullifier

## Testing

`cargo check` passes.

Closes #466