### PR TITLE
Wire speculative execution into AutonomousAgent

### DIFF
--- a/runtime/src/agent/manager.ts
+++ b/runtime/src/agent/manager.ts
@@ -648,6 +648,20 @@ export class AgentManager {
   }
 
   /**
+   * Get the Solana RPC connection used by this manager.
+   */
+  getConnection(): Connection {
+    return this.connection;
+  }
+
+  /**
+   * Get the program ID used by this manager.
+   */
+  getProgramId(): PublicKey {
+    return this.programId;
+  }
+
+  /**
    * Get current reputation score (0-10000, representing 0.00% - 100.00%).
    *
    * @returns Reputation score

--- a/runtime/src/autonomous/index.ts
+++ b/runtime/src/autonomous/index.ts
@@ -19,6 +19,7 @@ export {
   type AutonomousAgentConfig,
   type AutonomousAgentStats,
   type DiscoveryMode,
+  type SpeculationConfig,
   // Default strategy
   DefaultClaimStrategy,
 } from './types.js';

--- a/runtime/src/autonomous/speculation-adapter.test.ts
+++ b/runtime/src/autonomous/speculation-adapter.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi } from 'vitest';
+import { PublicKey, SystemProgram } from '@solana/web3.js';
+import {
+  autonomousTaskToOnChainTask,
+  onChainTaskToAutonomousTask,
+  packBigintsToProofHash,
+  executorToTaskHandler,
+} from './speculation-adapter.js';
+import { TaskStatus, type Task, type TaskExecutor } from './types.js';
+import { OnChainTaskStatus, type OnChainTask, type TaskExecutionContext } from '../task/types.js';
+import { TaskType } from '../events/types.js';
+import { silentLogger } from '../utils/logger.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    pda: PublicKey.unique(),
+    taskId: new Uint8Array(32).fill(1),
+    creator: PublicKey.unique(),
+    requiredCapabilities: 3n,
+    reward: 1_000_000n,
+    description: new Uint8Array(64).fill(2),
+    constraintHash: new Uint8Array(32),
+    deadline: 1700000000,
+    maxWorkers: 5,
+    currentClaims: 2,
+    status: TaskStatus.InProgress,
+    ...overrides,
+  };
+}
+
+function makeOnChainTask(overrides: Partial<OnChainTask> = {}): OnChainTask {
+  return {
+    taskId: new Uint8Array(32).fill(3),
+    creator: PublicKey.unique(),
+    requiredCapabilities: 7n,
+    description: new Uint8Array(64).fill(4),
+    constraintHash: new Uint8Array(32),
+    rewardAmount: 2_000_000n,
+    maxWorkers: 3,
+    currentWorkers: 1,
+    status: OnChainTaskStatus.Open,
+    taskType: TaskType.Exclusive,
+    createdAt: 1700000000,
+    deadline: 1700100000,
+    completedAt: 0,
+    escrow: PublicKey.unique(),
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 255,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// autonomousTaskToOnChainTask
+// ============================================================================
+
+describe('autonomousTaskToOnChainTask', () => {
+  it('maps core fields correctly', () => {
+    const task = makeTask();
+    const result = autonomousTaskToOnChainTask(task);
+
+    expect(result.taskId).toBe(task.taskId);
+    expect(result.creator).toBe(task.creator);
+    expect(result.requiredCapabilities).toBe(task.requiredCapabilities);
+    expect(result.description).toBe(task.description);
+    expect(result.constraintHash).toBe(task.constraintHash);
+    expect(result.rewardAmount).toBe(task.reward);
+    expect(result.maxWorkers).toBe(task.maxWorkers);
+    expect(result.currentWorkers).toBe(task.currentClaims);
+    expect(result.deadline).toBe(task.deadline);
+  });
+
+  it('maps status correctly', () => {
+    expect(autonomousTaskToOnChainTask(makeTask({ status: TaskStatus.Open })).status)
+      .toBe(OnChainTaskStatus.Open);
+    expect(autonomousTaskToOnChainTask(makeTask({ status: TaskStatus.InProgress })).status)
+      .toBe(OnChainTaskStatus.InProgress);
+    expect(autonomousTaskToOnChainTask(makeTask({ status: TaskStatus.Completed })).status)
+      .toBe(OnChainTaskStatus.Completed);
+    expect(autonomousTaskToOnChainTask(makeTask({ status: TaskStatus.Cancelled })).status)
+      .toBe(OnChainTaskStatus.Cancelled);
+    expect(autonomousTaskToOnChainTask(makeTask({ status: TaskStatus.Disputed })).status)
+      .toBe(OnChainTaskStatus.Disputed);
+  });
+
+  it('fills default values for fields not in autonomous Task', () => {
+    const result = autonomousTaskToOnChainTask(makeTask());
+
+    expect(result.taskType).toBe(TaskType.Exclusive);
+    expect(result.escrow.equals(SystemProgram.programId)).toBe(true);
+    expect(result.result).toEqual(new Uint8Array(64));
+    expect(result.completions).toBe(0);
+    expect(result.requiredCompletions).toBe(1);
+    expect(result.bump).toBe(0);
+    expect(result.createdAt).toBe(0);
+    expect(result.completedAt).toBe(0);
+  });
+});
+
+// ============================================================================
+// onChainTaskToAutonomousTask
+// ============================================================================
+
+describe('onChainTaskToAutonomousTask', () => {
+  it('maps core fields correctly', () => {
+    const onChain = makeOnChainTask();
+    const pda = PublicKey.unique();
+    const result = onChainTaskToAutonomousTask(onChain, pda);
+
+    expect(result.pda).toBe(pda);
+    expect(result.taskId).toBe(onChain.taskId);
+    expect(result.creator).toBe(onChain.creator);
+    expect(result.requiredCapabilities).toBe(onChain.requiredCapabilities);
+    expect(result.reward).toBe(onChain.rewardAmount);
+    expect(result.description).toBe(onChain.description);
+    expect(result.constraintHash).toBe(onChain.constraintHash);
+    expect(result.deadline).toBe(onChain.deadline);
+    expect(result.maxWorkers).toBe(onChain.maxWorkers);
+    expect(result.currentClaims).toBe(onChain.currentWorkers);
+  });
+
+  it('maps OnChainTaskStatus to TaskStatus', () => {
+    const pda = PublicKey.unique();
+
+    expect(onChainTaskToAutonomousTask(makeOnChainTask({ status: OnChainTaskStatus.Open }), pda).status)
+      .toBe(TaskStatus.Open);
+    expect(onChainTaskToAutonomousTask(makeOnChainTask({ status: OnChainTaskStatus.InProgress }), pda).status)
+      .toBe(TaskStatus.InProgress);
+    expect(onChainTaskToAutonomousTask(makeOnChainTask({ status: OnChainTaskStatus.Completed }), pda).status)
+      .toBe(TaskStatus.Completed);
+    expect(onChainTaskToAutonomousTask(makeOnChainTask({ status: OnChainTaskStatus.Cancelled }), pda).status)
+      .toBe(TaskStatus.Cancelled);
+    expect(onChainTaskToAutonomousTask(makeOnChainTask({ status: OnChainTaskStatus.Disputed }), pda).status)
+      .toBe(TaskStatus.Disputed);
+    // PendingValidation maps to InProgress
+    expect(onChainTaskToAutonomousTask(makeOnChainTask({ status: OnChainTaskStatus.PendingValidation }), pda).status)
+      .toBe(TaskStatus.InProgress);
+  });
+});
+
+// ============================================================================
+// Round-trip conversion
+// ============================================================================
+
+describe('round-trip conversion', () => {
+  it('preserves core fields through Task → OnChainTask → Task', () => {
+    const original = makeTask();
+    const onChain = autonomousTaskToOnChainTask(original);
+    const roundTripped = onChainTaskToAutonomousTask(onChain, original.pda);
+
+    expect(roundTripped.pda).toBe(original.pda);
+    expect(roundTripped.taskId).toBe(original.taskId);
+    expect(roundTripped.creator).toBe(original.creator);
+    expect(roundTripped.requiredCapabilities).toBe(original.requiredCapabilities);
+    expect(roundTripped.reward).toBe(original.reward);
+    expect(roundTripped.description).toBe(original.description);
+    expect(roundTripped.constraintHash).toBe(original.constraintHash);
+    expect(roundTripped.deadline).toBe(original.deadline);
+    expect(roundTripped.maxWorkers).toBe(original.maxWorkers);
+    expect(roundTripped.currentClaims).toBe(original.currentClaims);
+    expect(roundTripped.status).toBe(original.status);
+  });
+});
+
+// ============================================================================
+// packBigintsToProofHash
+// ============================================================================
+
+describe('packBigintsToProofHash', () => {
+  it('encodes bigints in LE format', () => {
+    const result = packBigintsToProofHash([1n, 0n, 0n, 0n]);
+
+    // 1n in 8-byte LE: [1, 0, 0, 0, 0, 0, 0, 0]
+    expect(result[0]).toBe(1);
+    expect(result[1]).toBe(0);
+    expect(result[7]).toBe(0);
+    expect(result.length).toBe(32);
+  });
+
+  it('encodes a multi-byte value correctly', () => {
+    // 0x0102 = 258 → LE: [2, 1, 0, 0, 0, 0, 0, 0]
+    const result = packBigintsToProofHash([258n, 0n, 0n, 0n]);
+
+    expect(result[0]).toBe(2);
+    expect(result[1]).toBe(1);
+    expect(result[2]).toBe(0);
+  });
+
+  it('handles all 4 elements', () => {
+    const result = packBigintsToProofHash([1n, 2n, 3n, 4n]);
+
+    // Element 0 at offset 0
+    expect(result[0]).toBe(1);
+    // Element 1 at offset 8
+    expect(result[8]).toBe(2);
+    // Element 2 at offset 16
+    expect(result[16]).toBe(3);
+    // Element 3 at offset 24
+    expect(result[24]).toBe(4);
+  });
+
+  it('returns 32-byte array for empty input', () => {
+    const result = packBigintsToProofHash([]);
+    expect(result.length).toBe(32);
+    expect(result.every((b) => b === 0)).toBe(true);
+  });
+
+  it('handles more than 4 elements by truncating', () => {
+    const result = packBigintsToProofHash([1n, 2n, 3n, 4n, 5n, 6n]);
+    // Only first 4 should be encoded
+    expect(result[0]).toBe(1);
+    expect(result[8]).toBe(2);
+    expect(result[16]).toBe(3);
+    expect(result[24]).toBe(4);
+    expect(result.length).toBe(32);
+  });
+
+  it('encodes large bigints correctly (8-byte LE)', () => {
+    // Max u64: 2^64 - 1 = 18446744073709551615
+    const maxU64 = (1n << 64n) - 1n;
+    const result = packBigintsToProofHash([maxU64, 0n, 0n, 0n]);
+
+    // All 8 bytes should be 0xFF
+    for (let i = 0; i < 8; i++) {
+      expect(result[i]).toBe(0xff);
+    }
+  });
+});
+
+// ============================================================================
+// executorToTaskHandler
+// ============================================================================
+
+describe('executorToTaskHandler', () => {
+  it('converts executor output to TaskExecutionResult', async () => {
+    const executor: TaskExecutor = {
+      execute: vi.fn().mockResolvedValue([10n, 20n, 30n, 40n]),
+    };
+
+    const handler = executorToTaskHandler(executor);
+
+    const context: TaskExecutionContext = {
+      task: makeOnChainTask(),
+      taskPda: PublicKey.unique(),
+      claimPda: PublicKey.unique(),
+      agentId: new Uint8Array(32),
+      agentPda: PublicKey.unique(),
+      logger: silentLogger,
+      signal: new AbortController().signal,
+    };
+
+    const result = await handler(context);
+
+    expect(result.proofHash).toBeInstanceOf(Uint8Array);
+    expect(result.proofHash.length).toBe(32);
+    // Verify LE encoding of first element (10n)
+    expect(result.proofHash[0]).toBe(10);
+    expect(result.proofHash[8]).toBe(20);
+    expect(result.proofHash[16]).toBe(30);
+    expect(result.proofHash[24]).toBe(40);
+  });
+
+  it('passes converted autonomous Task to executor', async () => {
+    const executeFn = vi.fn().mockResolvedValue([1n, 2n, 3n, 4n]);
+    const executor: TaskExecutor = { execute: executeFn };
+
+    const handler = executorToTaskHandler(executor);
+
+    const onChainTask = makeOnChainTask({ rewardAmount: 5_000_000n });
+    const taskPda = PublicKey.unique();
+    const context: TaskExecutionContext = {
+      task: onChainTask,
+      taskPda,
+      claimPda: PublicKey.unique(),
+      agentId: new Uint8Array(32),
+      agentPda: PublicKey.unique(),
+      logger: silentLogger,
+      signal: new AbortController().signal,
+    };
+
+    await handler(context);
+
+    // Verify the executor received an autonomous Task with correct field mapping
+    const receivedTask = executeFn.mock.calls[0][0];
+    expect(receivedTask.pda).toBe(taskPda);
+    expect(receivedTask.reward).toBe(5_000_000n);
+    expect(receivedTask.taskId).toBe(onChainTask.taskId);
+  });
+
+  it('propagates executor errors', async () => {
+    const executor: TaskExecutor = {
+      execute: vi.fn().mockRejectedValue(new Error('execution failed')),
+    };
+
+    const handler = executorToTaskHandler(executor);
+
+    const context: TaskExecutionContext = {
+      task: makeOnChainTask(),
+      taskPda: PublicKey.unique(),
+      claimPda: PublicKey.unique(),
+      agentId: new Uint8Array(32),
+      agentPda: PublicKey.unique(),
+      logger: silentLogger,
+      signal: new AbortController().signal,
+    };
+
+    await expect(handler(context)).rejects.toThrow('execution failed');
+  });
+});

--- a/runtime/src/autonomous/speculation-adapter.ts
+++ b/runtime/src/autonomous/speculation-adapter.ts
@@ -1,0 +1,157 @@
+/**
+ * Speculation Adapter - Bridges autonomous and task module type systems.
+ *
+ * These functions convert between the autonomous module's `Task` type and
+ * the task module's `OnChainTask` type, enabling SpeculativeExecutor to
+ * work with the AutonomousAgent's task discovery pipeline.
+ *
+ * Internal module — not exported from public API.
+ *
+ * @module
+ */
+
+import { PublicKey, SystemProgram } from '@solana/web3.js';
+import type { Task, TaskExecutor as AutonomousTaskExecutor } from './types.js';
+import { TaskStatus } from './types.js';
+import type {
+  OnChainTask,
+  TaskHandler,
+  TaskExecutionResult,
+  TaskExecutionContext,
+} from '../task/types.js';
+import { OnChainTaskStatus } from '../task/types.js';
+import { TaskType } from '../events/types.js';
+import { bigintsToProofHash } from '../utils/encoding.js';
+
+// Re-export for backward compat (tests import from here)
+export { bigintsToProofHash as packBigintsToProofHash } from '../utils/encoding.js';
+
+// ============================================================================
+// Task Type Converters
+// ============================================================================
+
+/**
+ * Maps autonomous TaskStatus to OnChainTaskStatus.
+ */
+function mapTaskStatus(status: TaskStatus): OnChainTaskStatus {
+  switch (status) {
+    case TaskStatus.Open:
+      return OnChainTaskStatus.Open;
+    case TaskStatus.InProgress:
+      return OnChainTaskStatus.InProgress;
+    case TaskStatus.Completed:
+      return OnChainTaskStatus.Completed;
+    case TaskStatus.Cancelled:
+      return OnChainTaskStatus.Cancelled;
+    case TaskStatus.Disputed:
+      return OnChainTaskStatus.Disputed;
+    default:
+      return OnChainTaskStatus.Open;
+  }
+}
+
+/**
+ * Maps OnChainTaskStatus to autonomous TaskStatus.
+ */
+function mapOnChainTaskStatus(status: OnChainTaskStatus): TaskStatus {
+  switch (status) {
+    case OnChainTaskStatus.Open:
+      return TaskStatus.Open;
+    case OnChainTaskStatus.InProgress:
+      return TaskStatus.InProgress;
+    case OnChainTaskStatus.Completed:
+      return TaskStatus.Completed;
+    case OnChainTaskStatus.Cancelled:
+      return TaskStatus.Cancelled;
+    case OnChainTaskStatus.Disputed:
+      return TaskStatus.Disputed;
+    case OnChainTaskStatus.PendingValidation:
+      return TaskStatus.InProgress;
+    default:
+      return TaskStatus.Open;
+  }
+}
+
+/**
+ * Convert an autonomous Task to an OnChainTask for the task module.
+ *
+ * Fields not available in the autonomous Task type are filled with
+ * sensible defaults (taskType=Exclusive, escrow=SystemProgram, etc.).
+ *
+ * @param task - Autonomous module Task
+ * @returns OnChainTask compatible with SpeculativeExecutor
+ */
+export function autonomousTaskToOnChainTask(task: Task): OnChainTask {
+  return {
+    taskId: task.taskId,
+    creator: task.creator,
+    requiredCapabilities: task.requiredCapabilities,
+    description: task.description,
+    constraintHash: task.constraintHash,
+    rewardAmount: task.reward,
+    maxWorkers: task.maxWorkers,
+    currentWorkers: task.currentClaims,
+    status: mapTaskStatus(task.status),
+    taskType: TaskType.Exclusive,
+    createdAt: 0,
+    deadline: task.deadline,
+    completedAt: 0,
+    escrow: SystemProgram.programId,
+    result: new Uint8Array(64),
+    completions: 0,
+    requiredCompletions: 1,
+    bump: 0,
+  };
+}
+
+/**
+ * Convert an OnChainTask back to an autonomous Task.
+ *
+ * Used in callbacks so the autonomous module receives its expected type.
+ *
+ * @param task - Task module OnChainTask
+ * @param pda - Task PDA address
+ * @returns Autonomous module Task
+ */
+export function onChainTaskToAutonomousTask(task: OnChainTask, pda: PublicKey): Task {
+  return {
+    pda,
+    taskId: task.taskId,
+    creator: task.creator,
+    requiredCapabilities: task.requiredCapabilities,
+    reward: task.rewardAmount,
+    description: task.description,
+    constraintHash: task.constraintHash,
+    deadline: task.deadline,
+    maxWorkers: task.maxWorkers,
+    currentClaims: task.currentWorkers,
+    status: mapOnChainTaskStatus(task.status),
+  };
+}
+
+/**
+ * Wrap an autonomous TaskExecutor as a task-module TaskHandler.
+ *
+ * The adapter:
+ * 1. Converts the TaskExecutionContext.task (OnChainTask) to autonomous Task
+ * 2. Calls executor.execute(task) to get bigint[] output
+ * 3. Packs the output into a 32-byte LE proofHash
+ * 4. Returns a TaskExecutionResult
+ *
+ * @param executor - Autonomous module TaskExecutor
+ * @returns TaskHandler compatible with SpeculativeExecutor
+ */
+export function executorToTaskHandler(executor: AutonomousTaskExecutor): TaskHandler {
+  return async (context: TaskExecutionContext): Promise<TaskExecutionResult> => {
+    // Convert OnChainTask → autonomous Task for the executor
+    const task = onChainTaskToAutonomousTask(context.task, context.taskPda);
+
+    // Execute via the autonomous executor
+    const output = await executor.execute(task);
+
+    // Pack bigints into proofHash
+    const proofHash = bigintsToProofHash(output);
+
+    return { proofHash };
+  };
+}

--- a/runtime/src/builder.ts
+++ b/runtime/src/builder.ts
@@ -43,6 +43,7 @@ import type {
   DiscoveryMode,
   Task,
   AutonomousAgentStats,
+  SpeculationConfig,
 } from './autonomous/types.js';
 import { DisputeOperations } from './dispute/operations.js';
 import type { AgencCoordination } from './types/agenc_coordination.js';
@@ -156,6 +157,9 @@ export class AgentBuilder {
   private scanIntervalMs?: number;
   private maxConcurrentTasks?: number;
 
+  // Speculation
+  private speculationConfig?: SpeculationConfig;
+
   // Callbacks
   private callbacks?: AgentCallbacks;
 
@@ -261,6 +265,11 @@ export class AgentBuilder {
     return this;
   }
 
+  withSpeculation(config?: SpeculationConfig): this {
+    this.speculationConfig = config ?? { enabled: true };
+    return this;
+  }
+
   withCallbacks(callbacks: AgentCallbacks): this {
     this.callbacks = callbacks;
     return this;
@@ -359,6 +368,7 @@ export class AgentBuilder {
       discoveryMode: this.discoveryMode,
       scanIntervalMs: this.scanIntervalMs,
       maxConcurrentTasks: this.maxConcurrentTasks,
+      speculation: this.speculationConfig,
       onTaskDiscovered: this.callbacks?.onTaskDiscovered,
       onTaskClaimed: this.callbacks?.onTaskClaimed,
       onTaskExecuted: this.callbacks?.onTaskExecuted,

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -8,6 +8,7 @@
  */
 
 import { PublicKey, SystemProgram, type AccountMeta } from '@solana/web3.js';
+import { toAnchorBytes } from '../utils/encoding.js';
 import type { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
 import type { Logger } from '../utils/logger.js';
@@ -255,9 +256,9 @@ export class DisputeOperations {
 
       const builder = this.program.methods
         .initiateDispute(
-          Array.from(params.disputeId) as unknown as number[],
-          Array.from(params.taskId) as unknown as number[],
-          Array.from(params.evidenceHash) as unknown as number[],
+          toAnchorBytes(params.disputeId),
+          toAnchorBytes(params.taskId),
+          toAnchorBytes(params.evidenceHash),
           params.resolutionType,
           params.evidence,
         )

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -230,6 +230,9 @@ export {
   agentIdsEqual,
   lamportsToSol,
   solToLamports,
+  bigintsToProofHash,
+  proofHashToBigints,
+  toAnchorBytes,
 } from './utils/index.js';
 
 // Event monitoring (Phase 2)
@@ -395,6 +398,7 @@ export {
   type AutonomousAgentConfig,
   type AutonomousAgentStats,
   type DiscoveryMode,
+  type SpeculationConfig,
   DefaultClaimStrategy,
 } from './autonomous/index.js';
 

--- a/runtime/src/llm/response-converter.ts
+++ b/runtime/src/llm/response-converter.ts
@@ -10,6 +10,7 @@
  */
 
 import { createHash } from 'crypto';
+import { proofHashToBigints } from '../utils/encoding.js';
 
 /**
  * Convert an LLM text response to 4 bigints via SHA-256 hashing.
@@ -21,13 +22,5 @@ import { createHash } from 'crypto';
  */
 export function responseToOutput(response: string): bigint[] {
   const hash = createHash('sha256').update(response, 'utf-8').digest();
-  const output: bigint[] = [];
-  for (let i = 0; i < 4; i++) {
-    let value = 0n;
-    for (let j = 0; j < 8; j++) {
-      value |= BigInt(hash[i * 8 + j]) << BigInt(j * 8);
-    }
-    output.push(value);
-  }
-  return output;
+  return proofHashToBigints(new Uint8Array(hash));
 }

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -9,6 +9,7 @@
  */
 
 import { PublicKey, SystemProgram } from '@solana/web3.js';
+import { toAnchorBytes } from '../utils/encoding.js';
 import { BN, type Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
 import type { Logger } from '../utils/logger.js';
@@ -350,8 +351,8 @@ export class TaskOperations {
     try {
       const signature = await this.program.methods
         .completeTask(
-          Array.from(proofHash) as unknown as number[],
-          resultData ? (Array.from(resultData) as unknown as number[]) : null,
+          toAnchorBytes(proofHash),
+          resultData ? (toAnchorBytes(resultData)) : null,
         )
         .accountsPartial({
           task: taskPda,
@@ -413,9 +414,9 @@ export class TaskOperations {
 
       const proof = {
         proofData: Buffer.from(proofData),
-        constraintHash: Array.from(constraintHash) as unknown as number[],
-        outputCommitment: Array.from(outputCommitment) as unknown as number[],
-        expectedBinding: Array.from(expectedBinding) as unknown as number[],
+        constraintHash: toAnchorBytes(constraintHash),
+        outputCommitment: toAnchorBytes(outputCommitment),
+        expectedBinding: toAnchorBytes(expectedBinding),
       };
 
       const signature = await this.program.methods

--- a/runtime/src/utils/index.ts
+++ b/runtime/src/utils/index.ts
@@ -15,6 +15,9 @@ export {
   agentIdsEqual,
   lamportsToSol,
   solToLamports,
+  bigintsToProofHash,
+  proofHashToBigints,
+  toAnchorBytes,
 } from './encoding.js';
 
 export { PdaWithBump, derivePda, validateIdLength } from './pda.js';


### PR DESCRIPTION
## Summary

- Connect existing speculative execution system (`task/` module) into `AutonomousAgent` for async proof generation and dependency-aware task speculation
- Add `SpeculationConfig` to `AutonomousAgentConfig` (disabled by default, fully backward-compatible)
- Create `speculation-adapter.ts` bridging the autonomous and task module type systems (`Task` ↔ `OnChainTask`)
- Wire `SpeculativeExecutor` into agent start/stop/claimAndProcess lifecycle with proof pipeline events
- Add `withSpeculation()` to `AgentBuilder` fluent API
- Fix critical tech debt: extract 3x-duplicated LE bigint encoding into shared `bigintsToProofHash()`/`proofHashToBigints()` utils
- Fix high tech debt: add `toAnchorBytes()` helper, `AgentManager.getConnection()`/`getProgramId()` accessors, split 90-line `claimAndProcess` into focused methods

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run build` — ESM + CJS + DTS output
- [x] `npm run test` — 1718 tests pass (15 new adapter tests + all 1703 existing)
- [x] Speculation disabled by default — all existing behavior unchanged
- [x] New exports backward-compatible (additive only)