### PR TITLE
docs: document remainder distribution in calculate_reward_per_worker

### DIFF
--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -36,6 +36,10 @@ pub fn calculate_reward_split(task: &Task, protocol_fee_bps: u16) -> Result<(u64
 }
 
 /// Calculate per-worker reward based on task type.
+///
+/// Note: Remainder distribution is deterministic based on worker index.
+/// First N workers get +1 lamport where N = total % num_workers.
+/// This is predictable but fair across all workers.
 fn calculate_reward_per_worker(task: &Task) -> Result<u64> {
     match task.task_type {
         TaskType::Collaborative => {


### PR DESCRIPTION
Adds documentation explaining how remainder lamports are distributed deterministically based on worker index.

Fixes #436