### PR TITLE
refactor: deduplicate rate limiting and add test utilities

### DIFF
--- a/programs/agenc-coordination/src/instructions/rate_limit_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/rate_limit_helpers.rs
@@ -16,16 +16,206 @@ pub const ACTION_TYPE_DISPUTE_INITIATION: u8 = 1;
 pub const LIMIT_TYPE_COOLDOWN: u8 = 0;
 pub const LIMIT_TYPE_24H_WINDOW: u8 = 1;
 
-/// Check rate limits for task creation and update agent state.
+/// Rate limit action type for parameterized checking
+#[derive(Clone, Copy)]
+pub enum RateLimitAction {
+    TaskCreation,
+    DisputeInitiation,
+}
+
+impl RateLimitAction {
+    /// Get the action type constant for events
+    pub fn action_type(&self) -> u8 {
+        match self {
+            RateLimitAction::TaskCreation => ACTION_TYPE_TASK_CREATION,
+            RateLimitAction::DisputeInitiation => ACTION_TYPE_DISPUTE_INITIATION,
+        }
+    }
+
+    /// Get cooldown from protocol config
+    pub fn get_cooldown(&self, config: &ProtocolConfig) -> i64 {
+        match self {
+            RateLimitAction::TaskCreation => config.task_creation_cooldown,
+            RateLimitAction::DisputeInitiation => config.dispute_initiation_cooldown,
+        }
+    }
+
+    /// Get max actions per 24h from protocol config
+    pub fn get_max_per_24h(&self, config: &ProtocolConfig) -> u8 {
+        match self {
+            RateLimitAction::TaskCreation => config.max_tasks_per_24h,
+            RateLimitAction::DisputeInitiation => config.max_disputes_per_24h,
+        }
+    }
+
+    /// Get last action timestamp from agent
+    pub fn get_last_timestamp(&self, agent: &AgentRegistration) -> i64 {
+        match self {
+            RateLimitAction::TaskCreation => agent.last_task_created,
+            RateLimitAction::DisputeInitiation => agent.last_dispute_initiated,
+        }
+    }
+
+    /// Get current count from agent
+    pub fn get_count(&self, agent: &AgentRegistration) -> u8 {
+        match self {
+            RateLimitAction::TaskCreation => agent.task_count_24h,
+            RateLimitAction::DisputeInitiation => agent.dispute_count_24h,
+        }
+    }
+
+    /// Update last action timestamp on agent
+    pub fn set_last_timestamp(&self, agent: &mut AgentRegistration, timestamp: i64) {
+        match self {
+            RateLimitAction::TaskCreation => agent.last_task_created = timestamp,
+            RateLimitAction::DisputeInitiation => agent.last_dispute_initiated = timestamp,
+        }
+    }
+
+    /// Increment count on agent, returns error on overflow
+    pub fn increment_count(&self, agent: &mut AgentRegistration) -> Result<()> {
+        match self {
+            RateLimitAction::TaskCreation => {
+                agent.task_count_24h = agent
+                    .task_count_24h
+                    .checked_add(1)
+                    .ok_or(CoordinationError::ArithmeticOverflow)?;
+            }
+            RateLimitAction::DisputeInitiation => {
+                agent.dispute_count_24h = agent
+                    .dispute_count_24h
+                    .checked_add(1)
+                    .ok_or(CoordinationError::ArithmeticOverflow)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Emit a rate limit hit event with the given parameters
+fn emit_rate_limit_hit(
+    agent_id: [u8; 32],
+    action: RateLimitAction,
+    limit_type: u8,
+    current_count: u8,
+    max_count: u8,
+    cooldown_remaining: i64,
+    timestamp: i64,
+) {
+    emit!(RateLimitHit {
+        agent_id,
+        action_type: action.action_type(),
+        limit_type,
+        current_count,
+        max_count,
+        cooldown_remaining,
+        timestamp,
+    });
+}
+
+/// Reset the 24h rate limit window if expired.
+///
+/// Both task and dispute counters reset together when the window expires.
+/// This ensures clean state at window boundaries.
+fn maybe_reset_window(agent: &mut AgentRegistration, clock: &Clock) {
+    // Using saturating_sub intentionally - handles clock drift safely
+    if clock
+        .unix_timestamp
+        .saturating_sub(agent.rate_limit_window_start)
+        >= WINDOW_24H
+    {
+        // Round window start to prevent drift
+        let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
+        agent.rate_limit_window_start = window_start;
+        // Note: Both counters reset together when window expires.
+        // This is intentional - ensures clean state at window boundary.
+        agent.task_count_24h = 0;
+        agent.dispute_count_24h = 0;
+    }
+}
+
+/// Generic rate limit checker for both task creation and dispute initiation.
 ///
 /// This function enforces two rate limiting mechanisms:
-/// 1. **Cooldown period**: Minimum time between task creations
-/// 2. **24-hour window limit**: Maximum tasks per rolling 24-hour window
+/// 1. **Cooldown period**: Minimum time between actions
+/// 2. **24-hour window limit**: Maximum actions per rolling 24-hour window
 ///
-/// If rate limits pass, the function updates the agent's counters:
-/// - Increments `task_count_24h`
-/// - Updates `last_task_created` timestamp
-/// - Updates `last_active` timestamp
+/// If rate limits pass, the function updates the agent's counters and timestamps.
+///
+/// # Arguments
+/// * `agent` - Mutable reference to the agent's registration
+/// * `config` - Protocol configuration containing rate limit settings
+/// * `clock` - Current clock for timestamp comparisons
+/// * `action` - The type of action being rate limited
+///
+/// # Errors
+/// * `CooldownNotElapsed` - Action cooldown has not passed
+/// * `RateLimitExceeded` - 24-hour action limit exceeded
+/// * `ArithmeticOverflow` - Counter overflow (shouldn't happen in practice)
+pub fn check_rate_limits(
+    agent: &mut AgentRegistration,
+    config: &ProtocolConfig,
+    clock: &Clock,
+    action: RateLimitAction,
+) -> Result<()> {
+    let cooldown = action.get_cooldown(config);
+    let max_per_24h = action.get_max_per_24h(config);
+    let last_timestamp = action.get_last_timestamp(agent);
+
+    // Check cooldown period
+    if cooldown > 0 && last_timestamp > 0 {
+        // Using saturating_sub intentionally - handles clock drift safely
+        let elapsed = clock.unix_timestamp.saturating_sub(last_timestamp);
+        if elapsed < cooldown {
+            // Using saturating_sub intentionally - underflow returns 0 (safe time calculation)
+            let remaining = cooldown.saturating_sub(elapsed);
+            emit_rate_limit_hit(
+                agent.agent_id,
+                action,
+                LIMIT_TYPE_COOLDOWN,
+                action.get_count(agent),
+                max_per_24h,
+                remaining,
+                clock.unix_timestamp,
+            );
+            return Err(CoordinationError::CooldownNotElapsed.into());
+        }
+    }
+
+    // Check 24h window limit
+    if max_per_24h > 0 {
+        // Reset window if 24h has passed
+        maybe_reset_window(agent, clock);
+
+        // Check if limit exceeded
+        let current_count = action.get_count(agent);
+        if current_count >= max_per_24h {
+            emit_rate_limit_hit(
+                agent.agent_id,
+                action,
+                LIMIT_TYPE_24H_WINDOW,
+                current_count,
+                max_per_24h,
+                0,
+                clock.unix_timestamp,
+            );
+            return Err(CoordinationError::RateLimitExceeded.into());
+        }
+
+        // Increment counter
+        action.increment_count(agent)?;
+    }
+
+    // Update timestamps
+    action.set_last_timestamp(agent, clock.unix_timestamp);
+    agent.last_active = clock.unix_timestamp;
+
+    Ok(())
+}
+
+/// Check rate limits for task creation and update agent state.
+///
+/// Wrapper around `check_rate_limits` for backwards compatibility.
 ///
 /// # Arguments
 /// * `creator_agent` - Mutable reference to the agent's registration
@@ -41,84 +231,12 @@ pub fn check_task_creation_rate_limits(
     config: &ProtocolConfig,
     clock: &Clock,
 ) -> Result<()> {
-    // Check cooldown period
-    if config.task_creation_cooldown > 0 && creator_agent.last_task_created > 0 {
-        // Using saturating_sub intentionally - handles clock drift safely
-        let elapsed = clock
-            .unix_timestamp
-            .saturating_sub(creator_agent.last_task_created);
-        if elapsed < config.task_creation_cooldown {
-            // Using saturating_sub intentionally - underflow returns 0 (safe time calculation)
-            let remaining = config.task_creation_cooldown.saturating_sub(elapsed);
-            emit!(RateLimitHit {
-                agent_id: creator_agent.agent_id,
-                action_type: 0, // task_creation
-                limit_type: 0,  // cooldown
-                current_count: creator_agent.task_count_24h,
-                max_count: config.max_tasks_per_24h,
-                cooldown_remaining: remaining,
-                timestamp: clock.unix_timestamp,
-            });
-            return Err(CoordinationError::CooldownNotElapsed.into());
-        }
-    }
-
-    // Check 24h window limit
-    if config.max_tasks_per_24h > 0 {
-        // Reset window if 24h has passed
-        // Using saturating_sub intentionally - handles clock drift safely
-        if clock
-            .unix_timestamp
-            .saturating_sub(creator_agent.rate_limit_window_start)
-            >= WINDOW_24H
-        {
-            // Round window start to prevent drift
-            let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
-            creator_agent.rate_limit_window_start = window_start;
-            // Note: Both counters reset together when window expires.
-            // This is intentional - ensures clean state at window boundary.
-            creator_agent.task_count_24h = 0;
-            creator_agent.dispute_count_24h = 0;
-        }
-
-        // Check if limit exceeded
-        if creator_agent.task_count_24h >= config.max_tasks_per_24h {
-            emit!(RateLimitHit {
-                agent_id: creator_agent.agent_id,
-                action_type: 0, // task_creation
-                limit_type: 1,  // 24h_window
-                current_count: creator_agent.task_count_24h,
-                max_count: config.max_tasks_per_24h,
-                cooldown_remaining: 0,
-                timestamp: clock.unix_timestamp,
-            });
-            return Err(CoordinationError::RateLimitExceeded.into());
-        }
-
-        // Increment counter
-        creator_agent.task_count_24h = creator_agent
-            .task_count_24h
-            .checked_add(1)
-            .ok_or(CoordinationError::ArithmeticOverflow)?;
-    }
-
-    // Update last task created timestamp
-    creator_agent.last_task_created = clock.unix_timestamp;
-    creator_agent.last_active = clock.unix_timestamp;
-
-    Ok(())
+    check_rate_limits(creator_agent, config, clock, RateLimitAction::TaskCreation)
 }
 
 /// Check rate limits for dispute initiation and update agent state.
 ///
-/// This function enforces two rate limiting mechanisms:
-/// 1. **Cooldown period**: Minimum time between dispute initiations
-/// 2. **24-hour window limit**: Maximum disputes per rolling 24-hour window
-///
-/// If rate limits pass, the function updates the agent's counters:
-/// - Increments `dispute_count_24h`
-/// - Updates `last_dispute_initiated` timestamp
-/// - Updates `last_active` timestamp
+/// Wrapper around `check_rate_limits` for backwards compatibility.
 ///
 /// # Arguments
 /// * `agent` - Mutable reference to the agent's registration
@@ -134,70 +252,5 @@ pub fn check_dispute_initiation_rate_limits(
     config: &ProtocolConfig,
     clock: &Clock,
 ) -> Result<()> {
-    // Check cooldown period
-    if config.dispute_initiation_cooldown > 0 && agent.last_dispute_initiated > 0 {
-        // Using saturating_sub intentionally - handles clock drift safely
-        let elapsed = clock
-            .unix_timestamp
-            .saturating_sub(agent.last_dispute_initiated);
-        if elapsed < config.dispute_initiation_cooldown {
-            // Using saturating_sub intentionally - underflow returns 0 (safe time calculation)
-            let remaining = config.dispute_initiation_cooldown.saturating_sub(elapsed);
-            emit!(RateLimitHit {
-                agent_id: agent.agent_id,
-                action_type: ACTION_TYPE_DISPUTE_INITIATION,
-                limit_type: LIMIT_TYPE_COOLDOWN,
-                current_count: agent.dispute_count_24h,
-                max_count: config.max_disputes_per_24h,
-                cooldown_remaining: remaining,
-                timestamp: clock.unix_timestamp,
-            });
-            return Err(CoordinationError::CooldownNotElapsed.into());
-        }
-    }
-
-    // Check 24h window limit
-    if config.max_disputes_per_24h > 0 {
-        // Reset window if 24h has passed
-        // Using saturating_sub intentionally - handles clock drift safely
-        if clock
-            .unix_timestamp
-            .saturating_sub(agent.rate_limit_window_start)
-            >= WINDOW_24H
-        {
-            // Round window start to prevent drift
-            let window_start = (clock.unix_timestamp / WINDOW_24H) * WINDOW_24H;
-            agent.rate_limit_window_start = window_start;
-            // Note: Both counters reset together when window expires.
-            // This is intentional - ensures clean state at window boundary.
-            agent.task_count_24h = 0;
-            agent.dispute_count_24h = 0;
-        }
-
-        // Check if limit exceeded
-        if agent.dispute_count_24h >= config.max_disputes_per_24h {
-            emit!(RateLimitHit {
-                agent_id: agent.agent_id,
-                action_type: ACTION_TYPE_DISPUTE_INITIATION,
-                limit_type: LIMIT_TYPE_24H_WINDOW,
-                current_count: agent.dispute_count_24h,
-                max_count: config.max_disputes_per_24h,
-                cooldown_remaining: 0,
-                timestamp: clock.unix_timestamp,
-            });
-            return Err(CoordinationError::RateLimitExceeded.into());
-        }
-
-        // Increment counter
-        agent.dispute_count_24h = agent
-            .dispute_count_24h
-            .checked_add(1)
-            .ok_or(CoordinationError::ArithmeticOverflow)?;
-    }
-
-    // Update last dispute initiated timestamp
-    agent.last_dispute_initiated = clock.unix_timestamp;
-    agent.last_active = clock.unix_timestamp;
-
-    Ok(())
+    check_rate_limits(agent, config, clock, RateLimitAction::DisputeInitiation)
 }

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,0 +1,356 @@
+/**
+ * Shared test utilities for AgenC integration tests.
+ *
+ * This module provides common helpers to reduce boilerplate across test files:
+ * - PDA derivation functions
+ * - Capability and task type constants
+ * - Helper functions for test setup
+ */
+
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { Keypair, PublicKey, Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import type { AgencCoordination } from "../target/types/agenc_coordination";
+
+// ============================================================================
+// Capability Constants (matches program)
+// ============================================================================
+
+export const CAPABILITY_COMPUTE = 1 << 0;
+export const CAPABILITY_INFERENCE = 1 << 1;
+export const CAPABILITY_STORAGE = 1 << 2;
+export const CAPABILITY_NETWORK = 1 << 3;
+export const CAPABILITY_SENSOR = 1 << 4;
+export const CAPABILITY_ACTUATOR = 1 << 5;
+export const CAPABILITY_COORDINATOR = 1 << 6;
+export const CAPABILITY_ARBITER = 1 << 7;
+export const CAPABILITY_VALIDATOR = 1 << 8;
+export const CAPABILITY_AGGREGATOR = 1 << 9;
+
+// ============================================================================
+// Task Type Constants (matches program)
+// ============================================================================
+
+export const TASK_TYPE_EXCLUSIVE = 0;
+export const TASK_TYPE_COLLABORATIVE = 1;
+export const TASK_TYPE_COMPETITIVE = 2;
+
+// ============================================================================
+// Resolution Type Constants (matches program)
+// ============================================================================
+
+export const RESOLUTION_TYPE_REFUND = 0;
+export const RESOLUTION_TYPE_COMPLETE = 1;
+export const RESOLUTION_TYPE_SPLIT = 2;
+
+// ============================================================================
+// Valid Evidence String (minimum 50 characters required)
+// ============================================================================
+
+export const VALID_EVIDENCE =
+  "This is valid dispute evidence that exceeds the minimum 50 character requirement for the dispute system.";
+
+// ============================================================================
+// PDA Derivation Functions
+// ============================================================================
+
+/**
+ * Derive the protocol config PDA (singleton).
+ */
+export function deriveProtocolPda(programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("protocol")],
+    programId
+  )[0];
+}
+
+/**
+ * Derive an agent registration PDA from agent ID.
+ */
+export function deriveAgentPda(agentId: Buffer, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("agent"), agentId],
+    programId
+  )[0];
+}
+
+/**
+ * Derive a task PDA from creator pubkey and task ID.
+ */
+export function deriveTaskPda(
+  creatorPubkey: PublicKey,
+  taskId: Buffer,
+  programId: PublicKey
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("task"), creatorPubkey.toBuffer(), taskId],
+    programId
+  )[0];
+}
+
+/**
+ * Derive an escrow PDA from task PDA.
+ */
+export function deriveEscrowPda(taskPda: PublicKey, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("escrow"), taskPda.toBuffer()],
+    programId
+  )[0];
+}
+
+/**
+ * Derive a claim PDA from task PDA and worker agent PDA.
+ */
+export function deriveClaimPda(
+  taskPda: PublicKey,
+  workerAgentPda: PublicKey,
+  programId: PublicKey
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("claim"), taskPda.toBuffer(), workerAgentPda.toBuffer()],
+    programId
+  )[0];
+}
+
+/**
+ * Derive a dispute PDA from dispute ID.
+ */
+export function deriveDisputePda(disputeId: Buffer, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("dispute"), disputeId],
+    programId
+  )[0];
+}
+
+/**
+ * Derive a vote PDA from dispute PDA and voter agent PDA.
+ */
+export function deriveVotePda(
+  disputePda: PublicKey,
+  voterAgentPda: PublicKey,
+  programId: PublicKey
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("vote"), disputePda.toBuffer(), voterAgentPda.toBuffer()],
+    programId
+  )[0];
+}
+
+/**
+ * Derive an authority vote PDA from dispute PDA and voter authority.
+ */
+export function deriveAuthorityVotePda(
+  disputePda: PublicKey,
+  voterAuthority: PublicKey,
+  programId: PublicKey
+): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("authority_vote"), disputePda.toBuffer(), voterAuthority.toBuffer()],
+    programId
+  )[0];
+}
+
+/**
+ * Derive a shared state PDA from key string.
+ */
+export function deriveStatePda(key: string, programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [Buffer.from("state"), Buffer.from(key)],
+    programId
+  )[0];
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Generate a unique run ID to prevent conflicts with persisted validator state.
+ * Call once at the start of each test file.
+ */
+export function generateRunId(): string {
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+}
+
+/**
+ * Create a unique agent ID with the given prefix and run ID.
+ * Ensures IDs don't collide across test runs.
+ */
+export function makeAgentId(prefix: string, runId: string): Buffer {
+  return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+}
+
+/**
+ * Create a unique task ID with the given prefix and run ID.
+ */
+export function makeTaskId(prefix: string, runId: string): Buffer {
+  return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+}
+
+/**
+ * Create a unique dispute ID with the given prefix and run ID.
+ */
+export function makeDisputeId(prefix: string, runId: string): Buffer {
+  return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+}
+
+/**
+ * Get a default deadline 1 hour in the future.
+ */
+export function getDefaultDeadline(): BN {
+  return new BN(Math.floor(Date.now() / 1000) + 3600);
+}
+
+/**
+ * Get a deadline N seconds in the future.
+ */
+export function getDeadlineInSeconds(seconds: number): BN {
+  return new BN(Math.floor(Date.now() / 1000) + seconds);
+}
+
+/**
+ * Sleep for a specified number of milliseconds.
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Fund a wallet with SOL via airdrop.
+ */
+export async function fundWallet(
+  connection: Connection,
+  wallet: PublicKey,
+  lamports: number = 5 * LAMPORTS_PER_SOL
+): Promise<void> {
+  const sig = await connection.requestAirdrop(wallet, lamports);
+  await connection.confirmTransaction(sig, "confirmed");
+}
+
+/**
+ * Fund multiple wallets in parallel.
+ */
+export async function fundWallets(
+  connection: Connection,
+  wallets: PublicKey[],
+  lamports: number = 5 * LAMPORTS_PER_SOL
+): Promise<void> {
+  const sigs = await Promise.all(
+    wallets.map((wallet) => connection.requestAirdrop(wallet, lamports))
+  );
+  await Promise.all(
+    sigs.map((sig) => connection.confirmTransaction(sig, "confirmed"))
+  );
+}
+
+// ============================================================================
+// Worker Pool for Fast Test Execution
+// ============================================================================
+
+export interface PooledWorker {
+  wallet: Keypair;
+  agentId: Buffer;
+  agentPda: PublicKey;
+  inUse: boolean;
+}
+
+/**
+ * Create a worker pool for fast test execution.
+ * Pre-funds and registers workers to avoid airdrop delays.
+ */
+export async function createWorkerPool(
+  connection: Connection,
+  program: Program<AgencCoordination>,
+  protocolPda: PublicKey,
+  runId: string,
+  size: number = 20,
+  capabilities: number = CAPABILITY_COMPUTE,
+  stake: number = LAMPORTS_PER_SOL
+): Promise<PooledWorker[]> {
+  const pool: PooledWorker[] = [];
+  const wallets: Keypair[] = [];
+  const airdropSigs: string[] = [];
+
+  // Generate wallets and request airdrops in parallel
+  for (let i = 0; i < size; i++) {
+    const wallet = Keypair.generate();
+    wallets.push(wallet);
+    const sig = await connection.requestAirdrop(wallet.publicKey, 10 * LAMPORTS_PER_SOL);
+    airdropSigs.push(sig);
+  }
+
+  // Confirm all airdrops
+  await Promise.all(
+    airdropSigs.map((sig) => connection.confirmTransaction(sig, "confirmed"))
+  );
+
+  // Register all workers in parallel
+  const registerPromises = wallets.map(async (wallet, i) => {
+    const agentId = makeAgentId(`pool${i}`, runId);
+    const agentPda = deriveAgentPda(agentId, program.programId);
+
+    await program.methods
+      .registerAgent(
+        Array.from(agentId),
+        new BN(capabilities),
+        `https://pool-worker-${i}.example.com`,
+        null,
+        new BN(stake)
+      )
+      .accountsPartial({
+        agent: agentPda,
+        protocolConfig: protocolPda,
+        authority: wallet.publicKey,
+      })
+      .signers([wallet])
+      .rpc();
+
+    pool.push({
+      wallet,
+      agentId,
+      agentPda,
+      inUse: false,
+    });
+  });
+
+  await Promise.all(registerPromises);
+  return pool;
+}
+
+/**
+ * Get a worker from the pool, marking it as in use.
+ */
+export function getWorkerFromPool(pool: PooledWorker[]): PooledWorker | null {
+  const worker = pool.find((w) => !w.inUse);
+  if (worker) {
+    worker.inUse = true;
+  }
+  return worker ?? null;
+}
+
+/**
+ * Return a worker to the pool.
+ */
+export function returnWorkerToPool(worker: PooledWorker): void {
+  worker.inUse = false;
+}
+
+// ============================================================================
+// Assertion Helpers
+// ============================================================================
+
+/**
+ * Check if an error message contains any of the expected patterns.
+ */
+export function errorContainsAny(error: unknown, patterns: string[]): boolean {
+  const message = (error as { message?: string })?.message ?? "";
+  const errorCode = (error as { error?: { errorCode?: { code: string } } })?.error?.errorCode?.code ?? "";
+  return patterns.some((p) => message.includes(p) || errorCode.includes(p));
+}
+
+/**
+ * Extract error code from an Anchor error.
+ */
+export function getErrorCode(error: unknown): string | undefined {
+  return (error as { error?: { errorCode?: { code: string } } })?.error?.errorCode?.code;
+}


### PR DESCRIPTION
## Summary

- Refactor `rate_limit_helpers.rs` to eliminate code duplication
  - Create generic `check_rate_limits()` function with `RateLimitAction` enum
  - Extract `emit_rate_limit_hit()` helper for event emission
  - Extract `maybe_reset_window()` helper for window reset logic
  - Reduce ~140 duplicate lines to shared implementation
  - Maintain backwards-compatible wrapper functions

- Add `tests/test-utils.ts` with shared test helpers
  - PDA derivation functions (agent, task, escrow, claim, dispute, vote, state)
  - Capability and task type constants matching program
  - Run ID and unique ID generation for test isolation
  - Deadline helpers
  - Worker pool utilities for fast test execution
  - Error assertion helpers

## Test plan

- [x] `anchor build` compiles successfully
- [x] All 141 tests pass (`anchor test`)
- [x] Rate limiting behavior unchanged (wrapper functions maintain API)