### PR TITLE
feat(runtime): add ZK proof engine with caching (Phase 7)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -428,6 +428,27 @@ export {
   type SerializedProtocolConfig,
 } from './tools/index.js';
 
+// ZK Proof Engine (Phase 7)
+export {
+  // Core types
+  type ProofEngineConfig,
+  type ProofCacheConfig,
+  type ProofInputs,
+  type EngineProofResult,
+  type ProofEngineStats,
+  type HashResult,
+  type ToolsStatus,
+  // Error classes
+  ProofGenerationError,
+  ProofVerificationError,
+  ProofCacheError,
+  // Cache
+  ProofCache,
+  deriveCacheKey,
+  // Engine
+  ProofEngine,
+} from './proof/index.js';
+
 // Memory Backends (Phase 6)
 export {
   // Core types

--- a/runtime/src/proof/cache.ts
+++ b/runtime/src/proof/cache.ts
@@ -1,0 +1,101 @@
+/**
+ * ProofCache - In-memory proof cache with TTL and LRU eviction.
+ *
+ * @module
+ */
+
+import type { EngineProofResult, ProofCacheConfig, ProofInputs } from './types.js';
+
+/** Default TTL: 5 minutes */
+const DEFAULT_TTL_MS = 300_000;
+
+/** Default max entries */
+const DEFAULT_MAX_ENTRIES = 100;
+
+interface CacheEntry {
+  result: EngineProofResult;
+  expiresAt: number;
+}
+
+/**
+ * Derive a deterministic cache key from proof inputs.
+ *
+ * Format: `taskPda.toBase58()|agentPubkey.toBase58()|output[0]|output[1]|output[2]|output[3]|salt`
+ */
+export function deriveCacheKey(inputs: ProofInputs): string {
+  return `${inputs.taskPda.toBase58()}|${inputs.agentPubkey.toBase58()}|${inputs.output.join('|')}|${inputs.salt}`;
+}
+
+/**
+ * In-memory proof cache with TTL-based expiration and LRU eviction.
+ *
+ * Uses a Map which preserves insertion order for LRU approximation.
+ * When capacity is exceeded, the oldest entry is evicted.
+ */
+export class ProofCache {
+  private readonly cache: Map<string, CacheEntry> = new Map();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(config?: ProofCacheConfig) {
+    this.ttlMs = config?.ttlMs ?? DEFAULT_TTL_MS;
+    this.maxEntries = config?.maxEntries ?? DEFAULT_MAX_ENTRIES;
+  }
+
+  /**
+   * Get a cached proof result by inputs.
+   * Returns undefined if not found or expired.
+   */
+  get(inputs: ProofInputs): EngineProofResult | undefined {
+    const key = deriveCacheKey(inputs);
+    const entry = this.cache.get(key);
+
+    if (!entry) {
+      return undefined;
+    }
+
+    // Check TTL expiry
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+
+    // Move to end for LRU (delete + re-set preserves insertion order)
+    this.cache.delete(key);
+    this.cache.set(key, entry);
+
+    return entry.result;
+  }
+
+  /**
+   * Store a proof result in the cache.
+   */
+  set(inputs: ProofInputs, result: EngineProofResult): void {
+    const key = deriveCacheKey(inputs);
+
+    // Evict oldest entry if at capacity (and this is a new key)
+    if (!this.cache.has(key) && this.cache.size >= this.maxEntries) {
+      const firstKey = this.cache.keys().next().value as string;
+      this.cache.delete(firstKey);
+    }
+
+    this.cache.set(key, {
+      result,
+      expiresAt: Date.now() + this.ttlMs,
+    });
+  }
+
+  /**
+   * Clear all cached entries.
+   */
+  clear(): void {
+    this.cache.clear();
+  }
+
+  /**
+   * Get current number of cached entries (including expired).
+   */
+  get size(): number {
+    return this.cache.size;
+  }
+}

--- a/runtime/src/proof/engine.test.ts
+++ b/runtime/src/proof/engine.test.ts
@@ -1,0 +1,552 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { Keypair, PublicKey } from '@solana/web3.js';
+
+// Mock @agenc/sdk before imports
+vi.mock('@agenc/sdk', () => {
+  const mockProof = Buffer.alloc(256, 0xab);
+  const mockHash = Buffer.alloc(32, 0xcd);
+
+  return {
+    generateProof: vi.fn().mockResolvedValue({
+      proof: mockProof,
+      constraintHash: mockHash,
+      outputCommitment: Buffer.alloc(32, 0xef),
+      expectedBinding: Buffer.alloc(32, 0x12),
+      proofSize: 256,
+      generationTime: 42,
+    }),
+    verifyProofLocally: vi.fn().mockResolvedValue(true),
+    computeHashes: vi.fn().mockReturnValue({
+      constraintHash: 123n,
+      outputCommitment: 456n,
+      expectedBinding: 789n,
+    }),
+    generateSalt: vi.fn().mockReturnValue(999n),
+    checkToolsAvailable: vi.fn().mockReturnValue({
+      snarkjs: true,
+      snarkjsVersion: '0.7.0',
+    }),
+    // Re-export types that the module expects
+    PROGRAM_ID: new PublicKey('EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ'),
+    DEVNET_RPC: 'https://api.devnet.solana.com',
+    MAINNET_RPC: 'https://api.mainnet-beta.solana.com',
+    SEEDS: {},
+    HASH_SIZE: 32,
+    RESULT_DATA_SIZE: 64,
+    U64_SIZE: 8,
+    DISCRIMINATOR_SIZE: 8,
+    OUTPUT_FIELD_COUNT: 4,
+    PROOF_SIZE_BYTES: 256,
+    VERIFICATION_COMPUTE_UNITS: 200000,
+    PUBLIC_INPUTS_COUNT: 67,
+    PERCENT_BASE: 10000,
+    DEFAULT_FEE_PERCENT: 250,
+    PRIVACY_CASH_PROGRAM_ID: new PublicKey('11111111111111111111111111111111'),
+    TaskState: { Open: 0, InProgress: 1 },
+    TaskStatus: {},
+  };
+});
+
+import {
+  generateProof as mockGenerateProof,
+  verifyProofLocally as mockVerifyProofLocally,
+  computeHashes as mockComputeHashes,
+  generateSalt as mockGenerateSalt,
+  checkToolsAvailable as mockCheckToolsAvailable,
+} from '@agenc/sdk';
+import { ProofEngine } from './engine.js';
+import { ProofCache, deriveCacheKey } from './cache.js';
+import { ProofGenerationError, ProofVerificationError, ProofCacheError } from './errors.js';
+import { RuntimeErrorCodes, RuntimeError } from '../types/errors.js';
+import type { ProofInputs, EngineProofResult } from './types.js';
+
+function makeInputs(): ProofInputs {
+  return {
+    taskPda: Keypair.generate().publicKey,
+    agentPubkey: Keypair.generate().publicKey,
+    output: [1n, 2n, 3n, 4n],
+    salt: 12345n,
+  };
+}
+
+describe('ProofEngine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==========================================================================
+  // Construction
+  // ==========================================================================
+
+  describe('construction', () => {
+    it('creates with default config', () => {
+      const engine = new ProofEngine();
+      expect(engine).toBeInstanceOf(ProofEngine);
+    });
+
+    it('creates with custom config', () => {
+      const engine = new ProofEngine({
+        circuitPath: '/custom/path',
+        verifyAfterGeneration: true,
+        cache: { ttlMs: 60_000, maxEntries: 50 },
+      });
+      expect(engine).toBeInstanceOf(ProofEngine);
+    });
+
+    it('creates without cache when config.cache is omitted', () => {
+      const engine = new ProofEngine({});
+      const stats = engine.getStats();
+      expect(stats.cacheSize).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // generate() without cache
+  // ==========================================================================
+
+  describe('generate without cache', () => {
+    it('calls SDK generateProof and returns EngineProofResult', async () => {
+      const engine = new ProofEngine();
+      const inputs = makeInputs();
+      const result = await engine.generate(inputs);
+
+      expect(mockGenerateProof).toHaveBeenCalledOnce();
+      expect(result.proof).toBeInstanceOf(Uint8Array);
+      expect(result.proof.length).toBe(256);
+      expect(result.constraintHash).toBeInstanceOf(Uint8Array);
+      expect(result.constraintHash.length).toBe(32);
+      expect(result.outputCommitment).toBeInstanceOf(Uint8Array);
+      expect(result.expectedBinding).toBeInstanceOf(Uint8Array);
+      expect(result.proofSize).toBe(256);
+      expect(result.fromCache).toBe(false);
+      expect(result.verified).toBe(false);
+      expect(result.generationTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('passes circuitPath to SDK', async () => {
+      const engine = new ProofEngine({ circuitPath: '/my/circuit' });
+      const inputs = makeInputs();
+      await engine.generate(inputs);
+
+      expect(mockGenerateProof).toHaveBeenCalledWith(
+        expect.objectContaining({ circuitPath: '/my/circuit' }),
+      );
+    });
+
+    it('wraps SDK errors in ProofGenerationError', async () => {
+      vi.mocked(mockGenerateProof).mockRejectedValueOnce(new Error('snarkjs boom'));
+      const engine = new ProofEngine();
+
+      await expect(engine.generate(makeInputs())).rejects.toThrow(ProofGenerationError);
+    });
+
+    it('ProofGenerationError message includes SDK error details', async () => {
+      vi.mocked(mockGenerateProof).mockRejectedValueOnce(new Error('snarkjs boom'));
+      const engine = new ProofEngine();
+
+      await expect(engine.generate(makeInputs())).rejects.toThrow('snarkjs boom');
+    });
+
+    it('wraps non-Error SDK throws in ProofGenerationError', async () => {
+      vi.mocked(mockGenerateProof).mockRejectedValueOnce('string error');
+      const engine = new ProofEngine();
+
+      await expect(engine.generate(makeInputs())).rejects.toThrow(ProofGenerationError);
+    });
+  });
+
+  // ==========================================================================
+  // generate() with cache
+  // ==========================================================================
+
+  describe('generate with cache', () => {
+    it('stores result in cache on miss', async () => {
+      const engine = new ProofEngine({ cache: { ttlMs: 60_000 } });
+      const inputs = makeInputs();
+
+      const result1 = await engine.generate(inputs);
+      expect(result1.fromCache).toBe(false);
+
+      // Second call should hit cache
+      const result2 = await engine.generate(inputs);
+      expect(result2.fromCache).toBe(true);
+      expect(mockGenerateProof).toHaveBeenCalledOnce(); // Only first call
+    });
+
+    it('returns cached result with fromCache: true', async () => {
+      const engine = new ProofEngine({ cache: { ttlMs: 60_000 } });
+      const inputs = makeInputs();
+
+      await engine.generate(inputs);
+      const cached = await engine.generate(inputs);
+
+      expect(cached.fromCache).toBe(true);
+      expect(cached.proof).toBeInstanceOf(Uint8Array);
+      expect(cached.proof.length).toBe(256);
+    });
+
+    it('respects cache TTL expiry', async () => {
+      vi.useFakeTimers();
+      const engine = new ProofEngine({ cache: { ttlMs: 1000 } });
+      const inputs = makeInputs();
+
+      await engine.generate(inputs);
+
+      // Advance past TTL
+      vi.advanceTimersByTime(1500);
+
+      await engine.generate(inputs);
+      expect(mockGenerateProof).toHaveBeenCalledTimes(2);
+
+      vi.useRealTimers();
+    });
+
+    it('evicts oldest entry when cache is full', async () => {
+      const engine = new ProofEngine({ cache: { ttlMs: 60_000, maxEntries: 2 } });
+
+      const inputs1 = makeInputs();
+      const inputs2 = makeInputs();
+      const inputs3 = makeInputs();
+
+      await engine.generate(inputs1);
+      await engine.generate(inputs2);
+      await engine.generate(inputs3); // Should evict inputs1
+
+      // inputs1 should be evicted, so next call generates new proof
+      vi.mocked(mockGenerateProof).mockClear();
+      await engine.generate(inputs1);
+      expect(mockGenerateProof).toHaveBeenCalledOnce();
+
+      // inputs3 should still be cached
+      vi.mocked(mockGenerateProof).mockClear();
+      await engine.generate(inputs3);
+      expect(mockGenerateProof).not.toHaveBeenCalled();
+    });
+
+    it('clearCache clears all entries', async () => {
+      const engine = new ProofEngine({ cache: { ttlMs: 60_000 } });
+      const inputs = makeInputs();
+
+      await engine.generate(inputs);
+      engine.clearCache();
+
+      vi.mocked(mockGenerateProof).mockClear();
+      await engine.generate(inputs);
+      expect(mockGenerateProof).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ==========================================================================
+  // generate() with verification
+  // ==========================================================================
+
+  describe('generate with verification', () => {
+    it('verifies proof after generation when configured', async () => {
+      vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(true);
+      const engine = new ProofEngine({ verifyAfterGeneration: true });
+
+      const result = await engine.generate(makeInputs());
+      expect(mockVerifyProofLocally).toHaveBeenCalledOnce();
+      expect(result.verified).toBe(true);
+    });
+
+    it('throws ProofVerificationError when verification returns false', async () => {
+      vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(false);
+      const engine = new ProofEngine({ verifyAfterGeneration: true });
+
+      await expect(engine.generate(makeInputs())).rejects.toThrow(ProofVerificationError);
+    });
+
+    it('throws ProofVerificationError when verification throws', async () => {
+      vi.mocked(mockVerifyProofLocally).mockRejectedValueOnce(new Error('vkey not found'));
+      const engine = new ProofEngine({ verifyAfterGeneration: true });
+
+      await expect(engine.generate(makeInputs())).rejects.toThrow(ProofVerificationError);
+    });
+
+    it('does not verify when verifyAfterGeneration is false', async () => {
+      const engine = new ProofEngine({ verifyAfterGeneration: false });
+      await engine.generate(makeInputs());
+      expect(mockVerifyProofLocally).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // verify()
+  // ==========================================================================
+
+  describe('verify', () => {
+    it('delegates to SDK verifyProofLocally', async () => {
+      vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(true);
+      const engine = new ProofEngine();
+
+      const valid = await engine.verify(new Uint8Array(256), [1n, 2n]);
+      expect(valid).toBe(true);
+      expect(mockVerifyProofLocally).toHaveBeenCalledOnce();
+    });
+
+    it('tracks verification stats on success', async () => {
+      vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(true);
+      const engine = new ProofEngine();
+
+      await engine.verify(new Uint8Array(256), []);
+      const stats = engine.getStats();
+      expect(stats.verificationsPerformed).toBe(1);
+      expect(stats.verificationsFailed).toBe(0);
+    });
+
+    it('tracks verification stats on failure', async () => {
+      vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(false);
+      const engine = new ProofEngine();
+
+      await engine.verify(new Uint8Array(256), []);
+      const stats = engine.getStats();
+      expect(stats.verificationsPerformed).toBe(1);
+      expect(stats.verificationsFailed).toBe(1);
+    });
+
+    it('throws ProofVerificationError when SDK throws', async () => {
+      vi.mocked(mockVerifyProofLocally).mockRejectedValueOnce(new Error('boom'));
+      const engine = new ProofEngine();
+
+      await expect(engine.verify(new Uint8Array(256), [])).rejects.toThrow(
+        ProofVerificationError,
+      );
+    });
+  });
+
+  // ==========================================================================
+  // computeHashes()
+  // ==========================================================================
+
+  describe('computeHashes', () => {
+    it('delegates to SDK computeHashes', () => {
+      const engine = new ProofEngine();
+      const inputs = makeInputs();
+
+      const result = engine.computeHashes(inputs);
+      expect(mockComputeHashes).toHaveBeenCalledWith(
+        inputs.taskPda,
+        inputs.agentPubkey,
+        inputs.output,
+        inputs.salt,
+      );
+      expect(result.constraintHash).toBe(123n);
+      expect(result.outputCommitment).toBe(456n);
+      expect(result.expectedBinding).toBe(789n);
+    });
+  });
+
+  // ==========================================================================
+  // generateSalt()
+  // ==========================================================================
+
+  describe('generateSalt', () => {
+    it('delegates to SDK generateSalt', () => {
+      const engine = new ProofEngine();
+      const salt = engine.generateSalt();
+      expect(mockGenerateSalt).toHaveBeenCalledOnce();
+      expect(salt).toBe(999n);
+    });
+  });
+
+  // ==========================================================================
+  // checkTools()
+  // ==========================================================================
+
+  describe('checkTools', () => {
+    it('delegates to SDK checkToolsAvailable', () => {
+      const engine = new ProofEngine();
+      const status = engine.checkTools();
+      expect(mockCheckToolsAvailable).toHaveBeenCalledOnce();
+      expect(status.snarkjs).toBe(true);
+      expect(status.snarkjsVersion).toBe('0.7.0');
+    });
+  });
+
+  // ==========================================================================
+  // getStats()
+  // ==========================================================================
+
+  describe('getStats', () => {
+    it('returns initial zero stats', () => {
+      const engine = new ProofEngine();
+      const stats = engine.getStats();
+
+      expect(stats.proofsGenerated).toBe(0);
+      expect(stats.totalRequests).toBe(0);
+      expect(stats.cacheHits).toBe(0);
+      expect(stats.cacheMisses).toBe(0);
+      expect(stats.avgGenerationTimeMs).toBe(0);
+      expect(stats.verificationsPerformed).toBe(0);
+      expect(stats.verificationsFailed).toBe(0);
+      expect(stats.cacheSize).toBe(0);
+    });
+
+    it('tracks generation stats', async () => {
+      const engine = new ProofEngine();
+
+      await engine.generate(makeInputs());
+      await engine.generate(makeInputs());
+
+      const stats = engine.getStats();
+      expect(stats.proofsGenerated).toBe(2);
+      expect(stats.totalRequests).toBe(2);
+      expect(stats.avgGenerationTimeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('tracks cache hit/miss stats', async () => {
+      const engine = new ProofEngine({ cache: { ttlMs: 60_000 } });
+      const inputs = makeInputs();
+
+      await engine.generate(inputs); // miss
+      await engine.generate(inputs); // hit
+
+      const stats = engine.getStats();
+      expect(stats.cacheHits).toBe(1);
+      expect(stats.cacheMisses).toBe(1);
+      expect(stats.totalRequests).toBe(2);
+      expect(stats.proofsGenerated).toBe(1); // only 1 actual generation
+      expect(stats.cacheSize).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // ProofGenerator interface
+  // ==========================================================================
+
+  describe('ProofGenerator interface', () => {
+    it('generatePublicProof returns proofHash', async () => {
+      const engine = new ProofEngine();
+      const proofHash = new Uint8Array(32).fill(0xaa);
+      const result = await engine.generatePublicProof(
+        {} as any,
+        { proofHash, resultData: new Uint8Array(64) },
+      );
+      expect(result).toBe(proofHash);
+    });
+
+    it('generatePrivateProof returns proof bytes', async () => {
+      const engine = new ProofEngine();
+      const proof = new Uint8Array(256).fill(0xbb);
+      const result = await engine.generatePrivateProof(
+        {} as any,
+        {
+          proof,
+          constraintHash: new Uint8Array(32),
+          outputCommitment: new Uint8Array(32),
+          expectedBinding: new Uint8Array(32),
+        },
+      );
+      expect(result).toBe(proof);
+    });
+  });
+});
+
+// =============================================================================
+// ProofCache unit tests
+// =============================================================================
+
+describe('ProofCache', () => {
+  function makeCacheResult(): EngineProofResult {
+    return {
+      proof: new Uint8Array(256).fill(0x01),
+      constraintHash: new Uint8Array(32).fill(0x02),
+      outputCommitment: new Uint8Array(32).fill(0x03),
+      expectedBinding: new Uint8Array(32).fill(0x04),
+      proofSize: 256,
+      generationTimeMs: 100,
+      fromCache: false,
+      verified: false,
+    };
+  }
+
+  it('returns undefined for missing key', () => {
+    const cache = new ProofCache();
+    expect(cache.get(makeInputs())).toBeUndefined();
+  });
+
+  it('stores and retrieves entries', () => {
+    const cache = new ProofCache();
+    const inputs = makeInputs();
+    const result = makeCacheResult();
+
+    cache.set(inputs, result);
+    const retrieved = cache.get(inputs);
+
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.proof).toEqual(result.proof);
+  });
+
+  it('clears all entries', () => {
+    const cache = new ProofCache();
+    cache.set(makeInputs(), makeCacheResult());
+    cache.set(makeInputs(), makeCacheResult());
+
+    expect(cache.size).toBe(2);
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});
+
+// =============================================================================
+// deriveCacheKey unit tests
+// =============================================================================
+
+describe('deriveCacheKey', () => {
+  it('produces deterministic key from inputs', () => {
+    const taskPda = Keypair.generate().publicKey;
+    const agentPubkey = Keypair.generate().publicKey;
+    const inputs: ProofInputs = {
+      taskPda,
+      agentPubkey,
+      output: [1n, 2n, 3n, 4n],
+      salt: 12345n,
+    };
+
+    const key1 = deriveCacheKey(inputs);
+    const key2 = deriveCacheKey(inputs);
+    expect(key1).toBe(key2);
+    expect(key1).toContain(taskPda.toBase58());
+    expect(key1).toContain(agentPubkey.toBase58());
+    expect(key1).toContain('12345');
+  });
+
+  it('produces different keys for different inputs', () => {
+    const inputs1 = makeInputs();
+    const inputs2 = makeInputs();
+
+    expect(deriveCacheKey(inputs1)).not.toBe(deriveCacheKey(inputs2));
+  });
+});
+
+// =============================================================================
+// Error class tests
+// =============================================================================
+
+describe('Proof error classes', () => {
+  it('ProofGenerationError has correct properties', () => {
+    const err = new ProofGenerationError('circuit not found');
+    expect(err.name).toBe('ProofGenerationError');
+    expect(err.code).toBe(RuntimeErrorCodes.PROOF_GENERATION_ERROR);
+    expect(err.cause).toBe('circuit not found');
+    expect(err.message).toContain('circuit not found');
+    expect(err instanceof RuntimeError).toBe(true);
+  });
+
+  it('ProofVerificationError has correct properties', () => {
+    const err = new ProofVerificationError('invalid proof');
+    expect(err.name).toBe('ProofVerificationError');
+    expect(err.code).toBe(RuntimeErrorCodes.PROOF_VERIFICATION_ERROR);
+    expect(err.message).toContain('invalid proof');
+    expect(err instanceof RuntimeError).toBe(true);
+  });
+
+  it('ProofCacheError has correct properties', () => {
+    const err = new ProofCacheError('serialization failed');
+    expect(err.name).toBe('ProofCacheError');
+    expect(err.code).toBe(RuntimeErrorCodes.PROOF_CACHE_ERROR);
+    expect(err.message).toContain('serialization failed');
+    expect(err instanceof RuntimeError).toBe(true);
+  });
+});

--- a/runtime/src/proof/engine.ts
+++ b/runtime/src/proof/engine.ts
@@ -1,0 +1,253 @@
+/**
+ * ProofEngine - ZK proof generation engine with caching and stats tracking.
+ *
+ * Wraps the SDK's ZK proof functions with caching, verification,
+ * statistics tracking, and error wrapping. Implements ProofGenerator
+ * from the proof pipeline for plug-and-play integration.
+ *
+ * @module
+ */
+
+import {
+  generateProof as sdkGenerateProof,
+  verifyProofLocally as sdkVerifyProofLocally,
+  computeHashes as sdkComputeHashes,
+  generateSalt as sdkGenerateSalt,
+  checkToolsAvailable as sdkCheckToolsAvailable,
+} from '@agenc/sdk';
+import type { HashResult, ToolsStatus } from '@agenc/sdk';
+import type { ProofGenerator } from '../task/proof-pipeline.js';
+import type { OnChainTask, TaskExecutionResult, PrivateTaskExecutionResult } from '../task/types.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import type {
+  ProofEngineConfig,
+  ProofInputs,
+  EngineProofResult,
+  ProofEngineStats,
+} from './types.js';
+import { ProofCache } from './cache.js';
+import { ProofGenerationError, ProofVerificationError } from './errors.js';
+
+const DEFAULT_CIRCUIT_PATH = './circuits-circom/task_completion';
+
+/**
+ * ProofEngine wraps the SDK's ZK proof functions with caching,
+ * stats tracking, and error wrapping.
+ *
+ * Implements ProofGenerator for integration with ProofPipeline.
+ *
+ * @example
+ * ```typescript
+ * const engine = new ProofEngine({
+ *   cache: { ttlMs: 300_000, maxEntries: 100 },
+ *   verifyAfterGeneration: false,
+ * });
+ *
+ * const result = await engine.generate({
+ *   taskPda,
+ *   agentPubkey,
+ *   output: [1n, 2n, 3n, 4n],
+ *   salt: engine.generateSalt(),
+ * });
+ * ```
+ */
+export class ProofEngine implements ProofGenerator {
+  private readonly circuitPath: string;
+  private readonly verifyAfterGeneration: boolean;
+  private readonly cache: ProofCache | null;
+  private readonly logger: Logger;
+
+  // Stats
+  private _proofsGenerated = 0;
+  private _totalRequests = 0;
+  private _cacheHits = 0;
+  private _cacheMisses = 0;
+  private _totalGenerationTimeMs = 0;
+  private _verificationsPerformed = 0;
+  private _verificationsFailed = 0;
+
+  constructor(config?: ProofEngineConfig) {
+    this.circuitPath = config?.circuitPath ?? DEFAULT_CIRCUIT_PATH;
+    this.verifyAfterGeneration = config?.verifyAfterGeneration ?? false;
+    this.cache = config?.cache ? new ProofCache(config.cache) : null;
+    this.logger = config?.logger ?? silentLogger;
+  }
+
+  /**
+   * Generate a ZK proof for the given inputs.
+   *
+   * Checks cache first (if enabled). On cache miss, calls the SDK's
+   * generateProof function, optionally verifies, caches, and returns.
+   */
+  async generate(inputs: ProofInputs): Promise<EngineProofResult> {
+    this._totalRequests++;
+
+    // Check cache
+    if (this.cache) {
+      const cached = this.cache.get(inputs);
+      if (cached) {
+        this._cacheHits++;
+        this.logger.debug('Proof cache hit');
+        return { ...cached, fromCache: true };
+      }
+      this._cacheMisses++;
+    }
+
+    // Generate proof via SDK
+    const startTime = Date.now();
+    let sdkResult;
+    try {
+      sdkResult = await sdkGenerateProof({
+        taskPda: inputs.taskPda,
+        agentPubkey: inputs.agentPubkey,
+        output: inputs.output,
+        salt: inputs.salt,
+        circuitPath: this.circuitPath,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      throw new ProofGenerationError(message);
+    }
+    const generationTimeMs = Date.now() - startTime;
+
+    // Convert Buffer -> Uint8Array
+    const result: EngineProofResult = {
+      proof: new Uint8Array(sdkResult.proof),
+      constraintHash: new Uint8Array(sdkResult.constraintHash),
+      outputCommitment: new Uint8Array(sdkResult.outputCommitment),
+      expectedBinding: new Uint8Array(sdkResult.expectedBinding),
+      proofSize: sdkResult.proofSize,
+      generationTimeMs,
+      fromCache: false,
+      verified: false,
+    };
+
+    this._proofsGenerated++;
+    this._totalGenerationTimeMs += generationTimeMs;
+
+    // Verify if configured
+    if (this.verifyAfterGeneration) {
+      this._verificationsPerformed++;
+      try {
+        const valid = await sdkVerifyProofLocally(
+          sdkResult.proof,
+          [],
+          this.circuitPath,
+        );
+        if (!valid) {
+          this._verificationsFailed++;
+          throw new ProofVerificationError('Generated proof failed local verification');
+        }
+        result.verified = true;
+      } catch (err) {
+        if (err instanceof ProofVerificationError) {
+          throw err;
+        }
+        this._verificationsFailed++;
+        const message = err instanceof Error ? err.message : String(err);
+        throw new ProofVerificationError(message);
+      }
+    }
+
+    // Cache result
+    if (this.cache) {
+      this.cache.set(inputs, result);
+    }
+
+    this.logger.debug(`Proof generated in ${generationTimeMs}ms`);
+    return result;
+  }
+
+  /**
+   * Verify a proof locally.
+   */
+  async verify(proof: Uint8Array, publicSignals: bigint[]): Promise<boolean> {
+    this._verificationsPerformed++;
+    try {
+      const proofBuffer = Buffer.from(proof);
+      const valid = await sdkVerifyProofLocally(proofBuffer, publicSignals, this.circuitPath);
+      if (!valid) {
+        this._verificationsFailed++;
+      }
+      return valid;
+    } catch (err) {
+      this._verificationsFailed++;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new ProofVerificationError(message);
+    }
+  }
+
+  /**
+   * Compute hashes (constraintHash, outputCommitment, expectedBinding) without generating a proof.
+   */
+  computeHashes(inputs: ProofInputs): HashResult {
+    return sdkComputeHashes(inputs.taskPda, inputs.agentPubkey, inputs.output, inputs.salt);
+  }
+
+  /**
+   * Generate a cryptographically secure random salt.
+   */
+  generateSalt(): bigint {
+    return sdkGenerateSalt();
+  }
+
+  /**
+   * Clear the proof cache.
+   */
+  clearCache(): void {
+    this.cache?.clear();
+  }
+
+  /**
+   * Get engine statistics.
+   */
+  getStats(): ProofEngineStats {
+    return {
+      proofsGenerated: this._proofsGenerated,
+      totalRequests: this._totalRequests,
+      cacheHits: this._cacheHits,
+      cacheMisses: this._cacheMisses,
+      avgGenerationTimeMs:
+        this._proofsGenerated > 0
+          ? this._totalGenerationTimeMs / this._proofsGenerated
+          : 0,
+      verificationsPerformed: this._verificationsPerformed,
+      verificationsFailed: this._verificationsFailed,
+      cacheSize: this.cache?.size ?? 0,
+    };
+  }
+
+  /**
+   * Check if required ZK tools are available.
+   */
+  checkTools(): ToolsStatus {
+    return sdkCheckToolsAvailable();
+  }
+
+  // ==========================================================================
+  // ProofGenerator interface (for ProofPipeline integration)
+  // ==========================================================================
+
+  /**
+   * Generate proof for public task completion.
+   * Returns the proofHash from the execution result.
+   */
+  async generatePublicProof(
+    _task: OnChainTask,
+    result: TaskExecutionResult,
+  ): Promise<Uint8Array> {
+    return result.proofHash;
+  }
+
+  /**
+   * Generate proof for private (ZK) task completion.
+   * Returns the proof bytes from the execution result.
+   */
+  async generatePrivateProof(
+    _task: OnChainTask,
+    result: PrivateTaskExecutionResult,
+  ): Promise<Uint8Array> {
+    return result.proof;
+  }
+}

--- a/runtime/src/proof/errors.ts
+++ b/runtime/src/proof/errors.ts
@@ -1,0 +1,58 @@
+/**
+ * Proof-specific error types for @agenc/runtime
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Error thrown when ZK proof generation fails.
+ */
+export class ProofGenerationError extends RuntimeError {
+  public readonly cause: string;
+
+  constructor(cause: string) {
+    super(
+      `Proof generation failed: ${cause}`,
+      RuntimeErrorCodes.PROOF_GENERATION_ERROR,
+    );
+    this.name = 'ProofGenerationError';
+    this.cause = cause;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ProofGenerationError);
+    }
+  }
+}
+
+/**
+ * Error thrown when ZK proof verification fails.
+ */
+export class ProofVerificationError extends RuntimeError {
+  constructor(message: string) {
+    super(
+      `Proof verification failed: ${message}`,
+      RuntimeErrorCodes.PROOF_VERIFICATION_ERROR,
+    );
+    this.name = 'ProofVerificationError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ProofVerificationError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a proof cache operation fails.
+ */
+export class ProofCacheError extends RuntimeError {
+  constructor(message: string) {
+    super(
+      `Proof cache error: ${message}`,
+      RuntimeErrorCodes.PROOF_CACHE_ERROR,
+    );
+    this.name = 'ProofCacheError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ProofCacheError);
+    }
+  }
+}

--- a/runtime/src/proof/index.ts
+++ b/runtime/src/proof/index.ts
@@ -1,0 +1,32 @@
+/**
+ * ZK Proof Engine for @agenc/runtime
+ *
+ * Provides proof generation with caching, verification,
+ * and statistics tracking (Phase 7).
+ *
+ * @module
+ */
+
+// Core types
+export type {
+  ProofEngineConfig,
+  ProofCacheConfig,
+  ProofInputs,
+  EngineProofResult,
+  ProofEngineStats,
+  HashResult,
+  ToolsStatus,
+} from './types.js';
+
+// Error classes
+export {
+  ProofGenerationError,
+  ProofVerificationError,
+  ProofCacheError,
+} from './errors.js';
+
+// Cache
+export { ProofCache, deriveCacheKey } from './cache.js';
+
+// Engine
+export { ProofEngine } from './engine.js';

--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -1,0 +1,94 @@
+/**
+ * Type definitions for the ProofEngine module (Phase 7).
+ *
+ * @module
+ */
+
+import type { PublicKey } from '@solana/web3.js';
+import type { Logger } from '../utils/logger.js';
+
+// Re-export HashResult from SDK for convenience
+export type { HashResult } from '@agenc/sdk';
+export type { ToolsStatus } from '@agenc/sdk';
+
+/**
+ * Configuration for the proof cache.
+ */
+export interface ProofCacheConfig {
+  /** Time-to-live in milliseconds. Default: 300_000 (5 min) */
+  ttlMs?: number;
+  /** Maximum number of cached entries. Default: 100 */
+  maxEntries?: number;
+}
+
+/**
+ * Configuration for the ProofEngine.
+ */
+export interface ProofEngineConfig {
+  /** Path to the circuit directory. Default: './circuits-circom/task_completion' */
+  circuitPath?: string;
+  /** Whether to verify proofs after generation. Default: false */
+  verifyAfterGeneration?: boolean;
+  /** Cache configuration. Omit to disable caching. */
+  cache?: ProofCacheConfig;
+  /** Logger instance */
+  logger?: Logger;
+}
+
+/**
+ * Input parameters for proof generation.
+ */
+export interface ProofInputs {
+  /** Task PDA address */
+  taskPda: PublicKey;
+  /** Agent's public key */
+  agentPubkey: PublicKey;
+  /** Task output (4 field elements) */
+  output: bigint[];
+  /** Random salt for commitment */
+  salt: bigint;
+}
+
+/**
+ * Result from the ProofEngine's generate() method.
+ */
+export interface EngineProofResult {
+  /** Generated proof bytes (256 bytes Groth16) */
+  proof: Uint8Array;
+  /** Constraint hash (32 bytes) */
+  constraintHash: Uint8Array;
+  /** Output commitment (32 bytes) */
+  outputCommitment: Uint8Array;
+  /** Expected binding (32 bytes) */
+  expectedBinding: Uint8Array;
+  /** Size of the proof in bytes */
+  proofSize: number;
+  /** Time taken for proof generation in milliseconds */
+  generationTimeMs: number;
+  /** Whether the result was served from cache */
+  fromCache: boolean;
+  /** Whether the proof was verified after generation */
+  verified: boolean;
+}
+
+/**
+ * Statistics snapshot from the ProofEngine.
+ */
+export interface ProofEngineStats {
+  /** Number of proofs actually generated (excludes cache hits) */
+  proofsGenerated: number;
+  /** Total number of generate() calls */
+  totalRequests: number;
+  /** Number of cache hits */
+  cacheHits: number;
+  /** Number of cache misses */
+  cacheMisses: number;
+  /** Average generation time in ms (excludes cache hits) */
+  avgGenerationTimeMs: number;
+  /** Number of verification checks performed */
+  verificationsPerformed: number;
+  /** Number of verification failures */
+  verificationsFailed: number;
+  /** Current cache size */
+  cacheSize: number;
+}

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -39,8 +39,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY).toBe('RECENT_VOTE_ACTIVITY');
   });
 
-  it('has exactly 24 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(24);
+  it('has exactly 27 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(27);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -64,6 +64,12 @@ export const RuntimeErrorCodes = {
   MEMORY_CONNECTION_ERROR: 'MEMORY_CONNECTION_ERROR',
   /** Memory serialization/deserialization failure */
   MEMORY_SERIALIZATION_ERROR: 'MEMORY_SERIALIZATION_ERROR',
+  /** ZK proof generation failed */
+  PROOF_GENERATION_ERROR: 'PROOF_GENERATION_ERROR',
+  /** ZK proof verification failed */
+  PROOF_VERIFICATION_ERROR: 'PROOF_VERIFICATION_ERROR',
+  /** Proof cache operation failed */
+  PROOF_CACHE_ERROR: 'PROOF_CACHE_ERROR',
 } as const;
 
 /** Union type of all runtime error code values */


### PR DESCRIPTION
## Summary

- Add `ProofEngine` class that wraps SDK proof functions (`generateProof`, `verifyProofLocally`, `computeHashes`, `generateSalt`) with in-memory caching, stats tracking, and error wrapping
- Implements `ProofGenerator` interface from `task/proof-pipeline.ts` for plug-and-play integration with the speculative execution pipeline
- Add `ProofCache` with TTL-based expiration and LRU eviction via deterministic cache keys
- Add 3 new `RuntimeErrorCodes` (25-27): `PROOF_GENERATION_ERROR`, `PROOF_VERIFICATION_ERROR`, `PROOF_CACHE_ERROR`

## New files

| File | Purpose |
|------|---------|
| `runtime/src/proof/types.ts` | `ProofEngineConfig`, `ProofInputs`, `EngineProofResult`, `ProofEngineStats` |
| `runtime/src/proof/errors.ts` | `ProofGenerationError`, `ProofVerificationError`, `ProofCacheError` |
| `runtime/src/proof/cache.ts` | `ProofCache` (in-memory TTL + LRU), `deriveCacheKey()` |
| `runtime/src/proof/engine.ts` | `ProofEngine` class |
| `runtime/src/proof/engine.test.ts` | 37 tests (fully mocked SDK, no snarkjs needed) |
| `runtime/src/proof/index.ts` | Barrel exports |

## Modified files

| File | Change |
|------|--------|
| `runtime/src/types/errors.ts` | 3 new RuntimeErrorCodes (24 → 27) |
| `runtime/src/types/errors.test.ts` | Updated expected count |
| `runtime/src/index.ts` | Phase 7 export block |

## Test plan

- [x] 37 new proof engine tests pass (cache, generation, verification, stats, errors, ProofGenerator interface)
- [x] All 1599 existing tests still pass (0 regressions)
- [x] TypeScript typecheck passes
- [x] Build succeeds (ESM + CJS + DTS)