### PR TITLE
refactor: centralize WINDOW_24H constant

### DIFF
--- a/programs/agenc-coordination/src/instructions/constants.rs
+++ b/programs/agenc-coordination/src/instructions/constants.rs
@@ -17,3 +17,6 @@ pub const REPUTATION_PER_COMPLETION: u16 = 100;
 
 /// Maximum reputation an agent can accumulate
 pub const MAX_REPUTATION: u16 = 10000;
+
+/// 24-hour window in seconds (86400)
+pub const WINDOW_24H: i64 = 86400;

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -9,8 +9,7 @@ use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
-/// 24 hours in seconds
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 #[derive(Accounts)]
 #[instruction(task_id: [u8; 32])]

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -7,8 +7,7 @@ use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
-/// 24 hours in seconds
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 #[derive(Accounts)]
 #[instruction(task_id: [u8; 32])]

--- a/programs/agenc-coordination/src/instructions/initiate_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/initiate_dispute.rs
@@ -9,9 +9,7 @@ use crate::state::{
 use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 
-
-/// 24 hours in seconds for rate limit window
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 /// Maximum evidence string length
 const MAX_EVIDENCE_LEN: usize = 256;

--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -6,8 +6,7 @@ use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig};
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
-/// 24 hours in seconds for rate limit window
-const WINDOW_24H: i64 = 24 * 60 * 60;
+use super::constants::WINDOW_24H;
 
 /// Initial reputation score for new agents (50% = 5000/10000)
 const INITIAL_REPUTATION: u16 = 5000;


### PR DESCRIPTION
## Summary
Centralizes the `WINDOW_24H` constant (86400 seconds / 24 hours) to `constants.rs` instead of defining it locally in multiple files.

## Changes
- Added `pub const WINDOW_24H: i64 = 86400;` to `constants.rs`
- Updated imports in:
  - `create_task.rs`
  - `create_dependent_task.rs`
  - `initiate_dispute.rs`
  - `register_agent.rs`

## Testing
- `cargo check` passes

Fixes #377