### PR TITLE
feat: implement reputation system

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -441,4 +441,11 @@ pub enum CoordinationError {
 
     #[msg("Bond not yet matured")]
     BondNotMatured,
+
+    // Reputation errors (7600-7699)
+    #[msg("Agent reputation below task minimum requirement")]
+    InsufficientReputation,
+
+    #[msg("Invalid minimum reputation: must be <= 10000")]
+    InvalidMinReputation,
 }

--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -57,6 +57,7 @@ pub struct TaskCreated {
     pub reward_amount: u64,
     pub task_type: u8,
     pub deadline: i64,
+    pub min_reputation: u16,
     pub timestamp: i64,
 }
 
@@ -298,5 +299,26 @@ pub struct ProtocolFeeUpdated {
     pub old_fee_bps: u16,
     pub new_fee_bps: u16,
     pub updated_by: Pubkey,
+    pub timestamp: i64,
+}
+
+/// Reason codes for reputation changes
+pub mod reputation_reason {
+    /// Reputation increased from task completion
+    pub const COMPLETION: u8 = 0;
+    /// Reputation decreased from losing a dispute
+    pub const DISPUTE_SLASH: u8 = 1;
+    /// Reputation decreased from inactivity decay
+    pub const DECAY: u8 = 2;
+}
+
+/// Emitted when an agent's reputation changes
+#[event]
+pub struct ReputationChanged {
+    pub agent_id: [u8; 32],
+    pub old_reputation: u16,
+    pub new_reputation: u16,
+    /// Reason: 0=completion, 1=dispute_slash, 2=decay
+    pub reason: u8,
     pub timestamp: i64,
 }

--- a/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
@@ -9,7 +9,8 @@
 //! After this window, slashing can no longer be applied.
 
 use crate::errors::CoordinationError;
-use crate::instructions::constants::PERCENT_BASE;
+use crate::events::{reputation_reason, ReputationChanged};
+use crate::instructions::constants::{MIN_REPUTATION, PERCENT_BASE, REPUTATION_SLASH_LOSS};
 
 /// Window for applying slashing after dispute resolution (7 days)
 /// After this period, slashing can no longer be applied (fix #414)
@@ -147,6 +148,22 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
         slash_amount > 0,
         CoordinationError::InvalidSlashAmount
     );
+
+    // Apply reputation penalty for losing the dispute (before lamport transfer to satisfy borrow checker)
+    let old_rep = worker_agent.reputation;
+    worker_agent.reputation = worker_agent
+        .reputation
+        .saturating_sub(REPUTATION_SLASH_LOSS)
+        .max(MIN_REPUTATION);
+    if worker_agent.reputation != old_rep {
+        emit!(ReputationChanged {
+            agent_id: worker_agent.agent_id,
+            old_reputation: old_rep,
+            new_reputation: worker_agent.reputation,
+            reason: reputation_reason::DISPUTE_SLASH,
+            timestamp: clock.unix_timestamp,
+        });
+    }
 
     if slash_amount > 0 {
         worker_agent.stake = worker_agent

--- a/programs/agenc-coordination/src/instructions/constants.rs
+++ b/programs/agenc-coordination/src/instructions/constants.rs
@@ -20,3 +20,22 @@ pub const MAX_REPUTATION: u16 = 10000;
 
 /// 24-hour window in seconds (86400)
 pub const WINDOW_24H: i64 = 86400;
+
+// ============================================================================
+// Reputation System Constants
+// ============================================================================
+
+/// Minimum possible reputation score
+pub const MIN_REPUTATION: u16 = 0;
+
+/// Reputation points lost when losing a dispute (worker or initiator)
+pub const REPUTATION_SLASH_LOSS: u16 = 300;
+
+/// Reputation points decayed per inactive period
+pub const REPUTATION_DECAY_RATE: u16 = 50;
+
+/// Duration of one decay period in seconds (30 days)
+pub const REPUTATION_DECAY_PERIOD: i64 = 2_592_000;
+
+/// Minimum reputation score after decay (floor)
+pub const REPUTATION_DECAY_MIN: u16 = 1000;

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -82,8 +82,9 @@ pub fn handler(
     task_type: u8,
     constraint_hash: Option<[u8; 32]>,
     dependency_type: u8,
+    min_reputation: u16,
 ) -> Result<()> {
-    validate_task_params(&task_id, &description, required_capabilities, max_workers, task_type)?;
+    validate_task_params(&task_id, &description, required_capabilities, max_workers, task_type, min_reputation)?;
     // Validate parent task belongs to same creator (#520)
     require!(
         ctx.accounts.parent_task.creator == ctx.accounts.creator.key(),
@@ -143,6 +144,7 @@ pub fn handler(
         ctx.bumps.task,
         config.protocol_fee_bps,
         clock.unix_timestamp,
+        min_reputation,
     )?;
 
     // Override dependency fields (defaults are None from init_task_fields)

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -77,8 +77,9 @@ pub fn handler(
     deadline: i64,
     task_type: u8,
     constraint_hash: Option<[u8; 32]>,
+    min_reputation: u16,
 ) -> Result<()> {
-    validate_task_params(&task_id, &description, required_capabilities, max_workers, task_type)?;
+    validate_task_params(&task_id, &description, required_capabilities, max_workers, task_type, min_reputation)?;
     // Validate reward is not zero (#540) - not in shared validator since dependent tasks allow zero
     require!(reward_amount > 0, CoordinationError::InvalidReward);
 
@@ -128,6 +129,7 @@ pub fn handler(
         ctx.bumps.task,
         config.protocol_fee_bps,
         clock.unix_timestamp,
+        min_reputation,
     )?;
 
     // Initialize escrow
@@ -145,6 +147,7 @@ pub fn handler(
         reward_amount,
         task_type,
         deadline,
+        min_reputation,
         timestamp: clock.unix_timestamp,
     });
 

--- a/programs/agenc-coordination/src/instructions/task_init_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/task_init_helpers.rs
@@ -1,6 +1,7 @@
 //! Shared helpers for task initialization (create_task + create_dependent_task)
 
 use crate::errors::CoordinationError;
+use crate::instructions::constants::MAX_REPUTATION;
 use crate::state::{DependencyType, ProtocolConfig, Task, TaskEscrow, TaskStatus, TaskType};
 use anchor_lang::prelude::*;
 
@@ -13,6 +14,7 @@ pub fn validate_task_params(
     required_capabilities: u64,
     max_workers: u8,
     task_type: u8,
+    min_reputation: u16,
 ) -> Result<()> {
     // Validate task_id is not zero (#367)
     require!(*task_id != [0u8; 32], CoordinationError::InvalidTaskId);
@@ -32,6 +34,10 @@ pub fn validate_task_params(
         CoordinationError::InvalidMaxWorkers
     );
     require!(task_type <= 2, CoordinationError::InvalidTaskType);
+    require!(
+        min_reputation <= MAX_REPUTATION,
+        CoordinationError::InvalidMinReputation
+    );
 
     Ok(())
 }
@@ -53,6 +59,7 @@ pub fn init_task_fields(
     bump: u8,
     protocol_fee_bps: u16,
     timestamp: i64,
+    min_reputation: u16,
 ) -> Result<()> {
     task.task_id = task_id;
     task.creator = creator;
@@ -80,6 +87,7 @@ pub fn init_task_fields(
     task.protocol_fee_bps = protocol_fee_bps;
     task.dependency_type = DependencyType::None;
     task.depends_on = None;
+    task.min_reputation = min_reputation;
 
     Ok(())
 }

--- a/programs/agenc-coordination/src/instructions/vote_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/vote_dispute.rs
@@ -139,7 +139,15 @@ pub fn handler(ctx: Context<VoteDispute>, approve: bool) -> Result<()> {
     let max_vote_weight = config
         .min_arbiter_stake
         .saturating_mul(10);
-    let vote_weight = arbiter.stake.min(max_vote_weight);
+    let stake_weight = arbiter.stake.min(max_vote_weight);
+    // Apply reputation multiplier: rep/10000 scales weight 0-100%
+    let vote_weight = (stake_weight as u128)
+        .checked_mul(arbiter.reputation as u128)
+        .ok_or(CoordinationError::ArithmeticOverflow)?
+        .checked_div(crate::instructions::constants::MAX_REPUTATION as u128)
+        .ok_or(CoordinationError::ArithmeticOverflow)? as u64;
+    // Ensure minimum weight of 1 if arbiter has any stake
+    let vote_weight = if stake_weight > 0 { vote_weight.max(1) } else { 0 };
 
     // Record vote
     vote.dispute = dispute.key();

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -97,6 +97,7 @@ pub mod agenc_coordination {
         deadline: i64,
         task_type: u8,
         constraint_hash: Option<[u8; 32]>,
+        min_reputation: u16,
     ) -> Result<()> {
         instructions::create_task::handler(
             ctx,
@@ -108,6 +109,7 @@ pub mod agenc_coordination {
             deadline,
             task_type,
             constraint_hash,
+            min_reputation,
         )
     }
 
@@ -137,6 +139,7 @@ pub mod agenc_coordination {
         task_type: u8,
         constraint_hash: Option<[u8; 32]>,
         dependency_type: u8,
+        min_reputation: u16,
     ) -> Result<()> {
         instructions::create_dependent_task::handler(
             ctx,
@@ -149,6 +152,7 @@ pub mod agenc_coordination {
             task_type,
             constraint_hash,
             dependency_type,
+            min_reputation,
         )
     }
 

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -518,8 +518,11 @@ pub struct Task {
     pub depends_on: Option<Pubkey>,
     /// Type of dependency relationship
     pub dependency_type: DependencyType,
+    /// Minimum reputation score (0-10000) required for workers to claim this task.
+    /// 0 means no reputation gate (default for backward compatibility).
+    pub min_reputation: u16,
     /// Reserved
-    pub _reserved: [u8; 32],
+    pub _reserved: [u8; 30],
 }
 
 impl Default for Task {
@@ -546,7 +549,8 @@ impl Default for Task {
             protocol_fee_bps: 0,
             depends_on: None,
             dependency_type: DependencyType::default(),
-            _reserved: [0u8; 32],
+            min_reputation: 0,
+            _reserved: [0u8; 30],
         }
     }
 }
@@ -576,7 +580,8 @@ impl Task {
         2 +  // protocol_fee_bps
         33 + // depends_on (Option<Pubkey>: 1 byte discriminator + 32 bytes pubkey)
         1 +  // dependency_type
-        32; // reserved
+        2 +  // min_reputation
+        30; // reserved
 }
 
 /// Worker's claim on a task

--- a/tests/audit-high-severity.ts
+++ b/tests/audit-high-severity.ts
@@ -236,7 +236,8 @@ describe("audit-high-severity", () => {
           1,
           new BN(0),
           TASK_TYPE_COMPETITIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           creatorAgent: nonAgentPda,
@@ -268,7 +269,8 @@ describe("audit-high-severity", () => {
         3,
         new BN(0),
         TASK_TYPE_COLLABORATIVE,
-        null  // constraint_hash
+        null,  // constraint_hash
+        0, // min_reputation
       )
       .accountsPartial({
         creatorAgent: creatorAgentPda,
@@ -396,7 +398,8 @@ describe("audit-high-severity", () => {
         1,
         new BN(0),
         TASK_TYPE_COMPETITIVE,
-        null  // constraint_hash
+        null,  // constraint_hash
+        0, // min_reputation
       )
       .accountsPartial({
         creatorAgent: creatorAgentPda,
@@ -503,7 +506,8 @@ describe("audit-high-severity", () => {
         2,
         new BN(0),
         TASK_TYPE_COMPETITIVE,
-        null  // constraint_hash
+        null,  // constraint_hash
+        0, // min_reputation
       )
       .accountsPartial({
         creatorAgent: creatorAgentPda,
@@ -598,7 +602,8 @@ describe("audit-high-severity", () => {
         1,
         new BN(0),
         TASK_TYPE_COMPETITIVE,
-        null  // constraint_hash
+        null,  // constraint_hash
+        0, // min_reputation
       )
       .accountsPartial({
         creatorAgent: creatorAgentPda,
@@ -812,7 +817,8 @@ describe("audit-high-severity", () => {
         1,
         new BN(0),
         TASK_TYPE_COMPETITIVE,
-        null
+        null,
+        0, // min_reputation
       )
       .accountsPartial({
         creatorAgent: creatorAgentPda,

--- a/tests/complete_task_private.ts
+++ b/tests/complete_task_private.ts
@@ -232,7 +232,8 @@ describe("complete_task_private", () => {
           1, // max_workers
           new BN(0), // deadline (no deadline)
           TASK_TYPE_EXCLUSIVE,
-          Array.from(privateConstraintHash) // constraint_hash (non-zero = private task)
+          Array.from(privateConstraintHash), // constraint_hash (non-zero = private task)
+          0, // min_reputation
         )
         .accountsPartial({
           task: privateTaskPda,
@@ -370,7 +371,8 @@ describe("complete_task_private", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          Array.from(Buffer.alloc(HASH_SIZE, 0)) // All zeros = PUBLIC task
+          Array.from(Buffer.alloc(HASH_SIZE, 0)), // All zeros = PUBLIC task
+          0, // min_reputation
         )
         .accountsPartial({
           task: publicTaskPda,
@@ -450,7 +452,8 @@ describe("complete_task_private", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          Array.from(constraintHash)
+          Array.from(constraintHash),
+          0, // min_reputation
         )
         .accountsPartial({
           task: cancelledTaskPda,

--- a/tests/coordination-security.ts
+++ b/tests/coordination-security.ts
@@ -412,7 +412,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -456,7 +457,8 @@ describe("coordination-security", () => {
             3,
             new BN(0),
             TASK_TYPE_COLLABORATIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -491,7 +493,8 @@ describe("coordination-security", () => {
             5,
             new BN(0),
             TASK_TYPE_COMPETITIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -626,7 +629,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -703,7 +707,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -908,7 +913,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -963,7 +969,8 @@ describe("coordination-security", () => {
             2,
             new BN(0),
             TASK_TYPE_COLLABORATIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1027,7 +1034,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1112,7 +1120,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1179,7 +1188,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1241,7 +1251,8 @@ describe("coordination-security", () => {
             1,
             new BN(pastDeadline),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1297,7 +1308,8 @@ describe("coordination-security", () => {
             1,
             new BN(nearFutureDeadline),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1367,7 +1379,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1498,7 +1511,8 @@ describe("coordination-security", () => {
             2,
             new BN(0),
             TASK_TYPE_COLLABORATIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1615,7 +1629,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1689,7 +1704,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1765,7 +1781,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -1931,7 +1948,8 @@ describe("coordination-security", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,

--- a/tests/dispute-slash-logic.ts
+++ b/tests/dispute-slash-logic.ts
@@ -261,7 +261,8 @@ describe("dispute-slash-logic (issue #136)", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           creatorAgent: creatorAgentPda,
@@ -355,7 +356,8 @@ describe("dispute-slash-logic (issue #136)", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           creatorAgent: creatorAgentPda,

--- a/tests/integration.ts
+++ b/tests/integration.ts
@@ -351,7 +351,8 @@ describe("AgenC Integration Tests", () => {
             1,                                    // max_workers: u8
             new BN(Math.floor(Date.now() / 1000) + 86400), // deadline: i64 (must be > 0 and in future)
             TASK_TYPE_EXCLUSIVE,                  // task_type: u8
-            null                                  // constraint_hash: Option<[u8; 32]>
+            null,                                  // constraint_hash: Option<[u8; 32]>
+            0, // min_reputation
           )
           .accountsPartial({
             // task: auto-resolved from taskId arg + creator account
@@ -411,7 +412,8 @@ describe("AgenC Integration Tests", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -533,7 +535,8 @@ describe("AgenC Integration Tests", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,
@@ -715,7 +718,8 @@ describe("AgenC Integration Tests", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,

--- a/tests/rate-limiting.ts
+++ b/tests/rate-limiting.ts
@@ -122,7 +122,8 @@ describe("rate-limiting", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -191,7 +192,8 @@ describe("rate-limiting", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -265,7 +267,8 @@ describe("rate-limiting", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -452,7 +455,8 @@ describe("rate-limiting", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -599,7 +603,8 @@ describe("rate-limiting", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda1,
@@ -642,7 +647,8 @@ describe("rate-limiting", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda2,

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -450,7 +450,8 @@ describe("AgenC Devnet Smoke Tests", () => {
           1, // max_workers
           deadline,
           TASK_TYPE_EXCLUSIVE,
-          null // constraint_hash
+          null, // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           creatorAgent: creatorAgentPda,
@@ -701,7 +702,8 @@ describe("AgenC Devnet Smoke Tests", () => {
           1,
           new BN(Math.floor(Date.now() / 1000) + 86400),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           creatorAgent: creatorAgentPda,

--- a/tests/sybil-attack.ts
+++ b/tests/sybil-attack.ts
@@ -182,7 +182,8 @@ describe("sybil-attack", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           creatorAgent: creatorAgentPda,
@@ -485,7 +486,8 @@ describe("sybil-attack", () => {
             1,
             new BN(0),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             creatorAgent: creatorAgentPda,

--- a/tests/test_1.ts
+++ b/tests/test_1.ts
@@ -381,7 +381,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -415,7 +416,8 @@ describe("test_1", () => {
           3,
           getDefaultDeadline(),
           TASK_TYPE_COLLABORATIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -449,7 +451,8 @@ describe("test_1", () => {
           5,
           getDefaultDeadline(),
           TASK_TYPE_COMPETITIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -485,7 +488,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -524,7 +528,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null  // constraint_hash
+            null,  // constraint_hash
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -562,7 +567,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -598,7 +604,8 @@ describe("test_1", () => {
             0,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -636,7 +643,8 @@ describe("test_1", () => {
             1,
             new BN(pastDeadline),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -672,7 +680,8 @@ describe("test_1", () => {
             1,
             new BN(0),
             99,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -710,7 +719,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -758,7 +768,8 @@ describe("test_1", () => {
           3,
           getDefaultDeadline(),
           TASK_TYPE_COLLABORATIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -818,7 +829,8 @@ describe("test_1", () => {
           3,
           getDefaultDeadline(),
           TASK_TYPE_COLLABORATIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -894,7 +906,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -955,7 +968,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1009,7 +1023,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1061,7 +1076,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1140,7 +1156,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1205,7 +1222,8 @@ describe("test_1", () => {
             1,
             new BN(pastDeadline),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -1243,7 +1261,8 @@ describe("test_1", () => {
           2,
           getDefaultDeadline(),
           TASK_TYPE_COLLABORATIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1319,7 +1338,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1376,7 +1396,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1455,7 +1476,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1518,7 +1540,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1567,7 +1590,8 @@ describe("test_1", () => {
           3,
           getDefaultDeadline(),
           TASK_TYPE_COLLABORATIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1644,7 +1668,8 @@ describe("test_1", () => {
           2,
           getDefaultDeadline(),
           TASK_TYPE_COLLABORATIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1708,7 +1733,8 @@ describe("test_1", () => {
           100,  // Max allowed is 100
           getDefaultDeadline(),
           TASK_TYPE_COLLABORATIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1749,7 +1775,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1831,7 +1858,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -1929,7 +1957,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -1981,7 +2010,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2048,7 +2078,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2105,7 +2136,8 @@ describe("test_1", () => {
             2, // max 2 workers
             new BN(shortDeadline),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2191,7 +2223,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2276,7 +2309,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2355,7 +2389,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2423,7 +2458,8 @@ describe("test_1", () => {
             2,
             getDefaultDeadline(),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2474,7 +2510,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2537,7 +2574,8 @@ describe("test_1", () => {
             2,
             getDefaultDeadline(),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2590,7 +2628,8 @@ describe("test_1", () => {
             2,
             getDefaultDeadline(),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2690,7 +2729,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2755,7 +2795,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -2947,7 +2988,8 @@ describe("test_1", () => {
               1,
               getDefaultDeadline(),
               TASK_TYPE_EXCLUSIVE,
-              null
+              null,
+              0, // min_reputation
             )
             .accountsPartial({
               task: taskPda,
@@ -2984,7 +3026,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3035,7 +3078,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3090,7 +3134,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3158,7 +3203,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3226,7 +3272,8 @@ describe("test_1", () => {
             2,
             getDefaultDeadline(),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3315,7 +3362,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3375,7 +3423,8 @@ describe("test_1", () => {
             1,
             new BN(shortDeadline),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3538,7 +3587,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3646,7 +3696,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3746,7 +3797,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3842,7 +3894,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -3936,7 +3989,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4049,7 +4103,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -4103,7 +4158,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -4166,7 +4222,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -4240,7 +4297,8 @@ describe("test_1", () => {
           1,
           getDefaultDeadline(),
           TASK_TYPE_EXCLUSIVE,
-          null
+          null,
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -4327,7 +4385,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4382,7 +4441,8 @@ describe("test_1", () => {
               1,
               getDefaultDeadline(),
               TASK_TYPE_EXCLUSIVE,
-              null
+              null,
+              0, // min_reputation
             )
             .accountsPartial({
               task: taskPda,
@@ -4421,7 +4481,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4481,6 +4542,9 @@ describe("test_1", () => {
         const treasuryBalanceAfter = await provider.connection.getBalance(treasuryPubkey);
 
         // Calculate expected amounts
+        // Verify the on-chain fee matches expected protocol fee
+        const taskAccount = await program.account.task.fetch(taskPda);
+        expect(taskAccount.protocolFeeBps).to.equal(PROTOCOL_FEE_BPS, "Task protocol_fee_bps should match protocol config");
         const protocolFee = Math.floor((rewardAmount * PROTOCOL_FEE_BPS) / 10000);
         const workerReward = rewardAmount - protocolFee;
 
@@ -4519,7 +4583,8 @@ describe("test_1", () => {
             3, // 3 workers required
             getDefaultDeadline(),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4627,7 +4692,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4699,7 +4765,8 @@ describe("test_1", () => {
             2,
             new BN(shortDeadline),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4774,7 +4841,8 @@ describe("test_1", () => {
             2,
             getDefaultDeadline(),
             TASK_TYPE_COLLABORATIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4855,7 +4923,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4924,7 +4993,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -4986,7 +5056,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5054,7 +5125,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5144,7 +5216,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5218,7 +5291,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5303,7 +5377,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5366,7 +5441,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId0), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Resolution type 0".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda0, escrow: escrowPda0, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -5416,7 +5492,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5482,7 +5559,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5561,7 +5639,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5636,7 +5715,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5774,7 +5854,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5843,7 +5924,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -5916,7 +5998,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -6017,7 +6100,8 @@ describe("test_1", () => {
             1,
             getDefaultDeadline(),
             TASK_TYPE_EXCLUSIVE,
-            null
+            null,
+            0, // min_reputation
           )
           .accountsPartial({
             task: taskPda,
@@ -6093,7 +6177,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Voting capability test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6175,7 +6260,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Stake test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6239,7 +6325,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Deadline vote test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6315,7 +6402,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Double vote test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6405,7 +6493,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Vote count test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6448,7 +6537,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Inactive voter test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6547,7 +6637,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Early resolve test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6598,7 +6689,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Zero votes test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6641,7 +6733,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Status change test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6733,7 +6826,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Reputation increment test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6919,7 +7013,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Stats increment test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -6981,7 +7076,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Earnings test".padEnd(64, "\0")),
-          new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7043,7 +7139,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Active tasks test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7088,7 +7185,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Multi-claim test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7133,7 +7231,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Overflow claim test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7182,7 +7281,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("PDA uniqueness test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7227,7 +7327,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("First wins test".padEnd(64, "\0")),
-          new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7273,7 +7374,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("All completions test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7341,7 +7443,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Worker count test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7399,7 +7502,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Completion count test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7514,7 +7618,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId1), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Track test 1".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda1, escrow: escrowPda1, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7539,7 +7644,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId2), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Track test 2".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda2, escrow: escrowPda2, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7595,7 +7701,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Max workers test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 100, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 100, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7616,7 +7723,8 @@ describe("test_1", () => {
           await program.methods.createTask(
             Array.from(taskId), new BN(CAPABILITY_COMPUTE),
             Buffer.from("Zero workers test".padEnd(64, "\0")),
-            new BN(LAMPORTS_PER_SOL / 100), 0, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+            new BN(LAMPORTS_PER_SOL / 100), 0, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+            0, // min_reputation
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
@@ -7638,7 +7746,8 @@ describe("test_1", () => {
           await program.methods.createTask(
             Array.from(taskId), new BN(CAPABILITY_COMPUTE),
             Buffer.from("Zero reward test".padEnd(64, "\0")),
-            new BN(0), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+            new BN(0), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+            0, // min_reputation
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
@@ -7662,7 +7771,8 @@ describe("test_1", () => {
             Array.from(taskId), new BN(CAPABILITY_COMPUTE),
             Buffer.from("Huge reward test".padEnd(64, "\0")),
             new BN("18446744073709551615"), // u64::MAX
-            1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+            1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+            0, // min_reputation
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
@@ -7686,7 +7796,8 @@ describe("test_1", () => {
           await program.methods.createTask(
             Array.from(taskId), new BN(CAPABILITY_COMPUTE),
             Buffer.from("No deadline test".padEnd(64, "\0")),
-            new BN(LAMPORTS_PER_SOL), 1, new BN(0), TASK_TYPE_EXCLUSIVE, null
+            new BN(LAMPORTS_PER_SOL), 1, new BN(0), TASK_TYPE_EXCLUSIVE, null,
+            0, // min_reputation
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
@@ -7712,7 +7823,8 @@ describe("test_1", () => {
           await program.methods.createTask(
             Array.from(taskId), new BN(CAPABILITY_COMPUTE),
             Buffer.from("Past deadline test".padEnd(64, "\0")),
-            new BN(0), 1, new BN(pastDeadline), TASK_TYPE_EXCLUSIVE, null
+            new BN(0), 1, new BN(pastDeadline), TASK_TYPE_EXCLUSIVE, null,
+            0, // min_reputation
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
@@ -7736,7 +7848,8 @@ describe("test_1", () => {
           await program.methods.createTask(
             Array.from(taskId), new BN(CAPABILITY_COMPUTE),
             Buffer.from("Invalid type test".padEnd(64, "\0")),
-            new BN(0), 1, new BN(0), 3, null // Invalid: only 0, 1, 2 are valid
+            new BN(0), 1, new BN(0), 3, null, // Invalid: only 0, 1, 2 are valid
+            0, // min_reputation
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
@@ -7900,7 +8013,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Invariant test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7936,7 +8050,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Completion invariant".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null
+          new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -7986,7 +8101,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Escrow invariant".padEnd(64, "\0")),
-          new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -8051,7 +8167,8 @@ describe("test_1", () => {
           await program.methods.createTask(
             Array.from(taskId), new BN(CAPABILITY_COMPUTE),
             Buffer.from(`Busy task ${i}`.padEnd(64, "\0")),
-            new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+            new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+            0, // min_reputation
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
@@ -8078,7 +8195,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId11), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Busy task 10".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda11, escrow: escrowPda11, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -8119,7 +8237,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(taskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Stats increase test".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -8189,7 +8308,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(sharedTaskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Shared ID test 1".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda1, escrow: escrowPda1, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
@@ -8204,7 +8324,8 @@ describe("test_1", () => {
         await program.methods.createTask(
           Array.from(sharedTaskId), new BN(CAPABILITY_COMPUTE),
           Buffer.from("Shared ID test 2".padEnd(64, "\0")),
-          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null
+          new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
+          0, // min_reputation
         ).accountsPartial({
           task: taskPda2, escrow: escrowPda2, protocolConfig: protocolPda,
           creatorAgent: deriveAgentPda(agentId1),
@@ -8266,6 +8387,232 @@ describe("test_1", () => {
         } catch (e: any) {
           expect(e.message).to.include("already in use");
         }
+      });
+    });
+  });
+
+  describe("Reputation System", () => {
+    describe("Reputation gate on claim_task", () => {
+      it("rejects claim when worker reputation is below task min_reputation", async () => {
+        const { wallet: w, agentId: wId, agentPda: wPda } = await createFreshWorker(CAPABILITY_COMPUTE);
+
+        // Create task with min_reputation = 6000 (default agent rep is 5000)
+        const taskId = makeAgentId(`rep-gate`);
+        const taskPda = deriveTaskPda(creator.publicKey, taskId);
+        const escrowPda = deriveEscrowPda(taskPda);
+
+        await program.methods
+          .createTask(
+            Array.from(taskId),
+            new BN(CAPABILITY_COMPUTE),
+            Buffer.from("Reputation gated task".padEnd(64, "\0")),
+            new BN(LAMPORTS_PER_SOL / 100),
+            1,
+            getDefaultDeadline(),
+            TASK_TYPE_EXCLUSIVE,
+            null,  // constraint_hash
+            6000,  // min_reputation (worker has 5000)
+          )
+          .accountsPartial({
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            creatorAgent: creatorAgentPda,
+            authority: creator.publicKey,
+            creator: creator.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([creator])
+          .rpc();
+
+        const claimPda = deriveClaimPda(taskPda, wPda);
+        try {
+          await program.methods
+            .claimTask()
+            .accountsPartial({
+              task: taskPda,
+              claim: claimPda,
+              protocolConfig: protocolPda,
+              worker: wPda,
+              authority: w.publicKey,
+              systemProgram: SystemProgram.programId,
+            })
+            .signers([w])
+            .rpc();
+          expect.fail("Should have failed with InsufficientReputation");
+        } catch (e: any) {
+          expect(e.message).to.include("InsufficientReputation");
+        }
+      });
+
+      it("allows claim when worker reputation meets task min_reputation", async () => {
+        const { wallet: w, agentId: wId, agentPda: wPda } = await createFreshWorker(CAPABILITY_COMPUTE);
+
+        // Create task with min_reputation = 5000 (default agent rep is 5000)
+        const taskId = makeAgentId(`rep-ok`);
+        const taskPda = deriveTaskPda(creator.publicKey, taskId);
+        const escrowPda = deriveEscrowPda(taskPda);
+
+        await program.methods
+          .createTask(
+            Array.from(taskId),
+            new BN(CAPABILITY_COMPUTE),
+            Buffer.from("Reputation ok task".padEnd(64, "\0")),
+            new BN(LAMPORTS_PER_SOL / 100),
+            1,
+            getDefaultDeadline(),
+            TASK_TYPE_EXCLUSIVE,
+            null,  // constraint_hash
+            5000,  // min_reputation (worker has exactly 5000)
+          )
+          .accountsPartial({
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            creatorAgent: creatorAgentPda,
+            authority: creator.publicKey,
+            creator: creator.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([creator])
+          .rpc();
+
+        const claimPda = deriveClaimPda(taskPda, wPda);
+        await program.methods
+          .claimTask()
+          .accountsPartial({
+            task: taskPda,
+            claim: claimPda,
+            protocolConfig: protocolPda,
+            worker: wPda,
+            authority: w.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([w])
+          .rpc();
+
+        // Verify claim succeeded
+        const taskAccount = await program.account.task.fetch(taskPda);
+        expect(taskAccount.currentWorkers).to.equal(1);
+      });
+
+      it("allows claim when min_reputation is 0 (no gate)", async () => {
+        const { wallet: w, agentId: wId, agentPda: wPda } = await createFreshWorker(CAPABILITY_COMPUTE);
+
+        const taskId = makeAgentId(`rep-0`);
+        const taskPda = deriveTaskPda(creator.publicKey, taskId);
+        const escrowPda = deriveEscrowPda(taskPda);
+
+        await program.methods
+          .createTask(
+            Array.from(taskId),
+            new BN(CAPABILITY_COMPUTE),
+            Buffer.from("No reputation gate".padEnd(64, "\0")),
+            new BN(LAMPORTS_PER_SOL / 100),
+            1,
+            getDefaultDeadline(),
+            TASK_TYPE_EXCLUSIVE,
+            null,  // constraint_hash
+            0,  // min_reputation (no gate)
+          )
+          .accountsPartial({
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            creatorAgent: creatorAgentPda,
+            authority: creator.publicKey,
+            creator: creator.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([creator])
+          .rpc();
+
+        const claimPda = deriveClaimPda(taskPda, wPda);
+        await program.methods
+          .claimTask()
+          .accountsPartial({
+            task: taskPda,
+            claim: claimPda,
+            protocolConfig: protocolPda,
+            worker: wPda,
+            authority: w.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([w])
+          .rpc();
+
+        const taskAccount = await program.account.task.fetch(taskPda);
+        expect(taskAccount.currentWorkers).to.equal(1);
+      });
+    });
+
+    describe("Task creation validation", () => {
+      it("rejects min_reputation > 10000 (InvalidMinReputation)", async () => {
+        const taskId = makeAgentId(`rep-inv`);
+        const taskPda = deriveTaskPda(creator.publicKey, taskId);
+        const escrowPda = deriveEscrowPda(taskPda);
+
+        try {
+          await program.methods
+            .createTask(
+              Array.from(taskId),
+              new BN(CAPABILITY_COMPUTE),
+              Buffer.from("Invalid rep task".padEnd(64, "\0")),
+              new BN(LAMPORTS_PER_SOL / 100),
+              1,
+              getDefaultDeadline(),
+              TASK_TYPE_EXCLUSIVE,
+              null,  // constraint_hash
+              10001,  // min_reputation > MAX_REPUTATION
+            )
+            .accountsPartial({
+              task: taskPda,
+              escrow: escrowPda,
+              protocolConfig: protocolPda,
+              creatorAgent: creatorAgentPda,
+              authority: creator.publicKey,
+              creator: creator.publicKey,
+              systemProgram: SystemProgram.programId,
+            })
+            .signers([creator])
+            .rpc();
+          expect.fail("Should have failed with InvalidMinReputation");
+        } catch (e: any) {
+          expect(e.message).to.include("InvalidMinReputation");
+        }
+      });
+
+      it("stores min_reputation on task account", async () => {
+        const taskId = makeAgentId(`rep-str`);
+        const taskPda = deriveTaskPda(creator.publicKey, taskId);
+        const escrowPda = deriveEscrowPda(taskPda);
+
+        await program.methods
+          .createTask(
+            Array.from(taskId),
+            new BN(CAPABILITY_COMPUTE),
+            Buffer.from("Stored rep task".padEnd(64, "\0")),
+            new BN(LAMPORTS_PER_SOL / 100),
+            1,
+            getDefaultDeadline(),
+            TASK_TYPE_EXCLUSIVE,
+            null,  // constraint_hash
+            7500,  // min_reputation
+          )
+          .accountsPartial({
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            creatorAgent: creatorAgentPda,
+            authority: creator.publicKey,
+            creator: creator.publicKey,
+            systemProgram: SystemProgram.programId,
+          })
+          .signers([creator])
+          .rpc();
+
+        const taskAccount = await program.account.task.fetch(taskPda);
+        expect(taskAccount.minReputation).to.equal(7500);
       });
     });
   });

--- a/tests/test_cu_benchmarks.ts
+++ b/tests/test_cu_benchmarks.ts
@@ -233,7 +233,8 @@ describe("CU Benchmarks", () => {
         1,
         new BN(deadline),
         0, // Exclusive
-        null // No constraint hash
+        null, // No constraint hash
+        0, // min_reputation
       )
       .accountsPartial({
         task: taskPda,

--- a/tests/upgrades.ts
+++ b/tests/upgrades.ts
@@ -224,7 +224,8 @@ describe("upgrades", () => {
           1,
           new BN(0),
           0,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,
@@ -320,7 +321,8 @@ describe("upgrades", () => {
           1,
           new BN(0),
           0,
-          null  // constraint_hash
+          null,  // constraint_hash
+          0, // min_reputation
         )
         .accountsPartial({
           task: taskPda,

--- a/tests/zk-proof-lifecycle.ts
+++ b/tests/zk-proof-lifecycle.ts
@@ -138,7 +138,8 @@ describe("ZK Proof Verification Lifecycle", () => {
         maxWorkers,
         new BN(0),
         taskType,
-        Array.from(constraintHash)
+        Array.from(constraintHash),
+        0, // min_reputation
       )
       .accountsPartial({
         task: taskPda,
@@ -410,7 +411,8 @@ describe("ZK Proof Verification Lifecycle", () => {
           1,
           new BN(0),
           TASK_TYPE_EXCLUSIVE,
-          Array.from(Buffer.alloc(HASH_SIZE, 0)) // Zero = public
+          Array.from(Buffer.alloc(HASH_SIZE, 0)), // Zero = public
+          0, // min_reputation
         )
         .accountsPartial({
           task: publicTaskPda,


### PR DESCRIPTION
## Summary

- **Claim gating**: Tasks can set `min_reputation` requirement; agents below threshold are rejected
- **Vote weighting**: Dispute votes scaled by arbiter reputation (`weight = stake * rep / 10000`)
- **Fee discounts**: Workers with rep >= 8000 get 5-15 bps protocol fee reduction at completion
- **Dispute slashing**: Both workers and initiators lose 300 reputation on lost disputes
- **Inactivity decay**: 50 rep/30 days passive decay (floor 1000), applied at claim time
- **Events**: `ReputationChanged` emitted for all reputation modifications (completion, slash, decay)

Uses existing `reputation` field (u16, 0-10000, init 5000). Repurposes 2 of 32 `_reserved` bytes in Task for `min_reputation` — no account size change, backward compatible (existing tasks read 0 = no gate).

28 files changed (16 Rust, 12 test files), 818 insertions, 191 deletions. All 146 tests passing (5 new).

## Test plan

- [x] All 141 existing tests pass with `min_reputation: 0` backward compat
- [x] New test: rejects claim when worker rep < min_reputation
- [x] New test: allows claim when worker rep >= min_reputation
- [x] New test: allows claim when min_reputation is 0
- [x] New test: rejects min_reputation > 10000
- [x] New test: stores min_reputation on task account