### PR TITLE
refactor: tech debt cleanup across Rust handlers, MCP tools, and demo app

### DIFF
--- a/demo-app/src/App.tsx
+++ b/demo-app/src/App.tsx
@@ -10,6 +10,14 @@ import Step5VerifyOnChain from './components/steps/Step5VerifyOnChain'
 import Step6PrivateWithdraw from './components/steps/Step6PrivateWithdraw'
 import CompletionSummary from './components/CompletionSummary'
 
+export interface StepProps {
+  taskState: TaskState
+  updateTaskState: (updates: Partial<TaskState>) => void
+  onNext: () => void
+  onPrev: () => void
+  connection: Connection | null
+}
+
 export interface TaskState {
   taskId: string
   requirements: string
@@ -95,6 +103,12 @@ const getRpcEndpoint = (): string => {
 
 const DEVNET_RPC = getRpcEndpoint()
 
+// Transaction confirmation timeout - configurable via VITE_TX_TIMEOUT env var
+const TX_TIMEOUT_MS = (() => {
+  const timeout = Number(import.meta.env.VITE_TX_TIMEOUT);
+  return Number.isFinite(timeout) && timeout > 0 ? timeout : 60000;
+})();
+
 // Connection error state type
 interface ConnectionState {
   connection: Connection | null
@@ -128,10 +142,7 @@ function App() {
     try {
       const conn = new Connection(DEVNET_RPC, {
         commitment: 'confirmed',
-        confirmTransactionInitialTimeout: (() => {
-          const timeout = Number(import.meta.env.VITE_TX_TIMEOUT);
-          return Number.isFinite(timeout) && timeout > 0 ? timeout : 60000;
-        })(),
+        confirmTransactionInitialTimeout: TX_TIMEOUT_MS,
       })
       // Verify connection is working by fetching slot
       await conn.getSlot()

--- a/demo-app/src/components/steps/Step1CreateTask.tsx
+++ b/demo-app/src/components/steps/Step1CreateTask.tsx
@@ -1,17 +1,8 @@
 import { useState } from 'react'
-import { Connection } from '@solana/web3.js'
-import { TaskState } from '../../App'
+import type { StepProps } from '../../App'
 import StepCard from '../StepCard'
 
-interface Props {
-  taskState: TaskState
-  updateTaskState: (updates: Partial<TaskState>) => void
-  onNext: () => void
-  onPrev: () => void
-  connection: Connection | null
-}
-
-export default function Step1CreateTask({ taskState, updateTaskState, onNext }: Props) {
+export default function Step1CreateTask({ taskState, updateTaskState, onNext }: StepProps) {
   const [requirements, setRequirements] = useState(taskState.requirements || 'Compute the sum of [1, 2, 3, 4]')
   const [escrowAmount, setEscrowAmount] = useState(taskState.escrowAmount || 0.1)
   const [isProcessing, setIsProcessing] = useState(false)

--- a/demo-app/src/components/steps/Step2ShieldEscrow.tsx
+++ b/demo-app/src/components/steps/Step2ShieldEscrow.tsx
@@ -1,17 +1,8 @@
 import { useState } from 'react'
-import { Connection } from '@solana/web3.js'
-import { TaskState } from '../../App'
+import type { StepProps } from '../../App'
 import StepCard from '../StepCard'
 
-interface Props {
-  taskState: TaskState
-  updateTaskState: (updates: Partial<TaskState>) => void
-  onNext: () => void
-  onPrev: () => void
-  connection: Connection | null
-}
-
-export default function Step2ShieldEscrow({ taskState, updateTaskState, onNext, onPrev }: Props) {
+export default function Step2ShieldEscrow({ taskState, updateTaskState, onNext, onPrev }: StepProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [progress, setProgress] = useState(0)
 

--- a/demo-app/src/components/steps/Step3ClaimTask.tsx
+++ b/demo-app/src/components/steps/Step3ClaimTask.tsx
@@ -1,17 +1,8 @@
 import { useState } from 'react'
-import { Connection } from '@solana/web3.js'
-import { TaskState } from '../../App'
+import type { StepProps } from '../../App'
 import StepCard from '../StepCard'
 
-interface Props {
-  taskState: TaskState
-  updateTaskState: (updates: Partial<TaskState>) => void
-  onNext: () => void
-  onPrev: () => void
-  connection: Connection | null
-}
-
-export default function Step3ClaimTask({ taskState, updateTaskState, onNext, onPrev }: Props) {
+export default function Step3ClaimTask({ taskState, updateTaskState, onNext, onPrev }: StepProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [workerGenerated, setWorkerGenerated] = useState(false)
 

--- a/demo-app/src/components/steps/Step4GenerateProof.tsx
+++ b/demo-app/src/components/steps/Step4GenerateProof.tsx
@@ -1,15 +1,6 @@
 import { useState } from 'react'
-import { Connection } from '@solana/web3.js'
-import { TaskState } from '../../App'
+import type { StepProps } from '../../App'
 import StepCard from '../StepCard'
-
-interface Props {
-  taskState: TaskState
-  updateTaskState: (updates: Partial<TaskState>) => void
-  onNext: () => void
-  onPrev: () => void
-  connection: Connection | null
-}
 
 const PROOF_STAGES = [
   { id: 1, label: 'Computing output', duration: 800 },
@@ -18,7 +9,7 @@ const PROOF_STAGES = [
   { id: 4, label: 'Optimizing for TX size', duration: 500 },
 ]
 
-export default function Step4GenerateProof({ updateTaskState, onNext, onPrev }: Props) {
+export default function Step4GenerateProof({ updateTaskState, onNext, onPrev }: StepProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [currentStage, setCurrentStage] = useState(0)
   const [proofStats, setProofStats] = useState({

--- a/demo-app/src/components/steps/Step5VerifyOnChain.tsx
+++ b/demo-app/src/components/steps/Step5VerifyOnChain.tsx
@@ -1,19 +1,10 @@
 import { useState } from 'react'
-import { Connection } from '@solana/web3.js'
-import { TaskState } from '../../App'
+import type { StepProps } from '../../App'
 import StepCard from '../StepCard'
-
-interface Props {
-  taskState: TaskState
-  updateTaskState: (updates: Partial<TaskState>) => void
-  onNext: () => void
-  onPrev: () => void
-  connection: Connection | null
-}
 
 const VERIFIER_PROGRAM = '8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ'
 
-export default function Step5VerifyOnChain({ taskState, updateTaskState, onNext, onPrev }: Props) {
+export default function Step5VerifyOnChain({ taskState, updateTaskState, onNext, onPrev }: StepProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [verificationStage, setVerificationStage] = useState<'idle' | 'submitting' | 'verifying' | 'confirmed'>('idle')
 

--- a/demo-app/src/components/steps/Step6PrivateWithdraw.tsx
+++ b/demo-app/src/components/steps/Step6PrivateWithdraw.tsx
@@ -1,17 +1,8 @@
 import { useState } from 'react'
-import { Connection } from '@solana/web3.js'
-import { TaskState } from '../../App'
+import type { StepProps } from '../../App'
 import StepCard from '../StepCard'
 
-interface Props {
-  taskState: TaskState
-  updateTaskState: (updates: Partial<TaskState>) => void
-  onNext: () => void
-  onPrev: () => void
-  connection: Connection | null
-}
-
-export default function Step6PrivateWithdraw({ taskState, updateTaskState, onNext, onPrev }: Props) {
+export default function Step6PrivateWithdraw({ taskState, updateTaskState, onNext, onPrev }: StepProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [withdrawStage, setWithdrawStage] = useState<'idle' | 'generating' | 'withdrawing' | 'complete'>('idle')
   const [recipientGenerated, setRecipientGenerated] = useState(false)

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -20,20 +20,20 @@ import {
   getSigningProgram,
   getCurrentProgramId,
 } from '../utils/connection.js';
-import { formatSol, formatTimestamp, formatStatus } from '../utils/formatting.js';
+import { formatSol, formatTimestamp, formatStatus, safePubkey, safeBigInt } from '../utils/formatting.js';
 
 function formatAgentState(account: Record<string, unknown>, pda: PublicKey): string {
   const agentId = account.agentId as Uint8Array | number[];
   const idBytes = agentId instanceof Uint8Array ? agentId : new Uint8Array(agentId);
 
-  const caps = BigInt((account.capabilities as { toString(): string }).toString());
+  const caps = safeBigInt(account.capabilities);
   const capNames = getCapabilityNames(caps);
 
   const lines = [
     'Agent ID: ' + agentIdToShortString(idBytes),
     'Full ID: ' + agentIdToString(idBytes),
     'PDA: ' + pda.toBase58(),
-    'Authority: ' + (account.authority as PublicKey).toBase58(),
+    'Authority: ' + safePubkey(account.authority),
     'Status: ' + formatStatus(account.status as number | Record<string, unknown>),
     'Capabilities: ' + (capNames.length > 0 ? capNames.join(', ') : 'None') + ' (bitmask: ' + caps + ')',
     'Endpoint: ' + ((account.endpoint as string) || 'Not set'),
@@ -221,7 +221,7 @@ export function registerAgentTools(server: McpServer): void {
           const acc = a.account as unknown as Record<string, unknown>;
           const agentId = acc.agentId as Uint8Array | number[];
           const idBytes = agentId instanceof Uint8Array ? agentId : new Uint8Array(agentId);
-          const caps = BigInt((acc.capabilities as { toString(): string }).toString());
+          const caps = safeBigInt(acc.capabilities);
           return [
             '[' + (i + 1) + '] ' + agentIdToShortString(idBytes),
             '    PDA: ' + a.publicKey.toBase58(),

--- a/mcp/src/tools/disputes.ts
+++ b/mcp/src/tools/disputes.ts
@@ -7,6 +7,7 @@ import {
   formatTimestamp,
   formatDisputeStatus,
   formatResolutionType,
+  safePubkey,
 } from '../utils/formatting.js';
 
 function formatDisputeAccount(account: Record<string, unknown>, pda: PublicKey): string {
@@ -22,8 +23,8 @@ function formatDisputeAccount(account: Record<string, unknown>, pda: PublicKey):
     'Resolution Type: ' + formatResolutionType(account.resolutionType as number | Record<string, unknown>),
     '',
     '--- Parties ---',
-    'Task PDA: ' + (account.task as PublicKey).toBase58(),
-    'Initiator: ' + (account.initiator as PublicKey).toBase58(),
+    'Task PDA: ' + safePubkey(account.task),
+    'Initiator: ' + safePubkey(account.initiator),
     '',
     '--- Voting ---',
     'Votes For: ' + (account.votesFor ?? 0),

--- a/mcp/src/tools/protocol.ts
+++ b/mcp/src/tools/protocol.ts
@@ -15,15 +15,15 @@ import {
   getReadOnlyProgram,
   getCurrentProgramId,
 } from '../utils/connection.js';
-import { formatSol } from '../utils/formatting.js';
+import { formatSol, safePubkey } from '../utils/formatting.js';
 
 function formatProtocolConfig(config: Record<string, unknown>, pda: PublicKey): string {
   const lines = [
     'Protocol Config PDA: ' + pda.toBase58(),
     '',
     '--- Authority ---',
-    'Authority: ' + (config.authority as PublicKey).toBase58(),
-    'Treasury: ' + (config.treasury as PublicKey).toBase58(),
+    'Authority: ' + safePubkey(config.authority),
+    'Treasury: ' + safePubkey(config.treasury),
     '',
     '--- Fees & Thresholds ---',
     'Protocol Fee: ' + config.protocolFeeBps + ' bps (' + (Number(config.protocolFeeBps) / 100).toFixed(2) + '%)',

--- a/mcp/src/tools/tasks.ts
+++ b/mcp/src/tools/tasks.ts
@@ -14,6 +14,8 @@ import {
   formatTaskStatus,
   formatTaskType,
   formatBytes,
+  safePubkey,
+  safeBigInt,
 } from '../utils/formatting.js';
 
 function deriveTaskPda(
@@ -40,13 +42,13 @@ function formatTaskAccount(account: Record<string, unknown>, pda: PublicKey): st
   const taskId = account.taskId as Uint8Array | number[];
   const idHex = Buffer.from(taskId instanceof Uint8Array ? taskId : new Uint8Array(taskId)).toString('hex');
 
-  const reqCaps = BigInt((account.requiredCapabilities as { toString(): string })?.toString?.() ?? '0');
+  const reqCaps = safeBigInt(account.requiredCapabilities);
   const capNames = getCapabilityNames(reqCaps);
 
   const lines = [
     'Task PDA: ' + pda.toBase58(),
     'Task ID: ' + idHex,
-    'Creator: ' + (account.creator as PublicKey).toBase58(),
+    'Creator: ' + safePubkey(account.creator),
     'Status: ' + formatTaskStatus(account.status as number | Record<string, unknown>),
     'Type: ' + formatTaskType(account.taskType as number | Record<string, unknown>),
     '',

--- a/mcp/src/utils/formatting.ts
+++ b/mcp/src/utils/formatting.ts
@@ -23,6 +23,31 @@ export function formatTimestamp(ts: number): string {
 }
 
 /**
+ * Safely extract a base58 string from a value that may be a PublicKey.
+ * Returns the base58 string if the value has a `toBase58` method, otherwise
+ * falls back to String coercion. Prevents crashes on missing/malformed fields.
+ */
+export function safePubkey(val: unknown): string {
+  if (val != null && typeof val === 'object' && 'toBase58' in val) {
+    return (val as PublicKey).toBase58();
+  }
+  return String(val ?? 'Unknown');
+}
+
+/**
+ * Safely convert an Anchor BN-like value to bigint.
+ * Handles bigint, BN (via toString), and null/undefined (returns 0n).
+ */
+export function safeBigInt(val: unknown): bigint {
+  if (val == null) return 0n;
+  if (typeof val === 'bigint') return val;
+  if (typeof val === 'object' && 'toString' in val) {
+    return BigInt((val as { toString(): string }).toString());
+  }
+  return BigInt(val as string | number);
+}
+
+/**
  * Format a public key with optional truncation.
  */
 export function formatPubkey(pubkey: PublicKey | string, truncate = false): string {

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -398,10 +398,10 @@ fn validate_worker_accounts(
         CoordinationError::NotClaimed
     );
 
-    // Unwrap is safe here - we verified all are Some
-    let worker = worker.as_ref().unwrap();
-    let worker_claim = worker_claim.as_ref().unwrap();
-    let worker_authority = worker_authority.as_ref().unwrap();
+    // Safe: we verified provided_count == 3 above (all are Some)
+    let worker = worker.as_ref().expect("verified provided_count == 3 above");
+    let worker_claim = worker_claim.as_ref().expect("verified provided_count == 3 above");
+    let worker_authority = worker_authority.as_ref().expect("verified provided_count == 3 above");
 
     // Verify worker matches claim
     require!(

--- a/programs/agenc-coordination/src/utils/compute_budget.rs
+++ b/programs/agenc-coordination/src/utils/compute_budget.rs
@@ -134,7 +134,12 @@ pub fn calculate_tiered_fee(base_fee_bps: u16, completed_tasks: u64) -> u16 {
 pub fn log_compute_units(label: &str) {
     msg!("CU checkpoint [{}]", label);
     #[cfg(target_os = "solana")]
-    anchor_lang::solana_program::log::sol_log_compute_units();
+    {
+        extern "C" {
+            fn sol_log_compute_units_();
+        }
+        unsafe { sol_log_compute_units_() };
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Extract local helpers in `expire_dispute.rs` (`distribute_expired_funds`, `process_arbiter_vote_pair_expired`, `cleanup_worker_claims_expired`) — handler reduced from ~300 to ~180 lines
- Extract `mark_defendant_workers` helper in `initiate_dispute.rs`
- Replace `.unwrap()` with `.expect()` in `resolve_dispute.rs` for developer clarity
- Add `safePubkey()`/`safeBigInt()` helpers to MCP formatting utils, replacing unsafe `as PublicKey` casts in agents, tasks, disputes, protocol tools
- Deduplicate `StepProps` interface across 6 demo app step components into shared export from `App.tsx`
- Extract `TX_TIMEOUT_MS` constant in demo app connection config
- Fix pre-existing `sol_log_compute_units` build error in `compute_budget.rs`

## Test plan

- [x] `anchor build` passes
- [x] `anchor test` — all 141 tests pass
- [x] `cd demo-app && npm run build` passes
- [x] `cd sdk && npm run build && npm run typecheck` passes