### PR TITLE
fix(coordination): validate endpoint URL format

### DIFF
--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -22,6 +22,7 @@
 pub mod completion_helpers;
 pub mod constants;
 pub mod rate_limit_helpers;
+pub mod validation;
 
 pub mod apply_dispute_slash;
 pub mod apply_initiator_slash;

--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -7,6 +7,7 @@ use crate::utils::validation::validate_string_input;
 use anchor_lang::prelude::*;
 
 use super::constants::WINDOW_24H;
+use super::validation::validate_endpoint;
 
 /// Initial reputation score for new agents (50% = 5000/10000)
 const INITIAL_REPUTATION: u16 = 5000;
@@ -57,11 +58,11 @@ pub fn handler(
 
     require!(capabilities != 0, CoordinationError::InvalidCapabilities);
     require!(!endpoint.is_empty(), CoordinationError::InvalidInput);
-    require!(endpoint.len() <= 128, CoordinationError::StringTooLong);
     require!(
         validate_string_input(&endpoint),
         CoordinationError::InvalidInput
     );
+    validate_endpoint(&endpoint)?;
 
     let metadata = metadata_uri.unwrap_or_default();
     require!(metadata.len() <= 128, CoordinationError::StringTooLong);

--- a/programs/agenc-coordination/src/instructions/update_agent.rs
+++ b/programs/agenc-coordination/src/instructions/update_agent.rs
@@ -6,6 +6,7 @@
 
 use crate::errors::CoordinationError;
 use crate::events::AgentUpdated;
+use crate::instructions::validation::validate_endpoint;
 use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig};
 use crate::utils::validation::validate_string_input;
 use anchor_lang::prelude::*;
@@ -48,11 +49,11 @@ pub fn handler(
 
     if let Some(ep) = endpoint {
         require!(!ep.is_empty(), CoordinationError::InvalidInput);
-        require!(ep.len() <= 128, CoordinationError::StringTooLong);
         require!(
             validate_string_input(&ep),
             CoordinationError::InvalidInput
         );
+        validate_endpoint(&ep)?;
         agent.endpoint = ep;
     }
 

--- a/programs/agenc-coordination/src/instructions/validation.rs
+++ b/programs/agenc-coordination/src/instructions/validation.rs
@@ -1,0 +1,27 @@
+//! Shared validation helpers for instruction handlers
+
+use crate::errors::CoordinationError;
+use anchor_lang::prelude::*;
+
+/// Validates an agent endpoint URL.
+///
+/// - Empty strings are allowed (agent may not have a public endpoint)
+/// - Non-empty endpoints must start with "http://" or "https://"
+/// - Maximum length is 128 characters
+pub fn validate_endpoint(endpoint: &str) -> Result<()> {
+    // Allow empty (agent may not have public endpoint)
+    if endpoint.is_empty() {
+        return Ok(());
+    }
+
+    // Must start with http:// or https://
+    require!(
+        endpoint.starts_with("http://") || endpoint.starts_with("https://"),
+        CoordinationError::InvalidInput
+    );
+
+    // Length check
+    require!(endpoint.len() <= 128, CoordinationError::StringTooLong);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Adds URL format validation for agent endpoints as described in #419.

## Changes
- Created `validation.rs` module with `validate_endpoint()` helper function
- Applied validation in both `register_agent.rs` and `update_agent.rs`

## Validation Logic
- **Empty strings are allowed** - agents may not have a public endpoint
- **Non-empty endpoints must start with `http://` or `https://`** - rejects invalid URLs like `ftp://`, random text, XSS attempts
- **Max length of 128 chars** - existing check preserved

This is a lightweight, compute-efficient validation (simple prefix check) suitable for on-chain execution.

## Testing
- Library builds successfully with `cargo build --lib`
- Note: Full test suite has a pre-existing compilation issue unrelated to this change (missing `protocol_fee_bps` field in test helper)

Fixes #419