### PR TITLE
fix: deduplicate rate limiting logic into shared helper

### DIFF
--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -1,7 +1,7 @@
 //! Create a new task that depends on an existing parent task
 
 use crate::errors::CoordinationError;
-use crate::events::{DependentTaskCreated, RateLimitHit};
+use crate::events::DependentTaskCreated;
 use crate::state::{
     AgentRegistration, DependencyType, ProtocolConfig, Task, TaskEscrow, TaskStatus, TaskType,
 };
@@ -9,7 +9,7 @@ use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
-use super::constants::WINDOW_24H;
+use super::rate_limit_helpers::check_task_creation_rate_limits;
 
 #[derive(Accounts)]
 #[instruction(task_id: [u8; 32])]
@@ -116,70 +116,8 @@ pub fn handler(
 
     let creator_agent = &mut ctx.accounts.creator_agent;
 
-    // Check cooldown period
-    if config.task_creation_cooldown > 0 && creator_agent.last_task_created > 0 {
-        // Using saturating_sub intentionally - handles clock drift safely
-        let elapsed = clock
-            .unix_timestamp
-            .saturating_sub(creator_agent.last_task_created);
-        if elapsed < config.task_creation_cooldown {
-            // Using saturating_sub intentionally - underflow returns 0 (safe time calculation)
-            let remaining = config.task_creation_cooldown.saturating_sub(elapsed);
-            emit!(RateLimitHit {
-                agent_id: creator_agent.agent_id,
-                action_type: 0, // task_creation
-                limit_type: 0,  // cooldown
-                current_count: creator_agent.task_count_24h,
-                max_count: config.max_tasks_per_24h,
-                cooldown_remaining: remaining,
-                timestamp: clock.unix_timestamp,
-            });
-            return Err(CoordinationError::CooldownNotElapsed.into());
-        }
-    }
-
-    // Check 24h window limit
-    if config.max_tasks_per_24h > 0 {
-        // Reset window if 24h has passed
-        // Using saturating_sub intentionally - handles clock drift safely
-        if clock
-            .unix_timestamp
-            .saturating_sub(creator_agent.rate_limit_window_start)
-            >= WINDOW_24H
-        {
-            // Round window start to prevent drift
-            let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
-            creator_agent.rate_limit_window_start = window_start;
-            // Note: Both counters reset together when window expires.
-            // This is intentional - ensures clean state at window boundary.
-            creator_agent.task_count_24h = 0;
-            creator_agent.dispute_count_24h = 0;
-        }
-
-        // Check if limit exceeded
-        if creator_agent.task_count_24h >= config.max_tasks_per_24h {
-            emit!(RateLimitHit {
-                agent_id: creator_agent.agent_id,
-                action_type: 0, // task_creation
-                limit_type: 1,  // 24h_window
-                current_count: creator_agent.task_count_24h,
-                max_count: config.max_tasks_per_24h,
-                cooldown_remaining: 0,
-                timestamp: clock.unix_timestamp,
-            });
-            return Err(CoordinationError::RateLimitExceeded.into());
-        }
-
-        // Increment counter
-        creator_agent.task_count_24h = creator_agent
-            .task_count_24h
-            .checked_add(1)
-            .ok_or(CoordinationError::ArithmeticOverflow)?;
-    }
-
-    // Update last task created timestamp
-    creator_agent.last_task_created = clock.unix_timestamp;
-    creator_agent.last_active = clock.unix_timestamp;
+    // Check rate limits and update agent state
+    check_task_creation_rate_limits(creator_agent, config, &clock)?;
 
     // Transfer reward to escrow
     if reward_amount > 0 {

--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -21,6 +21,7 @@
 
 pub mod completion_helpers;
 pub mod constants;
+pub mod rate_limit_helpers;
 
 pub mod apply_dispute_slash;
 pub mod apply_initiator_slash;

--- a/programs/agenc-coordination/src/instructions/rate_limit_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/rate_limit_helpers.rs
@@ -1,0 +1,102 @@
+//! Shared helper functions for rate limiting logic.
+//!
+//! Used by both `create_task` and `create_dependent_task` instructions.
+
+use crate::errors::CoordinationError;
+use crate::events::RateLimitHit;
+use crate::instructions::constants::WINDOW_24H;
+use crate::state::{AgentRegistration, ProtocolConfig};
+use anchor_lang::prelude::*;
+
+/// Check rate limits for task creation and update agent state.
+///
+/// This function enforces two rate limiting mechanisms:
+/// 1. **Cooldown period**: Minimum time between task creations
+/// 2. **24-hour window limit**: Maximum tasks per rolling 24-hour window
+///
+/// If rate limits pass, the function updates the agent's counters:
+/// - Increments `task_count_24h`
+/// - Updates `last_task_created` timestamp
+/// - Updates `last_active` timestamp
+///
+/// # Arguments
+/// * `creator_agent` - Mutable reference to the agent's registration
+/// * `config` - Protocol configuration containing rate limit settings
+/// * `clock` - Current clock for timestamp comparisons
+///
+/// # Errors
+/// * `CooldownNotElapsed` - Task creation cooldown has not passed
+/// * `RateLimitExceeded` - 24-hour task limit exceeded
+/// * `ArithmeticOverflow` - Counter overflow (shouldn't happen in practice)
+pub fn check_task_creation_rate_limits(
+    creator_agent: &mut AgentRegistration,
+    config: &ProtocolConfig,
+    clock: &Clock,
+) -> Result<()> {
+    // Check cooldown period
+    if config.task_creation_cooldown > 0 && creator_agent.last_task_created > 0 {
+        // Using saturating_sub intentionally - handles clock drift safely
+        let elapsed = clock
+            .unix_timestamp
+            .saturating_sub(creator_agent.last_task_created);
+        if elapsed < config.task_creation_cooldown {
+            // Using saturating_sub intentionally - underflow returns 0 (safe time calculation)
+            let remaining = config.task_creation_cooldown.saturating_sub(elapsed);
+            emit!(RateLimitHit {
+                agent_id: creator_agent.agent_id,
+                action_type: 0, // task_creation
+                limit_type: 0,  // cooldown
+                current_count: creator_agent.task_count_24h,
+                max_count: config.max_tasks_per_24h,
+                cooldown_remaining: remaining,
+                timestamp: clock.unix_timestamp,
+            });
+            return Err(CoordinationError::CooldownNotElapsed.into());
+        }
+    }
+
+    // Check 24h window limit
+    if config.max_tasks_per_24h > 0 {
+        // Reset window if 24h has passed
+        // Using saturating_sub intentionally - handles clock drift safely
+        if clock
+            .unix_timestamp
+            .saturating_sub(creator_agent.rate_limit_window_start)
+            >= WINDOW_24H
+        {
+            // Round window start to prevent drift
+            let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
+            creator_agent.rate_limit_window_start = window_start;
+            // Note: Both counters reset together when window expires.
+            // This is intentional - ensures clean state at window boundary.
+            creator_agent.task_count_24h = 0;
+            creator_agent.dispute_count_24h = 0;
+        }
+
+        // Check if limit exceeded
+        if creator_agent.task_count_24h >= config.max_tasks_per_24h {
+            emit!(RateLimitHit {
+                agent_id: creator_agent.agent_id,
+                action_type: 0, // task_creation
+                limit_type: 1,  // 24h_window
+                current_count: creator_agent.task_count_24h,
+                max_count: config.max_tasks_per_24h,
+                cooldown_remaining: 0,
+                timestamp: clock.unix_timestamp,
+            });
+            return Err(CoordinationError::RateLimitExceeded.into());
+        }
+
+        // Increment counter
+        creator_agent.task_count_24h = creator_agent
+            .task_count_24h
+            .checked_add(1)
+            .ok_or(CoordinationError::ArithmeticOverflow)?;
+    }
+
+    // Update last task created timestamp
+    creator_agent.last_task_created = clock.unix_timestamp;
+    creator_agent.last_active = clock.unix_timestamp;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Extracts the duplicated rate limiting logic from `create_task.rs` and `create_dependent_task.rs` into a shared helper function in a new `rate_limit_helpers.rs` module.

## Changes
- **New file:** `rate_limit_helpers.rs` with `check_task_creation_rate_limits()` function
- **Updated:** `create_task.rs` - replaced ~50 lines of rate limiting code with single helper call
- **Updated:** `create_dependent_task.rs` - replaced ~50 lines of rate limiting code with single helper call  
- **Updated:** `mod.rs` - added export for new module
- **Fixed:** `completion_helpers.rs` - added missing `protocol_fee_bps` field to test Task struct

## Impact
- Eliminates code duplication (~100 lines removed, ~95 lines in consolidated helper)
- Single source of truth for rate limiting logic
- Future rate limit changes only need to be made in one place
- No functional changes to rate limiting behavior

## Testing
- `cargo check` passes
- Code compiles successfully
- Note: Some pre-existing test failures unrelated to this change (struct size mismatches in state.rs, zero-reward edge cases)

Closes #404