### PR TITLE
fix: add protocol version check to cancel_task instruction

### DIFF
--- a/programs/agenc-coordination/src/instructions/cancel_task.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_task.rs
@@ -2,7 +2,8 @@
 
 use crate::errors::CoordinationError;
 use crate::events::TaskCancelled;
-use crate::state::{AgentRegistration, Task, TaskClaim, TaskEscrow, TaskStatus};
+use crate::state::{AgentRegistration, ProtocolConfig, Task, TaskClaim, TaskEscrow, TaskStatus};
+use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
@@ -26,6 +27,12 @@ pub struct CancelTask<'info> {
     #[account(mut)]
     pub creator: Signer<'info>,
 
+    #[account(
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+
     pub system_program: Program<'info, System>,
 }
 
@@ -33,6 +40,8 @@ pub fn handler(ctx: Context<CancelTask>) -> Result<()> {
     let task = &mut ctx.accounts.task;
     let escrow = &mut ctx.accounts.escrow;
     let clock = Clock::get()?;
+
+    check_version_compatible(&ctx.accounts.protocol_config)?;
 
     // Validate status transition is allowed (fix #538)
     require!(

--- a/tests/complete_task_private.ts
+++ b/tests/complete_task_private.ts
@@ -470,6 +470,8 @@ describe("complete_task_private", () => {
           task: cancelledTaskPda,
           escrow: cancelledEscrowPda,
           creator: creator.publicKey,
+          protocolConfig: protocolPda,
+          protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
         })
         .signers([creator])

--- a/tests/coordination-security.ts
+++ b/tests/coordination-security.ts
@@ -611,6 +611,7 @@ describe("coordination-security", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
           })
           .signers([creator])
           .rpc();
@@ -893,6 +894,7 @@ describe("coordination-security", () => {
               task: taskPda,
               escrow: escrowPda,
               creator: unauthorized.publicKey,
+              protocolConfig: protocolPda,
             })
             .signers([unauthorized])
             .rpc();
@@ -1298,6 +1300,7 @@ describe("coordination-security", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
           })
           .signers([creator])
           .rpc();

--- a/tests/integration.ts
+++ b/tests/integration.ts
@@ -802,6 +802,8 @@ describe("AgenC Integration Tests", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
+          protocolConfig: protocolPda,
             // systemProgram: auto-resolved
           })
           .signers([creator])

--- a/tests/test_1.ts
+++ b/tests/test_1.ts
@@ -1146,6 +1146,7 @@ describe("test_1", () => {
           task: taskPda,
           escrow: escrowPda,
           creator: creator.publicKey,
+          protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
         })
         .signers([creator])
@@ -1458,6 +1459,7 @@ describe("test_1", () => {
           task: taskPda,
           escrow: escrowPda,
           creator: creator.publicKey,
+          protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
         })
         .signers([creator])
@@ -2054,6 +2056,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -2137,6 +2140,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -2299,6 +2303,7 @@ describe("test_1", () => {
               task: taskPda,
               escrow: escrowPda,
               creator: creator.publicKey,
+              protocolConfig: protocolPda,
               systemProgram: SystemProgram.programId,
             })
             .signers([creator])
@@ -2347,6 +2352,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -2465,6 +2471,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -2478,6 +2485,7 @@ describe("test_1", () => {
               task: taskPda,
               escrow: escrowPda,
               creator: creator.publicKey,
+              protocolConfig: protocolPda,
               systemProgram: SystemProgram.programId,
             })
             .signers([creator])
@@ -2740,6 +2748,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -3298,6 +3307,7 @@ describe("test_1", () => {
               task: taskPda,
               escrow: escrowPda,
               creator: nonCreator.publicKey,
+              protocolConfig: protocolPda,
               systemProgram: SystemProgram.programId,
             })
             .signers([nonCreator])
@@ -3385,6 +3395,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -4013,6 +4024,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: unauthorized.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([unauthorized])
@@ -4153,6 +4165,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -4199,6 +4212,7 @@ describe("test_1", () => {
           task: taskPda,
           escrow: escrowPda,
           creator: creator.publicKey,
+          protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
         })
         .signers([creator])
@@ -4609,6 +4623,7 @@ describe("test_1", () => {
             task: taskPda,
             escrow: escrowPda,
             creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           })
           .signers([creator])
@@ -4695,6 +4710,7 @@ describe("test_1", () => {
         try {
           await program.methods.cancelTask().accountsPartial({
             task: taskPda, escrow: escrowPda, creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           }).signers([creator]).rpc();
           expect.fail("Expected TaskCannotBeCancelled error");
@@ -4832,6 +4848,7 @@ describe("test_1", () => {
         try {
           await program.methods.cancelTask().accountsPartial({
             task: taskPda, escrow: escrowPda, creator: creator.publicKey,
+            protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
           }).signers([creator]).rpc();
           expect.fail("Should have failed");
@@ -4934,6 +4951,7 @@ describe("test_1", () => {
 
         await program.methods.cancelTask().accountsPartial({
           task: taskPda, escrow: escrowPda, creator: creator.publicKey,
+          protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
         }).signers([creator]).rpc();
 
@@ -5466,6 +5484,7 @@ describe("test_1", () => {
 
         await program.methods.cancelTask().accountsPartial({
           task: taskPda, escrow: escrowPda, creator: creator.publicKey,
+          protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
         }).signers([creator]).rpc();
 

--- a/tests/zk-proof-lifecycle.ts
+++ b/tests/zk-proof-lifecycle.ts
@@ -641,6 +641,7 @@ describe("ZK Proof Verification Lifecycle", () => {
           task: taskPda,
           escrow: escrowPda,
           creator: taskCreator.publicKey,
+          protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
         })
         .signers([taskCreator])


### PR DESCRIPTION
## Summary
Fixes #382

This PR adds the missing protocol version check to the `cancel_task` instruction.

## Changes
1. Added `protocol_config` account to `CancelTask` accounts struct
2. Added `check_version_compatible()` call at the start of the handler
3. Updated all test files to include `protocolConfig` in `cancelTask` calls

## Why this is needed
The `cancel_task` instruction was missing the protocol version check that other instructions like `complete_task` have. This could allow operations on accounts with incompatible protocol versions during migrations, potentially leading to inconsistent state.

## Testing
- Library compiles successfully with `cargo check`
- Test files updated to include the new required account
- The anchor build for tests had a pre-existing failure in `completion_helpers.rs` unrelated to these changes