### PR TITLE
Fix #434: Handle expires_at = 0 edge case

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -125,6 +125,9 @@ pub enum CoordinationError {
     #[msg("Claim has expired")]
     ClaimExpired,
 
+    #[msg("Invalid expiration: expires_at cannot be zero")]
+    InvalidExpiration,
+
     #[msg("Invalid proof of work")]
     InvalidProof,
 

--- a/programs/agenc-coordination/src/instructions/expire_claim.rs
+++ b/programs/agenc-coordination/src/instructions/expire_claim.rs
@@ -89,9 +89,15 @@ pub fn handler(ctx: Context<ExpireClaim>) -> Result<()> {
         CoordinationError::ClaimAlreadyCompleted
     );
 
+    // Claims with expires_at = 0 are invalid (shouldn't exist)
+    require!(
+        claim.expires_at > 0,
+        CoordinationError::InvalidExpiration
+    );
+
     // Check claim has expired
     require!(
-        claim.expires_at > 0 && clock.unix_timestamp > claim.expires_at,
+        clock.unix_timestamp > claim.expires_at,
         CoordinationError::ClaimNotExpired
     );
 


### PR DESCRIPTION
## Summary
Fixes #434 - Handle expires_at = 0 edge case in expire_claim.

## Changes
- Added separate check for `expires_at = 0` with `InvalidExpiration` error in `expire_claim.rs`
- Added new `InvalidExpiration` error variant to `errors.rs`

## Rationale
Previously, the check `claim.expires_at > 0 && clock.unix_timestamp > claim.expires_at` combined two different conditions. If a claim had `expires_at = 0` (which should never happen), it would return `ClaimNotExpired` which is misleading.

Now:
- `expires_at = 0` → `InvalidExpiration` (indicates corrupted/invalid state)
- `clock.unix_timestamp <= expires_at` → `ClaimNotExpired` (normal "not yet expired")

## Testing
- `cargo check` passes