### PR TITLE
fix: lock protocol fee at task creation

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -120,8 +120,8 @@ pub fn handler(
         );
     }
 
-    // Read protocol fee before any mutable borrows of protocol_config
-    let protocol_fee_bps = ctx.accounts.protocol_config.protocol_fee_bps;
+    // Use the protocol fee locked at task creation (#479)
+    let protocol_fee_bps = task.protocol_fee_bps;
 
     // Validate proof_hash is not zero
     require!(

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -194,6 +194,8 @@ pub fn handler(
     task.completions = 0;
     task.required_completions = if task_type == 1 { max_workers } else { 1 };
     task.bump = ctx.bumps.task;
+    // Lock protocol fee at task creation (#479)
+    task.protocol_fee_bps = config.protocol_fee_bps;
 
     // Independent task - no dependencies
     task.dependency_type = DependencyType::None;

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -507,6 +507,8 @@ pub struct Task {
     pub required_completions: u8,
     /// Bump seed
     pub bump: u8,
+    /// Protocol fee in basis points, locked at task creation (#479)
+    pub protocol_fee_bps: u16,
     /// Optional parent task this task depends on (None for independent tasks)
     pub depends_on: Option<Pubkey>,
     /// Type of dependency relationship
@@ -536,6 +538,7 @@ impl Default for Task {
             completions: 0,
             required_completions: 1,
             bump: 0,
+            protocol_fee_bps: 0,
             depends_on: None,
             dependency_type: DependencyType::default(),
             _reserved: [0u8; 32],
@@ -565,6 +568,7 @@ impl Task {
         1 +  // completions
         1 +  // required_completions
         1 +  // bump
+        2 +  // protocol_fee_bps
         33 + // depends_on (Option<Pubkey>: 1 byte discriminator + 32 bytes pubkey)
         1 +  // dependency_type
         32; // reserved


### PR DESCRIPTION
## Summary
Fix #479: Protocol fee changes no longer affect tasks already in progress.

## Changes
- Added `protocol_fee_bps: u16` field to `Task` struct in state.rs
- Updated `Task::SIZE` constant (+2 bytes)
- In create_task.rs: set `task.protocol_fee_bps = config.protocol_fee_bps`
- In complete_task.rs: use `task.protocol_fee_bps` instead of `config.protocol_fee_bps`

## Testing
- `cargo check` passes

Fixes #479