### PR TITLE
feat(runtime): add examples and API quick reference (Phase 9)

### DIFF
--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -1,0 +1,350 @@
+# Runtime API Quick Reference
+
+Practical usage patterns and entry points for `@agenc/runtime`. For comprehensive type signatures and field-level documentation, see [CLAUDE.md](../CLAUDE.md).
+
+## Getting Started
+
+```bash
+npm install @agenc/runtime
+cd runtime && npm run build
+```
+
+```typescript
+import { Connection, Keypair } from '@solana/web3.js';
+import {
+  AgentRuntime,
+  AgentCapabilities,
+  createProgram,
+  createReadOnlyProgram,
+  keypairToWallet,
+} from '@agenc/runtime';
+
+// Read-only access (queries, event subscriptions — no wallet)
+const program = createReadOnlyProgram(connection);
+
+// Full access (transactions — requires wallet)
+const provider = new AnchorProvider(connection, wallet, { commitment: 'confirmed' });
+const program = createProgram(provider);
+```
+
+## Module Map
+
+| Module | Primary Class | Purpose | Config Type |
+|--------|--------------|---------|-------------|
+| `agent/` | `AgentManager` | Register, update, deregister agents | `AgentManagerConfig` |
+| `runtime.ts` | `AgentRuntime` | Lifecycle wrapper around AgentManager | `AgentRuntimeConfig` |
+| `autonomous/` | `AutonomousAgent` | Self-operating agent with task discovery | `AutonomousAgentConfig` |
+| `task/` | `TaskOperations` | Claim, complete, cancel tasks on-chain | `TaskOpsConfig` |
+| `events/` | `EventMonitor` | Subscribe to all protocol events | `EventMonitorConfig` |
+| `llm/` | `LLMTaskExecutor` | Bridge LLM providers to task execution | `LLMTaskExecutorConfig` |
+| `llm/grok/` | `GrokProvider` | xAI Grok adapter (via `openai` SDK) | `GrokProviderConfig` |
+| `llm/anthropic/` | `AnthropicProvider` | Anthropic adapter | `AnthropicProviderConfig` |
+| `llm/ollama/` | `OllamaProvider` | Ollama local adapter | `OllamaProviderConfig` |
+| `tools/` | `ToolRegistry` | MCP-compatible tool management | `ToolRegistryConfig` |
+| `memory/` | `InMemoryBackend` | Zero-dep memory storage | `InMemoryBackendConfig` |
+| `memory/sqlite/` | `SqliteBackend` | SQLite-backed storage | `SqliteBackendConfig` |
+| `memory/redis/` | `RedisBackend` | Redis-backed storage | `RedisBackendConfig` |
+| `proof/` | `ProofEngine` | ZK proof generation with caching | `ProofEngineConfig` |
+| `dispute/` | `DisputeOperations` | Dispute lifecycle transactions | `DisputeOpsConfig` |
+| `skills/` | `SkillRegistry` | Skill registration and lifecycle | `SkillRegistryConfig` |
+
+## Common Patterns
+
+### Agent Lifecycle
+
+```typescript
+const runtime = new AgentRuntime({
+  connection,
+  wallet: keypair,
+  capabilities: BigInt(AgentCapabilities.COMPUTE | AgentCapabilities.INFERENCE),
+  initialStake: 500_000_000n,
+  logLevel: 'info',
+});
+
+runtime.registerShutdownHandlers(); // SIGINT/SIGTERM
+await runtime.start();              // register or load + set Active
+// ... agent operations ...
+await runtime.stop();               // set Inactive + cleanup
+```
+
+### LLM Provider Selection
+
+```typescript
+import { GrokProvider, AnthropicProvider, OllamaProvider } from '@agenc/runtime';
+
+// Grok (requires: npm install openai)
+const grok = new GrokProvider({ apiKey: process.env.XAI_API_KEY!, model: 'grok-3', tools });
+
+// Anthropic (requires: npm install @anthropic-ai/sdk)
+const anthropic = new AnthropicProvider({ apiKey: '...', model: 'claude-sonnet-4-5-20250929', tools });
+
+// Ollama (requires: npm install ollama + local Ollama server)
+const ollama = new OllamaProvider({ model: 'llama3', tools });
+```
+
+All providers implement `LLMProvider`: `chat()`, `chatStream()`, `healthCheck()`.
+
+### Tool Wiring (Critical Two-Site Pattern)
+
+Both sites must be connected for tool calls to work:
+
+```typescript
+import { ToolRegistry, createAgencTools, LLMTaskExecutor } from '@agenc/runtime';
+
+const registry = new ToolRegistry({ logger });
+registry.registerAll(createAgencTools({ connection, program, logger }));
+
+// Site 1: Tool DEFINITIONS go to the provider (so the LLM knows what tools exist)
+const provider = new GrokProvider({ apiKey, model, tools: registry.toLLMTools() });
+
+// Site 2: Tool HANDLER goes to the executor (executes tool calls during task loop)
+const executor = new LLMTaskExecutor({
+  provider,
+  toolHandler: registry.createToolHandler(),
+});
+```
+
+### Memory Integration
+
+```typescript
+import { InMemoryBackend, entryToMessage } from '@agenc/runtime';
+
+const memory = new InMemoryBackend({ maxEntriesPerSession: 1000 });
+
+// Store entries
+await memory.addEntry({ sessionId: 'sess-1', role: 'user', content: 'Hello' });
+
+// Retrieve and convert to LLM format
+const thread = await memory.getThread('sess-1');
+const llmMessages = thread.map(entryToMessage);
+
+// Key-value storage
+await memory.set('config:model', 'grok-3', 300_000); // with 5min TTL
+const model = await memory.get<string>('config:model');
+```
+
+### Event Subscription
+
+```typescript
+import { EventMonitor, createReadOnlyProgram } from '@agenc/runtime';
+
+// Read-only program works for events (uses Connection WebSocket internally)
+const program = createReadOnlyProgram(connection);
+const monitor = new EventMonitor({ program, logger });
+
+monitor.subscribeToTaskEvents({
+  onTaskCreated: (event, slot, sig) => { /* ... */ },
+  onTaskCompleted: (event) => { /* ... */ },
+});
+
+monitor.subscribeToDisputeEvents({ /* ... */ });
+monitor.subscribeToProtocolEvents({ /* ... */ });
+monitor.subscribeToAgentEvents({ /* ... */ });
+
+monitor.start();
+const metrics = monitor.getMetrics(); // { totalEventsReceived, eventCounts, uptimeMs }
+await monitor.stop();
+```
+
+### Proof Generation
+
+```typescript
+import { ProofEngine } from '@agenc/runtime';
+
+const engine = new ProofEngine({
+  circuitPath: './circuits-circom/task_completion',
+  verifyAfterGeneration: false,
+  cache: { ttlMs: 300_000, maxEntries: 100 },
+});
+
+const result = await engine.generate({
+  taskPda, agentPubkey,
+  output: [1n, 2n, 3n, 4n],
+  salt: engine.generateSalt(),
+});
+// result.fromCache, result.verified, result.proof, result.proofHash
+```
+
+### Dispute Operations
+
+```typescript
+import { DisputeOperations } from '@agenc/runtime';
+
+const ops = new DisputeOperations({ program, agentId, logger });
+
+const active = await ops.fetchActiveDisputes();      // memcmp-filtered
+const forTask = await ops.fetchDisputesForTask(taskPda);
+
+await ops.initiateDispute({ disputeId, taskPda, taskId, evidenceHash, resolutionType: 0, evidence: '...' });
+await ops.voteOnDispute({ disputePda, taskPda, approve: true });
+await ops.resolveDispute({ disputePda, taskPda, creatorPubkey, arbiterVotes: [...] });
+await ops.cancelDispute(disputePda, taskPda);
+await ops.expireDispute({ disputePda, taskPda, creatorPubkey, arbiterVotes: [] });
+await ops.applySlash({ disputePda, taskPda, workerClaimPda, workerAgentPda });
+```
+
+## Error Handling
+
+### RuntimeErrorCodes (31 codes)
+
+| Code | Error Class | Phase |
+|------|-------------|-------|
+| `AGENT_NOT_REGISTERED` | `AgentNotRegisteredError` | 1 |
+| `AGENT_ALREADY_REGISTERED` | `AgentAlreadyRegisteredError` | 1 |
+| `VALIDATION_ERROR` | `ValidationError` | 1 |
+| `RATE_LIMIT_ERROR` | `RateLimitError` | 1 |
+| `INSUFFICIENT_STAKE` | `InsufficientStakeError` | 1 |
+| `ACTIVE_TASKS_ERROR` | `ActiveTasksError` | 1 |
+| `PENDING_DISPUTE_VOTES` | `PendingDisputeVotesError` | 1 |
+| `RECENT_VOTE_ACTIVITY` | `RecentVoteActivityError` | 1 |
+| `TASK_NOT_FOUND` | `TaskNotFoundError` | 3 |
+| `TASK_NOT_CLAIMABLE` | `TaskNotClaimableError` | 3 |
+| `TASK_EXECUTION_FAILED` | `TaskExecutionError` | 3 |
+| `TASK_SUBMISSION_FAILED` | `TaskSubmissionError` | 3 |
+| `EXECUTOR_STATE_ERROR` | `ExecutorStateError` | 3 |
+| `TASK_TIMEOUT` | `TaskTimeoutError` | 3 |
+| `CLAIM_EXPIRED` | — | 3 |
+| `RETRY_EXHAUSTED` | — | 3 |
+| `LLM_PROVIDER_ERROR` | `LLMProviderError` | 4 |
+| `LLM_RATE_LIMIT` | `LLMRateLimitError` | 4 |
+| `LLM_RESPONSE_CONVERSION` | `LLMResponseConversionError` | 4 |
+| `LLM_TOOL_CALL_ERROR` | `LLMToolCallError` | 4 |
+| `LLM_TIMEOUT` | `LLMTimeoutError` | 4 |
+| `MEMORY_BACKEND_ERROR` | `MemoryBackendError` | 6 |
+| `MEMORY_CONNECTION_ERROR` | `MemoryConnectionError` | 6 |
+| `MEMORY_SERIALIZATION_ERROR` | `MemorySerializationError` | 6 |
+| `PROOF_GENERATION_ERROR` | `ProofGenerationError` | 7 |
+| `PROOF_VERIFICATION_ERROR` | `ProofVerificationError` | 7 |
+| `PROOF_CACHE_ERROR` | `ProofCacheError` | 7 |
+| `DISPUTE_NOT_FOUND` | `DisputeNotFoundError` | 8 |
+| `DISPUTE_VOTE_ERROR` | `DisputeVoteError` | 8 |
+| `DISPUTE_RESOLUTION_ERROR` | `DisputeResolutionError` | 8 |
+| `DISPUTE_SLASH_ERROR` | `DisputeSlashError` | 8 |
+
+All error classes extend `RuntimeError` which has a `code: string` field.
+
+```typescript
+import { isRuntimeError, RuntimeErrorCodes } from '@agenc/runtime';
+
+try {
+  await manager.register(params);
+} catch (err) {
+  if (isRuntimeError(err) && err.code === RuntimeErrorCodes.INSUFFICIENT_STAKE) {
+    // Handle specific error
+  }
+}
+```
+
+### Anchor Error Mapping
+
+Use `isAnchorError()` and `parseAnchorError()` for on-chain errors:
+
+```typescript
+import { isAnchorError, parseAnchorError, getAnchorErrorName } from '@agenc/runtime';
+
+try {
+  await program.methods.claimTask().rpc();
+} catch (err) {
+  if (isAnchorError(err)) {
+    const parsed = parseAnchorError(err);
+    console.log(parsed.code, parsed.name, parsed.message);
+  }
+}
+```
+
+## Configuration Reference
+
+### AgentRuntimeConfig
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `connection` | `Connection` | Yes | — |
+| `wallet` | `Keypair \| Wallet` | Yes | — |
+| `programId` | `PublicKey` | No | `PROGRAM_ID` |
+| `agentId` | `Uint8Array` | No | Random 32 bytes |
+| `capabilities` | `bigint` | For new agents | — |
+| `endpoint` | `string` | No | `agent://<short_id>` |
+| `metadataUri` | `string` | No | — |
+| `initialStake` | `bigint` | No | `0n` |
+| `logLevel` | `LogLevel` | No | Silent |
+
+### LLMProviderConfig (shared base)
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `model` | `string` | Yes | — |
+| `systemPrompt` | `string` | No | — |
+| `temperature` | `number` | No | — |
+| `maxTokens` | `number` | No | — |
+| `tools` | `LLMTool[]` | No | — |
+| `timeoutMs` | `number` | No | — |
+| `maxRetries` | `number` | No | — |
+
+Provider-specific additions:
+- **GrokProviderConfig**: `apiKey` (required), `baseURL`, `webSearch`, `searchMode`
+- **AnthropicProviderConfig**: `apiKey` (required)
+- **OllamaProviderConfig**: `baseURL` (default: `http://localhost:11434`)
+
+### LLMTaskExecutorConfig
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `provider` | `LLMProvider` | Yes | — |
+| `systemPrompt` | `string` | No | — |
+| `streaming` | `boolean` | No | `false` |
+| `onStreamChunk` | `StreamProgressCallback` | No | — |
+| `toolHandler` | `ToolHandler` | No | — |
+| `maxToolRounds` | `number` | No | `10` |
+| `responseToOutput` | `(response: string) => bigint[]` | No | SHA-256 converter |
+| `requiredCapabilities` | `bigint` | No | — |
+
+### Memory Backend Configs
+
+| Backend | Key Options | Defaults |
+|---------|------------|----------|
+| `InMemoryBackend` | `maxEntriesPerSession`, `maxTotalEntries`, `defaultTtlMs` | 1000, 100k, none |
+| `SqliteBackend` | `dbPath`, `walMode`, `cleanupOnConnect` | `:memory:`, true, true |
+| `RedisBackend` | `url` or `host`/`port`, `keyPrefix`, `connectTimeoutMs` | —, `agenc:memory:`, 5000 |
+
+### ProofEngineConfig
+
+| Field | Type | Required | Default |
+|-------|------|----------|---------|
+| `circuitPath` | `string` | No | `./circuits-circom/task_completion` |
+| `verifyAfterGeneration` | `boolean` | No | `false` |
+| `cache.ttlMs` | `number` | No | `300_000` |
+| `cache.maxEntries` | `number` | No | `100` |
+
+## Capability Constants
+
+```typescript
+import { AgentCapabilities, hasCapability, getCapabilityNames } from '@agenc/runtime';
+
+AgentCapabilities.COMPUTE     // 1n << 0n
+AgentCapabilities.INFERENCE   // 1n << 1n
+AgentCapabilities.STORAGE     // 1n << 2n
+AgentCapabilities.NETWORK     // 1n << 3n
+AgentCapabilities.SENSOR      // 1n << 4n
+AgentCapabilities.ACTUATOR    // 1n << 5n
+AgentCapabilities.COORDINATOR // 1n << 6n
+AgentCapabilities.ARBITER     // 1n << 7n
+AgentCapabilities.VALIDATOR   // 1n << 8n
+AgentCapabilities.AGGREGATOR  // 1n << 9n
+```
+
+## Examples
+
+| Example | Path | Demonstrates |
+|---------|------|-------------|
+| Autonomous Agent | `examples/autonomous-agent/` | Task discovery, execution, ZK proofs |
+| LLM Agent | `examples/llm-agent/` | LLM providers, tool calling, streaming |
+| Dispute Arbiter | `examples/dispute-arbiter/` | DisputeOperations, voting, event monitoring |
+| Memory Agent | `examples/memory-agent/` | InMemoryBackend, session threads, KV store |
+| Event Dashboard | `examples/event-dashboard/` | EventMonitor, read-only mode, all event types |
+| Skill Jupiter | `examples/skill-jupiter/` | JupiterSkill, swap quotes, token balances |
+
+## Links
+
+- [CLAUDE.md](../CLAUDE.md) — Comprehensive type signatures and architecture
+- [SDK README](../sdk/README.md) — SDK usage documentation
+- [Architecture](architecture.md) — System architecture overview

--- a/examples/dispute-arbiter/index.ts
+++ b/examples/dispute-arbiter/index.ts
@@ -1,0 +1,220 @@
+/**
+ * Dispute Arbiter Agent
+ *
+ * Demonstrates an agent that monitors the AgenC protocol for disputes,
+ * evaluates evidence, and votes on outcomes using DisputeOperations.
+ *
+ * The agent:
+ *   1. Registers with ARBITER capability and sufficient stake
+ *   2. Subscribes to real-time dispute events via WebSocket
+ *   3. Periodically polls for active disputes it hasn't voted on
+ *   4. Evaluates dispute evidence and casts votes
+ *
+ * Usage:
+ *   npx ts-node examples/dispute-arbiter/index.ts
+ *
+ * Environment:
+ *   SOLANA_RPC_URL - RPC endpoint (default: devnet)
+ *   KEYPAIR_PATH   - Path to keypair file (default: ~/.config/solana/id.json)
+ *   MIN_STAKE      - Arbiter stake in SOL (default: 1.0)
+ *   POLL_INTERVAL  - Dispute poll interval in ms (default: 15000)
+ */
+
+import { Connection, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import { AnchorProvider } from '@coral-xyz/anchor';
+import {
+  AgentRuntime,
+  AgentCapabilities,
+  DisputeOperations,
+  OnChainDisputeStatus,
+  subscribeToAllDisputeEvents,
+  createProgram,
+  keypairToWallet,
+  createLogger,
+  generateAgentId,
+  bytesToHex,
+  loadDefaultKeypair,
+  type OnChainDispute,
+  type DisputeVoteError,
+} from '@agenc/runtime';
+
+const RPC_URL = process.env.SOLANA_RPC_URL || 'https://api.devnet.solana.com';
+const MIN_STAKE = parseFloat(process.env.MIN_STAKE || '1.0');
+const POLL_INTERVAL = parseInt(process.env.POLL_INTERVAL || '15000', 10);
+const logger = createLogger('info', '[Arbiter]');
+
+/** Set of dispute PDAs we've already voted on this session */
+const votedDisputes = new Set<string>();
+
+/**
+ * Simple dispute evaluation logic.
+ * In production, this would involve more sophisticated analysis —
+ * checking on-chain evidence, comparing task outputs, etc.
+ */
+function evaluateDispute(dispute: OnChainDispute): boolean {
+  // Approve if evidence is substantial (> 100 chars indicates detailed report)
+  if (dispute.evidence.length > 100) {
+    logger.info(`  Evidence is substantial (${dispute.evidence.length} chars) — approving`);
+    return true;
+  }
+
+  // Reject disputes with minimal evidence
+  logger.info(`  Evidence is minimal (${dispute.evidence.length} chars) — rejecting`);
+  return false;
+}
+
+/**
+ * Fetch active disputes and vote on any we haven't handled yet.
+ */
+async function processActiveDisputes(ops: DisputeOperations): Promise<void> {
+  const disputes = await ops.fetchActiveDisputes();
+  const pending = disputes.filter(d => !votedDisputes.has(d.pda.toBase58()));
+
+  if (pending.length === 0) return;
+
+  logger.info(`Found ${pending.length} dispute(s) to evaluate`);
+
+  for (const dispute of pending) {
+    const pdaShort = dispute.pda.toBase58().slice(0, 8);
+
+    // Skip if voting deadline has passed
+    const now = Math.floor(Date.now() / 1000);
+    if (dispute.votingDeadline > 0 && now > dispute.votingDeadline) {
+      logger.info(`Dispute ${pdaShort}... — voting ended, skipping`);
+      votedDisputes.add(dispute.pda.toBase58());
+      continue;
+    }
+
+    logger.info(`Evaluating dispute ${pdaShort}...`);
+    logger.info(`  Task: ${dispute.taskPda.toBase58().slice(0, 8)}...`);
+    logger.info(`  Votes: ${dispute.votesFor} for, ${dispute.votesAgainst} against`);
+
+    const approve = evaluateDispute(dispute);
+
+    try {
+      const result = await ops.voteOnDispute({
+        disputePda: dispute.pda,
+        taskPda: dispute.taskPda,
+        approve,
+      });
+      votedDisputes.add(dispute.pda.toBase58());
+      logger.info(`  Voted ${approve ? 'APPROVE' : 'REJECT'} — TX: ${result.signature.slice(0, 16)}...`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Common: already voted, not an arbiter, voting ended
+      logger.warn(`  Vote failed: ${message}`);
+      votedDisputes.add(dispute.pda.toBase58());
+    }
+  }
+}
+
+async function main() {
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('  AgenC Dispute Arbiter Agent');
+  console.log('='.repeat(60));
+  console.log('');
+
+  // Load keypair
+  let keypair: Keypair;
+  try {
+    keypair = await loadDefaultKeypair();
+    logger.info(`Loaded keypair: ${keypair.publicKey.toBase58()}`);
+  } catch {
+    keypair = Keypair.generate();
+    logger.info(`Generated keypair: ${keypair.publicKey.toBase58()}`);
+  }
+
+  const connection = new Connection(RPC_URL, 'confirmed');
+  const wallet = keypairToWallet(keypair);
+
+  // Check balance
+  const balance = await connection.getBalance(keypair.publicKey);
+  logger.info(`Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
+
+  if (balance < (MIN_STAKE + 0.1) * LAMPORTS_PER_SOL) {
+    logger.info('Requesting airdrop...');
+    try {
+      const sig = await connection.requestAirdrop(keypair.publicKey, 2 * LAMPORTS_PER_SOL);
+      await connection.confirmTransaction(sig);
+      logger.info('Airdrop successful!');
+    } catch (e) {
+      logger.error(`Airdrop failed: ${e}`);
+      process.exit(1);
+    }
+  }
+
+  // Start agent runtime with ARBITER capability
+  const runtime = new AgentRuntime({
+    connection,
+    wallet: keypair,
+    capabilities: BigInt(AgentCapabilities.ARBITER | AgentCapabilities.COMPUTE),
+    initialStake: BigInt(MIN_STAKE * LAMPORTS_PER_SOL),
+    logLevel: 'info',
+  });
+
+  runtime.registerShutdownHandlers();
+  await runtime.start();
+
+  const agentId = runtime.getAgentId()!;
+  logger.info(`Agent registered: ${bytesToHex(agentId).slice(0, 16)}...`);
+
+  // Create program and dispute operations
+  const provider = new AnchorProvider(connection, wallet, { commitment: 'confirmed' });
+  const program = createProgram(provider);
+  const ops = new DisputeOperations({
+    program,
+    agentId,
+    logger,
+  });
+
+  // Subscribe to real-time dispute events
+  logger.info('Subscribing to dispute events...');
+  const sub = subscribeToAllDisputeEvents(program, {
+    onDisputeInitiated: (event) => {
+      logger.info(`[EVENT] New dispute initiated — ID: ${bytesToHex(event.disputeId).slice(0, 16)}...`);
+    },
+    onDisputeVoteCast: (event) => {
+      logger.info(`[EVENT] Vote cast on dispute — ${event.approved ? 'APPROVE' : 'REJECT'} (${event.votesFor}/${event.votesAgainst})`);
+    },
+    onDisputeResolved: (event) => {
+      logger.info(`[EVENT] Dispute resolved — ${event.votesFor} for, ${event.votesAgainst} against`);
+    },
+    onDisputeExpired: (event) => {
+      logger.info(`[EVENT] Dispute expired — refund: ${Number(event.refundAmount) / LAMPORTS_PER_SOL} SOL`);
+    },
+  });
+
+  // Poll for active disputes periodically
+  logger.info(`Polling for disputes every ${POLL_INTERVAL / 1000}s...`);
+  logger.info('Press Ctrl+C to stop.');
+  console.log('');
+
+  const pollInterval = setInterval(async () => {
+    try {
+      await processActiveDisputes(ops);
+    } catch (err) {
+      logger.error(`Poll error: ${err instanceof Error ? err.message : err}`);
+    }
+  }, POLL_INTERVAL);
+
+  // Run initial poll immediately
+  await processActiveDisputes(ops).catch((err) => {
+    logger.error(`Initial poll error: ${err instanceof Error ? err.message : err}`);
+  });
+
+  // Keep running until Ctrl+C
+  process.on('SIGINT', async () => {
+    console.log('');
+    logger.info('Shutting down...');
+    clearInterval(pollInterval);
+    await sub.unsubscribe();
+    await runtime.stop();
+    logger.info(`Session summary: voted on ${votedDisputes.size} dispute(s)`);
+    process.exit(0);
+  });
+
+  await new Promise(() => {});
+}
+
+main().catch(console.error);

--- a/examples/event-dashboard/index.ts
+++ b/examples/event-dashboard/index.ts
@@ -1,0 +1,243 @@
+/**
+ * Real-Time Protocol Dashboard
+ *
+ * Demonstrates real-time monitoring of all AgenC protocol events using
+ * the EventMonitor class. Runs in read-only mode — no wallet required.
+ *
+ * Event categories monitored:
+ *   - Task events:     created, claimed, completed, cancelled
+ *   - Dispute events:  initiated, vote cast, resolved, expired
+ *   - Protocol events: initialized, reward distributed, rate limit hit,
+ *                      migration completed, version updated, state updated
+ *   - Agent events:    registered, updated, deregistered
+ *
+ * Usage:
+ *   npx ts-node examples/event-dashboard/index.ts
+ *
+ * Environment:
+ *   SOLANA_RPC_URL - RPC endpoint (default: devnet)
+ *   STATS_INTERVAL - Stats print interval in ms (default: 30000)
+ */
+
+import { Connection, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import {
+  EventMonitor,
+  createReadOnlyProgram,
+  createLogger,
+  bytesToHex,
+  lamportsToSol,
+  // Event types for callbacks
+  type TaskCreatedEvent,
+  type TaskClaimedEvent,
+  type TaskCompletedEvent,
+  type TaskCancelledEvent,
+  type DisputeInitiatedEvent,
+  type DisputeVoteCastEvent,
+  type DisputeResolvedEvent,
+  type DisputeExpiredEvent,
+  type ProtocolInitializedEvent,
+  type RewardDistributedEvent,
+  type RateLimitHitEvent,
+  type AgentRegisteredEvent,
+  type AgentUpdatedEvent,
+  type AgentDeregisteredEvent,
+} from '@agenc/runtime';
+
+const RPC_URL = process.env.SOLANA_RPC_URL || 'https://api.devnet.solana.com';
+const STATS_INTERVAL = parseInt(process.env.STATS_INTERVAL || '30000', 10);
+const logger = createLogger('info', '[Dashboard]');
+
+/** Format a hex ID for display */
+function shortId(id: Uint8Array | number[]): string {
+  return bytesToHex(id instanceof Uint8Array ? id : new Uint8Array(id)).slice(0, 12);
+}
+
+/** Format a timestamp */
+function formatTime(timestamp: number): string {
+  return new Date(timestamp * 1000).toLocaleTimeString();
+}
+
+async function main() {
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('  AgenC Real-Time Protocol Dashboard');
+  console.log('='.repeat(60));
+  console.log('');
+
+  const connection = new Connection(RPC_URL, 'confirmed');
+
+  // Read-only program — no wallet needed.
+  // Anchor event subscriptions work through Connection WebSocket (onLogs).
+  const program = createReadOnlyProgram(connection);
+
+  const monitor = new EventMonitor({ program, logger });
+
+  // --- Task Events ---
+  monitor.subscribeToTaskEvents({
+    onTaskCreated: (event: TaskCreatedEvent) => {
+      console.log(
+        `  [TASK:CREATED]    ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.taskId)}... | ` +
+        `Reward: ${lamportsToSol(event.rewardAmount)} SOL | ` +
+        `Creator: ${event.creator.toBase58().slice(0, 8)}...`
+      );
+    },
+    onTaskClaimed: (event: TaskClaimedEvent) => {
+      console.log(
+        `  [TASK:CLAIMED]    ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.taskId)}... | ` +
+        `Worker: ${event.worker.toBase58().slice(0, 8)}... | ` +
+        `Workers: ${event.currentWorkers}/${event.maxWorkers}`
+      );
+    },
+    onTaskCompleted: (event: TaskCompletedEvent) => {
+      console.log(
+        `  [TASK:COMPLETED]  ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.taskId)}... | ` +
+        `Reward: ${lamportsToSol(event.rewardPaid)} SOL`
+      );
+    },
+    onTaskCancelled: (event: TaskCancelledEvent) => {
+      console.log(
+        `  [TASK:CANCELLED]  ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.taskId)}... | ` +
+        `Refund: ${lamportsToSol(event.refundAmount)} SOL`
+      );
+    },
+  });
+
+  // --- Dispute Events ---
+  monitor.subscribeToDisputeEvents({
+    onDisputeInitiated: (event: DisputeInitiatedEvent) => {
+      console.log(
+        `  [DISPUTE:NEW]     ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.disputeId)}... | ` +
+        `Initiator: ${event.initiator.toBase58().slice(0, 8)}...`
+      );
+    },
+    onDisputeVoteCast: (event: DisputeVoteCastEvent) => {
+      console.log(
+        `  [DISPUTE:VOTE]    ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.disputeId)}... | ` +
+        `${event.approved ? 'APPROVE' : 'REJECT'} (${event.votesFor}/${event.votesAgainst})`
+      );
+    },
+    onDisputeResolved: (event: DisputeResolvedEvent) => {
+      console.log(
+        `  [DISPUTE:RESOLVED] ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.disputeId)}... | ` +
+        `Votes: ${event.votesFor} for, ${event.votesAgainst} against`
+      );
+    },
+    onDisputeExpired: (event: DisputeExpiredEvent) => {
+      console.log(
+        `  [DISPUTE:EXPIRED] ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.disputeId)}... | ` +
+        `Refund: ${lamportsToSol(event.refundAmount)} SOL`
+      );
+    },
+  });
+
+  // --- Protocol Events ---
+  monitor.subscribeToProtocolEvents({
+    onProtocolInitialized: (event: ProtocolInitializedEvent) => {
+      console.log(
+        `  [PROTO:INIT]      ${formatTime(event.timestamp)} | ` +
+        `Authority: ${event.authority.toBase58().slice(0, 8)}... | ` +
+        `Fee: ${event.protocolFeeBps} bps`
+      );
+    },
+    onRewardDistributed: (event: RewardDistributedEvent) => {
+      console.log(
+        `  [PROTO:REWARD]    ${formatTime(event.timestamp)} | ` +
+        `Amount: ${lamportsToSol(event.amount)} SOL | ` +
+        `Fee: ${lamportsToSol(event.protocolFee)} SOL`
+      );
+    },
+    onRateLimitHit: (event: RateLimitHitEvent) => {
+      console.log(
+        `  [PROTO:RATELIMIT] ${formatTime(event.timestamp)} | ` +
+        `Agent: ${shortId(event.agentId)}... | ` +
+        `${event.currentCount}/${event.maxCount}`
+      );
+    },
+  });
+
+  // --- Agent Events ---
+  monitor.subscribeToAgentEvents({
+    onRegistered: (event: AgentRegisteredEvent) => {
+      console.log(
+        `  [AGENT:REGISTER]  ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.agentId)}... | ` +
+        `Caps: 0x${event.capabilities.toString(16)}`
+      );
+    },
+    onUpdated: (event: AgentUpdatedEvent) => {
+      console.log(
+        `  [AGENT:UPDATE]    ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.agentId)}... | ` +
+        `Status: ${event.status}`
+      );
+    },
+    onDeregistered: (event: AgentDeregisteredEvent) => {
+      console.log(
+        `  [AGENT:DEREGISTER] ${formatTime(event.timestamp)} | ` +
+        `ID: ${shortId(event.agentId)}...`
+      );
+    },
+  });
+
+  // Start the monitor (sets lifecycle flags, records start time)
+  monitor.start();
+
+  logger.info(`Connected to ${RPC_URL}`);
+  logger.info(`Monitoring all protocol events...`);
+  logger.info(`Stats interval: ${STATS_INTERVAL / 1000}s`);
+  logger.info('Press Ctrl+C to stop.');
+  console.log('');
+
+  // Print metrics periodically
+  const statsInterval = setInterval(() => {
+    const metrics = monitor.getMetrics();
+    const uptimeSec = Math.floor(metrics.uptimeMs / 1000);
+    const eventsPerMin = uptimeSec > 0
+      ? ((metrics.totalEventsReceived / uptimeSec) * 60).toFixed(1)
+      : '0';
+
+    console.log('');
+    console.log('--- Dashboard Metrics ---');
+    console.log(`  Uptime: ${uptimeSec}s`);
+    console.log(`  Total events: ${metrics.totalEventsReceived}`);
+    console.log(`  Events/min: ${eventsPerMin}`);
+
+    const counts = Object.entries(metrics.eventCounts);
+    if (counts.length > 0) {
+      console.log('  Breakdown:');
+      for (const [name, count] of counts.sort((a, b) => b[1] - a[1])) {
+        console.log(`    ${name}: ${count}`);
+      }
+    }
+    console.log('-------------------------');
+    console.log('');
+  }, STATS_INTERVAL);
+
+  // Graceful shutdown
+  process.on('SIGINT', async () => {
+    console.log('');
+    clearInterval(statsInterval);
+    const metrics = monitor.getMetrics();
+    logger.info(`Stopping... (${metrics.totalEventsReceived} events received)`);
+    await monitor.stop();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', async () => {
+    clearInterval(statsInterval);
+    await monitor.stop();
+    process.exit(0);
+  });
+
+  await new Promise(() => {});
+}
+
+main().catch(console.error);

--- a/examples/llm-agent/index.ts
+++ b/examples/llm-agent/index.ts
@@ -1,0 +1,238 @@
+/**
+ * LLM-Powered Task Agent
+ *
+ * Demonstrates an autonomous agent that uses an LLM provider (Grok, Anthropic,
+ * or Ollama) to execute tasks, with tool calling for on-chain protocol queries.
+ *
+ * The critical wiring pattern for tools:
+ *   1. registry.toLLMTools()        -> passed to the PROVIDER config as `tools`
+ *   2. registry.createToolHandler() -> passed to LLMTaskExecutor as `toolHandler`
+ *   Both are required — if either is missing, tool calls silently do nothing.
+ *
+ * Usage:
+ *   npx ts-node examples/llm-agent/index.ts
+ *
+ * Environment:
+ *   SOLANA_RPC_URL    - RPC endpoint (default: devnet)
+ *   KEYPAIR_PATH      - Path to keypair file (default: ~/.config/solana/id.json)
+ *
+ *   Provider selection (first match wins):
+ *   XAI_API_KEY       - Use Grok (xAI) provider
+ *   ANTHROPIC_API_KEY - Use Anthropic provider
+ *   (neither)         - Fall back to Ollama (local, no API key needed)
+ *
+ *   Model override:
+ *   GROK_MODEL        - Grok model (default: grok-3)
+ *   ANTHROPIC_MODEL   - Anthropic model (default: claude-sonnet-4-5-20250929)
+ *   OLLAMA_MODEL      - Ollama model (default: llama3)
+ *
+ * Prerequisites:
+ *   Install the SDK for your chosen provider:
+ *   - Grok:      npm install openai
+ *   - Anthropic: npm install @anthropic-ai/sdk
+ *   - Ollama:    npm install ollama
+ */
+
+import { Connection, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import {
+  AutonomousAgent,
+  AgentCapabilities,
+  loadDefaultKeypair,
+  createReadOnlyProgram,
+  createLogger,
+  // LLM
+  GrokProvider,
+  AnthropicProvider,
+  OllamaProvider,
+  LLMTaskExecutor,
+  // Tools
+  ToolRegistry,
+  createAgencTools,
+  // Types
+  type LLMProvider,
+  type Task,
+} from '@agenc/runtime';
+
+const RPC_URL = process.env.SOLANA_RPC_URL || 'https://api.devnet.solana.com';
+const logger = createLogger('info', '[LLM-Agent]');
+
+/**
+ * Select an LLM provider based on available environment variables.
+ * Priority: XAI_API_KEY > ANTHROPIC_API_KEY > Ollama (local).
+ */
+function createProvider(tools: ReturnType<ToolRegistry['toLLMTools']>): LLMProvider {
+  const xaiKey = process.env.XAI_API_KEY;
+  if (xaiKey) {
+    const model = process.env.GROK_MODEL || 'grok-3';
+    logger.info(`Using Grok provider (model: ${model})`);
+    return new GrokProvider({
+      apiKey: xaiKey,
+      model,
+      tools,
+      temperature: 0.7,
+      maxTokens: 2048,
+    });
+  }
+
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (anthropicKey) {
+    const model = process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-5-20250929';
+    logger.info(`Using Anthropic provider (model: ${model})`);
+    return new AnthropicProvider({
+      apiKey: anthropicKey,
+      model,
+      tools,
+      temperature: 0.7,
+      maxTokens: 2048,
+    });
+  }
+
+  const model = process.env.OLLAMA_MODEL || 'llama3';
+  logger.info(`Using Ollama provider (model: ${model}) — no API key found`);
+  return new OllamaProvider({
+    model,
+    tools,
+    temperature: 0.7,
+    maxTokens: 2048,
+  });
+}
+
+/**
+ * Set up the tool registry with built-in AgenC protocol query tools.
+ * Returns both the LLM tool definitions and the tool handler.
+ */
+function createTools(connection: Connection) {
+  const registry = new ToolRegistry({ logger });
+
+  // Register built-in protocol query tools:
+  //   agenc.listTasks, agenc.getTask, agenc.getAgent, agenc.getProtocolConfig
+  const readOnlyProgram = createReadOnlyProgram(connection);
+  registry.registerAll(createAgencTools({ connection, program: readOnlyProgram, logger }));
+
+  return {
+    tools: registry.toLLMTools(),
+    handler: registry.createToolHandler(),
+  };
+}
+
+async function main() {
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('  AgenC LLM-Powered Task Agent');
+  console.log('='.repeat(60));
+  console.log('');
+
+  // Load keypair
+  let keypair: Keypair;
+  try {
+    keypair = await loadDefaultKeypair();
+    logger.info(`Loaded keypair: ${keypair.publicKey.toBase58()}`);
+  } catch {
+    keypair = Keypair.generate();
+    logger.info(`Generated keypair: ${keypair.publicKey.toBase58()}`);
+    logger.info('(You will need to airdrop SOL to this address)');
+  }
+
+  const connection = new Connection(RPC_URL, 'confirmed');
+
+  // Check balance
+  const balance = await connection.getBalance(keypair.publicKey);
+  logger.info(`Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
+
+  if (balance < 0.1 * LAMPORTS_PER_SOL) {
+    logger.info('Requesting airdrop...');
+    try {
+      const sig = await connection.requestAirdrop(keypair.publicKey, 2 * LAMPORTS_PER_SOL);
+      await connection.confirmTransaction(sig);
+      logger.info('Airdrop successful!');
+    } catch (e) {
+      logger.error(`Airdrop failed: ${e}`);
+      process.exit(1);
+    }
+  }
+
+  // --- Tool wiring (critical two-site pattern) ---
+  // 1. Create tools and get both LLM tool definitions AND the handler
+  const { tools, handler } = createTools(connection);
+
+  // 2. Pass tool definitions to the PROVIDER (so the LLM knows what tools exist)
+  const provider = createProvider(tools);
+
+  // 3. Create executor with BOTH the provider AND the handler
+  //    The handler is called when the LLM makes tool calls during execution
+  const executor = new LLMTaskExecutor({
+    provider,
+    toolHandler: handler,
+    systemPrompt: [
+      'You are an AI agent executing tasks on the AgenC protocol.',
+      'You can query protocol state using the available tools.',
+      'Analyze the task description and provide a thoughtful response.',
+    ].join(' '),
+    streaming: true,
+    onStreamChunk: (chunk) => {
+      if (chunk.content) process.stdout.write(chunk.content);
+      if (chunk.done) console.log('');
+    },
+  });
+
+  // Create the autonomous agent with the LLM executor
+  const agent = new AutonomousAgent({
+    connection,
+    wallet: keypair,
+    capabilities: BigInt(AgentCapabilities.COMPUTE | AgentCapabilities.INFERENCE),
+    initialStake: BigInt(0.5 * LAMPORTS_PER_SOL),
+    logLevel: 'info',
+    executor,
+    taskFilter: {
+      capabilities: BigInt(AgentCapabilities.COMPUTE),
+      minReward: BigInt(0.01 * LAMPORTS_PER_SOL),
+    },
+    scanIntervalMs: 10000,
+    maxConcurrentTasks: 1,
+    onTaskDiscovered: (task: Task) => {
+      logger.info(`Discovered task ${task.pda.toBase58().slice(0, 8)}... (${Number(task.reward) / LAMPORTS_PER_SOL} SOL)`);
+    },
+    onTaskClaimed: (task: Task, tx: string) => {
+      logger.info(`Claimed task ${task.pda.toBase58().slice(0, 8)}... TX: ${tx.slice(0, 16)}...`);
+    },
+    onTaskCompleted: (task: Task, tx: string) => {
+      logger.info(`Completed task ${task.pda.toBase58().slice(0, 8)}... TX: ${tx.slice(0, 16)}...`);
+    },
+    onTaskFailed: (task: Task, error: Error) => {
+      logger.error(`Task ${task.pda.toBase58().slice(0, 8)}... failed: ${error.message}`);
+    },
+    onEarnings: (amount: bigint) => {
+      logger.info(`Earned ${Number(amount) / LAMPORTS_PER_SOL} SOL`);
+    },
+  });
+
+  agent.registerShutdownHandlers();
+
+  try {
+    await agent.start();
+    logger.info('Agent running — scanning for tasks...');
+    logger.info('Press Ctrl+C to stop.');
+    console.log('');
+
+    // Print stats every 30s
+    const statsInterval = setInterval(() => {
+      const stats = agent.getStats();
+      console.log('');
+      console.log('--- Agent Stats ---');
+      console.log(`  Uptime: ${Math.floor(stats.uptimeMs / 1000)}s`);
+      console.log(`  Discovered: ${stats.tasksDiscovered} | Claimed: ${stats.tasksClaimed}`);
+      console.log(`  Completed: ${stats.tasksCompleted} | Failed: ${stats.tasksFailed}`);
+      console.log(`  Earnings: ${Number(stats.totalEarnings) / LAMPORTS_PER_SOL} SOL`);
+      console.log('-------------------');
+      console.log('');
+    }, 30000);
+
+    await new Promise(() => {});
+    clearInterval(statsInterval);
+  } catch (error) {
+    logger.error(`Agent error: ${error}`);
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);

--- a/examples/memory-agent/index.ts
+++ b/examples/memory-agent/index.ts
@@ -1,0 +1,268 @@
+/**
+ * Memory-Enhanced Agent
+ *
+ * Demonstrates an autonomous agent that uses a memory backend to persist
+ * context across task executions. The MemoryExecutor wraps any inner executor,
+ * storing task descriptions, results, and timing in memory threads.
+ *
+ * Features:
+ *   - Per-task session threads for execution history
+ *   - Global "agent-context" session for cross-task knowledge
+ *   - KV store for task metadata (durations, result counts)
+ *   - Memory query for retrieving past results
+ *   - LLM interop via entryToMessage() for feeding context to providers
+ *
+ * Usage:
+ *   npx ts-node examples/memory-agent/index.ts
+ *
+ * Environment:
+ *   SOLANA_RPC_URL - RPC endpoint (default: devnet)
+ *   KEYPAIR_PATH   - Path to keypair file (default: ~/.config/solana/id.json)
+ *
+ * Backends:
+ *   This example uses InMemoryBackend (zero deps). For persistence, swap to:
+ *     - SqliteBackend:  npm install better-sqlite3
+ *     - RedisBackend:   npm install ioredis
+ */
+
+import { Connection, Keypair, LAMPORTS_PER_SOL } from '@solana/web3.js';
+import {
+  AutonomousAgent,
+  AgentCapabilities,
+  loadDefaultKeypair,
+  createLogger,
+  // Memory
+  InMemoryBackend,
+  entryToMessage,
+  // Types
+  type MemoryBackend,
+  type Task,
+  type AutonomousTaskExecutor as TaskExecutor,
+} from '@agenc/runtime';
+// For alternative backends:
+// import { SqliteBackend } from '@agenc/runtime';
+// import { RedisBackend } from '@agenc/runtime';
+
+const RPC_URL = process.env.SOLANA_RPC_URL || 'https://api.devnet.solana.com';
+const AGENT_CONTEXT_SESSION = 'agent-context';
+const logger = createLogger('info', '[Memory-Agent]');
+
+/**
+ * TaskExecutor that wraps an inner executor with memory operations.
+ *
+ * Before execution: loads recent context from memory.
+ * After execution: stores the task description, result, and timing.
+ */
+class MemoryExecutor implements TaskExecutor {
+  constructor(
+    private readonly memory: MemoryBackend,
+    private readonly inner: TaskExecutor,
+  ) {}
+
+  async execute(task: Task): Promise<bigint[]> {
+    const taskPda = task.pda.toBase58();
+    const sessionId = `task-${taskPda.slice(0, 16)}`;
+    const startTime = Date.now();
+
+    // Load recent context from the global agent session
+    const recentContext = await this.memory.getThread(AGENT_CONTEXT_SESSION, 5);
+    if (recentContext.length > 0) {
+      const messages = recentContext.map(entryToMessage);
+      logger.info(`Loaded ${messages.length} context entries from previous tasks`);
+    }
+
+    // Store the task description in this task's session
+    const description = Buffer.from(task.description).toString('utf-8').replace(/\0/g, '').trim();
+    await this.memory.addEntry({
+      sessionId,
+      role: 'user',
+      content: `Task: ${description}`,
+      taskPda,
+      metadata: { reward: task.reward.toString() },
+    });
+
+    // Execute the inner executor
+    const result = await this.inner.execute(task);
+
+    const durationMs = Date.now() - startTime;
+
+    // Store the result in this task's session
+    await this.memory.addEntry({
+      sessionId,
+      role: 'assistant',
+      content: `Result: [${result.join(', ')}]`,
+      taskPda,
+      metadata: { durationMs },
+    });
+
+    // Store a summary in the global agent context (with TTL for cleanup)
+    await this.memory.addEntry({
+      sessionId: AGENT_CONTEXT_SESSION,
+      role: 'assistant',
+      content: `Completed task ${taskPda.slice(0, 8)}... in ${durationMs}ms (reward: ${Number(task.reward) / LAMPORTS_PER_SOL} SOL)`,
+      ttlMs: 3600_000, // 1 hour TTL
+    });
+
+    // Store timing in KV for aggregate stats
+    const taskCount = (await this.memory.get<number>('stats:taskCount')) ?? 0;
+    const totalDuration = (await this.memory.get<number>('stats:totalDurationMs')) ?? 0;
+    await this.memory.set('stats:taskCount', taskCount + 1);
+    await this.memory.set('stats:totalDurationMs', totalDuration + durationMs);
+
+    logger.info(`Task ${taskPda.slice(0, 8)}... completed in ${durationMs}ms — stored in memory`);
+    return result;
+  }
+
+  canExecute(task: Task): boolean {
+    return this.inner.canExecute?.(task) ?? true;
+  }
+}
+
+/**
+ * Simple deterministic executor (same as EchoExecutor in autonomous-agent example)
+ */
+class SimpleExecutor implements TaskExecutor {
+  async execute(task: Task): Promise<bigint[]> {
+    const output: bigint[] = [];
+    for (let i = 0; i < 4; i++) {
+      let value = 0n;
+      for (let j = 0; j < 8; j++) {
+        const idx = (i * 8 + j) % task.taskId.length;
+        value |= BigInt(task.taskId[idx]) << BigInt(j * 8);
+      }
+      output.push(value);
+    }
+    return output;
+  }
+
+  canExecute(): boolean {
+    return true;
+  }
+}
+
+async function main() {
+  console.log('');
+  console.log('='.repeat(60));
+  console.log('  AgenC Memory-Enhanced Agent');
+  console.log('='.repeat(60));
+  console.log('');
+
+  // Load keypair
+  let keypair: Keypair;
+  try {
+    keypair = await loadDefaultKeypair();
+    logger.info(`Loaded keypair: ${keypair.publicKey.toBase58()}`);
+  } catch {
+    keypair = Keypair.generate();
+    logger.info(`Generated keypair: ${keypair.publicKey.toBase58()}`);
+  }
+
+  const connection = new Connection(RPC_URL, 'confirmed');
+
+  // Check balance
+  const balance = await connection.getBalance(keypair.publicKey);
+  logger.info(`Balance: ${balance / LAMPORTS_PER_SOL} SOL`);
+
+  if (balance < 0.1 * LAMPORTS_PER_SOL) {
+    logger.info('Requesting airdrop...');
+    try {
+      const sig = await connection.requestAirdrop(keypair.publicKey, 2 * LAMPORTS_PER_SOL);
+      await connection.confirmTransaction(sig);
+      logger.info('Airdrop successful!');
+    } catch (e) {
+      logger.error(`Airdrop failed: ${e}`);
+      process.exit(1);
+    }
+  }
+
+  // Create memory backend
+  // Zero-dependency in-memory backend — swap for SqliteBackend or RedisBackend for persistence:
+  //   const memory = new SqliteBackend({ dbPath: './agent-memory.db', walMode: true, logger });
+  //   const memory = new RedisBackend({ host: 'localhost', keyPrefix: 'agenc:memory:', logger });
+  const memory = new InMemoryBackend({
+    maxEntriesPerSession: 500,
+    maxTotalEntries: 10_000,
+    logger,
+  });
+
+  const healthy = await memory.healthCheck();
+  logger.info(`Memory backend: ${memory.name} (healthy: ${healthy})`);
+
+  // Wrap the simple executor with memory
+  const executor = new MemoryExecutor(memory, new SimpleExecutor());
+
+  // Create autonomous agent
+  const agent = new AutonomousAgent({
+    connection,
+    wallet: keypair,
+    capabilities: BigInt(AgentCapabilities.COMPUTE | AgentCapabilities.STORAGE),
+    initialStake: BigInt(0.5 * LAMPORTS_PER_SOL),
+    logLevel: 'info',
+    executor,
+    taskFilter: {
+      capabilities: BigInt(AgentCapabilities.COMPUTE),
+    },
+    scanIntervalMs: 10000,
+    maxConcurrentTasks: 1,
+    onTaskCompleted: async () => {
+      // Print memory stats after each completion
+      const taskCount = (await memory.get<number>('stats:taskCount')) ?? 0;
+      const totalDuration = (await memory.get<number>('stats:totalDurationMs')) ?? 0;
+      const avgMs = taskCount > 0 ? Math.round(totalDuration / taskCount) : 0;
+      const sessions = await memory.listSessions();
+      logger.info(`Memory stats: ${taskCount} tasks, avg ${avgMs}ms, ${sessions.length} sessions`);
+    },
+    onTaskFailed: (task: Task, error: Error) => {
+      logger.error(`Task ${task.pda.toBase58().slice(0, 8)}... failed: ${error.message}`);
+    },
+  });
+
+  agent.registerShutdownHandlers();
+
+  try {
+    await agent.start();
+    logger.info('Agent running with memory-enhanced execution');
+    logger.info('Press Ctrl+C to stop.');
+    console.log('');
+
+    // Print detailed memory stats every 60s
+    const statsInterval = setInterval(async () => {
+      const sessions = await memory.listSessions();
+      const taskCount = (await memory.get<number>('stats:taskCount')) ?? 0;
+      const totalDuration = (await memory.get<number>('stats:totalDurationMs')) ?? 0;
+      const contextThread = await memory.getThread(AGENT_CONTEXT_SESSION, 100);
+
+      console.log('');
+      console.log('--- Memory Stats ---');
+      console.log(`  Sessions: ${sessions.length}`);
+      console.log(`  Tasks completed: ${taskCount}`);
+      console.log(`  Avg duration: ${taskCount > 0 ? Math.round(totalDuration / taskCount) : 0}ms`);
+      console.log(`  Context entries: ${contextThread.length}`);
+      console.log('--------------------');
+      console.log('');
+    }, 60000);
+
+    // Graceful shutdown
+    process.on('SIGINT', async () => {
+      console.log('');
+      logger.info('Shutting down...');
+      clearInterval(statsInterval);
+
+      // Query all task results before closing
+      const results = await memory.query({ role: 'assistant', limit: 100 });
+      logger.info(`Total stored results: ${results.length}`);
+
+      await memory.close();
+      await agent.stop();
+      process.exit(0);
+    });
+
+    await new Promise(() => {});
+  } catch (error) {
+    logger.error(`Agent error: ${error}`);
+    await memory.close();
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Add 4 new examples demonstrating runtime Phases 4-8: LLM agent with tool calling, dispute arbiter, memory-enhanced agent, real-time event dashboard
- Add `docs/RUNTIME_API.md` quick reference with module map, common patterns, error codes table, and configuration reference
- All examples follow existing `autonomous-agent` conventions (no package.json, `@agenc/runtime` imports, JSDoc headers)

## Test plan
- [x] `npm run build` passes (no source changes)
- [x] `npm run typecheck` passes
- [x] All imports verified against `runtime/src/index.ts` barrel exports
- [ ] Manual: `npx ts-node examples/llm-agent/index.ts` with `XAI_API_KEY` set
- [ ] Manual: `npx ts-node examples/event-dashboard/index.ts` against devnet