### PR TITLE
feat(runtime): add LLM provider adapters (Phase 4)

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -15,7 +15,7 @@
   "files": ["dist", "idl", "README.md"],
   "scripts": {
     "prebuild": "npm run build --prefix ../sdk && node scripts/copy-idl.js",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama",
     "typecheck": "tsc --noEmit",
     "pretest": "npm run build --prefix ../sdk",
     "test": "vitest run",
@@ -29,6 +29,11 @@
     "type": "git",
     "url": "https://github.com/tetsuo-ai/AgenC",
     "directory": "runtime"
+  },
+  "optionalDependencies": {
+    "openai": "^4.0.0",
+    "@anthropic-ai/sdk": "^0.30.0",
+    "ollama": "^0.5.0"
   },
   "dependencies": {
     "@agenc/sdk": "file:../sdk"

--- a/runtime/src/autonomous/types.ts
+++ b/runtime/src/autonomous/types.ts
@@ -107,6 +107,11 @@ export interface TaskExecutor {
 }
 
 /**
+ * Alias for TaskExecutor used in autonomous agent context
+ */
+export type AutonomousTaskExecutor = TaskExecutor;
+
+/**
  * Discovery mode for finding tasks
  */
 export type DiscoveryMode = 'polling' | 'events' | 'hybrid';

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -347,6 +347,40 @@ export {
   WELL_KNOWN_TOKENS,
 } from './skills/index.js';
 
+// LLM Adapters (Phase 4)
+export {
+  // Core types
+  type LLMProvider,
+  type LLMProviderConfig,
+  type LLMMessage,
+  type LLMResponse,
+  type LLMStreamChunk,
+  type LLMTool,
+  type LLMToolCall,
+  type LLMUsage,
+  type MessageRole,
+  type StreamProgressCallback,
+  type ToolHandler,
+  // Error classes
+  LLMProviderError,
+  LLMRateLimitError,
+  LLMResponseConversionError,
+  LLMToolCallError,
+  LLMTimeoutError,
+  // Response converter
+  responseToOutput,
+  // LLM Task Executor
+  LLMTaskExecutor,
+  type LLMTaskExecutorConfig,
+  // Provider adapters
+  GrokProvider,
+  type GrokProviderConfig,
+  AnthropicProvider,
+  type AnthropicProviderConfig,
+  OllamaProvider,
+  type OllamaProviderConfig,
+} from './llm/index.js';
+
 // Autonomous Agent System
 export {
   AutonomousAgent,
@@ -356,7 +390,7 @@ export {
   TaskStatus as AutonomousTaskStatus,
   type TaskFilter,
   type ClaimStrategy,
-  type TaskExecutor,
+  type AutonomousTaskExecutor,
   type AutonomousAgentConfig,
   type AutonomousAgentStats,
   DefaultClaimStrategy,

--- a/runtime/src/llm/anthropic/adapter.test.ts
+++ b/runtime/src/llm/anthropic/adapter.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LLMMessage } from '../types.js';
+import { LLMProviderError, LLMRateLimitError } from '../errors.js';
+
+// Mock the @anthropic-ai/sdk module
+const mockMessagesCreate = vi.fn();
+
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: class MockAnthropic {
+      messages = { create: mockMessagesCreate };
+      constructor(_opts: any) {}
+    },
+  };
+});
+
+import { AnthropicProvider } from './adapter.js';
+
+function makeResponse(overrides: Record<string, any> = {}) {
+  return {
+    content: [{ type: 'text', text: 'Hello!' }],
+    usage: { input_tokens: 10, output_tokens: 5 },
+    model: 'claude-sonnet-4-5-20250929',
+    stop_reason: 'end_turn',
+    ...overrides,
+  };
+}
+
+describe('AnthropicProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('extracts system prompt to top-level parameter', async () => {
+    mockMessagesCreate.mockResolvedValueOnce(makeResponse());
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    await provider.chat([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hello' },
+    ]);
+
+    const params = mockMessagesCreate.mock.calls[0][0];
+    expect(params.system).toBe('You are helpful.');
+    expect(params.messages).toEqual([{ role: 'user', content: 'Hello' }]);
+  });
+
+  it('converts tools to Anthropic format', async () => {
+    mockMessagesCreate.mockResolvedValueOnce(makeResponse());
+
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      tools: [{
+        type: 'function',
+        function: {
+          name: 'search',
+          description: 'Search the web',
+          parameters: { type: 'object', properties: { q: { type: 'string' } } },
+        },
+      }],
+    });
+    await provider.chat([{ role: 'user', content: 'test' }]);
+
+    const params = mockMessagesCreate.mock.calls[0][0];
+    expect(params.tools).toEqual([{
+      name: 'search',
+      description: 'Search the web',
+      input_schema: { type: 'object', properties: { q: { type: 'string' } } },
+    }]);
+  });
+
+  it('aggregates text content blocks', async () => {
+    const response = makeResponse({
+      content: [
+        { type: 'text', text: 'Hello ' },
+        { type: 'text', text: 'world!' },
+      ],
+    });
+    mockMessagesCreate.mockResolvedValueOnce(response);
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    const result = await provider.chat([{ role: 'user', content: 'test' }]);
+
+    expect(result.content).toBe('Hello world!');
+  });
+
+  it('parses tool_use content blocks', async () => {
+    const response = makeResponse({
+      content: [
+        { type: 'text', text: '' },
+        { type: 'tool_use', id: 'toolu_1', name: 'search', input: { q: 'test' } },
+      ],
+      stop_reason: 'tool_use',
+    });
+    mockMessagesCreate.mockResolvedValueOnce(response);
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    const result = await provider.chat([{ role: 'user', content: 'test' }]);
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]).toEqual({
+      id: 'toolu_1',
+      name: 'search',
+      arguments: '{"q":"test"}',
+    });
+    expect(result.finishReason).toBe('tool_calls');
+  });
+
+  it('formats tool result messages as tool_result content blocks', async () => {
+    mockMessagesCreate.mockResolvedValueOnce(makeResponse());
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    await provider.chat([
+      { role: 'user', content: 'search' },
+      { role: 'tool', content: 'result data', toolCallId: 'toolu_1', toolName: 'search' },
+    ]);
+
+    const params = mockMessagesCreate.mock.calls[0][0];
+    expect(params.messages[1]).toEqual({
+      role: 'user',
+      content: [{
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: 'result data',
+      }],
+    });
+  });
+
+  it('enables extended thinking when configured', async () => {
+    mockMessagesCreate.mockResolvedValueOnce(makeResponse());
+
+    const provider = new AnthropicProvider({
+      apiKey: 'test-key',
+      extendedThinking: true,
+      thinkingBudgetTokens: 5000,
+    });
+    await provider.chat([{ role: 'user', content: 'think hard' }]);
+
+    const params = mockMessagesCreate.mock.calls[0][0];
+    expect(params.thinking).toEqual({
+      type: 'enabled',
+      budget_tokens: 5000,
+    });
+  });
+
+  it('handles streaming events', async () => {
+    const events = [
+      { type: 'message_start', message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 10 } } },
+      { type: 'content_block_start', content_block: { type: 'text' } },
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: 'Hello' } },
+      { type: 'content_block_delta', delta: { type: 'text_delta', text: ' world' } },
+      { type: 'content_block_stop' },
+      { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 5 } },
+    ];
+    mockMessagesCreate.mockResolvedValueOnce((async function* () {
+      for (const e of events) yield e;
+    })());
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    const onChunk = vi.fn();
+    const result = await provider.chatStream(
+      [{ role: 'user', content: 'test' }],
+      onChunk,
+    );
+
+    expect(result.content).toBe('Hello world');
+    expect(result.usage.promptTokens).toBe(10);
+    expect(result.usage.completionTokens).toBe(5);
+    expect(onChunk).toHaveBeenCalledWith({ content: 'Hello', done: false });
+  });
+
+  it('streams tool use blocks', async () => {
+    const events = [
+      { type: 'message_start', message: { model: 'claude-sonnet-4-5-20250929', usage: { input_tokens: 10 } } },
+      { type: 'content_block_start', content_block: { type: 'tool_use', id: 'toolu_1', name: 'search' } },
+      { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '{"q":' } },
+      { type: 'content_block_delta', delta: { type: 'input_json_delta', partial_json: '"test"}' } },
+      { type: 'content_block_stop' },
+      { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 3 } },
+    ];
+    mockMessagesCreate.mockResolvedValueOnce((async function* () {
+      for (const e of events) yield e;
+    })());
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    const onChunk = vi.fn();
+    const result = await provider.chatStream(
+      [{ role: 'user', content: 'test' }],
+      onChunk,
+    );
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].arguments).toBe('{"q":"test"}');
+    expect(result.finishReason).toBe('tool_calls');
+  });
+
+  it('maps 429 error to LLMRateLimitError', async () => {
+    mockMessagesCreate.mockRejectedValueOnce({ status: 429, message: 'Rate limited', headers: {} });
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    await expect(provider.chat([{ role: 'user', content: 'test' }]))
+      .rejects.toThrow(LLMRateLimitError);
+  });
+
+  it('maps general errors to LLMProviderError', async () => {
+    mockMessagesCreate.mockRejectedValueOnce({ status: 500, message: 'Internal server error' });
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    await expect(provider.chat([{ role: 'user', content: 'test' }]))
+      .rejects.toThrow(LLMProviderError);
+  });
+
+  it('returns usage information', async () => {
+    mockMessagesCreate.mockResolvedValueOnce(makeResponse());
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    const result = await provider.chat([{ role: 'user', content: 'test' }]);
+
+    expect(result.usage).toEqual({
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it('maps stop reasons correctly', async () => {
+    mockMessagesCreate.mockResolvedValueOnce(makeResponse({ stop_reason: 'max_tokens' }));
+
+    const provider = new AnthropicProvider({ apiKey: 'test-key' });
+    const result = await provider.chat([{ role: 'user', content: 'test' }]);
+
+    expect(result.finishReason).toBe('length');
+  });
+});

--- a/runtime/src/llm/anthropic/adapter.ts
+++ b/runtime/src/llm/anthropic/adapter.ts
@@ -1,0 +1,281 @@
+/**
+ * Anthropic Claude LLM provider adapter.
+ *
+ * Uses the `@anthropic-ai/sdk` package.
+ * The SDK is loaded lazily on first use — it's an optional dependency.
+ *
+ * @module
+ */
+
+import type {
+  LLMProvider,
+  LLMMessage,
+  LLMResponse,
+  LLMToolCall,
+  LLMUsage,
+  LLMTool,
+  StreamProgressCallback,
+} from '../types.js';
+import type { AnthropicProviderConfig } from './types.js';
+import { LLMProviderError, LLMRateLimitError, LLMTimeoutError } from '../errors.js';
+
+const DEFAULT_MODEL = 'claude-sonnet-4-5-20250929';
+
+export class AnthropicProvider implements LLMProvider {
+  readonly name = 'anthropic';
+
+  private client: unknown | null = null;
+  private readonly config: AnthropicProviderConfig;
+  private readonly tools: LLMTool[];
+
+  constructor(config: AnthropicProviderConfig) {
+    this.config = { ...config, model: config.model ?? DEFAULT_MODEL };
+    this.tools = config.tools ?? [];
+  }
+
+  async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+    const client = await this.ensureClient();
+    const params = this.buildParams(messages);
+
+    try {
+      const response = await (client as any).messages.create(params);
+      return this.parseResponse(response);
+    } catch (err: unknown) {
+      throw this.mapError(err);
+    }
+  }
+
+  async chatStream(messages: LLMMessage[], onChunk: StreamProgressCallback): Promise<LLMResponse> {
+    const client = await this.ensureClient();
+    const params = { ...this.buildParams(messages), stream: true };
+
+    try {
+      const stream = await (client as any).messages.create(params);
+
+      let content = '';
+      let toolCalls: LLMToolCall[] = [];
+      let model = this.config.model;
+      let finishReason: LLMResponse['finishReason'] = 'stop';
+      let inputTokens = 0;
+      let outputTokens = 0;
+      let currentToolUse: { id: string; name: string; arguments: string } | null = null;
+
+      for await (const event of stream as AsyncIterable<any>) {
+        switch (event.type) {
+          case 'message_start':
+            if (event.message?.model) model = event.message.model;
+            if (event.message?.usage) inputTokens = event.message.usage.input_tokens ?? 0;
+            break;
+
+          case 'content_block_start':
+            if (event.content_block?.type === 'tool_use') {
+              currentToolUse = {
+                id: event.content_block.id,
+                name: event.content_block.name,
+                arguments: '',
+              };
+            }
+            break;
+
+          case 'content_block_delta':
+            if (event.delta?.type === 'text_delta' && event.delta.text) {
+              content += event.delta.text;
+              onChunk({ content: event.delta.text, done: false });
+            }
+            if (event.delta?.type === 'input_json_delta' && event.delta.partial_json && currentToolUse) {
+              currentToolUse.arguments += event.delta.partial_json;
+            }
+            break;
+
+          case 'content_block_stop':
+            if (currentToolUse) {
+              toolCalls.push(currentToolUse);
+              currentToolUse = null;
+            }
+            break;
+
+          case 'message_delta':
+            if (event.delta?.stop_reason) {
+              finishReason = this.mapStopReason(event.delta.stop_reason);
+            }
+            if (event.usage) outputTokens = event.usage.output_tokens ?? 0;
+            break;
+        }
+      }
+
+      onChunk({ content: '', done: true, toolCalls });
+
+      return {
+        content,
+        toolCalls,
+        usage: { promptTokens: inputTokens, completionTokens: outputTokens, totalTokens: inputTokens + outputTokens },
+        model,
+        finishReason,
+      };
+    } catch (err: unknown) {
+      throw this.mapError(err);
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const client = await this.ensureClient();
+      // Minimal request to verify API connectivity
+      await (client as any).messages.create({
+        model: this.config.model,
+        max_tokens: 1,
+        messages: [{ role: 'user', content: 'ping' }],
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async ensureClient(): Promise<unknown> {
+    if (this.client) return this.client;
+
+    let Anthropic: any;
+    try {
+      const mod = await import('@anthropic-ai/sdk');
+      Anthropic = mod.default ?? mod.Anthropic ?? mod;
+    } catch {
+      throw new LLMProviderError(
+        this.name,
+        '@anthropic-ai/sdk package not installed. Install it: npm install @anthropic-ai/sdk',
+      );
+    }
+
+    this.client = new Anthropic({
+      apiKey: this.config.apiKey,
+      baseURL: this.config.baseURL,
+      timeout: this.config.timeoutMs,
+      maxRetries: this.config.maxRetries ?? 2,
+    });
+    return this.client;
+  }
+
+  private buildParams(messages: LLMMessage[]): Record<string, unknown> {
+    // Extract system message — Anthropic uses a top-level `system` parameter
+    let systemPrompt: string | undefined;
+    const conversationMessages: LLMMessage[] = [];
+    for (const msg of messages) {
+      if (msg.role === 'system') {
+        systemPrompt = msg.content;
+      } else {
+        conversationMessages.push(msg);
+      }
+    }
+
+    const params: Record<string, unknown> = {
+      model: this.config.model,
+      messages: conversationMessages.map((m) => this.toAnthropicMessage(m)),
+      max_tokens: this.config.maxTokens ?? 4096,
+    };
+
+    if (systemPrompt) params.system = systemPrompt;
+    if (this.config.temperature !== undefined) params.temperature = this.config.temperature;
+
+    // Convert tools to Anthropic format
+    if (this.tools.length > 0) {
+      params.tools = this.tools.map((t) => ({
+        name: t.function.name,
+        description: t.function.description,
+        input_schema: t.function.parameters,
+      }));
+    }
+
+    // Extended thinking
+    if (this.config.extendedThinking) {
+      params.thinking = {
+        type: 'enabled',
+        budget_tokens: this.config.thinkingBudgetTokens ?? 10000,
+      };
+    }
+
+    return params;
+  }
+
+  private toAnthropicMessage(msg: LLMMessage): Record<string, unknown> {
+    if (msg.role === 'tool') {
+      return {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: msg.toolCallId,
+          content: msg.content,
+        }],
+      };
+    }
+
+    if (msg.role === 'assistant') {
+      return { role: 'assistant', content: msg.content };
+    }
+
+    return { role: 'user', content: msg.content };
+  }
+
+  private parseResponse(response: any): LLMResponse {
+    let content = '';
+    const toolCalls: LLMToolCall[] = [];
+
+    for (const block of response.content ?? []) {
+      if (block.type === 'text') {
+        content += block.text;
+      } else if (block.type === 'tool_use') {
+        toolCalls.push({
+          id: block.id,
+          name: block.name,
+          arguments: JSON.stringify(block.input),
+        });
+      }
+    }
+
+    const usage: LLMUsage = {
+      promptTokens: response.usage?.input_tokens ?? 0,
+      completionTokens: response.usage?.output_tokens ?? 0,
+      totalTokens: (response.usage?.input_tokens ?? 0) + (response.usage?.output_tokens ?? 0),
+    };
+
+    return {
+      content,
+      toolCalls,
+      usage,
+      model: response.model ?? this.config.model,
+      finishReason: this.mapStopReason(response.stop_reason),
+    };
+  }
+
+  private mapStopReason(reason: string | undefined): LLMResponse['finishReason'] {
+    switch (reason) {
+      case 'end_turn': return 'stop';
+      case 'tool_use': return 'tool_calls';
+      case 'max_tokens': return 'length';
+      default: return 'stop';
+    }
+  }
+
+  private mapError(err: unknown): Error {
+    if (err instanceof LLMProviderError || err instanceof LLMRateLimitError || err instanceof LLMTimeoutError) {
+      return err;
+    }
+
+    const e = err as any;
+    const status = e?.status ?? e?.statusCode;
+    const message = e?.message ?? String(err);
+
+    if (status === 429) {
+      const retryAfter = e?.headers?.['retry-after'];
+      return new LLMRateLimitError(
+        this.name,
+        retryAfter ? parseInt(retryAfter, 10) * 1000 : undefined,
+      );
+    }
+
+    if (e?.code === 'ETIMEDOUT' || e?.code === 'ECONNABORTED' || message.includes('timeout')) {
+      return new LLMTimeoutError(this.name, this.config.timeoutMs ?? 0);
+    }
+
+    return new LLMProviderError(this.name, message, status);
+  }
+}

--- a/runtime/src/llm/anthropic/index.ts
+++ b/runtime/src/llm/anthropic/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Anthropic Claude LLM provider module
+ *
+ * @module
+ */
+
+export { AnthropicProvider } from './adapter.js';
+export type { AnthropicProviderConfig } from './types.js';

--- a/runtime/src/llm/anthropic/types.ts
+++ b/runtime/src/llm/anthropic/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Anthropic provider configuration types
+ *
+ * @module
+ */
+
+import type { LLMProviderConfig } from '../types.js';
+
+/**
+ * Configuration specific to the Anthropic Claude provider.
+ */
+export interface AnthropicProviderConfig extends LLMProviderConfig {
+  /** Anthropic API key */
+  apiKey: string;
+  /** Base URL for the Anthropic API */
+  baseURL?: string;
+  /** Enable extended thinking */
+  extendedThinking?: boolean;
+  /** Budget for thinking tokens (requires extendedThinking) */
+  thinkingBudgetTokens?: number;
+}

--- a/runtime/src/llm/errors.ts
+++ b/runtime/src/llm/errors.ts
@@ -1,0 +1,107 @@
+/**
+ * LLM-specific error types for @agenc/runtime
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Error thrown when an LLM provider returns an error response.
+ */
+export class LLMProviderError extends RuntimeError {
+  public readonly providerName: string;
+  public readonly statusCode?: number;
+
+  constructor(providerName: string, message: string, statusCode?: number) {
+    super(
+      `${providerName} error: ${message}`,
+      RuntimeErrorCodes.LLM_PROVIDER_ERROR,
+    );
+    this.name = 'LLMProviderError';
+    this.providerName = providerName;
+    this.statusCode = statusCode;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LLMProviderError);
+    }
+  }
+}
+
+/**
+ * Error thrown when an LLM provider rate limits the request.
+ */
+export class LLMRateLimitError extends RuntimeError {
+  public readonly providerName: string;
+  public readonly retryAfterMs?: number;
+
+  constructor(providerName: string, retryAfterMs?: number) {
+    const msg = retryAfterMs
+      ? `${providerName} rate limited, retry after ${retryAfterMs}ms`
+      : `${providerName} rate limited`;
+    super(msg, RuntimeErrorCodes.LLM_RATE_LIMIT);
+    this.name = 'LLMRateLimitError';
+    this.providerName = providerName;
+    this.retryAfterMs = retryAfterMs;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LLMRateLimitError);
+    }
+  }
+}
+
+/**
+ * Error thrown when converting an LLM response to the 4-bigint output format fails.
+ */
+export class LLMResponseConversionError extends RuntimeError {
+  public readonly response: string;
+
+  constructor(message: string, response: string) {
+    super(`Response conversion failed: ${message}`, RuntimeErrorCodes.LLM_RESPONSE_CONVERSION);
+    this.name = 'LLMResponseConversionError';
+    this.response = response;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LLMResponseConversionError);
+    }
+  }
+}
+
+/**
+ * Error thrown when an LLM tool call fails.
+ */
+export class LLMToolCallError extends RuntimeError {
+  public readonly toolName: string;
+  public readonly toolCallId: string;
+
+  constructor(toolName: string, toolCallId: string, message: string) {
+    super(
+      `Tool call "${toolName}" (${toolCallId}) failed: ${message}`,
+      RuntimeErrorCodes.LLM_TOOL_CALL_ERROR,
+    );
+    this.name = 'LLMToolCallError';
+    this.toolName = toolName;
+    this.toolCallId = toolCallId;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LLMToolCallError);
+    }
+  }
+}
+
+/**
+ * Error thrown when an LLM request times out.
+ */
+export class LLMTimeoutError extends RuntimeError {
+  public readonly providerName: string;
+  public readonly timeoutMs: number;
+
+  constructor(providerName: string, timeoutMs: number) {
+    super(
+      `${providerName} request timed out after ${timeoutMs}ms`,
+      RuntimeErrorCodes.LLM_TIMEOUT,
+    );
+    this.name = 'LLMTimeoutError';
+    this.providerName = providerName;
+    this.timeoutMs = timeoutMs;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LLMTimeoutError);
+    }
+  }
+}

--- a/runtime/src/llm/executor.test.ts
+++ b/runtime/src/llm/executor.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PublicKey } from '@solana/web3.js';
+import { LLMTaskExecutor } from './executor.js';
+import type { LLMProvider, LLMResponse, LLMMessage, StreamProgressCallback } from './types.js';
+import type { Task } from '../autonomous/types.js';
+import { TaskStatus } from '../autonomous/types.js';
+
+function createMockProvider(overrides: Partial<LLMProvider> = {}): LLMProvider {
+  return {
+    name: 'mock',
+    chat: vi.fn<[LLMMessage[]], Promise<LLMResponse>>().mockResolvedValue({
+      content: 'mock response',
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: 'mock-model',
+      finishReason: 'stop',
+    }),
+    chatStream: vi.fn<[LLMMessage[], StreamProgressCallback], Promise<LLMResponse>>().mockResolvedValue({
+      content: 'mock stream response',
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: 'mock-model',
+      finishReason: 'stop',
+    }),
+    healthCheck: vi.fn<[], Promise<boolean>>().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+function createMockTask(descriptionStr = 'test task'): Task {
+  const desc = Buffer.alloc(64, 0);
+  Buffer.from(descriptionStr, 'utf-8').copy(desc);
+
+  return {
+    pda: PublicKey.default,
+    taskId: new Uint8Array(32),
+    creator: PublicKey.default,
+    requiredCapabilities: 1n, // COMPUTE
+    reward: 1_000_000n,
+    description: desc,
+    constraintHash: new Uint8Array(32),
+    deadline: 0,
+    maxWorkers: 1,
+    currentClaims: 0,
+    status: TaskStatus.Open,
+  };
+}
+
+describe('LLMTaskExecutor', () => {
+  it('calls provider.chat and returns 4 bigints', async () => {
+    const provider = createMockProvider();
+    const executor = new LLMTaskExecutor({ provider });
+
+    const output = await executor.execute(createMockTask());
+
+    expect(provider.chat).toHaveBeenCalledOnce();
+    expect(output).toHaveLength(4);
+    for (const v of output) {
+      expect(typeof v).toBe('bigint');
+    }
+  });
+
+  it('uses streaming when configured', async () => {
+    const onStreamChunk = vi.fn();
+    const provider = createMockProvider();
+    const executor = new LLMTaskExecutor({
+      provider,
+      streaming: true,
+      onStreamChunk,
+    });
+
+    await executor.execute(createMockTask());
+
+    expect(provider.chatStream).toHaveBeenCalledOnce();
+    expect(provider.chat).not.toHaveBeenCalled();
+  });
+
+  it('includes system prompt in messages', async () => {
+    const provider = createMockProvider();
+    const executor = new LLMTaskExecutor({
+      provider,
+      systemPrompt: 'You are a helpful agent.',
+    });
+
+    await executor.execute(createMockTask());
+
+    const messages = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0][0] as LLMMessage[];
+    expect(messages[0]).toEqual({
+      role: 'system',
+      content: 'You are a helpful agent.',
+    });
+    expect(messages[1].role).toBe('user');
+  });
+
+  it('strips null bytes from task description', async () => {
+    const provider = createMockProvider();
+    const executor = new LLMTaskExecutor({ provider });
+
+    // Task description with null padding
+    const task = createMockTask('hello');
+    await executor.execute(task);
+
+    const messages = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0][0] as LLMMessage[];
+    expect(messages[0].content).toContain('Description: hello');
+    expect(messages[0].content).not.toContain('\0');
+  });
+
+  it('handles tool call loop', async () => {
+    const toolCallResponse: LLMResponse = {
+      content: '',
+      toolCalls: [{ id: 'call_1', name: 'lookup', arguments: '{"key":"val"}' }],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: 'mock-model',
+      finishReason: 'tool_calls',
+    };
+    const finalResponse: LLMResponse = {
+      content: 'final answer',
+      toolCalls: [],
+      usage: { promptTokens: 20, completionTokens: 10, totalTokens: 30 },
+      model: 'mock-model',
+      finishReason: 'stop',
+    };
+
+    const chatFn = vi.fn<[LLMMessage[]], Promise<LLMResponse>>()
+      .mockResolvedValueOnce(toolCallResponse)
+      .mockResolvedValueOnce(finalResponse);
+
+    const provider = createMockProvider({ chat: chatFn });
+    const toolHandler = vi.fn().mockResolvedValue('tool result');
+
+    const executor = new LLMTaskExecutor({ provider, toolHandler });
+    const output = await executor.execute(createMockTask());
+
+    expect(chatFn).toHaveBeenCalledTimes(2);
+    expect(toolHandler).toHaveBeenCalledWith('lookup', { key: 'val' });
+    expect(output).toHaveLength(4);
+  });
+
+  it('terminates tool call loop at maxToolRounds', async () => {
+    const toolCallResponse: LLMResponse = {
+      content: 'thinking...',
+      toolCalls: [{ id: 'call_1', name: 'lookup', arguments: '{}' }],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: 'mock-model',
+      finishReason: 'tool_calls',
+    };
+
+    const chatFn = vi.fn<[LLMMessage[]], Promise<LLMResponse>>()
+      .mockResolvedValue(toolCallResponse);
+
+    const provider = createMockProvider({ chat: chatFn });
+    const toolHandler = vi.fn().mockResolvedValue('result');
+
+    const executor = new LLMTaskExecutor({
+      provider,
+      toolHandler,
+      maxToolRounds: 3,
+    });
+
+    const output = await executor.execute(createMockTask());
+
+    // 1 initial + 3 rounds = 4 calls total
+    expect(chatFn).toHaveBeenCalledTimes(4);
+    expect(output).toHaveLength(4);
+  });
+
+  it('uses custom responseToOutput', async () => {
+    const provider = createMockProvider();
+    const custom = vi.fn().mockReturnValue([1n, 2n, 3n, 4n]);
+
+    const executor = new LLMTaskExecutor({
+      provider,
+      responseToOutput: custom,
+    });
+
+    const output = await executor.execute(createMockTask());
+
+    expect(custom).toHaveBeenCalledWith('mock response');
+    expect(output).toEqual([1n, 2n, 3n, 4n]);
+  });
+
+  it('canExecute returns true when no capabilities filter set', () => {
+    const provider = createMockProvider();
+    const executor = new LLMTaskExecutor({ provider });
+    expect(executor.canExecute(createMockTask())).toBe(true);
+  });
+
+  it('canExecute filters by requiredCapabilities', () => {
+    const provider = createMockProvider();
+    const executor = new LLMTaskExecutor({
+      provider,
+      requiredCapabilities: 0b11n, // COMPUTE | INFERENCE
+    });
+
+    const taskCompute = createMockTask();
+    taskCompute.requiredCapabilities = 1n; // COMPUTE only — subset of 0b11
+    expect(executor.canExecute(taskCompute)).toBe(true);
+
+    const taskStorage = createMockTask();
+    taskStorage.requiredCapabilities = 4n; // STORAGE — not in 0b11
+    expect(executor.canExecute(taskStorage)).toBe(false);
+  });
+});

--- a/runtime/src/llm/executor.ts
+++ b/runtime/src/llm/executor.ts
@@ -1,0 +1,159 @@
+/**
+ * LLMTaskExecutor — bridges an LLMProvider to the autonomous TaskExecutor interface.
+ *
+ * Decodes the 64-byte task description, sends it to the LLM provider,
+ * handles tool call loops, and converts the text response to 4 bigints.
+ *
+ * @module
+ */
+
+import type { TaskExecutor, Task } from '../autonomous/types.js';
+import type { LLMProvider, LLMMessage, StreamProgressCallback, ToolHandler } from './types.js';
+import { responseToOutput } from './response-converter.js';
+
+/**
+ * Configuration for LLMTaskExecutor
+ */
+export interface LLMTaskExecutorConfig {
+  /** The LLM provider to use for task execution */
+  provider: LLMProvider;
+  /** System prompt providing context for task execution */
+  systemPrompt?: string;
+  /** Whether to use streaming (invokes onStreamChunk per chunk) */
+  streaming?: boolean;
+  /** Callback for streaming progress */
+  onStreamChunk?: StreamProgressCallback;
+  /** Tool handler for function calling */
+  toolHandler?: ToolHandler;
+  /** Maximum tool call rounds before forcing text response (default: 10) */
+  maxToolRounds?: number;
+  /** Custom response-to-output converter (overrides SHA-256 default) */
+  responseToOutput?: (response: string) => bigint[];
+  /** Required capabilities bitmask — canExecute returns false if task doesn't match */
+  requiredCapabilities?: bigint;
+}
+
+/**
+ * TaskExecutor implementation that delegates task execution to an LLM provider.
+ *
+ * The executor:
+ * 1. Decodes the 64-byte task description to UTF-8 (strips null padding)
+ * 2. Builds a conversation with optional system prompt + task description
+ * 3. Sends to the LLM provider (streaming or non-streaming)
+ * 4. Handles tool call loops up to maxToolRounds
+ * 5. Converts the final text response to 4 bigints
+ */
+export class LLMTaskExecutor implements TaskExecutor {
+  private readonly provider: LLMProvider;
+  private readonly systemPrompt?: string;
+  private readonly streaming: boolean;
+  private readonly onStreamChunk?: StreamProgressCallback;
+  private readonly toolHandler?: ToolHandler;
+  private readonly maxToolRounds: number;
+  private readonly convertResponse: (response: string) => bigint[];
+  private readonly requiredCapabilities?: bigint;
+
+  constructor(config: LLMTaskExecutorConfig) {
+    this.provider = config.provider;
+    this.systemPrompt = config.systemPrompt;
+    this.streaming = config.streaming ?? false;
+    this.onStreamChunk = config.onStreamChunk;
+    this.toolHandler = config.toolHandler;
+    this.maxToolRounds = config.maxToolRounds ?? 10;
+    this.convertResponse = config.responseToOutput ?? responseToOutput;
+    this.requiredCapabilities = config.requiredCapabilities;
+  }
+
+  async execute(task: Task): Promise<bigint[]> {
+    const description = decodeDescription(task.description);
+    const messages = this.buildMessages(task, description);
+
+    let response;
+    if (this.streaming && this.onStreamChunk) {
+      response = await this.provider.chatStream(messages, this.onStreamChunk);
+    } else {
+      response = await this.provider.chat(messages);
+    }
+
+    // Handle tool call loop
+    let rounds = 0;
+    while (response.finishReason === 'tool_calls' && response.toolCalls.length > 0 && this.toolHandler) {
+      if (rounds >= this.maxToolRounds) {
+        break;
+      }
+      rounds++;
+
+      // Add assistant message with tool calls
+      messages.push({
+        role: 'assistant',
+        content: response.content,
+      });
+
+      // Execute each tool call and add results
+      for (const toolCall of response.toolCalls) {
+        let args: Record<string, unknown>;
+        try {
+          args = JSON.parse(toolCall.arguments) as Record<string, unknown>;
+        } catch {
+          args = {};
+        }
+        const result = await this.toolHandler(toolCall.name, args);
+        messages.push({
+          role: 'tool',
+          content: result,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        });
+      }
+
+      if (this.streaming && this.onStreamChunk) {
+        response = await this.provider.chatStream(messages, this.onStreamChunk);
+      } else {
+        response = await this.provider.chat(messages);
+      }
+    }
+
+    return this.convertResponse(response.content);
+  }
+
+  canExecute(task: Task): boolean {
+    if (this.requiredCapabilities === undefined) {
+      return true;
+    }
+    return (task.requiredCapabilities & this.requiredCapabilities) === task.requiredCapabilities;
+  }
+
+  private buildMessages(task: Task, description: string): LLMMessage[] {
+    const messages: LLMMessage[] = [];
+
+    if (this.systemPrompt) {
+      messages.push({ role: 'system', content: this.systemPrompt });
+    }
+
+    const taskInfo = [
+      `Task ID: ${Buffer.from(task.taskId).toString('hex')}`,
+      `Reward: ${task.reward} lamports`,
+      `Deadline: ${task.deadline > 0 ? new Date(task.deadline * 1000).toISOString() : 'none'}`,
+      `Description: ${description}`,
+    ].join('\n');
+
+    messages.push({ role: 'user', content: taskInfo });
+    return messages;
+  }
+}
+
+/**
+ * Decode a 64-byte task description to a UTF-8 string.
+ * Strips trailing null bytes and trims whitespace.
+ */
+function decodeDescription(description: Uint8Array): string {
+  // Find the first null byte to strip padding
+  let end = description.length;
+  for (let i = 0; i < description.length; i++) {
+    if (description[i] === 0) {
+      end = i;
+      break;
+    }
+  }
+  return Buffer.from(description.subarray(0, end)).toString('utf-8').trim();
+}

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LLMMessage } from '../types.js';
+import { LLMProviderError, LLMRateLimitError } from '../errors.js';
+
+// Mock the openai module
+const mockCreate = vi.fn();
+const mockModelsListFn = vi.fn();
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      chat = { completions: { create: mockCreate } };
+      models = { list: mockModelsListFn };
+      constructor(_opts: any) {}
+    },
+  };
+});
+
+// Import after mock setup
+import { GrokProvider } from './adapter.js';
+
+function makeCompletion(overrides: Record<string, any> = {}) {
+  return {
+    choices: [
+      {
+        message: { content: 'Hello!', tool_calls: [] },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    model: 'grok-3',
+    ...overrides,
+  };
+}
+
+describe('GrokProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends messages in OpenAI-compatible format', async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    const messages: LLMMessage[] = [
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hello' },
+    ];
+
+    const response = await provider.chat(messages);
+
+    expect(mockCreate).toHaveBeenCalledOnce();
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.model).toBe('grok-3');
+    expect(params.messages).toEqual([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hello' },
+    ]);
+    expect(response.content).toBe('Hello!');
+    expect(response.finishReason).toBe('stop');
+  });
+
+  it('parses tool calls from response', async () => {
+    const completion = makeCompletion({
+      choices: [
+        {
+          message: {
+            content: '',
+            tool_calls: [
+              { id: 'call_1', function: { name: 'search', arguments: '{"q":"test"}' } },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    });
+    mockCreate.mockResolvedValueOnce(completion);
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    const response = await provider.chat([{ role: 'user', content: 'search for test' }]);
+
+    expect(response.toolCalls).toHaveLength(1);
+    expect(response.toolCalls[0].name).toBe('search');
+    expect(response.finishReason).toBe('tool_calls');
+  });
+
+  it('injects web_search tool when webSearch is true', async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const provider = new GrokProvider({ apiKey: 'test-key', webSearch: true });
+    await provider.chat([{ role: 'user', content: 'test' }]);
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.tools).toBeDefined();
+    const names = params.tools.map((t: any) => t.function.name);
+    expect(names).toContain('web_search');
+  });
+
+  it('passes usage information', async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    const response = await provider.chat([{ role: 'user', content: 'test' }]);
+
+    expect(response.usage).toEqual({
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it('handles streaming', async () => {
+    const chunks = [
+      { choices: [{ delta: { content: 'Hello' }, finish_reason: null }] },
+      { choices: [{ delta: { content: ' world' }, finish_reason: 'stop' }], model: 'grok-3' },
+    ];
+    mockCreate.mockResolvedValueOnce((async function* () {
+      for (const c of chunks) yield c;
+    })());
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    const onChunk = vi.fn();
+    const response = await provider.chatStream(
+      [{ role: 'user', content: 'test' }],
+      onChunk,
+    );
+
+    expect(response.content).toBe('Hello world');
+    expect(onChunk).toHaveBeenCalledWith({ content: 'Hello', done: false });
+    expect(onChunk).toHaveBeenCalledWith({ content: ' world', done: false });
+    expect(onChunk).toHaveBeenCalledWith({ content: '', done: true, toolCalls: [] });
+  });
+
+  it('maps 429 error to LLMRateLimitError', async () => {
+    mockCreate.mockRejectedValueOnce({ status: 429, message: 'Rate limited', headers: {} });
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    await expect(provider.chat([{ role: 'user', content: 'test' }]))
+      .rejects.toThrow(LLMRateLimitError);
+  });
+
+  it('maps general errors to LLMProviderError', async () => {
+    mockCreate.mockRejectedValueOnce({ status: 500, message: 'Internal server error' });
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    await expect(provider.chat([{ role: 'user', content: 'test' }]))
+      .rejects.toThrow(LLMProviderError);
+  });
+
+  it('healthCheck returns true on success', async () => {
+    mockModelsListFn.mockResolvedValueOnce({ data: [] });
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    const result = await provider.healthCheck();
+    expect(result).toBe(true);
+  });
+
+  it('healthCheck returns false on failure', async () => {
+    mockModelsListFn.mockRejectedValueOnce(new Error('fail'));
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    const result = await provider.healthCheck();
+    expect(result).toBe(false);
+  });
+
+  it('uses custom model', async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const provider = new GrokProvider({ apiKey: 'test-key', model: 'grok-3-mini' });
+    await provider.chat([{ role: 'user', content: 'test' }]);
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.model).toBe('grok-3-mini');
+  });
+
+  it('formats tool result messages correctly', async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const provider = new GrokProvider({ apiKey: 'test-key' });
+    await provider.chat([
+      { role: 'user', content: 'search' },
+      { role: 'tool', content: 'result data', toolCallId: 'call_1', toolName: 'search' },
+    ]);
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.messages[1]).toEqual({
+      role: 'tool',
+      content: 'result data',
+      tool_call_id: 'call_1',
+    });
+  });
+});

--- a/runtime/src/llm/grok/index.ts
+++ b/runtime/src/llm/grok/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Grok (xAI) LLM provider module
+ *
+ * @module
+ */
+
+export { GrokProvider } from './adapter.js';
+export type { GrokProviderConfig } from './types.js';

--- a/runtime/src/llm/grok/types.ts
+++ b/runtime/src/llm/grok/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Grok provider configuration types
+ *
+ * @module
+ */
+
+import type { LLMProviderConfig } from '../types.js';
+
+/**
+ * Configuration specific to the Grok (xAI) provider.
+ * Uses the `openai` SDK pointed at the xAI API.
+ */
+export interface GrokProviderConfig extends LLMProviderConfig {
+  /** xAI API key */
+  apiKey: string;
+  /** Base URL for the xAI API (default: 'https://api.x.ai/v1') */
+  baseURL?: string;
+  /** Enable web search tool (injects a web_search tool) */
+  webSearch?: boolean;
+  /** Search mode when web search is enabled */
+  searchMode?: 'auto' | 'on' | 'off';
+}

--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -1,0 +1,43 @@
+/**
+ * LLM Adapters for @agenc/runtime
+ *
+ * Provides LLM provider adapters that bridge language models
+ * to the AgenC task execution system (Phase 4).
+ *
+ * @module
+ */
+
+// Core types
+export type {
+  LLMProvider,
+  LLMProviderConfig,
+  LLMMessage,
+  LLMResponse,
+  LLMStreamChunk,
+  LLMTool,
+  LLMToolCall,
+  LLMUsage,
+  MessageRole,
+  StreamProgressCallback,
+  ToolHandler,
+} from './types.js';
+
+// Error classes
+export {
+  LLMProviderError,
+  LLMRateLimitError,
+  LLMResponseConversionError,
+  LLMToolCallError,
+  LLMTimeoutError,
+} from './errors.js';
+
+// Response converter
+export { responseToOutput } from './response-converter.js';
+
+// LLM Task Executor
+export { LLMTaskExecutor, type LLMTaskExecutorConfig } from './executor.js';
+
+// Provider adapters
+export { GrokProvider, type GrokProviderConfig } from './grok/index.js';
+export { AnthropicProvider, type AnthropicProviderConfig } from './anthropic/index.js';
+export { OllamaProvider, type OllamaProviderConfig } from './ollama/index.js';

--- a/runtime/src/llm/ollama/adapter.test.ts
+++ b/runtime/src/llm/ollama/adapter.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { LLMMessage } from '../types.js';
+import { LLMProviderError } from '../errors.js';
+
+// Mock the ollama module
+const mockChat = vi.fn();
+const mockList = vi.fn();
+
+vi.mock('ollama', () => {
+  return {
+    Ollama: class MockOllama {
+      chat = mockChat;
+      list = mockList;
+      constructor(_opts: any) {}
+    },
+  };
+});
+
+import { OllamaProvider } from './adapter.js';
+
+function makeResponse(overrides: Record<string, any> = {}) {
+  return {
+    message: { content: 'Hello!', role: 'assistant', tool_calls: [] },
+    model: 'llama3',
+    prompt_eval_count: 10,
+    eval_count: 5,
+    ...overrides,
+  };
+}
+
+describe('OllamaProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends messages in correct format', async () => {
+    mockChat.mockResolvedValueOnce(makeResponse());
+
+    const provider = new OllamaProvider({});
+    const messages: LLMMessage[] = [
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hello' },
+    ];
+    const response = await provider.chat(messages);
+
+    expect(mockChat).toHaveBeenCalledOnce();
+    const params = mockChat.mock.calls[0][0];
+    expect(params.model).toBe('llama3');
+    expect(params.messages).toEqual([
+      { role: 'system', content: 'You are helpful.' },
+      { role: 'user', content: 'Hello' },
+    ]);
+    expect(response.content).toBe('Hello!');
+  });
+
+  it('passes options for temperature and context', async () => {
+    mockChat.mockResolvedValueOnce(makeResponse());
+
+    const provider = new OllamaProvider({
+      temperature: 0.7,
+      numCtx: 8192,
+      numGpu: 1,
+    });
+    await provider.chat([{ role: 'user', content: 'test' }]);
+
+    const params = mockChat.mock.calls[0][0];
+    expect(params.options).toEqual({
+      temperature: 0.7,
+      num_ctx: 8192,
+      num_gpu: 1,
+    });
+  });
+
+  it('uses custom model', async () => {
+    mockChat.mockResolvedValueOnce(makeResponse());
+
+    const provider = new OllamaProvider({ model: 'mistral' });
+    await provider.chat([{ role: 'user', content: 'test' }]);
+
+    const params = mockChat.mock.calls[0][0];
+    expect(params.model).toBe('mistral');
+  });
+
+  it('parses tool calls', async () => {
+    const response = makeResponse({
+      message: {
+        content: '',
+        role: 'assistant',
+        tool_calls: [
+          { function: { name: 'search', arguments: { q: 'test' } } },
+        ],
+      },
+    });
+    mockChat.mockResolvedValueOnce(response);
+
+    const provider = new OllamaProvider({});
+    const result = await provider.chat([{ role: 'user', content: 'test' }]);
+
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].name).toBe('search');
+    expect(result.toolCalls[0].arguments).toBe('{"q":"test"}');
+    expect(result.finishReason).toBe('tool_calls');
+  });
+
+  it('handles streaming via async iterable', async () => {
+    const chunks = [
+      { message: { content: 'Hello' }, model: 'llama3' },
+      { message: { content: ' world' }, model: 'llama3', prompt_eval_count: 10, eval_count: 5 },
+    ];
+    mockChat.mockResolvedValueOnce((async function* () {
+      for (const c of chunks) yield c;
+    })());
+
+    const provider = new OllamaProvider({});
+    const onChunk = vi.fn();
+    const result = await provider.chatStream(
+      [{ role: 'user', content: 'test' }],
+      onChunk,
+    );
+
+    expect(result.content).toBe('Hello world');
+    expect(onChunk).toHaveBeenCalledWith({ content: 'Hello', done: false });
+    expect(onChunk).toHaveBeenCalledWith({ content: ' world', done: false });
+    expect(onChunk).toHaveBeenCalledWith({ content: '', done: true, toolCalls: [] });
+  });
+
+  it('returns usage information', async () => {
+    mockChat.mockResolvedValueOnce(makeResponse());
+
+    const provider = new OllamaProvider({});
+    const result = await provider.chat([{ role: 'user', content: 'test' }]);
+
+    expect(result.usage).toEqual({
+      promptTokens: 10,
+      completionTokens: 5,
+      totalTokens: 15,
+    });
+  });
+
+  it('healthCheck returns true when server is running', async () => {
+    mockList.mockResolvedValueOnce({ models: [] });
+
+    const provider = new OllamaProvider({});
+    const result = await provider.healthCheck();
+    expect(result).toBe(true);
+    expect(mockList).toHaveBeenCalledOnce();
+  });
+
+  it('healthCheck returns false when server is not running', async () => {
+    mockList.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const provider = new OllamaProvider({});
+    const result = await provider.healthCheck();
+    expect(result).toBe(false);
+  });
+
+  it('maps ECONNREFUSED to descriptive error', async () => {
+    mockChat.mockRejectedValueOnce({ code: 'ECONNREFUSED', message: 'Connection refused' });
+
+    const provider = new OllamaProvider({});
+    await expect(provider.chat([{ role: 'user', content: 'test' }]))
+      .rejects.toThrow(/Cannot connect to Ollama/);
+  });
+
+  it('maps general errors to LLMProviderError', async () => {
+    mockChat.mockRejectedValueOnce({ message: 'model not found' });
+
+    const provider = new OllamaProvider({});
+    await expect(provider.chat([{ role: 'user', content: 'test' }]))
+      .rejects.toThrow(LLMProviderError);
+  });
+
+  it('passes keepAlive configuration', async () => {
+    mockChat.mockResolvedValueOnce(makeResponse());
+
+    const provider = new OllamaProvider({ keepAlive: '10m' });
+    await provider.chat([{ role: 'user', content: 'test' }]);
+
+    const params = mockChat.mock.calls[0][0];
+    expect(params.keep_alive).toBe('10m');
+  });
+
+  it('passes tools in OpenAI-compatible format', async () => {
+    mockChat.mockResolvedValueOnce(makeResponse());
+
+    const provider = new OllamaProvider({
+      tools: [{
+        type: 'function',
+        function: { name: 'lookup', description: 'Look up info', parameters: { type: 'object' } },
+      }],
+    });
+    await provider.chat([{ role: 'user', content: 'test' }]);
+
+    const params = mockChat.mock.calls[0][0];
+    expect(params.tools).toHaveLength(1);
+    expect(params.tools[0].function.name).toBe('lookup');
+  });
+});

--- a/runtime/src/llm/ollama/adapter.ts
+++ b/runtime/src/llm/ollama/adapter.ts
@@ -1,0 +1,208 @@
+/**
+ * Ollama local LLM provider adapter.
+ *
+ * Uses the `ollama` SDK for local model inference.
+ * The SDK is loaded lazily on first use — it's an optional dependency.
+ *
+ * @module
+ */
+
+import type {
+  LLMProvider,
+  LLMMessage,
+  LLMResponse,
+  LLMToolCall,
+  LLMUsage,
+  LLMTool,
+  StreamProgressCallback,
+} from '../types.js';
+import type { OllamaProviderConfig } from './types.js';
+import { LLMProviderError, LLMTimeoutError } from '../errors.js';
+
+const DEFAULT_HOST = 'http://localhost:11434';
+const DEFAULT_MODEL = 'llama3';
+
+export class OllamaProvider implements LLMProvider {
+  readonly name = 'ollama';
+
+  private client: unknown | null = null;
+  private readonly config: OllamaProviderConfig;
+  private readonly tools: LLMTool[];
+
+  constructor(config: OllamaProviderConfig) {
+    this.config = {
+      ...config,
+      model: config.model ?? DEFAULT_MODEL,
+      host: config.host ?? DEFAULT_HOST,
+    };
+    this.tools = config.tools ?? [];
+  }
+
+  async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+    const client = await this.ensureClient();
+    const params = this.buildParams(messages);
+
+    try {
+      const response = await (client as any).chat(params);
+      return this.parseResponse(response);
+    } catch (err: unknown) {
+      throw this.mapError(err);
+    }
+  }
+
+  async chatStream(messages: LLMMessage[], onChunk: StreamProgressCallback): Promise<LLMResponse> {
+    const client = await this.ensureClient();
+    const params = { ...this.buildParams(messages), stream: true };
+
+    try {
+      const stream = await (client as any).chat(params);
+
+      let content = '';
+      let model = this.config.model;
+      let toolCalls: LLMToolCall[] = [];
+      let promptTokens = 0;
+      let completionTokens = 0;
+
+      for await (const chunk of stream as AsyncIterable<any>) {
+        if (chunk.message?.content) {
+          content += chunk.message.content;
+          onChunk({ content: chunk.message.content, done: false });
+        }
+
+        // Accumulate tool calls
+        if (chunk.message?.tool_calls) {
+          for (const tc of chunk.message.tool_calls) {
+            toolCalls.push({
+              id: tc.function?.name ?? `call_${toolCalls.length}`,
+              name: tc.function?.name ?? '',
+              arguments: JSON.stringify(tc.function?.arguments ?? {}),
+            });
+          }
+        }
+
+        if (chunk.model) model = chunk.model;
+        if (chunk.prompt_eval_count) promptTokens = chunk.prompt_eval_count;
+        if (chunk.eval_count) completionTokens = chunk.eval_count;
+      }
+
+      const finishReason: LLMResponse['finishReason'] = toolCalls.length > 0 ? 'tool_calls' : 'stop';
+      onChunk({ content: '', done: true, toolCalls });
+
+      return {
+        content,
+        toolCalls,
+        usage: { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens },
+        model,
+        finishReason,
+      };
+    } catch (err: unknown) {
+      throw this.mapError(err);
+    }
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      const client = await this.ensureClient();
+      await (client as any).list();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async ensureClient(): Promise<unknown> {
+    if (this.client) return this.client;
+
+    let OllamaClass: any;
+    try {
+      const mod = await import('ollama');
+      OllamaClass = mod.Ollama ?? mod.default;
+    } catch {
+      throw new LLMProviderError(
+        this.name,
+        'ollama package not installed. Install it: npm install ollama',
+      );
+    }
+
+    this.client = new OllamaClass({ host: this.config.host });
+    return this.client;
+  }
+
+  private buildParams(messages: LLMMessage[]): Record<string, unknown> {
+    const params: Record<string, unknown> = {
+      model: this.config.model,
+      messages: messages.map((m) => this.toOllamaMessage(m)),
+    };
+
+    // Build options
+    const options: Record<string, unknown> = {};
+    if (this.config.temperature !== undefined) options.temperature = this.config.temperature;
+    if (this.config.numCtx !== undefined) options.num_ctx = this.config.numCtx;
+    if (this.config.numGpu !== undefined) options.num_gpu = this.config.numGpu;
+    if (Object.keys(options).length > 0) params.options = options;
+
+    if (this.config.keepAlive !== undefined) params.keep_alive = this.config.keepAlive;
+
+    // Tools — Ollama uses OpenAI-compatible format
+    if (this.tools.length > 0) params.tools = this.tools;
+
+    return params;
+  }
+
+  private toOllamaMessage(msg: LLMMessage): Record<string, unknown> {
+    if (msg.role === 'tool') {
+      return {
+        role: 'tool',
+        content: msg.content,
+      };
+    }
+    return { role: msg.role, content: msg.content };
+  }
+
+  private parseResponse(response: any): LLMResponse {
+    const message = response.message ?? {};
+    const content = message.content ?? '';
+
+    const toolCalls: LLMToolCall[] = (message.tool_calls ?? []).map((tc: any, i: number) => ({
+      id: tc.function?.name ?? `call_${i}`,
+      name: tc.function?.name ?? '',
+      arguments: JSON.stringify(tc.function?.arguments ?? {}),
+    }));
+
+    const usage: LLMUsage = {
+      promptTokens: response.prompt_eval_count ?? 0,
+      completionTokens: response.eval_count ?? 0,
+      totalTokens: (response.prompt_eval_count ?? 0) + (response.eval_count ?? 0),
+    };
+
+    return {
+      content,
+      toolCalls,
+      usage,
+      model: response.model ?? this.config.model,
+      finishReason: toolCalls.length > 0 ? 'tool_calls' : 'stop',
+    };
+  }
+
+  private mapError(err: unknown): Error {
+    if (err instanceof LLMProviderError || err instanceof LLMTimeoutError) {
+      return err;
+    }
+
+    const e = err as any;
+    const message = e?.message ?? String(err);
+
+    if (e?.code === 'ECONNREFUSED') {
+      return new LLMProviderError(
+        this.name,
+        `Cannot connect to Ollama at ${this.config.host}. Is the server running?`,
+      );
+    }
+
+    if (e?.code === 'ETIMEDOUT' || message.includes('timeout')) {
+      return new LLMTimeoutError(this.name, this.config.timeoutMs ?? 0);
+    }
+
+    return new LLMProviderError(this.name, message, e?.status);
+  }
+}

--- a/runtime/src/llm/ollama/index.ts
+++ b/runtime/src/llm/ollama/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Ollama local LLM provider module
+ *
+ * @module
+ */
+
+export { OllamaProvider } from './adapter.js';
+export type { OllamaProviderConfig } from './types.js';

--- a/runtime/src/llm/ollama/types.ts
+++ b/runtime/src/llm/ollama/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Ollama provider configuration types
+ *
+ * @module
+ */
+
+import type { LLMProviderConfig } from '../types.js';
+
+/**
+ * Configuration specific to the Ollama local inference provider.
+ */
+export interface OllamaProviderConfig extends LLMProviderConfig {
+  /** Ollama server host URL (default: 'http://localhost:11434') */
+  host?: string;
+  /** Keep model in memory after request (default: '5m') */
+  keepAlive?: string;
+  /** Context window size */
+  numCtx?: number;
+  /** Number of GPU layers */
+  numGpu?: number;
+}

--- a/runtime/src/llm/response-converter.test.ts
+++ b/runtime/src/llm/response-converter.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'crypto';
+import { responseToOutput } from './response-converter.js';
+
+describe('responseToOutput', () => {
+  it('returns exactly 4 bigints', () => {
+    const output = responseToOutput('hello world');
+    expect(output).toHaveLength(4);
+    for (const v of output) {
+      expect(typeof v).toBe('bigint');
+    }
+  });
+
+  it('is deterministic — same input produces same output', () => {
+    const a = responseToOutput('test response');
+    const b = responseToOutput('test response');
+    expect(a).toEqual(b);
+  });
+
+  it('produces different output for different input', () => {
+    const a = responseToOutput('response A');
+    const b = responseToOutput('response B');
+    expect(a).not.toEqual(b);
+  });
+
+  it('all values fit in 64 bits', () => {
+    const MAX_U64 = (1n << 64n) - 1n;
+    const output = responseToOutput('some text to hash');
+    for (const v of output) {
+      expect(v).toBeGreaterThanOrEqual(0n);
+      expect(v).toBeLessThanOrEqual(MAX_U64);
+    }
+  });
+
+  it('handles empty string', () => {
+    const output = responseToOutput('');
+    expect(output).toHaveLength(4);
+    // SHA-256 of empty string is well-known
+    const emptyHash = createHash('sha256').update('', 'utf-8').digest();
+    expect(emptyHash.length).toBe(32);
+    // Verify values are non-zero (SHA-256 of '' is not all zeros)
+    const allZero = output.every((v) => v === 0n);
+    expect(allZero).toBe(false);
+  });
+
+  it('handles unicode input', () => {
+    const output = responseToOutput('こんにちは世界 🌍');
+    expect(output).toHaveLength(4);
+    for (const v of output) {
+      expect(typeof v).toBe('bigint');
+      expect(v).toBeGreaterThanOrEqual(0n);
+    }
+  });
+
+  it('matches known SHA-256 test vector', () => {
+    // SHA-256("abc") = ba7816bf 8f01cfea 414140de 5dae2223 b00361a3 96177a9c b410ff61 f20015ad
+    const output = responseToOutput('abc');
+    // First 8 bytes LE: ba 78 16 bf 8f 01 cf ea
+    const expected0 =
+      0xban |
+      (0x78n << 8n) |
+      (0x16n << 16n) |
+      (0xbfn << 24n) |
+      (0x8fn << 32n) |
+      (0x01n << 40n) |
+      (0xcfn << 48n) |
+      (0xean << 56n);
+    expect(output[0]).toBe(expected0);
+  });
+});

--- a/runtime/src/llm/response-converter.ts
+++ b/runtime/src/llm/response-converter.ts
@@ -1,0 +1,33 @@
+/**
+ * Converts LLM text responses to the 4-bigint output format
+ * required by the ZK proof system.
+ *
+ * Uses SHA-256 to hash the response, then splits the 32-byte digest
+ * into 4 x 8-byte little-endian chunks, each converted to a bigint.
+ * Values are 64-bit (max ~1.8e19), well within the BN254 field (~2^254).
+ *
+ * @module
+ */
+
+import { createHash } from 'crypto';
+
+/**
+ * Convert an LLM text response to 4 bigints via SHA-256 hashing.
+ *
+ * Deterministic: same input always produces the same output.
+ *
+ * @param response - The text response from the LLM
+ * @returns Array of exactly 4 bigints
+ */
+export function responseToOutput(response: string): bigint[] {
+  const hash = createHash('sha256').update(response, 'utf-8').digest();
+  const output: bigint[] = [];
+  for (let i = 0; i < 4; i++) {
+    let value = 0n;
+    for (let j = 0; j < 8; j++) {
+      value |= BigInt(hash[i * 8 + j]) << BigInt(j * 8);
+    }
+    output.push(value);
+  }
+  return output;
+}

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -1,0 +1,121 @@
+/**
+ * LLM provider types for @agenc/runtime
+ *
+ * Defines the core interfaces for LLM adapters that bridge
+ * language model providers to the AgenC task execution system.
+ *
+ * @module
+ */
+
+/**
+ * Message role in a conversation
+ */
+export type MessageRole = 'system' | 'user' | 'assistant' | 'tool';
+
+/**
+ * A single message in an LLM conversation
+ */
+export interface LLMMessage {
+  role: MessageRole;
+  content: string;
+  /** For tool result messages — the ID of the tool call being responded to */
+  toolCallId?: string;
+  /** For tool result messages — the name of the tool */
+  toolName?: string;
+}
+
+/**
+ * Tool definition in OpenAI-compatible format
+ */
+export interface LLMTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
+}
+
+/**
+ * A tool call requested by the LLM
+ */
+export interface LLMToolCall {
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+/**
+ * Token usage statistics
+ */
+export interface LLMUsage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+}
+
+/**
+ * Response from an LLM provider
+ */
+export interface LLMResponse {
+  content: string;
+  toolCalls: LLMToolCall[];
+  usage: LLMUsage;
+  model: string;
+  finishReason: 'stop' | 'tool_calls' | 'length' | 'content_filter' | 'error';
+}
+
+/**
+ * A chunk from a streaming LLM response
+ */
+export interface LLMStreamChunk {
+  content: string;
+  done: boolean;
+  toolCalls?: LLMToolCall[];
+}
+
+/**
+ * Callback for streaming progress updates
+ */
+export type StreamProgressCallback = (chunk: LLMStreamChunk) => void;
+
+/**
+ * Handler for tool calls — maps tool name + arguments to a string result
+ */
+export type ToolHandler = (name: string, args: Record<string, unknown>) => Promise<string>;
+
+/**
+ * Core LLM provider interface that all adapters implement
+ */
+export interface LLMProvider {
+  readonly name: string;
+  chat(messages: LLMMessage[]): Promise<LLMResponse>;
+  chatStream(messages: LLMMessage[], onChunk: StreamProgressCallback): Promise<LLMResponse>;
+  healthCheck(): Promise<boolean>;
+}
+
+/**
+ * Shared configuration for all LLM providers
+ */
+export interface LLMProviderConfig {
+  /** Model identifier (e.g. 'grok-3', 'claude-sonnet-4-5-20250929', 'llama3') */
+  model: string;
+  /** System prompt prepended to conversations */
+  systemPrompt?: string;
+  /** Sampling temperature (0.0 - 2.0) */
+  temperature?: number;
+  /** Maximum tokens in the response */
+  maxTokens?: number;
+  /** Tools available to the model */
+  tools?: LLMTool[];
+  /** Handler called when the model invokes a tool */
+  toolHandler?: ToolHandler;
+  /** Maximum tool call rounds before forcing a text response (default: 10) */
+  maxToolRounds?: number;
+  /** Request timeout in milliseconds */
+  timeoutMs?: number;
+  /** Maximum automatic retries on transient failures */
+  maxRetries?: number;
+  /** Base delay between retries in milliseconds */
+  retryDelayMs?: number;
+}

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -39,8 +39,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY).toBe('RECENT_VOTE_ACTIVITY');
   });
 
-  it('has exactly 16 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(16);
+  it('has exactly 21 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(21);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -48,6 +48,16 @@ export const RuntimeErrorCodes = {
   CLAIM_EXPIRED: 'CLAIM_EXPIRED',
   /** All retry attempts exhausted */
   RETRY_EXHAUSTED: 'RETRY_EXHAUSTED',
+  /** LLM provider returned an error */
+  LLM_PROVIDER_ERROR: 'LLM_PROVIDER_ERROR',
+  /** LLM provider rate limit exceeded */
+  LLM_RATE_LIMIT: 'LLM_RATE_LIMIT',
+  /** Failed to convert LLM response to output */
+  LLM_RESPONSE_CONVERSION: 'LLM_RESPONSE_CONVERSION',
+  /** LLM tool call failed */
+  LLM_TOOL_CALL_ERROR: 'LLM_TOOL_CALL_ERROR',
+  /** LLM request timed out */
+  LLM_TIMEOUT: 'LLM_TIMEOUT',
 } as const;
 
 /** Union type of all runtime error code values */


### PR DESCRIPTION
## Summary

- Adds LLM adapter system enabling autonomous agents to use language models for task execution
- Three provider adapters: **Grok** (xAI), **Anthropic** (Claude), **Ollama** (local)
- `LLMTaskExecutor` bridges any `LLMProvider` to the autonomous `TaskExecutor` interface
- SDKs are optional dependencies loaded lazily via dynamic `import()` — build succeeds without them
- Response converter: SHA-256 hash of LLM text output → 4 bigints for ZK proof compatibility

## Details

**New files (19):**
- `runtime/src/llm/types.ts` — Core interfaces (LLMProvider, LLMMessage, LLMResponse, LLMTool, etc.)
- `runtime/src/llm/errors.ts` — 5 error classes (LLMProviderError, LLMRateLimitError, LLMResponseConversionError, LLMToolCallError, LLMTimeoutError)
- `runtime/src/llm/response-converter.ts` — SHA-256 → 4 x 64-bit LE bigints
- `runtime/src/llm/executor.ts` — LLMTaskExecutor with tool call loop, streaming, custom converter support
- `runtime/src/llm/grok/adapter.ts` — Uses `openai` SDK, web search injection, xAI base URL
- `runtime/src/llm/anthropic/adapter.ts` — System prompt extraction, tool schema conversion, extended thinking
- `runtime/src/llm/ollama/adapter.ts` — Local inference, async iterable streaming, health check via `list()`
- Barrel exports and provider-specific config types

**Modified files:**
- `runtime/src/types/errors.ts` — 5 new `RuntimeErrorCodes` for LLM errors
- `runtime/src/index.ts` — LLM exports section added
- `runtime/package.json` — `optionalDependencies` + tsup `--external` flags
- `runtime/src/autonomous/types.ts` — `AutonomousTaskExecutor` type alias (fixes pre-existing naming conflict)

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm run test` — 51 new tests, 781 total passing (20 pre-existing failures from missing snarkjs, unrelated)
- [x] `npm run build` — clean ESM + CJS output, optional deps externalized
- [ ] Verify `import { GrokProvider, LLMTaskExecutor } from '@agenc/runtime'` resolves in a consumer project