### PR TITLE
feat(runtime): add dispute operations module (Phase 8)

### DIFF
--- a/runtime/src/dispute/errors.ts
+++ b/runtime/src/dispute/errors.ts
@@ -1,0 +1,98 @@
+/**
+ * Dispute-specific error classes for @agenc/runtime
+ *
+ * All dispute errors extend RuntimeError and use codes from RuntimeErrorCodes.
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Error thrown when a dispute cannot be found by its PDA.
+ */
+export class DisputeNotFoundError extends RuntimeError {
+  /** The PDA of the dispute that was not found (base58 string) */
+  public readonly disputePda: string;
+
+  constructor(disputePda: string) {
+    super(
+      `Dispute not found: ${disputePda}`,
+      RuntimeErrorCodes.DISPUTE_NOT_FOUND
+    );
+    this.name = 'DisputeNotFoundError';
+    this.disputePda = disputePda;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DisputeNotFoundError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a dispute vote operation fails.
+ */
+export class DisputeVoteError extends RuntimeError {
+  /** The PDA of the dispute (base58 string) */
+  public readonly disputePda: string;
+  /** The reason the vote failed */
+  public readonly reason: string;
+
+  constructor(disputePda: string, reason: string) {
+    super(
+      `Dispute vote failed for ${disputePda}: ${reason}`,
+      RuntimeErrorCodes.DISPUTE_VOTE_ERROR
+    );
+    this.name = 'DisputeVoteError';
+    this.disputePda = disputePda;
+    this.reason = reason;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DisputeVoteError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a dispute resolution operation fails.
+ */
+export class DisputeResolutionError extends RuntimeError {
+  /** The PDA of the dispute (base58 string) */
+  public readonly disputePda: string;
+  /** The reason the resolution failed */
+  public readonly reason: string;
+
+  constructor(disputePda: string, reason: string) {
+    super(
+      `Dispute resolution failed for ${disputePda}: ${reason}`,
+      RuntimeErrorCodes.DISPUTE_RESOLUTION_ERROR
+    );
+    this.name = 'DisputeResolutionError';
+    this.disputePda = disputePda;
+    this.reason = reason;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DisputeResolutionError);
+    }
+  }
+}
+
+/**
+ * Error thrown when a dispute slash operation fails.
+ */
+export class DisputeSlashError extends RuntimeError {
+  /** The PDA of the dispute (base58 string) */
+  public readonly disputePda: string;
+  /** The reason the slash failed */
+  public readonly reason: string;
+
+  constructor(disputePda: string, reason: string) {
+    super(
+      `Dispute slash failed for ${disputePda}: ${reason}`,
+      RuntimeErrorCodes.DISPUTE_SLASH_ERROR
+    );
+    this.name = 'DisputeSlashError';
+    this.disputePda = disputePda;
+    this.reason = reason;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, DisputeSlashError);
+    }
+  }
+}

--- a/runtime/src/dispute/index.ts
+++ b/runtime/src/dispute/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Dispute operations module (PDA derivation, types, parsing, operations)
+ * @module
+ */
+
+export * from './pda.js';
+export * from './types.js';
+export * from './errors.js';
+export * from './operations.js';

--- a/runtime/src/dispute/operations.test.ts
+++ b/runtime/src/dispute/operations.test.ts
@@ -1,0 +1,911 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { PublicKey, Keypair, SystemProgram } from '@solana/web3.js';
+import { DisputeOperations, type DisputeOpsConfig } from './operations.js';
+import {
+  parseOnChainDispute,
+  parseOnChainDisputeVote,
+  disputeStatusToString,
+  OnChainDisputeStatus,
+  DISPUTE_STATUS_OFFSET,
+  DISPUTE_TASK_OFFSET,
+} from './types.js';
+import { ResolutionType } from '../events/types.js';
+import { deriveDisputePda, deriveVotePda, findDisputePda, findVotePda } from './pda.js';
+import {
+  DisputeNotFoundError,
+  DisputeVoteError,
+  DisputeResolutionError,
+  DisputeSlashError,
+} from './errors.js';
+import { RuntimeError, RuntimeErrorCodes, AnchorErrorCodes } from '../types/errors.js';
+import { PROGRAM_ID, SEEDS } from '@agenc/sdk';
+import { silentLogger } from '../utils/logger.js';
+import { generateAgentId } from '../utils/encoding.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function randomPubkey(): PublicKey {
+  return Keypair.generate().publicKey;
+}
+
+function randomBytes(len: number): Uint8Array {
+  return new Uint8Array(Array.from({ length: len }, () => Math.floor(Math.random() * 256)));
+}
+
+/** Create an Anchor-like error with code */
+function anchorError(code: number) {
+  return { code, message: `custom program error: 0x${code.toString(16)}` };
+}
+
+/** Create a mock raw dispute account */
+function mockRawDispute(overrides: Record<string, any> = {}): Record<string, any> {
+  return {
+    disputeId: Array.from(randomBytes(32)),
+    task: randomPubkey(),
+    initiator: randomPubkey(),
+    initiatorAuthority: randomPubkey(),
+    evidenceHash: Array.from(randomBytes(32)),
+    resolutionType: { refund: {} },
+    status: { active: {} },
+    createdAt: { toNumber: () => 1700000000 },
+    resolvedAt: { toNumber: () => 0 },
+    votesFor: { toString: () => '100' },
+    votesAgainst: { toString: () => '50' },
+    totalVoters: 3,
+    votingDeadline: { toNumber: () => 1700086400 },
+    expiresAt: { toNumber: () => 1700172800 },
+    slashApplied: false,
+    initiatorSlashApplied: false,
+    workerStakeAtDispute: { toString: () => '1000000000' },
+    initiatedByCreator: false,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+/** Create a mock raw vote account */
+function mockRawVote(overrides: Record<string, any> = {}): Record<string, any> {
+  return {
+    dispute: randomPubkey(),
+    voter: randomPubkey(),
+    approved: true,
+    votedAt: { toNumber: () => 1700001000 },
+    stakeAtVote: { toString: () => '500000000' },
+    bump: 254,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Mock Program Factory
+// ============================================================================
+
+function createMockProgram(overrides: Record<string, any> = {}) {
+  const rpcMock = vi.fn().mockResolvedValue('mock-signature');
+
+  const methodBuilder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    remainingAccounts: vi.fn().mockReturnThis(),
+    rpc: rpcMock,
+  };
+
+  return {
+    programId: PROGRAM_ID,
+    provider: {
+      publicKey: randomPubkey(),
+    },
+    account: {
+      dispute: {
+        fetch: vi.fn(),
+        fetchNullable: vi.fn(),
+        all: vi.fn().mockResolvedValue([]),
+      },
+      disputeVote: {
+        fetch: vi.fn(),
+        fetchNullable: vi.fn(),
+      },
+      protocolConfig: {
+        fetch: vi.fn().mockResolvedValue({ treasury: randomPubkey() }),
+      },
+    },
+    methods: {
+      initiateDispute: vi.fn().mockReturnValue(methodBuilder),
+      voteDispute: vi.fn().mockReturnValue(methodBuilder),
+      resolveDispute: vi.fn().mockReturnValue(methodBuilder),
+      cancelDispute: vi.fn().mockReturnValue(methodBuilder),
+      expireDispute: vi.fn().mockReturnValue(methodBuilder),
+      applyDisputeSlash: vi.fn().mockReturnValue(methodBuilder),
+    },
+    _methodBuilder: methodBuilder,
+    _rpcMock: rpcMock,
+    ...overrides,
+  } as any;
+}
+
+// ============================================================================
+// Parse Function Tests
+// ============================================================================
+
+describe('parseOnChainDispute', () => {
+  it('parses BN fields to correct types', () => {
+    const raw = mockRawDispute();
+    const parsed = parseOnChainDispute(raw);
+
+    expect(parsed.disputeId).toBeInstanceOf(Uint8Array);
+    expect(parsed.disputeId.length).toBe(32);
+    expect(parsed.createdAt).toBe(1700000000);
+    expect(parsed.resolvedAt).toBe(0);
+    expect(parsed.votesFor).toBe(100n);
+    expect(parsed.votesAgainst).toBe(50n);
+    expect(parsed.totalVoters).toBe(3);
+    expect(parsed.votingDeadline).toBe(1700086400);
+    expect(parsed.expiresAt).toBe(1700172800);
+    expect(parsed.workerStakeAtDispute).toBe(1000000000n);
+    expect(parsed.bump).toBe(255);
+  });
+
+  it('parses enum objects correctly', () => {
+    const raw = mockRawDispute({
+      resolutionType: { complete: {} },
+      status: { resolved: {} },
+    });
+    const parsed = parseOnChainDispute(raw);
+
+    expect(parsed.resolutionType).toBe(ResolutionType.Complete);
+    expect(parsed.status).toBe(OnChainDisputeStatus.Resolved);
+  });
+
+  it('parses boolean fields', () => {
+    const raw = mockRawDispute({
+      slashApplied: true,
+      initiatorSlashApplied: true,
+      initiatedByCreator: true,
+    });
+    const parsed = parseOnChainDispute(raw);
+
+    expect(parsed.slashApplied).toBe(true);
+    expect(parsed.initiatorSlashApplied).toBe(true);
+    expect(parsed.initiatedByCreator).toBe(true);
+  });
+
+  it('handles all resolution types', () => {
+    expect(parseOnChainDispute(mockRawDispute({ resolutionType: { refund: {} } })).resolutionType).toBe(ResolutionType.Refund);
+    expect(parseOnChainDispute(mockRawDispute({ resolutionType: { complete: {} } })).resolutionType).toBe(ResolutionType.Complete);
+    expect(parseOnChainDispute(mockRawDispute({ resolutionType: { split: {} } })).resolutionType).toBe(ResolutionType.Split);
+  });
+
+  it('handles all dispute statuses', () => {
+    expect(parseOnChainDispute(mockRawDispute({ status: { active: {} } })).status).toBe(OnChainDisputeStatus.Active);
+    expect(parseOnChainDispute(mockRawDispute({ status: { resolved: {} } })).status).toBe(OnChainDisputeStatus.Resolved);
+    expect(parseOnChainDispute(mockRawDispute({ status: { expired: {} } })).status).toBe(OnChainDisputeStatus.Expired);
+    expect(parseOnChainDispute(mockRawDispute({ status: { cancelled: {} } })).status).toBe(OnChainDisputeStatus.Cancelled);
+  });
+});
+
+describe('parseOnChainDisputeVote', () => {
+  it('parses raw vote data correctly', () => {
+    const raw = mockRawVote();
+    const parsed = parseOnChainDisputeVote(raw);
+
+    expect(parsed.approved).toBe(true);
+    expect(parsed.votedAt).toBe(1700001000);
+    expect(parsed.stakeAtVote).toBe(500000000n);
+    expect(parsed.bump).toBe(254);
+  });
+
+  it('parses rejected vote', () => {
+    const parsed = parseOnChainDisputeVote(mockRawVote({ approved: false }));
+    expect(parsed.approved).toBe(false);
+  });
+});
+
+describe('disputeStatusToString', () => {
+  it('converts all statuses', () => {
+    expect(disputeStatusToString(OnChainDisputeStatus.Active)).toBe('Active');
+    expect(disputeStatusToString(OnChainDisputeStatus.Resolved)).toBe('Resolved');
+    expect(disputeStatusToString(OnChainDisputeStatus.Expired)).toBe('Expired');
+    expect(disputeStatusToString(OnChainDisputeStatus.Cancelled)).toBe('Cancelled');
+  });
+
+  it('returns Unknown for invalid status', () => {
+    expect(disputeStatusToString(99 as OnChainDisputeStatus)).toBe('Unknown(99)');
+  });
+});
+
+// ============================================================================
+// PDA Derivation Tests
+// ============================================================================
+
+describe('deriveDisputePda', () => {
+  it('derives deterministic PDA', () => {
+    const disputeId = randomBytes(32);
+    const { address: pda1, bump: bump1 } = deriveDisputePda(disputeId);
+    const { address: pda2, bump: bump2 } = deriveDisputePda(disputeId);
+
+    expect(pda1.equals(pda2)).toBe(true);
+    expect(bump1).toBe(bump2);
+  });
+
+  it('throws on invalid length', () => {
+    expect(() => deriveDisputePda(new Uint8Array(16))).toThrow('Invalid disputeId length');
+  });
+
+  it('findDisputePda returns same address', () => {
+    const disputeId = randomBytes(32);
+    const { address } = deriveDisputePda(disputeId);
+    const pda = findDisputePda(disputeId);
+    expect(pda.equals(address)).toBe(true);
+  });
+});
+
+describe('deriveVotePda', () => {
+  it('derives deterministic PDA', () => {
+    const disputePda = randomPubkey();
+    const arbiterPda = randomPubkey();
+    const { address: pda1, bump: bump1 } = deriveVotePda(disputePda, arbiterPda);
+    const { address: pda2, bump: bump2 } = deriveVotePda(disputePda, arbiterPda);
+
+    expect(pda1.equals(pda2)).toBe(true);
+    expect(bump1).toBe(bump2);
+  });
+
+  it('findVotePda returns same address', () => {
+    const disputePda = randomPubkey();
+    const arbiterPda = randomPubkey();
+    const { address } = deriveVotePda(disputePda, arbiterPda);
+    const pda = findVotePda(disputePda, arbiterPda);
+    expect(pda.equals(address)).toBe(true);
+  });
+});
+
+// ============================================================================
+// Error Class Tests
+// ============================================================================
+
+describe('DisputeNotFoundError', () => {
+  it('has correct properties', () => {
+    const pda = randomPubkey().toBase58();
+    const err = new DisputeNotFoundError(pda);
+
+    expect(err).toBeInstanceOf(RuntimeError);
+    expect(err.name).toBe('DisputeNotFoundError');
+    expect(err.code).toBe(RuntimeErrorCodes.DISPUTE_NOT_FOUND);
+    expect(err.disputePda).toBe(pda);
+    expect(err.message).toContain(pda);
+  });
+});
+
+describe('DisputeVoteError', () => {
+  it('has correct properties', () => {
+    const pda = randomPubkey().toBase58();
+    const err = new DisputeVoteError(pda, 'Voting ended');
+
+    expect(err).toBeInstanceOf(RuntimeError);
+    expect(err.name).toBe('DisputeVoteError');
+    expect(err.code).toBe(RuntimeErrorCodes.DISPUTE_VOTE_ERROR);
+    expect(err.disputePda).toBe(pda);
+    expect(err.reason).toBe('Voting ended');
+  });
+});
+
+describe('DisputeResolutionError', () => {
+  it('has correct properties', () => {
+    const pda = randomPubkey().toBase58();
+    const err = new DisputeResolutionError(pda, 'Not authorized');
+
+    expect(err).toBeInstanceOf(RuntimeError);
+    expect(err.name).toBe('DisputeResolutionError');
+    expect(err.code).toBe(RuntimeErrorCodes.DISPUTE_RESOLUTION_ERROR);
+    expect(err.disputePda).toBe(pda);
+    expect(err.reason).toBe('Not authorized');
+  });
+});
+
+describe('DisputeSlashError', () => {
+  it('has correct properties', () => {
+    const pda = randomPubkey().toBase58();
+    const err = new DisputeSlashError(pda, 'Already applied');
+
+    expect(err).toBeInstanceOf(RuntimeError);
+    expect(err.name).toBe('DisputeSlashError');
+    expect(err.code).toBe(RuntimeErrorCodes.DISPUTE_SLASH_ERROR);
+    expect(err.disputePda).toBe(pda);
+    expect(err.reason).toBe('Already applied');
+  });
+});
+
+// ============================================================================
+// DisputeOperations - Query Tests
+// ============================================================================
+
+describe('DisputeOperations', () => {
+  let program: ReturnType<typeof createMockProgram>;
+  let ops: DisputeOperations;
+  const agentId = generateAgentId();
+
+  beforeEach(() => {
+    program = createMockProgram();
+    ops = new DisputeOperations({
+      program,
+      agentId,
+      logger: silentLogger,
+    });
+  });
+
+  describe('fetchDispute', () => {
+    it('returns parsed dispute when found', async () => {
+      const disputePda = randomPubkey();
+      const raw = mockRawDispute();
+      program.account.dispute.fetchNullable.mockResolvedValue(raw);
+
+      const result = await ops.fetchDispute(disputePda);
+
+      expect(result).not.toBeNull();
+      expect(result!.createdAt).toBe(1700000000);
+      expect(result!.votesFor).toBe(100n);
+    });
+
+    it('returns null when not found', async () => {
+      const disputePda = randomPubkey();
+      program.account.dispute.fetchNullable.mockResolvedValue(null);
+
+      const result = await ops.fetchDispute(disputePda);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('fetchDisputeByIds', () => {
+    it('returns dispute and PDA when found', async () => {
+      const disputeId = randomBytes(32);
+      const raw = mockRawDispute();
+      program.account.dispute.fetchNullable.mockResolvedValue(raw);
+
+      const result = await ops.fetchDisputeByIds(disputeId);
+
+      expect(result).not.toBeNull();
+      expect(result!.disputePda).toBeDefined();
+      expect(result!.dispute.createdAt).toBe(1700000000);
+    });
+
+    it('returns null when not found', async () => {
+      const disputeId = randomBytes(32);
+      program.account.dispute.fetchNullable.mockResolvedValue(null);
+
+      const result = await ops.fetchDisputeByIds(disputeId);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('fetchAllDisputes', () => {
+    it('returns all disputes', async () => {
+      program.account.dispute.all.mockResolvedValue([
+        { publicKey: randomPubkey(), account: mockRawDispute() },
+        { publicKey: randomPubkey(), account: mockRawDispute() },
+      ]);
+
+      const results = await ops.fetchAllDisputes();
+
+      expect(results).toHaveLength(2);
+    });
+  });
+
+  describe('fetchActiveDisputes', () => {
+    it('uses memcmp filter', async () => {
+      program.account.dispute.all.mockResolvedValue([
+        { publicKey: randomPubkey(), account: mockRawDispute() },
+      ]);
+
+      const results = await ops.fetchActiveDisputes();
+
+      expect(results).toHaveLength(1);
+      expect(program.account.dispute.all).toHaveBeenCalledWith([
+        expect.objectContaining({
+          memcmp: expect.objectContaining({
+            offset: DISPUTE_STATUS_OFFSET,
+          }),
+        }),
+      ]);
+    });
+
+    it('falls back to full scan on memcmp failure', async () => {
+      // First call (memcmp) fails, second call (fallback) succeeds
+      program.account.dispute.all
+        .mockRejectedValueOnce(new Error('memcmp not supported'))
+        .mockResolvedValueOnce([
+          { publicKey: randomPubkey(), account: mockRawDispute({ status: { active: {} } }) },
+          { publicKey: randomPubkey(), account: mockRawDispute({ status: { resolved: {} } }) },
+        ]);
+
+      const results = await ops.fetchActiveDisputes();
+
+      // Only the active one should be returned
+      expect(results).toHaveLength(1);
+      expect(results[0].dispute.status).toBe(OnChainDisputeStatus.Active);
+    });
+  });
+
+  describe('fetchDisputesForTask', () => {
+    it('uses memcmp filter on task field', async () => {
+      const taskPda = randomPubkey();
+      program.account.dispute.all.mockResolvedValue([
+        { publicKey: randomPubkey(), account: mockRawDispute({ task: taskPda }) },
+      ]);
+
+      const results = await ops.fetchDisputesForTask(taskPda);
+
+      expect(results).toHaveLength(1);
+      expect(program.account.dispute.all).toHaveBeenCalledWith([
+        expect.objectContaining({
+          memcmp: expect.objectContaining({
+            offset: DISPUTE_TASK_OFFSET,
+            bytes: taskPda.toBase58(),
+          }),
+        }),
+      ]);
+    });
+  });
+
+  describe('fetchVote', () => {
+    it('returns parsed vote when found', async () => {
+      const votePda = randomPubkey();
+      program.account.disputeVote.fetchNullable.mockResolvedValue(mockRawVote());
+
+      const result = await ops.fetchVote(votePda);
+
+      expect(result).not.toBeNull();
+      expect(result!.approved).toBe(true);
+      expect(result!.stakeAtVote).toBe(500000000n);
+    });
+
+    it('returns null when not found', async () => {
+      const votePda = randomPubkey();
+      program.account.disputeVote.fetchNullable.mockResolvedValue(null);
+
+      const result = await ops.fetchVote(votePda);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Transaction Tests
+  // ==========================================================================
+
+  describe('initiateDispute', () => {
+    it('initiates dispute as worker', async () => {
+      const result = await ops.initiateDispute({
+        disputeId: randomBytes(32),
+        taskPda: randomPubkey(),
+        taskId: randomBytes(32),
+        evidenceHash: randomBytes(32),
+        resolutionType: 0,
+        evidence: 'Worker did not complete the task properly. Detailed explanation of the issue.',
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(result.disputePda).toBeDefined();
+      expect(program.methods.initiateDispute).toHaveBeenCalled();
+      expect(program._methodBuilder.accountsPartial).toHaveBeenCalled();
+    });
+
+    it('initiates dispute as creator with defendant workers', async () => {
+      const workers = [
+        { claimPda: randomPubkey(), workerPda: randomPubkey() },
+        { claimPda: randomPubkey(), workerPda: randomPubkey() },
+      ];
+
+      const result = await ops.initiateDispute({
+        disputeId: randomBytes(32),
+        taskPda: randomPubkey(),
+        taskId: randomBytes(32),
+        evidenceHash: randomBytes(32),
+        resolutionType: 1,
+        evidence: 'Task was not completed according to specifications. Need resolution.',
+        workerAgentPda: randomPubkey(),
+        workerClaimPda: randomPubkey(),
+        defendantWorkers: workers,
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(program._methodBuilder.remainingAccounts).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ pubkey: workers[0].claimPda, isWritable: true, isSigner: false }),
+          expect.objectContaining({ pubkey: workers[0].workerPda, isWritable: true, isSigner: false }),
+        ]),
+      );
+    });
+
+    it('maps InsufficientEvidence error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.InsufficientEvidence));
+
+      await expect(
+        ops.initiateDispute({
+          disputeId: randomBytes(32),
+          taskPda: randomPubkey(),
+          taskId: randomBytes(32),
+          evidenceHash: randomBytes(32),
+          resolutionType: 0,
+          evidence: 'short',
+        }),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+
+    it('maps EvidenceTooLong error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.EvidenceTooLong));
+
+      await expect(
+        ops.initiateDispute({
+          disputeId: randomBytes(32),
+          taskPda: randomPubkey(),
+          taskId: randomBytes(32),
+          evidenceHash: randomBytes(32),
+          resolutionType: 0,
+          evidence: 'x'.repeat(300),
+        }),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+  });
+
+  describe('voteOnDispute', () => {
+    it('casts approval vote', async () => {
+      const result = await ops.voteOnDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        approve: true,
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(result.votePda).toBeDefined();
+      expect(program.methods.voteDispute).toHaveBeenCalledWith(true);
+    });
+
+    it('casts rejection vote', async () => {
+      const result = await ops.voteOnDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        approve: false,
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(program.methods.voteDispute).toHaveBeenCalledWith(false);
+    });
+
+    it('maps NotArbiter error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.NotArbiter));
+
+      await expect(
+        ops.voteOnDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          approve: true,
+        }),
+      ).rejects.toThrow(DisputeVoteError);
+    });
+
+    it('maps VotingEnded error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.VotingEnded));
+
+      await expect(
+        ops.voteOnDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          approve: true,
+        }),
+      ).rejects.toThrow(DisputeVoteError);
+    });
+
+    it('maps AlreadyVoted error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.AlreadyVoted));
+
+      await expect(
+        ops.voteOnDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          approve: true,
+        }),
+      ).rejects.toThrow(DisputeVoteError);
+    });
+
+    it('maps DisputeNotActive error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.DisputeNotActive));
+
+      await expect(
+        ops.voteOnDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          approve: true,
+        }),
+      ).rejects.toThrow(DisputeVoteError);
+    });
+  });
+
+  describe('resolveDispute', () => {
+    it('resolves with refund (no worker accounts)', async () => {
+      const result = await ops.resolveDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        creatorPubkey: randomPubkey(),
+        arbiterVotes: [],
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(program.methods.resolveDispute).toHaveBeenCalled();
+    });
+
+    it('resolves with worker accounts and arbiter remaining_accounts', async () => {
+      const arbiterVotes = [
+        { votePda: randomPubkey(), arbiterAgentPda: randomPubkey() },
+        { votePda: randomPubkey(), arbiterAgentPda: randomPubkey() },
+      ];
+
+      const result = await ops.resolveDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        creatorPubkey: randomPubkey(),
+        workerClaimPda: randomPubkey(),
+        workerAgentPda: randomPubkey(),
+        workerAuthority: randomPubkey(),
+        arbiterVotes,
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(program._methodBuilder.remainingAccounts).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          expect.objectContaining({ pubkey: arbiterVotes[0].votePda }),
+          expect.objectContaining({ pubkey: arbiterVotes[0].arbiterAgentPda }),
+          expect.objectContaining({ pubkey: arbiterVotes[1].votePda }),
+          expect.objectContaining({ pubkey: arbiterVotes[1].arbiterAgentPda }),
+        ]),
+      );
+    });
+
+    it('resolves with extra workers for collaborative tasks', async () => {
+      const extraWorkers = [
+        { claimPda: randomPubkey(), workerPda: randomPubkey() },
+      ];
+      const arbiterVotes = [
+        { votePda: randomPubkey(), arbiterAgentPda: randomPubkey() },
+      ];
+
+      await ops.resolveDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        creatorPubkey: randomPubkey(),
+        arbiterVotes,
+        extraWorkers,
+      });
+
+      // remaining_accounts should have 2 (arbiter pair) + 2 (worker pair) = 4
+      const remainingCall = program._methodBuilder.remainingAccounts.mock.calls[0][0];
+      expect(remainingCall).toHaveLength(4);
+    });
+
+    it('maps VotingNotEnded error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.VotingNotEnded));
+
+      await expect(
+        ops.resolveDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          creatorPubkey: randomPubkey(),
+          arbiterVotes: [],
+        }),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+
+    it('maps InsufficientVotes error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.InsufficientVotes));
+
+      await expect(
+        ops.resolveDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          creatorPubkey: randomPubkey(),
+          arbiterVotes: [],
+        }),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+
+    it('maps UnauthorizedResolver error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.UnauthorizedResolver));
+
+      await expect(
+        ops.resolveDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          creatorPubkey: randomPubkey(),
+          arbiterVotes: [],
+        }),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+
+    it('maps DisputeAlreadyResolved error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.DisputeAlreadyResolved));
+
+      await expect(
+        ops.resolveDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          creatorPubkey: randomPubkey(),
+          arbiterVotes: [],
+        }),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+  });
+
+  describe('cancelDispute', () => {
+    it('cancels dispute successfully', async () => {
+      const disputePda = randomPubkey();
+      const taskPda = randomPubkey();
+
+      const result = await ops.cancelDispute(disputePda, taskPda);
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(result.disputePda.equals(disputePda)).toBe(true);
+      expect(program.methods.cancelDispute).toHaveBeenCalled();
+    });
+
+    it('maps DisputeNotActive error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.DisputeNotActive));
+
+      await expect(
+        ops.cancelDispute(randomPubkey(), randomPubkey()),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+
+    it('maps UnauthorizedResolver error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.UnauthorizedResolver));
+
+      await expect(
+        ops.cancelDispute(randomPubkey(), randomPubkey()),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+  });
+
+  describe('expireDispute', () => {
+    it('expires dispute with remaining_accounts', async () => {
+      const arbiterVotes = [
+        { votePda: randomPubkey(), arbiterAgentPda: randomPubkey() },
+      ];
+
+      const result = await ops.expireDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        creatorPubkey: randomPubkey(),
+        arbiterVotes,
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(program.methods.expireDispute).toHaveBeenCalled();
+      expect(program._methodBuilder.remainingAccounts).toHaveBeenCalled();
+    });
+
+    it('maps DisputeNotExpired error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.DisputeNotExpired));
+
+      await expect(
+        ops.expireDispute({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          creatorPubkey: randomPubkey(),
+          arbiterVotes: [],
+        }),
+      ).rejects.toThrow(DisputeResolutionError);
+    });
+  });
+
+  describe('applySlash', () => {
+    it('applies slash with treasury fetch', async () => {
+      const result = await ops.applySlash({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        workerClaimPda: randomPubkey(),
+        workerAgentPda: randomPubkey(),
+      });
+
+      expect(result.transactionSignature).toBe('mock-signature');
+      expect(program.methods.applyDisputeSlash).toHaveBeenCalled();
+      // Treasury fetched from protocol config
+      expect(program.account.protocolConfig.fetch).toHaveBeenCalled();
+    });
+
+    it('caches treasury across calls', async () => {
+      await ops.applySlash({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        workerClaimPda: randomPubkey(),
+        workerAgentPda: randomPubkey(),
+      });
+
+      await ops.applySlash({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        workerClaimPda: randomPubkey(),
+        workerAgentPda: randomPubkey(),
+      });
+
+      // Should only fetch protocol config once (cached)
+      expect(program.account.protocolConfig.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps SlashAlreadyApplied error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.SlashAlreadyApplied));
+
+      await expect(
+        ops.applySlash({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          workerClaimPda: randomPubkey(),
+          workerAgentPda: randomPubkey(),
+        }),
+      ).rejects.toThrow(DisputeSlashError);
+    });
+
+    it('maps DisputeNotResolved error', async () => {
+      program._rpcMock.mockRejectedValueOnce(anchorError(AnchorErrorCodes.DisputeNotResolved));
+
+      await expect(
+        ops.applySlash({
+          disputePda: randomPubkey(),
+          taskPda: randomPubkey(),
+          workerClaimPda: randomPubkey(),
+          workerAgentPda: randomPubkey(),
+        }),
+      ).rejects.toThrow(DisputeSlashError);
+    });
+  });
+
+  // ==========================================================================
+  // buildRemainingAccounts Tests (tested via transaction methods)
+  // ==========================================================================
+
+  describe('buildRemainingAccounts (integration)', () => {
+    it('handles arbiter-only remaining accounts', async () => {
+      const arbiterVotes = [
+        { votePda: randomPubkey(), arbiterAgentPda: randomPubkey() },
+      ];
+
+      await ops.resolveDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        creatorPubkey: randomPubkey(),
+        arbiterVotes,
+      });
+
+      const remainingCall = program._methodBuilder.remainingAccounts.mock.calls[0][0];
+      expect(remainingCall).toHaveLength(2); // 1 pair = 2 accounts
+      expect(remainingCall[0].pubkey.equals(arbiterVotes[0].votePda)).toBe(true);
+      expect(remainingCall[1].pubkey.equals(arbiterVotes[0].arbiterAgentPda)).toBe(true);
+    });
+
+    it('handles arbiter + worker remaining accounts in correct order', async () => {
+      const arbiterVotes = [
+        { votePda: randomPubkey(), arbiterAgentPda: randomPubkey() },
+      ];
+      const extraWorkers = [
+        { claimPda: randomPubkey(), workerPda: randomPubkey() },
+      ];
+
+      await ops.resolveDispute({
+        disputePda: randomPubkey(),
+        taskPda: randomPubkey(),
+        creatorPubkey: randomPubkey(),
+        arbiterVotes,
+        extraWorkers,
+      });
+
+      const remainingCall = program._methodBuilder.remainingAccounts.mock.calls[0][0];
+      expect(remainingCall).toHaveLength(4);
+      // Arbiter pair first
+      expect(remainingCall[0].pubkey.equals(arbiterVotes[0].votePda)).toBe(true);
+      expect(remainingCall[1].pubkey.equals(arbiterVotes[0].arbiterAgentPda)).toBe(true);
+      // Worker pair second
+      expect(remainingCall[2].pubkey.equals(extraWorkers[0].claimPda)).toBe(true);
+      expect(remainingCall[3].pubkey.equals(extraWorkers[0].workerPda)).toBe(true);
+    });
+  });
+});

--- a/runtime/src/dispute/pda.ts
+++ b/runtime/src/dispute/pda.ts
@@ -1,0 +1,95 @@
+/**
+ * PDA derivation helpers for dispute-related accounts
+ * @module
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import { PROGRAM_ID, SEEDS } from '@agenc/sdk';
+import type { PdaWithBump } from '../agent/pda.js';
+
+// Re-export PdaWithBump for consumers importing from dispute module
+export type { PdaWithBump } from '../agent/pda.js';
+
+/**
+ * Derives the dispute PDA and bump seed.
+ * Seeds: ["dispute", dispute_id]
+ *
+ * @param disputeId - 32-byte dispute identifier
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ * @throws Error if disputeId is not 32 bytes
+ */
+export function deriveDisputePda(
+  disputeId: Uint8Array,
+  programId: PublicKey = PROGRAM_ID
+): PdaWithBump {
+  if (disputeId.length !== 32) {
+    throw new Error(
+      `Invalid disputeId length: ${disputeId.length} (must be 32)`
+    );
+  }
+
+  const [address, bump] = PublicKey.findProgramAddressSync(
+    [SEEDS.DISPUTE, Buffer.from(disputeId)],
+    programId
+  );
+
+  return { address, bump };
+}
+
+/**
+ * Finds the dispute PDA address (without bump).
+ * Convenience wrapper around deriveDisputePda.
+ *
+ * @param disputeId - 32-byte dispute identifier
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ * @throws Error if disputeId is not 32 bytes
+ */
+export function findDisputePda(
+  disputeId: Uint8Array,
+  programId: PublicKey = PROGRAM_ID
+): PublicKey {
+  return deriveDisputePda(disputeId, programId).address;
+}
+
+/**
+ * Derives the vote PDA and bump seed.
+ * Seeds: ["vote", dispute_pda, arbiter_agent_pda]
+ *
+ * Note: The voter is the arbiter's AGENT PDA, not the wallet.
+ *
+ * @param disputePda - Dispute account PDA
+ * @param arbiterAgentPda - Arbiter agent account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address and bump seed
+ */
+export function deriveVotePda(
+  disputePda: PublicKey,
+  arbiterAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID
+): PdaWithBump {
+  const [address, bump] = PublicKey.findProgramAddressSync(
+    [SEEDS.VOTE, disputePda.toBuffer(), arbiterAgentPda.toBuffer()],
+    programId
+  );
+
+  return { address, bump };
+}
+
+/**
+ * Finds the vote PDA address (without bump).
+ * Convenience wrapper around deriveVotePda.
+ *
+ * @param disputePda - Dispute account PDA
+ * @param arbiterAgentPda - Arbiter agent account PDA
+ * @param programId - Program ID (defaults to PROGRAM_ID)
+ * @returns PDA address
+ */
+export function findVotePda(
+  disputePda: PublicKey,
+  arbiterAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID
+): PublicKey {
+  return deriveVotePda(disputePda, arbiterAgentPda, programId).address;
+}

--- a/runtime/src/dispute/types.ts
+++ b/runtime/src/dispute/types.ts
@@ -1,0 +1,363 @@
+/**
+ * Dispute type definitions, parsing utilities, and parameter types
+ * for the Phase 8 Dispute Operations module.
+ *
+ * @module
+ */
+
+import type { PublicKey } from '@solana/web3.js';
+import { ResolutionType } from '../events/types.js';
+
+// Re-export ResolutionType for consumers importing from dispute module
+export { ResolutionType } from '../events/types.js';
+
+// ============================================================================
+// On-Chain Dispute Status Enum (matches state.rs DisputeStatus)
+// ============================================================================
+
+/**
+ * Dispute status values matching on-chain enum.
+ * Stored as u8 on-chain.
+ */
+export enum OnChainDisputeStatus {
+  /** Dispute is active and accepting votes */
+  Active = 0,
+  /** Dispute has been resolved */
+  Resolved = 1,
+  /** Dispute has expired */
+  Expired = 2,
+  /** Dispute was cancelled by initiator */
+  Cancelled = 3,
+}
+
+// ============================================================================
+// Account Layout Constants
+// ============================================================================
+
+/**
+ * Byte offset of the `status` field in the on-chain Dispute account.
+ *
+ * Layout: 8 (discriminator) + 32 (dispute_id) + 32 (task) + 32 (initiator)
+ *       + 32 (initiator_authority) + 32 (evidence_hash) + 1 (resolution_type) = 169
+ */
+export const DISPUTE_STATUS_OFFSET = 169;
+
+/**
+ * Byte offset of the `task` field in the on-chain Dispute account.
+ *
+ * Layout: 8 (discriminator) + 32 (dispute_id) = 40
+ */
+export const DISPUTE_TASK_OFFSET = 40;
+
+// ============================================================================
+// On-Chain Interfaces (parsed, developer-friendly types)
+// ============================================================================
+
+/**
+ * Parsed on-chain Dispute account data.
+ * Matches the state.rs Dispute struct with TypeScript-native types.
+ * PDA seeds: ["dispute", dispute_id]
+ */
+export interface OnChainDispute {
+  /** Dispute identifier (32 bytes) */
+  disputeId: Uint8Array;
+  /** Related task PDA */
+  task: PublicKey;
+  /** Initiator agent PDA */
+  initiator: PublicKey;
+  /** Initiator's authority wallet */
+  initiatorAuthority: PublicKey;
+  /** Evidence hash (32 bytes) */
+  evidenceHash: Uint8Array;
+  /** Proposed resolution type */
+  resolutionType: ResolutionType;
+  /** Current dispute status */
+  status: OnChainDisputeStatus;
+  /** Creation timestamp (Unix seconds) */
+  createdAt: number;
+  /** Resolution timestamp (Unix seconds, 0 if unresolved) */
+  resolvedAt: number;
+  /** Votes for approval (u64 as bigint) */
+  votesFor: bigint;
+  /** Votes against (u64 as bigint) */
+  votesAgainst: bigint;
+  /** Total arbiters who voted */
+  totalVoters: number;
+  /** Voting deadline (Unix seconds) */
+  votingDeadline: number;
+  /** Dispute expiration (Unix seconds) */
+  expiresAt: number;
+  /** Whether worker slashing has been applied */
+  slashApplied: boolean;
+  /** Whether initiator slashing has been applied */
+  initiatorSlashApplied: boolean;
+  /** Snapshot of worker's stake at dispute initiation (u64 as bigint) */
+  workerStakeAtDispute: bigint;
+  /** Whether the dispute was initiated by the task creator */
+  initiatedByCreator: boolean;
+  /** Bump seed */
+  bump: number;
+}
+
+/**
+ * Parsed on-chain DisputeVote account data.
+ * Matches the state.rs DisputeVote struct with TypeScript-native types.
+ * PDA seeds: ["vote", dispute, voter_agent_pda]
+ */
+export interface OnChainDisputeVote {
+  /** Dispute account PDA */
+  dispute: PublicKey;
+  /** Voter (arbiter agent PDA) */
+  voter: PublicKey;
+  /** Vote (true = approve, false = reject) */
+  approved: boolean;
+  /** Vote timestamp (Unix seconds) */
+  votedAt: number;
+  /** Arbiter's stake at time of voting (u64 as bigint) */
+  stakeAtVote: bigint;
+  /** Bump seed */
+  bump: number;
+}
+
+// ============================================================================
+// Parameter Types
+// ============================================================================
+
+/**
+ * Parameters for initiating a dispute.
+ */
+export interface InitiateDisputeParams {
+  /** Dispute identifier (32 bytes) */
+  disputeId: Uint8Array;
+  /** Task account PDA */
+  taskPda: PublicKey;
+  /** Task identifier (32 bytes) — instruction arg */
+  taskId: Uint8Array;
+  /** Evidence hash (32 bytes) — instruction arg */
+  evidenceHash: Uint8Array;
+  /** Resolution type (0=Refund, 1=Complete, 2=Split) — instruction arg */
+  resolutionType: number;
+  /** Evidence string (max 256 chars) — instruction arg */
+  evidence: string;
+  /** Optional: worker agent PDA (when creator initiates) */
+  workerAgentPda?: PublicKey;
+  /** Optional: worker claim PDA (when creator initiates) */
+  workerClaimPda?: PublicKey;
+  /** Optional: defendant worker pairs for remaining_accounts */
+  defendantWorkers?: Array<{ claimPda: PublicKey; workerPda: PublicKey }>;
+}
+
+/**
+ * Parameters for voting on a dispute.
+ */
+export interface VoteDisputeParams {
+  /** Dispute account PDA */
+  disputePda: PublicKey;
+  /** Task account PDA */
+  taskPda: PublicKey;
+  /** Whether to approve (true) or reject (false) */
+  approve: boolean;
+  /** Optional: worker claim PDA for arbiter party validation */
+  workerClaimPda?: PublicKey;
+}
+
+/**
+ * Parameters for resolving a dispute.
+ */
+export interface ResolveDisputeParams {
+  /** Dispute account PDA */
+  disputePda: PublicKey;
+  /** Task account PDA */
+  taskPda: PublicKey;
+  /** Task creator's public key */
+  creatorPubkey: PublicKey;
+  /** Optional: worker claim PDA (required for Complete/Split) */
+  workerClaimPda?: PublicKey;
+  /** Optional: worker agent PDA (required for Complete/Split) */
+  workerAgentPda?: PublicKey;
+  /** Optional: worker authority wallet (required for Complete/Split) */
+  workerAuthority?: PublicKey;
+  /** Arbiter vote PDAs + agent PDAs for remaining_accounts */
+  arbiterVotes: Array<{ votePda: PublicKey; arbiterAgentPda: PublicKey }>;
+  /** Optional: extra worker pairs for collaborative tasks */
+  extraWorkers?: Array<{ claimPda: PublicKey; workerPda: PublicKey }>;
+}
+
+/**
+ * Parameters for expiring a dispute.
+ */
+export interface ExpireDisputeParams {
+  /** Dispute account PDA */
+  disputePda: PublicKey;
+  /** Task account PDA */
+  taskPda: PublicKey;
+  /** Task creator's public key */
+  creatorPubkey: PublicKey;
+  /** Optional: worker claim PDA */
+  workerClaimPda?: PublicKey;
+  /** Optional: worker agent PDA */
+  workerAgentPda?: PublicKey;
+  /** Optional: worker authority wallet */
+  workerAuthority?: PublicKey;
+  /** Arbiter vote PDAs + agent PDAs for remaining_accounts */
+  arbiterVotes: Array<{ votePda: PublicKey; arbiterAgentPda: PublicKey }>;
+  /** Optional: extra worker pairs for collaborative tasks */
+  extraWorkers?: Array<{ claimPda: PublicKey; workerPda: PublicKey }>;
+}
+
+/**
+ * Parameters for applying a dispute slash.
+ */
+export interface ApplySlashParams {
+  /** Dispute account PDA */
+  disputePda: PublicKey;
+  /** Task account PDA */
+  taskPda: PublicKey;
+  /** Worker claim PDA */
+  workerClaimPda: PublicKey;
+  /** Worker agent PDA */
+  workerAgentPda: PublicKey;
+}
+
+// ============================================================================
+// Result Types
+// ============================================================================
+
+/**
+ * Result of a dispute initiation transaction.
+ */
+export interface DisputeResult {
+  /** Dispute account PDA */
+  disputePda: PublicKey;
+  /** Transaction signature */
+  transactionSignature: string;
+}
+
+/**
+ * Result of a dispute vote transaction.
+ */
+export interface VoteResult {
+  /** Vote account PDA */
+  votePda: PublicKey;
+  /** Transaction signature */
+  transactionSignature: string;
+}
+
+// ============================================================================
+// Parse Functions
+// ============================================================================
+
+/**
+ * Parse raw Anchor dispute account data to typed OnChainDispute.
+ *
+ * @param raw - Raw account data from program.account.dispute.fetch()
+ * @returns Parsed dispute data
+ */
+export function parseOnChainDispute(raw: Record<string, unknown>): OnChainDispute {
+  const r = raw as Record<string, any>;
+  return {
+    disputeId: toUint8Array(r.disputeId),
+    task: r.task,
+    initiator: r.initiator,
+    initiatorAuthority: r.initiatorAuthority,
+    evidenceHash: toUint8Array(r.evidenceHash),
+    resolutionType: parseResolutionType(r.resolutionType),
+    status: parseDisputeStatus(r.status),
+    createdAt: toBNNumber(r.createdAt),
+    resolvedAt: toBNNumber(r.resolvedAt),
+    votesFor: toBNBigint(r.votesFor),
+    votesAgainst: toBNBigint(r.votesAgainst),
+    totalVoters: typeof r.totalVoters === 'number' ? r.totalVoters : Number(r.totalVoters),
+    votingDeadline: toBNNumber(r.votingDeadline),
+    expiresAt: toBNNumber(r.expiresAt),
+    slashApplied: Boolean(r.slashApplied),
+    initiatorSlashApplied: Boolean(r.initiatorSlashApplied),
+    workerStakeAtDispute: toBNBigint(r.workerStakeAtDispute),
+    initiatedByCreator: Boolean(r.initiatedByCreator),
+    bump: typeof r.bump === 'number' ? r.bump : Number(r.bump),
+  };
+}
+
+/**
+ * Parse raw Anchor dispute vote account data to typed OnChainDisputeVote.
+ *
+ * @param raw - Raw account data from program.account.disputeVote.fetch()
+ * @returns Parsed vote data
+ */
+export function parseOnChainDisputeVote(raw: Record<string, unknown>): OnChainDisputeVote {
+  const r = raw as Record<string, any>;
+  return {
+    dispute: r.dispute,
+    voter: r.voter,
+    approved: Boolean(r.approved),
+    votedAt: toBNNumber(r.votedAt),
+    stakeAtVote: toBNBigint(r.stakeAtVote),
+    bump: typeof r.bump === 'number' ? r.bump : Number(r.bump),
+  };
+}
+
+/**
+ * Convert an OnChainDisputeStatus to a human-readable string.
+ */
+export function disputeStatusToString(status: OnChainDisputeStatus): string {
+  switch (status) {
+    case OnChainDisputeStatus.Active:
+      return 'Active';
+    case OnChainDisputeStatus.Resolved:
+      return 'Resolved';
+    case OnChainDisputeStatus.Expired:
+      return 'Expired';
+    case OnChainDisputeStatus.Cancelled:
+      return 'Cancelled';
+    default:
+      return `Unknown(${status})`;
+  }
+}
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+/** Convert BN-like value to number */
+function toBNNumber(val: unknown): number {
+  if (typeof val === 'number') return val;
+  if (val && typeof (val as any).toNumber === 'function') return (val as any).toNumber();
+  return Number(val);
+}
+
+/** Convert BN-like value to bigint */
+function toBNBigint(val: unknown): bigint {
+  if (typeof val === 'bigint') return val;
+  if (val && typeof (val as any).toString === 'function') return BigInt((val as any).toString());
+  return BigInt(String(val));
+}
+
+/** Convert number[] or Uint8Array to Uint8Array */
+function toUint8Array(val: unknown): Uint8Array {
+  if (val instanceof Uint8Array) return val;
+  if (Array.isArray(val)) return new Uint8Array(val);
+  return new Uint8Array(0);
+}
+
+/** Parse Anchor's resolution_type enum object to ResolutionType */
+function parseResolutionType(val: unknown): ResolutionType {
+  if (typeof val === 'number') return val as ResolutionType;
+  if (val && typeof val === 'object') {
+    if ('refund' in val) return ResolutionType.Refund;
+    if ('complete' in val) return ResolutionType.Complete;
+    if ('split' in val) return ResolutionType.Split;
+  }
+  return ResolutionType.Refund;
+}
+
+/** Parse Anchor's dispute status enum object to OnChainDisputeStatus */
+function parseDisputeStatus(val: unknown): OnChainDisputeStatus {
+  if (typeof val === 'number') return val as OnChainDisputeStatus;
+  if (val && typeof val === 'object') {
+    if ('active' in val) return OnChainDisputeStatus.Active;
+    if ('resolved' in val) return OnChainDisputeStatus.Resolved;
+    if ('expired' in val) return OnChainDisputeStatus.Expired;
+    if ('cancelled' in val) return OnChainDisputeStatus.Cancelled;
+  }
+  return OnChainDisputeStatus.Active;
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -475,3 +475,39 @@ export {
   RedisBackend,
   type RedisBackendConfig,
 } from './memory/index.js';
+
+// Dispute Operations (Phase 8)
+export {
+  // Enums
+  OnChainDisputeStatus,
+  // Constants
+  DISPUTE_STATUS_OFFSET,
+  DISPUTE_TASK_OFFSET,
+  // Functions
+  parseOnChainDispute,
+  parseOnChainDisputeVote,
+  disputeStatusToString,
+  // PDA derivation
+  deriveDisputePda,
+  findDisputePda,
+  deriveVotePda,
+  findVotePda,
+  // Error classes
+  DisputeNotFoundError,
+  DisputeVoteError,
+  DisputeResolutionError,
+  DisputeSlashError,
+  // Operations class
+  DisputeOperations,
+  // Types
+  type OnChainDispute,
+  type OnChainDisputeVote,
+  type InitiateDisputeParams,
+  type VoteDisputeParams,
+  type ResolveDisputeParams,
+  type ExpireDisputeParams,
+  type ApplySlashParams,
+  type DisputeResult,
+  type VoteResult,
+  type DisputeOpsConfig,
+} from './dispute/index.js';

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -39,8 +39,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY).toBe('RECENT_VOTE_ACTIVITY');
   });
 
-  it('has exactly 27 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(27);
+  it('has exactly 31 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(31);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -70,6 +70,14 @@ export const RuntimeErrorCodes = {
   PROOF_VERIFICATION_ERROR: 'PROOF_VERIFICATION_ERROR',
   /** Proof cache operation failed */
   PROOF_CACHE_ERROR: 'PROOF_CACHE_ERROR',
+  /** Dispute not found by PDA */
+  DISPUTE_NOT_FOUND: 'DISPUTE_NOT_FOUND',
+  /** Dispute vote operation failed */
+  DISPUTE_VOTE_ERROR: 'DISPUTE_VOTE_ERROR',
+  /** Dispute resolution operation failed */
+  DISPUTE_RESOLUTION_ERROR: 'DISPUTE_RESOLUTION_ERROR',
+  /** Dispute slash operation failed */
+  DISPUTE_SLASH_ERROR: 'DISPUTE_SLASH_ERROR',
 } as const;
 
 /** Union type of all runtime error code values */

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -170,6 +170,40 @@ export {
   type RetryPolicy,
 } from '../task/index.js';
 
+// Dispute types and utilities (Phase 8)
+export {
+  // Enums
+  OnChainDisputeStatus,
+  // Constants
+  DISPUTE_STATUS_OFFSET,
+  DISPUTE_TASK_OFFSET,
+  // Functions
+  parseOnChainDispute,
+  parseOnChainDisputeVote,
+  disputeStatusToString,
+  // PDA derivation
+  deriveDisputePda,
+  findDisputePda,
+  deriveVotePda,
+  findVotePda,
+  // Error classes
+  DisputeNotFoundError,
+  DisputeVoteError,
+  DisputeResolutionError,
+  DisputeSlashError,
+  // Types
+  type OnChainDispute,
+  type OnChainDisputeVote,
+  type InitiateDisputeParams,
+  type VoteDisputeParams,
+  type ResolveDisputeParams,
+  type ExpireDisputeParams,
+  type ApplySlashParams,
+  type DisputeResult,
+  type VoteResult,
+  type DisputeOpsConfig,
+} from '../dispute/index.js';
+
 // Event monitoring types (Phase 2)
 export {
   // Enums


### PR DESCRIPTION
## Summary

- Add `DisputeOperations` class wrapping 6 on-chain dispute instructions: initiate, vote, resolve, cancel, expire, and applySlash
- Add PDA helpers (`deriveDisputePda`, `deriveVotePda`) and parse functions for on-chain dispute/vote accounts
- Add 4 dispute error classes (`DisputeNotFoundError`, `DisputeVoteError`, `DisputeResolutionError`, `DisputeSlashError`) with RuntimeErrorCodes 28-31
- Add memcmp-filtered queries (`fetchActiveDisputes`, `fetchDisputesForTask`) following TaskOperations pattern
- Add `buildRemainingAccounts()` helper for arbiter vote + worker account pairs
- Treasury caching pattern identical to TaskOperations
- 56 unit tests with mocked program (no chain required)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` — 1655 passed, 56 new dispute tests
- [x] `npm run build` — ESM + CJS + DTS all succeed
- [x] RuntimeErrorCodes count updated 27 → 31 in errors.test.ts
- [x] Existing tests unaffected (0 failures introduced)