### PR TITLE
docs(vote_dispute): document vote account closure behavior

### DIFF
--- a/programs/agenc-coordination/src/instructions/vote_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/vote_dispute.rs
@@ -167,6 +167,9 @@ pub fn handler(ctx: Context<VoteDispute>, approve: bool) -> Result<()> {
         .checked_add(1)
         .ok_or(CoordinationError::VoteOverflow)?;
 
+    // Note: If a vote account is closed externally, active_dispute_votes
+    // will be inconsistent. Vote accounts should only be closed via
+    // dispute resolution or expiration.
     arbiter.active_dispute_votes = arbiter
         .active_dispute_votes
         .checked_add(1)


### PR DESCRIPTION
Adds documentation clarifying that if a vote account is closed externally, `active_dispute_votes` will be inconsistent. Vote accounts should only be closed via dispute resolution or expiration.

Fixes #441