### PR TITLE
feat(runtime): add MCP-compatible tool system (Phase 5)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -395,3 +395,35 @@ export {
   type AutonomousAgentStats,
   DefaultClaimStrategy,
 } from './autonomous/index.js';
+
+// Tool System (Phase 5)
+export {
+  // Core types
+  type Tool,
+  type ToolResult,
+  type ToolContext,
+  type ToolRegistryConfig,
+  type JSONSchema,
+  bigintReplacer,
+  safeStringify,
+  // Error types
+  ToolNotFoundError,
+  ToolAlreadyRegisteredError,
+  ToolExecutionError,
+  // Registry
+  ToolRegistry,
+  // Skill-to-Tool adapter
+  skillToTools,
+  type ActionSchemaMap,
+  type SkillToToolsOptions,
+  JUPITER_ACTION_SCHEMAS,
+  // Built-in AgenC tools
+  createAgencTools,
+  createListTasksTool,
+  createGetTaskTool,
+  createGetAgentTool,
+  createGetProtocolConfigTool,
+  type SerializedTask,
+  type SerializedAgent,
+  type SerializedProtocolConfig,
+} from './tools/index.js';

--- a/runtime/src/tools/agenc/agenc-tools.test.ts
+++ b/runtime/src/tools/agenc/agenc-tools.test.ts
@@ -1,0 +1,322 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PublicKey } from '@solana/web3.js';
+import { createAgencTools } from './index.js';
+import {
+  createListTasksTool,
+  createGetTaskTool,
+  createGetAgentTool,
+  createGetProtocolConfigTool,
+} from './tools.js';
+import type { ToolContext } from '../types.js';
+import { silentLogger } from '../../utils/logger.js';
+import { OnChainTaskStatus } from '../../task/types.js';
+import { TaskType } from '../../events/types.js';
+
+// ============================================================================
+// Mock Data Factories
+// ============================================================================
+
+const TASK_PDA = PublicKey.unique();
+const AGENT_PDA = PublicKey.unique();
+const CREATOR = PublicKey.unique();
+const ESCROW = PublicKey.unique();
+
+function makeMockTask(overrides: Record<string, unknown> = {}) {
+  return {
+    taskId: new Uint8Array(32),
+    creator: CREATOR,
+    requiredCapabilities: 3n, // COMPUTE | INFERENCE
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    rewardAmount: 1_000_000_000n,
+    maxWorkers: 1,
+    currentWorkers: 0,
+    status: OnChainTaskStatus.Open,
+    taskType: TaskType.Exclusive,
+    createdAt: 1700000000,
+    deadline: 1700003600,
+    completedAt: 0,
+    escrow: ESCROW,
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+function makeMockAgent() {
+  return {
+    agentId: new Uint8Array(32),
+    authority: PublicKey.unique(),
+    capabilities: 1n,
+    status: { active: {} },
+    registeredAt: { toNumber: () => 1700000000 },
+    lastActive: { toNumber: () => 1700000100 },
+    endpoint: 'agent://test',
+    metadataUri: '',
+    tasksCompleted: { toString: () => '5' },
+    totalEarned: { toString: () => '5000000000' },
+    reputation: 8000,
+    activeTasks: 1,
+    stake: { toString: () => '1000000000' },
+    lastTaskCreated: { toNumber: () => 0 },
+    lastDisputeInitiated: { toNumber: () => 0 },
+    taskCount24h: 0,
+    disputeCount24h: 0,
+    rateLimitWindowStart: { toNumber: () => 0 },
+    activeDisputeVotes: 0,
+    lastVoteTimestamp: { toNumber: () => 0 },
+    lastStateUpdate: { toNumber: () => 0 },
+    bump: 254,
+  };
+}
+
+function makeMockProtocolConfig() {
+  return {
+    authority: PublicKey.unique(),
+    treasury: PublicKey.unique(),
+    disputeThreshold: 51,
+    protocolFeeBps: 100,
+    minArbiterStake: { toString: () => '5000000000' },
+    minAgentStake: { toString: () => '1000000000' },
+    maxClaimDuration: { toNumber: () => 3600 },
+    maxDisputeDuration: { toNumber: () => 86400 },
+    totalAgents: { toString: () => '10' },
+    totalTasks: { toString: () => '50' },
+    completedTasks: { toString: () => '40' },
+    totalValueDistributed: { toString: () => '100000000000' },
+    bump: 255,
+    multisigThreshold: 2,
+    multisigOwnersLen: 3,
+    taskCreationCooldown: { toNumber: () => 60 },
+    maxTasksPer24h: 10,
+    disputeInitiationCooldown: { toNumber: () => 300 },
+    maxDisputesPer24h: 2,
+    minStakeForDispute: { toString: () => '2000000000' },
+    slashPercentage: 10,
+    protocolVersion: 1,
+    minSupportedVersion: 1,
+    multisigOwners: [PublicKey.unique(), PublicKey.unique(), PublicKey.unique()],
+  };
+}
+
+// ============================================================================
+// Mock TaskOperations
+// ============================================================================
+
+function createMockOps() {
+  return {
+    fetchClaimableTasks: vi.fn(async () => [
+      { task: makeMockTask(), taskPda: TASK_PDA },
+      { task: makeMockTask({ status: OnChainTaskStatus.InProgress }), taskPda: PublicKey.unique() },
+    ]),
+    fetchAllTasks: vi.fn(async () => [
+      { task: makeMockTask(), taskPda: TASK_PDA },
+      { task: makeMockTask({ status: OnChainTaskStatus.InProgress }), taskPda: PublicKey.unique() },
+      { task: makeMockTask({ status: OnChainTaskStatus.Completed }), taskPda: PublicKey.unique() },
+    ]),
+    fetchTask: vi.fn(async (pda: PublicKey) => {
+      if (pda.equals(TASK_PDA)) return makeMockTask();
+      return null;
+    }),
+  };
+}
+
+// ============================================================================
+// Mock Program
+// ============================================================================
+
+function createMockProgram() {
+  return {
+    programId: PublicKey.unique(),
+    account: {
+      agentRegistration: {
+        fetch: vi.fn(async (pda: PublicKey) => {
+          if (pda.equals(AGENT_PDA)) return makeMockAgent();
+          throw new Error('Account does not exist');
+        }),
+      },
+      protocolConfig: {
+        fetch: vi.fn(async () => makeMockProtocolConfig()),
+      },
+    },
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('createAgencTools', () => {
+  it('returns exactly 4 tools', () => {
+    const mockProgram = createMockProgram() as unknown as ToolContext['program'];
+    const tools = createAgencTools({
+      connection: {} as ToolContext['connection'],
+      program: mockProgram,
+      logger: silentLogger,
+    });
+
+    expect(tools).toHaveLength(4);
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'agenc.getAgent',
+      'agenc.getProtocolConfig',
+      'agenc.getTask',
+      'agenc.listTasks',
+    ]);
+  });
+});
+
+describe('agenc.listTasks', () => {
+  let tool: ReturnType<typeof createListTasksTool>;
+  let mockOps: ReturnType<typeof createMockOps>;
+
+  beforeEach(() => {
+    mockOps = createMockOps();
+    tool = createListTasksTool(mockOps as never, silentLogger);
+  });
+
+  it('uses fetchClaimableTasks for open status (default)', async () => {
+    const result = await tool.execute({});
+    const parsed = JSON.parse(result.content);
+
+    expect(mockOps.fetchClaimableTasks).toHaveBeenCalled();
+    expect(mockOps.fetchAllTasks).not.toHaveBeenCalled();
+    expect(parsed.count).toBe(1); // Only Open tasks
+  });
+
+  it('uses fetchClaimableTasks for in_progress status', async () => {
+    const result = await tool.execute({ status: 'in_progress' });
+    const parsed = JSON.parse(result.content);
+
+    expect(mockOps.fetchClaimableTasks).toHaveBeenCalled();
+    expect(mockOps.fetchAllTasks).not.toHaveBeenCalled();
+    expect(parsed.count).toBe(1); // Only InProgress tasks
+  });
+
+  it('uses fetchAllTasks for all status', async () => {
+    const result = await tool.execute({ status: 'all' });
+    const parsed = JSON.parse(result.content);
+
+    expect(mockOps.fetchAllTasks).toHaveBeenCalled();
+    expect(parsed.count).toBe(3);
+  });
+
+  it('respects limit parameter', async () => {
+    const result = await tool.execute({ status: 'all', limit: 1 });
+    const parsed = JSON.parse(result.content);
+
+    expect(parsed.count).toBe(1);
+    expect(parsed.total).toBe(3);
+  });
+
+  it('clamps limit to MAX_LIMIT', async () => {
+    const result = await tool.execute({ status: 'all', limit: 999 });
+    const parsed = JSON.parse(result.content);
+
+    // Should still work (just capped at 200)
+    expect(parsed.count).toBe(3);
+  });
+
+  it('returns valid task fields', async () => {
+    const result = await tool.execute({});
+    const parsed = JSON.parse(result.content);
+
+    expect(parsed.tasks[0]).toHaveProperty('taskPda');
+    expect(parsed.tasks[0]).toHaveProperty('status', 'Open');
+    expect(parsed.tasks[0]).toHaveProperty('rewardSol');
+    expect(parsed.tasks[0]).toHaveProperty('requiredCapabilities');
+    expect(parsed.tasks[0]).toHaveProperty('isPrivate');
+  });
+});
+
+describe('agenc.getTask', () => {
+  let tool: ReturnType<typeof createGetTaskTool>;
+  let mockOps: ReturnType<typeof createMockOps>;
+
+  beforeEach(() => {
+    mockOps = createMockOps();
+    tool = createGetTaskTool(mockOps as never, silentLogger);
+  });
+
+  it('returns task details for valid PDA', async () => {
+    const result = await tool.execute({ taskPda: TASK_PDA.toBase58() });
+    const parsed = JSON.parse(result.content);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.taskPda).toBe(TASK_PDA.toBase58());
+    expect(parsed.status).toBe('Open');
+  });
+
+  it('returns isError for invalid base58', async () => {
+    const result = await tool.execute({ taskPda: 'not-valid-base58!!!' });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toContain('Invalid base58');
+  });
+
+  it('returns isError for not-found task', async () => {
+    const result = await tool.execute({ taskPda: PublicKey.unique().toBase58() });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toContain('not found');
+  });
+
+  it('returns isError for missing taskPda', async () => {
+    const result = await tool.execute({});
+    expect(result.isError).toBe(true);
+  });
+});
+
+describe('agenc.getAgent', () => {
+  let tool: ReturnType<typeof createGetAgentTool>;
+
+  beforeEach(() => {
+    const mockProgram = createMockProgram();
+    tool = createGetAgentTool(mockProgram as never, silentLogger);
+  });
+
+  it('returns agent details for valid PDA', async () => {
+    const result = await tool.execute({ agentPda: AGENT_PDA.toBase58() });
+    const parsed = JSON.parse(result.content);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.agentPda).toBe(AGENT_PDA.toBase58());
+    expect(parsed.status).toBe('Active');
+    expect(parsed.capabilities).toContain('COMPUTE');
+  });
+
+  it('returns isError for invalid base58', async () => {
+    const result = await tool.execute({ agentPda: '!!!invalid' });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toContain('Invalid base58');
+  });
+
+  it('returns isError for not-found agent', async () => {
+    const result = await tool.execute({ agentPda: PublicKey.unique().toBase58() });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content).error).toContain('not found');
+  });
+});
+
+describe('agenc.getProtocolConfig', () => {
+  let tool: ReturnType<typeof createGetProtocolConfigTool>;
+
+  beforeEach(() => {
+    const mockProgram = createMockProgram();
+    tool = createGetProtocolConfigTool(mockProgram as never, silentLogger);
+  });
+
+  it('returns protocol config', async () => {
+    const result = await tool.execute({});
+    const parsed = JSON.parse(result.content);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed).toHaveProperty('protocolFeeBps', 100);
+    expect(parsed).toHaveProperty('disputeThreshold', 51);
+    expect(parsed).toHaveProperty('protocolVersion', 1);
+    expect(parsed).toHaveProperty('totalTasks', '50');
+  });
+});

--- a/runtime/src/tools/agenc/index.ts
+++ b/runtime/src/tools/agenc/index.ts
@@ -1,0 +1,62 @@
+/**
+ * Built-in AgenC protocol query tools.
+ *
+ * @module
+ */
+
+import type { Tool, ToolContext } from '../types.js';
+import { TaskOperations } from '../../task/operations.js';
+import { createReadOnlyProgram } from '../../idl.js';
+import {
+  createListTasksTool,
+  createGetTaskTool,
+  createGetAgentTool,
+  createGetProtocolConfigTool,
+} from './tools.js';
+
+// Re-export serialized types
+export type { SerializedTask, SerializedAgent, SerializedProtocolConfig } from './types.js';
+
+// Re-export individual tool factories for advanced usage
+export {
+  createListTasksTool,
+  createGetTaskTool,
+  createGetAgentTool,
+  createGetProtocolConfigTool,
+} from './tools.js';
+
+/**
+ * Create all 4 built-in AgenC protocol query tools.
+ *
+ * The factory creates a single `TaskOperations` instance shared by
+ * all tools. If no program is provided in the context, a read-only
+ * program is created from the connection.
+ *
+ * @param context - Tool context with connection and optional program
+ * @returns Array of 4 Tool instances
+ *
+ * @example
+ * ```typescript
+ * const tools = createAgencTools({ connection, logger });
+ * registry.registerAll(tools);
+ * ```
+ */
+export function createAgencTools(context: ToolContext): Tool[] {
+  const program = context.program ?? createReadOnlyProgram(context.connection);
+
+  // Dummy agentId — built-in tools only use query methods that don't reference agentId
+  const dummyAgentId = new Uint8Array(32);
+
+  const ops = new TaskOperations({
+    program,
+    agentId: dummyAgentId,
+    logger: context.logger,
+  });
+
+  return [
+    createListTasksTool(ops, context.logger),
+    createGetTaskTool(ops, context.logger),
+    createGetAgentTool(program, context.logger),
+    createGetProtocolConfigTool(program, context.logger),
+  ];
+}

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -1,0 +1,305 @@
+/**
+ * Built-in AgenC protocol query tools.
+ *
+ * Four read-only tools for querying on-chain state:
+ * - agenc.listTasks — list tasks with optional status filter
+ * - agenc.getTask — fetch a single task by PDA
+ * - agenc.getAgent — fetch agent registration by PDA
+ * - agenc.getProtocolConfig — fetch protocol configuration
+ *
+ * @module
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../../types/agenc_coordination.js';
+import type { Tool, ToolResult } from '../types.js';
+import { safeStringify } from '../types.js';
+import { TaskOperations } from '../../task/operations.js';
+import {
+  taskStatusToString,
+  taskTypeToString,
+  isPrivateTask,
+  OnChainTaskStatus,
+} from '../../task/types.js';
+import { parseAgentState, agentStatusToString } from '../../agent/types.js';
+import { getCapabilityNames } from '../../agent/capabilities.js';
+import { parseProtocolConfig } from '../../types/protocol.js';
+import { findProtocolPda } from '../../agent/pda.js';
+import { lamportsToSol, bytesToHex } from '../../utils/encoding.js';
+import type { Logger } from '../../utils/logger.js';
+import type { OnChainTask } from '../../task/types.js';
+import type { AgentState } from '../../agent/types.js';
+import type { ProtocolConfig } from '../../types/protocol.js';
+import type { SerializedTask, SerializedAgent, SerializedProtocolConfig } from './types.js';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/**
+ * Return a JSON error ToolResult without throwing.
+ */
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+/**
+ * Safely parse a base58 string into a PublicKey.
+ * Returns null and an error result if invalid.
+ */
+function parseBase58(input: unknown): [PublicKey | null, ToolResult | null] {
+  if (typeof input !== 'string' || input.length === 0) {
+    return [null, errorResult('Missing or invalid address')];
+  }
+  try {
+    return [new PublicKey(input), null];
+  } catch {
+    return [null, errorResult(`Invalid base58 address: ${input}`)];
+  }
+}
+
+// ============================================================================
+// Serialization Helpers
+// ============================================================================
+
+function serializeTask(task: OnChainTask, taskPda: PublicKey): SerializedTask {
+  return {
+    taskPda: taskPda.toBase58(),
+    taskId: bytesToHex(task.taskId),
+    creator: task.creator.toBase58(),
+    status: taskStatusToString(task.status),
+    taskType: taskTypeToString(task.taskType),
+    rewardAmount: task.rewardAmount.toString(),
+    rewardSol: lamportsToSol(task.rewardAmount),
+    requiredCapabilities: getCapabilityNames(task.requiredCapabilities),
+    maxWorkers: task.maxWorkers,
+    currentWorkers: task.currentWorkers,
+    deadline: task.deadline,
+    isPrivate: isPrivateTask(task),
+    createdAt: task.createdAt,
+    completions: task.completions,
+    requiredCompletions: task.requiredCompletions,
+    description: bytesToHex(task.description),
+  };
+}
+
+function serializeAgent(agent: AgentState, agentPda: PublicKey): SerializedAgent {
+  return {
+    agentPda: agentPda.toBase58(),
+    agentId: bytesToHex(agent.agentId),
+    authority: agent.authority.toBase58(),
+    status: agentStatusToString(agent.status),
+    capabilities: getCapabilityNames(agent.capabilities),
+    endpoint: agent.endpoint,
+    stake: agent.stake.toString(),
+    activeTasks: agent.activeTasks,
+    reputation: agent.reputation,
+    tasksCompleted: agent.tasksCompleted.toString(),
+    totalEarned: agent.totalEarned.toString(),
+  };
+}
+
+function serializeProtocolConfig(config: ProtocolConfig): SerializedProtocolConfig {
+  return {
+    authority: config.authority.toBase58(),
+    treasury: config.treasury.toBase58(),
+    protocolFeeBps: config.protocolFeeBps,
+    disputeThreshold: config.disputeThreshold,
+    minAgentStake: config.minAgentStake.toString(),
+    minArbiterStake: config.minArbiterStake.toString(),
+    maxClaimDuration: config.maxClaimDuration,
+    maxDisputeDuration: config.maxDisputeDuration,
+    totalAgents: config.totalAgents.toString(),
+    totalTasks: config.totalTasks.toString(),
+    completedTasks: config.completedTasks.toString(),
+    totalValueDistributed: config.totalValueDistributed.toString(),
+    taskCreationCooldown: config.taskCreationCooldown,
+    maxTasksPer24h: config.maxTasksPer24h,
+    disputeInitiationCooldown: config.disputeInitiationCooldown,
+    maxDisputesPer24h: config.maxDisputesPer24h,
+    minStakeForDispute: config.minStakeForDispute.toString(),
+    slashPercentage: config.slashPercentage,
+    protocolVersion: config.protocolVersion,
+    minSupportedVersion: config.minSupportedVersion,
+  };
+}
+
+// ============================================================================
+// Tool Factory Functions
+// ============================================================================
+
+/**
+ * Create the agenc.listTasks tool.
+ */
+export function createListTasksTool(
+  ops: TaskOperations,
+  logger: Logger,
+): Tool {
+  return {
+    name: 'agenc.listTasks',
+    description:
+      'List tasks on the AgenC protocol. Filter by status (open, in_progress, all). Returns task details including reward, capabilities, and deadline.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        status: {
+          type: 'string',
+          enum: ['open', 'in_progress', 'all'],
+          description: 'Filter by task status (default: open)',
+        },
+        limit: {
+          type: 'number',
+          description: `Maximum tasks to return (default: ${DEFAULT_LIMIT}, max: ${MAX_LIMIT})`,
+        },
+      },
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const status = (args.status as string) || 'open';
+        const rawLimit = typeof args.limit === 'number' ? args.limit : DEFAULT_LIMIT;
+        const limit = Math.min(Math.max(1, rawLimit), MAX_LIMIT);
+
+        let tasks: Array<{ task: OnChainTask; taskPda: PublicKey }>;
+
+        if (status === 'all') {
+          tasks = await ops.fetchAllTasks();
+        } else {
+          // fetchClaimableTasks uses memcmp filters (scalable)
+          const claimable = await ops.fetchClaimableTasks();
+          if (status === 'open') {
+            tasks = claimable.filter((t) => t.task.status === OnChainTaskStatus.Open);
+          } else {
+            // in_progress
+            tasks = claimable.filter((t) => t.task.status === OnChainTaskStatus.InProgress);
+          }
+        }
+
+        const limited = tasks.slice(0, limit);
+        const serialized = limited.map((t) => serializeTask(t.task, t.taskPda));
+
+        return {
+          content: safeStringify({
+            count: serialized.length,
+            total: tasks.length,
+            tasks: serialized,
+          }),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        logger.error(`agenc.listTasks failed: ${msg}`);
+        return errorResult(msg);
+      }
+    },
+  };
+}
+
+/**
+ * Create the agenc.getTask tool.
+ */
+export function createGetTaskTool(
+  ops: TaskOperations,
+  logger: Logger,
+): Tool {
+  return {
+    name: 'agenc.getTask',
+    description:
+      'Get details for a specific AgenC task by its PDA address (base58).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        taskPda: {
+          type: 'string',
+          description: 'Task account PDA address (base58)',
+        },
+      },
+      required: ['taskPda'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const [pda, err] = parseBase58(args.taskPda);
+      if (err) return err;
+
+      try {
+        const task = await ops.fetchTask(pda!);
+        if (!task) {
+          return errorResult(`Task not found: ${pda!.toBase58()}`);
+        }
+        return { content: safeStringify(serializeTask(task, pda!)) };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(`agenc.getTask failed: ${msg}`);
+        return errorResult(msg);
+      }
+    },
+  };
+}
+
+/**
+ * Create the agenc.getAgent tool.
+ */
+export function createGetAgentTool(
+  program: Program<AgencCoordination>,
+  logger: Logger,
+): Tool {
+  return {
+    name: 'agenc.getAgent',
+    description:
+      'Get details for an AgenC agent by its PDA address (base58). Returns status, capabilities, stake, and performance metrics.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        agentPda: {
+          type: 'string',
+          description: 'Agent registration PDA address (base58)',
+        },
+      },
+      required: ['agentPda'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const [pda, err] = parseBase58(args.agentPda);
+      if (err) return err;
+
+      try {
+        const raw = await program.account.agentRegistration.fetch(pda!);
+        const agent = parseAgentState(raw);
+        return { content: safeStringify(serializeAgent(agent, pda!)) };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        if (msg.includes('Account does not exist') || msg.includes('could not find')) {
+          return errorResult(`Agent not found: ${pda!.toBase58()}`);
+        }
+        logger.error(`agenc.getAgent failed: ${msg}`);
+        return errorResult(msg);
+      }
+    },
+  };
+}
+
+/**
+ * Create the agenc.getProtocolConfig tool.
+ */
+export function createGetProtocolConfigTool(
+  program: Program<AgencCoordination>,
+  logger: Logger,
+): Tool {
+  return {
+    name: 'agenc.getProtocolConfig',
+    description:
+      'Get the AgenC protocol configuration including fees, stake requirements, rate limits, and protocol version.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+    async execute(): Promise<ToolResult> {
+      try {
+        const protocolPda = findProtocolPda(program.programId);
+        const raw = await program.account.protocolConfig.fetch(protocolPda);
+        const config = parseProtocolConfig(raw);
+        return { content: safeStringify(serializeProtocolConfig(config)) };
+      } catch (error) {
+        const msg = error instanceof Error ? error.message : String(error);
+        logger.error(`agenc.getProtocolConfig failed: ${msg}`);
+        return errorResult(msg);
+      }
+    },
+  };
+}

--- a/runtime/src/tools/agenc/types.ts
+++ b/runtime/src/tools/agenc/types.ts
@@ -1,0 +1,73 @@
+/**
+ * JSON-safe serialized types for AgenC built-in tool responses.
+ *
+ * All bigint → string, PublicKey → base58, Uint8Array → hex,
+ * enums → string names.
+ *
+ * @module
+ */
+
+/**
+ * JSON-safe representation of an on-chain Task.
+ */
+export interface SerializedTask {
+  taskPda: string;
+  taskId: string;
+  creator: string;
+  status: string;
+  taskType: string;
+  rewardAmount: string;
+  rewardSol: string;
+  requiredCapabilities: string[];
+  maxWorkers: number;
+  currentWorkers: number;
+  deadline: number;
+  isPrivate: boolean;
+  createdAt: number;
+  completions: number;
+  requiredCompletions: number;
+  description: string;
+}
+
+/**
+ * JSON-safe representation of an on-chain AgentRegistration.
+ */
+export interface SerializedAgent {
+  agentPda: string;
+  agentId: string;
+  authority: string;
+  status: string;
+  capabilities: string[];
+  endpoint: string;
+  stake: string;
+  activeTasks: number;
+  reputation: number;
+  tasksCompleted: string;
+  totalEarned: string;
+}
+
+/**
+ * JSON-safe representation of the ProtocolConfig.
+ */
+export interface SerializedProtocolConfig {
+  authority: string;
+  treasury: string;
+  protocolFeeBps: number;
+  disputeThreshold: number;
+  minAgentStake: string;
+  minArbiterStake: string;
+  maxClaimDuration: number;
+  maxDisputeDuration: number;
+  totalAgents: string;
+  totalTasks: string;
+  completedTasks: string;
+  totalValueDistributed: string;
+  taskCreationCooldown: number;
+  maxTasksPer24h: number;
+  disputeInitiationCooldown: number;
+  maxDisputesPer24h: number;
+  minStakeForDispute: string;
+  slashPercentage: number;
+  protocolVersion: number;
+  minSupportedVersion: number;
+}

--- a/runtime/src/tools/errors.ts
+++ b/runtime/src/tools/errors.ts
@@ -1,0 +1,67 @@
+/**
+ * Tool-specific error types for @agenc/runtime
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Error thrown when a tool cannot be found by name.
+ */
+export class ToolNotFoundError extends RuntimeError {
+  /** The name of the tool that was not found */
+  public readonly toolName: string;
+
+  constructor(toolName: string) {
+    super(`Tool not found: "${toolName}"`, RuntimeErrorCodes.VALIDATION_ERROR);
+    this.name = 'ToolNotFoundError';
+    this.toolName = toolName;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ToolNotFoundError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a tool with the same name is already registered.
+ */
+export class ToolAlreadyRegisteredError extends RuntimeError {
+  /** The name of the duplicate tool */
+  public readonly toolName: string;
+
+  constructor(toolName: string) {
+    super(
+      `Tool "${toolName}" is already registered`,
+      RuntimeErrorCodes.VALIDATION_ERROR,
+    );
+    this.name = 'ToolAlreadyRegisteredError';
+    this.toolName = toolName;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ToolAlreadyRegisteredError);
+    }
+  }
+}
+
+/**
+ * Error thrown when tool execution fails.
+ */
+export class ToolExecutionError extends RuntimeError {
+  /** The name of the tool that failed */
+  public readonly toolName: string;
+  /** The cause of the failure */
+  public readonly cause: string;
+
+  constructor(toolName: string, cause: string) {
+    super(
+      `Tool "${toolName}" execution failed: ${cause}`,
+      RuntimeErrorCodes.LLM_TOOL_CALL_ERROR,
+    );
+    this.name = 'ToolExecutionError';
+    this.toolName = toolName;
+    this.cause = cause;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ToolExecutionError);
+    }
+  }
+}

--- a/runtime/src/tools/index.ts
+++ b/runtime/src/tools/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Tool system for @agenc/runtime
+ *
+ * MCP-compatible tool registry that bridges the Skills system and
+ * LLM adapters. Provides built-in AgenC protocol query tools and
+ * a skill-to-tool adapter.
+ *
+ * @module
+ */
+
+// Core types
+export {
+  type Tool,
+  type ToolResult,
+  type ToolContext,
+  type ToolRegistryConfig,
+  type JSONSchema,
+  bigintReplacer,
+  safeStringify,
+} from './types.js';
+
+// Error types
+export {
+  ToolNotFoundError,
+  ToolAlreadyRegisteredError,
+  ToolExecutionError,
+} from './errors.js';
+
+// Registry
+export { ToolRegistry } from './registry.js';
+
+// Skill-to-Tool adapter
+export {
+  skillToTools,
+  type ActionSchemaMap,
+  type SkillToToolsOptions,
+  JUPITER_ACTION_SCHEMAS,
+} from './skill-adapter.js';
+
+// Built-in AgenC tools
+export {
+  createAgencTools,
+  createListTasksTool,
+  createGetTaskTool,
+  createGetAgentTool,
+  createGetProtocolConfigTool,
+  type SerializedTask,
+  type SerializedAgent,
+  type SerializedProtocolConfig,
+} from './agenc/index.js';

--- a/runtime/src/tools/registry.test.ts
+++ b/runtime/src/tools/registry.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ToolRegistry } from './registry.js';
+import { ToolNotFoundError, ToolAlreadyRegisteredError } from './errors.js';
+import type { Tool, ToolResult } from './types.js';
+
+function makeTool(name: string, overrides?: Partial<Tool>): Tool {
+  return {
+    name,
+    description: `Test tool: ${name}`,
+    inputSchema: { type: 'object', properties: {} },
+    execute: overrides?.execute ?? (async () => ({ content: `result from ${name}` })),
+    ...overrides,
+  };
+}
+
+describe('ToolRegistry', () => {
+  // --------------------------------------------------------------------------
+  // Registration
+  // --------------------------------------------------------------------------
+
+  it('registers and retrieves a tool', () => {
+    const registry = new ToolRegistry();
+    const tool = makeTool('test.echo');
+    registry.register(tool);
+
+    expect(registry.get('test.echo')).toBe(tool);
+    expect(registry.size).toBe(1);
+  });
+
+  it('throws on duplicate registration', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('test.echo'));
+
+    expect(() => registry.register(makeTool('test.echo'))).toThrow(ToolAlreadyRegisteredError);
+  });
+
+  it('registerAll registers multiple tools', () => {
+    const registry = new ToolRegistry();
+    registry.registerAll([makeTool('a'), makeTool('b'), makeTool('c')]);
+    expect(registry.size).toBe(3);
+  });
+
+  // --------------------------------------------------------------------------
+  // Unregistration
+  // --------------------------------------------------------------------------
+
+  it('unregister removes a tool', () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('test.echo'));
+
+    expect(registry.unregister('test.echo')).toBe(true);
+    expect(registry.get('test.echo')).toBeUndefined();
+    expect(registry.size).toBe(0);
+  });
+
+  it('unregister returns false for unknown tool', () => {
+    const registry = new ToolRegistry();
+    expect(registry.unregister('nope')).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Lookup
+  // --------------------------------------------------------------------------
+
+  it('get returns undefined for unknown tool', () => {
+    const registry = new ToolRegistry();
+    expect(registry.get('nope')).toBeUndefined();
+  });
+
+  it('getOrThrow throws for unknown tool', () => {
+    const registry = new ToolRegistry();
+    expect(() => registry.getOrThrow('nope')).toThrow(ToolNotFoundError);
+  });
+
+  it('listNames returns all names', () => {
+    const registry = new ToolRegistry();
+    registry.registerAll([makeTool('b'), makeTool('a')]);
+    expect(registry.listNames()).toEqual(['b', 'a']);
+  });
+
+  it('listAll returns all tools', () => {
+    const registry = new ToolRegistry();
+    const tools = [makeTool('x'), makeTool('y')];
+    registry.registerAll(tools);
+    expect(registry.listAll()).toEqual(tools);
+  });
+
+  // --------------------------------------------------------------------------
+  // toLLMTools
+  // --------------------------------------------------------------------------
+
+  it('toLLMTools maps tools correctly', () => {
+    const registry = new ToolRegistry();
+    const schema = { type: 'object', properties: { q: { type: 'string' } } };
+    registry.register(makeTool('test.search', {
+      description: 'Search things',
+      inputSchema: schema,
+    }));
+
+    const llmTools = registry.toLLMTools();
+    expect(llmTools).toHaveLength(1);
+    expect(llmTools[0]).toEqual({
+      type: 'function',
+      function: {
+        name: 'test.search',
+        description: 'Search things',
+        parameters: schema,
+      },
+    });
+  });
+
+  it('toLLMTools returns empty array when no tools', () => {
+    const registry = new ToolRegistry();
+    expect(registry.toLLMTools()).toEqual([]);
+  });
+
+  // --------------------------------------------------------------------------
+  // createToolHandler
+  // --------------------------------------------------------------------------
+
+  it('createToolHandler dispatches to correct tool', async () => {
+    const registry = new ToolRegistry();
+    const executeFn = vi.fn(async (): Promise<ToolResult> => ({
+      content: '{"status":"ok"}',
+    }));
+    registry.register(makeTool('test.run', { execute: executeFn }));
+
+    const handler = registry.createToolHandler();
+    const result = await handler('test.run', { foo: 'bar' });
+
+    expect(executeFn).toHaveBeenCalledWith({ foo: 'bar' });
+    expect(result).toBe('{"status":"ok"}');
+  });
+
+  it('createToolHandler returns error JSON for unknown tool', async () => {
+    const registry = new ToolRegistry();
+    const handler = registry.createToolHandler();
+    const result = await handler('nope', {});
+
+    expect(JSON.parse(result)).toEqual({ error: 'Tool not found: "nope"' });
+  });
+
+  it('createToolHandler catches thrown errors', async () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('test.fail', {
+      execute: async () => { throw new Error('boom'); },
+    }));
+
+    const handler = registry.createToolHandler();
+    const result = await handler('test.fail', {});
+
+    expect(JSON.parse(result)).toEqual({ error: 'boom' });
+  });
+
+  it('createToolHandler returns error content from tool', async () => {
+    const registry = new ToolRegistry();
+    registry.register(makeTool('test.soft-fail', {
+      execute: async (): Promise<ToolResult> => ({
+        content: '{"error":"invalid input"}',
+        isError: true,
+      }),
+    }));
+
+    const handler = registry.createToolHandler();
+    const result = await handler('test.soft-fail', {});
+
+    expect(result).toBe('{"error":"invalid input"}');
+  });
+});

--- a/runtime/src/tools/skill-adapter.test.ts
+++ b/runtime/src/tools/skill-adapter.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from 'vitest';
+import { skillToTools, JUPITER_ACTION_SCHEMAS } from './skill-adapter.js';
+import { ToolExecutionError } from './errors.js';
+import type { Skill, SkillAction, SkillMetadata } from '../skills/types.js';
+import { SkillState } from '../skills/types.js';
+import type { JSONSchema } from './types.js';
+
+function makeSkill(
+  actions: SkillAction[],
+  state: SkillState = SkillState.Ready,
+  name = 'test-skill',
+): Skill {
+  return {
+    metadata: {
+      name,
+      description: 'Test skill',
+      version: '0.1.0',
+      requiredCapabilities: 0n,
+    } as SkillMetadata,
+    state,
+    initialize: vi.fn(),
+    shutdown: vi.fn(),
+    getActions: () => actions,
+    getAction: (n: string) => actions.find((a) => a.name === n),
+  };
+}
+
+function makeAction(name: string, result: unknown = { ok: true }): SkillAction {
+  return {
+    name,
+    description: `Action: ${name}`,
+    execute: vi.fn(async () => result),
+  };
+}
+
+describe('skillToTools', () => {
+  it('creates namespaced tools from skill actions', () => {
+    const skill = makeSkill([makeAction('getQuote'), makeAction('executeSwap')]);
+    const schemas: Record<string, JSONSchema> = {
+      getQuote: { type: 'object', properties: {} },
+      executeSwap: { type: 'object', properties: {} },
+    };
+
+    const tools = skillToTools(skill, { schemas });
+
+    expect(tools).toHaveLength(2);
+    expect(tools[0].name).toBe('test-skill.getQuote');
+    expect(tools[1].name).toBe('test-skill.executeSwap');
+  });
+
+  it('uses custom namespace', () => {
+    const skill = makeSkill([makeAction('doStuff')]);
+    const tools = skillToTools(skill, {
+      schemas: { doStuff: { type: 'object' } },
+      namespace: 'custom',
+    });
+
+    expect(tools[0].name).toBe('custom.doStuff');
+  });
+
+  it('skips actions without schema', () => {
+    const skill = makeSkill([
+      makeAction('exposed'),
+      makeAction('hidden'),
+    ]);
+
+    const tools = skillToTools(skill, {
+      schemas: { exposed: { type: 'object' } },
+    });
+
+    expect(tools).toHaveLength(1);
+    expect(tools[0].name).toBe('test-skill.exposed');
+  });
+
+  it('throws on non-Ready skill', () => {
+    const skill = makeSkill([makeAction('a')], SkillState.Created);
+
+    expect(() =>
+      skillToTools(skill, { schemas: { a: { type: 'object' } } }),
+    ).toThrow(ToolExecutionError);
+  });
+
+  it('execute wraps result with safeStringify (handles bigint)', async () => {
+    const skill = makeSkill([makeAction('bigResult', { amount: 1000000000n, ok: true })]);
+    const tools = skillToTools(skill, {
+      schemas: { bigResult: { type: 'object' } },
+    });
+
+    const result = await tools[0].execute({});
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.amount).toBe('1000000000');
+    expect(parsed.ok).toBe(true);
+  });
+
+  it('catches action errors and returns ToolResult.isError', async () => {
+    const action: SkillAction = {
+      name: 'failing',
+      description: 'Fails',
+      execute: async () => { throw new Error('network error'); },
+    };
+    const skill = makeSkill([action]);
+    const tools = skillToTools(skill, {
+      schemas: { failing: { type: 'object' } },
+    });
+
+    const result = await tools[0].execute({});
+
+    expect(result.isError).toBe(true);
+    expect(JSON.parse(result.content)).toEqual({ error: 'network error' });
+  });
+});
+
+describe('JUPITER_ACTION_SCHEMAS', () => {
+  it('has entries for all 7 Jupiter actions', () => {
+    const expected = [
+      'getQuote',
+      'executeSwap',
+      'getSolBalance',
+      'getTokenBalance',
+      'transferSol',
+      'transferToken',
+      'getTokenPrice',
+    ];
+    expect(Object.keys(JUPITER_ACTION_SCHEMAS).sort()).toEqual(expected.sort());
+  });
+
+  it('each schema has type: object', () => {
+    for (const schema of Object.values(JUPITER_ACTION_SCHEMAS)) {
+      expect(schema.type).toBe('object');
+    }
+  });
+});

--- a/runtime/src/tools/skill-adapter.ts
+++ b/runtime/src/tools/skill-adapter.ts
@@ -1,0 +1,173 @@
+/**
+ * Skill-to-Tool adapter.
+ *
+ * Converts Skill actions into Tool instances, bridging the skill system
+ * to the MCP-compatible tool registry.
+ *
+ * @module
+ */
+
+import type { Skill, SkillAction } from '../skills/types.js';
+import { SkillState } from '../skills/types.js';
+import type { Tool, JSONSchema, ToolResult } from './types.js';
+import { safeStringify } from './types.js';
+import { ToolExecutionError } from './errors.js';
+
+/**
+ * Map of action names to their JSON Schema definitions.
+ * Only actions with a schema entry are exposed as tools.
+ */
+export type ActionSchemaMap = Record<string, JSONSchema>;
+
+/**
+ * Options for converting a skill to tools.
+ */
+export interface SkillToToolsOptions {
+  /** JSON Schema for each action to expose */
+  schemas: ActionSchemaMap;
+  /** Namespace prefix (defaults to skill.metadata.name) */
+  namespace?: string;
+}
+
+/**
+ * Convert a Skill's actions into Tool instances.
+ *
+ * Each SkillAction becomes a Tool with:
+ * - name: `${namespace}.${action.name}`
+ * - inputSchema: from the schema map
+ * - execute: wraps action.execute, serializes result with safeStringify
+ *
+ * Actions without a schema entry are skipped.
+ *
+ * @param skill - The skill to convert (must be in Ready state)
+ * @param options - Schema map and optional namespace override
+ * @returns Array of Tool instances
+ * @throws ToolExecutionError if skill is not in Ready state
+ */
+export function skillToTools(skill: Skill, options: SkillToToolsOptions): Tool[] {
+  if (skill.state !== SkillState.Ready) {
+    throw new ToolExecutionError(
+      skill.metadata.name,
+      `Skill must be in Ready state (current: ${SkillState[skill.state]})`,
+    );
+  }
+
+  const namespace = options.namespace ?? skill.metadata.name;
+  const actions = skill.getActions();
+  const tools: Tool[] = [];
+
+  for (const action of actions) {
+    const schema = options.schemas[action.name];
+    if (!schema) {
+      continue;
+    }
+
+    tools.push(createToolFromAction(namespace, action, schema));
+  }
+
+  return tools;
+}
+
+/**
+ * Create a single Tool from a SkillAction.
+ */
+function createToolFromAction(
+  namespace: string,
+  action: SkillAction,
+  schema: JSONSchema,
+): Tool {
+  return {
+    name: `${namespace}.${action.name}`,
+    description: action.description,
+    inputSchema: schema,
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const result = await action.execute(args);
+        return { content: safeStringify(result) };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: safeStringify({ error: message }),
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Pre-built Schema Maps
+// ============================================================================
+
+/**
+ * JSON Schema definitions for all 7 Jupiter skill actions.
+ *
+ * Bigint fields use `type: 'string'` since JSON cannot represent bigint.
+ * The LLM sends numeric strings which the action casts internally.
+ */
+export const JUPITER_ACTION_SCHEMAS: ActionSchemaMap = {
+  getQuote: {
+    type: 'object',
+    properties: {
+      inputMint: { type: 'string', description: 'Input token mint address (base58)' },
+      outputMint: { type: 'string', description: 'Output token mint address (base58)' },
+      amount: { type: 'string', description: 'Amount in smallest unit (e.g. lamports)' },
+      slippageBps: { type: 'number', description: 'Slippage tolerance in basis points' },
+      onlyDirectRoutes: { type: 'boolean', description: 'Restrict to direct routes only' },
+    },
+    required: ['inputMint', 'outputMint', 'amount'],
+  },
+  executeSwap: {
+    type: 'object',
+    properties: {
+      inputMint: { type: 'string', description: 'Input token mint address (base58)' },
+      outputMint: { type: 'string', description: 'Output token mint address (base58)' },
+      amount: { type: 'string', description: 'Amount in smallest unit (e.g. lamports)' },
+      slippageBps: { type: 'number', description: 'Slippage tolerance in basis points' },
+      onlyDirectRoutes: { type: 'boolean', description: 'Restrict to direct routes only' },
+    },
+    required: ['inputMint', 'outputMint', 'amount'],
+  },
+  getSolBalance: {
+    type: 'object',
+    properties: {
+      address: { type: 'string', description: 'Wallet address (base58). Omit for own wallet.' },
+    },
+  },
+  getTokenBalance: {
+    type: 'object',
+    properties: {
+      mint: { type: 'string', description: 'Token mint address (base58)' },
+      owner: { type: 'string', description: 'Owner wallet address (base58). Omit for own wallet.' },
+    },
+    required: ['mint'],
+  },
+  transferSol: {
+    type: 'object',
+    properties: {
+      recipient: { type: 'string', description: 'Recipient wallet address (base58)' },
+      lamports: { type: 'string', description: 'Amount in lamports' },
+    },
+    required: ['recipient', 'lamports'],
+  },
+  transferToken: {
+    type: 'object',
+    properties: {
+      recipient: { type: 'string', description: 'Recipient wallet address (base58)' },
+      mint: { type: 'string', description: 'Token mint address (base58)' },
+      amount: { type: 'string', description: 'Amount in smallest unit' },
+    },
+    required: ['recipient', 'mint', 'amount'],
+  },
+  getTokenPrice: {
+    type: 'object',
+    properties: {
+      mints: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Token mint addresses to look up',
+      },
+    },
+    required: ['mints'],
+  },
+};

--- a/runtime/src/tools/types.ts
+++ b/runtime/src/tools/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Core tool system types for @agenc/runtime
+ *
+ * Defines the MCP-compatible Tool interface and supporting types
+ * that bridge Skills and LLM adapters.
+ *
+ * @module
+ */
+
+import type { Connection } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../types/agenc_coordination.js';
+import type { Logger } from '../utils/logger.js';
+
+/**
+ * JSON Schema type alias.
+ * Matches LLMTool.function.parameters exactly — zero additional deps.
+ */
+export type JSONSchema = Record<string, unknown>;
+
+/**
+ * Result returned by a tool execution.
+ *
+ * `content` is a string because both `ToolHandler` (LLM system) and
+ * MCP specify text content for tool results.
+ */
+export interface ToolResult {
+  /** Result content — JSON string for structured data, plain text otherwise */
+  content: string;
+  /** True if execution failed (error message in content) */
+  isError?: boolean;
+  /** Optional metadata for logging — not sent to LLMs */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * MCP-compatible tool interface.
+ *
+ * Tools are the atomic unit of functionality exposed to LLM agents.
+ * They can be converted to `LLMTool[]` for provider configs and
+ * dispatched via `ToolHandler` for the executor.
+ */
+export interface Tool {
+  /** Namespaced tool name (e.g. "jupiter.getQuote", "agenc.listTasks") */
+  readonly name: string;
+  /** Human-readable description for LLM consumption */
+  readonly description: string;
+  /** JSON Schema describing the input parameters */
+  readonly inputSchema: JSONSchema;
+  /** Execute the tool with the given arguments */
+  execute(args: Record<string, unknown>): Promise<ToolResult>;
+}
+
+/**
+ * Context provided to built-in tool factories.
+ *
+ * Omits `wallet` because built-in tools are read-only queries.
+ */
+export interface ToolContext {
+  /** Solana RPC connection */
+  readonly connection: Connection;
+  /** Optional Anchor program instance (tools can create read-only if absent) */
+  readonly program?: Program<AgencCoordination>;
+  /** Logger instance */
+  readonly logger: Logger;
+}
+
+/**
+ * Configuration for ToolRegistry.
+ */
+export interface ToolRegistryConfig {
+  /** Logger for registry operations */
+  logger?: Logger;
+}
+
+/**
+ * Bigint-safe JSON replacer.
+ *
+ * Use with `JSON.stringify` for any data that may contain bigint values
+ * (e.g. lamport amounts, capability masks). Without this, `JSON.stringify`
+ * throws `TypeError: Do not know how to serialize a BigInt`.
+ */
+export function bigintReplacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? value.toString() : value;
+}
+
+/**
+ * Bigint-safe `JSON.stringify` wrapper.
+ *
+ * Equivalent to `JSON.stringify(value, bigintReplacer)`.
+ */
+export function safeStringify(value: unknown): string {
+  return JSON.stringify(value, bigintReplacer);
+}


### PR DESCRIPTION
## Summary

- Add `ToolRegistry` class that bridges Skills and LLM adapters via `toLLMTools()` and `createToolHandler()`
- Add `skillToTools()` adapter to convert `SkillAction[]` into `Tool[]` with JSON Schema definitions
- Add 4 built-in AgenC protocol query tools: `agenc.listTasks`, `agenc.getTask`, `agenc.getAgent`, `agenc.getProtocolConfig`
- Add `bigintReplacer`/`safeStringify` utilities for JSON-safe serialization of on-chain data

## Details

**12 new files** under `runtime/src/tools/`:

| Component | Files |
|-----------|-------|
| Core types | `types.ts` — `Tool`, `ToolResult`, `ToolContext`, `JSONSchema` |
| Errors | `errors.ts` — `ToolNotFoundError`, `ToolAlreadyRegisteredError`, `ToolExecutionError` |
| Registry | `registry.ts` — manages tools, generates `LLMTool[]` and `ToolHandler` |
| Skill adapter | `skill-adapter.ts` — `skillToTools()` + `JUPITER_ACTION_SCHEMAS` |
| Built-in tools | `agenc/tools.ts` — 4 read-only protocol query tools |
| Factory | `agenc/index.ts` — `createAgencTools()` creates all 4 with shared `TaskOperations` |

**Key design decisions:**
- Uses `fetchClaimableTasks()` (memcmp-filtered) instead of `fetchAllTasks()` for scalability
- Base58 input validation returns `{ isError: true }` content (never throws raw errors to LLM)
- No new `RuntimeErrorCodes` — reuses `VALIDATION_ERROR` and `LLM_TOOL_CALL_ERROR`
- No new npm dependencies

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes  
- [x] `registry.test.ts` — 15 tests pass
- [x] `skill-adapter.test.ts` — 8 tests pass
- [x] `agenc-tools.test.ts` — blocked by pre-existing snarkjs import issue (same as 20+ other test files)
- [x] All exports verified in `dist/index.d.ts`