### PR TITLE
Fix clippy manual range warning in dependency_type validation

### DIFF
--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -91,7 +91,7 @@ pub fn handler(
     require!(max_workers > 0 && max_workers <= 100, CoordinationError::InvalidMaxWorkers);
     require!(task_type <= 2, CoordinationError::InvalidTaskType);
     require!(
-        dependency_type >= 1 && dependency_type <= 3,
+        (1..=3).contains(&dependency_type),
         CoordinationError::InvalidDependencyType
     );
 


### PR DESCRIPTION
## Summary
Fixes clippy warning about manual range check in `create_dependent_task.rs`.

## Changes
- Replace `dependency_type >= 1 && dependency_type <= 3` with `(1..=3).contains(&dependency_type)`

This uses proper range syntax as recommended by clippy.

Fixes #409