### PR TITLE
feat: add cancel_dispute instruction

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -132,6 +132,15 @@ pub struct DisputeVoteCast {
     pub timestamp: i64,
 }
 
+/// Emitted when a dispute is cancelled by its initiator (fix #587)
+#[event]
+pub struct DisputeCancelled {
+    pub dispute_id: [u8; 32],
+    pub task: Pubkey,
+    pub initiator: Pubkey,
+    pub cancelled_at: i64,
+}
+
 /// Emitted when a dispute is resolved
 ///
 /// The `outcome` field distinguishes between different resolution paths:

--- a/programs/agenc-coordination/src/instructions/cancel_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_dispute.rs
@@ -1,0 +1,71 @@
+//! Cancel a dispute before any votes are cast
+//!
+//! This allows dispute initiators to cancel their disputes early if:
+//! - They realize they made a mistake
+//! - The parties reach an off-chain settlement
+//! - Circumstances change making the dispute moot
+//!
+//! Constraints:
+//! - Only the initiator can cancel
+//! - Only active disputes can be cancelled
+//! - No votes must have been cast yet (total_voters == 0)
+
+use crate::errors::CoordinationError;
+use crate::events::DisputeCancelled;
+use crate::state::{Dispute, DisputeStatus, Task, TaskStatus};
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct CancelDispute<'info> {
+    #[account(
+        mut,
+        seeds = [b"dispute", dispute.dispute_id.as_ref()],
+        bump = dispute.bump,
+        constraint = dispute.status == DisputeStatus::Active @ CoordinationError::DisputeNotActive
+    )]
+    pub dispute: Account<'info, Dispute>,
+
+    #[account(
+        mut,
+        seeds = [b"task", task.creator.as_ref(), task.task_id.as_ref()],
+        bump = task.bump,
+        constraint = task.key() == dispute.task @ CoordinationError::InvalidInput
+    )]
+    pub task: Account<'info, Task>,
+
+    /// Only the initiator's authority can cancel
+    #[account(
+        constraint = authority.key() == dispute.initiator_authority @ CoordinationError::UnauthorizedResolver
+    )]
+    pub authority: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<CancelDispute>) -> Result<()> {
+    let dispute = &mut ctx.accounts.dispute;
+    let task = &mut ctx.accounts.task;
+    let clock = Clock::get()?;
+
+    // Can only cancel if no votes have been cast
+    require!(
+        dispute.total_voters == 0,
+        CoordinationError::VotingEnded
+    );
+
+    // Update dispute status
+    dispute.status = DisputeStatus::Cancelled;
+    dispute.resolved_at = clock.unix_timestamp;
+
+    // Restore task status to InProgress (was Disputed)
+    if task.status == TaskStatus::Disputed {
+        task.status = TaskStatus::InProgress;
+    }
+
+    emit!(DisputeCancelled {
+        dispute_id: dispute.dispute_id,
+        task: dispute.task,
+        initiator: dispute.initiator,
+        cancelled_at: clock.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -26,6 +26,7 @@ pub mod validation;
 
 pub mod apply_dispute_slash;
 pub mod apply_initiator_slash;
+pub mod cancel_dispute;
 pub mod cancel_task;
 pub mod claim_task;
 pub mod complete_task;
@@ -52,6 +53,8 @@ pub mod vote_dispute;
 pub use apply_dispute_slash::*;
 #[allow(ambiguous_glob_reexports)]
 pub use apply_initiator_slash::*;
+#[allow(ambiguous_glob_reexports)]
+pub use cancel_dispute::*;
 #[allow(ambiguous_glob_reexports)]
 pub use cancel_task::*;
 #[allow(ambiguous_glob_reexports)]

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -193,6 +193,12 @@ pub mod agenc_coordination {
         instructions::cancel_task::handler(ctx)
     }
 
+    /// Cancel a dispute before any votes are cast.
+    /// Only the dispute initiator can cancel, and only if no arbiter has voted yet.
+    pub fn cancel_dispute(ctx: Context<CancelDispute>) -> Result<()> {
+        instructions::cancel_dispute::handler(ctx)
+    }
+
     /// Update shared coordination state.
     /// Used for broadcasting state changes to other agents.
     ///

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -183,6 +183,7 @@ pub enum DisputeStatus {
     Active = 0,
     Resolved = 1,
     Expired = 2,
+    Cancelled = 3,
 }
 
 /// Reason for slashing an agent's stake


### PR DESCRIPTION
## Summary
Fixes #587

Allows dispute initiators to cancel disputes before any votes are cast.

## Changes
- Add `DisputeStatus::Cancelled` variant
- Add `cancel_dispute` instruction with initiator-only access
- Require `total_voters == 0` to prevent canceling after voting starts
- Restore task status to InProgress when cancelled
- Emit `DisputeCancelled` event

## Testing
- `cargo check` passes