### PR TITLE
fix(register_agent): reject empty endpoint strings

### DIFF
--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -56,6 +56,7 @@ pub fn handler(
     );
 
     require!(capabilities != 0, CoordinationError::InvalidCapabilities);
+    require!(!endpoint.is_empty(), CoordinationError::InvalidInput);
     require!(endpoint.len() <= 128, CoordinationError::StringTooLong);
 
     let metadata = metadata_uri.unwrap_or_default();


### PR DESCRIPTION
## Summary
Adds validation to reject empty endpoint strings in `register_agent`.

## Changes
1. **Rust program fix**: Added `require!(!endpoint.is_empty(), CoordinationError::InvalidInput)` before the max length check in `register_agent.rs`
2. **Test**: Added test case `Fails when registering agent with empty endpoint` in `coordination-security.ts`

## Details
Previously, agents could be registered with an empty endpoint string, creating "unreachable" agents that off-chain systems cannot contact. This fix ensures that endpoints must be non-empty during registration.

Fixes #386