### PR TITLE
docs(migrate): clarify v2 migration is intentional no-op

### DIFF
--- a/programs/agenc-coordination/src/instructions/migrate.rs
+++ b/programs/agenc-coordination/src/instructions/migrate.rs
@@ -91,10 +91,10 @@ fn apply_migration(_config: &mut ProtocolConfig, version: u8) -> Result<()> {
             // Version 1 is the initial version, no migration needed
             Ok(())
         }
+        // Version 2 migration is intentionally a no-op
+        // Placeholder for future schema changes
         2 => {
-            // Future: Version 2 migration logic
-            // Example: Initialize new fields, transform existing data
-            // config.new_field = default_value;
+            // No-op: Reserved for future use
             Ok(())
         }
         _ => {


### PR DESCRIPTION
## Summary
Updated documentation in `migrate.rs` to clarify that the version 2 migration is intentionally a no-op, reserved for future schema changes.

## Changes
- Added clear comments explaining the no-op nature of v2 migration
- Replaced placeholder comments with explicit documentation

Fixes #426