### PR TITLE
fix: use agent_status constants instead of magic numbers

### DIFF
--- a/programs/agenc-coordination/fuzz/src/invariants.rs
+++ b/programs/agenc-coordination/fuzz/src/invariants.rs
@@ -132,6 +132,14 @@ pub mod task_status {
     pub const DISPUTED: u8 = 5;
 }
 
+/// Agent status enum values (mirrors AgentStatus in state.rs)
+pub mod agent_status {
+    pub const INACTIVE: u8 = 0;
+    pub const ACTIVE: u8 = 1;
+    pub const BUSY: u8 = 2;
+    pub const SUSPENDED: u8 = 3;
+}
+
 /// T1: Valid State Transitions
 pub fn check_task_state_transition(from: u8, to: u8) -> TaskInvariantResult {
     let valid = match (from, to) {

--- a/programs/agenc-coordination/fuzz/src/scenarios.rs
+++ b/programs/agenc-coordination/fuzz/src/scenarios.rs
@@ -33,7 +33,8 @@ pub struct SimulatedEscrow {
 pub struct SimulatedAgent {
     pub agent_id: [u8; 32],
     pub capabilities: u64,
-    pub status: u8, // 0=Inactive, 1=Active, 2=Busy, 3=Suspended
+    /// Agent status (see `agent_status` module in invariants.rs for values)
+    pub status: u8,
     pub active_tasks: u8,
     pub reputation: u16,
     pub stake: u64,
@@ -121,7 +122,7 @@ pub fn simulate_claim_task(
     }
 
     // Check worker is active
-    if worker.status != 1 {
+    if worker.status != agent_status::ACTIVE {
         return SimulationResult::Error("AgentNotActive".to_string());
     }
 
@@ -346,7 +347,7 @@ pub fn simulate_vote_dispute(
     }
 
     // Check arbiter is active
-    if arbiter.status != 1 {
+    if arbiter.status != agent_status::ACTIVE {
         return SimulationResult::Error("AgentNotActive".to_string());
     }
 
@@ -590,7 +591,7 @@ mod tests {
         SimulatedAgent {
             agent_id: [2u8; 32],
             capabilities: 0xFF, // All capabilities
-            status: 1,          // Active
+            status: agent_status::ACTIVE,
             active_tasks: 0,
             reputation: 5000,
             stake: 1_000_000,


### PR DESCRIPTION
## Summary
Add `agent_status` module with named constants for agent status values, replacing magic number comparisons in fuzz scenarios.

## Changes
- Added `agent_status` module in `invariants.rs` with constants:
  - `INACTIVE = 0`
  - `ACTIVE = 1`
  - `BUSY = 2`
  - `SUSPENDED = 3`
- Replaced magic number `1` with `agent_status::ACTIVE` in `scenarios.rs`:
  - Worker active check
  - Arbiter active check  
  - Test setup function
- Updated `SimulatedAgent` struct comment to reference the module

## Testing
- `cargo check` passes
- Fuzz tests compile successfully

Fixes #399