### PR TITLE
docs: document rate limit counter reset behavior

### DIFF
--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -141,6 +141,8 @@ pub fn handler(
             // Round window start to prevent drift
             let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
             creator_agent.rate_limit_window_start = window_start;
+            // Note: Both counters reset together when window expires.
+            // This is intentional - ensures clean state at window boundary.
             creator_agent.task_count_24h = 0;
             creator_agent.dispute_count_24h = 0;
         }

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -128,6 +128,8 @@ pub fn handler(
             // Round window start to prevent drift
             let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
             creator_agent.rate_limit_window_start = window_start;
+            // Note: Both counters reset together when window expires.
+            // This is intentional - ensures clean state at window boundary.
             creator_agent.task_count_24h = 0;
             creator_agent.dispute_count_24h = 0;
         }

--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -187,6 +187,8 @@ pub fn handler(
             // Round window start to prevent drift
             let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
             agent.rate_limit_window_start = window_start;
+            // Note: Both counters reset together when window expires.
+            // This is intentional - ensures clean state at window boundary.
             agent.task_count_24h = 0;
             agent.dispute_count_24h = 0;
         }


### PR DESCRIPTION
Add documentation explaining why both `task_count_24h` and `dispute_count_24h` reset together when the rate limit window expires. This intentional design ensures a clean state at each window boundary.

## Changes
- Added doc comments in `initiate_dispute.rs`
- Added doc comments in `create_task.rs`
- Added doc comments in `create_dependent_task.rs`

Fixes #449