### PR TITLE
fix(claim_task): replace magic 10 with MAX_ACTIVE_TASKS constant

### DIFF
--- a/programs/agenc-coordination/src/instructions/claim_task.rs
+++ b/programs/agenc-coordination/src/instructions/claim_task.rs
@@ -104,8 +104,9 @@ pub fn handler(ctx: Context<ClaimTask>) -> Result<()> {
     );
 
     // Check worker doesn't have too many active tasks
+    const MAX_ACTIVE_TASKS: u8 = 10;
     require!(
-        worker.active_tasks < 10,
+        worker.active_tasks < MAX_ACTIVE_TASKS,
         CoordinationError::MaxActiveTasksReached
     );
 


### PR DESCRIPTION
Replaces the hardcoded magic number `10` with a named constant `MAX_ACTIVE_TASKS` for improved code readability and maintainability.

## Changes
- Added `const MAX_ACTIVE_TASKS: u8 = 10;` in `claim_task.rs`
- Updated the `require!` check to use the constant instead of the hardcoded value

## Testing
- `cargo check` passes

Fixes #383