### PR TITLE
refactor: tech debt cleanup across Rust, SDK, runtime, and tests

### DIFF
--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -22,6 +22,7 @@
 pub mod completion_helpers;
 pub mod constants;
 pub mod rate_limit_helpers;
+pub mod slash_helpers;
 pub mod task_init_helpers;
 pub mod validation;
 

--- a/programs/agenc-coordination/src/instructions/slash_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/slash_helpers.rs
@@ -1,0 +1,89 @@
+//! Shared helper functions for dispute slashing.
+//!
+//! Extracts common logic between `apply_dispute_slash` and `apply_initiator_slash`
+//! to reduce duplication while keeping each handler self-contained for its
+//! specific preconditions.
+
+use crate::errors::CoordinationError;
+use crate::events::{reputation_reason, ReputationChanged};
+use crate::instructions::constants::{MIN_REPUTATION, PERCENT_BASE, REPUTATION_SLASH_LOSS};
+use crate::state::AgentRegistration;
+use anchor_lang::prelude::*;
+
+/// Window for applying slashing after dispute resolution (7 days).
+/// After this period, slashing can no longer be applied (fix #414).
+pub const SLASH_WINDOW: i64 = 7 * 24 * 60 * 60;
+
+/// Validates that the slash window has not expired since dispute resolution.
+pub fn validate_slash_window(resolved_at: i64, clock: &Clock) -> Result<()> {
+    require!(
+        clock.unix_timestamp <= resolved_at.saturating_add(SLASH_WINDOW),
+        CoordinationError::SlashWindowExpired
+    );
+    Ok(())
+}
+
+/// Calculates the approval percentage from dispute votes.
+///
+/// Returns `(total_votes, approval_pct)`.
+/// Errors if total_votes is 0 or on arithmetic overflow.
+pub fn calculate_approval_percentage(
+    votes_for: u64,
+    votes_against: u64,
+) -> Result<(u64, u64)> {
+    let total_votes = votes_for
+        .checked_add(votes_against)
+        .ok_or(CoordinationError::ArithmeticOverflow)?;
+    require!(total_votes > 0, CoordinationError::InsufficientVotes);
+
+    let approval_pct = votes_for
+        .checked_mul(PERCENT_BASE)
+        .ok_or(CoordinationError::ArithmeticOverflow)?
+        .checked_div(total_votes)
+        .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+    Ok((total_votes, approval_pct))
+}
+
+/// Applies a reputation penalty to an agent for losing a dispute.
+/// Emits a `ReputationChanged` event if the reputation actually changed.
+pub fn apply_reputation_penalty(agent: &mut AgentRegistration, clock: &Clock) -> Result<()> {
+    let old_rep = agent.reputation;
+    agent.reputation = agent
+        .reputation
+        .saturating_sub(REPUTATION_SLASH_LOSS)
+        .max(MIN_REPUTATION);
+    if agent.reputation != old_rep {
+        emit!(ReputationChanged {
+            agent_id: agent.agent_id,
+            old_reputation: old_rep,
+            new_reputation: agent.reputation,
+            reason: reputation_reason::DISPUTE_SLASH,
+            timestamp: clock.unix_timestamp,
+        });
+    }
+    Ok(())
+}
+
+/// Transfers slashed lamports from an agent account to the treasury.
+///
+/// Only handles the raw lamport transfer. The caller is responsible for
+/// updating `agent.stake` on the deserialized Account before calling this.
+pub fn transfer_slash_to_treasury(
+    agent_info: &AccountInfo,
+    treasury_info: &AccountInfo,
+    slash_amount: u64,
+) -> Result<()> {
+    if slash_amount > 0 {
+        **agent_info.try_borrow_mut_lamports()? = agent_info
+            .lamports()
+            .checked_sub(slash_amount)
+            .ok_or(CoordinationError::InsufficientFunds)?;
+
+        **treasury_info.try_borrow_mut_lamports()? = treasury_info
+            .lamports()
+            .checked_add(slash_amount)
+            .ok_or(CoordinationError::ArithmeticOverflow)?;
+    }
+    Ok(())
+}

--- a/runtime/src/events/dispute.ts
+++ b/runtime/src/events/dispute.ts
@@ -5,7 +5,6 @@
 
 import { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
-import { agentIdsEqual } from '../utils/encoding.js';
 import type {
   EventCallback,
   EventSubscription,
@@ -26,6 +25,7 @@ import {
   parseDisputeResolvedEvent,
   parseDisputeExpiredEvent,
 } from './parse.js';
+import { createEventSubscription } from './factory.js';
 
 /**
  * Subscribes to DisputeInitiated events.
@@ -40,19 +40,17 @@ export function subscribeToDisputeInitiated(
   callback: EventCallback<DisputeInitiatedEvent>,
   options?: DisputeEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'disputeInitiated',
-    (rawEvent: RawDisputeInitiatedEvent, slot: number, signature: string) => {
-      const event = parseDisputeInitiatedEvent(rawEvent);
-      if (options?.disputeId && !agentIdsEqual(event.disputeId, options.disputeId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawDisputeInitiatedEvent, DisputeInitiatedEvent, DisputeEventFilterOptions>(
+    program,
+    {
+      eventName: 'disputeInitiated',
+      parse: parseDisputeInitiatedEvent,
+      getFilterId: (event) => event.disputeId,
+      getFilterValue: (opts) => opts.disputeId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -68,19 +66,17 @@ export function subscribeToDisputeVoteCast(
   callback: EventCallback<DisputeVoteCastEvent>,
   options?: DisputeEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'disputeVoteCast',
-    (rawEvent: RawDisputeVoteCastEvent, slot: number, signature: string) => {
-      const event = parseDisputeVoteCastEvent(rawEvent);
-      if (options?.disputeId && !agentIdsEqual(event.disputeId, options.disputeId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawDisputeVoteCastEvent, DisputeVoteCastEvent, DisputeEventFilterOptions>(
+    program,
+    {
+      eventName: 'disputeVoteCast',
+      parse: parseDisputeVoteCastEvent,
+      getFilterId: (event) => event.disputeId,
+      getFilterValue: (opts) => opts.disputeId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -96,19 +92,17 @@ export function subscribeToDisputeResolved(
   callback: EventCallback<DisputeResolvedEvent>,
   options?: DisputeEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'disputeResolved',
-    (rawEvent: RawDisputeResolvedEvent, slot: number, signature: string) => {
-      const event = parseDisputeResolvedEvent(rawEvent);
-      if (options?.disputeId && !agentIdsEqual(event.disputeId, options.disputeId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawDisputeResolvedEvent, DisputeResolvedEvent, DisputeEventFilterOptions>(
+    program,
+    {
+      eventName: 'disputeResolved',
+      parse: parseDisputeResolvedEvent,
+      getFilterId: (event) => event.disputeId,
+      getFilterValue: (opts) => opts.disputeId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -124,19 +118,17 @@ export function subscribeToDisputeExpired(
   callback: EventCallback<DisputeExpiredEvent>,
   options?: DisputeEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'disputeExpired',
-    (rawEvent: RawDisputeExpiredEvent, slot: number, signature: string) => {
-      const event = parseDisputeExpiredEvent(rawEvent);
-      if (options?.disputeId && !agentIdsEqual(event.disputeId, options.disputeId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawDisputeExpiredEvent, DisputeExpiredEvent, DisputeEventFilterOptions>(
+    program,
+    {
+      eventName: 'disputeExpired',
+      parse: parseDisputeExpiredEvent,
+      getFilterId: (event) => event.disputeId,
+      getFilterValue: (opts) => opts.disputeId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**

--- a/runtime/src/events/factory.ts
+++ b/runtime/src/events/factory.ts
@@ -1,0 +1,78 @@
+/**
+ * Event subscription factory
+ *
+ * Reduces boilerplate across event subscription modules by extracting
+ * the common addEventListener → parse → filter → callback pattern.
+ *
+ * @module
+ */
+
+import { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../types/agenc_coordination.js';
+import { agentIdsEqual } from '../utils/encoding.js';
+import type { EventSubscription } from './types.js';
+
+/**
+ * Configuration for a single event subscription.
+ *
+ * @typeParam TRaw - Raw event type from Anchor
+ * @typeParam TParsed - Parsed event type
+ * @typeParam TOptions - Filter options type
+ */
+export interface EventSubscriptionConfig<TRaw, TParsed, TOptions> {
+  /** Anchor event name (camelCase) */
+  eventName: string;
+  /** Parse raw Anchor event to typed form */
+  parse: (raw: TRaw) => TParsed;
+  /** Extract the filterable ID from the parsed event (e.g., event.taskId) */
+  getFilterId?: (event: TParsed) => Uint8Array;
+  /** Extract the filter value from options (e.g., options.taskId) */
+  getFilterValue?: (options: TOptions) => Uint8Array | undefined;
+}
+
+/**
+ * Generic event callback type matching EventCallback<T> from types.ts.
+ */
+type Callback<T> = (event: T, slot: number, signature: string) => void;
+
+/**
+ * Create an event subscription using the common pattern:
+ * addEventListener → parse → filter → callback.
+ *
+ * @param program - The Anchor program instance
+ * @param config - Event subscription configuration
+ * @param callback - User callback for matching events
+ * @param options - Optional filter options
+ * @returns Subscription handle for unsubscribing
+ */
+export function createEventSubscription<TRaw, TParsed, TOptions>(
+  program: Program<AgencCoordination>,
+  config: EventSubscriptionConfig<TRaw, TParsed, TOptions>,
+  callback: Callback<TParsed>,
+  options?: TOptions,
+): EventSubscription {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- eventName is validated at call sites
+  const listenerId = program.addEventListener(
+    config.eventName as any,
+    (rawEvent: TRaw, slot: number, signature: string) => {
+      const event = config.parse(rawEvent);
+
+      // Apply filter if configured and options provided
+      if (options && config.getFilterId && config.getFilterValue) {
+        const filterValue = config.getFilterValue(options);
+        if (filterValue) {
+          const eventId = config.getFilterId(event);
+          if (!agentIdsEqual(eventId, filterValue)) return;
+        }
+      }
+
+      callback(event, slot, signature);
+    },
+  );
+
+  return {
+    unsubscribe: async () => {
+      await program.removeEventListener(listenerId);
+    },
+  };
+}

--- a/runtime/src/events/index.ts
+++ b/runtime/src/events/index.ts
@@ -101,6 +101,12 @@ export {
   subscribeToAllProtocolEvents,
 } from './protocol.js';
 
+// Event subscription factory
+export {
+  createEventSubscription,
+  type EventSubscriptionConfig,
+} from './factory.js';
+
 // EventMonitor class
 export {
   EventMonitor,

--- a/runtime/src/events/protocol.ts
+++ b/runtime/src/events/protocol.ts
@@ -5,7 +5,6 @@
 
 import { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
-import { agentIdsEqual } from '../utils/encoding.js';
 import type {
   EventCallback,
   EventSubscription,
@@ -32,6 +31,7 @@ import {
   parseMigrationCompletedEvent,
   parseProtocolVersionUpdatedEvent,
 } from './parse.js';
+import { createEventSubscription } from './factory.js';
 
 /**
  * Subscribes to StateUpdated events.
@@ -44,18 +44,11 @@ export function subscribeToStateUpdated(
   program: Program<AgencCoordination>,
   callback: EventCallback<StateUpdatedEvent>,
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'stateUpdated',
-    (rawEvent: RawStateUpdatedEvent, slot: number, signature: string) => {
-      const event = parseStateUpdatedEvent(rawEvent);
-      callback(event, slot, signature);
-    }
+  return createEventSubscription<RawStateUpdatedEvent, StateUpdatedEvent, never>(
+    program,
+    { eventName: 'stateUpdated', parse: parseStateUpdatedEvent },
+    callback,
   );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
-    },
-  };
 }
 
 /**
@@ -69,18 +62,11 @@ export function subscribeToProtocolInitialized(
   program: Program<AgencCoordination>,
   callback: EventCallback<ProtocolInitializedEvent>,
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'protocolInitialized',
-    (rawEvent: RawProtocolInitializedEvent, slot: number, signature: string) => {
-      const event = parseProtocolInitializedEvent(rawEvent);
-      callback(event, slot, signature);
-    }
+  return createEventSubscription<RawProtocolInitializedEvent, ProtocolInitializedEvent, never>(
+    program,
+    { eventName: 'protocolInitialized', parse: parseProtocolInitializedEvent },
+    callback,
   );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
-    },
-  };
 }
 
 /**
@@ -96,19 +82,17 @@ export function subscribeToRewardDistributed(
   callback: EventCallback<RewardDistributedEvent>,
   options?: ProtocolEventFilterOptions,
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'rewardDistributed',
-    (rawEvent: RawRewardDistributedEvent, slot: number, signature: string) => {
-      const event = parseRewardDistributedEvent(rawEvent);
-      if (options?.taskId && !agentIdsEqual(event.taskId, options.taskId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawRewardDistributedEvent, RewardDistributedEvent, ProtocolEventFilterOptions>(
+    program,
+    {
+      eventName: 'rewardDistributed',
+      parse: parseRewardDistributedEvent,
+      getFilterId: (event) => event.taskId,
+      getFilterValue: (opts) => opts.taskId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -124,19 +108,17 @@ export function subscribeToRateLimitHit(
   callback: EventCallback<RateLimitHitEvent>,
   options?: ProtocolEventFilterOptions,
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'rateLimitHit',
-    (rawEvent: RawRateLimitHitEvent, slot: number, signature: string) => {
-      const event = parseRateLimitHitEvent(rawEvent);
-      if (options?.agentId && !agentIdsEqual(event.agentId, options.agentId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawRateLimitHitEvent, RateLimitHitEvent, ProtocolEventFilterOptions>(
+    program,
+    {
+      eventName: 'rateLimitHit',
+      parse: parseRateLimitHitEvent,
+      getFilterId: (event) => event.agentId,
+      getFilterValue: (opts) => opts.agentId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -150,18 +132,11 @@ export function subscribeToMigrationCompleted(
   program: Program<AgencCoordination>,
   callback: EventCallback<MigrationCompletedEvent>,
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'migrationCompleted',
-    (rawEvent: RawMigrationCompletedEvent, slot: number, signature: string) => {
-      const event = parseMigrationCompletedEvent(rawEvent);
-      callback(event, slot, signature);
-    }
+  return createEventSubscription<RawMigrationCompletedEvent, MigrationCompletedEvent, never>(
+    program,
+    { eventName: 'migrationCompleted', parse: parseMigrationCompletedEvent },
+    callback,
   );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
-    },
-  };
 }
 
 /**
@@ -175,18 +150,11 @@ export function subscribeToProtocolVersionUpdated(
   program: Program<AgencCoordination>,
   callback: EventCallback<ProtocolVersionUpdatedEvent>,
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'protocolVersionUpdated',
-    (rawEvent: RawProtocolVersionUpdatedEvent, slot: number, signature: string) => {
-      const event = parseProtocolVersionUpdatedEvent(rawEvent);
-      callback(event, slot, signature);
-    }
+  return createEventSubscription<RawProtocolVersionUpdatedEvent, ProtocolVersionUpdatedEvent, never>(
+    program,
+    { eventName: 'protocolVersionUpdated', parse: parseProtocolVersionUpdatedEvent },
+    callback,
   );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
-    },
-  };
 }
 
 /**

--- a/runtime/src/events/task.ts
+++ b/runtime/src/events/task.ts
@@ -5,7 +5,6 @@
 
 import { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
-import { agentIdsEqual } from '../utils/encoding.js';
 import type {
   EventCallback,
   EventSubscription,
@@ -26,6 +25,7 @@ import {
   parseTaskCompletedEvent,
   parseTaskCancelledEvent,
 } from './parse.js';
+import { createEventSubscription } from './factory.js';
 
 /**
  * Subscribes to TaskCreated events.
@@ -40,19 +40,17 @@ export function subscribeToTaskCreated(
   callback: EventCallback<TaskCreatedEvent>,
   options?: TaskEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'taskCreated',
-    (rawEvent: RawTaskCreatedEvent, slot: number, signature: string) => {
-      const event = parseTaskCreatedEvent(rawEvent);
-      if (options?.taskId && !agentIdsEqual(event.taskId, options.taskId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawTaskCreatedEvent, TaskCreatedEvent, TaskEventFilterOptions>(
+    program,
+    {
+      eventName: 'taskCreated',
+      parse: parseTaskCreatedEvent,
+      getFilterId: (event) => event.taskId,
+      getFilterValue: (opts) => opts.taskId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -68,19 +66,17 @@ export function subscribeToTaskClaimed(
   callback: EventCallback<TaskClaimedEvent>,
   options?: TaskEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'taskClaimed',
-    (rawEvent: RawTaskClaimedEvent, slot: number, signature: string) => {
-      const event = parseTaskClaimedEvent(rawEvent);
-      if (options?.taskId && !agentIdsEqual(event.taskId, options.taskId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawTaskClaimedEvent, TaskClaimedEvent, TaskEventFilterOptions>(
+    program,
+    {
+      eventName: 'taskClaimed',
+      parse: parseTaskClaimedEvent,
+      getFilterId: (event) => event.taskId,
+      getFilterValue: (opts) => opts.taskId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -96,19 +92,17 @@ export function subscribeToTaskCompleted(
   callback: EventCallback<TaskCompletedEvent>,
   options?: TaskEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'taskCompleted',
-    (rawEvent: RawTaskCompletedEvent, slot: number, signature: string) => {
-      const event = parseTaskCompletedEvent(rawEvent);
-      if (options?.taskId && !agentIdsEqual(event.taskId, options.taskId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawTaskCompletedEvent, TaskCompletedEvent, TaskEventFilterOptions>(
+    program,
+    {
+      eventName: 'taskCompleted',
+      parse: parseTaskCompletedEvent,
+      getFilterId: (event) => event.taskId,
+      getFilterValue: (opts) => opts.taskId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**
@@ -124,19 +118,17 @@ export function subscribeToTaskCancelled(
   callback: EventCallback<TaskCancelledEvent>,
   options?: TaskEventFilterOptions
 ): EventSubscription {
-  const listenerId = program.addEventListener(
-    'taskCancelled',
-    (rawEvent: RawTaskCancelledEvent, slot: number, signature: string) => {
-      const event = parseTaskCancelledEvent(rawEvent);
-      if (options?.taskId && !agentIdsEqual(event.taskId, options.taskId)) return;
-      callback(event, slot, signature);
-    }
-  );
-  return {
-    unsubscribe: async () => {
-      await program.removeEventListener(listenerId);
+  return createEventSubscription<RawTaskCancelledEvent, TaskCancelledEvent, TaskEventFilterOptions>(
+    program,
+    {
+      eventName: 'taskCancelled',
+      parse: parseTaskCancelledEvent,
+      getFilterId: (event) => event.taskId,
+      getFilterValue: (opts) => opts.taskId,
     },
-  };
+    callback,
+    options,
+  );
 }
 
 /**

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -50,7 +50,7 @@ export const OUTPUT_FIELD_COUNT = 4;
 /** Proof size in bytes (Groth16 via groth16-solana) */
 export const PROOF_SIZE_BYTES = 256;
 
-/** Approximate verification compute units (deprecated, use RECOMMENDED_CU below) */
+/** @deprecated Use RECOMMENDED_CU_COMPLETE_TASK_PRIVATE instead */
 export const VERIFICATION_COMPUTE_UNITS = 50_000;
 
 /** Timeout for nargo execute in ms (2 minutes) */

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -103,5 +103,14 @@ export {
   DependentTask,
 } from './queries';
 
+export {
+  createLogger,
+  silentLogger,
+  setSdkLogLevel,
+  getSdkLogger,
+  Logger,
+  LogLevel,
+} from './logger';
+
 // Version info
 export const VERSION = '1.0.0';

--- a/sdk/src/logger.ts
+++ b/sdk/src/logger.ts
@@ -1,0 +1,97 @@
+/**
+ * Logger utility for @agenc/sdk
+ *
+ * Provides a lightweight, dependency-free logging system with configurable
+ * log levels and formatted output.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LOG_LEVELS: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+export interface Logger {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+  setLevel(level: LogLevel): void;
+}
+
+/**
+ * Create a logger instance with the specified minimum level
+ *
+ * @param minLevel - Minimum log level to output (default: 'info')
+ * @param prefix - Prefix for log messages (default: '[AgenC SDK]')
+ * @returns Logger instance
+ */
+export function createLogger(minLevel: LogLevel = 'info', prefix = '[AgenC SDK]'): Logger {
+  let currentLevel = LOG_LEVELS[minLevel];
+
+  const log = (level: LogLevel, message: string, ...args: unknown[]) => {
+    if (LOG_LEVELS[level] >= currentLevel) {
+      const timestamp = new Date().toISOString();
+      const levelStr = level.toUpperCase().padEnd(5);
+      const fullMessage = `${timestamp} ${levelStr} ${prefix} ${message}`;
+
+      switch (level) {
+        case 'debug':
+          console.debug(fullMessage, ...args);
+          break;
+        case 'info':
+          console.info(fullMessage, ...args);
+          break;
+        case 'warn':
+          console.warn(fullMessage, ...args);
+          break;
+        case 'error':
+          console.error(fullMessage, ...args);
+          break;
+      }
+    }
+  };
+
+  return {
+    debug: (message, ...args) => log('debug', message, ...args),
+    info: (message, ...args) => log('info', message, ...args),
+    warn: (message, ...args) => log('warn', message, ...args),
+    error: (message, ...args) => log('error', message, ...args),
+    setLevel: (level) => {
+      currentLevel = LOG_LEVELS[level];
+    },
+  };
+}
+
+/**
+ * No-op logger for silent operation
+ */
+export const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  setLevel: () => {},
+};
+
+// Module-level SDK logger singleton
+let sdkLogger: Logger = silentLogger;
+
+/**
+ * Set the global SDK log level. Creates a new logger with the specified level.
+ * Affects all standalone SDK functions that use getSdkLogger().
+ */
+export function setSdkLogLevel(level: LogLevel): void {
+  sdkLogger = createLogger(level);
+}
+
+/**
+ * Get the global SDK logger instance.
+ * Returns silentLogger by default until setSdkLogLevel() is called.
+ */
+export function getSdkLogger(): Logger {
+  return sdkLogger;
+}

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -14,6 +14,7 @@ import {
 } from '@solana/web3.js';
 import { type Program, BN } from '@coral-xyz/anchor';
 import { PROGRAM_ID, SEEDS, TaskState, U64_SIZE, DISCRIMINATOR_SIZE, PERCENT_BASE, DEFAULT_FEE_PERCENT } from './constants';
+import { getSdkLogger } from './logger';
 
 export { TaskState };
 
@@ -341,7 +342,7 @@ export async function getTask(
 
     // Validate required fields exist
     if (taskData.creator === undefined || taskData.state === undefined) {
-      console.warn('Task account data missing required fields');
+      getSdkLogger().warn('Task account data missing required fields');
       return null;
     }
 
@@ -367,7 +368,7 @@ export async function getTask(
       return null;
     }
     // Log unexpected errors for debugging while still returning null for API compatibility
-    console.warn(`getTask(${taskId}) encountered unexpected error:`, errorMessage);
+    getSdkLogger().warn(`getTask(${taskId}) encountered unexpected error: ${errorMessage}`);
     return null;
   }
 }
@@ -409,7 +410,7 @@ export async function getTasksByCreator(
 
     // Validate required fields exist
     if (data.creator === undefined || data.state === undefined) {
-      console.warn(`Task at index ${idx} missing required fields, skipping`);
+      getSdkLogger().warn(`Task at index ${idx} missing required fields, skipping`);
       continue;
     }
 

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -26,22 +26,31 @@ import {
   TASK_TYPE_COLLABORATIVE,
   TASK_TYPE_COMPETITIVE,
   sleep,
+  createId,
+  createDescription,
+  createHash,
+  deriveProtocolPda,
+  deriveAgentPda as _deriveAgentPda,
+  deriveTaskPda as _deriveTaskPda,
+  deriveEscrowPda as _deriveEscrowPda,
+  deriveClaimPda as _deriveClaimPda,
+  AIRDROP_SOL,
+  MIN_BALANCE_SOL,
+  MAX_AIRDROP_ATTEMPTS,
+  BASE_DELAY_MS,
+  MAX_DELAY_MS,
+  DEFAULT_MIN_STAKE_LAMPORTS,
+  DEFAULT_PROTOCOL_FEE_BPS,
+  DEFAULT_DISPUTE_THRESHOLD,
 } from "./test-utils";
 
 // ============================================================================
-// CONSTANTS
+// CONSTANTS (imported from test-utils, local aliases for backwards compat)
 // ============================================================================
 
-const AIRDROP_SOL = 2;
-const MIN_BALANCE_SOL = 1;
-const MAX_AIRDROP_ATTEMPTS = 5;
-const BASE_DELAY_MS = 500;
-const MAX_DELAY_MS = 8000;
-
-// Protocol configuration
-const MIN_STAKE = 1 * LAMPORTS_PER_SOL;
-const PROTOCOL_FEE_BPS = 100; // 1%
-const DISPUTE_THRESHOLD = 51;
+const MIN_STAKE = DEFAULT_MIN_STAKE_LAMPORTS;
+const PROTOCOL_FEE_BPS = DEFAULT_PROTOCOL_FEE_BPS;
+const DISPUTE_THRESHOLD = DEFAULT_DISPUTE_THRESHOLD;
 
 // ============================================================================
 // HELPER FUNCTIONS
@@ -97,73 +106,25 @@ const ensureBalance = async (
   }
 };
 
-/**
- * Create a 32-byte buffer from a string (padded with zeros)
- */
-function createId(name: string): Buffer {
-  return Buffer.from(name.padEnd(32, "\0"));
-}
-
-/**
- * Create a 64-byte description buffer
- */
-function createDescription(desc: string): number[] {
-  const buf = Buffer.alloc(64);
-  buf.write(desc);
-  return Array.from(buf);
-}
-
-/**
- * Create a 32-byte hash buffer
- */
-function createHash(data: string): number[] {
-  const buf = Buffer.alloc(32);
-  buf.write(data);
-  return Array.from(buf);
-}
-
-// ============================================================================
-// PDA DERIVATION HELPERS
-// ============================================================================
-
+// PDA helpers delegate to test-utils (3-arg versions with programId)
 function deriveProtocolConfigPda(programId: PublicKey): PublicKey {
-  const [pda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("protocol")],
-    programId
-  );
-  return pda;
+  return deriveProtocolPda(programId);
 }
 
 function deriveAgentPda(agentId: Buffer, programId: PublicKey): PublicKey {
-  const [pda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("agent"), agentId],
-    programId
-  );
-  return pda;
+  return _deriveAgentPda(agentId, programId);
 }
 
 function deriveTaskPda(creator: PublicKey, taskId: Buffer, programId: PublicKey): PublicKey {
-  const [pda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("task"), creator.toBuffer(), taskId],
-    programId
-  );
-  return pda;
+  return _deriveTaskPda(creator, taskId, programId);
 }
 
 function deriveEscrowPda(taskPda: PublicKey, programId: PublicKey): PublicKey {
-  const [pda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("escrow"), taskPda.toBuffer()],
-    programId
-  );
-  return pda;
+  return _deriveEscrowPda(taskPda, programId);
 }
 
 function deriveClaimPda(taskPda: PublicKey, workerAgentPda: PublicKey, programId: PublicKey): PublicKey {
-  const [pda] = PublicKey.findProgramAddressSync(
-    [Buffer.from("claim"), taskPda.toBuffer(), workerAgentPda.toBuffer()],
-    programId
-  );
-  return pda;
+  return _deriveClaimPda(taskPda, workerAgentPda, programId);
 }
 
 // ============================================================================

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -161,6 +161,57 @@ export function deriveStatePda(key: string, programId: PublicKey): PublicKey {
 }
 
 // ============================================================================
+// Buffer Creation Helpers
+// ============================================================================
+
+/**
+ * Create a 32-byte buffer from a string (padded with zeros).
+ */
+export function createId(name: string): Buffer {
+  return Buffer.from(name.padEnd(32, "\0"));
+}
+
+/**
+ * Create a 64-byte description array from a string.
+ */
+export function createDescription(desc: string): number[] {
+  const buf = Buffer.alloc(64);
+  buf.write(desc);
+  return Array.from(buf);
+}
+
+/**
+ * Create a 32-byte hash array from a string.
+ */
+export function createHash(data: string): number[] {
+  const buf = Buffer.alloc(32);
+  buf.write(data);
+  return Array.from(buf);
+}
+
+// ============================================================================
+// Default Protocol Configuration Constants
+// ============================================================================
+
+/** Default airdrop amount in SOL for test wallets */
+export const AIRDROP_SOL = 2;
+/** Minimum balance threshold before re-airdropping */
+export const MIN_BALANCE_SOL = 1;
+/** Maximum retries for airdrop requests */
+export const MAX_AIRDROP_ATTEMPTS = 5;
+/** Base delay for exponential backoff (ms) */
+export const BASE_DELAY_MS = 500;
+/** Maximum delay between retries (ms) */
+export const MAX_DELAY_MS = 8000;
+
+/** Default min stake for protocol initialization (1 SOL) */
+export const DEFAULT_MIN_STAKE_LAMPORTS = 1 * LAMPORTS_PER_SOL;
+/** Default protocol fee in basis points (1% = 100 bps) */
+export const DEFAULT_PROTOCOL_FEE_BPS = 100;
+/** Default dispute threshold percentage */
+export const DEFAULT_DISPUTE_THRESHOLD = 51;
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 

--- a/tests/test_1.ts
+++ b/tests/test_1.ts
@@ -15,6 +15,10 @@ import {
   generateRunId,
   getDefaultDeadline,
   sleep,
+  deriveAgentPda as _deriveAgentPda,
+  deriveTaskPda as _deriveTaskPda,
+  deriveEscrowPda as _deriveEscrowPda,
+  deriveClaimPda as _deriveClaimPda,
 } from "./test-utils";
 
 describe("test_1", () => {
@@ -47,32 +51,21 @@ describe("test_1", () => {
   let creatorAgentId: Buffer;
 
 
+  // PDA helpers close over program.programId for convenience (2-arg variants)
   function deriveAgentPda(agentId: Buffer): PublicKey {
-    return PublicKey.findProgramAddressSync(
-      [Buffer.from("agent"), agentId],
-      program.programId
-    )[0];
+    return _deriveAgentPda(agentId, program.programId);
   }
 
   function deriveTaskPda(creatorPubkey: PublicKey, taskId: Buffer): PublicKey {
-    return PublicKey.findProgramAddressSync(
-      [Buffer.from("task"), creatorPubkey.toBuffer(), taskId],
-      program.programId
-    )[0];
+    return _deriveTaskPda(creatorPubkey, taskId, program.programId);
   }
 
   function deriveEscrowPda(taskPda: PublicKey): PublicKey {
-    return PublicKey.findProgramAddressSync(
-      [Buffer.from("escrow"), taskPda.toBuffer()],
-      program.programId
-    )[0];
+    return _deriveEscrowPda(taskPda, program.programId);
   }
 
   function deriveClaimPda(taskPda: PublicKey, workerPubkey: PublicKey): PublicKey {
-    return PublicKey.findProgramAddressSync(
-      [Buffer.from("claim"), taskPda.toBuffer(), workerPubkey.toBuffer()],
-      program.programId
-    )[0];
+    return _deriveClaimPda(taskPda, workerPubkey, program.programId);
   }
 
   // Helper to generate unique agent IDs to avoid conflicts with persisted validator state


### PR DESCRIPTION
## Summary

- **Phase 1**: Fix silent error swallowing in executor.ts, add `@deprecated` to `VERIFICATION_COMPUTE_UNITS`, extract `waitForActiveTasks()` method
- **Phase 2**: Add SDK logger (`sdk/src/logger.ts`) and replace all `console.log`/`console.warn` calls in client.ts, privacy.ts, tasks.ts
- **Phase 3**: Add event subscription factory (`runtime/src/events/factory.ts`) and refactor all 4 event subscription modules to use it, removing duplicate `EventSubscription` interface
- **Phase 4**: Extract `slash_helpers.rs` with shared slash logic, refactor both slash handlers, extract `validate_arbiter_not_participant()` in vote_dispute.rs
- **Phase 5**: Add shared helpers and protocol constants to test-utils.ts, replace local PDA helpers in smoke.ts and test_1.ts with delegating wrappers

Net reduction of 89 lines. 21 files changed (3 new).

## Test plan

- [x] `anchor build` — compiles clean
- [x] `cd sdk && npm run build && npm run typecheck` — passes
- [x] `cd runtime && npm run test` — 730 unit tests pass
- [x] `anchor test` — all 146 integration tests pass