### PR TITLE
docs: document VOTE_COOLDOWN relation to WINDOW_24H

### DIFF
--- a/programs/agenc-coordination/src/instructions/deregister_agent.rs
+++ b/programs/agenc-coordination/src/instructions/deregister_agent.rs
@@ -53,7 +53,9 @@ pub fn handler(ctx: Context<DeregisterAgent>) -> Result<()> {
     // Only check vote cooldown if agent has actually voted before
     // When last_vote_timestamp is 0 (never voted), skip the check
     if agent.last_vote_timestamp > 0 {
-        const VOTE_COOLDOWN: i64 = 24 * 60 * 60;
+        /// Vote cooldown period (same as WINDOW_24H for consistency)
+        /// Intentionally duplicated to allow independent adjustment
+        const VOTE_COOLDOWN: i64 = 86400;
         let time_since_vote = clock
             .unix_timestamp
             .checked_sub(agent.last_vote_timestamp)


### PR DESCRIPTION
## Summary
Adds documentation comment to VOTE_COOLDOWN explaining its relation to WINDOW_24H.

## Changes
- Added doc comment explaining the constant is intentionally duplicated from WINDOW_24H (both 86400 seconds / 24 hours)
- Changed inline calculation `24 * 60 * 60` to explicit `86400` for clarity

Fixes #405