### PR TITLE
fix(coordination): check version on first update

### DIFF
--- a/programs/agenc-coordination/src/instructions/update_state.rs
+++ b/programs/agenc-coordination/src/instructions/update_state.rs
@@ -60,13 +60,11 @@ pub fn handler(
         CoordinationError::InvalidStateValue
     );
 
-    // Check version for optimistic locking (if state already exists)
-    if state.version > 0 {
-        require!(
-            state.version == expected_version,
-            CoordinationError::VersionMismatch
-        );
-    }
+    // Always check version (fix #431 - first update was bypassing)
+    require!(
+        state.version == expected_version,
+        CoordinationError::VersionMismatch
+    );
 
     // Update state
     state.owner = ctx.accounts.authority.key();


### PR DESCRIPTION
## Summary
Fixes #431

The version check was only applied when `state.version > 0`, meaning the first update (version == 0) bypassed the check entirely. This could allow a race condition where multiple callers try to initialize the same state.

## Changes
- Removed the conditional check (`if state.version > 0`)
- Now always verifies `state.version == expected_version`

## Testing
- `cargo check` passes