### PR TITLE
fix(update_agent): reject empty endpoint strings

### DIFF
--- a/programs/agenc-coordination/src/instructions/update_agent.rs
+++ b/programs/agenc-coordination/src/instructions/update_agent.rs
@@ -46,6 +46,7 @@ pub fn handler(
     }
 
     if let Some(ep) = endpoint {
+        require!(!ep.is_empty(), CoordinationError::InvalidInput);
         require!(ep.len() <= 128, CoordinationError::StringTooLong);
         agent.endpoint = ep;
     }


### PR DESCRIPTION
## Summary
Adds validation to reject empty endpoint strings in the `update_agent` instruction.

## Changes
- Added `require!(!ep.is_empty(), CoordinationError::InvalidInput)` check before existing length validation

## Issue
Closes #389

## Details
The `update_agent` instruction previously allowed setting endpoint to an empty string, which would:
- Make agents unreachable
- Bypass validation that may be added to registration
- Cause inconsistent validation between register and update operations
- Lead to off-chain system failures when trying to reach such agents

The fix follows the recommended approach from the issue: check for empty strings before the existing max-length check, returning `InvalidInput` error.