### PR TITLE
docs: document reserved _config param in apply_migration

### DIFF
--- a/programs/agenc-coordination/src/instructions/migrate.rs
+++ b/programs/agenc-coordination/src/instructions/migrate.rs
@@ -85,6 +85,12 @@ pub fn handler(ctx: Context<MigrateProtocol>, target_version: u8) -> Result<()> 
 
 /// Apply migration for a specific version
 /// Add new version handlers here as the protocol evolves
+///
+/// # Arguments
+/// * `_config` - Protocol configuration to mutate. Currently unused but reserved
+///   for future migrations that will need to initialize new fields or transform
+///   existing data (e.g., `config.new_field = default_value`).
+/// * `version` - Target version to migrate to
 fn apply_migration(_config: &mut ProtocolConfig, version: u8) -> Result<()> {
     match version {
         1 => {


### PR DESCRIPTION
## Summary
Document why the `_config` parameter in `apply_migration` is reserved for future use rather than removing it.

## Changes
Added documentation comment explaining that the parameter is intentionally kept for future migrations that will need to mutate protocol configuration (e.g., initializing new fields or transforming existing data).

## Testing
- `cargo check` passes

Closes #420