### PR TITLE
docs: document claim account closure behavior

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -22,6 +22,9 @@ pub struct CompleteTask<'info> {
     )]
     pub task: Account<'info, Task>,
 
+    /// Note: Claim account is closed after completion.
+    /// If proof-of-completion is needed later, store result_hash
+    /// in an event or separate completion record.
     #[account(
         mut,
         close = authority,


### PR DESCRIPTION
Adds documentation to `complete_task.rs` explaining that the claim account is closed after task completion, and recommends storing `result_hash` in events or separate records if proof-of-completion is needed later.

## Changes
- Added doc comments above the `claim` field in `CompleteTask` struct

Fixes #472