### PR TITLE
docs: document shared remaining_accounts pattern in dispute handlers

### DIFF
--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -154,6 +154,11 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
     }
 
     // Decrement active_dispute_votes for each arbiter who voted (fix #328)
+    //
+    // Worker accounts processing - shared pattern with resolve_dispute/expire_dispute
+    // The duplication is intentional to avoid cross-instruction dependencies
+    // and keep each instruction self-contained.
+    //
     // remaining_accounts format (fix #333):
     // - First: (vote, arbiter) pairs for total_voters
     // - Then: optional (claim, worker) pairs for additional workers on collaborative tasks

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -290,6 +290,11 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
     }
 
     // Update dispute status - decrement active_dispute_votes for each arbiter
+    //
+    // Worker accounts processing - shared pattern with resolve_dispute/expire_dispute
+    // The duplication is intentional to avoid cross-instruction dependencies
+    // and keep each instruction self-contained.
+    //
     // remaining_accounts format (fix #333):
     // - First: (vote, arbiter) pairs for total_voters
     // - Then: optional (claim, worker) pairs for additional workers on collaborative tasks


### PR DESCRIPTION
Add documentation comment explaining the intentional duplication between resolve_dispute and expire_dispute for processing worker accounts. This pattern avoids cross-instruction dependencies and keeps each instruction self-contained.

## Changes
- Added doc comments to `resolve_dispute.rs` explaining the shared remaining_accounts processing pattern
- Added doc comments to `expire_dispute.rs` explaining the shared remaining_accounts processing pattern

The comment clarifies that the duplication is intentional design to avoid cross-instruction dependencies.

Fixes #443