### PR TITLE
fix: Close escrow and claim accounts to return rent

### DIFF
--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -221,6 +221,7 @@ mod tests {
             bump: 0,
             depends_on: None,
             dependency_type: DependencyType::default(),
+            protocol_fee_bps: 100, // 1% default for tests
             _reserved: [0u8; 32],
         }
     }

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -143,6 +143,132 @@
               }
             ]
           }
+        },
+        {
+          "name": "treasury",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "apply_initiator_slash",
+      "docs": [
+        "Apply slashing to a dispute initiator when their dispute is rejected.",
+        "This provides symmetric slashing: workers are slashed for bad work,",
+        "initiators are slashed for frivolous disputes."
+      ],
+      "discriminator": [
+        63,
+        59,
+        40,
+        189,
+        124,
+        61,
+        159,
+        168
+      ],
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task being disputed - validates initiator was a participant"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "initiator_agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "initiator_agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "treasury",
+          "writable": true
         }
       ],
       "args": []
@@ -407,6 +533,11 @@
         },
         {
           "name": "claim",
+          "docs": [
+            "Note: Claim account is closed after completion.",
+            "If proof-of-completion is needed later, store result_hash",
+            "in an event or separate completion record."
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -433,6 +564,10 @@
         },
         {
           "name": "escrow",
+          "docs": [
+            "Note: Escrow account is closed after completion.",
+            "Rent is returned to the task creator who funded it."
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -453,6 +588,10 @@
               }
             ]
           }
+        },
+        {
+          "name": "creator",
+          "writable": true
         },
         {
           "name": "worker",
@@ -609,6 +748,10 @@
         },
         {
           "name": "escrow",
+          "docs": [
+            "Note: Escrow account is closed after completion.",
+            "Rent is returned to the task creator who funded it."
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -629,6 +772,10 @@
               }
             ]
           }
+        },
+        {
+          "name": "creator",
+          "writable": true
         },
         {
           "name": "worker",
@@ -670,6 +817,36 @@
                   111,
                   108
                 ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "nullifier_account",
+          "docs": [
+            "Nullifier account to prevent proof/knowledge reuse.",
+            "If this account already exists, the proof has been used before."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  110,
+                  117,
+                  108,
+                  108,
+                  105,
+                  102,
+                  105,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "proof.nullifier"
               }
             ]
           }
@@ -1197,6 +1374,14 @@
       ],
       "accounts": [
         {
+          "name": "caller",
+          "docs": [
+            "Caller who triggers the expiration - receives cleanup reward"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
           "name": "task",
           "writable": true,
           "pda": {
@@ -1219,6 +1404,29 @@
                 "kind": "account",
                 "path": "task.task_id",
                 "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
               }
             ]
           }
@@ -1484,6 +1692,15 @@
           "signer": true
         },
         {
+          "name": "second_signer",
+          "docs": [
+            "Second multisig signer required at initialization to prevent single-party setup.",
+            "Must be different from authority and must be in multisig_owners.",
+            "This ensures at least two parties are involved in protocol initialization (fix #556)."
+          ],
+          "signer": true
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -1499,6 +1716,10 @@
         },
         {
           "name": "min_stake",
+          "type": "u64"
+        },
+        {
+          "name": "min_stake_for_dispute",
           "type": "u64"
         },
         {
@@ -1630,6 +1851,49 @@
               }
             ]
           }
+        },
+        {
+          "name": "initiator_claim",
+          "docs": [
+            "Optional: Initiator's claim if they are a worker (not the creator)"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "agent"
+              }
+            ]
+          }
+        },
+        {
+          "name": "worker_agent",
+          "docs": [
+            "Optional: Worker agent to be disputed (required when initiator is task creator)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Optional: Worker's claim (required when worker_agent is provided)"
+          ],
+          "optional": true
         },
         {
           "name": "authority",
@@ -1932,6 +2196,7 @@
         },
         {
           "name": "protocol_config",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -1962,8 +2227,10 @@
           "name": "worker_claim",
           "docs": [
             "Worker's claim proving they worked on task (fix #59)",
-            "Required for Complete/Split resolutions that pay a worker"
+            "Required for Complete/Split resolutions that pay a worker",
+            "Made mutable to allow closing after dispute resolution (fix #439)"
           ],
+          "writable": true,
           "optional": true,
           "pda": {
             "seeds": [
@@ -1991,6 +2258,11 @@
         },
         {
           "name": "worker",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_authority",
           "writable": true,
           "optional": true
         },
@@ -2278,6 +2550,10 @@
                 ]
               },
               {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
                 "kind": "arg",
                 "path": "state_key"
               }
@@ -2383,6 +2659,69 @@
                 "kind": "account",
                 "path": "dispute.dispute_id",
                 "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task account for arbiter party validation (fix #461)"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          },
+          "relations": [
+            "dispute"
+          ]
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Optional: Worker's claim on the task (for arbiter party validation, fix #461)",
+            "If provided, validates arbiter is not the worker"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker_claim.worker",
+                "account": "TaskClaim"
               }
             ]
           }
@@ -2582,6 +2921,19 @@
       ]
     },
     {
+      "name": "Nullifier",
+      "discriminator": [
+        18,
+        56,
+        142,
+        165,
+        181,
+        158,
+        187,
+        133
+      ]
+    },
+    {
       "name": "ProtocolConfig",
       "discriminator": [
         207,
@@ -2672,6 +3024,19 @@
         250,
         210,
         166
+      ]
+    },
+    {
+      "name": "ArbiterVotesCleanedUp",
+      "discriminator": [
+        50,
+        95,
+        231,
+        24,
+        238,
+        79,
+        179,
+        220
       ]
     },
     {
@@ -2805,6 +3170,19 @@
       ]
     },
     {
+      "name": "ProtocolFeeUpdated",
+      "discriminator": [
+        172,
+        56,
+        83,
+        113,
+        219,
+        69,
+        69,
+        105
+      ]
+    },
+    {
       "name": "ProtocolInitialized",
       "discriminator": [
         173,
@@ -2841,6 +3219,19 @@
         167,
         242,
         145
+      ]
+    },
+    {
+      "name": "RateLimitsUpdated",
+      "discriminator": [
+        32,
+        232,
+        72,
+        132,
+        73,
+        25,
+        219,
+        10
       ]
     },
     {
@@ -2958,398 +3349,643 @@
     },
     {
       "code": 6004,
+      "name": "InvalidCapabilities",
+      "msg": "Agent capabilities bitmask cannot be zero"
+    },
+    {
+      "code": 6005,
       "name": "MaxActiveTasksReached",
       "msg": "Agent has reached maximum active tasks"
     },
     {
-      "code": 6005,
+      "code": 6006,
       "name": "AgentHasActiveTasks",
       "msg": "Agent has active tasks and cannot be deregistered"
     },
     {
-      "code": 6006,
+      "code": 6007,
       "name": "UnauthorizedAgent",
       "msg": "Only the agent authority can perform this action"
     },
     {
-      "code": 6007,
+      "code": 6008,
+      "name": "InvalidAgentId",
+      "msg": "Invalid agent ID: agent_id cannot be all zeros"
+    },
+    {
+      "code": 6009,
       "name": "AgentRegistrationRequired",
       "msg": "Agent registration required to create tasks"
     },
     {
-      "code": 6008,
+      "code": 6010,
       "name": "AgentSuspended",
       "msg": "Agent is suspended and cannot change status"
     },
     {
-      "code": 6009,
+      "code": 6011,
+      "name": "AgentBusyWithTasks",
+      "msg": "Agent cannot set status to Active while having active tasks"
+    },
+    {
+      "code": 6012,
       "name": "TaskNotFound",
       "msg": "Task not found"
     },
     {
-      "code": 6010,
+      "code": 6013,
       "name": "TaskNotOpen",
       "msg": "Task is not open for claims"
     },
     {
-      "code": 6011,
+      "code": 6014,
       "name": "TaskFullyClaimed",
       "msg": "Task has reached maximum workers"
     },
     {
-      "code": 6012,
+      "code": 6015,
       "name": "TaskExpired",
       "msg": "Task has expired"
     },
     {
-      "code": 6013,
+      "code": 6016,
       "name": "TaskNotExpired",
       "msg": "Task deadline has not passed"
     },
     {
-      "code": 6014,
+      "code": 6017,
       "name": "DeadlinePassed",
       "msg": "Task deadline has passed"
     },
     {
-      "code": 6015,
+      "code": 6018,
       "name": "TaskNotInProgress",
       "msg": "Task is not in progress"
     },
     {
-      "code": 6016,
+      "code": 6019,
       "name": "TaskAlreadyCompleted",
       "msg": "Task is already completed"
     },
     {
-      "code": 6017,
+      "code": 6020,
       "name": "TaskCannotBeCancelled",
       "msg": "Task cannot be cancelled"
     },
     {
-      "code": 6018,
+      "code": 6021,
       "name": "UnauthorizedTaskAction",
       "msg": "Only the task creator can perform this action"
     },
     {
-      "code": 6019,
+      "code": 6022,
       "name": "InvalidCreator",
       "msg": "Invalid creator"
     },
     {
-      "code": 6020,
+      "code": 6023,
+      "name": "InvalidTaskId",
+      "msg": "Invalid task ID: cannot be zero"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidDescription",
+      "msg": "Invalid description: cannot be empty"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidMaxWorkers",
+      "msg": "Invalid max workers: must be between 1 and 100"
+    },
+    {
+      "code": 6026,
       "name": "InvalidTaskType",
       "msg": "Invalid task type"
     },
     {
-      "code": 6021,
+      "code": 6027,
+      "name": "InvalidDeadline",
+      "msg": "Invalid deadline: deadline must be greater than zero"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidReward",
+      "msg": "Invalid reward: reward must be greater than zero"
+    },
+    {
+      "code": 6029,
       "name": "CompetitiveTaskAlreadyWon",
       "msg": "Competitive task already completed by another worker"
     },
     {
-      "code": 6022,
+      "code": 6030,
       "name": "NoWorkers",
       "msg": "Task has no workers"
     },
     {
-      "code": 6023,
+      "code": 6031,
       "name": "ConstraintHashMismatch",
       "msg": "Proof constraint hash does not match task's stored constraint hash"
     },
     {
-      "code": 6024,
+      "code": 6032,
       "name": "NotPrivateTask",
       "msg": "Task is not a private task (no constraint hash set)"
     },
     {
-      "code": 6025,
+      "code": 6033,
       "name": "AlreadyClaimed",
       "msg": "Worker has already claimed this task"
     },
     {
-      "code": 6026,
+      "code": 6034,
       "name": "NotClaimed",
       "msg": "Worker has not claimed this task"
     },
     {
-      "code": 6027,
+      "code": 6035,
       "name": "ClaimAlreadyCompleted",
       "msg": "Claim has already been completed"
     },
     {
-      "code": 6028,
+      "code": 6036,
       "name": "ClaimNotExpired",
       "msg": "Claim has not expired yet"
     },
     {
-      "code": 6029,
+      "code": 6037,
+      "name": "ClaimExpired",
+      "msg": "Claim has expired"
+    },
+    {
+      "code": 6038,
+      "name": "InvalidExpiration",
+      "msg": "Invalid expiration: expires_at cannot be zero"
+    },
+    {
+      "code": 6039,
       "name": "InvalidProof",
       "msg": "Invalid proof of work"
     },
     {
-      "code": 6030,
+      "code": 6040,
       "name": "ZkVerificationFailed",
       "msg": "ZK proof verification failed"
     },
     {
-      "code": 6031,
+      "code": 6041,
       "name": "InvalidProofSize",
       "msg": "Invalid proof size - expected 256 bytes for Groth16"
     },
     {
-      "code": 6032,
+      "code": 6042,
       "name": "InvalidProofBinding",
       "msg": "Invalid proof binding: expected_binding cannot be all zeros"
     },
     {
-      "code": 6033,
+      "code": 6043,
       "name": "InvalidOutputCommitment",
       "msg": "Invalid output commitment: output_commitment cannot be all zeros"
     },
     {
-      "code": 6034,
+      "code": 6044,
+      "name": "InvalidRentRecipient",
+      "msg": "Invalid rent recipient: must be worker authority"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidProofHash",
+      "msg": "Invalid proof hash: proof_hash cannot be all zeros"
+    },
+    {
+      "code": 6046,
+      "name": "InvalidResultData",
+      "msg": "Invalid result data: result_data cannot be all zeros when provided"
+    },
+    {
+      "code": 6047,
       "name": "DisputeNotActive",
       "msg": "Dispute is not active"
     },
     {
-      "code": 6035,
+      "code": 6048,
       "name": "VotingEnded",
       "msg": "Voting period has ended"
     },
     {
-      "code": 6036,
+      "code": 6049,
       "name": "VotingNotEnded",
       "msg": "Voting period has not ended"
     },
     {
-      "code": 6037,
+      "code": 6050,
       "name": "AlreadyVoted",
       "msg": "Already voted on this dispute"
     },
     {
-      "code": 6038,
+      "code": 6051,
       "name": "NotArbiter",
       "msg": "Not authorized to vote (not an arbiter)"
     },
     {
-      "code": 6039,
+      "code": 6052,
       "name": "InsufficientVotes",
       "msg": "Insufficient votes to resolve"
     },
     {
-      "code": 6040,
+      "code": 6053,
       "name": "DisputeAlreadyResolved",
       "msg": "Dispute has already been resolved"
     },
     {
-      "code": 6041,
+      "code": 6054,
       "name": "UnauthorizedResolver",
       "msg": "Only protocol authority or dispute initiator can resolve disputes"
     },
     {
-      "code": 6042,
+      "code": 6055,
       "name": "ActiveDisputeVotes",
       "msg": "Agent has active dispute votes pending resolution"
     },
     {
-      "code": 6043,
+      "code": 6056,
       "name": "RecentVoteActivity",
       "msg": "Agent must wait 24 hours after voting before deregistering"
     },
     {
-      "code": 6044,
+      "code": 6057,
       "name": "AuthorityAlreadyVoted",
       "msg": "Authority has already voted on this dispute"
     },
     {
-      "code": 6045,
+      "code": 6058,
       "name": "InsufficientEvidence",
       "msg": "Insufficient dispute evidence provided"
     },
     {
-      "code": 6046,
+      "code": 6059,
       "name": "EvidenceTooLong",
       "msg": "Dispute evidence exceeds maximum allowed length"
     },
     {
-      "code": 6047,
+      "code": 6060,
       "name": "DisputeNotExpired",
       "msg": "Dispute has not expired"
     },
     {
-      "code": 6048,
+      "code": 6061,
       "name": "SlashAlreadyApplied",
       "msg": "Dispute slashing already applied"
     },
     {
-      "code": 6049,
+      "code": 6062,
       "name": "DisputeNotResolved",
       "msg": "Dispute has not been resolved"
     },
     {
-      "code": 6050,
+      "code": 6063,
+      "name": "NotTaskParticipant",
+      "msg": "Only task creator or workers can initiate disputes"
+    },
+    {
+      "code": 6064,
+      "name": "InvalidEvidenceHash",
+      "msg": "Invalid evidence hash: cannot be all zeros"
+    },
+    {
+      "code": 6065,
+      "name": "ArbiterIsDisputeParticipant",
+      "msg": "Arbiter cannot vote on disputes they are a participant in"
+    },
+    {
+      "code": 6066,
+      "name": "InsufficientQuorum",
+      "msg": "Insufficient quorum: minimum number of voters not reached"
+    },
+    {
+      "code": 6067,
+      "name": "ActiveDisputesExist",
+      "msg": "Agent has active disputes as defendant and cannot deregister"
+    },
+    {
+      "code": 6068,
+      "name": "WorkerAgentRequired",
+      "msg": "Worker agent account required when creator initiates dispute"
+    },
+    {
+      "code": 6069,
+      "name": "WorkerClaimRequired",
+      "msg": "Worker claim account required when creator initiates dispute"
+    },
+    {
+      "code": 6070,
+      "name": "WorkerNotInDispute",
+      "msg": "Worker was not involved in this dispute"
+    },
+    {
+      "code": 6071,
+      "name": "InitiatorCannotResolve",
+      "msg": "Dispute initiator cannot resolve their own dispute"
+    },
+    {
+      "code": 6072,
       "name": "VersionMismatch",
       "msg": "State version mismatch (concurrent modification)"
     },
     {
-      "code": 6051,
+      "code": 6073,
       "name": "StateKeyExists",
       "msg": "State key already exists"
     },
     {
-      "code": 6052,
+      "code": 6074,
       "name": "StateNotFound",
       "msg": "State not found"
     },
     {
-      "code": 6053,
+      "code": 6075,
+      "name": "InvalidStateValue",
+      "msg": "Invalid state value: state_value cannot be all zeros"
+    },
+    {
+      "code": 6076,
       "name": "ProtocolAlreadyInitialized",
       "msg": "Protocol is already initialized"
     },
     {
-      "code": 6054,
+      "code": 6077,
       "name": "ProtocolNotInitialized",
       "msg": "Protocol is not initialized"
     },
     {
-      "code": 6055,
+      "code": 6078,
       "name": "InvalidProtocolFee",
       "msg": "Invalid protocol fee (must be <= 1000 bps)"
     },
     {
-      "code": 6056,
-      "name": "InvalidDisputeThreshold",
-      "msg": "Invalid dispute threshold"
+      "code": 6079,
+      "name": "InvalidTreasury",
+      "msg": "Invalid treasury: treasury account cannot be default pubkey"
     },
     {
-      "code": 6057,
+      "code": 6080,
+      "name": "InvalidDisputeThreshold",
+      "msg": "Invalid dispute threshold: must be 1-100 (percentage of votes required)"
+    },
+    {
+      "code": 6081,
       "name": "InsufficientStake",
       "msg": "Insufficient stake for arbiter registration"
     },
     {
-      "code": 6058,
+      "code": 6082,
       "name": "MultisigInvalidThreshold",
       "msg": "Invalid multisig threshold"
     },
     {
-      "code": 6059,
+      "code": 6083,
       "name": "MultisigInvalidSigners",
       "msg": "Invalid multisig signer configuration"
     },
     {
-      "code": 6060,
+      "code": 6084,
       "name": "MultisigNotEnoughSigners",
       "msg": "Not enough multisig signers"
     },
     {
-      "code": 6061,
+      "code": 6085,
       "name": "MultisigDuplicateSigner",
       "msg": "Duplicate multisig signer provided"
     },
     {
-      "code": 6062,
+      "code": 6086,
       "name": "MultisigDefaultSigner",
       "msg": "Multisig signer cannot be default pubkey"
     },
     {
-      "code": 6063,
+      "code": 6087,
       "name": "MultisigSignerNotSystemOwned",
       "msg": "Multisig signer account not owned by System Program"
     },
     {
-      "code": 6064,
+      "code": 6088,
       "name": "InvalidInput",
       "msg": "Invalid input parameter"
     },
     {
-      "code": 6065,
+      "code": 6089,
       "name": "ArithmeticOverflow",
       "msg": "Arithmetic overflow"
     },
     {
-      "code": 6066,
+      "code": 6090,
       "name": "VoteOverflow",
       "msg": "Vote count overflow"
     },
     {
-      "code": 6067,
+      "code": 6091,
       "name": "InsufficientFunds",
       "msg": "Insufficient funds"
     },
     {
-      "code": 6068,
+      "code": 6092,
+      "name": "RewardTooSmall",
+      "msg": "Reward too small: worker must receive at least 1 lamport"
+    },
+    {
+      "code": 6093,
       "name": "CorruptedData",
       "msg": "Account data is corrupted"
     },
     {
-      "code": 6069,
+      "code": 6094,
       "name": "StringTooLong",
       "msg": "String too long"
     },
     {
-      "code": 6070,
+      "code": 6095,
       "name": "InvalidAccountOwner",
       "msg": "Account owner validation failed: account not owned by this program"
     },
     {
-      "code": 6071,
+      "code": 6096,
       "name": "RateLimitExceeded",
       "msg": "Rate limit exceeded: maximum actions per 24h window reached"
     },
     {
-      "code": 6072,
+      "code": 6097,
       "name": "CooldownNotElapsed",
       "msg": "Cooldown period has not elapsed since last action"
     },
     {
-      "code": 6073,
+      "code": 6098,
+      "name": "UpdateTooFrequent",
+      "msg": "Agent update too frequent: must wait cooldown period"
+    },
+    {
+      "code": 6099,
+      "name": "InvalidCooldown",
+      "msg": "Cooldown value cannot be negative"
+    },
+    {
+      "code": 6100,
+      "name": "CooldownTooLarge",
+      "msg": "Cooldown value exceeds maximum (24 hours)"
+    },
+    {
+      "code": 6101,
+      "name": "RateLimitTooHigh",
+      "msg": "Rate limit value exceeds maximum allowed (1000)"
+    },
+    {
+      "code": 6102,
+      "name": "CooldownTooLong",
+      "msg": "Cooldown value exceeds maximum allowed (1 week)"
+    },
+    {
+      "code": 6103,
       "name": "InsufficientStakeForDispute",
       "msg": "Insufficient stake to initiate dispute"
     },
     {
-      "code": 6074,
+      "code": 6104,
       "name": "VersionMismatchProtocol",
       "msg": "Protocol version mismatch: account version incompatible with current program"
     },
     {
-      "code": 6075,
+      "code": 6105,
       "name": "AccountVersionTooOld",
       "msg": "Account version too old: migration required"
     },
     {
-      "code": 6076,
+      "code": 6106,
       "name": "AccountVersionTooNew",
       "msg": "Account version too new: program upgrade required"
     },
     {
-      "code": 6077,
+      "code": 6107,
       "name": "InvalidMigrationSource",
       "msg": "Migration not allowed: invalid source version"
     },
     {
-      "code": 6078,
+      "code": 6108,
       "name": "InvalidMigrationTarget",
       "msg": "Migration not allowed: invalid target version"
     },
     {
-      "code": 6079,
+      "code": 6109,
       "name": "UnauthorizedUpgrade",
       "msg": "Only upgrade authority can perform this action"
     },
     {
-      "code": 6080,
+      "code": 6110,
+      "name": "InvalidMinVersion",
+      "msg": "Minimum version cannot exceed current protocol version"
+    },
+    {
+      "code": 6111,
+      "name": "ProtocolConfigRequired",
+      "msg": "Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts"
+    },
+    {
+      "code": 6112,
       "name": "ParentTaskCancelled",
       "msg": "Parent task has been cancelled"
     },
     {
-      "code": 6081,
+      "code": 6113,
       "name": "ParentTaskDisputed",
       "msg": "Parent task is in disputed state"
     },
     {
-      "code": 6082,
+      "code": 6114,
       "name": "InvalidDependencyType",
       "msg": "Invalid dependency type"
+    },
+    {
+      "code": 6115,
+      "name": "ParentTaskNotCompleted",
+      "msg": "Parent task must be completed before completing a proof-dependent task"
+    },
+    {
+      "code": 6116,
+      "name": "ParentTaskAccountRequired",
+      "msg": "Parent task account required for proof-dependent task completion"
+    },
+    {
+      "code": 6117,
+      "name": "UnauthorizedCreator",
+      "msg": "Parent task does not belong to the same creator"
+    },
+    {
+      "code": 6118,
+      "name": "NullifierAlreadySpent",
+      "msg": "Nullifier has already been spent - proof/knowledge reuse detected"
+    },
+    {
+      "code": 6119,
+      "name": "InvalidNullifier",
+      "msg": "Invalid nullifier: nullifier value cannot be all zeros"
+    },
+    {
+      "code": 6120,
+      "name": "IncompleteWorkerAccounts",
+      "msg": "All worker accounts must be provided when cancelling a task with active claims"
+    },
+    {
+      "code": 6121,
+      "name": "WorkerAccountsRequired",
+      "msg": "Worker accounts required when task has active workers"
+    },
+    {
+      "code": 6122,
+      "name": "DuplicateArbiter",
+      "msg": "Duplicate arbiter provided in remaining_accounts"
+    },
+    {
+      "code": 6123,
+      "name": "InsufficientEscrowBalance",
+      "msg": "Escrow has insufficient balance for reward transfer"
+    },
+    {
+      "code": 6124,
+      "name": "InvalidStatusTransition",
+      "msg": "Invalid task status transition"
+    },
+    {
+      "code": 6125,
+      "name": "StakeTooLow",
+      "msg": "Stake value is below minimum required (0.001 SOL)"
+    },
+    {
+      "code": 6126,
+      "name": "InvalidMinStake",
+      "msg": "min_stake_for_dispute must be greater than zero"
+    },
+    {
+      "code": 6127,
+      "name": "InvalidSlashAmount",
+      "msg": "Slash amount must be greater than zero"
+    },
+    {
+      "code": 6128,
+      "name": "BondAmountTooLow",
+      "msg": "Bond amount too low"
+    },
+    {
+      "code": 6129,
+      "name": "BondAlreadyExists",
+      "msg": "Bond already exists"
+    },
+    {
+      "code": 6130,
+      "name": "BondNotFound",
+      "msg": "Bond not found"
+    },
+    {
+      "code": 6131,
+      "name": "BondNotMatured",
+      "msg": "Bond not yet matured"
     }
   ],
   "types": [
@@ -3411,6 +4047,10 @@
             "type": "string"
           },
           {
+            "name": "stake_amount",
+            "type": "u64"
+          },
+          {
             "name": "timestamp",
             "type": "i64"
           }
@@ -3448,7 +4088,15 @@
           {
             "name": "capabilities",
             "docs": [
-              "Capability bitmask"
+              "Agent capabilities as a bitmask (u64).",
+              "",
+              "Each bit represents a specific capability the agent possesses.",
+              "See [`capability`] module for defined bits:",
+              "- Bits 0-9: Currently defined capabilities (COMPUTE, INFERENCE, etc.)",
+              "- Bits 10-63: Reserved for future protocol extensions",
+              "",
+              "Agents can only claim tasks where they have all required capabilities:",
+              "`(agent.capabilities & task.required_capabilities) == task.required_capabilities`"
             ],
             "type": "u64"
           },
@@ -3466,7 +4114,7 @@
           {
             "name": "endpoint",
             "docs": [
-              "Network endpoint (max 128 chars)"
+              "Network endpoint (max 256 chars)"
             ],
             "type": "string"
           },
@@ -3508,7 +4156,9 @@
           {
             "name": "reputation",
             "docs": [
-              "Reputation score (0-10000)"
+              "Agent reputation score (0-10000)",
+              "Initial value: 5000 (neutral starting point)",
+              "Can be adjusted via protocol config in future versions"
             ],
             "type": "u16"
           },
@@ -3590,14 +4240,23 @@
             "type": "i64"
           },
           {
+            "name": "disputes_as_defendant",
+            "docs": [
+              "Active disputes where this agent is a defendant (can be slashed)"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "_reserved",
             "docs": [
-              "Reserved for future use"
+              "Reserved bytes for future use.",
+              "Note: Not validated on deserialization - may contain arbitrary data",
+              "from previous versions. New fields should handle this gracefully."
             ],
             "type": {
               "array": [
                 "u8",
-                6
+                5
               ]
             }
           }
@@ -3658,6 +4317,30 @@
           {
             "name": "timestamp",
             "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ArbiterVotesCleanedUp",
+      "docs": [
+        "Emitted when arbiter votes are cleaned up during dispute expiration"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dispute_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "arbiter_count",
+            "type": "u8"
           }
         ]
       }
@@ -3729,6 +4412,10 @@
           {
             "name": "new_total",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3752,6 +4439,10 @@
           {
             "name": "amount",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3775,6 +4466,10 @@
           {
             "name": "amount",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3814,11 +4509,18 @@
       "name": "CoordinationState",
       "docs": [
         "Shared coordination state",
-        "PDA seeds: [\"state\", state_key]"
+        "PDA seeds: [\"state\", owner, state_key]"
       ],
       "type": {
         "kind": "struct",
         "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Owner authority - namespaces state to prevent cross-user collisions"
+            ],
+            "type": "pubkey"
+          },
           {
             "name": "state_key",
             "docs": [
@@ -3877,7 +4579,7 @@
     {
       "name": "DependencyType",
       "docs": [
-        "Dependency type for speculative execution decisions"
+        "Task dependency type for speculative execution decisions"
       ],
       "repr": {
         "kind": "rust"
@@ -3967,7 +4669,14 @@
           {
             "name": "initiator",
             "docs": [
-              "Initiator"
+              "Initiator (agent PDA)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "initiator_authority",
+            "docs": [
+              "Initiator's authority wallet (for resolver constraint)"
             ],
             "type": "pubkey"
           },
@@ -4036,30 +4745,48 @@
           {
             "name": "total_voters",
             "docs": [
-              "Total eligible voters"
+              "Total arbiters who voted (max 255 due to u8)",
+              "Note: Increase to u16 if more arbiters needed"
             ],
             "type": "u8"
           },
           {
             "name": "voting_deadline",
             "docs": [
-              "Voting deadline"
+              "Voting deadline - after this, no new votes accepted",
+              "voting_deadline = created_at + voting_period"
             ],
             "type": "i64"
           },
           {
             "name": "expires_at",
             "docs": [
-              "Dispute expiration timestamp"
+              "Dispute expiration - after this, can call expire_dispute",
+              "expires_at = created_at + max_dispute_duration",
+              "Note: expires_at >= voting_deadline, allowing resolution after voting ends"
             ],
             "type": "i64"
           },
           {
             "name": "slash_applied",
             "docs": [
-              "Whether slashing has been applied"
+              "Whether worker slashing has been applied"
             ],
             "type": "bool"
+          },
+          {
+            "name": "initiator_slash_applied",
+            "docs": [
+              "Whether initiator slashing has been applied (for rejected disputes)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "worker_stake_at_dispute",
+            "docs": [
+              "Snapshot of worker's stake at dispute initiation (prevents stake withdrawal attacks)"
+            ],
+            "type": "u64"
           },
           {
             "name": "bump",
@@ -4250,6 +4977,13 @@
             "type": "i64"
           },
           {
+            "name": "stake_at_vote",
+            "docs": [
+              "Arbiter's stake at the time of voting (for weighted resolution)"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "bump",
             "docs": [
               "Bump seed"
@@ -4327,6 +5061,60 @@
       }
     },
     {
+      "name": "Nullifier",
+      "docs": [
+        "Nullifier account to prevent proof/knowledge reuse across tasks.",
+        "Once a nullifier is \"spent\" (account exists), the same proof/knowledge",
+        "combination cannot be used again.",
+        "PDA seeds: [\"nullifier\", nullifier_value]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nullifier_value",
+            "docs": [
+              "The nullifier value (derived from constraint_hash + agent_secret in ZK circuit)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "task",
+            "docs": [
+              "The task where this nullifier was first used"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "agent",
+            "docs": [
+              "The agent who spent this nullifier"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "spent_at",
+            "docs": [
+              "Timestamp when nullifier was spent"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
       "name": "PrivateCompletionProof",
       "type": {
         "kind": "struct",
@@ -4361,6 +5149,19 @@
                 32
               ]
             }
+          },
+          {
+            "name": "nullifier",
+            "docs": [
+              "Nullifier to prevent proof/knowledge reuse across tasks.",
+              "Derived in the ZK circuit as: Poseidon(constraint_hash, agent_secret)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           }
         ]
       }
@@ -4377,14 +5178,17 @@
           {
             "name": "authority",
             "docs": [
-              "Protocol authority"
+              "Protocol authority",
+              "Note: Cannot be updated after initialization."
             ],
             "type": "pubkey"
           },
           {
             "name": "treasury",
             "docs": [
-              "Treasury for protocol fees"
+              "Treasury address for protocol fees",
+              "Note: Cannot be updated after initialization.",
+              "Deploy new protocol if treasury change needed."
             ],
             "type": "pubkey"
           },
@@ -4522,6 +5326,13 @@
             "type": "u8"
           },
           {
+            "name": "voting_period",
+            "docs": [
+              "Voting period for disputes in seconds (default: 24 hours)"
+            ],
+            "type": "i64"
+          },
+          {
             "name": "protocol_version",
             "docs": [
               "Current protocol version (for upgrades)"
@@ -4538,7 +5349,8 @@
           {
             "name": "_padding",
             "docs": [
-              "Padding for alignment/future use"
+              "Padding for future use and alignment",
+              "Currently unused but reserved for backwards-compatible additions"
             ],
             "type": {
               "array": [
@@ -4550,7 +5362,19 @@
           {
             "name": "multisig_owners",
             "docs": [
-              "Multisig owners (fixed-size)"
+              "Multisig owners (immutable after init for security).",
+              "",
+              "# Security Note (see #464)",
+              "Multisig configuration **cannot be updated** after protocol initialization.",
+              "To change multisig, deploy new protocol.",
+              "",
+              "This is intentional:",
+              "- Prevents hostile takeover via multisig reconfiguration",
+              "- Ensures governance changes require protocol redeployment with proper ceremony",
+              "- The array is fully zeroed before population in `initialize_protocol`",
+              "",
+              "Only the first `multisig_owners_len` entries are valid; remaining slots",
+              "are always `Pubkey::default()`."
             ],
             "type": {
               "array": [
@@ -4558,6 +5382,33 @@
                 5
               ]
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolFeeUpdated",
+      "docs": [
+        "Emitted when protocol fee is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "new_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4665,6 +5516,45 @@
       }
     },
     {
+      "name": "RateLimitsUpdated",
+      "docs": [
+        "Emitted when rate limit configuration is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "task_creation_cooldown",
+            "type": "i64"
+          },
+          {
+            "name": "max_tasks_per_24h",
+            "type": "u8"
+          },
+          {
+            "name": "dispute_initiation_cooldown",
+            "type": "i64"
+          },
+          {
+            "name": "max_disputes_per_24h",
+            "type": "u8"
+          },
+          {
+            "name": "min_stake_for_dispute",
+            "type": "u64"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
       "name": "ResolutionType",
       "docs": [
         "Dispute resolution type"
@@ -4752,6 +5642,10 @@
           {
             "name": "expires_at",
             "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4770,6 +5664,15 @@
               "array": [
                 "u8",
                 32
+              ]
+            }
+          },
+          {
+            "name": "state_value",
+            "type": {
+              "array": [
+                "u8",
+                64
               ]
             }
           },
@@ -4819,7 +5722,11 @@
           {
             "name": "required_capabilities",
             "docs": [
-              "Required capability bitmask"
+              "Required capability bitmask (u64).",
+              "",
+              "Specifies which capabilities an agent must have to claim this task.",
+              "See [`capability`] module for defined bits. An agent can claim this",
+              "task only if: `(agent.capabilities & required_capabilities) == required_capabilities`"
             ],
             "type": "u64"
           },
@@ -4951,6 +5858,13 @@
               "Bump seed"
             ],
             "type": "u8"
+          },
+          {
+            "name": "protocol_fee_bps",
+            "docs": [
+              "Protocol fee in basis points, locked at task creation (#479)"
+            ],
+            "type": "u16"
           },
           {
             "name": "depends_on",
@@ -5185,6 +6099,15 @@
             }
           },
           {
+            "name": "result_data",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
             "name": "reward_paid",
             "type": "u64"
           },
@@ -5321,7 +6244,7 @@
     {
       "name": "TaskType",
       "docs": [
-        "Task type"
+        "Task type enumeration"
       ],
       "repr": {
         "kind": "rust"

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -155,6 +155,132 @@ export type AgencCoordination = {
               }
             ]
           }
+        },
+        {
+          "name": "treasury",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "applyInitiatorSlash",
+      "docs": [
+        "Apply slashing to a dispute initiator when their dispute is rejected.",
+        "This provides symmetric slashing: workers are slashed for bad work,",
+        "initiators are slashed for frivolous disputes."
+      ],
+      "discriminator": [
+        63,
+        59,
+        40,
+        189,
+        124,
+        61,
+        159,
+        168
+      ],
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task being disputed - validates initiator was a participant"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "initiatorAgent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "initiator_agent.agent_id",
+                "account": "agentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocolConfig",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "treasury",
+          "writable": true
         }
       ],
       "args": []
@@ -419,6 +545,11 @@ export type AgencCoordination = {
         },
         {
           "name": "claim",
+          "docs": [
+            "Note: Claim account is closed after completion.",
+            "If proof-of-completion is needed later, store result_hash",
+            "in an event or separate completion record."
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -445,6 +576,10 @@ export type AgencCoordination = {
         },
         {
           "name": "escrow",
+          "docs": [
+            "Note: Escrow account is closed after completion.",
+            "Rent is returned to the task creator who funded it."
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -465,6 +600,10 @@ export type AgencCoordination = {
               }
             ]
           }
+        },
+        {
+          "name": "creator",
+          "writable": true
         },
         {
           "name": "worker",
@@ -621,6 +760,10 @@ export type AgencCoordination = {
         },
         {
           "name": "escrow",
+          "docs": [
+            "Note: Escrow account is closed after completion.",
+            "Rent is returned to the task creator who funded it."
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -641,6 +784,10 @@ export type AgencCoordination = {
               }
             ]
           }
+        },
+        {
+          "name": "creator",
+          "writable": true
         },
         {
           "name": "worker",
@@ -682,6 +829,36 @@ export type AgencCoordination = {
                   111,
                   108
                 ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "nullifierAccount",
+          "docs": [
+            "Nullifier account to prevent proof/knowledge reuse.",
+            "If this account already exists, the proof has been used before."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  110,
+                  117,
+                  108,
+                  108,
+                  105,
+                  102,
+                  105,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "proof.nullifier"
               }
             ]
           }
@@ -1209,6 +1386,14 @@ export type AgencCoordination = {
       ],
       "accounts": [
         {
+          "name": "caller",
+          "docs": [
+            "Caller who triggers the expiration - receives cleanup reward"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
           "name": "task",
           "writable": true,
           "pda": {
@@ -1231,6 +1416,29 @@ export type AgencCoordination = {
                 "kind": "account",
                 "path": "task.task_id",
                 "account": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
               }
             ]
           }
@@ -1496,6 +1704,15 @@ export type AgencCoordination = {
           "signer": true
         },
         {
+          "name": "secondSigner",
+          "docs": [
+            "Second multisig signer required at initialization to prevent single-party setup.",
+            "Must be different from authority and must be in multisig_owners.",
+            "This ensures at least two parties are involved in protocol initialization (fix #556)."
+          ],
+          "signer": true
+        },
+        {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
         }
@@ -1511,6 +1728,10 @@ export type AgencCoordination = {
         },
         {
           "name": "minStake",
+          "type": "u64"
+        },
+        {
+          "name": "minStakeForDispute",
           "type": "u64"
         },
         {
@@ -1642,6 +1863,49 @@ export type AgencCoordination = {
               }
             ]
           }
+        },
+        {
+          "name": "initiatorClaim",
+          "docs": [
+            "Optional: Initiator's claim if they are a worker (not the creator)"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "agent"
+              }
+            ]
+          }
+        },
+        {
+          "name": "workerAgent",
+          "docs": [
+            "Optional: Worker agent to be disputed (required when initiator is task creator)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "workerClaim",
+          "docs": [
+            "Optional: Worker's claim (required when worker_agent is provided)"
+          ],
+          "optional": true
         },
         {
           "name": "authority",
@@ -1944,6 +2208,7 @@ export type AgencCoordination = {
         },
         {
           "name": "protocolConfig",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -1974,8 +2239,10 @@ export type AgencCoordination = {
           "name": "workerClaim",
           "docs": [
             "Worker's claim proving they worked on task (fix #59)",
-            "Required for Complete/Split resolutions that pay a worker"
+            "Required for Complete/Split resolutions that pay a worker",
+            "Made mutable to allow closing after dispute resolution (fix #439)"
           ],
+          "writable": true,
           "optional": true,
           "pda": {
             "seeds": [
@@ -2003,6 +2270,11 @@ export type AgencCoordination = {
         },
         {
           "name": "worker",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "workerAuthority",
           "writable": true,
           "optional": true
         },
@@ -2290,6 +2562,10 @@ export type AgencCoordination = {
                 ]
               },
               {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
                 "kind": "arg",
                 "path": "stateKey"
               }
@@ -2395,6 +2671,69 @@ export type AgencCoordination = {
                 "kind": "account",
                 "path": "dispute.dispute_id",
                 "account": "dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task account for arbiter party validation (fix #461)"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "task"
+              }
+            ]
+          },
+          "relations": [
+            "dispute"
+          ]
+        },
+        {
+          "name": "workerClaim",
+          "docs": [
+            "Optional: Worker's claim on the task (for arbiter party validation, fix #461)",
+            "If provided, validates arbiter is not the worker"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker_claim.worker",
+                "account": "taskClaim"
               }
             ]
           }
@@ -2594,6 +2933,19 @@ export type AgencCoordination = {
       ]
     },
     {
+      "name": "nullifier",
+      "discriminator": [
+        18,
+        56,
+        142,
+        165,
+        181,
+        158,
+        187,
+        133
+      ]
+    },
+    {
       "name": "protocolConfig",
       "discriminator": [
         207,
@@ -2684,6 +3036,19 @@ export type AgencCoordination = {
         250,
         210,
         166
+      ]
+    },
+    {
+      "name": "arbiterVotesCleanedUp",
+      "discriminator": [
+        50,
+        95,
+        231,
+        24,
+        238,
+        79,
+        179,
+        220
       ]
     },
     {
@@ -2817,6 +3182,19 @@ export type AgencCoordination = {
       ]
     },
     {
+      "name": "protocolFeeUpdated",
+      "discriminator": [
+        172,
+        56,
+        83,
+        113,
+        219,
+        69,
+        69,
+        105
+      ]
+    },
+    {
       "name": "protocolInitialized",
       "discriminator": [
         173,
@@ -2853,6 +3231,19 @@ export type AgencCoordination = {
         167,
         242,
         145
+      ]
+    },
+    {
+      "name": "rateLimitsUpdated",
+      "discriminator": [
+        32,
+        232,
+        72,
+        132,
+        73,
+        25,
+        219,
+        10
       ]
     },
     {
@@ -2970,398 +3361,643 @@ export type AgencCoordination = {
     },
     {
       "code": 6004,
+      "name": "invalidCapabilities",
+      "msg": "Agent capabilities bitmask cannot be zero"
+    },
+    {
+      "code": 6005,
       "name": "maxActiveTasksReached",
       "msg": "Agent has reached maximum active tasks"
     },
     {
-      "code": 6005,
+      "code": 6006,
       "name": "agentHasActiveTasks",
       "msg": "Agent has active tasks and cannot be deregistered"
     },
     {
-      "code": 6006,
+      "code": 6007,
       "name": "unauthorizedAgent",
       "msg": "Only the agent authority can perform this action"
     },
     {
-      "code": 6007,
+      "code": 6008,
+      "name": "invalidAgentId",
+      "msg": "Invalid agent ID: agent_id cannot be all zeros"
+    },
+    {
+      "code": 6009,
       "name": "agentRegistrationRequired",
       "msg": "Agent registration required to create tasks"
     },
     {
-      "code": 6008,
+      "code": 6010,
       "name": "agentSuspended",
       "msg": "Agent is suspended and cannot change status"
     },
     {
-      "code": 6009,
+      "code": 6011,
+      "name": "agentBusyWithTasks",
+      "msg": "Agent cannot set status to Active while having active tasks"
+    },
+    {
+      "code": 6012,
       "name": "taskNotFound",
       "msg": "Task not found"
     },
     {
-      "code": 6010,
+      "code": 6013,
       "name": "taskNotOpen",
       "msg": "Task is not open for claims"
     },
     {
-      "code": 6011,
+      "code": 6014,
       "name": "taskFullyClaimed",
       "msg": "Task has reached maximum workers"
     },
     {
-      "code": 6012,
+      "code": 6015,
       "name": "taskExpired",
       "msg": "Task has expired"
     },
     {
-      "code": 6013,
+      "code": 6016,
       "name": "taskNotExpired",
       "msg": "Task deadline has not passed"
     },
     {
-      "code": 6014,
+      "code": 6017,
       "name": "deadlinePassed",
       "msg": "Task deadline has passed"
     },
     {
-      "code": 6015,
+      "code": 6018,
       "name": "taskNotInProgress",
       "msg": "Task is not in progress"
     },
     {
-      "code": 6016,
+      "code": 6019,
       "name": "taskAlreadyCompleted",
       "msg": "Task is already completed"
     },
     {
-      "code": 6017,
+      "code": 6020,
       "name": "taskCannotBeCancelled",
       "msg": "Task cannot be cancelled"
     },
     {
-      "code": 6018,
+      "code": 6021,
       "name": "unauthorizedTaskAction",
       "msg": "Only the task creator can perform this action"
     },
     {
-      "code": 6019,
+      "code": 6022,
       "name": "invalidCreator",
       "msg": "Invalid creator"
     },
     {
-      "code": 6020,
+      "code": 6023,
+      "name": "invalidTaskId",
+      "msg": "Invalid task ID: cannot be zero"
+    },
+    {
+      "code": 6024,
+      "name": "invalidDescription",
+      "msg": "Invalid description: cannot be empty"
+    },
+    {
+      "code": 6025,
+      "name": "invalidMaxWorkers",
+      "msg": "Invalid max workers: must be between 1 and 100"
+    },
+    {
+      "code": 6026,
       "name": "invalidTaskType",
       "msg": "Invalid task type"
     },
     {
-      "code": 6021,
+      "code": 6027,
+      "name": "invalidDeadline",
+      "msg": "Invalid deadline: deadline must be greater than zero"
+    },
+    {
+      "code": 6028,
+      "name": "invalidReward",
+      "msg": "Invalid reward: reward must be greater than zero"
+    },
+    {
+      "code": 6029,
       "name": "competitiveTaskAlreadyWon",
       "msg": "Competitive task already completed by another worker"
     },
     {
-      "code": 6022,
+      "code": 6030,
       "name": "noWorkers",
       "msg": "Task has no workers"
     },
     {
-      "code": 6023,
+      "code": 6031,
       "name": "constraintHashMismatch",
       "msg": "Proof constraint hash does not match task's stored constraint hash"
     },
     {
-      "code": 6024,
+      "code": 6032,
       "name": "notPrivateTask",
       "msg": "Task is not a private task (no constraint hash set)"
     },
     {
-      "code": 6025,
+      "code": 6033,
       "name": "alreadyClaimed",
       "msg": "Worker has already claimed this task"
     },
     {
-      "code": 6026,
+      "code": 6034,
       "name": "notClaimed",
       "msg": "Worker has not claimed this task"
     },
     {
-      "code": 6027,
+      "code": 6035,
       "name": "claimAlreadyCompleted",
       "msg": "Claim has already been completed"
     },
     {
-      "code": 6028,
+      "code": 6036,
       "name": "claimNotExpired",
       "msg": "Claim has not expired yet"
     },
     {
-      "code": 6029,
+      "code": 6037,
+      "name": "claimExpired",
+      "msg": "Claim has expired"
+    },
+    {
+      "code": 6038,
+      "name": "invalidExpiration",
+      "msg": "Invalid expiration: expires_at cannot be zero"
+    },
+    {
+      "code": 6039,
       "name": "invalidProof",
       "msg": "Invalid proof of work"
     },
     {
-      "code": 6030,
+      "code": 6040,
       "name": "zkVerificationFailed",
       "msg": "ZK proof verification failed"
     },
     {
-      "code": 6031,
+      "code": 6041,
       "name": "invalidProofSize",
       "msg": "Invalid proof size - expected 256 bytes for Groth16"
     },
     {
-      "code": 6032,
+      "code": 6042,
       "name": "invalidProofBinding",
       "msg": "Invalid proof binding: expected_binding cannot be all zeros"
     },
     {
-      "code": 6033,
+      "code": 6043,
       "name": "invalidOutputCommitment",
       "msg": "Invalid output commitment: output_commitment cannot be all zeros"
     },
     {
-      "code": 6034,
+      "code": 6044,
+      "name": "invalidRentRecipient",
+      "msg": "Invalid rent recipient: must be worker authority"
+    },
+    {
+      "code": 6045,
+      "name": "invalidProofHash",
+      "msg": "Invalid proof hash: proof_hash cannot be all zeros"
+    },
+    {
+      "code": 6046,
+      "name": "invalidResultData",
+      "msg": "Invalid result data: result_data cannot be all zeros when provided"
+    },
+    {
+      "code": 6047,
       "name": "disputeNotActive",
       "msg": "Dispute is not active"
     },
     {
-      "code": 6035,
+      "code": 6048,
       "name": "votingEnded",
       "msg": "Voting period has ended"
     },
     {
-      "code": 6036,
+      "code": 6049,
       "name": "votingNotEnded",
       "msg": "Voting period has not ended"
     },
     {
-      "code": 6037,
+      "code": 6050,
       "name": "alreadyVoted",
       "msg": "Already voted on this dispute"
     },
     {
-      "code": 6038,
+      "code": 6051,
       "name": "notArbiter",
       "msg": "Not authorized to vote (not an arbiter)"
     },
     {
-      "code": 6039,
+      "code": 6052,
       "name": "insufficientVotes",
       "msg": "Insufficient votes to resolve"
     },
     {
-      "code": 6040,
+      "code": 6053,
       "name": "disputeAlreadyResolved",
       "msg": "Dispute has already been resolved"
     },
     {
-      "code": 6041,
+      "code": 6054,
       "name": "unauthorizedResolver",
       "msg": "Only protocol authority or dispute initiator can resolve disputes"
     },
     {
-      "code": 6042,
+      "code": 6055,
       "name": "activeDisputeVotes",
       "msg": "Agent has active dispute votes pending resolution"
     },
     {
-      "code": 6043,
+      "code": 6056,
       "name": "recentVoteActivity",
       "msg": "Agent must wait 24 hours after voting before deregistering"
     },
     {
-      "code": 6044,
+      "code": 6057,
       "name": "authorityAlreadyVoted",
       "msg": "Authority has already voted on this dispute"
     },
     {
-      "code": 6045,
+      "code": 6058,
       "name": "insufficientEvidence",
       "msg": "Insufficient dispute evidence provided"
     },
     {
-      "code": 6046,
+      "code": 6059,
       "name": "evidenceTooLong",
       "msg": "Dispute evidence exceeds maximum allowed length"
     },
     {
-      "code": 6047,
+      "code": 6060,
       "name": "disputeNotExpired",
       "msg": "Dispute has not expired"
     },
     {
-      "code": 6048,
+      "code": 6061,
       "name": "slashAlreadyApplied",
       "msg": "Dispute slashing already applied"
     },
     {
-      "code": 6049,
+      "code": 6062,
       "name": "disputeNotResolved",
       "msg": "Dispute has not been resolved"
     },
     {
-      "code": 6050,
+      "code": 6063,
+      "name": "notTaskParticipant",
+      "msg": "Only task creator or workers can initiate disputes"
+    },
+    {
+      "code": 6064,
+      "name": "invalidEvidenceHash",
+      "msg": "Invalid evidence hash: cannot be all zeros"
+    },
+    {
+      "code": 6065,
+      "name": "arbiterIsDisputeParticipant",
+      "msg": "Arbiter cannot vote on disputes they are a participant in"
+    },
+    {
+      "code": 6066,
+      "name": "insufficientQuorum",
+      "msg": "Insufficient quorum: minimum number of voters not reached"
+    },
+    {
+      "code": 6067,
+      "name": "activeDisputesExist",
+      "msg": "Agent has active disputes as defendant and cannot deregister"
+    },
+    {
+      "code": 6068,
+      "name": "workerAgentRequired",
+      "msg": "Worker agent account required when creator initiates dispute"
+    },
+    {
+      "code": 6069,
+      "name": "workerClaimRequired",
+      "msg": "Worker claim account required when creator initiates dispute"
+    },
+    {
+      "code": 6070,
+      "name": "workerNotInDispute",
+      "msg": "Worker was not involved in this dispute"
+    },
+    {
+      "code": 6071,
+      "name": "initiatorCannotResolve",
+      "msg": "Dispute initiator cannot resolve their own dispute"
+    },
+    {
+      "code": 6072,
       "name": "versionMismatch",
       "msg": "State version mismatch (concurrent modification)"
     },
     {
-      "code": 6051,
+      "code": 6073,
       "name": "stateKeyExists",
       "msg": "State key already exists"
     },
     {
-      "code": 6052,
+      "code": 6074,
       "name": "stateNotFound",
       "msg": "State not found"
     },
     {
-      "code": 6053,
+      "code": 6075,
+      "name": "invalidStateValue",
+      "msg": "Invalid state value: state_value cannot be all zeros"
+    },
+    {
+      "code": 6076,
       "name": "protocolAlreadyInitialized",
       "msg": "Protocol is already initialized"
     },
     {
-      "code": 6054,
+      "code": 6077,
       "name": "protocolNotInitialized",
       "msg": "Protocol is not initialized"
     },
     {
-      "code": 6055,
+      "code": 6078,
       "name": "invalidProtocolFee",
       "msg": "Invalid protocol fee (must be <= 1000 bps)"
     },
     {
-      "code": 6056,
-      "name": "invalidDisputeThreshold",
-      "msg": "Invalid dispute threshold"
+      "code": 6079,
+      "name": "invalidTreasury",
+      "msg": "Invalid treasury: treasury account cannot be default pubkey"
     },
     {
-      "code": 6057,
+      "code": 6080,
+      "name": "invalidDisputeThreshold",
+      "msg": "Invalid dispute threshold: must be 1-100 (percentage of votes required)"
+    },
+    {
+      "code": 6081,
       "name": "insufficientStake",
       "msg": "Insufficient stake for arbiter registration"
     },
     {
-      "code": 6058,
+      "code": 6082,
       "name": "multisigInvalidThreshold",
       "msg": "Invalid multisig threshold"
     },
     {
-      "code": 6059,
+      "code": 6083,
       "name": "multisigInvalidSigners",
       "msg": "Invalid multisig signer configuration"
     },
     {
-      "code": 6060,
+      "code": 6084,
       "name": "multisigNotEnoughSigners",
       "msg": "Not enough multisig signers"
     },
     {
-      "code": 6061,
+      "code": 6085,
       "name": "multisigDuplicateSigner",
       "msg": "Duplicate multisig signer provided"
     },
     {
-      "code": 6062,
+      "code": 6086,
       "name": "multisigDefaultSigner",
       "msg": "Multisig signer cannot be default pubkey"
     },
     {
-      "code": 6063,
+      "code": 6087,
       "name": "multisigSignerNotSystemOwned",
       "msg": "Multisig signer account not owned by System Program"
     },
     {
-      "code": 6064,
+      "code": 6088,
       "name": "invalidInput",
       "msg": "Invalid input parameter"
     },
     {
-      "code": 6065,
+      "code": 6089,
       "name": "arithmeticOverflow",
       "msg": "Arithmetic overflow"
     },
     {
-      "code": 6066,
+      "code": 6090,
       "name": "voteOverflow",
       "msg": "Vote count overflow"
     },
     {
-      "code": 6067,
+      "code": 6091,
       "name": "insufficientFunds",
       "msg": "Insufficient funds"
     },
     {
-      "code": 6068,
+      "code": 6092,
+      "name": "rewardTooSmall",
+      "msg": "Reward too small: worker must receive at least 1 lamport"
+    },
+    {
+      "code": 6093,
       "name": "corruptedData",
       "msg": "Account data is corrupted"
     },
     {
-      "code": 6069,
+      "code": 6094,
       "name": "stringTooLong",
       "msg": "String too long"
     },
     {
-      "code": 6070,
+      "code": 6095,
       "name": "invalidAccountOwner",
       "msg": "Account owner validation failed: account not owned by this program"
     },
     {
-      "code": 6071,
+      "code": 6096,
       "name": "rateLimitExceeded",
       "msg": "Rate limit exceeded: maximum actions per 24h window reached"
     },
     {
-      "code": 6072,
+      "code": 6097,
       "name": "cooldownNotElapsed",
       "msg": "Cooldown period has not elapsed since last action"
     },
     {
-      "code": 6073,
+      "code": 6098,
+      "name": "updateTooFrequent",
+      "msg": "Agent update too frequent: must wait cooldown period"
+    },
+    {
+      "code": 6099,
+      "name": "invalidCooldown",
+      "msg": "Cooldown value cannot be negative"
+    },
+    {
+      "code": 6100,
+      "name": "cooldownTooLarge",
+      "msg": "Cooldown value exceeds maximum (24 hours)"
+    },
+    {
+      "code": 6101,
+      "name": "rateLimitTooHigh",
+      "msg": "Rate limit value exceeds maximum allowed (1000)"
+    },
+    {
+      "code": 6102,
+      "name": "cooldownTooLong",
+      "msg": "Cooldown value exceeds maximum allowed (1 week)"
+    },
+    {
+      "code": 6103,
       "name": "insufficientStakeForDispute",
       "msg": "Insufficient stake to initiate dispute"
     },
     {
-      "code": 6074,
+      "code": 6104,
       "name": "versionMismatchProtocol",
       "msg": "Protocol version mismatch: account version incompatible with current program"
     },
     {
-      "code": 6075,
+      "code": 6105,
       "name": "accountVersionTooOld",
       "msg": "Account version too old: migration required"
     },
     {
-      "code": 6076,
+      "code": 6106,
       "name": "accountVersionTooNew",
       "msg": "Account version too new: program upgrade required"
     },
     {
-      "code": 6077,
+      "code": 6107,
       "name": "invalidMigrationSource",
       "msg": "Migration not allowed: invalid source version"
     },
     {
-      "code": 6078,
+      "code": 6108,
       "name": "invalidMigrationTarget",
       "msg": "Migration not allowed: invalid target version"
     },
     {
-      "code": 6079,
+      "code": 6109,
       "name": "unauthorizedUpgrade",
       "msg": "Only upgrade authority can perform this action"
     },
     {
-      "code": 6080,
+      "code": 6110,
+      "name": "invalidMinVersion",
+      "msg": "Minimum version cannot exceed current protocol version"
+    },
+    {
+      "code": 6111,
+      "name": "protocolConfigRequired",
+      "msg": "Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts"
+    },
+    {
+      "code": 6112,
       "name": "parentTaskCancelled",
       "msg": "Parent task has been cancelled"
     },
     {
-      "code": 6081,
+      "code": 6113,
       "name": "parentTaskDisputed",
       "msg": "Parent task is in disputed state"
     },
     {
-      "code": 6082,
+      "code": 6114,
       "name": "invalidDependencyType",
       "msg": "Invalid dependency type"
+    },
+    {
+      "code": 6115,
+      "name": "parentTaskNotCompleted",
+      "msg": "Parent task must be completed before completing a proof-dependent task"
+    },
+    {
+      "code": 6116,
+      "name": "parentTaskAccountRequired",
+      "msg": "Parent task account required for proof-dependent task completion"
+    },
+    {
+      "code": 6117,
+      "name": "unauthorizedCreator",
+      "msg": "Parent task does not belong to the same creator"
+    },
+    {
+      "code": 6118,
+      "name": "nullifierAlreadySpent",
+      "msg": "Nullifier has already been spent - proof/knowledge reuse detected"
+    },
+    {
+      "code": 6119,
+      "name": "invalidNullifier",
+      "msg": "Invalid nullifier: nullifier value cannot be all zeros"
+    },
+    {
+      "code": 6120,
+      "name": "incompleteWorkerAccounts",
+      "msg": "All worker accounts must be provided when cancelling a task with active claims"
+    },
+    {
+      "code": 6121,
+      "name": "workerAccountsRequired",
+      "msg": "Worker accounts required when task has active workers"
+    },
+    {
+      "code": 6122,
+      "name": "duplicateArbiter",
+      "msg": "Duplicate arbiter provided in remaining_accounts"
+    },
+    {
+      "code": 6123,
+      "name": "insufficientEscrowBalance",
+      "msg": "Escrow has insufficient balance for reward transfer"
+    },
+    {
+      "code": 6124,
+      "name": "invalidStatusTransition",
+      "msg": "Invalid task status transition"
+    },
+    {
+      "code": 6125,
+      "name": "stakeTooLow",
+      "msg": "Stake value is below minimum required (0.001 SOL)"
+    },
+    {
+      "code": 6126,
+      "name": "invalidMinStake",
+      "msg": "min_stake_for_dispute must be greater than zero"
+    },
+    {
+      "code": 6127,
+      "name": "invalidSlashAmount",
+      "msg": "Slash amount must be greater than zero"
+    },
+    {
+      "code": 6128,
+      "name": "bondAmountTooLow",
+      "msg": "Bond amount too low"
+    },
+    {
+      "code": 6129,
+      "name": "bondAlreadyExists",
+      "msg": "Bond already exists"
+    },
+    {
+      "code": 6130,
+      "name": "bondNotFound",
+      "msg": "Bond not found"
+    },
+    {
+      "code": 6131,
+      "name": "bondNotMatured",
+      "msg": "Bond not yet matured"
     }
   ],
   "types": [
@@ -3423,6 +4059,10 @@ export type AgencCoordination = {
             "type": "string"
           },
           {
+            "name": "stakeAmount",
+            "type": "u64"
+          },
+          {
             "name": "timestamp",
             "type": "i64"
           }
@@ -3460,7 +4100,15 @@ export type AgencCoordination = {
           {
             "name": "capabilities",
             "docs": [
-              "Capability bitmask"
+              "Agent capabilities as a bitmask (u64).",
+              "",
+              "Each bit represents a specific capability the agent possesses.",
+              "See [`capability`] module for defined bits:",
+              "- Bits 0-9: Currently defined capabilities (COMPUTE, INFERENCE, etc.)",
+              "- Bits 10-63: Reserved for future protocol extensions",
+              "",
+              "Agents can only claim tasks where they have all required capabilities:",
+              "`(agent.capabilities & task.required_capabilities) == task.required_capabilities`"
             ],
             "type": "u64"
           },
@@ -3478,7 +4126,7 @@ export type AgencCoordination = {
           {
             "name": "endpoint",
             "docs": [
-              "Network endpoint (max 128 chars)"
+              "Network endpoint (max 256 chars)"
             ],
             "type": "string"
           },
@@ -3520,7 +4168,9 @@ export type AgencCoordination = {
           {
             "name": "reputation",
             "docs": [
-              "Reputation score (0-10000)"
+              "Agent reputation score (0-10000)",
+              "Initial value: 5000 (neutral starting point)",
+              "Can be adjusted via protocol config in future versions"
             ],
             "type": "u16"
           },
@@ -3602,14 +4252,23 @@ export type AgencCoordination = {
             "type": "i64"
           },
           {
+            "name": "disputesAsDefendant",
+            "docs": [
+              "Active disputes where this agent is a defendant (can be slashed)"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "reserved",
             "docs": [
-              "Reserved for future use"
+              "Reserved bytes for future use.",
+              "Note: Not validated on deserialization - may contain arbitrary data",
+              "from previous versions. New fields should handle this gracefully."
             ],
             "type": {
               "array": [
                 "u8",
-                6
+                5
               ]
             }
           }
@@ -3670,6 +4329,30 @@ export type AgencCoordination = {
           {
             "name": "timestamp",
             "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "arbiterVotesCleanedUp",
+      "docs": [
+        "Emitted when arbiter votes are cleaned up during dispute expiration"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "disputeId",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "arbiterCount",
+            "type": "u8"
           }
         ]
       }
@@ -3741,6 +4424,10 @@ export type AgencCoordination = {
           {
             "name": "newTotal",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3764,6 +4451,10 @@ export type AgencCoordination = {
           {
             "name": "amount",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3787,6 +4478,10 @@ export type AgencCoordination = {
           {
             "name": "amount",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3826,11 +4521,18 @@ export type AgencCoordination = {
       "name": "coordinationState",
       "docs": [
         "Shared coordination state",
-        "PDA seeds: [\"state\", state_key]"
+        "PDA seeds: [\"state\", owner, state_key]"
       ],
       "type": {
         "kind": "struct",
         "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Owner authority - namespaces state to prevent cross-user collisions"
+            ],
+            "type": "pubkey"
+          },
           {
             "name": "stateKey",
             "docs": [
@@ -3889,7 +4591,7 @@ export type AgencCoordination = {
     {
       "name": "dependencyType",
       "docs": [
-        "Dependency type for speculative execution decisions"
+        "Task dependency type for speculative execution decisions"
       ],
       "repr": {
         "kind": "rust"
@@ -3979,7 +4681,14 @@ export type AgencCoordination = {
           {
             "name": "initiator",
             "docs": [
-              "Initiator"
+              "Initiator (agent PDA)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "initiatorAuthority",
+            "docs": [
+              "Initiator's authority wallet (for resolver constraint)"
             ],
             "type": "pubkey"
           },
@@ -4048,30 +4757,48 @@ export type AgencCoordination = {
           {
             "name": "totalVoters",
             "docs": [
-              "Total eligible voters"
+              "Total arbiters who voted (max 255 due to u8)",
+              "Note: Increase to u16 if more arbiters needed"
             ],
             "type": "u8"
           },
           {
             "name": "votingDeadline",
             "docs": [
-              "Voting deadline"
+              "Voting deadline - after this, no new votes accepted",
+              "voting_deadline = created_at + voting_period"
             ],
             "type": "i64"
           },
           {
             "name": "expiresAt",
             "docs": [
-              "Dispute expiration timestamp"
+              "Dispute expiration - after this, can call expire_dispute",
+              "expires_at = created_at + max_dispute_duration",
+              "Note: expires_at >= voting_deadline, allowing resolution after voting ends"
             ],
             "type": "i64"
           },
           {
             "name": "slashApplied",
             "docs": [
-              "Whether slashing has been applied"
+              "Whether worker slashing has been applied"
             ],
             "type": "bool"
+          },
+          {
+            "name": "initiatorSlashApplied",
+            "docs": [
+              "Whether initiator slashing has been applied (for rejected disputes)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "workerStakeAtDispute",
+            "docs": [
+              "Snapshot of worker's stake at dispute initiation (prevents stake withdrawal attacks)"
+            ],
+            "type": "u64"
           },
           {
             "name": "bump",
@@ -4262,6 +4989,13 @@ export type AgencCoordination = {
             "type": "i64"
           },
           {
+            "name": "stakeAtVote",
+            "docs": [
+              "Arbiter's stake at the time of voting (for weighted resolution)"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "bump",
             "docs": [
               "Bump seed"
@@ -4339,6 +5073,60 @@ export type AgencCoordination = {
       }
     },
     {
+      "name": "nullifier",
+      "docs": [
+        "Nullifier account to prevent proof/knowledge reuse across tasks.",
+        "Once a nullifier is \"spent\" (account exists), the same proof/knowledge",
+        "combination cannot be used again.",
+        "PDA seeds: [\"nullifier\", nullifier_value]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nullifierValue",
+            "docs": [
+              "The nullifier value (derived from constraint_hash + agent_secret in ZK circuit)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "task",
+            "docs": [
+              "The task where this nullifier was first used"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "agent",
+            "docs": [
+              "The agent who spent this nullifier"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "spentAt",
+            "docs": [
+              "Timestamp when nullifier was spent"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
       "name": "privateCompletionProof",
       "type": {
         "kind": "struct",
@@ -4373,6 +5161,19 @@ export type AgencCoordination = {
                 32
               ]
             }
+          },
+          {
+            "name": "nullifier",
+            "docs": [
+              "Nullifier to prevent proof/knowledge reuse across tasks.",
+              "Derived in the ZK circuit as: Poseidon(constraint_hash, agent_secret)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           }
         ]
       }
@@ -4389,14 +5190,17 @@ export type AgencCoordination = {
           {
             "name": "authority",
             "docs": [
-              "Protocol authority"
+              "Protocol authority",
+              "Note: Cannot be updated after initialization."
             ],
             "type": "pubkey"
           },
           {
             "name": "treasury",
             "docs": [
-              "Treasury for protocol fees"
+              "Treasury address for protocol fees",
+              "Note: Cannot be updated after initialization.",
+              "Deploy new protocol if treasury change needed."
             ],
             "type": "pubkey"
           },
@@ -4534,6 +5338,13 @@ export type AgencCoordination = {
             "type": "u8"
           },
           {
+            "name": "votingPeriod",
+            "docs": [
+              "Voting period for disputes in seconds (default: 24 hours)"
+            ],
+            "type": "i64"
+          },
+          {
             "name": "protocolVersion",
             "docs": [
               "Current protocol version (for upgrades)"
@@ -4550,7 +5361,8 @@ export type AgencCoordination = {
           {
             "name": "padding",
             "docs": [
-              "Padding for alignment/future use"
+              "Padding for future use and alignment",
+              "Currently unused but reserved for backwards-compatible additions"
             ],
             "type": {
               "array": [
@@ -4562,7 +5374,19 @@ export type AgencCoordination = {
           {
             "name": "multisigOwners",
             "docs": [
-              "Multisig owners (fixed-size)"
+              "Multisig owners (immutable after init for security).",
+              "",
+              "# Security Note (see #464)",
+              "Multisig configuration **cannot be updated** after protocol initialization.",
+              "To change multisig, deploy new protocol.",
+              "",
+              "This is intentional:",
+              "- Prevents hostile takeover via multisig reconfiguration",
+              "- Ensures governance changes require protocol redeployment with proper ceremony",
+              "- The array is fully zeroed before population in `initialize_protocol`",
+              "",
+              "Only the first `multisig_owners_len` entries are valid; remaining slots",
+              "are always `Pubkey::default()`."
             ],
             "type": {
               "array": [
@@ -4570,6 +5394,33 @@ export type AgencCoordination = {
                 5
               ]
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "protocolFeeUpdated",
+      "docs": [
+        "Emitted when protocol fee is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "oldFeeBps",
+            "type": "u16"
+          },
+          {
+            "name": "newFeeBps",
+            "type": "u16"
+          },
+          {
+            "name": "updatedBy",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4677,6 +5528,45 @@ export type AgencCoordination = {
       }
     },
     {
+      "name": "rateLimitsUpdated",
+      "docs": [
+        "Emitted when rate limit configuration is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "taskCreationCooldown",
+            "type": "i64"
+          },
+          {
+            "name": "maxTasksPer24h",
+            "type": "u8"
+          },
+          {
+            "name": "disputeInitiationCooldown",
+            "type": "i64"
+          },
+          {
+            "name": "maxDisputesPer24h",
+            "type": "u8"
+          },
+          {
+            "name": "minStakeForDispute",
+            "type": "u64"
+          },
+          {
+            "name": "updatedBy",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
       "name": "resolutionType",
       "docs": [
         "Dispute resolution type"
@@ -4764,6 +5654,10 @@ export type AgencCoordination = {
           {
             "name": "expiresAt",
             "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4782,6 +5676,15 @@ export type AgencCoordination = {
               "array": [
                 "u8",
                 32
+              ]
+            }
+          },
+          {
+            "name": "stateValue",
+            "type": {
+              "array": [
+                "u8",
+                64
               ]
             }
           },
@@ -4831,7 +5734,11 @@ export type AgencCoordination = {
           {
             "name": "requiredCapabilities",
             "docs": [
-              "Required capability bitmask"
+              "Required capability bitmask (u64).",
+              "",
+              "Specifies which capabilities an agent must have to claim this task.",
+              "See [`capability`] module for defined bits. An agent can claim this",
+              "task only if: `(agent.capabilities & required_capabilities) == required_capabilities`"
             ],
             "type": "u64"
           },
@@ -4963,6 +5870,13 @@ export type AgencCoordination = {
               "Bump seed"
             ],
             "type": "u8"
+          },
+          {
+            "name": "protocolFeeBps",
+            "docs": [
+              "Protocol fee in basis points, locked at task creation (#479)"
+            ],
+            "type": "u16"
           },
           {
             "name": "dependsOn",
@@ -5197,6 +6111,15 @@ export type AgencCoordination = {
             }
           },
           {
+            "name": "resultData",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
             "name": "rewardPaid",
             "type": "u64"
           },
@@ -5333,7 +6256,7 @@ export type AgencCoordination = {
     {
       "name": "taskType",
       "docs": [
-        "Task type"
+        "Task type enumeration"
       ],
       "repr": {
         "kind": "rust"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,10 +39,135 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
+"@esbuild/aix-ppc64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz#521cbd968dcf362094034947f76fa1b18d2d403c"
+  integrity sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==
+
+"@esbuild/android-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz#61ea550962d8aa12a9b33194394e007657a6df57"
+  integrity sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==
+
+"@esbuild/android-arm@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.2.tgz#554887821e009dd6d853f972fde6c5143f1de142"
+  integrity sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==
+
+"@esbuild/android-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.2.tgz#a7ce9d0721825fc578f9292a76d9e53334480ba2"
+  integrity sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==
+
+"@esbuild/darwin-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz#2cb7659bd5d109803c593cfc414450d5430c8256"
+  integrity sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==
+
+"@esbuild/darwin-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz#e741fa6b1abb0cd0364126ba34ca17fd5e7bf509"
+  integrity sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==
+
+"@esbuild/freebsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz#2b64e7116865ca172d4ce034114c21f3c93e397c"
+  integrity sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==
+
+"@esbuild/freebsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz#e5252551e66f499e4934efb611812f3820e990bb"
+  integrity sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==
+
+"@esbuild/linux-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz#dc4acf235531cd6984f5d6c3b13dbfb7ddb303cb"
+  integrity sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==
+
+"@esbuild/linux-arm@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz#56a900e39240d7d5d1d273bc053daa295c92e322"
+  integrity sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==
+
+"@esbuild/linux-ia32@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz#d4a36d473360f6870efcd19d52bbfff59a2ed1cc"
+  integrity sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==
+
+"@esbuild/linux-loong64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz#fcf0ab8c3eaaf45891d0195d4961cb18b579716a"
+  integrity sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==
+
+"@esbuild/linux-mips64el@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz#598b67d34048bb7ee1901cb12e2a0a434c381c10"
+  integrity sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==
+
+"@esbuild/linux-ppc64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz#3846c5df6b2016dab9bc95dde26c40f11e43b4c0"
+  integrity sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==
+
+"@esbuild/linux-riscv64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz#173d4475b37c8d2c3e1707e068c174bb3f53d07d"
+  integrity sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==
+
+"@esbuild/linux-s390x@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz#f7a4790105edcab8a5a31df26fbfac1aa3dacfab"
+  integrity sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==
+
 "@esbuild/linux-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz"
   integrity sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==
+
+"@esbuild/netbsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz#e2863c2cd1501845995cb11adf26f7fe4be527b0"
+  integrity sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==
+
+"@esbuild/netbsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz#93f7609e2885d1c0b5a1417885fba8d1fcc41272"
+  integrity sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==
+
+"@esbuild/openbsd-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz#a1985604a203cdc325fd47542e106fafd698f02e"
+  integrity sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==
+
+"@esbuild/openbsd-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz#8209e46c42f1ffbe6e4ef77a32e1f47d404ad42a"
+  integrity sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==
+
+"@esbuild/openharmony-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz#8fade4441893d9cc44cbd7dcf3776f508ab6fb2f"
+  integrity sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==
+
+"@esbuild/sunos-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz#980d4b9703a16f0f07016632424fc6d9a789dfc2"
+  integrity sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==
+
+"@esbuild/win32-arm64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz#1c09a3633c949ead3d808ba37276883e71f6111a"
+  integrity sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==
+
+"@esbuild/win32-ia32@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz#1b1e3a63ad4bef82200fef4e369e0fff7009eee5"
+  integrity sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==
+
+"@esbuild/win32-x64@0.27.2":
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz#9e585ab6086bef994c6e8a5b3a0481219ada862b"
+  integrity sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==
 
 "@noble/curves@^1.4.2":
   version "1.9.7"
@@ -51,7 +176,7 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@1.8.0":
+"@noble/hashes@1.8.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -286,7 +411,7 @@ buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   resolved "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz"
   integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==
 
-buffer@^6.0.3, buffer@~6.0.3, buffer@6.0.3:
+buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -313,7 +438,7 @@ chai-as-promised@^7.1.2:
   dependencies:
     check-error "^1.0.2"
 
-chai@^4.3.0, "chai@>= 2.1.2 < 6":
+chai@^4.3.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz"
   integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
@@ -537,6 +662,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2, fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
@@ -734,7 +864,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-mocha@^10.0.0, "mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X || ^11.X.X":
+mocha@^10.0.0:
   version "10.8.2"
   resolved "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz"
   integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==
@@ -1025,12 +1155,12 @@ type-detect@^4.0.0, type-detect@^4.1.0:
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz"
   integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
-typescript@^5.0.0, typescript@>=5.3.3:
+typescript@^5.0.0:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
-utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
+utf-8-validate@^5.0.2:
   version "5.0.10"
   resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
@@ -1074,7 +1204,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^7.5.10:
+ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==


### PR DESCRIPTION
Fixes #396

## Summary
Multiple code paths failed to close escrow and claim accounts after they were no longer needed, causing rent (~0.002 SOL each) to be permanently locked in the program.

## Changes

### 1. Close escrow in completion paths
- **complete_task.rs**: Added `close = creator` directive to escrow account
- **complete_task_private.rs**: Added `close = creator` directive to escrow account

The escrow rent is returned to the task creator who originally funded it.

### 2. Close claims in cancel_task.rs
- When a task is cancelled, claim accounts passed in `remaining_accounts` are now closed
- Rent is transferred back to the creator

### 3. Stack overflow prevention
- Boxed large accounts (Task, TaskClaim, TaskEscrow, AgentRegistration, ProtocolConfig) to avoid stack overflow errors in complete_task and complete_task_private

### 4. Test fix
- Fixed test mock in completion_helpers.rs that was missing the `protocol_fee_bps` field

## Notes
- resolve_dispute.rs and expire_dispute.rs already correctly close escrow with `close = creator`
- The claim is already correctly closed in resolve_dispute.rs (added via fix #439)
- Pre-existing stack overflow warnings in other instructions (apply_dispute_slash, initiate_dispute, vote_dispute) are not addressed in this PR