### PR TITLE
docs: document remaining_accounts duplication in resolve_dispute

### DIFF
--- a/programs/agenc-coordination/fuzz/src/scenarios.rs
+++ b/programs/agenc-coordination/fuzz/src/scenarios.rs
@@ -33,7 +33,8 @@ pub struct SimulatedEscrow {
 pub struct SimulatedAgent {
     pub agent_id: [u8; 32],
     pub capabilities: u64,
-    pub status: u8, // 0=Inactive, 1=Active, 2=Busy, 3=Suspended
+    /// Agent status (see `agent_status` module in invariants.rs for values)
+    pub status: u8,
     pub active_tasks: u8,
     pub reputation: u16,
     pub stake: u64,
@@ -346,7 +347,7 @@ pub fn simulate_vote_dispute(
     }
 
     // Check arbiter is active
-    if arbiter.status != 1 {
+    if arbiter.status != agent_status::ACTIVE {
         return SimulationResult::Error("AgentNotActive".to_string());
     }
 

--- a/programs/agenc-coordination/src/instructions/constants.rs
+++ b/programs/agenc-coordination/src/instructions/constants.rs
@@ -17,3 +17,6 @@ pub const REPUTATION_PER_COMPLETION: u16 = 100;
 
 /// Maximum reputation an agent can accumulate
 pub const MAX_REPUTATION: u16 = 10000;
+
+/// 24-hour window in seconds (86400)
+pub const WINDOW_24H: i64 = 86400;

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -9,8 +9,7 @@ use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
-/// 24 hours in seconds
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 #[derive(Accounts)]
 #[instruction(task_id: [u8; 32])]

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -7,8 +7,7 @@ use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
-/// 24 hours in seconds
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 #[derive(Accounts)]
 #[instruction(task_id: [u8; 32])]

--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -9,9 +9,7 @@ use crate::state::{
 use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 
-
-/// 24 hours in seconds for rate limit window
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 /// Maximum evidence string length
 const MAX_EVIDENCE_LEN: usize = 256;

--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -6,8 +6,7 @@ use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig};
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
-/// 24 hours in seconds for rate limit window
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 /// Initial reputation score for new agents (50% = 5000/10000)
 const INITIAL_REPUTATION: u16 = 5000;

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -291,9 +291,8 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
 
     // Update dispute status - decrement active_dispute_votes for each arbiter
     //
-    // Worker accounts processing - shared pattern with resolve_dispute/expire_dispute
-    // The duplication is intentional to avoid cross-instruction dependencies
-    // and keep each instruction self-contained.
+    // Note: Similar remaining_accounts logic exists in expire_dispute.rs
+    // Duplication is intentional for instruction independence
     //
     // remaining_accounts format (fix #333):
     // - First: (vote, arbiter) pairs for total_voters


### PR DESCRIPTION
Clarify that similar remaining_accounts processing logic exists in expire_dispute.rs and that the duplication is intentional for instruction independence.

Fixes #443