### PR TITLE
fix: require creator matches authority in CreateTask to prevent social engineering

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -33,6 +33,9 @@ pub enum CoordinationError {
     #[msg("Only the agent authority can perform this action")]
     UnauthorizedAgent,
 
+    #[msg("Creator must match authority to prevent social engineering")]
+    CreatorAuthorityMismatch,
+
     #[msg("Invalid agent ID: agent_id cannot be all zeros")]
     InvalidAgentId,
 

--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -219,6 +219,7 @@ mod tests {
             required_completions,
             completions,
             bump: 0,
+            protocol_fee_bps: 0,
             depends_on: None,
             dependency_type: DependencyType::default(),
             _reserved: [0u8; 32],

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -58,7 +58,12 @@ pub struct CreateDependentTask<'info> {
     /// The authority that owns the creator_agent
     pub authority: Signer<'info>,
 
-    #[account(mut)]
+    /// The creator who pays for and owns the task
+    /// Must match authority to prevent social engineering attacks (#375)
+    #[account(
+        mut,
+        constraint = creator.key() == authority.key() @ CoordinationError::CreatorAuthorityMismatch
+    )]
     pub creator: Signer<'info>,
 
     pub system_program: Program<'info, System>,

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -49,7 +49,12 @@ pub struct CreateTask<'info> {
     /// The authority that owns the creator_agent
     pub authority: Signer<'info>,
 
-    #[account(mut)]
+    /// The creator who pays for and owns the task
+    /// Must match authority to prevent social engineering attacks (#375)
+    #[account(
+        mut,
+        constraint = creator.key() == authority.key() @ CoordinationError::CreatorAuthorityMismatch
+    )]
     pub creator: Signer<'info>,
 
     pub system_program: Program<'info, System>,


### PR DESCRIPTION
## Summary
Fixes issue #375 - Creator/Authority Separation in CreateTask May Enable Social Engineering

## Changes
- Added `CreatorAuthorityMismatch` error to `errors.rs`
- Added constraint `creator.key() == authority.key()` to `CreateTask` accounts in `create_task.rs`
- Added the same constraint to `CreateDependentTask` accounts in `create_dependent_task.rs`
- Fixed missing `protocol_fee_bps` field in test helper function

## Security
This prevents social engineering attacks where an attacker could convince a victim to sign as `creator` while the attacker controls the `authority`. By requiring these to match, only the agent authority can create tasks for their agent.

## Testing
- Anchor build succeeds with the changes
- Cargo test (unit tests) pass for the changed files

Closes #375