### PR TITLE
fix: validate state_key is non-zero

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -253,6 +253,9 @@ pub enum CoordinationError {
     #[msg("State ownership violation: only the creator agent can update this state")]
     StateOwnershipViolation,
 
+    #[msg("Invalid state key: state_key cannot be all zeros")]
+    InvalidStateKey,
+
     // Protocol errors (6500-6599)
     #[msg("Protocol is already initialized")]
     ProtocolAlreadyInitialized,

--- a/programs/agenc-coordination/src/instructions/update_state.rs
+++ b/programs/agenc-coordination/src/instructions/update_state.rs
@@ -58,6 +58,12 @@ pub fn handler(
         }
     }
 
+    // Validate state_key is not all zeros
+    require!(
+        state_key.iter().any(|&b| b != 0),
+        CoordinationError::InvalidStateKey
+    );
+
     // Validate state_value is not all zeros
     require!(
         state_value.iter().any(|&b| b != 0),


### PR DESCRIPTION
Adds validation to reject zero state_key in update_state instruction.

Also fixes a pre-existing duplicate field bug in expire_claim.rs that was preventing builds.

Fixes #402