### PR TITLE
fix: fair refund distribution on dispute expiration

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -128,11 +128,16 @@ pub struct DisputeResolved {
 }
 
 /// Emitted when a dispute expires without resolution
+/// Updated in fix #418 to include fair distribution details
 #[event]
 pub struct DisputeExpired {
     pub dispute_id: [u8; 32],
     pub task_id: [u8; 32],
     pub refund_amount: u64,
+    /// Amount refunded to creator (fix #418)
+    pub creator_amount: u64,
+    /// Amount paid to worker (fix #418)
+    pub worker_amount: u64,
     pub timestamp: i64,
 }
 

--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -219,6 +219,7 @@ mod tests {
             required_completions,
             completions,
             bump: 0,
+            protocol_fee_bps: 0,
             depends_on: None,
             dependency_type: DependencyType::default(),
             _reserved: [0u8; 32],

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -143,6 +143,132 @@
               }
             ]
           }
+        },
+        {
+          "name": "treasury",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "apply_initiator_slash",
+      "docs": [
+        "Apply slashing to a dispute initiator when their dispute is rejected.",
+        "This provides symmetric slashing: workers are slashed for bad work,",
+        "initiators are slashed for frivolous disputes."
+      ],
+      "discriminator": [
+        63,
+        59,
+        40,
+        189,
+        124,
+        61,
+        159,
+        168
+      ],
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task being disputed - validates initiator was a participant"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "initiator_agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "initiator_agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "treasury",
+          "writable": true
         }
       ],
       "args": []
@@ -407,6 +533,11 @@
         },
         {
           "name": "claim",
+          "docs": [
+            "Note: Claim account is closed after completion.",
+            "If proof-of-completion is needed later, store result_hash",
+            "in an event or separate completion record."
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -670,6 +801,36 @@
                   111,
                   108
                 ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "nullifier_account",
+          "docs": [
+            "Nullifier account to prevent proof/knowledge reuse.",
+            "If this account already exists, the proof has been used before."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  110,
+                  117,
+                  108,
+                  108,
+                  105,
+                  102,
+                  105,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "proof.nullifier"
               }
             ]
           }
@@ -1197,6 +1358,14 @@
       ],
       "accounts": [
         {
+          "name": "caller",
+          "docs": [
+            "Caller who triggers the expiration - receives cleanup reward"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
           "name": "task",
           "writable": true,
           "pda": {
@@ -1219,6 +1388,29 @@
                 "kind": "account",
                 "path": "task.task_id",
                 "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
               }
             ]
           }
@@ -1402,7 +1594,8 @@
           "name": "worker_claim",
           "docs": [
             "Worker's claim on the disputed task (fix #137)",
-            "Optional - when provided, allows decrementing worker's active_tasks"
+            "Optional - when provided, allows decrementing worker's active_tasks",
+            "and enables fair refund distribution (fix #418)"
           ],
           "optional": true,
           "pda": {
@@ -1431,6 +1624,14 @@
         },
         {
           "name": "worker",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_authority",
+          "docs": [
+            "Required when worker should receive funds on expiration"
+          ],
           "writable": true,
           "optional": true
         }
@@ -1484,6 +1685,15 @@
           "signer": true
         },
         {
+          "name": "second_signer",
+          "docs": [
+            "Second multisig signer required at initialization to prevent single-party setup.",
+            "Must be different from authority and must be in multisig_owners.",
+            "This ensures at least two parties are involved in protocol initialization (fix #556)."
+          ],
+          "signer": true
+        },
+        {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
         }
@@ -1499,6 +1709,10 @@
         },
         {
           "name": "min_stake",
+          "type": "u64"
+        },
+        {
+          "name": "min_stake_for_dispute",
           "type": "u64"
         },
         {
@@ -1630,6 +1844,49 @@
               }
             ]
           }
+        },
+        {
+          "name": "initiator_claim",
+          "docs": [
+            "Optional: Initiator's claim if they are a worker (not the creator)"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "agent"
+              }
+            ]
+          }
+        },
+        {
+          "name": "worker_agent",
+          "docs": [
+            "Optional: Worker agent to be disputed (required when initiator is task creator)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Optional: Worker's claim (required when worker_agent is provided)"
+          ],
+          "optional": true
         },
         {
           "name": "authority",
@@ -1932,6 +2189,7 @@
         },
         {
           "name": "protocol_config",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -1962,8 +2220,10 @@
           "name": "worker_claim",
           "docs": [
             "Worker's claim proving they worked on task (fix #59)",
-            "Required for Complete/Split resolutions that pay a worker"
+            "Required for Complete/Split resolutions that pay a worker",
+            "Made mutable to allow closing after dispute resolution (fix #439)"
           ],
+          "writable": true,
           "optional": true,
           "pda": {
             "seeds": [
@@ -1991,6 +2251,11 @@
         },
         {
           "name": "worker",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_authority",
           "writable": true,
           "optional": true
         },
@@ -2278,6 +2543,10 @@
                 ]
               },
               {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
                 "kind": "arg",
                 "path": "state_key"
               }
@@ -2383,6 +2652,69 @@
                 "kind": "account",
                 "path": "dispute.dispute_id",
                 "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task account for arbiter party validation (fix #461)"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          },
+          "relations": [
+            "dispute"
+          ]
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Optional: Worker's claim on the task (for arbiter party validation, fix #461)",
+            "If provided, validates arbiter is not the worker"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker_claim.worker",
+                "account": "TaskClaim"
               }
             ]
           }
@@ -2582,6 +2914,19 @@
       ]
     },
     {
+      "name": "Nullifier",
+      "discriminator": [
+        18,
+        56,
+        142,
+        165,
+        181,
+        158,
+        187,
+        133
+      ]
+    },
+    {
       "name": "ProtocolConfig",
       "discriminator": [
         207,
@@ -2672,6 +3017,19 @@
         250,
         210,
         166
+      ]
+    },
+    {
+      "name": "ArbiterVotesCleanedUp",
+      "discriminator": [
+        50,
+        95,
+        231,
+        24,
+        238,
+        79,
+        179,
+        220
       ]
     },
     {
@@ -2805,6 +3163,19 @@
       ]
     },
     {
+      "name": "ProtocolFeeUpdated",
+      "discriminator": [
+        172,
+        56,
+        83,
+        113,
+        219,
+        69,
+        69,
+        105
+      ]
+    },
+    {
       "name": "ProtocolInitialized",
       "discriminator": [
         173,
@@ -2841,6 +3212,19 @@
         167,
         242,
         145
+      ]
+    },
+    {
+      "name": "RateLimitsUpdated",
+      "discriminator": [
+        32,
+        232,
+        72,
+        132,
+        73,
+        25,
+        219,
+        10
       ]
     },
     {
@@ -2958,398 +3342,643 @@
     },
     {
       "code": 6004,
+      "name": "InvalidCapabilities",
+      "msg": "Agent capabilities bitmask cannot be zero"
+    },
+    {
+      "code": 6005,
       "name": "MaxActiveTasksReached",
       "msg": "Agent has reached maximum active tasks"
     },
     {
-      "code": 6005,
+      "code": 6006,
       "name": "AgentHasActiveTasks",
       "msg": "Agent has active tasks and cannot be deregistered"
     },
     {
-      "code": 6006,
+      "code": 6007,
       "name": "UnauthorizedAgent",
       "msg": "Only the agent authority can perform this action"
     },
     {
-      "code": 6007,
+      "code": 6008,
+      "name": "InvalidAgentId",
+      "msg": "Invalid agent ID: agent_id cannot be all zeros"
+    },
+    {
+      "code": 6009,
       "name": "AgentRegistrationRequired",
       "msg": "Agent registration required to create tasks"
     },
     {
-      "code": 6008,
+      "code": 6010,
       "name": "AgentSuspended",
       "msg": "Agent is suspended and cannot change status"
     },
     {
-      "code": 6009,
+      "code": 6011,
+      "name": "AgentBusyWithTasks",
+      "msg": "Agent cannot set status to Active while having active tasks"
+    },
+    {
+      "code": 6012,
       "name": "TaskNotFound",
       "msg": "Task not found"
     },
     {
-      "code": 6010,
+      "code": 6013,
       "name": "TaskNotOpen",
       "msg": "Task is not open for claims"
     },
     {
-      "code": 6011,
+      "code": 6014,
       "name": "TaskFullyClaimed",
       "msg": "Task has reached maximum workers"
     },
     {
-      "code": 6012,
+      "code": 6015,
       "name": "TaskExpired",
       "msg": "Task has expired"
     },
     {
-      "code": 6013,
+      "code": 6016,
       "name": "TaskNotExpired",
       "msg": "Task deadline has not passed"
     },
     {
-      "code": 6014,
+      "code": 6017,
       "name": "DeadlinePassed",
       "msg": "Task deadline has passed"
     },
     {
-      "code": 6015,
+      "code": 6018,
       "name": "TaskNotInProgress",
       "msg": "Task is not in progress"
     },
     {
-      "code": 6016,
+      "code": 6019,
       "name": "TaskAlreadyCompleted",
       "msg": "Task is already completed"
     },
     {
-      "code": 6017,
+      "code": 6020,
       "name": "TaskCannotBeCancelled",
       "msg": "Task cannot be cancelled"
     },
     {
-      "code": 6018,
+      "code": 6021,
       "name": "UnauthorizedTaskAction",
       "msg": "Only the task creator can perform this action"
     },
     {
-      "code": 6019,
+      "code": 6022,
       "name": "InvalidCreator",
       "msg": "Invalid creator"
     },
     {
-      "code": 6020,
+      "code": 6023,
+      "name": "InvalidTaskId",
+      "msg": "Invalid task ID: cannot be zero"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidDescription",
+      "msg": "Invalid description: cannot be empty"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidMaxWorkers",
+      "msg": "Invalid max workers: must be between 1 and 100"
+    },
+    {
+      "code": 6026,
       "name": "InvalidTaskType",
       "msg": "Invalid task type"
     },
     {
-      "code": 6021,
+      "code": 6027,
+      "name": "InvalidDeadline",
+      "msg": "Invalid deadline: deadline must be greater than zero"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidReward",
+      "msg": "Invalid reward: reward must be greater than zero"
+    },
+    {
+      "code": 6029,
       "name": "CompetitiveTaskAlreadyWon",
       "msg": "Competitive task already completed by another worker"
     },
     {
-      "code": 6022,
+      "code": 6030,
       "name": "NoWorkers",
       "msg": "Task has no workers"
     },
     {
-      "code": 6023,
+      "code": 6031,
       "name": "ConstraintHashMismatch",
       "msg": "Proof constraint hash does not match task's stored constraint hash"
     },
     {
-      "code": 6024,
+      "code": 6032,
       "name": "NotPrivateTask",
       "msg": "Task is not a private task (no constraint hash set)"
     },
     {
-      "code": 6025,
+      "code": 6033,
       "name": "AlreadyClaimed",
       "msg": "Worker has already claimed this task"
     },
     {
-      "code": 6026,
+      "code": 6034,
       "name": "NotClaimed",
       "msg": "Worker has not claimed this task"
     },
     {
-      "code": 6027,
+      "code": 6035,
       "name": "ClaimAlreadyCompleted",
       "msg": "Claim has already been completed"
     },
     {
-      "code": 6028,
+      "code": 6036,
       "name": "ClaimNotExpired",
       "msg": "Claim has not expired yet"
     },
     {
-      "code": 6029,
+      "code": 6037,
+      "name": "ClaimExpired",
+      "msg": "Claim has expired"
+    },
+    {
+      "code": 6038,
+      "name": "InvalidExpiration",
+      "msg": "Invalid expiration: expires_at cannot be zero"
+    },
+    {
+      "code": 6039,
       "name": "InvalidProof",
       "msg": "Invalid proof of work"
     },
     {
-      "code": 6030,
+      "code": 6040,
       "name": "ZkVerificationFailed",
       "msg": "ZK proof verification failed"
     },
     {
-      "code": 6031,
+      "code": 6041,
       "name": "InvalidProofSize",
       "msg": "Invalid proof size - expected 256 bytes for Groth16"
     },
     {
-      "code": 6032,
+      "code": 6042,
       "name": "InvalidProofBinding",
       "msg": "Invalid proof binding: expected_binding cannot be all zeros"
     },
     {
-      "code": 6033,
+      "code": 6043,
       "name": "InvalidOutputCommitment",
       "msg": "Invalid output commitment: output_commitment cannot be all zeros"
     },
     {
-      "code": 6034,
+      "code": 6044,
+      "name": "InvalidRentRecipient",
+      "msg": "Invalid rent recipient: must be worker authority"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidProofHash",
+      "msg": "Invalid proof hash: proof_hash cannot be all zeros"
+    },
+    {
+      "code": 6046,
+      "name": "InvalidResultData",
+      "msg": "Invalid result data: result_data cannot be all zeros when provided"
+    },
+    {
+      "code": 6047,
       "name": "DisputeNotActive",
       "msg": "Dispute is not active"
     },
     {
-      "code": 6035,
+      "code": 6048,
       "name": "VotingEnded",
       "msg": "Voting period has ended"
     },
     {
-      "code": 6036,
+      "code": 6049,
       "name": "VotingNotEnded",
       "msg": "Voting period has not ended"
     },
     {
-      "code": 6037,
+      "code": 6050,
       "name": "AlreadyVoted",
       "msg": "Already voted on this dispute"
     },
     {
-      "code": 6038,
+      "code": 6051,
       "name": "NotArbiter",
       "msg": "Not authorized to vote (not an arbiter)"
     },
     {
-      "code": 6039,
+      "code": 6052,
       "name": "InsufficientVotes",
       "msg": "Insufficient votes to resolve"
     },
     {
-      "code": 6040,
+      "code": 6053,
       "name": "DisputeAlreadyResolved",
       "msg": "Dispute has already been resolved"
     },
     {
-      "code": 6041,
+      "code": 6054,
       "name": "UnauthorizedResolver",
       "msg": "Only protocol authority or dispute initiator can resolve disputes"
     },
     {
-      "code": 6042,
+      "code": 6055,
       "name": "ActiveDisputeVotes",
       "msg": "Agent has active dispute votes pending resolution"
     },
     {
-      "code": 6043,
+      "code": 6056,
       "name": "RecentVoteActivity",
       "msg": "Agent must wait 24 hours after voting before deregistering"
     },
     {
-      "code": 6044,
+      "code": 6057,
       "name": "AuthorityAlreadyVoted",
       "msg": "Authority has already voted on this dispute"
     },
     {
-      "code": 6045,
+      "code": 6058,
       "name": "InsufficientEvidence",
       "msg": "Insufficient dispute evidence provided"
     },
     {
-      "code": 6046,
+      "code": 6059,
       "name": "EvidenceTooLong",
       "msg": "Dispute evidence exceeds maximum allowed length"
     },
     {
-      "code": 6047,
+      "code": 6060,
       "name": "DisputeNotExpired",
       "msg": "Dispute has not expired"
     },
     {
-      "code": 6048,
+      "code": 6061,
       "name": "SlashAlreadyApplied",
       "msg": "Dispute slashing already applied"
     },
     {
-      "code": 6049,
+      "code": 6062,
       "name": "DisputeNotResolved",
       "msg": "Dispute has not been resolved"
     },
     {
-      "code": 6050,
+      "code": 6063,
+      "name": "NotTaskParticipant",
+      "msg": "Only task creator or workers can initiate disputes"
+    },
+    {
+      "code": 6064,
+      "name": "InvalidEvidenceHash",
+      "msg": "Invalid evidence hash: cannot be all zeros"
+    },
+    {
+      "code": 6065,
+      "name": "ArbiterIsDisputeParticipant",
+      "msg": "Arbiter cannot vote on disputes they are a participant in"
+    },
+    {
+      "code": 6066,
+      "name": "InsufficientQuorum",
+      "msg": "Insufficient quorum: minimum number of voters not reached"
+    },
+    {
+      "code": 6067,
+      "name": "ActiveDisputesExist",
+      "msg": "Agent has active disputes as defendant and cannot deregister"
+    },
+    {
+      "code": 6068,
+      "name": "WorkerAgentRequired",
+      "msg": "Worker agent account required when creator initiates dispute"
+    },
+    {
+      "code": 6069,
+      "name": "WorkerClaimRequired",
+      "msg": "Worker claim account required when creator initiates dispute"
+    },
+    {
+      "code": 6070,
+      "name": "WorkerNotInDispute",
+      "msg": "Worker was not involved in this dispute"
+    },
+    {
+      "code": 6071,
+      "name": "InitiatorCannotResolve",
+      "msg": "Dispute initiator cannot resolve their own dispute"
+    },
+    {
+      "code": 6072,
       "name": "VersionMismatch",
       "msg": "State version mismatch (concurrent modification)"
     },
     {
-      "code": 6051,
+      "code": 6073,
       "name": "StateKeyExists",
       "msg": "State key already exists"
     },
     {
-      "code": 6052,
+      "code": 6074,
       "name": "StateNotFound",
       "msg": "State not found"
     },
     {
-      "code": 6053,
+      "code": 6075,
+      "name": "InvalidStateValue",
+      "msg": "Invalid state value: state_value cannot be all zeros"
+    },
+    {
+      "code": 6076,
       "name": "ProtocolAlreadyInitialized",
       "msg": "Protocol is already initialized"
     },
     {
-      "code": 6054,
+      "code": 6077,
       "name": "ProtocolNotInitialized",
       "msg": "Protocol is not initialized"
     },
     {
-      "code": 6055,
+      "code": 6078,
       "name": "InvalidProtocolFee",
       "msg": "Invalid protocol fee (must be <= 1000 bps)"
     },
     {
-      "code": 6056,
-      "name": "InvalidDisputeThreshold",
-      "msg": "Invalid dispute threshold"
+      "code": 6079,
+      "name": "InvalidTreasury",
+      "msg": "Invalid treasury: treasury account cannot be default pubkey"
     },
     {
-      "code": 6057,
+      "code": 6080,
+      "name": "InvalidDisputeThreshold",
+      "msg": "Invalid dispute threshold: must be 1-100 (percentage of votes required)"
+    },
+    {
+      "code": 6081,
       "name": "InsufficientStake",
       "msg": "Insufficient stake for arbiter registration"
     },
     {
-      "code": 6058,
+      "code": 6082,
       "name": "MultisigInvalidThreshold",
       "msg": "Invalid multisig threshold"
     },
     {
-      "code": 6059,
+      "code": 6083,
       "name": "MultisigInvalidSigners",
       "msg": "Invalid multisig signer configuration"
     },
     {
-      "code": 6060,
+      "code": 6084,
       "name": "MultisigNotEnoughSigners",
       "msg": "Not enough multisig signers"
     },
     {
-      "code": 6061,
+      "code": 6085,
       "name": "MultisigDuplicateSigner",
       "msg": "Duplicate multisig signer provided"
     },
     {
-      "code": 6062,
+      "code": 6086,
       "name": "MultisigDefaultSigner",
       "msg": "Multisig signer cannot be default pubkey"
     },
     {
-      "code": 6063,
+      "code": 6087,
       "name": "MultisigSignerNotSystemOwned",
       "msg": "Multisig signer account not owned by System Program"
     },
     {
-      "code": 6064,
+      "code": 6088,
       "name": "InvalidInput",
       "msg": "Invalid input parameter"
     },
     {
-      "code": 6065,
+      "code": 6089,
       "name": "ArithmeticOverflow",
       "msg": "Arithmetic overflow"
     },
     {
-      "code": 6066,
+      "code": 6090,
       "name": "VoteOverflow",
       "msg": "Vote count overflow"
     },
     {
-      "code": 6067,
+      "code": 6091,
       "name": "InsufficientFunds",
       "msg": "Insufficient funds"
     },
     {
-      "code": 6068,
+      "code": 6092,
+      "name": "RewardTooSmall",
+      "msg": "Reward too small: worker must receive at least 1 lamport"
+    },
+    {
+      "code": 6093,
       "name": "CorruptedData",
       "msg": "Account data is corrupted"
     },
     {
-      "code": 6069,
+      "code": 6094,
       "name": "StringTooLong",
       "msg": "String too long"
     },
     {
-      "code": 6070,
+      "code": 6095,
       "name": "InvalidAccountOwner",
       "msg": "Account owner validation failed: account not owned by this program"
     },
     {
-      "code": 6071,
+      "code": 6096,
       "name": "RateLimitExceeded",
       "msg": "Rate limit exceeded: maximum actions per 24h window reached"
     },
     {
-      "code": 6072,
+      "code": 6097,
       "name": "CooldownNotElapsed",
       "msg": "Cooldown period has not elapsed since last action"
     },
     {
-      "code": 6073,
+      "code": 6098,
+      "name": "UpdateTooFrequent",
+      "msg": "Agent update too frequent: must wait cooldown period"
+    },
+    {
+      "code": 6099,
+      "name": "InvalidCooldown",
+      "msg": "Cooldown value cannot be negative"
+    },
+    {
+      "code": 6100,
+      "name": "CooldownTooLarge",
+      "msg": "Cooldown value exceeds maximum (24 hours)"
+    },
+    {
+      "code": 6101,
+      "name": "RateLimitTooHigh",
+      "msg": "Rate limit value exceeds maximum allowed (1000)"
+    },
+    {
+      "code": 6102,
+      "name": "CooldownTooLong",
+      "msg": "Cooldown value exceeds maximum allowed (1 week)"
+    },
+    {
+      "code": 6103,
       "name": "InsufficientStakeForDispute",
       "msg": "Insufficient stake to initiate dispute"
     },
     {
-      "code": 6074,
+      "code": 6104,
       "name": "VersionMismatchProtocol",
       "msg": "Protocol version mismatch: account version incompatible with current program"
     },
     {
-      "code": 6075,
+      "code": 6105,
       "name": "AccountVersionTooOld",
       "msg": "Account version too old: migration required"
     },
     {
-      "code": 6076,
+      "code": 6106,
       "name": "AccountVersionTooNew",
       "msg": "Account version too new: program upgrade required"
     },
     {
-      "code": 6077,
+      "code": 6107,
       "name": "InvalidMigrationSource",
       "msg": "Migration not allowed: invalid source version"
     },
     {
-      "code": 6078,
+      "code": 6108,
       "name": "InvalidMigrationTarget",
       "msg": "Migration not allowed: invalid target version"
     },
     {
-      "code": 6079,
+      "code": 6109,
       "name": "UnauthorizedUpgrade",
       "msg": "Only upgrade authority can perform this action"
     },
     {
-      "code": 6080,
+      "code": 6110,
+      "name": "InvalidMinVersion",
+      "msg": "Minimum version cannot exceed current protocol version"
+    },
+    {
+      "code": 6111,
+      "name": "ProtocolConfigRequired",
+      "msg": "Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts"
+    },
+    {
+      "code": 6112,
       "name": "ParentTaskCancelled",
       "msg": "Parent task has been cancelled"
     },
     {
-      "code": 6081,
+      "code": 6113,
       "name": "ParentTaskDisputed",
       "msg": "Parent task is in disputed state"
     },
     {
-      "code": 6082,
+      "code": 6114,
       "name": "InvalidDependencyType",
       "msg": "Invalid dependency type"
+    },
+    {
+      "code": 6115,
+      "name": "ParentTaskNotCompleted",
+      "msg": "Parent task must be completed before completing a proof-dependent task"
+    },
+    {
+      "code": 6116,
+      "name": "ParentTaskAccountRequired",
+      "msg": "Parent task account required for proof-dependent task completion"
+    },
+    {
+      "code": 6117,
+      "name": "UnauthorizedCreator",
+      "msg": "Parent task does not belong to the same creator"
+    },
+    {
+      "code": 6118,
+      "name": "NullifierAlreadySpent",
+      "msg": "Nullifier has already been spent - proof/knowledge reuse detected"
+    },
+    {
+      "code": 6119,
+      "name": "InvalidNullifier",
+      "msg": "Invalid nullifier: nullifier value cannot be all zeros"
+    },
+    {
+      "code": 6120,
+      "name": "IncompleteWorkerAccounts",
+      "msg": "All worker accounts must be provided when cancelling a task with active claims"
+    },
+    {
+      "code": 6121,
+      "name": "WorkerAccountsRequired",
+      "msg": "Worker accounts required when task has active workers"
+    },
+    {
+      "code": 6122,
+      "name": "DuplicateArbiter",
+      "msg": "Duplicate arbiter provided in remaining_accounts"
+    },
+    {
+      "code": 6123,
+      "name": "InsufficientEscrowBalance",
+      "msg": "Escrow has insufficient balance for reward transfer"
+    },
+    {
+      "code": 6124,
+      "name": "InvalidStatusTransition",
+      "msg": "Invalid task status transition"
+    },
+    {
+      "code": 6125,
+      "name": "StakeTooLow",
+      "msg": "Stake value is below minimum required (0.001 SOL)"
+    },
+    {
+      "code": 6126,
+      "name": "InvalidMinStake",
+      "msg": "min_stake_for_dispute must be greater than zero"
+    },
+    {
+      "code": 6127,
+      "name": "InvalidSlashAmount",
+      "msg": "Slash amount must be greater than zero"
+    },
+    {
+      "code": 6128,
+      "name": "BondAmountTooLow",
+      "msg": "Bond amount too low"
+    },
+    {
+      "code": 6129,
+      "name": "BondAlreadyExists",
+      "msg": "Bond already exists"
+    },
+    {
+      "code": 6130,
+      "name": "BondNotFound",
+      "msg": "Bond not found"
+    },
+    {
+      "code": 6131,
+      "name": "BondNotMatured",
+      "msg": "Bond not yet matured"
     }
   ],
   "types": [
@@ -3411,6 +4040,10 @@
             "type": "string"
           },
           {
+            "name": "stake_amount",
+            "type": "u64"
+          },
+          {
             "name": "timestamp",
             "type": "i64"
           }
@@ -3448,7 +4081,15 @@
           {
             "name": "capabilities",
             "docs": [
-              "Capability bitmask"
+              "Agent capabilities as a bitmask (u64).",
+              "",
+              "Each bit represents a specific capability the agent possesses.",
+              "See [`capability`] module for defined bits:",
+              "- Bits 0-9: Currently defined capabilities (COMPUTE, INFERENCE, etc.)",
+              "- Bits 10-63: Reserved for future protocol extensions",
+              "",
+              "Agents can only claim tasks where they have all required capabilities:",
+              "`(agent.capabilities & task.required_capabilities) == task.required_capabilities`"
             ],
             "type": "u64"
           },
@@ -3466,7 +4107,7 @@
           {
             "name": "endpoint",
             "docs": [
-              "Network endpoint (max 128 chars)"
+              "Network endpoint (max 256 chars)"
             ],
             "type": "string"
           },
@@ -3508,7 +4149,9 @@
           {
             "name": "reputation",
             "docs": [
-              "Reputation score (0-10000)"
+              "Agent reputation score (0-10000)",
+              "Initial value: 5000 (neutral starting point)",
+              "Can be adjusted via protocol config in future versions"
             ],
             "type": "u16"
           },
@@ -3590,14 +4233,23 @@
             "type": "i64"
           },
           {
+            "name": "disputes_as_defendant",
+            "docs": [
+              "Active disputes where this agent is a defendant (can be slashed)"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "_reserved",
             "docs": [
-              "Reserved for future use"
+              "Reserved bytes for future use.",
+              "Note: Not validated on deserialization - may contain arbitrary data",
+              "from previous versions. New fields should handle this gracefully."
             ],
             "type": {
               "array": [
                 "u8",
-                6
+                5
               ]
             }
           }
@@ -3658,6 +4310,30 @@
           {
             "name": "timestamp",
             "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ArbiterVotesCleanedUp",
+      "docs": [
+        "Emitted when arbiter votes are cleaned up during dispute expiration"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dispute_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "arbiter_count",
+            "type": "u8"
           }
         ]
       }
@@ -3729,6 +4405,10 @@
           {
             "name": "new_total",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3752,6 +4432,10 @@
           {
             "name": "amount",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3775,6 +4459,10 @@
           {
             "name": "amount",
             "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -3814,11 +4502,18 @@
       "name": "CoordinationState",
       "docs": [
         "Shared coordination state",
-        "PDA seeds: [\"state\", state_key]"
+        "PDA seeds: [\"state\", owner, state_key]"
       ],
       "type": {
         "kind": "struct",
         "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Owner authority - namespaces state to prevent cross-user collisions"
+            ],
+            "type": "pubkey"
+          },
           {
             "name": "state_key",
             "docs": [
@@ -3877,7 +4572,7 @@
     {
       "name": "DependencyType",
       "docs": [
-        "Dependency type for speculative execution decisions"
+        "Task dependency type for speculative execution decisions"
       ],
       "repr": {
         "kind": "rust"
@@ -3967,7 +4662,14 @@
           {
             "name": "initiator",
             "docs": [
-              "Initiator"
+              "Initiator (agent PDA)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "initiator_authority",
+            "docs": [
+              "Initiator's authority wallet (for resolver constraint)"
             ],
             "type": "pubkey"
           },
@@ -4036,30 +4738,48 @@
           {
             "name": "total_voters",
             "docs": [
-              "Total eligible voters"
+              "Total arbiters who voted (max 255 due to u8)",
+              "Note: Increase to u16 if more arbiters needed"
             ],
             "type": "u8"
           },
           {
             "name": "voting_deadline",
             "docs": [
-              "Voting deadline"
+              "Voting deadline - after this, no new votes accepted",
+              "voting_deadline = created_at + voting_period"
             ],
             "type": "i64"
           },
           {
             "name": "expires_at",
             "docs": [
-              "Dispute expiration timestamp"
+              "Dispute expiration - after this, can call expire_dispute",
+              "expires_at = created_at + max_dispute_duration",
+              "Note: expires_at >= voting_deadline, allowing resolution after voting ends"
             ],
             "type": "i64"
           },
           {
             "name": "slash_applied",
             "docs": [
-              "Whether slashing has been applied"
+              "Whether worker slashing has been applied"
             ],
             "type": "bool"
+          },
+          {
+            "name": "initiator_slash_applied",
+            "docs": [
+              "Whether initiator slashing has been applied (for rejected disputes)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "worker_stake_at_dispute",
+            "docs": [
+              "Snapshot of worker's stake at dispute initiation (prevents stake withdrawal attacks)"
+            ],
+            "type": "u64"
           },
           {
             "name": "bump",
@@ -4074,7 +4794,8 @@
     {
       "name": "DisputeExpired",
       "docs": [
-        "Emitted when a dispute expires without resolution"
+        "Emitted when a dispute expires without resolution",
+        "Updated in fix #418 to include fair distribution details"
       ],
       "type": {
         "kind": "struct",
@@ -4099,6 +4820,20 @@
           },
           {
             "name": "refund_amount",
+            "type": "u64"
+          },
+          {
+            "name": "creator_amount",
+            "docs": [
+              "Amount refunded to creator (fix #418)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "worker_amount",
+            "docs": [
+              "Amount paid to worker (fix #418)"
+            ],
             "type": "u64"
           },
           {
@@ -4250,6 +4985,13 @@
             "type": "i64"
           },
           {
+            "name": "stake_at_vote",
+            "docs": [
+              "Arbiter's stake at the time of voting (for weighted resolution)"
+            ],
+            "type": "u64"
+          },
+          {
             "name": "bump",
             "docs": [
               "Bump seed"
@@ -4327,6 +5069,60 @@
       }
     },
     {
+      "name": "Nullifier",
+      "docs": [
+        "Nullifier account to prevent proof/knowledge reuse across tasks.",
+        "Once a nullifier is \"spent\" (account exists), the same proof/knowledge",
+        "combination cannot be used again.",
+        "PDA seeds: [\"nullifier\", nullifier_value]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nullifier_value",
+            "docs": [
+              "The nullifier value (derived from constraint_hash + agent_secret in ZK circuit)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "task",
+            "docs": [
+              "The task where this nullifier was first used"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "agent",
+            "docs": [
+              "The agent who spent this nullifier"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "spent_at",
+            "docs": [
+              "Timestamp when nullifier was spent"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
       "name": "PrivateCompletionProof",
       "type": {
         "kind": "struct",
@@ -4361,6 +5157,19 @@
                 32
               ]
             }
+          },
+          {
+            "name": "nullifier",
+            "docs": [
+              "Nullifier to prevent proof/knowledge reuse across tasks.",
+              "Derived in the ZK circuit as: Poseidon(constraint_hash, agent_secret)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           }
         ]
       }
@@ -4377,14 +5186,17 @@
           {
             "name": "authority",
             "docs": [
-              "Protocol authority"
+              "Protocol authority",
+              "Note: Cannot be updated after initialization."
             ],
             "type": "pubkey"
           },
           {
             "name": "treasury",
             "docs": [
-              "Treasury for protocol fees"
+              "Treasury address for protocol fees",
+              "Note: Cannot be updated after initialization.",
+              "Deploy new protocol if treasury change needed."
             ],
             "type": "pubkey"
           },
@@ -4522,6 +5334,13 @@
             "type": "u8"
           },
           {
+            "name": "voting_period",
+            "docs": [
+              "Voting period for disputes in seconds (default: 24 hours)"
+            ],
+            "type": "i64"
+          },
+          {
             "name": "protocol_version",
             "docs": [
               "Current protocol version (for upgrades)"
@@ -4538,7 +5357,8 @@
           {
             "name": "_padding",
             "docs": [
-              "Padding for alignment/future use"
+              "Padding for future use and alignment",
+              "Currently unused but reserved for backwards-compatible additions"
             ],
             "type": {
               "array": [
@@ -4550,7 +5370,19 @@
           {
             "name": "multisig_owners",
             "docs": [
-              "Multisig owners (fixed-size)"
+              "Multisig owners (immutable after init for security).",
+              "",
+              "# Security Note (see #464)",
+              "Multisig configuration **cannot be updated** after protocol initialization.",
+              "To change multisig, deploy new protocol.",
+              "",
+              "This is intentional:",
+              "- Prevents hostile takeover via multisig reconfiguration",
+              "- Ensures governance changes require protocol redeployment with proper ceremony",
+              "- The array is fully zeroed before population in `initialize_protocol`",
+              "",
+              "Only the first `multisig_owners_len` entries are valid; remaining slots",
+              "are always `Pubkey::default()`."
             ],
             "type": {
               "array": [
@@ -4558,6 +5390,33 @@
                 5
               ]
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolFeeUpdated",
+      "docs": [
+        "Emitted when protocol fee is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "new_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4665,6 +5524,45 @@
       }
     },
     {
+      "name": "RateLimitsUpdated",
+      "docs": [
+        "Emitted when rate limit configuration is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "task_creation_cooldown",
+            "type": "i64"
+          },
+          {
+            "name": "max_tasks_per_24h",
+            "type": "u8"
+          },
+          {
+            "name": "dispute_initiation_cooldown",
+            "type": "i64"
+          },
+          {
+            "name": "max_disputes_per_24h",
+            "type": "u8"
+          },
+          {
+            "name": "min_stake_for_dispute",
+            "type": "u64"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
       "name": "ResolutionType",
       "docs": [
         "Dispute resolution type"
@@ -4752,6 +5650,10 @@
           {
             "name": "expires_at",
             "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }
@@ -4770,6 +5672,15 @@
               "array": [
                 "u8",
                 32
+              ]
+            }
+          },
+          {
+            "name": "state_value",
+            "type": {
+              "array": [
+                "u8",
+                64
               ]
             }
           },
@@ -4819,7 +5730,11 @@
           {
             "name": "required_capabilities",
             "docs": [
-              "Required capability bitmask"
+              "Required capability bitmask (u64).",
+              "",
+              "Specifies which capabilities an agent must have to claim this task.",
+              "See [`capability`] module for defined bits. An agent can claim this",
+              "task only if: `(agent.capabilities & required_capabilities) == required_capabilities`"
             ],
             "type": "u64"
           },
@@ -4951,6 +5866,13 @@
               "Bump seed"
             ],
             "type": "u8"
+          },
+          {
+            "name": "protocol_fee_bps",
+            "docs": [
+              "Protocol fee in basis points, locked at task creation (#479)"
+            ],
+            "type": "u16"
           },
           {
             "name": "depends_on",
@@ -5185,6 +6107,15 @@
             }
           },
           {
+            "name": "result_data",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
             "name": "reward_paid",
             "type": "u64"
           },
@@ -5321,7 +6252,7 @@
     {
       "name": "TaskType",
       "docs": [
-        "Task type"
+        "Task type enumeration"
       ],
       "repr": {
         "kind": "rust"


### PR DESCRIPTION
## Summary
Fixes #418 - Implements fair refund behavior when disputes expire without resolution.

## Changes
- **Fair refund logic**: When a dispute expires:
  - If worker completed task + no arbiter votes: Worker gets 100% (they did the work, dispute wasn't properly engaged)
  - If no completion + no votes: 50/50 split (neither party engaged arbiters)
  - If some votes but insufficient quorum: Creator gets refund (dispute was contested)
  
- **New `worker_authority` account**: Added optional account to ExpireDispute for routing payment to worker's wallet

- **Updated DisputeExpired event**: Now includes `creator_amount` and `worker_amount` fields for transparency

- **Stack optimization**: Uses `Box<Account>` for large accounts to avoid SBF stack overflow

## Testing
- Rust code compiles with `cargo build`
- Program builds with `cargo build-sbf`
- IDL generated and updated

## Rationale
The previous behavior always refunded the creator on expiration, which created asymmetric risk: creators could grief workers by initiating disputes and not providing evidence. This fix ensures fair outcomes based on context:
- Workers who complete tasks are protected if arbiters don't engage
- Neutral 50/50 split when both parties fail to engage arbitration
- Creator still gets refund when dispute was actively contested