### PR TITLE
fix: add grace period protection to expire_claim to prevent griefing attacks

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -146,6 +146,9 @@ pub enum CoordinationError {
     #[msg("Invalid rent recipient: must be worker authority")]
     InvalidRentRecipient,
 
+    #[msg("Grace period not passed: only worker authority can expire claim within 60 seconds of expiry")]
+    GracePeriodNotPassed,
+
     #[msg("Invalid proof hash: proof_hash cannot be all zeros")]
     InvalidProofHash,
 

--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -219,6 +219,7 @@ mod tests {
             required_completions,
             completions,
             bump: 0,
+            protocol_fee_bps: 0,
             depends_on: None,
             dependency_type: DependencyType::default(),
             _reserved: [0u8; 32],


### PR DESCRIPTION
## Summary

Fixes #421

This PR adds a 60-second grace period after claim expiry to protect workers from griefing attacks.

## Problem

The `expire_claim` instruction could be called by anyone immediately after a claim expired. This created a race condition where:
- Attackers could watch the mempool and submit `expire_claim` just as a worker's `complete_task` transaction landed
- MEV/validators could reorder transactions to ensure `expire_claim` executes before `complete_task`
- Workers' legitimate work could be invalidated at claim boundaries

## Solution

Added grace period protection:
- **During grace period (60 seconds after expiry)**: Only the worker authority can call `expire_claim`
- **After grace period**: Anyone can call it for permissionless cleanup

This preserves the cleanup incentive pattern while protecting workers from timing attacks.

## Changes

- Added `GRACE_PERIOD` constant (60 seconds) in `expire_claim.rs`
- Added `GracePeriodNotPassed` error in `errors.rs`
- Added check in handler: `grace_period_ended || is_worker_authority`
- Fixed pre-existing test issue: missing `protocol_fee_bps` in completion_helpers.rs

## Testing

- On-chain program compiles successfully with `anchor build`
- Rust unit tests pass

## Security

This is a defense-in-depth measure that adds minimal overhead (one timestamp comparison and one pubkey comparison) while significantly reducing the griefing attack surface.