### PR TITLE
feat(runtime): workflow DAG orchestrator

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -518,5 +518,34 @@ export {
   type DisputeOpsConfig,
 } from './dispute/index.js';
 
+// Workflow DAG Orchestrator (Phase 9)
+export {
+  // Enums
+  OnChainDependencyType,
+  WorkflowNodeStatus,
+  WorkflowStatus,
+  // Types
+  type TaskTemplate,
+  type WorkflowEdge,
+  type WorkflowDefinition,
+  type WorkflowNode,
+  type WorkflowState,
+  type WorkflowStats,
+  type WorkflowCallbacks,
+  type DAGOrchestratorConfig,
+  // Error classes
+  WorkflowValidationError,
+  WorkflowSubmissionError,
+  WorkflowMonitoringError,
+  WorkflowStateError,
+  // Validation
+  validateWorkflow,
+  topologicalSort,
+  // Classes
+  DAGSubmitter,
+  DAGMonitor,
+  DAGOrchestrator,
+} from './workflow/index.js';
+
 // Agent Builder (Phase 10)
 export { AgentBuilder, BuiltAgent } from './builder.js';

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -39,8 +39,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.RECENT_VOTE_ACTIVITY).toBe('RECENT_VOTE_ACTIVITY');
   });
 
-  it('has exactly 31 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(31);
+  it('has exactly 35 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(35);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -78,6 +78,14 @@ export const RuntimeErrorCodes = {
   DISPUTE_RESOLUTION_ERROR: 'DISPUTE_RESOLUTION_ERROR',
   /** Dispute slash operation failed */
   DISPUTE_SLASH_ERROR: 'DISPUTE_SLASH_ERROR',
+  /** Workflow definition failed validation */
+  WORKFLOW_VALIDATION_ERROR: 'WORKFLOW_VALIDATION_ERROR',
+  /** Workflow on-chain task submission failed */
+  WORKFLOW_SUBMISSION_ERROR: 'WORKFLOW_SUBMISSION_ERROR',
+  /** Workflow event subscription or polling failed */
+  WORKFLOW_MONITORING_ERROR: 'WORKFLOW_MONITORING_ERROR',
+  /** Workflow state transition or lookup failed */
+  WORKFLOW_STATE_ERROR: 'WORKFLOW_STATE_ERROR',
 } as const;
 
 /** Union type of all runtime error code values */

--- a/runtime/src/workflow/errors.ts
+++ b/runtime/src/workflow/errors.ts
@@ -1,0 +1,52 @@
+/**
+ * Workflow DAG Orchestrator — Error Classes
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Thrown when workflow definition fails validation.
+ * Covers: cycles, multi-parent nodes, dangling edges, duplicate names, empty graph.
+ */
+export class WorkflowValidationError extends RuntimeError {
+  constructor(message: string) {
+    super(message, RuntimeErrorCodes.WORKFLOW_VALIDATION_ERROR);
+    this.name = 'WorkflowValidationError';
+  }
+}
+
+/**
+ * Thrown when on-chain task creation fails during workflow submission.
+ */
+export class WorkflowSubmissionError extends RuntimeError {
+  /** The workflow node name that failed submission */
+  public readonly nodeName: string;
+
+  constructor(nodeName: string, message: string) {
+    super(`Submission failed for node "${nodeName}": ${message}`, RuntimeErrorCodes.WORKFLOW_SUBMISSION_ERROR);
+    this.name = 'WorkflowSubmissionError';
+    this.nodeName = nodeName;
+  }
+}
+
+/**
+ * Thrown when event subscription or polling fails during monitoring.
+ */
+export class WorkflowMonitoringError extends RuntimeError {
+  constructor(message: string) {
+    super(message, RuntimeErrorCodes.WORKFLOW_MONITORING_ERROR);
+    this.name = 'WorkflowMonitoringError';
+  }
+}
+
+/**
+ * Thrown for invalid state transitions or missing workflow state.
+ */
+export class WorkflowStateError extends RuntimeError {
+  constructor(message: string) {
+    super(message, RuntimeErrorCodes.WORKFLOW_STATE_ERROR);
+    this.name = 'WorkflowStateError';
+  }
+}

--- a/runtime/src/workflow/index.ts
+++ b/runtime/src/workflow/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Workflow DAG Orchestrator module.
+ *
+ * Provides multi-step task workflow submission and monitoring on the AgenC
+ * protocol. Workflows are tree-structured (single parent per task) to match
+ * the on-chain `depends_on: Option<Pubkey>` constraint.
+ *
+ * @module
+ */
+
+// Types
+export {
+  OnChainDependencyType,
+  WorkflowNodeStatus,
+  WorkflowStatus,
+  type TaskTemplate,
+  type WorkflowEdge,
+  type WorkflowDefinition,
+  type WorkflowNode,
+  type WorkflowState,
+  type WorkflowStats,
+  type WorkflowCallbacks,
+  type DAGOrchestratorConfig,
+} from './types.js';
+
+// Errors
+export {
+  WorkflowValidationError,
+  WorkflowSubmissionError,
+  WorkflowMonitoringError,
+  WorkflowStateError,
+} from './errors.js';
+
+// Validation
+export { validateWorkflow, topologicalSort } from './validation.js';
+
+// Submitter
+export { DAGSubmitter } from './submitter.js';
+
+// Monitor
+export { DAGMonitor } from './monitor.js';
+
+// Orchestrator
+export { DAGOrchestrator } from './orchestrator.js';

--- a/runtime/src/workflow/monitor.ts
+++ b/runtime/src/workflow/monitor.ts
@@ -1,0 +1,402 @@
+/**
+ * DAGMonitor — Event and poll-driven workflow completion tracking.
+ *
+ * Subscribes to `taskCompleted` and `taskCancelled` events with client-side
+ * filtering, plus periodic polling for missed events. Detects terminal
+ * workflow states and fires lifecycle callbacks.
+ *
+ * @module
+ */
+
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../types/agenc_coordination.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import {
+  parseTaskCompletedEvent,
+  parseTaskCancelledEvent,
+} from '../events/index.js';
+import type { WorkflowCallbacks, WorkflowState } from './types.js';
+import { WorkflowNodeStatus, WorkflowStatus } from './types.js';
+import { WorkflowStateError } from './errors.js';
+
+/** Default polling interval in ms */
+const DEFAULT_POLL_INTERVAL_MS = 10_000;
+
+interface MonitoredWorkflow {
+  state: WorkflowState;
+  callbacks: WorkflowCallbacks;
+  cancelOnParentFailure: boolean;
+  /** Set of task PDA base58 strings we're tracking */
+  knownPdas: Set<string>;
+  /** Map from task PDA base58 → node name for fast lookup */
+  pdaToName: Map<string, string>;
+  /** Map from taskId hex → node name (for event matching) */
+  taskIdToName: Map<string, string>;
+  /** Resolve function for waitForTerminal */
+  resolveTerminal?: (state: WorkflowState) => void;
+  /** Reject function for waitForTerminal timeout */
+  rejectTerminal?: (error: Error) => void;
+  /** Timeout handle for waitForTerminal */
+  timeoutHandle?: ReturnType<typeof setTimeout>;
+}
+
+export interface DAGMonitorConfig {
+  program: Program<AgencCoordination>;
+  logger?: Logger;
+  pollIntervalMs?: number;
+}
+
+/**
+ * Monitors workflow task completion via events and polling.
+ */
+export class DAGMonitor {
+  private readonly program: Program<AgencCoordination>;
+  private readonly logger: Logger;
+  private readonly pollIntervalMs: number;
+  private readonly workflows = new Map<string, MonitoredWorkflow>();
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private completedListenerId: number | null = null;
+  private cancelledListenerId: number | null = null;
+  private started = false;
+
+  constructor(config: DAGMonitorConfig) {
+    this.program = config.program;
+    this.logger = config.logger ?? silentLogger;
+    this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  }
+
+  /**
+   * Start monitoring a workflow for task completions.
+   */
+  startMonitoring(
+    state: WorkflowState,
+    callbacks: WorkflowCallbacks,
+    cancelOnParentFailure: boolean,
+  ): void {
+    const knownPdas = new Set<string>();
+    const pdaToName = new Map<string, string>();
+    const taskIdToName = new Map<string, string>();
+
+    for (const [name, node] of state.nodes) {
+      if (node.taskPda) {
+        const pdaStr = node.taskPda.toBase58();
+        knownPdas.add(pdaStr);
+        pdaToName.set(pdaStr, name);
+      }
+      if (node.taskId) {
+        const idHex = Buffer.from(node.taskId).toString('hex');
+        taskIdToName.set(idHex, name);
+      }
+    }
+
+    this.workflows.set(state.id, {
+      state,
+      callbacks,
+      cancelOnParentFailure,
+      knownPdas,
+      pdaToName,
+      taskIdToName,
+    });
+
+    // Start global event listeners if not already running
+    if (!this.started) {
+      this.startEventListeners();
+      this.startPolling();
+      this.started = true;
+    }
+  }
+
+  /**
+   * Stop monitoring a specific workflow.
+   */
+  stopMonitoring(workflowId: string): void {
+    const wf = this.workflows.get(workflowId);
+    if (wf) {
+      if (wf.timeoutHandle) {
+        clearTimeout(wf.timeoutHandle);
+      }
+      this.workflows.delete(workflowId);
+    }
+
+    // If no more workflows, clean up global listeners
+    if (this.workflows.size === 0) {
+      this.stopAll();
+    }
+  }
+
+  /**
+   * Wait for a workflow to reach terminal state.
+   *
+   * @param workflowId - Workflow identifier
+   * @param timeoutMs - Optional timeout in ms
+   * @returns Resolved workflow state
+   * @throws WorkflowStateError on timeout or if workflow not found
+   */
+  waitForTerminal(workflowId: string, timeoutMs?: number): Promise<WorkflowState> {
+    const wf = this.workflows.get(workflowId);
+    if (!wf) {
+      throw new WorkflowStateError(`Workflow "${workflowId}" not found`);
+    }
+
+    // Already terminal?
+    if (this.isTerminal(wf.state)) {
+      return Promise.resolve(wf.state);
+    }
+
+    return new Promise((resolve, reject) => {
+      wf.resolveTerminal = resolve;
+      wf.rejectTerminal = reject;
+
+      if (timeoutMs !== undefined && timeoutMs > 0) {
+        wf.timeoutHandle = setTimeout(() => {
+          wf.resolveTerminal = undefined;
+          wf.rejectTerminal = undefined;
+          reject(new WorkflowStateError(`Workflow "${workflowId}" timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }
+    });
+  }
+
+  /**
+   * Check if a workflow has reached a terminal state.
+   */
+  isTerminal(state: WorkflowState): boolean {
+    return (
+      state.status === WorkflowStatus.Completed ||
+      state.status === WorkflowStatus.Failed ||
+      state.status === WorkflowStatus.PartiallyCompleted
+    );
+  }
+
+  /**
+   * Stop all monitoring (event listeners + polling).
+   */
+  async shutdown(): Promise<void> {
+    this.stopAll();
+    // Clean up all workflow promises
+    for (const wf of this.workflows.values()) {
+      if (wf.timeoutHandle) {
+        clearTimeout(wf.timeoutHandle);
+      }
+    }
+    this.workflows.clear();
+  }
+
+  // ===========================================================================
+  // Event Listeners
+  // ===========================================================================
+
+  private startEventListeners(): void {
+    // Subscribe to taskCompleted (unfiltered — we filter client-side)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.completedListenerId = this.program.addEventListener(
+      'taskCompleted' as any,
+      (rawEvent: any, _slot: number, _signature: string) => {
+        try {
+          const event = parseTaskCompletedEvent(rawEvent);
+          const idHex = Buffer.from(event.taskId).toString('hex');
+
+          // Check all monitored workflows
+          for (const wf of this.workflows.values()) {
+            const nodeName = wf.taskIdToName.get(idHex);
+            if (nodeName) {
+              this.handleNodeCompleted(wf, nodeName);
+            }
+          }
+        } catch (err) {
+          this.logger.error(`Failed to parse taskCompleted event: ${err}`);
+        }
+      },
+    );
+
+    // Subscribe to taskCancelled (unfiltered)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this.cancelledListenerId = this.program.addEventListener(
+      'taskCancelled' as any,
+      (rawEvent: any, _slot: number, _signature: string) => {
+        try {
+          const event = parseTaskCancelledEvent(rawEvent);
+          const idHex = Buffer.from(event.taskId).toString('hex');
+
+          for (const wf of this.workflows.values()) {
+            const nodeName = wf.taskIdToName.get(idHex);
+            if (nodeName) {
+              this.handleNodeFailed(wf, nodeName, new Error('Task cancelled on-chain'));
+            }
+          }
+        } catch (err) {
+          this.logger.error(`Failed to parse taskCancelled event: ${err}`);
+        }
+      },
+    );
+
+    this.logger.debug('Event listeners started for workflow monitoring');
+  }
+
+  // ===========================================================================
+  // Polling Fallback
+  // ===========================================================================
+
+  private startPolling(): void {
+    this.pollTimer = setInterval(() => {
+      void this.pollAllWorkflows();
+    }, this.pollIntervalMs);
+  }
+
+  private async pollAllWorkflows(): Promise<void> {
+    for (const wf of this.workflows.values()) {
+      await this.pollWorkflow(wf);
+    }
+  }
+
+  private async pollWorkflow(wf: MonitoredWorkflow): Promise<void> {
+    for (const [name, node] of wf.state.nodes) {
+      if (node.status !== WorkflowNodeStatus.Created || !node.taskPda) {
+        continue;
+      }
+
+      try {
+        const taskAccount = await this.program.account.task.fetch(node.taskPda);
+        const status = taskAccount.status as Record<string, unknown>;
+
+        // Anchor represents enums as { completed: {} } etc.
+        if ('completed' in status) {
+          this.handleNodeCompleted(wf, name);
+        } else if ('cancelled' in status || 'disputed' in status) {
+          this.handleNodeFailed(wf, name, new Error(`Task status: ${Object.keys(status)[0]}`));
+        }
+      } catch (err) {
+        // Account not found or RPC error — log but don't fail
+        this.logger.debug(`Poll fetch failed for node "${name}": ${err}`);
+      }
+    }
+  }
+
+  // ===========================================================================
+  // State Transitions
+  // ===========================================================================
+
+  private handleNodeCompleted(wf: MonitoredWorkflow, nodeName: string): void {
+    const node = wf.state.nodes.get(nodeName);
+    if (!node || node.status === WorkflowNodeStatus.Completed) return;
+
+    node.status = WorkflowNodeStatus.Completed;
+    node.completedAt = Date.now();
+    this.logger.info(`Workflow "${wf.state.id}" node "${nodeName}" completed`);
+
+    wf.callbacks.onNodeCompleted?.(node);
+
+    this.checkTerminalState(wf);
+  }
+
+  private handleNodeFailed(wf: MonitoredWorkflow, nodeName: string, error: Error): void {
+    const node = wf.state.nodes.get(nodeName);
+    if (!node || node.status === WorkflowNodeStatus.Failed || node.status === WorkflowNodeStatus.Cancelled) return;
+
+    node.status = WorkflowNodeStatus.Failed;
+    node.error = error;
+    this.logger.warn(`Workflow "${wf.state.id}" node "${nodeName}" failed: ${error.message}`);
+
+    wf.callbacks.onNodeFailed?.(node, error);
+
+    if (wf.cancelOnParentFailure) {
+      this.cascadeCancelDescendants(wf, nodeName);
+    }
+
+    this.checkTerminalState(wf);
+  }
+
+  private cascadeCancelDescendants(wf: MonitoredWorkflow, failedName: string): void {
+    // Build parent->children adjacency
+    const children = new Map<string, string[]>();
+    for (const edge of wf.state.definition.edges) {
+      if (!children.has(edge.from)) {
+        children.set(edge.from, []);
+      }
+      children.get(edge.from)!.push(edge.to);
+    }
+
+    const queue = [failedName];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const kids = children.get(current);
+      if (!kids) continue;
+      for (const kid of kids) {
+        const kidNode = wf.state.nodes.get(kid)!;
+        if (
+          kidNode.status === WorkflowNodeStatus.Created ||
+          kidNode.status === WorkflowNodeStatus.Pending ||
+          kidNode.status === WorkflowNodeStatus.Creating
+        ) {
+          const reason = `Parent node "${failedName}" failed`;
+          kidNode.status = WorkflowNodeStatus.Cancelled;
+          kidNode.error = new Error(reason);
+          wf.callbacks.onNodeCancelled?.(kidNode, reason);
+          this.logger.info(`Cancelled descendant "${kid}" in workflow "${wf.state.id}"`);
+        }
+        queue.push(kid);
+      }
+    }
+  }
+
+  private checkTerminalState(wf: MonitoredWorkflow): void {
+    const nodes = Array.from(wf.state.nodes.values());
+    const allCompleted = nodes.every((n) => n.status === WorkflowNodeStatus.Completed);
+    const anyFailed = nodes.some((n) => n.status === WorkflowNodeStatus.Failed);
+    const anyCancelled = nodes.some((n) => n.status === WorkflowNodeStatus.Cancelled);
+    const anyPending = nodes.some(
+      (n) =>
+        n.status === WorkflowNodeStatus.Pending ||
+        n.status === WorkflowNodeStatus.Creating ||
+        n.status === WorkflowNodeStatus.Created
+    );
+
+    if (allCompleted) {
+      wf.state.status = WorkflowStatus.Completed;
+      wf.state.completedAt = Date.now();
+      wf.callbacks.onWorkflowCompleted?.(wf.state);
+      this.resolveWorkflow(wf);
+    } else if ((anyFailed || anyCancelled) && !anyPending) {
+      // All nodes resolved — some failed/cancelled, some completed
+      const anyCompleted = nodes.some((n) => n.status === WorkflowNodeStatus.Completed);
+      if (anyCompleted && !wf.cancelOnParentFailure) {
+        wf.state.status = WorkflowStatus.PartiallyCompleted;
+      } else {
+        wf.state.status = WorkflowStatus.Failed;
+      }
+      wf.state.completedAt = Date.now();
+      wf.callbacks.onWorkflowFailed?.(wf.state);
+      this.resolveWorkflow(wf);
+    }
+  }
+
+  private resolveWorkflow(wf: MonitoredWorkflow): void {
+    if (wf.timeoutHandle) {
+      clearTimeout(wf.timeoutHandle);
+      wf.timeoutHandle = undefined;
+    }
+    if (wf.resolveTerminal) {
+      wf.resolveTerminal(wf.state);
+      wf.resolveTerminal = undefined;
+      wf.rejectTerminal = undefined;
+    }
+  }
+
+  private stopAll(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+      this.pollTimer = null;
+    }
+    if (this.completedListenerId !== null) {
+      void this.program.removeEventListener(this.completedListenerId);
+      this.completedListenerId = null;
+    }
+    if (this.cancelledListenerId !== null) {
+      void this.program.removeEventListener(this.cancelledListenerId);
+      this.cancelledListenerId = null;
+    }
+    this.started = false;
+    this.logger.debug('Workflow monitoring stopped');
+  }
+}

--- a/runtime/src/workflow/orchestrator.test.ts
+++ b/runtime/src/workflow/orchestrator.test.ts
@@ -1,0 +1,713 @@
+/**
+ * Tests for the Workflow DAG Orchestrator module.
+ *
+ * Covers:
+ * - Validation (cycles, multi-parent, duplicates, self-loops, empty, edge refs, dep types)
+ * - Topological sort
+ * - DAGSubmitter (mocked program calls)
+ * - DAGMonitor (event and poll handling)
+ * - DAGOrchestrator (full compose flow)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
+import { validateWorkflow, topologicalSort } from './validation.js';
+import { WorkflowValidationError, WorkflowSubmissionError, WorkflowStateError } from './errors.js';
+import { DAGSubmitter } from './submitter.js';
+import { DAGMonitor } from './monitor.js';
+import { DAGOrchestrator } from './orchestrator.js';
+import {
+  OnChainDependencyType,
+  WorkflowNodeStatus,
+  WorkflowStatus,
+} from './types.js';
+import type {
+  WorkflowDefinition,
+  TaskTemplate,
+  WorkflowEdge,
+  WorkflowState,
+} from './types.js';
+import { RuntimeErrorCodes } from '../types/errors.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function makeTemplate(name: string, overrides?: Partial<TaskTemplate>): TaskTemplate {
+  return {
+    name,
+    requiredCapabilities: 1n,
+    description: new Uint8Array(64),
+    rewardAmount: 100_000_000n,
+    maxWorkers: 1,
+    deadline: 0,
+    taskType: 0,
+    ...overrides,
+  };
+}
+
+function makeDefinition(
+  tasks: TaskTemplate[],
+  edges: WorkflowEdge[] = [],
+  id = 'test-workflow',
+): WorkflowDefinition {
+  return { id, tasks, edges };
+}
+
+function makeMockProgram() {
+  const authority = Keypair.generate();
+  const mockRpc = vi.fn().mockResolvedValue('mock-tx-sig');
+
+  const methodChain = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    rpc: mockRpc,
+  };
+
+  const program = {
+    programId: new PublicKey('EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ'),
+    provider: {
+      publicKey: authority.publicKey,
+    },
+    methods: {
+      createTask: vi.fn().mockReturnValue(methodChain),
+      createDependentTask: vi.fn().mockReturnValue(methodChain),
+    },
+    account: {
+      task: {
+        fetch: vi.fn().mockResolvedValue({ status: { open: {} } }),
+      },
+    },
+    addEventListener: vi.fn().mockReturnValue(0),
+    removeEventListener: vi.fn().mockResolvedValue(undefined),
+  } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+  return { program, authority, mockRpc, methodChain };
+}
+
+// ============================================================================
+// Validation Tests
+// ============================================================================
+
+describe('validateWorkflow', () => {
+  it('rejects empty task array', () => {
+    expect(() => validateWorkflow(makeDefinition([]))).toThrow(WorkflowValidationError);
+    expect(() => validateWorkflow(makeDefinition([]))).toThrow('at least one task');
+  });
+
+  it('rejects duplicate task names', () => {
+    const def = makeDefinition([makeTemplate('a'), makeTemplate('a')]);
+    expect(() => validateWorkflow(def)).toThrow('Duplicate task name: "a"');
+  });
+
+  it('rejects empty task name', () => {
+    const def = makeDefinition([makeTemplate('')]);
+    expect(() => validateWorkflow(def)).toThrow('non-empty string');
+  });
+
+  it('rejects whitespace-only task name', () => {
+    const def = makeDefinition([makeTemplate('   ')]);
+    expect(() => validateWorkflow(def)).toThrow('non-empty string');
+  });
+
+  it('rejects edge with unknown "from" reference', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b')],
+      [{ from: 'x', to: 'b', dependencyType: OnChainDependencyType.Data }],
+    );
+    expect(() => validateWorkflow(def)).toThrow('unknown task "x" in "from"');
+  });
+
+  it('rejects edge with unknown "to" reference', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b')],
+      [{ from: 'a', to: 'y', dependencyType: OnChainDependencyType.Data }],
+    );
+    expect(() => validateWorkflow(def)).toThrow('unknown task "y" in "to"');
+  });
+
+  it('rejects self-loop', () => {
+    const def = makeDefinition(
+      [makeTemplate('a')],
+      [{ from: 'a', to: 'a', dependencyType: OnChainDependencyType.Data }],
+    );
+    expect(() => validateWorkflow(def)).toThrow('Self-loop');
+  });
+
+  it('rejects multi-parent node', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b'), makeTemplate('c')],
+      [
+        { from: 'a', to: 'c', dependencyType: OnChainDependencyType.Data },
+        { from: 'b', to: 'c', dependencyType: OnChainDependencyType.Ordering },
+      ],
+    );
+    expect(() => validateWorkflow(def)).toThrow('Multi-parent');
+  });
+
+  it('rejects cycle (A -> B -> A)', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b')],
+      [
+        { from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data },
+        { from: 'b', to: 'a', dependencyType: OnChainDependencyType.Ordering },
+      ],
+    );
+    // Multi-parent will fire first since 'a' has both no-parent root + incoming from 'b'
+    expect(() => validateWorkflow(def)).toThrow();
+  });
+
+  it('rejects dependency type None (0)', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b')],
+      [{ from: 'a', to: 'b', dependencyType: OnChainDependencyType.None }],
+    );
+    expect(() => validateWorkflow(def)).toThrow('Invalid dependency type');
+  });
+
+  it('rejects invalid dependency type (99)', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b')],
+      [{ from: 'a', to: 'b', dependencyType: 99 as any }],
+    );
+    expect(() => validateWorkflow(def)).toThrow('Invalid dependency type');
+  });
+
+  it('accepts valid linear chain', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b'), makeTemplate('c')],
+      [
+        { from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data },
+        { from: 'b', to: 'c', dependencyType: OnChainDependencyType.Ordering },
+      ],
+    );
+    expect(() => validateWorkflow(def)).not.toThrow();
+  });
+
+  it('accepts valid tree (one parent branches to two children)', () => {
+    const def = makeDefinition(
+      [makeTemplate('root'), makeTemplate('left'), makeTemplate('right')],
+      [
+        { from: 'root', to: 'left', dependencyType: OnChainDependencyType.Data },
+        { from: 'root', to: 'right', dependencyType: OnChainDependencyType.Proof },
+      ],
+    );
+    expect(() => validateWorkflow(def)).not.toThrow();
+  });
+
+  it('accepts single task with no edges', () => {
+    const def = makeDefinition([makeTemplate('solo')]);
+    expect(() => validateWorkflow(def)).not.toThrow();
+  });
+
+  it('accepts forest (multiple disconnected roots)', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b'), makeTemplate('c')],
+      [],
+    );
+    expect(() => validateWorkflow(def)).not.toThrow();
+  });
+});
+
+// ============================================================================
+// Topological Sort Tests
+// ============================================================================
+
+describe('topologicalSort', () => {
+  it('returns single task', () => {
+    const def = makeDefinition([makeTemplate('a')]);
+    expect(topologicalSort(def)).toEqual(['a']);
+  });
+
+  it('returns linear chain in order', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b'), makeTemplate('c')],
+      [
+        { from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data },
+        { from: 'b', to: 'c', dependencyType: OnChainDependencyType.Data },
+      ],
+    );
+    expect(topologicalSort(def)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('places parent before children in tree', () => {
+    const def = makeDefinition(
+      [makeTemplate('root'), makeTemplate('left'), makeTemplate('right')],
+      [
+        { from: 'root', to: 'left', dependencyType: OnChainDependencyType.Data },
+        { from: 'root', to: 'right', dependencyType: OnChainDependencyType.Data },
+      ],
+    );
+    const sorted = topologicalSort(def);
+    expect(sorted[0]).toBe('root');
+    expect(sorted).toContain('left');
+    expect(sorted).toContain('right');
+  });
+
+  it('handles forest with all roots', () => {
+    const def = makeDefinition(
+      [makeTemplate('x'), makeTemplate('y'), makeTemplate('z')],
+      [],
+    );
+    const sorted = topologicalSort(def);
+    expect(sorted).toHaveLength(3);
+    expect(sorted).toContain('x');
+    expect(sorted).toContain('y');
+    expect(sorted).toContain('z');
+  });
+
+  it('handles diamond-ish tree (deep chain)', () => {
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b'), makeTemplate('c'), makeTemplate('d')],
+      [
+        { from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data },
+        { from: 'a', to: 'c', dependencyType: OnChainDependencyType.Ordering },
+        { from: 'b', to: 'd', dependencyType: OnChainDependencyType.Proof },
+      ],
+    );
+    const sorted = topologicalSort(def);
+    expect(sorted.indexOf('a')).toBeLessThan(sorted.indexOf('b'));
+    expect(sorted.indexOf('a')).toBeLessThan(sorted.indexOf('c'));
+    expect(sorted.indexOf('b')).toBeLessThan(sorted.indexOf('d'));
+  });
+});
+
+// ============================================================================
+// Error Classes Tests
+// ============================================================================
+
+describe('Workflow error classes', () => {
+  it('WorkflowValidationError has correct code', () => {
+    const err = new WorkflowValidationError('test');
+    expect(err.code).toBe(RuntimeErrorCodes.WORKFLOW_VALIDATION_ERROR);
+    expect(err.name).toBe('WorkflowValidationError');
+  });
+
+  it('WorkflowSubmissionError includes node name', () => {
+    const err = new WorkflowSubmissionError('myNode', 'tx failed');
+    expect(err.code).toBe(RuntimeErrorCodes.WORKFLOW_SUBMISSION_ERROR);
+    expect(err.nodeName).toBe('myNode');
+    expect(err.message).toContain('myNode');
+    expect(err.message).toContain('tx failed');
+  });
+
+  it('WorkflowStateError has correct code', () => {
+    const err = new WorkflowStateError('not found');
+    expect(err.code).toBe(RuntimeErrorCodes.WORKFLOW_STATE_ERROR);
+    expect(err.name).toBe('WorkflowStateError');
+  });
+});
+
+// ============================================================================
+// DAGSubmitter Tests
+// ============================================================================
+
+describe('DAGSubmitter', () => {
+  let program: any;
+  let methodChain: any;
+  let mockRpc: any;
+  let agentId: Uint8Array;
+
+  beforeEach(() => {
+    ({ program, methodChain, mockRpc } = makeMockProgram());
+    agentId = new Uint8Array(32).fill(1);
+  });
+
+  it('submits root tasks via createTask', async () => {
+    const submitter = new DAGSubmitter({ program, agentId });
+    const def = makeDefinition([makeTemplate('root')]);
+    const state = buildTestState(def);
+
+    await submitter.submitAll(state, true);
+
+    expect(program.methods.createTask).toHaveBeenCalledOnce();
+    expect(program.methods.createDependentTask).not.toHaveBeenCalled();
+    expect(state.nodes.get('root')!.status).toBe(WorkflowNodeStatus.Created);
+    expect(state.nodes.get('root')!.transactionSignature).toBe('mock-tx-sig');
+  });
+
+  it('submits dependent tasks via createDependentTask', async () => {
+    const submitter = new DAGSubmitter({ program, agentId });
+    const def = makeDefinition(
+      [makeTemplate('parent'), makeTemplate('child')],
+      [{ from: 'parent', to: 'child', dependencyType: OnChainDependencyType.Data }],
+    );
+    const state = buildTestState(def);
+
+    await submitter.submitAll(state, true);
+
+    expect(program.methods.createTask).toHaveBeenCalledOnce();
+    expect(program.methods.createDependentTask).toHaveBeenCalledOnce();
+    expect(state.nodes.get('child')!.parentName).toBe('parent');
+    expect(state.nodes.get('child')!.parentPda).toBeTruthy();
+  });
+
+  it('sets taskId and taskPda on created nodes', async () => {
+    const submitter = new DAGSubmitter({ program, agentId });
+    const def = makeDefinition([makeTemplate('a')]);
+    const state = buildTestState(def);
+
+    await submitter.submitAll(state, true);
+
+    const node = state.nodes.get('a')!;
+    expect(node.taskId).toBeInstanceOf(Uint8Array);
+    expect(node.taskId!.length).toBe(32);
+    expect(node.taskPda).toBeInstanceOf(PublicKey);
+  });
+
+  it('cascade-cancels descendants on failure when cancelOnFailure is true', async () => {
+    mockRpc.mockResolvedValueOnce('tx-1').mockRejectedValueOnce(new Error('boom'));
+    const submitter = new DAGSubmitter({ program, agentId, maxRetries: 0 });
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b'), makeTemplate('c')],
+      [
+        { from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data },
+        { from: 'b', to: 'c', dependencyType: OnChainDependencyType.Ordering },
+      ],
+    );
+    const state = buildTestState(def);
+
+    await expect(submitter.submitAll(state, true)).rejects.toThrow(WorkflowSubmissionError);
+
+    expect(state.nodes.get('a')!.status).toBe(WorkflowNodeStatus.Created);
+    expect(state.nodes.get('b')!.status).toBe(WorkflowNodeStatus.Failed);
+    expect(state.nodes.get('c')!.status).toBe(WorkflowNodeStatus.Cancelled);
+  });
+
+  it('does not cascade-cancel when cancelOnFailure is false', async () => {
+    mockRpc.mockResolvedValueOnce('tx-1').mockRejectedValueOnce(new Error('boom'));
+    const submitter = new DAGSubmitter({ program, agentId, maxRetries: 0 });
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b'), makeTemplate('c')],
+      [
+        { from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data },
+        { from: 'b', to: 'c', dependencyType: OnChainDependencyType.Ordering },
+      ],
+    );
+    const state = buildTestState(def);
+
+    await expect(submitter.submitAll(state, false)).rejects.toThrow(WorkflowSubmissionError);
+
+    expect(state.nodes.get('a')!.status).toBe(WorkflowNodeStatus.Created);
+    expect(state.nodes.get('b')!.status).toBe(WorkflowNodeStatus.Failed);
+    // c should remain Pending, not Cancelled
+    expect(state.nodes.get('c')!.status).toBe(WorkflowNodeStatus.Pending);
+  });
+
+  it('retries on transient errors', async () => {
+    mockRpc.mockRejectedValueOnce(new Error('transient')).mockResolvedValueOnce('tx-ok');
+    const submitter = new DAGSubmitter({ program, agentId, maxRetries: 2, retryDelayMs: 1 });
+    const def = makeDefinition([makeTemplate('a')]);
+    const state = buildTestState(def);
+
+    await submitter.submitAll(state, true);
+
+    expect(state.nodes.get('a')!.status).toBe(WorkflowNodeStatus.Created);
+    expect(mockRpc).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes correct accounts to createTask', async () => {
+    const submitter = new DAGSubmitter({ program, agentId });
+    const template = makeTemplate('root', { constraintHash: new Uint8Array(32).fill(0xab) });
+    const def = makeDefinition([template]);
+    const state = buildTestState(def);
+
+    await submitter.submitAll(state, true);
+
+    expect(methodChain.accountsPartial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authority: program.provider.publicKey,
+        creator: program.provider.publicKey,
+      }),
+    );
+  });
+
+  it('submits tree with multiple children', async () => {
+    const submitter = new DAGSubmitter({ program, agentId });
+    const def = makeDefinition(
+      [makeTemplate('root'), makeTemplate('left'), makeTemplate('right')],
+      [
+        { from: 'root', to: 'left', dependencyType: OnChainDependencyType.Data },
+        { from: 'root', to: 'right', dependencyType: OnChainDependencyType.Proof },
+      ],
+    );
+    const state = buildTestState(def);
+
+    await submitter.submitAll(state, true);
+
+    expect(program.methods.createTask).toHaveBeenCalledOnce(); // root
+    expect(program.methods.createDependentTask).toHaveBeenCalledTimes(2); // left + right
+    for (const node of state.nodes.values()) {
+      expect(node.status).toBe(WorkflowNodeStatus.Created);
+    }
+  });
+});
+
+// ============================================================================
+// DAGMonitor Tests
+// ============================================================================
+
+describe('DAGMonitor', () => {
+  let program: any;
+
+  beforeEach(() => {
+    ({ program } = makeMockProgram());
+  });
+
+  it('detects terminal state when all nodes completed', () => {
+    const monitor = new DAGMonitor({ program });
+    const state: WorkflowState = {
+      id: 'wf-1',
+      definition: makeDefinition([makeTemplate('a')]),
+      status: WorkflowStatus.Running,
+      nodes: new Map([
+        ['a', {
+          name: 'a', template: makeTemplate('a'),
+          taskId: null, taskPda: null, parentName: null, parentPda: null,
+          dependencyType: OnChainDependencyType.None,
+          status: WorkflowNodeStatus.Completed,
+          transactionSignature: null, error: null,
+          createdAt: Date.now(), completedAt: Date.now(),
+        }],
+      ]),
+      startedAt: Date.now(),
+      completedAt: null,
+    };
+    expect(monitor.isTerminal({ ...state, status: WorkflowStatus.Completed })).toBe(true);
+  });
+
+  it('registers event listeners on startMonitoring', () => {
+    const monitor = new DAGMonitor({ program });
+    const def = makeDefinition([makeTemplate('a')]);
+    const state = buildTestState(def);
+    state.nodes.get('a')!.taskId = new Uint8Array(32);
+    state.nodes.get('a')!.taskPda = Keypair.generate().publicKey;
+    state.nodes.get('a')!.status = WorkflowNodeStatus.Created;
+
+    monitor.startMonitoring(state, {}, true);
+
+    // Should have registered taskCompleted and taskCancelled listeners
+    expect(program.addEventListener).toHaveBeenCalledTimes(2);
+    expect(program.addEventListener).toHaveBeenCalledWith('taskCompleted', expect.any(Function));
+    expect(program.addEventListener).toHaveBeenCalledWith('taskCancelled', expect.any(Function));
+  });
+
+  it('throws when waitForTerminal on unknown workflow', () => {
+    const monitor = new DAGMonitor({ program });
+    expect(() => monitor.waitForTerminal('unknown')).toThrow(WorkflowStateError);
+  });
+
+  it('resolves immediately if already terminal', async () => {
+    const monitor = new DAGMonitor({ program });
+    const def = makeDefinition([makeTemplate('a')]);
+    const state = buildTestState(def);
+    state.nodes.get('a')!.taskId = new Uint8Array(32);
+    state.nodes.get('a')!.taskPda = Keypair.generate().publicKey;
+    state.nodes.get('a')!.status = WorkflowNodeStatus.Completed;
+    state.status = WorkflowStatus.Completed;
+
+    monitor.startMonitoring(state, {}, true);
+    const result = await monitor.waitForTerminal(state.id);
+    expect(result.status).toBe(WorkflowStatus.Completed);
+  });
+});
+
+// ============================================================================
+// DAGOrchestrator Tests
+// ============================================================================
+
+describe('DAGOrchestrator', () => {
+  let program: any;
+  let agentId: Uint8Array;
+
+  beforeEach(() => {
+    ({ program } = makeMockProgram());
+    agentId = new Uint8Array(32).fill(1);
+  });
+
+  it('validate() delegates to validateWorkflow', () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    expect(() => orch.validate(makeDefinition([]))).toThrow(WorkflowValidationError);
+    expect(() => orch.validate(makeDefinition([makeTemplate('ok')]))).not.toThrow();
+  });
+
+  it('submit() creates tasks and returns Running state', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    const def = makeDefinition(
+      [makeTemplate('a'), makeTemplate('b')],
+      [{ from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data }],
+    );
+
+    const state = await orch.submit(def);
+
+    expect(state.status).toBe(WorkflowStatus.Running);
+    expect(state.nodes.get('a')!.status).toBe(WorkflowNodeStatus.Created);
+    expect(state.nodes.get('b')!.status).toBe(WorkflowNodeStatus.Created);
+    expect(state.startedAt).toBeGreaterThan(0);
+  });
+
+  it('submit() fires onNodeCreated callbacks', async () => {
+    const onNodeCreated = vi.fn();
+    const orch = new DAGOrchestrator({ program, agentId, callbacks: { onNodeCreated } });
+    const def = makeDefinition([makeTemplate('a')]);
+
+    await orch.submit(def);
+
+    expect(onNodeCreated).toHaveBeenCalledOnce();
+    expect(onNodeCreated).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'a', status: WorkflowNodeStatus.Created }),
+    );
+  });
+
+  it('submit() rejects duplicate workflow ID', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    const def = makeDefinition([makeTemplate('a')]);
+
+    await orch.submit(def);
+    await expect(orch.submit(def)).rejects.toThrow(WorkflowStateError);
+    await expect(orch.submit(def)).rejects.toThrow('already exists');
+  });
+
+  it('getState() returns null for unknown workflow', () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    expect(orch.getState('nope')).toBeNull();
+  });
+
+  it('getState() returns submitted workflow', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    const def = makeDefinition([makeTemplate('a')]);
+
+    await orch.submit(def);
+    const state = orch.getState('test-workflow');
+
+    expect(state).not.toBeNull();
+    expect(state!.id).toBe('test-workflow');
+  });
+
+  it('getStats() returns null for unknown workflow', () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    expect(orch.getStats('nope')).toBeNull();
+  });
+
+  it('getStats() returns correct counts', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    const def = makeDefinition(
+      [
+        makeTemplate('a', { rewardAmount: 100n }),
+        makeTemplate('b', { rewardAmount: 200n }),
+      ],
+      [{ from: 'a', to: 'b', dependencyType: OnChainDependencyType.Data }],
+    );
+
+    await orch.submit(def);
+    const stats = orch.getStats('test-workflow')!;
+
+    expect(stats.totalNodes).toBe(2);
+    // Both are "created" (waiting for completion monitoring)
+    expect(stats.created).toBe(2);
+    expect(stats.completed).toBe(0);
+    expect(stats.totalReward).toBe(300n);
+    expect(stats.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('waitForCompletion() rejects for unknown workflow', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    await expect(orch.waitForCompletion('nope')).rejects.toThrow(WorkflowStateError);
+  });
+
+  it('shutdown() does not throw', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    await expect(orch.shutdown()).resolves.not.toThrow();
+  });
+
+  it('submit() marks workflow Failed on submission error', async () => {
+    const { mockRpc } = makeMockProgram();
+    mockRpc.mockRejectedValue(new Error('rpc boom'));
+    // Use the program from makeMockProgram which has the failing rpc
+    const failProgram = makeMockProgram();
+    failProgram.mockRpc.mockRejectedValue(new Error('rpc boom'));
+
+    const orch = new DAGOrchestrator({
+      program: failProgram.program,
+      agentId,
+      maxRetries: 0,
+    });
+    const def = makeDefinition([makeTemplate('a')]);
+
+    await expect(orch.submit(def)).rejects.toThrow(WorkflowSubmissionError);
+
+    const state = orch.getState('test-workflow')!;
+    expect(state.status).toBe(WorkflowStatus.Failed);
+  });
+
+  it('handles Proof dependency type correctly', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    const def = makeDefinition(
+      [makeTemplate('prover'), makeTemplate('verifier')],
+      [{ from: 'prover', to: 'verifier', dependencyType: OnChainDependencyType.Proof }],
+    );
+
+    const state = await orch.submit(def);
+
+    const verifier = state.nodes.get('verifier')!;
+    expect(verifier.dependencyType).toBe(OnChainDependencyType.Proof);
+    expect(verifier.parentName).toBe('prover');
+  });
+
+  it('handles all three dependency types in one workflow', async () => {
+    const orch = new DAGOrchestrator({ program, agentId });
+    const def = makeDefinition(
+      [makeTemplate('root'), makeTemplate('data'), makeTemplate('order'), makeTemplate('proof')],
+      [
+        { from: 'root', to: 'data', dependencyType: OnChainDependencyType.Data },
+        { from: 'root', to: 'order', dependencyType: OnChainDependencyType.Ordering },
+        { from: 'root', to: 'proof', dependencyType: OnChainDependencyType.Proof },
+      ],
+    );
+
+    const state = await orch.submit(def);
+
+    expect(state.nodes.get('data')!.dependencyType).toBe(OnChainDependencyType.Data);
+    expect(state.nodes.get('order')!.dependencyType).toBe(OnChainDependencyType.Ordering);
+    expect(state.nodes.get('proof')!.dependencyType).toBe(OnChainDependencyType.Proof);
+    expect(state.nodes.get('root')!.dependencyType).toBe(OnChainDependencyType.None);
+  });
+});
+
+// ============================================================================
+// Helper: Build test state from definition
+// ============================================================================
+
+function buildTestState(def: WorkflowDefinition): WorkflowState {
+  const edgeByChild = new Map<string, { from: string; depType: OnChainDependencyType }>();
+  for (const edge of def.edges) {
+    edgeByChild.set(edge.to, { from: edge.from, depType: edge.dependencyType });
+  }
+
+  const nodes = new Map<string, import('./types.js').WorkflowNode>();
+  for (const template of def.tasks) {
+    const pe = edgeByChild.get(template.name);
+    nodes.set(template.name, {
+      name: template.name,
+      template,
+      taskId: null,
+      taskPda: null,
+      parentName: pe?.from ?? null,
+      parentPda: null,
+      dependencyType: pe?.depType ?? OnChainDependencyType.None,
+      status: WorkflowNodeStatus.Pending,
+      transactionSignature: null,
+      error: null,
+      createdAt: null,
+      completedAt: null,
+    });
+  }
+
+  return {
+    id: def.id,
+    definition: def,
+    status: WorkflowStatus.Pending,
+    nodes,
+    startedAt: null,
+    completedAt: null,
+  };
+}

--- a/runtime/src/workflow/orchestrator.ts
+++ b/runtime/src/workflow/orchestrator.ts
@@ -1,0 +1,235 @@
+/**
+ * DAGOrchestrator — Top-level workflow API.
+ *
+ * Validates workflow definitions, submits tasks on-chain via DAGSubmitter,
+ * and monitors completion via DAGMonitor.
+ *
+ * @module
+ */
+
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import type {
+  DAGOrchestratorConfig,
+  WorkflowDefinition,
+  WorkflowState,
+  WorkflowStats,
+  WorkflowCallbacks,
+} from './types.js';
+import {
+  WorkflowStatus,
+  WorkflowNodeStatus,
+  OnChainDependencyType,
+} from './types.js';
+import { WorkflowStateError } from './errors.js';
+import { validateWorkflow } from './validation.js';
+import { DAGSubmitter } from './submitter.js';
+import { DAGMonitor } from './monitor.js';
+
+/**
+ * Orchestrates multi-step task workflows on the AgenC protocol.
+ *
+ * Usage:
+ * ```typescript
+ * const orch = new DAGOrchestrator({ program, agentId });
+ * orch.validate(definition);            // throws on invalid
+ * const state = await orch.submit(definition);
+ * const final = await orch.waitForCompletion(definition.id);
+ * await orch.shutdown();
+ * ```
+ */
+export class DAGOrchestrator {
+  private readonly submitter: DAGSubmitter;
+  private readonly monitor: DAGMonitor;
+  private readonly logger: Logger;
+  private readonly callbacks: WorkflowCallbacks;
+  private readonly cancelOnParentFailure: boolean;
+  private readonly workflows = new Map<string, WorkflowState>();
+
+  constructor(config: DAGOrchestratorConfig) {
+    this.logger = config.logger ?? silentLogger;
+    this.callbacks = config.callbacks ?? {};
+    this.cancelOnParentFailure = config.cancelOnParentFailure ?? true;
+
+    this.submitter = new DAGSubmitter({
+      program: config.program,
+      agentId: config.agentId,
+      logger: this.logger,
+      maxRetries: config.maxRetries,
+      retryDelayMs: config.retryDelayMs,
+    });
+
+    this.monitor = new DAGMonitor({
+      program: config.program,
+      logger: this.logger,
+      pollIntervalMs: config.pollIntervalMs,
+    });
+  }
+
+  /**
+   * Validate a workflow definition without submitting.
+   *
+   * @throws WorkflowValidationError on any violation
+   */
+  validate(definition: WorkflowDefinition): void {
+    validateWorkflow(definition);
+  }
+
+  /**
+   * Submit a workflow: validate, create on-chain tasks, start monitoring.
+   *
+   * @param definition - The workflow definition
+   * @returns Workflow state (status will be Running after successful submission)
+   * @throws WorkflowValidationError if definition is invalid
+   * @throws WorkflowSubmissionError if on-chain task creation fails
+   * @throws WorkflowStateError if a workflow with the same ID already exists
+   */
+  async submit(definition: WorkflowDefinition): Promise<WorkflowState> {
+    if (this.workflows.has(definition.id)) {
+      throw new WorkflowStateError(
+        `Workflow "${definition.id}" already exists. Use a unique ID.`
+      );
+    }
+
+    // Validate
+    validateWorkflow(definition);
+
+    // Build initial state
+    const state = this.buildInitialState(definition);
+    this.workflows.set(definition.id, state);
+
+    state.status = WorkflowStatus.Running;
+    state.startedAt = Date.now();
+
+    // Submit all tasks on-chain
+    try {
+      await this.submitter.submitAll(state, this.cancelOnParentFailure);
+    } catch (err) {
+      // On submission failure, mark workflow as failed but keep it tracked
+      // (some nodes may have been created successfully)
+      state.status = WorkflowStatus.Failed;
+      state.completedAt = Date.now();
+      this.callbacks.onWorkflowFailed?.(state);
+      throw err;
+    }
+
+    // Fire onNodeCreated callbacks for all successfully created nodes
+    for (const node of state.nodes.values()) {
+      if (node.status === WorkflowNodeStatus.Created) {
+        this.callbacks.onNodeCreated?.(node);
+      }
+    }
+
+    // Start monitoring for completions
+    this.monitor.startMonitoring(state, this.callbacks, this.cancelOnParentFailure);
+
+    return state;
+  }
+
+  /**
+   * Get the current state of a workflow.
+   *
+   * @param workflowId - Workflow identifier
+   * @returns Workflow state, or null if not found
+   */
+  getState(workflowId: string): WorkflowState | null {
+    return this.workflows.get(workflowId) ?? null;
+  }
+
+  /**
+   * Get summary statistics for a workflow.
+   *
+   * @param workflowId - Workflow identifier
+   * @returns Stats, or null if workflow not found
+   */
+  getStats(workflowId: string): WorkflowStats | null {
+    const state = this.workflows.get(workflowId);
+    if (!state) return null;
+
+    const nodes = Array.from(state.nodes.values());
+    const now = Date.now();
+    const startedAt = state.startedAt ?? now;
+
+    return {
+      totalNodes: nodes.length,
+      pending: nodes.filter((n) => n.status === WorkflowNodeStatus.Pending || n.status === WorkflowNodeStatus.Creating).length,
+      created: nodes.filter((n) => n.status === WorkflowNodeStatus.Created).length,
+      completed: nodes.filter((n) => n.status === WorkflowNodeStatus.Completed).length,
+      failed: nodes.filter((n) => n.status === WorkflowNodeStatus.Failed).length,
+      cancelled: nodes.filter((n) => n.status === WorkflowNodeStatus.Cancelled).length,
+      elapsedMs: (state.completedAt ?? now) - startedAt,
+      totalReward: nodes.reduce((sum, n) => sum + n.template.rewardAmount, 0n),
+    };
+  }
+
+  /**
+   * Wait for a workflow to reach terminal state.
+   *
+   * @param workflowId - Workflow identifier
+   * @param timeoutMs - Optional timeout in ms
+   * @returns Final workflow state
+   * @throws WorkflowStateError if workflow not found or on timeout
+   */
+  async waitForCompletion(workflowId: string, timeoutMs?: number): Promise<WorkflowState> {
+    const state = this.workflows.get(workflowId);
+    if (!state) {
+      throw new WorkflowStateError(`Workflow "${workflowId}" not found`);
+    }
+
+    // Already terminal?
+    if (this.monitor.isTerminal(state)) {
+      return state;
+    }
+
+    return this.monitor.waitForTerminal(workflowId, timeoutMs);
+  }
+
+  /**
+   * Stop all monitoring and clean up resources.
+   */
+  async shutdown(): Promise<void> {
+    await this.monitor.shutdown();
+    this.logger.info('DAGOrchestrator shut down');
+  }
+
+  // ===========================================================================
+  // Internal Helpers
+  // ===========================================================================
+
+  private buildInitialState(definition: WorkflowDefinition): WorkflowState {
+    // Build edge map (child -> parent edge) for assigning parentName/dependencyType
+    const edgeByChild = new Map<string, { from: string; dependencyType: OnChainDependencyType }>();
+    for (const edge of definition.edges) {
+      edgeByChild.set(edge.to, { from: edge.from, dependencyType: edge.dependencyType });
+    }
+
+    const nodes = new Map<string, import('./types.js').WorkflowNode>();
+
+    for (const template of definition.tasks) {
+      const parentEdge = edgeByChild.get(template.name);
+      nodes.set(template.name, {
+        name: template.name,
+        template,
+        taskId: null,
+        taskPda: null,
+        parentName: parentEdge?.from ?? null,
+        parentPda: null,
+        dependencyType: parentEdge?.dependencyType ?? OnChainDependencyType.None,
+        status: WorkflowNodeStatus.Pending,
+        transactionSignature: null,
+        error: null,
+        createdAt: null,
+        completedAt: null,
+      });
+    }
+
+    return {
+      id: definition.id,
+      definition,
+      status: WorkflowStatus.Pending,
+      nodes,
+      startedAt: null,
+      completedAt: null,
+    };
+  }
+}

--- a/runtime/src/workflow/submitter.ts
+++ b/runtime/src/workflow/submitter.ts
@@ -1,0 +1,312 @@
+/**
+ * DAGSubmitter — Sequential on-chain task creation for workflow DAGs.
+ *
+ * Submits tasks in topological order, creating root tasks via `createTask`
+ * and dependent tasks via `createDependentTask`. Respects on-chain rate
+ * limits with automatic retry on cooldown errors.
+ *
+ * @module
+ */
+
+import { SystemProgram } from '@solana/web3.js';
+import { BN, type Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../types/agenc_coordination.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import { generateAgentId, toAnchorBytes } from '../utils/encoding.js';
+import { findAgentPda, findProtocolPda } from '../agent/pda.js';
+import { findTaskPda, findEscrowPda } from '../task/pda.js';
+import { isAnchorError, AnchorErrorCodes } from '../types/errors.js';
+import type { WorkflowState, WorkflowEdge } from './types.js';
+import { WorkflowNodeStatus, OnChainDependencyType } from './types.js';
+import { WorkflowSubmissionError } from './errors.js';
+import { topologicalSort } from './validation.js';
+
+/** Default retry delay in ms */
+const DEFAULT_RETRY_DELAY_MS = 1000;
+/** Default max retries */
+const DEFAULT_MAX_RETRIES = 3;
+/** Rate limit cooldown wait in ms (slightly over 1s to account for clock skew) */
+const RATE_LIMIT_WAIT_MS = 1500;
+
+export interface DAGSubmitterConfig {
+  program: Program<AgencCoordination>;
+  agentId: Uint8Array;
+  logger?: Logger;
+  maxRetries?: number;
+  retryDelayMs?: number;
+}
+
+/**
+ * Submits workflow tasks on-chain in topological order.
+ *
+ * Root tasks (no incoming edges) use `createTask`.
+ * Dependent tasks use `createDependentTask` with `parentTask` account.
+ */
+export class DAGSubmitter {
+  private readonly program: Program<AgencCoordination>;
+  private readonly agentId: Uint8Array;
+  private readonly logger: Logger;
+  private readonly maxRetries: number;
+  private readonly retryDelayMs: number;
+  private readonly agentPda;
+  private readonly protocolPda;
+
+  constructor(config: DAGSubmitterConfig) {
+    this.program = config.program;
+    this.agentId = config.agentId;
+    this.logger = config.logger ?? silentLogger;
+    this.maxRetries = config.maxRetries ?? DEFAULT_MAX_RETRIES;
+    this.retryDelayMs = config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    this.agentPda = findAgentPda(this.agentId, this.program.programId);
+    this.protocolPda = findProtocolPda(this.program.programId);
+  }
+
+  /**
+   * Submit all workflow tasks on-chain in topological order.
+   *
+   * Mutates `state.nodes` in place as tasks are created. On failure,
+   * already-created tasks remain in their `Created` state.
+   *
+   * @param state - Workflow state with all nodes in Pending status
+   * @param cancelOnFailure - If true, mark uncreated descendants as Cancelled on failure
+   * @returns Updated workflow state
+   * @throws WorkflowSubmissionError if a task creation fails after retries
+   */
+  async submitAll(state: WorkflowState, cancelOnFailure: boolean): Promise<WorkflowState> {
+    const order = topologicalSort(state.definition);
+    const edgeMap = this.buildEdgeMap(state.definition.edges);
+    const creator = this.program.provider.publicKey!;
+
+    for (const name of order) {
+      const node = state.nodes.get(name)!;
+
+      // Skip if already created or cancelled
+      if (node.status !== WorkflowNodeStatus.Pending) {
+        continue;
+      }
+
+      // Generate task ID and derive PDAs
+      const taskId = generateAgentId(); // random 32-byte ID
+      const taskPda = findTaskPda(creator, taskId, this.program.programId);
+      const escrowPda = findEscrowPda(taskPda, this.program.programId);
+
+      node.taskId = taskId;
+      node.taskPda = taskPda;
+      node.status = WorkflowNodeStatus.Creating;
+
+      // Resolve parent PDA if this is a dependent task
+      const edge = edgeMap.get(name);
+      if (edge) {
+        const parentNode = state.nodes.get(edge.from)!;
+        node.parentName = edge.from;
+        node.parentPda = parentNode.taskPda;
+        node.dependencyType = edge.dependencyType;
+      }
+
+      try {
+        const txSig = await this.submitWithRetry(
+          node, creator, taskId, taskPda, escrowPda
+        );
+        node.status = WorkflowNodeStatus.Created;
+        node.transactionSignature = txSig;
+        node.createdAt = Date.now();
+        this.logger.info(`Created workflow node "${name}" — tx: ${txSig}`);
+      } catch (err) {
+        node.status = WorkflowNodeStatus.Failed;
+        node.error = err instanceof Error ? err : new Error(String(err));
+        this.logger.error(`Failed to create node "${name}": ${node.error.message}`);
+
+        if (cancelOnFailure) {
+          this.cascadeCancel(state, name);
+        }
+
+        throw new WorkflowSubmissionError(name, node.error.message);
+      }
+    }
+
+    return state;
+  }
+
+  /**
+   * Submit a single task with retry and rate-limit backoff.
+   */
+  private async submitWithRetry(
+    node: import('./types.js').WorkflowNode,
+    creator: import('@solana/web3.js').PublicKey,
+    taskId: Uint8Array,
+    taskPda: import('@solana/web3.js').PublicKey,
+    escrowPda: import('@solana/web3.js').PublicKey,
+  ): Promise<string> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        if (node.parentPda) {
+          return await this.createDependentTask(
+            taskId, node.template, taskPda, escrowPda, node.parentPda, node.dependencyType, creator
+          );
+        } else {
+          return await this.createRootTask(
+            taskId, node.template, taskPda, escrowPda, creator
+          );
+        }
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+
+        // On rate limit errors, wait and retry
+        if (
+          isAnchorError(err, AnchorErrorCodes.RateLimitExceeded) ||
+          isAnchorError(err, AnchorErrorCodes.CooldownNotElapsed)
+        ) {
+          this.logger.warn(
+            `Rate limit hit for node "${node.name}", waiting ${RATE_LIMIT_WAIT_MS}ms (attempt ${attempt + 1}/${this.maxRetries + 1})`
+          );
+          await sleep(RATE_LIMIT_WAIT_MS);
+          continue;
+        }
+
+        // For other errors, apply exponential backoff
+        if (attempt < this.maxRetries) {
+          const delay = this.retryDelayMs * Math.pow(2, attempt);
+          this.logger.warn(
+            `Retrying node "${node.name}" in ${delay}ms (attempt ${attempt + 1}/${this.maxRetries + 1})`
+          );
+          await sleep(delay);
+        }
+      }
+    }
+
+    throw lastError ?? new Error('Unknown submission error');
+  }
+
+  /**
+   * Create a root task (no parent dependency).
+   */
+  private async createRootTask(
+    taskId: Uint8Array,
+    template: import('./types.js').TaskTemplate,
+    taskPda: import('@solana/web3.js').PublicKey,
+    escrowPda: import('@solana/web3.js').PublicKey,
+    creator: import('@solana/web3.js').PublicKey,
+  ): Promise<string> {
+    const constraintHash = template.constraintHash
+      ? Array.from(template.constraintHash)
+      : null;
+
+    return this.program.methods
+      .createTask(
+        toAnchorBytes(taskId),
+        new BN(template.requiredCapabilities.toString()),
+        toAnchorBytes(template.description),
+        new BN(template.rewardAmount.toString()),
+        template.maxWorkers,
+        new BN(template.deadline),
+        template.taskType,
+        constraintHash,
+        template.minReputation ?? 0,
+      )
+      .accountsPartial({
+        task: taskPda,
+        escrow: escrowPda,
+        protocolConfig: this.protocolPda,
+        creatorAgent: this.agentPda,
+        authority: creator,
+        creator,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+  }
+
+  /**
+   * Create a dependent task with parent reference.
+   */
+  private async createDependentTask(
+    taskId: Uint8Array,
+    template: import('./types.js').TaskTemplate,
+    taskPda: import('@solana/web3.js').PublicKey,
+    escrowPda: import('@solana/web3.js').PublicKey,
+    parentTaskPda: import('@solana/web3.js').PublicKey,
+    dependencyType: OnChainDependencyType,
+    creator: import('@solana/web3.js').PublicKey,
+  ): Promise<string> {
+    const constraintHash = template.constraintHash
+      ? Array.from(template.constraintHash)
+      : null;
+
+    return this.program.methods
+      .createDependentTask(
+        toAnchorBytes(taskId),
+        new BN(template.requiredCapabilities.toString()),
+        toAnchorBytes(template.description),
+        new BN(template.rewardAmount.toString()),
+        template.maxWorkers,
+        new BN(template.deadline),
+        template.taskType,
+        constraintHash,
+        dependencyType,
+        template.minReputation ?? 0,
+      )
+      .accountsPartial({
+        task: taskPda,
+        escrow: escrowPda,
+        parentTask: parentTaskPda,
+        protocolConfig: this.protocolPda,
+        creatorAgent: this.agentPda,
+        authority: creator,
+        creator,
+        systemProgram: SystemProgram.programId,
+      })
+      .rpc();
+  }
+
+  /**
+   * Build a map from child task name to the edge defining its parent.
+   * Assumes validation has already confirmed single-parent constraint.
+   */
+  private buildEdgeMap(edges: ReadonlyArray<WorkflowEdge>): Map<string, WorkflowEdge> {
+    const map = new Map<string, WorkflowEdge>();
+    for (const edge of edges) {
+      map.set(edge.to, edge);
+    }
+    return map;
+  }
+
+  /**
+   * Mark all descendants of a failed node as Cancelled.
+   */
+  private cascadeCancel(state: WorkflowState, failedName: string): void {
+    // Build parent->children adjacency
+    const children = new Map<string, string[]>();
+    for (const edge of state.definition.edges) {
+      if (!children.has(edge.from)) {
+        children.set(edge.from, []);
+      }
+      children.get(edge.from)!.push(edge.to);
+    }
+
+    // BFS from failed node
+    const queue = [failedName];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const kids = children.get(current);
+      if (!kids) continue;
+      for (const kid of kids) {
+        const kidNode = state.nodes.get(kid)!;
+        if (
+          kidNode.status === WorkflowNodeStatus.Pending ||
+          kidNode.status === WorkflowNodeStatus.Creating
+        ) {
+          kidNode.status = WorkflowNodeStatus.Cancelled;
+          kidNode.error = new Error(`Parent node "${failedName}" failed`);
+          this.logger.info(`Cancelled descendant node "${kid}" due to parent "${failedName}" failure`);
+        }
+        queue.push(kid);
+      }
+    }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/runtime/src/workflow/types.ts
+++ b/runtime/src/workflow/types.ts
@@ -1,0 +1,207 @@
+/**
+ * Workflow DAG Orchestrator — Type Definitions
+ *
+ * Types for defining, submitting, and monitoring multi-step task workflows
+ * on the AgenC protocol. The on-chain topology is a tree (each task has at
+ * most one parent via `depends_on: Option<Pubkey>`).
+ *
+ * @module
+ */
+
+import type { PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../types/agenc_coordination.js';
+import type { Logger } from '../utils/logger.js';
+
+// ============================================================================
+// On-Chain Dependency Type
+// ============================================================================
+
+/**
+ * Matches the on-chain Rust `DependencyType` enum values exactly.
+ *
+ * Separate from `DependencyGraph.DependencyType` in the speculative executor
+ * (which uses different ordinals).
+ */
+export enum OnChainDependencyType {
+  None = 0,
+  Data = 1,
+  Ordering = 2,
+  Proof = 3,
+}
+
+// ============================================================================
+// Workflow Definition (User Input — Immutable)
+// ============================================================================
+
+/**
+ * User-defined task blueprint (before on-chain submission).
+ */
+export interface TaskTemplate {
+  /** Local reference key (NOT on-chain task_id — that's generated at submission time) */
+  name: string;
+  /** Bitmask of required agent capabilities */
+  requiredCapabilities: bigint;
+  /** Task description or instruction hash (64 bytes) */
+  description: Uint8Array;
+  /** SOL reward for completion in lamports (can be 0 for dependents) */
+  rewardAmount: bigint;
+  /** Maximum number of agents that can work on this task */
+  maxWorkers: number;
+  /** Unix timestamp deadline (0 = no deadline) */
+  deadline: number;
+  /** 0=Exclusive, 1=Collaborative, 2=Competitive */
+  taskType: number;
+  /** For private tasks: hash of expected output (32 bytes). Null = public task. */
+  constraintHash?: Uint8Array;
+  /** Minimum reputation score (0-10000). Default 0. */
+  minReputation?: number;
+}
+
+/**
+ * Directed edge from parent task to child task.
+ */
+export interface WorkflowEdge {
+  /** Parent task name (must reference a TaskTemplate.name) */
+  from: string;
+  /** Child task name (must reference a TaskTemplate.name) */
+  to: string;
+  /** On-chain dependency type (1=Data, 2=Ordering, 3=Proof) */
+  dependencyType: OnChainDependencyType;
+}
+
+/**
+ * Immutable workflow definition provided by the user.
+ */
+export interface WorkflowDefinition {
+  /** User-supplied workflow identifier */
+  id: string;
+  /** Task blueprints */
+  tasks: ReadonlyArray<TaskTemplate>;
+  /** Dependency edges between tasks */
+  edges: ReadonlyArray<WorkflowEdge>;
+}
+
+// ============================================================================
+// Runtime State
+// ============================================================================
+
+/** Status of an individual workflow node. */
+export enum WorkflowNodeStatus {
+  Pending = 'pending',
+  Creating = 'creating',
+  Created = 'created',
+  Completed = 'completed',
+  Failed = 'failed',
+  Cancelled = 'cancelled',
+}
+
+/**
+ * Runtime state for a single task within the workflow.
+ */
+export interface WorkflowNode {
+  /** Local reference name (matches TaskTemplate.name) */
+  name: string;
+  /** The original template */
+  template: TaskTemplate;
+  /** Generated 32-byte on-chain task ID (null before submission) */
+  taskId: Uint8Array | null;
+  /** Derived task PDA (null before submission) */
+  taskPda: PublicKey | null;
+  /** Parent task name (null for root nodes) */
+  parentName: string | null;
+  /** Parent task PDA (null for root nodes, set after parent submission) */
+  parentPda: PublicKey | null;
+  /** Dependency type (None for roots, Data/Ordering/Proof for dependents) */
+  dependencyType: OnChainDependencyType;
+  /** Current status */
+  status: WorkflowNodeStatus;
+  /** Transaction signature from on-chain creation */
+  transactionSignature: string | null;
+  /** Error if status is Failed */
+  error: Error | null;
+  /** Timestamp when node was created on-chain */
+  createdAt: number | null;
+  /** Timestamp when node was completed */
+  completedAt: number | null;
+}
+
+/** Overall workflow status. */
+export enum WorkflowStatus {
+  Pending = 'pending',
+  Running = 'running',
+  Completed = 'completed',
+  Failed = 'failed',
+  PartiallyCompleted = 'partially_completed',
+}
+
+/**
+ * Full runtime state of a workflow.
+ */
+export interface WorkflowState {
+  /** Workflow identifier (from WorkflowDefinition.id) */
+  id: string;
+  /** The original definition */
+  definition: WorkflowDefinition;
+  /** Overall status */
+  status: WorkflowStatus;
+  /** Node states keyed by task name */
+  nodes: Map<string, WorkflowNode>;
+  /** When submission started */
+  startedAt: number | null;
+  /** When workflow reached terminal state */
+  completedAt: number | null;
+}
+
+/**
+ * Summary statistics for a workflow.
+ */
+export interface WorkflowStats {
+  totalNodes: number;
+  pending: number;
+  created: number;
+  completed: number;
+  failed: number;
+  cancelled: number;
+  elapsedMs: number;
+  /** Sum of all node reward amounts */
+  totalReward: bigint;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Callbacks for workflow lifecycle events.
+ */
+export interface WorkflowCallbacks {
+  onNodeCreated?: (node: WorkflowNode) => void;
+  onNodeCompleted?: (node: WorkflowNode) => void;
+  onNodeFailed?: (node: WorkflowNode, error: Error) => void;
+  onNodeCancelled?: (node: WorkflowNode, reason: string) => void;
+  onWorkflowCompleted?: (state: WorkflowState) => void;
+  onWorkflowFailed?: (state: WorkflowState) => void;
+}
+
+/**
+ * Configuration for DAGOrchestrator.
+ */
+export interface DAGOrchestratorConfig {
+  /** Anchor program instance (with wallet for signing) */
+  program: Program<AgencCoordination>;
+  /** 32-byte agent ID of the creator */
+  agentId: Uint8Array;
+  /** Logger instance */
+  logger?: Logger;
+  /** Lifecycle callbacks */
+  callbacks?: WorkflowCallbacks;
+  /** Cancel descendant tasks when a parent fails (default: true) */
+  cancelOnParentFailure?: boolean;
+  /** Polling interval for task completion checks in ms (default: 10_000) */
+  pollIntervalMs?: number;
+  /** Max retries for on-chain task creation (default: 3) */
+  maxRetries?: number;
+  /** Delay between retries in ms (default: 1000) */
+  retryDelayMs?: number;
+}

--- a/runtime/src/workflow/validation.ts
+++ b/runtime/src/workflow/validation.ts
@@ -1,0 +1,173 @@
+/**
+ * Workflow DAG validation.
+ *
+ * Validates that a WorkflowDefinition is a valid tree topology that can be
+ * submitted on-chain. The on-chain `depends_on: Option<Pubkey>` supports
+ * at most one parent per task, so multi-parent fan-in is rejected.
+ *
+ * @module
+ */
+
+import type { WorkflowDefinition } from './types.js';
+import { OnChainDependencyType } from './types.js';
+import { WorkflowValidationError } from './errors.js';
+
+/**
+ * Validate a workflow definition.
+ *
+ * Checks:
+ * 1. Non-empty task array
+ * 2. No duplicate task names
+ * 3. All edge references point to existing task names
+ * 4. No multi-parent nodes (each name appears as `to` in at most one edge)
+ * 5. No cycles (DFS back-edge detection)
+ * 6. No self-loops
+ * 7. Edge dependency types must be 1, 2, or 3 (not 0/None)
+ *
+ * @throws WorkflowValidationError on any violation
+ */
+export function validateWorkflow(definition: WorkflowDefinition): void {
+  const { tasks, edges } = definition;
+
+  // 1. Non-empty
+  if (!tasks || tasks.length === 0) {
+    throw new WorkflowValidationError('Workflow must have at least one task');
+  }
+
+  // 2. No duplicate names
+  const names = new Set<string>();
+  for (const task of tasks) {
+    if (!task.name || task.name.trim().length === 0) {
+      throw new WorkflowValidationError('Task name must be a non-empty string');
+    }
+    if (names.has(task.name)) {
+      throw new WorkflowValidationError(`Duplicate task name: "${task.name}"`);
+    }
+    names.add(task.name);
+  }
+
+  // 3. All edge references exist + 6. No self-loops + 7. Valid dependency types
+  for (const edge of edges) {
+    if (!names.has(edge.from)) {
+      throw new WorkflowValidationError(
+        `Edge references unknown task "${edge.from}" in "from" field`
+      );
+    }
+    if (!names.has(edge.to)) {
+      throw new WorkflowValidationError(
+        `Edge references unknown task "${edge.to}" in "to" field`
+      );
+    }
+    if (edge.from === edge.to) {
+      throw new WorkflowValidationError(
+        `Self-loop detected: task "${edge.from}" depends on itself`
+      );
+    }
+    if (
+      edge.dependencyType !== OnChainDependencyType.Data &&
+      edge.dependencyType !== OnChainDependencyType.Ordering &&
+      edge.dependencyType !== OnChainDependencyType.Proof
+    ) {
+      throw new WorkflowValidationError(
+        `Invalid dependency type ${edge.dependencyType} on edge "${edge.from}" -> "${edge.to}". ` +
+        'Must be Data (1), Ordering (2), or Proof (3)'
+      );
+    }
+  }
+
+  // 4. No multi-parent nodes
+  const childSeen = new Set<string>();
+  for (const edge of edges) {
+    if (childSeen.has(edge.to)) {
+      throw new WorkflowValidationError(
+        `Multi-parent detected: task "${edge.to}" has more than one incoming edge. ` +
+        'On-chain tasks support only one parent (depends_on: Option<Pubkey>)'
+      );
+    }
+    childSeen.add(edge.to);
+  }
+
+  // 5. Cycle detection via DFS
+  // Build adjacency list (parent -> children)
+  const adj = new Map<string, string[]>();
+  for (const name of names) {
+    adj.set(name, []);
+  }
+  for (const edge of edges) {
+    adj.get(edge.from)!.push(edge.to);
+  }
+
+  const WHITE = 0; // unvisited
+  const GRAY = 1;  // in current DFS path
+  const BLACK = 2; // fully explored
+  const color = new Map<string, number>();
+  for (const name of names) {
+    color.set(name, WHITE);
+  }
+
+  function dfs(node: string): boolean {
+    color.set(node, GRAY);
+    for (const child of adj.get(node)!) {
+      const c = color.get(child)!;
+      if (c === GRAY) return true; // back edge → cycle
+      if (c === WHITE && dfs(child)) return true;
+    }
+    color.set(node, BLACK);
+    return false;
+  }
+
+  for (const name of names) {
+    if (color.get(name) === WHITE) {
+      if (dfs(name)) {
+        throw new WorkflowValidationError('Cycle detected in workflow edges');
+      }
+    }
+  }
+}
+
+/**
+ * Topological sort of workflow nodes using Kahn's algorithm.
+ * Returns task names in submission order (parents before children).
+ *
+ * @param definition - Validated workflow definition
+ * @returns Array of task names in topological order
+ */
+export function topologicalSort(definition: WorkflowDefinition): string[] {
+  const { tasks, edges } = definition;
+  const names = tasks.map((t) => t.name);
+
+  // Build in-degree map and adjacency list
+  const inDegree = new Map<string, number>();
+  const adj = new Map<string, string[]>();
+  for (const name of names) {
+    inDegree.set(name, 0);
+    adj.set(name, []);
+  }
+  for (const edge of edges) {
+    adj.get(edge.from)!.push(edge.to);
+    inDegree.set(edge.to, inDegree.get(edge.to)! + 1);
+  }
+
+  // Seed queue with roots (in-degree 0)
+  const queue: string[] = [];
+  for (const name of names) {
+    if (inDegree.get(name) === 0) {
+      queue.push(name);
+    }
+  }
+
+  const sorted: string[] = [];
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    sorted.push(node);
+    for (const child of adj.get(node)!) {
+      const newDegree = inDegree.get(child)! - 1;
+      inDegree.set(child, newDegree);
+      if (newDegree === 0) {
+        queue.push(child);
+      }
+    }
+  }
+
+  return sorted;
+}


### PR DESCRIPTION
## Summary

- Adds `DAGOrchestrator` module (`runtime/src/workflow/`) for defining, submitting, and monitoring multi-step task workflows on the AgenC protocol
- Validates tree topology (single parent per task matching on-chain `depends_on: Option<Pubkey>` constraint), then submits tasks sequentially via `createTask`/`createDependentTask` with rate-limit retry
- Monitors completions via event subscriptions + polling fallback with cascade cancellation on parent failure
- Adds 4 new RuntimeErrorCodes (32-35) for workflow validation, submission, monitoring, and state errors
- 48 new vitest tests covering validation, topological sort, submitter, monitor, and orchestrator

## Test plan

- [x] `npm run build` — CJS + ESM + DTS clean
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 1766 passed (48 new + 1718 existing), 0 failed