### PR TITLE
fix: make no-vote dispute resolution explicit and documented

### DIFF
--- a/mcp/yarn.lock
+++ b/mcp/yarn.lock
@@ -5,7 +5,7 @@
 "@agenc/runtime@file:../runtime":
   version "0.1.0"
   dependencies:
-    "@agenc/sdk" "file:../../../.cache/yarn/v6/npm-@agenc-runtime-0.1.0-b271e0f0-7f46-4e73-ae3d-46cb2cae0d6a-1769661431064/node_modules/@agenc/sdk"
+    "@agenc/sdk" "file:../../../.cache/yarn/v6/npm-@agenc-runtime-0.1.0-af772cb2-dad3-4cdb-a6c8-7a5912ba8d32-1769661296938/node_modules/@agenc/sdk"
 
 "@agenc/sdk@file:../sdk":
   version "1.2.0"

--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -219,10 +219,9 @@ mod tests {
             required_completions,
             completions,
             bump: 0,
-            protocol_fee_bps: 0,
+            protocol_fee_bps: 100, // 1% default for tests
             depends_on: None,
             dependency_type: DependencyType::default(),
-            protocol_fee_bps: 100, // 1% default for tests
             _reserved: [0u8; 32],
         }
     }

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -4947,7 +4947,16 @@
     {
       "name": "DisputeResolved",
       "docs": [
-        "Emitted when a dispute is resolved"
+        "Emitted when a dispute is resolved",
+        "",
+        "The `outcome` field distinguishes between different resolution paths:",
+        "- 0 = Rejected (approved=false with actual votes cast)",
+        "- 1 = Approved (approved=true with votes meeting threshold)",
+        "- 2 = NoVoteDefault (no votes cast, defaulted to rejection - fix #425)",
+        "",
+        "The NoVoteDefault outcome indicates arbiter apathy rather than active rejection.",
+        "This allows consumers to distinguish between \"arbiters rejected this\" vs",
+        "\"no arbiters participated, so it defaulted to rejection\"."
       ],
       "type": {
         "kind": "struct",
@@ -4963,6 +4972,13 @@
           },
           {
             "name": "resolution_type",
+            "type": "u8"
+          },
+          {
+            "name": "outcome",
+            "docs": [
+              "Resolution outcome: 0=Rejected, 1=Approved, 2=NoVoteDefault"
+            ],
             "type": "u8"
           },
           {

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -4935,7 +4935,16 @@ export type AgencCoordination = {
     {
       "name": "disputeResolved",
       "docs": [
-        "Emitted when a dispute is resolved"
+        "Emitted when a dispute is resolved",
+        "",
+        "The `outcome` field distinguishes between different resolution paths:",
+        "- 0 = Rejected (approved=false with actual votes cast)",
+        "- 1 = Approved (approved=true with votes meeting threshold)",
+        "- 2 = NoVoteDefault (no votes cast, defaulted to rejection - fix #425)",
+        "",
+        "The NoVoteDefault outcome indicates arbiter apathy rather than active rejection.",
+        "This allows consumers to distinguish between \"arbiters rejected this\" vs",
+        "\"no arbiters participated, so it defaulted to rejection\"."
       ],
       "type": {
         "kind": "struct",
@@ -4951,6 +4960,13 @@ export type AgencCoordination = {
           },
           {
             "name": "resolutionType",
+            "type": "u8"
+          },
+          {
+            "name": "outcome",
+            "docs": [
+              "Resolution outcome: 0=Rejected, 1=Approved, 2=NoVoteDefault"
+            ],
             "type": "u8"
           },
           {


### PR DESCRIPTION
## Summary

Fixes #425 - Makes the no-vote default behavior in dispute resolution explicit and documented.

## Changes

### Added `dispute_outcome` constants (events.rs)
- `REJECTED` (0): Dispute was actively rejected by arbiters
- `APPROVED` (1): Dispute was approved by arbiters  
- `NO_VOTE_DEFAULT` (2): No votes were cast, defaulted to rejection (arbiter apathy)

### Updated `DisputeResolved` event
Added an `outcome` field that distinguishes between:
- Active rejection (arbiters voted against)
- Approval (arbiters voted in favor)
- No-vote default (no arbiters participated)

### Updated `resolve_dispute.rs`
- Now tracks the outcome type and emits it in the event
- Added detailed documentation explaining the distinction between arbiter apathy vs active rejection
- Consumers can now differentiate how to handle each case (e.g., extend deadline for no-vote cases)

### Fixed test helper (completion_helpers.rs)
- Added missing `protocol_fee_bps` field to `create_test_task` helper

## Impact
- **Breaking change**: `DisputeResolved` event now has an additional `outcome` field
- Event consumers should update to handle the new field
- No on-chain behavior changes - this is a clarity/observability improvement

## Testing
- [x] `cargo check` passes
- [x] `anchor build` passes (unit tests in Rust pass)
- [ ] Full integration test suite (skipped due to resource constraints)