### PR TITLE
fix: dedup completion/validation helpers and fix private task fee bug

### DIFF
--- a/programs/agenc-coordination/src/instructions/constants.rs
+++ b/programs/agenc-coordination/src/instructions/constants.rs
@@ -39,3 +39,31 @@ pub const REPUTATION_DECAY_PERIOD: i64 = 2_592_000;
 
 /// Minimum reputation score after decay (floor)
 pub const REPUTATION_DECAY_MIN: u16 = 1000;
+
+// ============================================================================
+// ZK Witness Constants
+// ============================================================================
+// Distinct from verifying_key.rs::PUBLIC_INPUTS_COUNT (67, verifier-level).
+// The witness has 68 field elements: 32 (task_id bytes) + 32 (agent bytes) + 4 (hashes).
+
+/// Number of field elements in the ZK public witness
+pub const ZK_WITNESS_FIELD_COUNT: usize = 68;
+
+/// Expected Groth16 proof size in bytes (2 G1 + 1 G2 on BN254, compressed)
+pub const ZK_EXPECTED_PROOF_SIZE: usize = 256;
+
+/// G1 point size (proof component A)
+pub const ZK_PROOF_A_SIZE: usize = 64;
+
+/// G2 point size (proof component B)
+pub const ZK_PROOF_B_SIZE: usize = 128;
+
+/// G1 point size (proof component C)
+pub const ZK_PROOF_C_SIZE: usize = 64;
+
+// ============================================================================
+// Dispute Resolution Constants
+// ============================================================================
+
+/// Minimum number of voters required for dispute resolution
+pub const MIN_VOTERS_FOR_RESOLUTION: usize = 3;

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -10,7 +10,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
 use super::rate_limit_helpers::check_task_creation_rate_limits;
-use super::task_init_helpers::{init_escrow_fields, init_task_fields, increment_total_tasks, validate_task_params};
+use super::task_init_helpers::{init_escrow_fields, init_task_fields, increment_total_tasks, validate_deadline, validate_task_params};
 
 #[derive(Accounts)]
 #[instruction(task_id: [u8; 32])]
@@ -100,13 +100,8 @@ pub fn handler(
 
     check_version_compatible(config)?;
 
-    // Validate deadline if set
-    if deadline > 0 {
-        require!(
-            deadline > clock.unix_timestamp,
-            CoordinationError::InvalidInput
-        );
-    }
+    // Validate deadline if set (optional for dependent tasks)
+    validate_deadline(deadline, &clock, false)?;
 
     let creator_agent = &mut ctx.accounts.creator_agent;
 

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -8,7 +8,7 @@ use anchor_lang::prelude::*;
 use anchor_lang::system_program;
 
 use super::rate_limit_helpers::check_task_creation_rate_limits;
-use super::task_init_helpers::{init_escrow_fields, init_task_fields, increment_total_tasks, validate_task_params};
+use super::task_init_helpers::{init_escrow_fields, init_task_fields, increment_total_tasks, validate_deadline, validate_task_params};
 
 #[derive(Accounts)]
 #[instruction(task_id: [u8; 32])]
@@ -89,11 +89,7 @@ pub fn handler(
     check_version_compatible(config)?;
 
     // Validate deadline - must be set and in the future (#575)
-    require!(deadline > 0, CoordinationError::InvalidDeadline);
-    require!(
-        deadline > clock.unix_timestamp,
-        CoordinationError::InvalidInput
-    );
+    validate_deadline(deadline, &clock, true)?;
 
     let creator_agent = &mut ctx.accounts.creator_agent;
 

--- a/programs/agenc-coordination/src/instructions/dispute_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/dispute_helpers.rs
@@ -7,6 +7,7 @@
 use std::collections::HashSet;
 
 use crate::errors::CoordinationError;
+use crate::instructions::validation::validate_account_owner;
 use crate::state::{AgentRegistration, DisputeVote, TaskClaim};
 use anchor_lang::prelude::*;
 
@@ -65,14 +66,8 @@ pub(crate) fn process_arbiter_vote_pair(
     arbiter_info: &AccountInfo,
     dispute_key: &Pubkey,
 ) -> Result<()> {
-    require!(
-        vote_info.owner == &crate::ID,
-        CoordinationError::InvalidAccountOwner
-    );
-    require!(
-        arbiter_info.owner == &crate::ID,
-        CoordinationError::InvalidAccountOwner
-    );
+    validate_account_owner(vote_info)?;
+    validate_account_owner(arbiter_info)?;
 
     let vote_data = vote_info.try_borrow_data()?;
     let vote = DisputeVote::try_deserialize(&mut &**vote_data)?;
@@ -106,14 +101,8 @@ pub(crate) fn process_worker_claim_pair(
     worker_info: &AccountInfo,
     task_key: &Pubkey,
 ) -> Result<()> {
-    require!(
-        claim_info.owner == &crate::ID,
-        CoordinationError::InvalidAccountOwner
-    );
-    require!(
-        worker_info.owner == &crate::ID,
-        CoordinationError::InvalidAccountOwner
-    );
+    validate_account_owner(claim_info)?;
+    validate_account_owner(worker_info)?;
 
     let claim_data = claim_info.try_borrow_data()?;
     let claim = TaskClaim::try_deserialize(&mut &**claim_data)?;

--- a/programs/agenc-coordination/src/instructions/task_init_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/task_init_helpers.rs
@@ -42,6 +42,23 @@ pub fn validate_task_params(
     Ok(())
 }
 
+/// Validates a task deadline.
+///
+/// If `required` is true, the deadline must be > 0 (uses `InvalidDeadline`).
+/// If the deadline is set (> 0), it must be in the future (uses `InvalidInput`).
+pub fn validate_deadline(deadline: i64, clock: &Clock, required: bool) -> Result<()> {
+    if required {
+        require!(deadline > 0, CoordinationError::InvalidDeadline);
+    }
+    if deadline > 0 {
+        require!(
+            deadline > clock.unix_timestamp,
+            CoordinationError::InvalidInput
+        );
+    }
+    Ok(())
+}
+
 /// Initializes common task fields. Sets `dependency_type = None` and `depends_on = None`
 /// by default; callers should override these after if the task has dependencies.
 pub fn init_task_fields(

--- a/programs/agenc-coordination/src/instructions/validation.rs
+++ b/programs/agenc-coordination/src/instructions/validation.rs
@@ -25,3 +25,15 @@ pub fn validate_endpoint(endpoint: &str) -> Result<()> {
 
     Ok(())
 }
+
+/// Validates that an account is owned by this program.
+///
+/// Use when processing `remaining_accounts` before deserialization to ensure
+/// the account belongs to the AgenC program and not an attacker-controlled program.
+pub fn validate_account_owner(account: &AccountInfo) -> Result<()> {
+    require!(
+        account.owner == &crate::ID,
+        CoordinationError::InvalidAccountOwner
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- **BUG FIX**: `complete_task_private.rs` was using `protocol_config.protocol_fee_bps` instead of `task.protocol_fee_bps` (the fee locked at task creation per #479). This means private completions ignored tiered fee discounts that the task creator earned.
- Extract 3 shared completion helpers (`validate_completion_prereqs`, `calculate_fee_with_reputation`, `execute_completion_rewards`) into `completion_helpers.rs`, eliminating ~120 duplicated lines across the two completion handlers
- Add `validate_account_owner()` helper (replaces 4 inline `require!` checks in `dispute_helpers.rs`)
- Add `validate_deadline()` helper (used by `create_task` and `create_dependent_task`)
- Centralize ZK witness/proof constants in `constants.rs` with distinct names from `verifying_key.rs`
- Harden `complete_task_private` with `can_transition_to` check and escrow balance validation (parity with public path)
- AutonomousAgent: poll backoff (pauses after 5 failures, auto-resumes after 60s), fire-and-forget operation tracking for graceful shutdown drain
- SDK: nargo/sunspot pre-validation before proof generation

## Test plan

- [x] `anchor build` — clean (no warnings)
- [x] `cd sdk && npm run build && npm run typecheck` — clean
- [x] `cd runtime && npm run build && npm run typecheck && npm run test` — 1718 passed
- [ ] `anchor test` — full integration suite (141 tests)