### PR TITLE
docs: document reputation field initial value and future config

### DIFF
--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -398,9 +398,9 @@ pub struct AgentRegistration {
     pub tasks_completed: u64,
     /// Total rewards earned
     pub total_earned: u64,
-    /// Reputation score (0-10000 logical range, stored as u16)
-    /// Note: Type allows 0-65535 but protocol uses 0-10000 scale
-    /// where 0 = worst, 10000 = perfect
+    /// Agent reputation score (0-10000)
+    /// Initial value: 5000 (neutral starting point)
+    /// Can be adjusted via protocol config in future versions
     pub reputation: u16,
     /// Active task count
     pub active_tasks: u8,


### PR DESCRIPTION
## Summary
Documents the hardcoded reputation initial value in AgentRegistration.

## Changes
- Updated reputation field documentation to clarify:
  - Score range: 0-10000
  - Initial value: 5000 (neutral starting point)
  - Future adjustability via protocol config

Fixes #423