### PR TITLE
fix: add 7-day time window for slashing

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -207,6 +207,9 @@ pub enum CoordinationError {
     #[msg("Dispute slashing already applied")]
     SlashAlreadyApplied,
 
+    #[msg("Slash window expired: must apply slashing within 7 days of resolution")]
+    SlashWindowExpired,
+
     #[msg("Dispute has not been resolved")]
     DisputeNotResolved,
 


### PR DESCRIPTION
## Summary
Fixes #414

Slashing must now be applied within 7 days of dispute resolution. After this window, slashing can no longer be applied.

## Changes
- Add SLASH_WINDOW constant (7 days)
- Add SlashWindowExpired error
- Check time window in apply_dispute_slash
- Check time window in apply_initiator_slash

## Rationale
Gives agents certainty about their stake status - after 7 days they know they won't be slashed for a resolved dispute.

## Testing
- `cargo check` passes