### PR TITLE
Require non-zero slash amount in apply_dispute_slash

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -405,6 +405,9 @@ pub enum CoordinationError {
     #[msg("min_stake_for_dispute must be greater than zero")]
     InvalidMinStake,
 
+    #[msg("Slash amount must be greater than zero")]
+    InvalidSlashAmount,
+
     // Speculation Bond errors (7500-7599)
     #[msg("Bond amount too low")]
     BondAmountTooLow,

--- a/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
@@ -132,6 +132,11 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
         .checked_div(PERCENT_BASE)
         .ok_or(CoordinationError::ArithmeticOverflow)?;
 
+    require!(
+        slash_amount > 0,
+        CoordinationError::InvalidSlashAmount
+    );
+
     if slash_amount > 0 {
         worker_agent.stake = worker_agent
             .stake


### PR DESCRIPTION
## Summary
Adds validation to ensure slash_amount is greater than zero before applying dispute slashing.

## Changes
- Added `InvalidSlashAmount` error variant to `CoordinationError`
- Added `require!` validation after slash_amount calculation in `apply_dispute_slash`

## Testing
- `cargo check` passes

Fixes #424