### PR TITLE
fix(coordination): validate required_capabilities in create_task

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -97,6 +97,9 @@ pub enum CoordinationError {
     #[msg("Invalid reward: reward must be greater than zero")]
     InvalidReward,
 
+    #[msg("Invalid required capabilities: required_capabilities cannot be zero")]
+    InvalidRequiredCapabilities,
+
     #[msg("Competitive task already completed by another worker")]
     CompetitiveTaskAlreadyWon,
 

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -81,6 +81,8 @@ pub fn handler(
     require!(task_id != [0u8; 32], CoordinationError::InvalidTaskId);
     // Validate description is not empty (#369)
     require!(description != [0u8; 64], CoordinationError::InvalidDescription);
+    // Validate required_capabilities is not zero (#413)
+    require!(required_capabilities != 0, CoordinationError::InvalidRequiredCapabilities);
     // Validate parent task belongs to same creator (#520)
     require!(
         ctx.accounts.parent_task.creator == ctx.accounts.creator.key(),

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -76,6 +76,8 @@ pub fn handler(
     require!(task_id != [0u8; 32], CoordinationError::InvalidTaskId);
     // Validate description is not empty (#369)
     require!(description != [0u8; 64], CoordinationError::InvalidDescription);
+    // Validate required_capabilities is not zero (#413)
+    require!(required_capabilities != 0, CoordinationError::InvalidRequiredCapabilities);
     // Validate max_workers bounds (#412)
     require!(max_workers > 0 && max_workers <= 100, CoordinationError::InvalidMaxWorkers);
     require!(task_type <= 2, CoordinationError::InvalidTaskType);


### PR DESCRIPTION
## Summary
Adds validation to ensure `required_capabilities` is non-zero when creating tasks via `create_task` and `create_dependent_task` instructions.

## Changes
- Added `InvalidRequiredCapabilities` error code in `errors.rs`
- Added validation in `create_task.rs` to reject `required_capabilities = 0`
- Added validation in `create_dependent_task.rs` to reject `required_capabilities = 0`

## Rationale
As noted in the issue, allowing `required_capabilities = 0` means any agent can claim the task regardless of capabilities. This could lead to inappropriate agents claiming specialized tasks.

The validation follows the same pattern as other input validations in the codebase (task_id, description, max_workers, etc.).

## Testing
- Rust code compiles successfully (`cargo check`)
- SDK tests pass (75/75)

Closes #413