### PR TITLE
feat(runtime): add skill library system with Jupiter DeFi skill

### DIFF
--- a/examples/skill-jupiter/index.ts
+++ b/examples/skill-jupiter/index.ts
@@ -1,0 +1,115 @@
+/**
+ * Jupiter Skill Example
+ *
+ * Demonstrates standalone usage of the skill library system
+ * with the Jupiter DeFi skill for token swaps, balance queries,
+ * and price lookups on Solana.
+ *
+ * Prerequisites:
+ *   - A funded Solana wallet (devnet or mainnet)
+ *   - RPC endpoint (defaults to devnet)
+ *
+ * Usage:
+ *   npx ts-node examples/skill-jupiter/index.ts
+ *
+ * Environment variables:
+ *   SOLANA_RPC_URL - RPC endpoint (default: https://api.devnet.solana.com)
+ *   SOLANA_KEYPAIR  - Path to keypair JSON file (default: ~/.config/solana/id.json)
+ */
+
+import { Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import {
+  SkillRegistry,
+  JupiterSkill,
+  WSOL_MINT,
+  USDC_MINT,
+  createLogger,
+  keypairToWallet,
+  loadDefaultKeypair,
+} from '../../runtime/src/index.js';
+
+async function main(): Promise<void> {
+  const logger = createLogger('info', '[Jupiter Example]');
+
+  // ── 1. Setup connection and wallet ──────────────────────────────────
+  const rpcUrl = process.env.SOLANA_RPC_URL ?? 'https://api.devnet.solana.com';
+  const connection = new Connection(rpcUrl, 'confirmed');
+  logger.info(`Connected to: ${rpcUrl}`);
+
+  let keypair: Keypair;
+  try {
+    keypair = await loadDefaultKeypair();
+  } catch {
+    logger.warn('No default keypair found, generating ephemeral keypair');
+    keypair = Keypair.generate();
+  }
+  const wallet = keypairToWallet(keypair);
+  logger.info(`Wallet: ${wallet.publicKey.toBase58()}`);
+
+  // ── 2. Create and register skills ──────────────────────────────────
+  const registry = new SkillRegistry({ logger });
+
+  const jupiter = new JupiterSkill({
+    defaultSlippageBps: 100, // 1% slippage for devnet
+    timeoutMs: 30_000,
+  });
+  registry.register(jupiter);
+
+  logger.info(`Registered skills: ${registry.listNames().join(', ')}`);
+
+  // ── 3. Initialize all skills ───────────────────────────────────────
+  await registry.initializeAll({ connection, wallet, logger });
+  logger.info(`Registry ready: ${registry.isReady()}`);
+
+  try {
+    // ── 4. Check SOL balance ───────────────────────────────────────────
+    const solBalance = await jupiter.getSolBalance();
+    logger.info(`SOL balance: ${solBalance.uiAmount} SOL (${solBalance.amount} lamports)`);
+
+    // ── 5. Get token prices ────────────────────────────────────────────
+    logger.info('Fetching token prices...');
+    const prices = await jupiter.getTokenPrice([WSOL_MINT, USDC_MINT]);
+    for (const [mint, price] of prices) {
+      logger.info(`  ${mint}: $${price.priceUsd}`);
+    }
+
+    // ── 6. Get a swap quote (SOL → USDC) ──────────────────────────────
+    logger.info('Fetching swap quote: 0.01 SOL → USDC...');
+    const quote = await jupiter.getQuote({
+      inputMint: WSOL_MINT,
+      outputMint: USDC_MINT,
+      amount: BigInt(0.01 * LAMPORTS_PER_SOL),
+    });
+    logger.info(`  Input:  ${quote.inAmount} (${WSOL_MINT})`);
+    logger.info(`  Output: ${quote.outAmount} (${USDC_MINT})`);
+    logger.info(`  Price impact: ${quote.priceImpactPct}%`);
+    logger.info(`  Min output (with slippage): ${quote.otherAmountThreshold}`);
+
+    // ── 7. Action registry demo ────────────────────────────────────────
+    logger.info('Available actions:');
+    for (const action of jupiter.getActions()) {
+      logger.info(`  - ${action.name}: ${action.description}`);
+    }
+
+    // ── 8. Registry lookup demo ────────────────────────────────────────
+    const defiSkills = registry.findByTag('defi');
+    logger.info(`Skills tagged "defi": ${defiSkills.map((s) => s.metadata.name).join(', ')}`);
+
+    // NOTE: To execute a swap, uncomment the following:
+    // const result = await jupiter.executeSwap({
+    //   inputMint: WSOL_MINT,
+    //   outputMint: USDC_MINT,
+    //   amount: BigInt(0.01 * LAMPORTS_PER_SOL),
+    // });
+    // logger.info(`Swap executed: ${result.txSignature}`);
+  } finally {
+    // ── 9. Shutdown ──────────────────────────────────────────────────
+    await registry.shutdownAll();
+    logger.info('Skills shut down. Done.');
+  }
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -306,3 +306,43 @@ export {
   type EventMonitorConfig,
   type EventMonitorMetrics,
 } from './events/index.js';
+
+// Skill library system
+export {
+  // Core types
+  type Skill,
+  type SkillMetadata,
+  type SkillAction,
+  type SkillContext,
+  type SemanticVersion,
+  type SkillRegistryConfig,
+  SkillState,
+  // Error types
+  SkillNotFoundError,
+  SkillNotReadyError,
+  SkillActionNotFoundError,
+  SkillInitializationError,
+  SkillAlreadyRegisteredError,
+  // Registry
+  SkillRegistry,
+  // Jupiter skill
+  JupiterSkill,
+  JupiterClient,
+  JupiterApiError,
+  type JupiterSkillConfig,
+  type SwapQuoteParams,
+  type SwapQuote,
+  type SwapResult,
+  type TokenBalance,
+  type TransferSolParams,
+  type TransferTokenParams,
+  type TransferResult,
+  type TokenPrice,
+  type TokenMint,
+  JUPITER_API_BASE_URL,
+  JUPITER_PRICE_API_URL,
+  WSOL_MINT,
+  USDC_MINT,
+  USDT_MINT,
+  WELL_KNOWN_TOKENS,
+} from './skills/index.js';

--- a/runtime/src/skills/errors.ts
+++ b/runtime/src/skills/errors.ts
@@ -1,0 +1,107 @@
+/**
+ * Skill-specific error types for @agenc/runtime
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Error thrown when a skill cannot be found by name.
+ */
+export class SkillNotFoundError extends RuntimeError {
+  /** The name of the skill that was not found */
+  public readonly skillName: string;
+
+  constructor(skillName: string) {
+    super(`Skill not found: "${skillName}"`, RuntimeErrorCodes.VALIDATION_ERROR);
+    this.name = 'SkillNotFoundError';
+    this.skillName = skillName;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SkillNotFoundError);
+    }
+  }
+}
+
+/**
+ * Error thrown when attempting to use a skill that is not in Ready state.
+ */
+export class SkillNotReadyError extends RuntimeError {
+  /** The name of the skill that is not ready */
+  public readonly skillName: string;
+
+  constructor(skillName: string) {
+    super(
+      `Skill "${skillName}" is not ready. Call initialize() first.`,
+      RuntimeErrorCodes.EXECUTOR_STATE_ERROR,
+    );
+    this.name = 'SkillNotReadyError';
+    this.skillName = skillName;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SkillNotReadyError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a skill action cannot be found by name.
+ */
+export class SkillActionNotFoundError extends RuntimeError {
+  /** The name of the skill */
+  public readonly skillName: string;
+  /** The name of the action that was not found */
+  public readonly actionName: string;
+
+  constructor(skillName: string, actionName: string) {
+    super(
+      `Action "${actionName}" not found on skill "${skillName}"`,
+      RuntimeErrorCodes.VALIDATION_ERROR,
+    );
+    this.name = 'SkillActionNotFoundError';
+    this.skillName = skillName;
+    this.actionName = actionName;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SkillActionNotFoundError);
+    }
+  }
+}
+
+/**
+ * Error thrown when skill initialization fails.
+ */
+export class SkillInitializationError extends RuntimeError {
+  /** The name of the skill that failed to initialize */
+  public readonly skillName: string;
+
+  constructor(skillName: string, cause: string) {
+    super(
+      `Failed to initialize skill "${skillName}": ${cause}`,
+      RuntimeErrorCodes.EXECUTOR_STATE_ERROR,
+    );
+    this.name = 'SkillInitializationError';
+    this.skillName = skillName;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SkillInitializationError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a skill with the same name is already registered.
+ */
+export class SkillAlreadyRegisteredError extends RuntimeError {
+  /** The name of the duplicate skill */
+  public readonly skillName: string;
+
+  constructor(skillName: string) {
+    super(
+      `Skill "${skillName}" is already registered`,
+      RuntimeErrorCodes.VALIDATION_ERROR,
+    );
+    this.name = 'SkillAlreadyRegisteredError';
+    this.skillName = skillName;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, SkillAlreadyRegisteredError);
+    }
+  }
+}

--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -1,0 +1,55 @@
+/**
+ * Skill library system for @agenc/runtime
+ *
+ * Provides a pluggable skill abstraction for packaging reusable
+ * blockchain operations (swaps, transfers, staking) as composable units.
+ *
+ * @module
+ */
+
+// Core types
+export {
+  type Skill,
+  type SkillMetadata,
+  type SkillAction,
+  type SkillContext,
+  type SemanticVersion,
+  type SkillRegistryConfig,
+  SkillState,
+} from './types.js';
+
+// Error types
+export {
+  SkillNotFoundError,
+  SkillNotReadyError,
+  SkillActionNotFoundError,
+  SkillInitializationError,
+  SkillAlreadyRegisteredError,
+} from './errors.js';
+
+// Registry
+export { SkillRegistry } from './registry.js';
+
+// Jupiter skill
+export {
+  JupiterSkill,
+  JupiterClient,
+  JupiterApiError,
+  type JupiterClientConfig,
+  type JupiterSkillConfig,
+  type SwapQuoteParams,
+  type SwapQuote,
+  type SwapResult,
+  type TokenBalance,
+  type TransferSolParams,
+  type TransferTokenParams,
+  type TransferResult,
+  type TokenPrice,
+  type TokenMint,
+  JUPITER_API_BASE_URL,
+  JUPITER_PRICE_API_URL,
+  WSOL_MINT,
+  USDC_MINT,
+  USDT_MINT,
+  WELL_KNOWN_TOKENS,
+} from './jupiter/index.js';

--- a/runtime/src/skills/jupiter/constants.ts
+++ b/runtime/src/skills/jupiter/constants.ts
@@ -1,0 +1,29 @@
+/**
+ * Jupiter API constants and well-known token mints.
+ *
+ * @module
+ */
+
+import type { TokenMint } from './types.js';
+
+/** Jupiter V6 Quote API base URL */
+export const JUPITER_API_BASE_URL = 'https://quote-api.jup.ag/v6';
+
+/** Jupiter Price API base URL */
+export const JUPITER_PRICE_API_URL = 'https://price.jup.ag/v6';
+
+/** Wrapped SOL mint address */
+export const WSOL_MINT = 'So11111111111111111111111111111111111111112';
+
+/** USDC mint (Solana mainnet) */
+export const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+
+/** USDT mint (Solana mainnet) */
+export const USDT_MINT = 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB';
+
+/** Well-known token registry mapping mint address to symbol and decimals */
+export const WELL_KNOWN_TOKENS: ReadonlyMap<string, TokenMint> = new Map<string, TokenMint>([
+  [WSOL_MINT, { address: WSOL_MINT, symbol: 'SOL', decimals: 9 }],
+  [USDC_MINT, { address: USDC_MINT, symbol: 'USDC', decimals: 6 }],
+  [USDT_MINT, { address: USDT_MINT, symbol: 'USDT', decimals: 6 }],
+]);

--- a/runtime/src/skills/jupiter/index.ts
+++ b/runtime/src/skills/jupiter/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Jupiter skill module for @agenc/runtime
+ *
+ * @module
+ */
+
+export { JupiterSkill } from './jupiter-skill.js';
+export { JupiterClient, JupiterApiError } from './jupiter-client.js';
+export type { JupiterClientConfig } from './jupiter-client.js';
+
+export type {
+  JupiterSkillConfig,
+  SwapQuoteParams,
+  SwapQuote,
+  SwapResult,
+  TokenBalance,
+  TransferSolParams,
+  TransferTokenParams,
+  TransferResult,
+  TokenPrice,
+  TokenMint,
+} from './types.js';
+
+export {
+  JUPITER_API_BASE_URL,
+  JUPITER_PRICE_API_URL,
+  WSOL_MINT,
+  USDC_MINT,
+  USDT_MINT,
+  WELL_KNOWN_TOKENS,
+} from './constants.js';

--- a/runtime/src/skills/jupiter/jupiter-client.test.ts
+++ b/runtime/src/skills/jupiter/jupiter-client.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { JupiterClient, JupiterApiError } from './jupiter-client.js';
+import { silentLogger } from '../../utils/logger.js';
+import { JUPITER_API_BASE_URL } from './constants.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+
+describe('JupiterClient', () => {
+  let client: JupiterClient;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+
+    client = new JupiterClient({
+      apiBaseUrl: JUPITER_API_BASE_URL,
+      timeoutMs: 5000,
+      logger: silentLogger,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('getQuote', () => {
+    it('returns parsed quote from Jupiter API', async () => {
+      const mockResponse = {
+        inputMint: 'So11111111111111111111111111111111111111112',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        inAmount: '1000000000',
+        outAmount: '25500000',
+        otherAmountThreshold: '25245000',
+        priceImpactPct: '0.01',
+        routePlan: [],
+      };
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const quote = await client.getQuote({
+        inputMint: 'So11111111111111111111111111111111111111112',
+        outputMint: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+        amount: 1_000_000_000n,
+        slippageBps: 50,
+      });
+
+      expect(quote.inputMint).toBe('So11111111111111111111111111111111111111112');
+      expect(quote.outputMint).toBe('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+      expect(quote.inAmount).toBe(1_000_000_000n);
+      expect(quote.outAmount).toBe(25_500_000n);
+      expect(quote.otherAmountThreshold).toBe(25_245_000n);
+      expect(quote.priceImpactPct).toBe(0.01);
+      expect(quote.rawQuote).toBeDefined();
+
+      // Verify fetch was called with correct URL
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const callUrl = mockFetch.mock.calls[0][0] as string;
+      expect(callUrl).toContain('/quote');
+      expect(callUrl).toContain('inputMint=So11111111111111111111111111111111111111112');
+      expect(callUrl).toContain('amount=1000000000');
+      expect(callUrl).toContain('slippageBps=50');
+    });
+
+    it('includes onlyDirectRoutes param when set', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          inputMint: 'a',
+          outputMint: 'b',
+          inAmount: '100',
+          outAmount: '200',
+          otherAmountThreshold: '190',
+          priceImpactPct: '0',
+        }),
+      });
+
+      await client.getQuote({
+        inputMint: 'a',
+        outputMint: 'b',
+        amount: 100n,
+        onlyDirectRoutes: true,
+      });
+
+      const callUrl = mockFetch.mock.calls[0][0] as string;
+      expect(callUrl).toContain('onlyDirectRoutes=true');
+    });
+
+    it('throws JupiterApiError on non-ok response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        text: async () => 'Bad Request',
+      });
+
+      await expect(
+        client.getQuote({
+          inputMint: 'a',
+          outputMint: 'b',
+          amount: 100n,
+        }),
+      ).rejects.toThrow(JupiterApiError);
+    });
+
+    it('throws on fetch timeout', async () => {
+      mockFetch.mockImplementationOnce(
+        () =>
+          new Promise((_, reject) => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            setTimeout(() => reject(err), 10);
+          }),
+      );
+
+      const fastClient = new JupiterClient({
+        apiBaseUrl: JUPITER_API_BASE_URL,
+        timeoutMs: 1,
+        logger: silentLogger,
+      });
+
+      await expect(
+        fastClient.getQuote({
+          inputMint: 'a',
+          outputMint: 'b',
+          amount: 100n,
+        }),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('getSwapTransaction', () => {
+    it('returns serialized transaction bytes', async () => {
+      const base64Tx = Buffer.from('mock-transaction-bytes').toString('base64');
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ swapTransaction: base64Tx }),
+      });
+
+      const txBytes = await client.getSwapTransaction(
+        { mock: 'quote' },
+        'So11111111111111111111111111111111111111112',
+      );
+
+      expect(txBytes).toBeInstanceOf(Uint8Array);
+      expect(Buffer.from(txBytes).toString()).toBe('mock-transaction-bytes');
+
+      // Verify POST body
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const callInit = mockFetch.mock.calls[0][1] as RequestInit;
+      expect(callInit.method).toBe('POST');
+      const body = JSON.parse(callInit.body as string);
+      expect(body.userPublicKey).toBe('So11111111111111111111111111111111111111112');
+      expect(body.wrapAndUnwrapSol).toBe(true);
+    });
+
+    it('throws if swapTransaction field is missing', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      await expect(
+        client.getSwapTransaction({ mock: 'quote' }, 'pubkey'),
+      ).rejects.toThrow(JupiterApiError);
+    });
+
+    it('throws on non-ok response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      await expect(
+        client.getSwapTransaction({ mock: 'quote' }, 'pubkey'),
+      ).rejects.toThrow(JupiterApiError);
+    });
+  });
+
+  describe('getPrice', () => {
+    it('returns price map for requested mints', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            'So11111111111111111111111111111111111111112': {
+              id: 'So11111111111111111111111111111111111111112',
+              price: 25.5,
+            },
+            'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v': {
+              id: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+              price: 1.0,
+            },
+          },
+        }),
+      });
+
+      const prices = await client.getPrice([
+        'So11111111111111111111111111111111111111112',
+        'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+      ]);
+
+      expect(prices.size).toBe(2);
+      expect(prices.get('So11111111111111111111111111111111111111112')?.priceUsd).toBe(25.5);
+      expect(prices.get('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v')?.priceUsd).toBe(1.0);
+    });
+
+    it('returns empty map for empty mints array', async () => {
+      const prices = await client.getPrice([]);
+      expect(prices.size).toBe(0);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('throws on non-ok response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: async () => 'Rate Limited',
+      });
+
+      await expect(client.getPrice(['mint'])).rejects.toThrow(JupiterApiError);
+    });
+  });
+});

--- a/runtime/src/skills/jupiter/jupiter-client.ts
+++ b/runtime/src/skills/jupiter/jupiter-client.ts
@@ -1,0 +1,247 @@
+/**
+ * Low-level HTTP client for Jupiter V6 API.
+ *
+ * Handles request serialization, response parsing, and error handling
+ * for the Jupiter Quote, Swap, and Price APIs.
+ *
+ * @module
+ */
+
+import type { Logger } from '../../utils/logger.js';
+import type { SwapQuoteParams, SwapQuote, TokenPrice } from './types.js';
+import { JUPITER_PRICE_API_URL } from './constants.js';
+
+/**
+ * Configuration for JupiterClient.
+ */
+export interface JupiterClientConfig {
+  /** Jupiter V6 API base URL */
+  apiBaseUrl: string;
+  /** Request timeout in milliseconds */
+  timeoutMs: number;
+  /** Logger */
+  logger: Logger;
+}
+
+/**
+ * Error thrown when a Jupiter API request fails.
+ */
+export class JupiterApiError extends Error {
+  /** HTTP status code, if available */
+  public readonly statusCode: number | undefined;
+  /** The API endpoint that failed */
+  public readonly endpoint: string;
+
+  constructor(message: string, endpoint: string, statusCode?: number) {
+    super(message);
+    this.name = 'JupiterApiError';
+    this.endpoint = endpoint;
+    this.statusCode = statusCode;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, JupiterApiError);
+    }
+  }
+}
+
+/**
+ * Low-level HTTP client for Jupiter V6 API.
+ *
+ * @example
+ * ```typescript
+ * const client = new JupiterClient({
+ *   apiBaseUrl: 'https://quote-api.jup.ag/v6',
+ *   timeoutMs: 30000,
+ *   logger,
+ * });
+ *
+ * const quote = await client.getQuote({
+ *   inputMint: WSOL_MINT,
+ *   outputMint: USDC_MINT,
+ *   amount: 1_000_000_000n,
+ * });
+ * ```
+ */
+export class JupiterClient {
+  private readonly apiBaseUrl: string;
+  private readonly timeoutMs: number;
+  private readonly logger: Logger;
+
+  constructor(config: JupiterClientConfig) {
+    this.apiBaseUrl = config.apiBaseUrl;
+    this.timeoutMs = config.timeoutMs;
+    this.logger = config.logger;
+  }
+
+  /**
+   * Fetch a swap quote from Jupiter V6.
+   *
+   * @param params - Quote request parameters
+   * @returns The swap quote
+   * @throws JupiterApiError on request failure
+   */
+  async getQuote(params: SwapQuoteParams): Promise<SwapQuote> {
+    const url = new URL('/quote', this.apiBaseUrl);
+    url.searchParams.set('inputMint', params.inputMint);
+    url.searchParams.set('outputMint', params.outputMint);
+    url.searchParams.set('amount', params.amount.toString());
+
+    if (params.slippageBps !== undefined) {
+      url.searchParams.set('slippageBps', params.slippageBps.toString());
+    }
+    if (params.onlyDirectRoutes) {
+      url.searchParams.set('onlyDirectRoutes', 'true');
+    }
+
+    this.logger.debug(`Jupiter quote request: ${url.toString()}`);
+
+    const response = await this.fetchWithTimeout(url.toString(), {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => 'unknown');
+      throw new JupiterApiError(
+        `Quote request failed (${response.status}): ${body}`,
+        '/quote',
+        response.status,
+      );
+    }
+
+    const data = await response.json() as Record<string, unknown>;
+
+    return {
+      inputMint: String(data.inputMint),
+      outputMint: String(data.outputMint),
+      inAmount: BigInt(data.inAmount as string),
+      outAmount: BigInt(data.outAmount as string),
+      otherAmountThreshold: BigInt(data.otherAmountThreshold as string),
+      priceImpactPct: Number(data.priceImpactPct),
+      rawQuote: data,
+    };
+  }
+
+  /**
+   * Get a serialized swap transaction from Jupiter.
+   *
+   * @param quoteResponse - The raw quote response from getQuote
+   * @param userPublicKey - The user's wallet public key (base58)
+   * @param wrapUnwrapSol - Whether to wrap/unwrap SOL automatically (default true)
+   * @returns Serialized transaction as Uint8Array
+   * @throws JupiterApiError on request failure
+   */
+  async getSwapTransaction(
+    quoteResponse: Record<string, unknown>,
+    userPublicKey: string,
+    wrapUnwrapSol = true,
+  ): Promise<Uint8Array> {
+    const url = new URL('/swap', this.apiBaseUrl);
+
+    this.logger.debug('Jupiter swap transaction request');
+
+    const response = await this.fetchWithTimeout(url.toString(), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      },
+      body: JSON.stringify({
+        quoteResponse,
+        userPublicKey,
+        wrapAndUnwrapSol: wrapUnwrapSol,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => 'unknown');
+      throw new JupiterApiError(
+        `Swap transaction request failed (${response.status}): ${body}`,
+        '/swap',
+        response.status,
+      );
+    }
+
+    const data = await response.json() as Record<string, unknown>;
+    const swapTransaction = data.swapTransaction as string | undefined;
+
+    if (!swapTransaction) {
+      throw new JupiterApiError(
+        'Swap response missing swapTransaction field',
+        '/swap',
+      );
+    }
+
+    return Buffer.from(swapTransaction, 'base64');
+  }
+
+  /**
+   * Fetch token prices from Jupiter Price API.
+   *
+   * @param mints - Array of token mint addresses (base58)
+   * @returns Map of mint address to price info
+   * @throws JupiterApiError on request failure
+   */
+  async getPrice(mints: string[]): Promise<Map<string, TokenPrice>> {
+    if (mints.length === 0) {
+      return new Map();
+    }
+
+    const url = new URL('/price', JUPITER_PRICE_API_URL);
+    url.searchParams.set('ids', mints.join(','));
+
+    this.logger.debug(`Jupiter price request for ${mints.length} token(s)`);
+
+    const response = await this.fetchWithTimeout(url.toString(), {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => 'unknown');
+      throw new JupiterApiError(
+        `Price request failed (${response.status}): ${body}`,
+        '/price',
+        response.status,
+      );
+    }
+
+    const data = await response.json() as Record<string, unknown>;
+    const priceData = data.data as Record<string, Record<string, unknown>> | undefined;
+    const result = new Map<string, TokenPrice>();
+
+    if (priceData) {
+      for (const [mint, info] of Object.entries(priceData)) {
+        if (info && typeof info.price === 'number') {
+          result.set(mint, { mint, priceUsd: info.price });
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Execute fetch with timeout using AbortController.
+   */
+  private async fetchWithTimeout(
+    url: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new JupiterApiError(
+          `Request timed out after ${this.timeoutMs}ms`,
+          url,
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/runtime/src/skills/jupiter/jupiter-skill.test.ts
+++ b/runtime/src/skills/jupiter/jupiter-skill.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { JupiterSkill } from './jupiter-skill.js';
+import { SkillState } from '../types.js';
+import { SkillNotReadyError } from '../errors.js';
+import type { SkillContext } from '../types.js';
+import { silentLogger } from '../../utils/logger.js';
+import { Keypair, Connection, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import type { Wallet } from '../../types/wallet.js';
+import { WSOL_MINT, USDC_MINT } from './constants.js';
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+
+function createMockWallet(): Wallet {
+  const keypair = Keypair.generate();
+  return {
+    publicKey: keypair.publicKey,
+    signTransaction: vi.fn(async (tx) => tx),
+    signAllTransactions: vi.fn(async (txs) => txs),
+  };
+}
+
+function createMockConnection(): Connection {
+  return {
+    getBalance: vi.fn(async () => 5 * LAMPORTS_PER_SOL),
+    getTokenAccountsByOwner: vi.fn(async () => ({ value: [] })),
+    getParsedAccountInfo: vi.fn(async () => ({ value: null })),
+    getAccountInfo: vi.fn(async () => null),
+    sendRawTransaction: vi.fn(async () => 'mock_tx_signature'),
+    confirmTransaction: vi.fn(async () => ({ value: { err: null } })),
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: '11111111111111111111111111111111',
+      lastValidBlockHeight: 100,
+    })),
+  } as unknown as Connection;
+}
+
+function createMockContext(): SkillContext {
+  return {
+    connection: createMockConnection(),
+    wallet: createMockWallet(),
+    logger: silentLogger,
+  };
+}
+
+describe('JupiterSkill', () => {
+  let skill: JupiterSkill;
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+    skill = new JupiterSkill();
+  });
+
+  describe('metadata', () => {
+    it('has correct metadata', () => {
+      expect(skill.metadata.name).toBe('jupiter');
+      expect(skill.metadata.version).toBe('0.1.0');
+      expect(skill.metadata.requiredCapabilities).toBe(1n | 8n); // COMPUTE | NETWORK
+      expect(skill.metadata.tags).toEqual(['defi', 'swap', 'transfer', 'jupiter']);
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('starts in Created state', () => {
+      expect(skill.state).toBe(SkillState.Created);
+    });
+
+    it('transitions to Ready after initialize', async () => {
+      await skill.initialize(createMockContext());
+      expect(skill.state).toBe(SkillState.Ready);
+    });
+
+    it('transitions to Stopped after shutdown', async () => {
+      await skill.initialize(createMockContext());
+      await skill.shutdown();
+      expect(skill.state).toBe(SkillState.Stopped);
+    });
+  });
+
+  describe('action registry', () => {
+    it('exposes 7 actions', async () => {
+      await skill.initialize(createMockContext());
+      const actions = skill.getActions();
+      expect(actions).toHaveLength(7);
+      expect(actions.map((a) => a.name).sort()).toEqual([
+        'executeSwap',
+        'getQuote',
+        'getSolBalance',
+        'getTokenBalance',
+        'getTokenPrice',
+        'transferSol',
+        'transferToken',
+      ]);
+    });
+
+    it('getAction returns correct action by name', () => {
+      const action = skill.getAction('getQuote');
+      expect(action).toBeDefined();
+      expect(action!.name).toBe('getQuote');
+    });
+
+    it('getAction returns undefined for unknown name', () => {
+      expect(skill.getAction('nonexistent')).toBeUndefined();
+    });
+  });
+
+  describe('ensureReady guard', () => {
+    it('throws SkillNotReadyError when not initialized', async () => {
+      await expect(
+        skill.getQuote({
+          inputMint: WSOL_MINT,
+          outputMint: USDC_MINT,
+          amount: 100n,
+        }),
+      ).rejects.toThrow(SkillNotReadyError);
+    });
+
+    it('throws SkillNotReadyError after shutdown', async () => {
+      await skill.initialize(createMockContext());
+      await skill.shutdown();
+
+      await expect(
+        skill.getSolBalance(),
+      ).rejects.toThrow(SkillNotReadyError);
+    });
+  });
+
+  describe('getSolBalance', () => {
+    it('returns SOL balance for wallet', async () => {
+      const ctx = createMockContext();
+      await skill.initialize(ctx);
+
+      const balance = await skill.getSolBalance();
+
+      expect(balance.mint).toBe(WSOL_MINT);
+      expect(balance.symbol).toBe('SOL');
+      expect(balance.amount).toBe(BigInt(5 * LAMPORTS_PER_SOL));
+      expect(balance.decimals).toBe(9);
+      expect(balance.uiAmount).toBe(5);
+      expect(ctx.connection.getBalance).toHaveBeenCalledWith(ctx.wallet.publicKey);
+    });
+
+    it('returns balance for a specific address', async () => {
+      const ctx = createMockContext();
+      await skill.initialize(ctx);
+
+      const other = Keypair.generate().publicKey;
+      await skill.getSolBalance(other);
+
+      expect(ctx.connection.getBalance).toHaveBeenCalledWith(other);
+    });
+  });
+
+  describe('getTokenBalance', () => {
+    it('returns zero balance when no token accounts exist', async () => {
+      const ctx = createMockContext();
+      await skill.initialize(ctx);
+
+      const mint = new PublicKey(USDC_MINT);
+      const balance = await skill.getTokenBalance(mint);
+
+      expect(balance.mint).toBe(USDC_MINT);
+      expect(balance.amount).toBe(0n);
+      expect(balance.symbol).toBe('USDC');
+    });
+  });
+
+  describe('getQuote', () => {
+    it('calls Jupiter API and returns parsed quote', async () => {
+      const ctx = createMockContext();
+      await skill.initialize(ctx);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          inputMint: WSOL_MINT,
+          outputMint: USDC_MINT,
+          inAmount: '1000000000',
+          outAmount: '25500000',
+          otherAmountThreshold: '25245000',
+          priceImpactPct: '0.01',
+        }),
+      });
+
+      const quote = await skill.getQuote({
+        inputMint: WSOL_MINT,
+        outputMint: USDC_MINT,
+        amount: 1_000_000_000n,
+      });
+
+      expect(quote.inAmount).toBe(1_000_000_000n);
+      expect(quote.outAmount).toBe(25_500_000n);
+    });
+
+    it('applies default slippage when not specified', async () => {
+      const ctx = createMockContext();
+      await skill.initialize(ctx);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          inputMint: 'a',
+          outputMint: 'b',
+          inAmount: '100',
+          outAmount: '200',
+          otherAmountThreshold: '190',
+          priceImpactPct: '0',
+        }),
+      });
+
+      await skill.getQuote({
+        inputMint: 'a',
+        outputMint: 'b',
+        amount: 100n,
+      });
+
+      // Default slippage of 50 bps should be applied
+      const callUrl = mockFetch.mock.calls[0][0] as string;
+      expect(callUrl).toContain('slippageBps=50');
+    });
+  });
+
+  describe('getTokenPrice', () => {
+    it('returns prices for requested mints', async () => {
+      const ctx = createMockContext();
+      await skill.initialize(ctx);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            [WSOL_MINT]: { id: WSOL_MINT, price: 25.5 },
+          },
+        }),
+      });
+
+      const prices = await skill.getTokenPrice([WSOL_MINT]);
+      expect(prices.get(WSOL_MINT)?.priceUsd).toBe(25.5);
+    });
+  });
+
+  describe('custom config', () => {
+    it('accepts custom slippage and timeout', () => {
+      const custom = new JupiterSkill({
+        defaultSlippageBps: 100,
+        timeoutMs: 60_000,
+        apiBaseUrl: 'https://custom-api.example.com',
+      });
+      expect(custom.metadata.name).toBe('jupiter');
+    });
+  });
+});

--- a/runtime/src/skills/jupiter/jupiter-skill.ts
+++ b/runtime/src/skills/jupiter/jupiter-skill.ts
@@ -1,0 +1,446 @@
+/**
+ * Jupiter DeFi skill implementation.
+ *
+ * Provides token swap, balance query, transfer, and price lookup
+ * operations via the Jupiter V6 aggregator and Solana RPC.
+ *
+ * @module
+ */
+
+import type { Connection } from '@solana/web3.js';
+import {
+  PublicKey,
+  SystemProgram,
+  VersionedTransaction,
+  TransactionMessage,
+  LAMPORTS_PER_SOL,
+} from '@solana/web3.js';
+import type { Skill, SkillMetadata, SkillAction, SkillContext, SemanticVersion } from '../types.js';
+import { SkillState } from '../types.js';
+import { SkillNotReadyError } from '../errors.js';
+import { JupiterClient } from './jupiter-client.js';
+import { JUPITER_API_BASE_URL, WSOL_MINT, WELL_KNOWN_TOKENS } from './constants.js';
+import type {
+  JupiterSkillConfig,
+  SwapQuoteParams,
+  SwapQuote,
+  SwapResult,
+  TokenBalance,
+  TransferSolParams,
+  TransferTokenParams,
+  TransferResult,
+  TokenPrice,
+} from './types.js';
+import type { Logger } from '../../utils/logger.js';
+import type { Wallet } from '../../types/wallet.js';
+import { Capability } from '../../agent/capabilities.js';
+
+const DEFAULT_SLIPPAGE_BPS = 50;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const VERSION: SemanticVersion = '0.1.0';
+
+/**
+ * Jupiter DeFi skill providing token swap and transfer operations.
+ *
+ * Actions:
+ * - `getQuote` — Fetch swap quote via Jupiter V6 aggregator
+ * - `executeSwap` — Execute a token swap (quote + sign + submit)
+ * - `getSolBalance` — Check SOL balance for an address
+ * - `getTokenBalance` — Check SPL token balance
+ * - `transferSol` — Send SOL to a recipient
+ * - `transferToken` — Send SPL token (auto-creates recipient ATA)
+ * - `getTokenPrice` — Look up token price in USD
+ *
+ * @example
+ * ```typescript
+ * const jupiter = new JupiterSkill({ defaultSlippageBps: 100 });
+ * const registry = new SkillRegistry();
+ * registry.register(jupiter);
+ * await registry.initializeAll({ connection, wallet, logger });
+ *
+ * const quote = await jupiter.getQuote({
+ *   inputMint: WSOL_MINT,
+ *   outputMint: USDC_MINT,
+ *   amount: 1_000_000_000n,
+ * });
+ * ```
+ */
+export class JupiterSkill implements Skill {
+  readonly metadata: SkillMetadata = {
+    name: 'jupiter',
+    description: 'Jupiter V6 DEX aggregator skill for token swaps, transfers, and price lookups',
+    version: VERSION,
+    requiredCapabilities: Capability.COMPUTE | Capability.NETWORK,
+    tags: ['defi', 'swap', 'transfer', 'jupiter'],
+  };
+
+  private _state: SkillState = SkillState.Created;
+  private connection: Connection | null = null;
+  private wallet: Wallet | null = null;
+  private logger: Logger | null = null;
+  private client: JupiterClient | null = null;
+
+  private readonly defaultSlippageBps: number;
+  private readonly apiBaseUrl: string;
+  private readonly timeoutMs: number;
+
+  private readonly actions: ReadonlyArray<SkillAction>;
+
+  constructor(config?: JupiterSkillConfig) {
+    this.apiBaseUrl = config?.apiBaseUrl ?? JUPITER_API_BASE_URL;
+    this.defaultSlippageBps = config?.defaultSlippageBps ?? DEFAULT_SLIPPAGE_BPS;
+    this.timeoutMs = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    // Build action registry (bound to this instance)
+    this.actions = [
+      {
+        name: 'getQuote',
+        description: 'Get a swap quote from Jupiter V6 aggregator',
+        execute: (params: unknown) => this.getQuote(params as SwapQuoteParams),
+      },
+      {
+        name: 'executeSwap',
+        description: 'Execute a token swap via Jupiter V6',
+        execute: (params: unknown) => this.executeSwap(params as SwapQuoteParams),
+      },
+      {
+        name: 'getSolBalance',
+        description: 'Get SOL balance for an address',
+        execute: (params: unknown) => this.getSolBalance(params as PublicKey | undefined),
+      },
+      {
+        name: 'getTokenBalance',
+        description: 'Get SPL token balance',
+        execute: (params: unknown) => {
+          const p = params as { mint: PublicKey; owner?: PublicKey };
+          return this.getTokenBalance(p.mint, p.owner);
+        },
+      },
+      {
+        name: 'transferSol',
+        description: 'Transfer SOL to a recipient',
+        execute: (params: unknown) => this.transferSol(params as TransferSolParams),
+      },
+      {
+        name: 'transferToken',
+        description: 'Transfer SPL token to a recipient',
+        execute: (params: unknown) => this.transferToken(params as TransferTokenParams),
+      },
+      {
+        name: 'getTokenPrice',
+        description: 'Get token price in USD via Jupiter Price API',
+        execute: (params: unknown) => this.getTokenPrice(params as string[]),
+      },
+    ];
+  }
+
+  get state(): SkillState {
+    return this._state;
+  }
+
+  async initialize(context: SkillContext): Promise<void> {
+    this._state = SkillState.Initializing;
+    try {
+      this.connection = context.connection;
+      this.wallet = context.wallet;
+      this.logger = context.logger;
+      this.client = new JupiterClient({
+        apiBaseUrl: this.apiBaseUrl,
+        timeoutMs: this.timeoutMs,
+        logger: context.logger,
+      });
+      this._state = SkillState.Ready;
+    } catch (err) {
+      this._state = SkillState.Error;
+      throw err;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this._state = SkillState.ShuttingDown;
+    this.client = null;
+    this.connection = null;
+    this.wallet = null;
+    this.logger = null;
+    this._state = SkillState.Stopped;
+  }
+
+  getActions(): ReadonlyArray<SkillAction> {
+    return this.actions;
+  }
+
+  getAction(name: string): SkillAction | undefined {
+    return this.actions.find((a) => a.name === name);
+  }
+
+  // ============================================================================
+  // Typed action methods
+  // ============================================================================
+
+  /**
+   * Fetch a swap quote from Jupiter V6.
+   */
+  async getQuote(params: SwapQuoteParams): Promise<SwapQuote> {
+    this.ensureReady();
+    const quoteParams: SwapQuoteParams = {
+      ...params,
+      slippageBps: params.slippageBps ?? this.defaultSlippageBps,
+    };
+    return this.client!.getQuote(quoteParams);
+  }
+
+  /**
+   * Execute a full token swap: fetch quote, build transaction, sign, and submit.
+   */
+  async executeSwap(params: SwapQuoteParams): Promise<SwapResult> {
+    this.ensureReady();
+
+    // 1. Get quote
+    const quote = await this.getQuote(params);
+    this.logger!.info(
+      `Swap quote: ${quote.inAmount} ${quote.inputMint} -> ${quote.outAmount} ${quote.outputMint} (impact: ${quote.priceImpactPct}%)`,
+    );
+
+    // 2. Get serialized transaction
+    const txBytes = await this.client!.getSwapTransaction(
+      quote.rawQuote,
+      this.wallet!.publicKey.toBase58(),
+    );
+
+    // 3. Deserialize and sign
+    const tx = VersionedTransaction.deserialize(txBytes);
+    const signedTx = await this.wallet!.signTransaction(tx);
+
+    // 4. Send and confirm
+    const rawTx = signedTx.serialize();
+    const txSignature = await this.connection!.sendRawTransaction(rawTx, {
+      skipPreflight: false,
+      maxRetries: 3,
+    });
+
+    this.logger!.info(`Swap transaction sent: ${txSignature}`);
+
+    const latestBlockhash = await this.connection!.getLatestBlockhash();
+    await this.connection!.confirmTransaction({
+      signature: txSignature,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    });
+
+    this.logger!.info(`Swap confirmed: ${txSignature}`);
+
+    return {
+      txSignature,
+      inputAmount: quote.inAmount,
+      outputAmount: quote.outAmount,
+      inputMint: quote.inputMint,
+      outputMint: quote.outputMint,
+    };
+  }
+
+  /**
+   * Get SOL balance for an address.
+   * Defaults to the skill wallet's address.
+   */
+  async getSolBalance(address?: PublicKey): Promise<TokenBalance> {
+    this.ensureReady();
+
+    const owner = address ?? this.wallet!.publicKey;
+    const lamports = await this.connection!.getBalance(owner);
+
+    return {
+      mint: WSOL_MINT,
+      symbol: 'SOL',
+      amount: BigInt(lamports),
+      decimals: 9,
+      uiAmount: lamports / LAMPORTS_PER_SOL,
+    };
+  }
+
+  /**
+   * Get SPL token balance for a mint.
+   * Defaults to the skill wallet as owner.
+   */
+  async getTokenBalance(mint: PublicKey, owner?: PublicKey): Promise<TokenBalance> {
+    this.ensureReady();
+
+    const walletOwner = owner ?? this.wallet!.publicKey;
+    const tokenAccounts = await this.connection!.getTokenAccountsByOwner(walletOwner, {
+      mint,
+    });
+
+    let amount = 0n;
+    let decimals = 0;
+
+    if (tokenAccounts.value.length > 0) {
+      // Parse token account data (SPL Token account layout: 165 bytes)
+      // Bytes 64-72: amount (u64 LE)
+      const data = tokenAccounts.value[0].account.data;
+      if (data.length >= 72) {
+        const amountBuf = data.subarray(64, 72);
+        amount = amountBuf.readBigUInt64LE(0);
+      }
+
+      // Get decimals from mint account
+      const mintInfo = await this.connection!.getParsedAccountInfo(mint);
+      if (mintInfo.value && 'parsed' in mintInfo.value.data) {
+        const parsed = mintInfo.value.data.parsed as Record<string, Record<string, unknown>>;
+        decimals = Number(parsed.info?.decimals ?? 0);
+      }
+    }
+
+    const mintStr = mint.toBase58();
+    const knownToken = WELL_KNOWN_TOKENS.get(mintStr);
+    const symbol = knownToken?.symbol ?? null;
+    const uiAmount = decimals > 0 ? Number(amount) / Math.pow(10, decimals) : Number(amount);
+
+    return { mint: mintStr, symbol, amount, decimals, uiAmount };
+  }
+
+  /**
+   * Transfer SOL to a recipient.
+   */
+  async transferSol(params: TransferSolParams): Promise<TransferResult> {
+    this.ensureReady();
+
+    const instruction = SystemProgram.transfer({
+      fromPubkey: this.wallet!.publicKey,
+      toPubkey: params.recipient,
+      lamports: params.lamports,
+    });
+
+    const latestBlockhash = await this.connection!.getLatestBlockhash();
+    const messageV0 = new TransactionMessage({
+      payerKey: this.wallet!.publicKey,
+      recentBlockhash: latestBlockhash.blockhash,
+      instructions: [instruction],
+    }).compileToV0Message();
+
+    const tx = new VersionedTransaction(messageV0);
+    const signedTx = await this.wallet!.signTransaction(tx);
+
+    const txSignature = await this.connection!.sendRawTransaction(signedTx.serialize(), {
+      skipPreflight: false,
+      maxRetries: 3,
+    });
+
+    await this.connection!.confirmTransaction({
+      signature: txSignature,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    });
+
+    this.logger!.info(
+      `SOL transfer confirmed: ${params.lamports} lamports to ${params.recipient.toBase58()} (${txSignature})`,
+    );
+
+    return { txSignature, amount: params.lamports };
+  }
+
+  /**
+   * Transfer SPL token to a recipient.
+   *
+   * Creates the recipient's Associated Token Account (ATA) if it doesn't exist.
+   * Uses raw instructions instead of @solana/spl-token to avoid the peer dependency.
+   */
+  async transferToken(params: TransferTokenParams): Promise<TransferResult> {
+    this.ensureReady();
+
+    const TOKEN_PROGRAM_ID = new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA');
+    const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
+      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+    );
+
+    // Derive sender ATA
+    const senderAta = PublicKey.findProgramAddressSync(
+      [this.wallet!.publicKey.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), params.mint.toBuffer()],
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    )[0];
+
+    // Derive recipient ATA
+    const recipientAta = PublicKey.findProgramAddressSync(
+      [params.recipient.toBuffer(), TOKEN_PROGRAM_ID.toBuffer(), params.mint.toBuffer()],
+      ASSOCIATED_TOKEN_PROGRAM_ID,
+    )[0];
+
+    const instructions = [];
+
+    // Check if recipient ATA exists, if not, create it
+    const recipientAtaInfo = await this.connection!.getAccountInfo(recipientAta);
+    if (!recipientAtaInfo) {
+      // Create Associated Token Account instruction (manual to avoid spl-token dep)
+      instructions.push({
+        programId: ASSOCIATED_TOKEN_PROGRAM_ID,
+        keys: [
+          { pubkey: this.wallet!.publicKey, isSigner: true, isWritable: true },
+          { pubkey: recipientAta, isSigner: false, isWritable: true },
+          { pubkey: params.recipient, isSigner: false, isWritable: false },
+          { pubkey: params.mint, isSigner: false, isWritable: false },
+          { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+          { pubkey: TOKEN_PROGRAM_ID, isSigner: false, isWritable: false },
+        ],
+        data: Buffer.alloc(0),
+      });
+    }
+
+    // SPL Token transfer instruction (instruction index 3)
+    const transferData = Buffer.alloc(9);
+    transferData.writeUInt8(3, 0); // Transfer instruction
+    transferData.writeBigUInt64LE(params.amount, 1);
+
+    instructions.push({
+      programId: TOKEN_PROGRAM_ID,
+      keys: [
+        { pubkey: senderAta, isSigner: false, isWritable: true },
+        { pubkey: recipientAta, isSigner: false, isWritable: true },
+        { pubkey: this.wallet!.publicKey, isSigner: true, isWritable: false },
+      ],
+      data: transferData,
+    });
+
+    const latestBlockhash = await this.connection!.getLatestBlockhash();
+    const messageV0 = new TransactionMessage({
+      payerKey: this.wallet!.publicKey,
+      recentBlockhash: latestBlockhash.blockhash,
+      instructions,
+    }).compileToV0Message();
+
+    const tx = new VersionedTransaction(messageV0);
+    const signedTx = await this.wallet!.signTransaction(tx);
+
+    const txSignature = await this.connection!.sendRawTransaction(signedTx.serialize(), {
+      skipPreflight: false,
+      maxRetries: 3,
+    });
+
+    await this.connection!.confirmTransaction({
+      signature: txSignature,
+      blockhash: latestBlockhash.blockhash,
+      lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+    });
+
+    this.logger!.info(
+      `Token transfer confirmed: ${params.amount} of ${params.mint.toBase58()} to ${params.recipient.toBase58()} (${txSignature})`,
+    );
+
+    return { txSignature, amount: params.amount };
+  }
+
+  /**
+   * Get token prices in USD via Jupiter Price API.
+   */
+  async getTokenPrice(mints: string[]): Promise<Map<string, TokenPrice>> {
+    this.ensureReady();
+    return this.client!.getPrice(mints);
+  }
+
+  // ============================================================================
+  // Private helpers
+  // ============================================================================
+
+  private ensureReady(): void {
+    if (this._state !== SkillState.Ready) {
+      throw new SkillNotReadyError('jupiter');
+    }
+  }
+}

--- a/runtime/src/skills/jupiter/types.ts
+++ b/runtime/src/skills/jupiter/types.ts
@@ -1,0 +1,141 @@
+/**
+ * Jupiter skill type definitions.
+ *
+ * @module
+ */
+
+import type { PublicKey } from '@solana/web3.js';
+
+/**
+ * Well-known token mint descriptor.
+ */
+export interface TokenMint {
+  /** Mint address (base58) */
+  readonly address: string;
+  /** Token symbol (e.g. "SOL", "USDC") */
+  readonly symbol: string;
+  /** Token decimals */
+  readonly decimals: number;
+}
+
+/**
+ * Configuration for JupiterSkill.
+ */
+export interface JupiterSkillConfig {
+  /** Jupiter V6 API base URL (default: https://quote-api.jup.ag/v6) */
+  apiBaseUrl?: string;
+  /** Default slippage in basis points (default: 50 = 0.5%) */
+  defaultSlippageBps?: number;
+  /** Request timeout in milliseconds (default: 30000) */
+  timeoutMs?: number;
+}
+
+/**
+ * Parameters for requesting a swap quote.
+ */
+export interface SwapQuoteParams {
+  /** Input token mint address (base58) */
+  inputMint: string;
+  /** Output token mint address (base58) */
+  outputMint: string;
+  /** Amount in smallest unit (lamports for SOL) */
+  amount: bigint;
+  /** Slippage tolerance in basis points (overrides default) */
+  slippageBps?: number;
+  /** Restrict to direct routes only */
+  onlyDirectRoutes?: boolean;
+}
+
+/**
+ * Swap quote response from Jupiter.
+ */
+export interface SwapQuote {
+  /** Input token mint */
+  inputMint: string;
+  /** Output token mint */
+  outputMint: string;
+  /** Input amount in smallest unit */
+  inAmount: bigint;
+  /** Expected output amount in smallest unit */
+  outAmount: bigint;
+  /** Minimum output amount with slippage applied */
+  otherAmountThreshold: bigint;
+  /** Price impact percentage (0-100) */
+  priceImpactPct: number;
+  /** Raw quote response (needed for swap execution) */
+  rawQuote: Record<string, unknown>;
+}
+
+/**
+ * Result of a swap execution.
+ */
+export interface SwapResult {
+  /** Transaction signature */
+  txSignature: string;
+  /** Input amount consumed */
+  inputAmount: bigint;
+  /** Output amount received */
+  outputAmount: bigint;
+  /** Input token mint */
+  inputMint: string;
+  /** Output token mint */
+  outputMint: string;
+}
+
+/**
+ * Token balance information.
+ */
+export interface TokenBalance {
+  /** Token mint address */
+  mint: string;
+  /** Token symbol if known */
+  symbol: string | null;
+  /** Balance in smallest unit */
+  amount: bigint;
+  /** Token decimals */
+  decimals: number;
+  /** Balance as human-readable number */
+  uiAmount: number;
+}
+
+/**
+ * Parameters for transferring SOL.
+ */
+export interface TransferSolParams {
+  /** Recipient public key */
+  recipient: PublicKey;
+  /** Amount in lamports */
+  lamports: bigint;
+}
+
+/**
+ * Parameters for transferring an SPL token.
+ */
+export interface TransferTokenParams {
+  /** Recipient wallet public key (not ATA) */
+  recipient: PublicKey;
+  /** Token mint address */
+  mint: PublicKey;
+  /** Amount in smallest unit */
+  amount: bigint;
+}
+
+/**
+ * Result of a transfer operation.
+ */
+export interface TransferResult {
+  /** Transaction signature */
+  txSignature: string;
+  /** Amount transferred */
+  amount: bigint;
+}
+
+/**
+ * Token price information.
+ */
+export interface TokenPrice {
+  /** Token mint address */
+  mint: string;
+  /** Price in USD */
+  priceUsd: number;
+}

--- a/runtime/src/skills/registry.test.ts
+++ b/runtime/src/skills/registry.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SkillRegistry } from './registry.js';
+import { SkillState } from './types.js';
+import type { Skill, SkillContext, SkillAction } from './types.js';
+import {
+  SkillNotFoundError,
+  SkillAlreadyRegisteredError,
+  SkillInitializationError,
+} from './errors.js';
+import { silentLogger } from '../utils/logger.js';
+import { Keypair, Connection } from '@solana/web3.js';
+
+function createMockSkill(
+  name: string,
+  options?: {
+    capabilities?: bigint;
+    tags?: string[];
+    initFail?: boolean;
+    shutdownFail?: boolean;
+  },
+): Skill {
+  let state = SkillState.Created;
+  return {
+    metadata: {
+      name,
+      description: `Mock skill: ${name}`,
+      version: '1.0.0',
+      requiredCapabilities: options?.capabilities ?? 0n,
+      tags: options?.tags,
+    },
+    get state() {
+      return state;
+    },
+    initialize: vi.fn(async () => {
+      if (options?.initFail) {
+        state = SkillState.Error;
+        throw new Error('init failed');
+      }
+      state = SkillState.Ready;
+    }),
+    shutdown: vi.fn(async () => {
+      if (options?.shutdownFail) {
+        throw new Error('shutdown failed');
+      }
+      state = SkillState.Stopped;
+    }),
+    getActions: vi.fn(() => []),
+    getAction: vi.fn(() => undefined),
+  };
+}
+
+function createMockContext(): SkillContext {
+  return {
+    connection: {} as Connection,
+    wallet: {
+      publicKey: Keypair.generate().publicKey,
+      signTransaction: vi.fn(async (tx) => tx),
+      signAllTransactions: vi.fn(async (txs) => txs),
+    },
+    logger: silentLogger,
+  };
+}
+
+describe('SkillRegistry', () => {
+  let registry: SkillRegistry;
+
+  beforeEach(() => {
+    registry = new SkillRegistry({ logger: silentLogger });
+  });
+
+  describe('register', () => {
+    it('registers a skill by name', () => {
+      const skill = createMockSkill('test-skill');
+      registry.register(skill);
+      expect(registry.size).toBe(1);
+      expect(registry.get('test-skill')).toBe(skill);
+    });
+
+    it('throws on duplicate name', () => {
+      registry.register(createMockSkill('dup'));
+      expect(() => registry.register(createMockSkill('dup'))).toThrow(
+        SkillAlreadyRegisteredError,
+      );
+    });
+
+    it('registers multiple skills', () => {
+      registry.register(createMockSkill('a'));
+      registry.register(createMockSkill('b'));
+      registry.register(createMockSkill('c'));
+      expect(registry.size).toBe(3);
+    });
+  });
+
+  describe('unregister', () => {
+    it('removes a registered skill', () => {
+      registry.register(createMockSkill('rem'));
+      expect(registry.unregister('rem')).toBe(true);
+      expect(registry.size).toBe(0);
+    });
+
+    it('returns false for unknown skill', () => {
+      expect(registry.unregister('unknown')).toBe(false);
+    });
+  });
+
+  describe('get / getOrThrow', () => {
+    it('returns undefined for unknown skill', () => {
+      expect(registry.get('nope')).toBeUndefined();
+    });
+
+    it('throws SkillNotFoundError for unknown skill via getOrThrow', () => {
+      expect(() => registry.getOrThrow('nope')).toThrow(SkillNotFoundError);
+    });
+
+    it('returns the skill if registered', () => {
+      const skill = createMockSkill('found');
+      registry.register(skill);
+      expect(registry.getOrThrow('found')).toBe(skill);
+    });
+  });
+
+  describe('findByCapability', () => {
+    it('finds skills matching capability bitmask', () => {
+      const compute = createMockSkill('compute', { capabilities: 1n }); // COMPUTE
+      const network = createMockSkill('network', { capabilities: 8n }); // NETWORK
+      const both = createMockSkill('both', { capabilities: 1n | 8n }); // COMPUTE | NETWORK
+
+      registry.register(compute);
+      registry.register(network);
+      registry.register(both);
+
+      // Agent with COMPUTE | NETWORK capabilities
+      const results = registry.findByCapability(1n | 8n);
+      expect(results).toHaveLength(3);
+
+      // Agent with only COMPUTE
+      const computeOnly = registry.findByCapability(1n);
+      expect(computeOnly).toHaveLength(1);
+      expect(computeOnly[0].metadata.name).toBe('compute');
+    });
+
+    it('returns empty array if no skills match', () => {
+      registry.register(createMockSkill('a', { capabilities: 1n }));
+      expect(registry.findByCapability(8n)).toHaveLength(0);
+    });
+  });
+
+  describe('findByTag', () => {
+    it('finds skills by tag', () => {
+      registry.register(createMockSkill('a', { tags: ['defi', 'swap'] }));
+      registry.register(createMockSkill('b', { tags: ['nft'] }));
+      registry.register(createMockSkill('c', { tags: ['defi', 'staking'] }));
+
+      const defiSkills = registry.findByTag('defi');
+      expect(defiSkills).toHaveLength(2);
+      expect(defiSkills.map((s) => s.metadata.name)).toEqual(['a', 'c']);
+    });
+
+    it('returns empty array for unknown tag', () => {
+      registry.register(createMockSkill('a', { tags: ['x'] }));
+      expect(registry.findByTag('nope')).toHaveLength(0);
+    });
+  });
+
+  describe('listNames / listAll', () => {
+    it('lists all registered names', () => {
+      registry.register(createMockSkill('alpha'));
+      registry.register(createMockSkill('beta'));
+      expect(registry.listNames()).toEqual(['alpha', 'beta']);
+    });
+
+    it('listAll returns all skill instances', () => {
+      const a = createMockSkill('a');
+      const b = createMockSkill('b');
+      registry.register(a);
+      registry.register(b);
+      expect(registry.listAll()).toEqual([a, b]);
+    });
+  });
+
+  describe('initializeAll', () => {
+    it('initializes all registered skills', async () => {
+      const a = createMockSkill('a');
+      const b = createMockSkill('b');
+      registry.register(a);
+      registry.register(b);
+
+      await registry.initializeAll(createMockContext());
+
+      expect(a.initialize).toHaveBeenCalledOnce();
+      expect(b.initialize).toHaveBeenCalledOnce();
+      expect(a.state).toBe(SkillState.Ready);
+      expect(b.state).toBe(SkillState.Ready);
+    });
+
+    it('throws if any skill fails to initialize', async () => {
+      registry.register(createMockSkill('ok'));
+      registry.register(createMockSkill('bad', { initFail: true }));
+
+      await expect(registry.initializeAll(createMockContext())).rejects.toThrow(
+        SkillInitializationError,
+      );
+    });
+
+    it('still initializes other skills even if one fails', async () => {
+      const ok = createMockSkill('ok');
+      registry.register(ok);
+      registry.register(createMockSkill('bad', { initFail: true }));
+
+      try {
+        await registry.initializeAll(createMockContext());
+      } catch {
+        // expected
+      }
+
+      expect(ok.initialize).toHaveBeenCalledOnce();
+      expect(ok.state).toBe(SkillState.Ready);
+    });
+  });
+
+  describe('shutdownAll', () => {
+    it('shuts down all ready skills', async () => {
+      const a = createMockSkill('a');
+      const b = createMockSkill('b');
+      registry.register(a);
+      registry.register(b);
+
+      await registry.initializeAll(createMockContext());
+      await registry.shutdownAll();
+
+      expect(a.shutdown).toHaveBeenCalledOnce();
+      expect(b.shutdown).toHaveBeenCalledOnce();
+      expect(a.state).toBe(SkillState.Stopped);
+      expect(b.state).toBe(SkillState.Stopped);
+    });
+
+    it('does not throw if a skill fails to shut down', async () => {
+      const bad = createMockSkill('bad', { shutdownFail: true });
+      registry.register(bad);
+
+      await registry.initializeAll(createMockContext());
+      // Should not throw
+      await registry.shutdownAll();
+    });
+
+    it('skips skills not in Ready or Error state', async () => {
+      const skill = createMockSkill('created');
+      registry.register(skill);
+
+      // skill is in Created state, never initialized
+      await registry.shutdownAll();
+      expect(skill.shutdown).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isReady', () => {
+    it('returns false when empty', () => {
+      expect(registry.isReady()).toBe(false);
+    });
+
+    it('returns true when all skills are Ready', async () => {
+      registry.register(createMockSkill('a'));
+      registry.register(createMockSkill('b'));
+      await registry.initializeAll(createMockContext());
+
+      expect(registry.isReady()).toBe(true);
+    });
+
+    it('returns false if any skill is not Ready', async () => {
+      registry.register(createMockSkill('ok'));
+      registry.register(createMockSkill('not-init'));
+
+      // Only initialize the first one manually
+      const ctx = createMockContext();
+      const ok = registry.get('ok')!;
+      await ok.initialize(ctx);
+
+      expect(registry.isReady()).toBe(false);
+    });
+  });
+});

--- a/runtime/src/skills/registry.ts
+++ b/runtime/src/skills/registry.ts
@@ -1,0 +1,201 @@
+/**
+ * Skill registry for managing skill instances.
+ *
+ * @module
+ */
+
+import type { Skill, SkillContext, SkillRegistryConfig } from './types.js';
+import { SkillState } from './types.js';
+import {
+  SkillNotFoundError,
+  SkillAlreadyRegisteredError,
+  SkillInitializationError,
+} from './errors.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+
+/**
+ * Registry for managing skill instances.
+ *
+ * Skills are registered by name and can be looked up by name, capability,
+ * or tag. The registry handles batch lifecycle (initialize/shutdown) for
+ * all registered skills.
+ *
+ * @example
+ * ```typescript
+ * const registry = new SkillRegistry({ logger });
+ * registry.register(new JupiterSkill());
+ *
+ * await registry.initializeAll({ connection, wallet, logger });
+ *
+ * const jupiter = registry.getOrThrow('jupiter');
+ * const quote = await jupiter.getAction('getQuote')?.execute(params);
+ *
+ * await registry.shutdownAll();
+ * ```
+ */
+export class SkillRegistry {
+  private readonly skills: Map<string, Skill> = new Map();
+  private readonly logger: Logger;
+
+  constructor(config?: SkillRegistryConfig) {
+    this.logger = config?.logger ?? silentLogger;
+  }
+
+  /**
+   * Register a skill. Throws if a skill with the same name is already registered.
+   */
+  register(skill: Skill): void {
+    const name = skill.metadata.name;
+    if (this.skills.has(name)) {
+      throw new SkillAlreadyRegisteredError(name);
+    }
+    this.skills.set(name, skill);
+    this.logger.info(`Skill registered: "${name}" v${skill.metadata.version}`);
+  }
+
+  /**
+   * Unregister a skill by name.
+   * @returns true if the skill was found and removed, false otherwise
+   */
+  unregister(name: string): boolean {
+    const removed = this.skills.delete(name);
+    if (removed) {
+      this.logger.info(`Skill unregistered: "${name}"`);
+    }
+    return removed;
+  }
+
+  /**
+   * Get a skill by name.
+   * @returns The skill, or undefined if not found
+   */
+  get(name: string): Skill | undefined {
+    return this.skills.get(name);
+  }
+
+  /**
+   * Get a skill by name, throwing if not found.
+   */
+  getOrThrow(name: string): Skill {
+    const skill = this.skills.get(name);
+    if (!skill) {
+      throw new SkillNotFoundError(name);
+    }
+    return skill;
+  }
+
+  /**
+   * Find all skills that satisfy the required capability bitmask.
+   * A skill matches if its requiredCapabilities is a subset of (or equal to)
+   * the given bitmask, meaning the skill can operate within those capabilities.
+   */
+  findByCapability(capabilities: bigint): Skill[] {
+    const results: Skill[] = [];
+    for (const skill of this.skills.values()) {
+      const required = skill.metadata.requiredCapabilities;
+      if ((capabilities & required) === required) {
+        results.push(skill);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Find all skills matching a tag.
+   */
+  findByTag(tag: string): Skill[] {
+    const results: Skill[] = [];
+    for (const skill of this.skills.values()) {
+      if (skill.metadata.tags?.includes(tag)) {
+        results.push(skill);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * List all registered skill names.
+   */
+  listNames(): string[] {
+    return Array.from(this.skills.keys());
+  }
+
+  /**
+   * List all registered skills.
+   */
+  listAll(): ReadonlyArray<Skill> {
+    return Array.from(this.skills.values());
+  }
+
+  /**
+   * Number of registered skills.
+   */
+  get size(): number {
+    return this.skills.size;
+  }
+
+  /**
+   * Initialize all registered skills with the given context.
+   * Skills that fail to initialize are logged and set to Error state,
+   * but other skills continue initializing.
+   *
+   * @throws SkillInitializationError if any skill fails to initialize
+   */
+  async initializeAll(context: SkillContext): Promise<void> {
+    const failures: string[] = [];
+
+    for (const [name, skill] of this.skills) {
+      try {
+        this.logger.info(`Initializing skill: "${name}"`);
+        await skill.initialize(context);
+        this.logger.info(`Skill initialized: "${name}"`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.logger.error(`Failed to initialize skill "${name}": ${message}`);
+        failures.push(name);
+      }
+    }
+
+    if (failures.length > 0) {
+      throw new SkillInitializationError(
+        failures.join(', '),
+        `${failures.length} skill(s) failed to initialize`,
+      );
+    }
+  }
+
+  /**
+   * Shutdown all registered skills. Errors during shutdown are logged
+   * but do not prevent other skills from shutting down.
+   */
+  async shutdownAll(): Promise<void> {
+    for (const [name, skill] of this.skills) {
+      if (skill.state === SkillState.Ready || skill.state === SkillState.Error) {
+        try {
+          this.logger.info(`Shutting down skill: "${name}"`);
+          await skill.shutdown();
+          this.logger.info(`Skill shut down: "${name}"`);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.logger.error(`Error shutting down skill "${name}": ${message}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Check if all registered skills are in Ready state.
+   */
+  isReady(): boolean {
+    if (this.skills.size === 0) {
+      return false;
+    }
+    for (const skill of this.skills.values()) {
+      if (skill.state !== SkillState.Ready) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/runtime/src/skills/types.ts
+++ b/runtime/src/skills/types.ts
@@ -1,0 +1,128 @@
+/**
+ * Core skill system types for @agenc/runtime
+ *
+ * Provides the foundational interfaces for the skill library system,
+ * including skill lifecycle, actions, metadata, and registry configuration.
+ *
+ * @module
+ */
+
+import type { Connection } from '@solana/web3.js';
+import type { Logger } from '../utils/logger.js';
+import type { Wallet } from '../types/wallet.js';
+
+/**
+ * Semantic version string in major.minor.patch format
+ */
+export type SemanticVersion = `${number}.${number}.${number}`;
+
+/**
+ * Lifecycle state of a skill
+ */
+export enum SkillState {
+  /** Skill created but not initialized */
+  Created = 0,
+  /** Skill is currently initializing */
+  Initializing = 1,
+  /** Skill is ready for use */
+  Ready = 2,
+  /** Skill is shutting down */
+  ShuttingDown = 3,
+  /** Skill has been shut down */
+  Stopped = 4,
+  /** Skill encountered an error */
+  Error = 5,
+}
+
+/**
+ * Context provided to skills during initialization.
+ *
+ * Contains the shared resources a skill needs to interact
+ * with the Solana network.
+ */
+export interface SkillContext {
+  /** Solana RPC connection */
+  readonly connection: Connection;
+  /** Wallet for signing transactions */
+  readonly wallet: Wallet;
+  /** Logger instance */
+  readonly logger: Logger;
+}
+
+/**
+ * Metadata describing a skill's identity and requirements.
+ */
+export interface SkillMetadata {
+  /** Unique skill name (lowercase, kebab-case) */
+  readonly name: string;
+  /** Human-readable description */
+  readonly description: string;
+  /** Semantic version */
+  readonly version: SemanticVersion;
+  /** Required capability bitmask (maps to AgentCapabilities) */
+  readonly requiredCapabilities: bigint;
+  /** Optional tags for categorization */
+  readonly tags?: readonly string[];
+}
+
+/**
+ * Typed descriptor for a skill action.
+ *
+ * Each skill exposes a set of actions that can be invoked
+ * programmatically or through the action registry.
+ */
+export interface SkillAction<TParams = unknown, TResult = unknown> {
+  /** Action name */
+  readonly name: string;
+  /** Human-readable description */
+  readonly description: string;
+  /** Execute the action with typed parameters */
+  execute(params: TParams): Promise<TResult>;
+}
+
+/**
+ * Core Skill interface. All skills must implement this.
+ *
+ * Skills follow a lifecycle:
+ * Created -> Initializing -> Ready -> ShuttingDown -> Stopped
+ *
+ * If initialization or operation fails, the skill enters the Error state.
+ */
+export interface Skill {
+  /** Skill metadata */
+  readonly metadata: SkillMetadata;
+
+  /** Current lifecycle state */
+  readonly state: SkillState;
+
+  /**
+   * Initialize the skill with runtime context.
+   * Called once before any actions are invoked.
+   */
+  initialize(context: SkillContext): Promise<void>;
+
+  /**
+   * Graceful shutdown. Release resources.
+   */
+  shutdown(): Promise<void>;
+
+  /**
+   * List all actions this skill provides.
+   * Available after initialization.
+   */
+  getActions(): ReadonlyArray<SkillAction>;
+
+  /**
+   * Get a specific action by name.
+   * @returns The action, or undefined if not found
+   */
+  getAction(name: string): SkillAction | undefined;
+}
+
+/**
+ * Configuration for SkillRegistry
+ */
+export interface SkillRegistryConfig {
+  /** Logger for registry operations */
+  logger?: Logger;
+}


### PR DESCRIPTION
## Summary

  - Add pluggable skill abstraction layer (`Skill` interface, `SkillRegistry`, typed action registry) for packaging reusable
   blockchain operations as composable units
  - Implement `JupiterSkill` as the first concrete skill with 7 actions: `getQuote`, `executeSwap`, `getSolBalance`,
  `getTokenBalance`, `transferSol`, `transferToken`, `getTokenPrice`
  - Add `JupiterClient` low-level HTTP client for Jupiter V6 Quote, Swap, and Price APIs
  - Include well-known token constants (SOL, USDC, USDT) and full TypeScript types for all params/results
  - 49 unit tests across 3 test files covering registry, client, and skill
  - No dependency on the autonomous agent module — `SkillAwareExecutor` bridge deferred

  ## Test plan

  - [x] `npx vitest run src/skills/` — 49/49 tests pass
  - [x] `npx tsc --noEmit` — zero type errors
  - [x] Full test suite — no regressions (1346 tests pass)
  - [ ] Manual: run `examples/skill-jupiter/index.ts` against devnet with funded wallet

  Closes #761
  Works towards #760