### PR TITLE
refactor: extract shared dispute helpers, deduplicate PDA derivations

### DIFF
--- a/programs/agenc-coordination/src/instructions/dispute_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/dispute_helpers.rs
@@ -1,0 +1,138 @@
+//! Shared helper functions for dispute resolution and expiration.
+//!
+//! These helpers process `remaining_accounts` for both `resolve_dispute` and
+//! `expire_dispute` instructions, avoiding code duplication across the two
+//! instruction handlers.
+
+use std::collections::HashSet;
+
+use crate::errors::CoordinationError;
+use crate::state::{AgentRegistration, DisputeVote, TaskClaim};
+use anchor_lang::prelude::*;
+
+/// Validates the structure of remaining_accounts for dispute processing.
+///
+/// Ensures:
+/// - At least `total_voters * 2` accounts are present (vote, arbiter pairs)
+/// - Any extra accounts come in pairs (claim, worker)
+///
+/// Returns the number of arbiter accounts (total_voters * 2).
+pub(crate) fn validate_remaining_accounts_structure(
+    remaining_accounts: &[AccountInfo],
+    total_voters: u8,
+) -> Result<usize> {
+    let arbiter_accounts = (total_voters as usize)
+        .checked_mul(2)
+        .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+    // Validate we have at least enough accounts for arbiters
+    require!(
+        remaining_accounts.len() >= arbiter_accounts,
+        CoordinationError::InvalidInput
+    );
+
+    // Additional accounts must come in pairs (claim, worker)
+    let extra_accounts = remaining_accounts.len() - arbiter_accounts;
+    require!(extra_accounts % 2 == 0, CoordinationError::InvalidInput);
+
+    Ok(arbiter_accounts)
+}
+
+/// Checks for duplicate arbiters in remaining_accounts (fix #583).
+///
+/// Iterates over (vote, arbiter) pairs and ensures no arbiter appears twice.
+pub(crate) fn check_duplicate_arbiters(
+    remaining_accounts: &[AccountInfo],
+    arbiter_accounts: usize,
+) -> Result<()> {
+    let mut seen_arbiters: HashSet<Pubkey> = HashSet::new();
+    for i in (0..arbiter_accounts).step_by(2) {
+        let arbiter_key = remaining_accounts[i + 1].key();
+        require!(
+            seen_arbiters.insert(arbiter_key),
+            CoordinationError::DuplicateArbiter
+        );
+    }
+    Ok(())
+}
+
+/// Processes a single (vote, arbiter) pair from remaining_accounts.
+///
+/// Validates ownership, deserializes the vote, verifies it belongs to the dispute
+/// and matches the arbiter, then decrements the arbiter's active_dispute_votes counter.
+pub(crate) fn process_arbiter_vote_pair(
+    vote_info: &AccountInfo,
+    arbiter_info: &AccountInfo,
+    dispute_key: &Pubkey,
+) -> Result<()> {
+    require!(
+        vote_info.owner == &crate::ID,
+        CoordinationError::InvalidAccountOwner
+    );
+    require!(
+        arbiter_info.owner == &crate::ID,
+        CoordinationError::InvalidAccountOwner
+    );
+
+    let vote_data = vote_info.try_borrow_data()?;
+    let vote = DisputeVote::try_deserialize(&mut &**vote_data)?;
+    require!(
+        vote.dispute == *dispute_key,
+        CoordinationError::InvalidInput
+    );
+    require!(
+        vote.voter == arbiter_info.key(),
+        CoordinationError::InvalidInput
+    );
+    drop(vote_data);
+
+    require!(arbiter_info.is_writable, CoordinationError::InvalidInput);
+    let mut arbiter_data = arbiter_info.try_borrow_mut_data()?;
+    let mut arbiter = AgentRegistration::try_deserialize(&mut &**arbiter_data)?;
+    // Using saturating_sub intentionally - underflow returns 0 (safe counter decrement)
+    arbiter.active_dispute_votes = arbiter.active_dispute_votes.saturating_sub(1);
+    arbiter.try_serialize(&mut &mut arbiter_data[8..])?;
+
+    Ok(())
+}
+
+/// Processes a single (claim, worker) pair from remaining_accounts.
+///
+/// Validates ownership, deserializes the claim, verifies it belongs to the task
+/// and matches the worker, then decrements the worker's active_tasks counter.
+/// Used for collaborative tasks where multiple workers claimed the task.
+pub(crate) fn process_worker_claim_pair(
+    claim_info: &AccountInfo,
+    worker_info: &AccountInfo,
+    task_key: &Pubkey,
+) -> Result<()> {
+    require!(
+        claim_info.owner == &crate::ID,
+        CoordinationError::InvalidAccountOwner
+    );
+    require!(
+        worker_info.owner == &crate::ID,
+        CoordinationError::InvalidAccountOwner
+    );
+
+    let claim_data = claim_info.try_borrow_data()?;
+    let claim = TaskClaim::try_deserialize(&mut &**claim_data)?;
+    require!(
+        claim.task == *task_key,
+        CoordinationError::InvalidInput
+    );
+    require!(
+        claim.worker == worker_info.key(),
+        CoordinationError::InvalidInput
+    );
+    drop(claim_data);
+
+    require!(worker_info.is_writable, CoordinationError::InvalidInput);
+    let mut worker_data = worker_info.try_borrow_mut_data()?;
+    let mut worker_reg = AgentRegistration::try_deserialize(&mut &**worker_data)?;
+    // Using saturating_sub intentionally - underflow returns 0 (safe counter decrement)
+    worker_reg.active_tasks = worker_reg.active_tasks.saturating_sub(1);
+    worker_reg.try_serialize(&mut &mut worker_data[8..])?;
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -12,13 +12,15 @@
 //! - No completion + no votes: 50/50 split (neither party engaged arbiters)
 //! - Some votes but insufficient quorum: Creator gets refund (dispute was contested)
 
-use std::collections::HashSet;
-
 use crate::errors::CoordinationError;
 use crate::events::{ArbiterVotesCleanedUp, DisputeExpired};
+use crate::instructions::dispute_helpers::{
+    check_duplicate_arbiters, process_arbiter_vote_pair, process_worker_claim_pair,
+    validate_remaining_accounts_structure,
+};
 use crate::state::{
-    AgentRegistration, Dispute, DisputeStatus, DisputeVote, ProtocolConfig, Task, TaskClaim,
-    TaskEscrow, TaskStatus,
+    AgentRegistration, Dispute, DisputeStatus, ProtocolConfig, Task, TaskClaim, TaskEscrow,
+    TaskStatus,
 };
 use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
@@ -203,43 +205,19 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
 
     // Decrement active_dispute_votes for each arbiter who voted (fix #328)
     //
-    // Worker accounts processing - shared pattern with resolve_dispute/expire_dispute
-    // The duplication is intentional to avoid cross-instruction dependencies
-    // and keep each instruction self-contained.
-    //
     // remaining_accounts format (fix #333):
     // - First: (vote, arbiter) pairs for total_voters
     // - Then: optional (claim, worker) pairs for additional workers on collaborative tasks
-    let arbiter_accounts = dispute
-        .total_voters
-        .checked_mul(2)
-        .ok_or(CoordinationError::ArithmeticOverflow)? as usize;
+    let arbiter_accounts =
+        validate_remaining_accounts_structure(ctx.remaining_accounts, dispute.total_voters)?;
+    check_duplicate_arbiters(ctx.remaining_accounts, arbiter_accounts)?;
 
-    // Validate we have at least enough accounts for arbiters
-    require!(
-        ctx.remaining_accounts.len() >= arbiter_accounts,
-        CoordinationError::InvalidInput
-    );
-
-    // Additional accounts must come in pairs (claim, worker)
-    let extra_accounts = ctx.remaining_accounts.len() - arbiter_accounts;
-    require!(extra_accounts % 2 == 0, CoordinationError::InvalidInput);
-
-    // Check for duplicate arbiters (fix #583)
-    let mut seen_arbiters: HashSet<Pubkey> = HashSet::new();
     for i in (0..arbiter_accounts).step_by(2) {
-        let arbiter_key = ctx.remaining_accounts[i + 1].key();
-        require!(
-            seen_arbiters.insert(arbiter_key),
-            CoordinationError::DuplicateArbiter
-        );
-    }
-
-    // Process arbiter (vote, arbiter) pairs
-    for i in (0..arbiter_accounts).step_by(2) {
-        let vote_info = &ctx.remaining_accounts[i];
-        let arbiter_info = &ctx.remaining_accounts[i + 1];
-        process_arbiter_vote_pair_expired(vote_info, arbiter_info, &dispute.key())?;
+        process_arbiter_vote_pair(
+            &ctx.remaining_accounts[i],
+            &ctx.remaining_accounts[i + 1],
+            &dispute.key(),
+        )?;
     }
 
     // Emit event for arbiter vote cleanup (fix #572)
@@ -249,11 +227,13 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
     });
 
     // Process additional worker (claim, worker) pairs to decrement active_tasks (fix #333)
-    // This handles collaborative tasks where multiple workers claimed the task
-    cleanup_worker_claims_expired(
-        &ctx.remaining_accounts[arbiter_accounts..],
-        &task.key(),
-    )?;
+    for i in (arbiter_accounts..ctx.remaining_accounts.len()).step_by(2) {
+        process_worker_claim_pair(
+            &ctx.remaining_accounts[i],
+            &ctx.remaining_accounts[i + 1],
+            &task.key(),
+        )?;
+    }
 
     task.status = TaskStatus::Cancelled;
     dispute.status = DisputeStatus::Expired;
@@ -342,89 +322,3 @@ fn distribute_expired_funds(
     Ok((creator_amount, worker_amount))
 }
 
-/// Processes a single (vote, arbiter) pair to decrement `active_dispute_votes`.
-///
-/// Validates account ownership, vote-dispute linkage, and vote-arbiter linkage
-/// before updating the arbiter's counter.
-fn process_arbiter_vote_pair_expired(
-    vote_info: &AccountInfo,
-    arbiter_info: &AccountInfo,
-    dispute_key: &Pubkey,
-) -> Result<()> {
-    require!(
-        vote_info.owner == &crate::ID,
-        CoordinationError::InvalidAccountOwner
-    );
-    require!(
-        arbiter_info.owner == &crate::ID,
-        CoordinationError::InvalidAccountOwner
-    );
-
-    let vote_data = vote_info.try_borrow_data()?;
-    let vote = DisputeVote::try_deserialize(&mut &**vote_data)?;
-    require!(
-        vote.dispute == *dispute_key,
-        CoordinationError::InvalidInput
-    );
-    require!(
-        vote.voter == arbiter_info.key(),
-        CoordinationError::InvalidInput
-    );
-    drop(vote_data);
-
-    require!(arbiter_info.is_writable, CoordinationError::InvalidInput);
-    let mut arbiter_data = arbiter_info.try_borrow_mut_data()?;
-    let mut arbiter = AgentRegistration::try_deserialize(&mut &**arbiter_data)?;
-    // Using saturating_sub intentionally - underflow returns 0 (safe counter decrement)
-    arbiter.active_dispute_votes = arbiter.active_dispute_votes.saturating_sub(1);
-    arbiter.try_serialize(&mut &mut arbiter_data[8..])?;
-
-    Ok(())
-}
-
-/// Processes (claim, worker) pairs to decrement `active_tasks` on dispute expiration.
-///
-/// Validates account ownership, claim-task linkage, and claim-worker linkage
-/// before updating each worker's active_tasks counter.
-fn cleanup_worker_claims_expired(
-    remaining_accounts: &[AccountInfo],
-    task_key: &Pubkey,
-) -> Result<()> {
-    for i in (0..remaining_accounts.len()).step_by(2) {
-        let claim_info = &remaining_accounts[i];
-        let worker_info = &remaining_accounts[i + 1];
-
-        // Validate account ownership
-        require!(
-            claim_info.owner == &crate::ID,
-            CoordinationError::InvalidAccountOwner
-        );
-        require!(
-            worker_info.owner == &crate::ID,
-            CoordinationError::InvalidAccountOwner
-        );
-
-        // Validate claim belongs to this task
-        let claim_data = claim_info.try_borrow_data()?;
-        let claim = TaskClaim::try_deserialize(&mut &**claim_data)?;
-        require!(
-            claim.task == *task_key,
-            CoordinationError::InvalidInput
-        );
-        require!(
-            claim.worker == worker_info.key(),
-            CoordinationError::InvalidInput
-        );
-        drop(claim_data);
-
-        // Decrement worker's active_tasks
-        require!(worker_info.is_writable, CoordinationError::InvalidInput);
-        let mut worker_data = worker_info.try_borrow_mut_data()?;
-        let mut worker_reg = AgentRegistration::try_deserialize(&mut &**worker_data)?;
-        // Using saturating_sub intentionally - underflow returns 0 (safe counter decrement)
-        worker_reg.active_tasks = worker_reg.active_tasks.saturating_sub(1);
-        worker_reg.try_serialize(&mut &mut worker_data[8..])?;
-    }
-
-    Ok(())
-}

--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -21,6 +21,7 @@
 
 pub mod completion_helpers;
 pub mod constants;
+pub mod dispute_helpers;
 pub mod rate_limit_helpers;
 pub mod slash_helpers;
 pub mod task_init_helpers;

--- a/runtime/src/autonomous/agent.ts
+++ b/runtime/src/autonomous/agent.ts
@@ -20,6 +20,8 @@ import {
 } from './types.js';
 import { Logger, createLogger, silentLogger } from '../utils/logger.js';
 import { createProgram } from '../idl.js';
+import { findClaimPda, findEscrowPda } from '../task/pda.js';
+import { findProtocolPda } from '../agent/pda.js';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
 import type { Wallet } from '../types/wallet.js';
 import { keypairToWallet } from '../types/wallet.js';
@@ -554,17 +556,8 @@ export class AutonomousAgent extends AgentRuntime {
       throw new Error('Agent not registered');
     }
 
-    // Derive claim PDA
-    const [claimPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('claim'), task.pda.toBuffer(), agentPda.toBuffer()],
-      this.program.programId
-    );
-
-    // Derive protocol PDA
-    const [protocolPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('protocol')],
-      this.program.programId
-    );
+    const claimPda = findClaimPda(task.pda, agentPda, this.program.programId);
+    const protocolPda = findProtocolPda(this.program.programId);
 
     const tx = await this.program.methods
       .claimTask()
@@ -614,19 +607,9 @@ export class AutonomousAgent extends AgentRuntime {
     const agentPda = this.getAgentPda();
     if (!agentPda) throw new Error('Agent not registered');
 
-    // Derive PDAs
-    const [claimPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('claim'), task.pda.toBuffer(), agentPda.toBuffer()],
-      this.program.programId
-    );
-    const [escrowPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('escrow'), task.pda.toBuffer()],
-      this.program.programId
-    );
-    const [protocolPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('protocol')],
-      this.program.programId
-    );
+    const claimPda = findClaimPda(task.pda, agentPda, this.program.programId);
+    const escrowPda = findEscrowPda(task.pda, this.program.programId);
+    const protocolPda = findProtocolPda(this.program.programId);
 
     // Fetch protocol config for treasury
     const protocolConfig = await (
@@ -681,19 +664,9 @@ export class AutonomousAgent extends AgentRuntime {
     this.onProofGenerated?.(task, proofResult.proofSize, proofDuration);
     this.autonomousLogger.info(`Proof generated in ${proofDuration}ms (${proofResult.proofSize} bytes)`);
 
-    // Derive PDAs
-    const [claimPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('claim'), task.pda.toBuffer(), agentPda.toBuffer()],
-      this.program.programId
-    );
-    const [escrowPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('escrow'), task.pda.toBuffer()],
-      this.program.programId
-    );
-    const [protocolPda] = PublicKey.findProgramAddressSync(
-      [Buffer.from('protocol')],
-      this.program.programId
-    );
+    const claimPda = findClaimPda(task.pda, agentPda, this.program.programId);
+    const escrowPda = findEscrowPda(task.pda, this.program.programId);
+    const protocolPda = findProtocolPda(this.program.programId);
 
     // Fetch protocol config
     const protocolConfig = await (


### PR DESCRIPTION
## Summary

- Extract 4 identical helper functions from `resolve_dispute.rs` and `expire_dispute.rs` into shared `dispute_helpers.rs` module (`validate_remaining_accounts_structure`, `check_duplicate_arbiters`, `process_arbiter_vote_pair`, `process_worker_claim_pair`)
- Replace 8 inline `PublicKey.findProgramAddressSync()` calls in `autonomous/agent.ts` with existing `findClaimPda`, `findEscrowPda`, `findProtocolPda` helpers
- Net reduction: ~126 lines of duplicated code

## Test plan

- [x] `anchor build` compiles cleanly (release + test profiles)
- [x] `npm run build && npm run typecheck` in runtime passes
- [x] All 1655 runtime unit tests pass (58 test files)
- [ ] `anchor test` — dispute resolution, expiration, and slash integration tests exercise the refactored helpers