### PR TITLE
fix: replace magic 60 with STATE_UPDATE_COOLDOWN constant

### DIFF
--- a/programs/agenc-coordination/src/instructions/update_state.rs
+++ b/programs/agenc-coordination/src/instructions/update_state.rs
@@ -1,5 +1,8 @@
 //! Update shared coordination state
 
+/// Minimum seconds between state updates per agent
+const STATE_UPDATE_COOLDOWN: i64 = 60; // seconds
+
 use crate::errors::CoordinationError;
 use crate::events::StateUpdated;
 use crate::state::{AgentRegistration, AgentStatus, CoordinationState};
@@ -49,7 +52,7 @@ pub fn handler(
 
     if agent.last_state_update > 0 {
         let elapsed = clock.unix_timestamp.saturating_sub(agent.last_state_update);
-        if elapsed < 60 {
+        if elapsed < STATE_UPDATE_COOLDOWN {
             return Err(CoordinationError::RateLimitExceeded.into());
         }
     }


### PR DESCRIPTION
Replaces the hardcoded magic number `60` with a named constant `STATE_UPDATE_COOLDOWN` for better code clarity and maintainability.

### Changes
- Added `STATE_UPDATE_COOLDOWN: i64 = 60` constant with doc comment
- Replaced magic number in cooldown check

Fixes #398