### PR TITLE
fix(solana): critical security audit fixes (#819, #823, #828, #839)

### DIFF
--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -40,6 +40,22 @@ pub struct AgentUpdated {
     pub timestamp: i64,
 }
 
+/// Emitted when an agent is suspended by the protocol authority (fix #819)
+#[event]
+pub struct AgentSuspended {
+    pub agent_id: [u8; 32],
+    pub authority: Pubkey,
+    pub timestamp: i64,
+}
+
+/// Emitted when an agent is unsuspended by the protocol authority (fix #819)
+#[event]
+pub struct AgentUnsuspended {
+    pub agent_id: [u8; 32],
+    pub authority: Pubkey,
+    pub timestamp: i64,
+}
+
 /// Emitted when an agent deregisters
 #[event]
 pub struct AgentDeregistered {

--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -45,6 +45,8 @@ pub mod initiate_dispute;
 pub mod migrate;
 pub mod register_agent;
 pub mod resolve_dispute;
+pub mod suspend_agent;
+pub mod unsuspend_agent;
 pub mod update_agent;
 pub mod update_protocol_fee;
 pub mod update_rate_limits;
@@ -85,6 +87,10 @@ pub use migrate::*;
 pub use register_agent::*;
 #[allow(ambiguous_glob_reexports)]
 pub use resolve_dispute::*;
+#[allow(ambiguous_glob_reexports)]
+pub use suspend_agent::*;
+#[allow(ambiguous_glob_reexports)]
+pub use unsuspend_agent::*;
 #[allow(ambiguous_glob_reexports)]
 pub use update_agent::*;
 #[allow(ambiguous_glob_reexports)]

--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -95,6 +95,21 @@ pub fn handler(
     agent.active_tasks = 0;
     agent.stake = stake_amount;
     agent.bump = ctx.bumps.agent;
+
+    // Transfer stake SOL from authority to agent PDA (fix #823)
+    // Previously stake was recorded but never actually deposited
+    if stake_amount > 0 {
+        anchor_lang::system_program::transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.to_account_info(),
+                anchor_lang::system_program::Transfer {
+                    from: ctx.accounts.authority.to_account_info(),
+                    to: agent.to_account_info(),
+                },
+            ),
+            stake_amount,
+        )?;
+    }
     // Initialize rate limiting fields
     agent.last_task_created = 0;
     agent.last_dispute_initiated = 0;

--- a/programs/agenc-coordination/src/instructions/suspend_agent.rs
+++ b/programs/agenc-coordination/src/instructions/suspend_agent.rs
@@ -1,0 +1,50 @@
+//! Suspend an agent (protocol authority only)
+//!
+//! Separates suspension from `update_agent` so that only the protocol authority
+//! can suspend agents, not the agent's own authority (fix #819).
+
+use crate::errors::CoordinationError;
+use crate::events::AgentSuspended;
+use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig};
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct SuspendAgent<'info> {
+    #[account(
+        mut,
+        seeds = [b"agent", agent.agent_id.as_ref()],
+        bump = agent.bump
+    )]
+    pub agent: Account<'info, AgentRegistration>,
+
+    #[account(
+        seeds = [b"protocol"],
+        bump = protocol_config.bump,
+        has_one = authority @ CoordinationError::UnauthorizedUpgrade
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+
+    pub authority: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<SuspendAgent>) -> Result<()> {
+    let agent = &mut ctx.accounts.agent;
+
+    require!(
+        agent.status != AgentStatus::Suspended,
+        CoordinationError::AgentSuspended
+    );
+
+    agent.status = AgentStatus::Suspended;
+
+    let clock = Clock::get()?;
+    agent.last_state_update = clock.unix_timestamp;
+
+    emit!(AgentSuspended {
+        agent_id: agent.agent_id,
+        authority: ctx.accounts.authority.key(),
+        timestamp: clock.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/instructions/unsuspend_agent.rs
+++ b/programs/agenc-coordination/src/instructions/unsuspend_agent.rs
@@ -1,0 +1,50 @@
+//! Unsuspend an agent (protocol authority only)
+//!
+//! Restores a suspended agent to Inactive status. Only the protocol authority
+//! can unsuspend agents (fix #819).
+
+use crate::errors::CoordinationError;
+use crate::events::AgentUnsuspended;
+use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig};
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct UnsuspendAgent<'info> {
+    #[account(
+        mut,
+        seeds = [b"agent", agent.agent_id.as_ref()],
+        bump = agent.bump
+    )]
+    pub agent: Account<'info, AgentRegistration>,
+
+    #[account(
+        seeds = [b"protocol"],
+        bump = protocol_config.bump,
+        has_one = authority @ CoordinationError::UnauthorizedUpgrade
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+
+    pub authority: Signer<'info>,
+}
+
+pub fn handler(ctx: Context<UnsuspendAgent>) -> Result<()> {
+    let agent = &mut ctx.accounts.agent;
+
+    require!(
+        agent.status == AgentStatus::Suspended,
+        CoordinationError::InvalidInput
+    );
+
+    agent.status = AgentStatus::Inactive;
+
+    let clock = Clock::get()?;
+    agent.last_state_update = clock.unix_timestamp;
+
+    emit!(AgentUnsuspended {
+        agent_id: agent.agent_id,
+        authority: ctx.accounts.authority.key(),
+        timestamp: clock.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -67,6 +67,18 @@ pub mod agenc_coordination {
         instructions::update_agent::handler(ctx, capabilities, endpoint, metadata_uri, status)
     }
 
+    /// Suspend an agent (protocol authority only, fix #819).
+    /// Prevents the agent from claiming tasks or participating in disputes.
+    pub fn suspend_agent(ctx: Context<SuspendAgent>) -> Result<()> {
+        instructions::suspend_agent::handler(ctx)
+    }
+
+    /// Unsuspend an agent (protocol authority only, fix #819).
+    /// Restores the agent to Inactive status.
+    pub fn unsuspend_agent(ctx: Context<UnsuspendAgent>) -> Result<()> {
+        instructions::unsuspend_agent::handler(ctx)
+    }
+
     /// Deregister an agent and reclaim rent.
     /// Agent must have no active tasks.
     pub fn deregister_agent(ctx: Context<DeregisterAgent>) -> Result<()> {

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -2418,6 +2418,146 @@
       "args": []
     },
     {
+      "name": "suspend_agent",
+      "docs": [
+        "Suspend an agent (protocol authority only, fix #819).",
+        "Prevents the agent from claiming tasks or participating in disputes."
+      ],
+      "discriminator": [
+        242,
+        28,
+        54,
+        59,
+        247,
+        20,
+        59,
+        110
+      ],
+      "accounts": [
+        {
+          "name": "agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "protocol_config"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "unsuspend_agent",
+      "docs": [
+        "Unsuspend an agent (protocol authority only, fix #819).",
+        "Restores the agent to Inactive status."
+      ],
+      "discriminator": [
+        79,
+        75,
+        53,
+        57,
+        177,
+        142,
+        131,
+        149
+      ],
+      "accounts": [
+        {
+          "name": "agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "protocol_config"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
       "name": "update_agent",
       "docs": [
         "Update an existing agent's registration data.",
@@ -3175,6 +3315,32 @@
         100,
         189,
         85
+      ]
+    },
+    {
+      "name": "AgentSuspended",
+      "discriminator": [
+        219,
+        202,
+        177,
+        3,
+        116,
+        220,
+        164,
+        148
+      ]
+    },
+    {
+      "name": "AgentUnsuspended",
+      "discriminator": [
+        26,
+        114,
+        30,
+        199,
+        235,
+        91,
+        134,
+        255
       ]
     },
     {
@@ -4525,6 +4691,62 @@
           },
           {
             "name": "Suspended"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AgentSuspended",
+      "docs": [
+        "Emitted when an agent is suspended by the protocol authority (fix #819)"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AgentUnsuspended",
+      "docs": [
+        "Emitted when an agent is unsuspended by the protocol authority (fix #819)"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }

--- a/tests/complete_task_private.ts
+++ b/tests/complete_task_private.ts
@@ -20,6 +20,7 @@ import { AgencCoordination } from "../target/types/agenc_coordination";
 import {
   CAPABILITY_COMPUTE,
   TASK_TYPE_EXCLUSIVE,
+  deriveProgramDataPda,
 } from "./test-utils";
 
 describe("complete_task_private", () => {
@@ -115,17 +116,18 @@ describe("complete_task_private", () => {
 
     // Initialize protocol if not already done
     try {
+      const programDataPda = deriveProgramDataPda(program.programId);
       await program.methods
-        .initializeProtocol(51, 100, new BN(1 * LAMPORTS_PER_SOL), 1, [provider.wallet.publicKey])
+        .initializeProtocol(51, 100, new BN(1 * LAMPORTS_PER_SOL), new BN(LAMPORTS_PER_SOL / 100), 1, [provider.wallet.publicKey, treasury.publicKey])
         .accountsPartial({
           protocolConfig: protocolPda,
           treasury: treasury.publicKey,
           authority: provider.wallet.publicKey,
+          secondSigner: treasury.publicKey,
           systemProgram: SystemProgram.programId,
         })
-        .remainingAccounts([
-          { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-        ])
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
+        .signers([treasury])
         .rpc();
       treasuryPubkey = treasury.publicKey;
     } catch (e: unknown) {

--- a/tests/coordination-security.ts
+++ b/tests/coordination-security.ts
@@ -28,6 +28,7 @@ import {
   deriveDisputePda,
   deriveVotePda,
   deriveAuthorityVotePda,
+  deriveProgramDataPda,
 } from "./test-utils";
 
 describe("coordination-security", () => {
@@ -37,6 +38,7 @@ describe("coordination-security", () => {
   const program = anchor.workspace.AgencCoordination as Program<AgencCoordination>;
 
   const protocolPda = deriveProtocolPda(program.programId);
+  const programDataPda = deriveProgramDataPda(program.programId);
 
   // Generate unique run ID to prevent conflicts with persisted validator state
   const runId = generateRunId();
@@ -111,9 +113,7 @@ describe("coordination-security", () => {
           authority: provider.wallet.publicKey,
           systemProgram: SystemProgram.programId,
         })
-        .remainingAccounts([
-          { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-        ])
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
         .rpc();
       treasuryPubkey = treasury.publicKey;
       console.log("Protocol initialized with treasury:", treasuryPubkey.toString());
@@ -1629,9 +1629,7 @@ describe("coordination-security", () => {
               treasury: treasury.publicKey,
               authority: provider.wallet.publicKey,
             })
-            .remainingAccounts([
-              { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-            ])
+            .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
             .rpc();
           expect.fail("Should have failed - invalid fee");
         } catch (e: unknown) {
@@ -1655,9 +1653,7 @@ describe("coordination-security", () => {
               treasury: treasury.publicKey,
               authority: provider.wallet.publicKey,
             })
-            .remainingAccounts([
-              { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-            ])
+            .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
             .rpc();
           expect.fail("Should have failed - invalid dispute threshold");
         } catch (e: unknown) {
@@ -1681,9 +1677,7 @@ describe("coordination-security", () => {
               treasury: treasury.publicKey,
               authority: provider.wallet.publicKey,
             })
-            .remainingAccounts([
-              { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-            ])
+            .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
             .rpc();
           expect.fail("Should have failed - invalid dispute threshold > 100");
         } catch (e: unknown) {

--- a/tests/dispute-slash-logic.ts
+++ b/tests/dispute-slash-logic.ts
@@ -42,6 +42,7 @@ import {
   TASK_TYPE_EXCLUSIVE,
   RESOLUTION_TYPE_REFUND,
   getDefaultDeadline,
+  deriveProgramDataPda,
 } from "./test-utils";
 
 describe("dispute-slash-logic (issue #136)", () => {
@@ -158,9 +159,10 @@ describe("dispute-slash-logic (issue #136)", () => {
           protocolConfig: protocolPda,
           treasury: treasury.publicKey,
           authority: provider.wallet.publicKey,
-          secondSigner: secondSigner.publicKey,  // new account (fix #556)
+          secondSigner: secondSigner.publicKey,
           systemProgram: SystemProgram.programId,
         })
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
         .signers([secondSigner])
         .rpc();
       treasuryPubkey = treasury.publicKey;

--- a/tests/integration.ts
+++ b/tests/integration.ts
@@ -41,6 +41,7 @@ import {
   deriveDisputePda as deriveDisputePdaUtil,
   deriveVotePda as deriveVotePdaUtil,
   deriveAuthorityVotePda as deriveAuthorityVotePdaUtil,
+  deriveProgramDataPda,
   generateRunId,
   makeAgentId,
   makeTaskId,
@@ -76,6 +77,7 @@ describe("AgenC Integration Tests", () => {
 
   // PDAs
   let protocolConfigPda: PublicKey;
+  let programDataPda: PublicKey;
 
   // ============================================================================
   // HELPER FUNCTIONS
@@ -119,6 +121,7 @@ describe("AgenC Integration Tests", () => {
 
     // Derive protocol PDA
     protocolConfigPda = deriveProtocolPda(program.programId);
+    programDataPda = deriveProgramDataPda(program.programId);
 
     // Airdrop SOL to test accounts
     const airdropAmount = 10 * LAMPORTS_PER_SOL;
@@ -166,6 +169,7 @@ describe("AgenC Integration Tests", () => {
             authority: provider.wallet.publicKey,
             // systemProgram: auto-resolved from address field
           })
+          .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
           .rpc();
 
         treasuryPubkey = treasury.publicKey;

--- a/tests/minimal-debug.ts
+++ b/tests/minimal-debug.ts
@@ -7,6 +7,7 @@ import { Program } from "@coral-xyz/anchor";
 import BN from "bn.js";
 import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { AgencCoordination } from "../target/types/agenc_coordination";
+import { deriveProgramDataPda } from "./test-utils";
 
 describe("minimal-debug", () => {
   const provider = anchor.AnchorProvider.env();
@@ -60,6 +61,7 @@ describe("minimal-debug", () => {
       // - threshold < multisig_owners.length
       const minStake = new BN(LAMPORTS_PER_SOL / 100);  // 0.01 SOL
       const minStakeForDispute = new BN(LAMPORTS_PER_SOL / 100);  // 0.01 SOL
+      const programDataPda = deriveProgramDataPda(program.programId);
       const tx = await program.methods
         .initializeProtocol(
           51,                // dispute_threshold
@@ -76,6 +78,7 @@ describe("minimal-debug", () => {
           secondSigner: secondSigner.publicKey,  // new account (fix #556)
           systemProgram: SystemProgram.programId,
         })
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
         .signers([secondSigner])
         .rpc();
       console.log("Transaction signature:", tx);

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -30,6 +30,7 @@ import {
   createDescription,
   createHash,
   deriveProtocolPda,
+  deriveProgramDataPda,
   deriveAgentPda as _deriveAgentPda,
   deriveTaskPda as _deriveTaskPda,
   deriveEscrowPda as _deriveEscrowPda,
@@ -201,6 +202,8 @@ describe("AgenC Devnet Smoke Tests", () => {
     it("should initialize or verify protocol config", async () => {
       console.log("\n[TEST] Checking protocol initialization...");
 
+      const programDataPda = deriveProgramDataPda(program.programId);
+
       try {
         // Try to initialize protocol
         // Args: dispute_threshold, protocol_fee_bps, min_stake, min_stake_for_dispute, multisig_threshold, multisig_owners
@@ -213,11 +216,12 @@ describe("AgenC Devnet Smoke Tests", () => {
             2,                                                    // multisig_threshold: u8
             [protocolAuthority.publicKey, secondSigner.publicKey] // multisig_owners: Vec<Pubkey>
           )
-          .accounts({
+          .accountsPartial({
             treasury: treasury.publicKey,
             authority: protocolAuthority.publicKey,
             secondSigner: secondSigner.publicKey,
           })
+          .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
           .signers([protocolAuthority, secondSigner])
           .rpc();
 

--- a/tests/sybil-attack.ts
+++ b/tests/sybil-attack.ts
@@ -16,6 +16,7 @@ import {
   CAPABILITY_ARBITER,
   TASK_TYPE_EXCLUSIVE,
   RESOLUTION_TYPE_REFUND,
+  deriveProgramDataPda,
 } from "./test-utils";
 
 describe("sybil-attack", () => {
@@ -90,17 +91,18 @@ describe("sybil-attack", () => {
 
     // Initialize protocol if not already done
     try {
+      const programDataPda = deriveProgramDataPda(program.programId);
       await program.methods
-        .initializeProtocol(51, 100, new BN(1 * LAMPORTS_PER_SOL), 1, [provider.wallet.publicKey])
+        .initializeProtocol(51, 100, new BN(1 * LAMPORTS_PER_SOL), new BN(LAMPORTS_PER_SOL / 100), 1, [provider.wallet.publicKey, treasury.publicKey])
         .accountsPartial({
           protocolConfig: protocolPda,
           treasury: treasury.publicKey,
           authority: provider.wallet.publicKey,
+          secondSigner: treasury.publicKey,
           systemProgram: SystemProgram.programId,
         })
-        .remainingAccounts([
-          { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-        ])
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
+        .signers([treasury])
         .rpc();
       treasuryPubkey = treasury.publicKey;
     } catch (e: any) {

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -31,6 +31,7 @@ import {
   deriveEscrowPda,
   deriveClaimPda,
   deriveProtocolPda,
+  deriveProgramDataPda,
   generateRunId,
   makeAgentId,
   createWorkerPool,
@@ -100,6 +101,7 @@ export function setupTestContext(ctx: TestContext): void {
     try {
       const minStake = new BN(LAMPORTS_PER_SOL / 100);
       const minStakeForDispute = new BN(LAMPORTS_PER_SOL / 100);
+      const programDataPda = deriveProgramDataPda(program.programId);
       await program.methods
         .initializeProtocol(51, 100, minStake, minStakeForDispute, 1, [provider.wallet.publicKey, ctx.secondSigner.publicKey])
         .accountsPartial({
@@ -109,6 +111,7 @@ export function setupTestContext(ctx: TestContext): void {
           secondSigner: ctx.secondSigner.publicKey,
           systemProgram: SystemProgram.programId,
         })
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
         .signers([ctx.secondSigner])
         .rpc();
       ctx.treasuryPubkey = ctx.treasury.publicKey;

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -64,6 +64,22 @@ export function deriveProtocolPda(programId: PublicKey): PublicKey {
   )[0];
 }
 
+/** BPF Loader Upgradeable program ID */
+export const BPF_LOADER_UPGRADEABLE_ID = new PublicKey(
+  "BPFLoaderUpgradeab1e11111111111111111111111"
+);
+
+/**
+ * Derive the ProgramData PDA for an upgradeable program.
+ * Used for initialize_protocol's upgrade authority check (fix #839).
+ */
+export function deriveProgramDataPda(programId: PublicKey): PublicKey {
+  return PublicKey.findProgramAddressSync(
+    [programId.toBuffer()],
+    BPF_LOADER_UPGRADEABLE_ID
+  )[0];
+}
+
 /**
  * Derive an agent registration PDA from agent ID.
  */

--- a/tests/test_1.ts
+++ b/tests/test_1.ts
@@ -19,6 +19,7 @@ import {
   deriveTaskPda as _deriveTaskPda,
   deriveEscrowPda as _deriveEscrowPda,
   deriveClaimPda as _deriveClaimPda,
+  deriveProgramDataPda,
 } from "./test-utils";
 
 describe("test_1", () => {
@@ -212,6 +213,7 @@ describe("test_1", () => {
       // - threshold < multisig_owners.length
       const minStake = new BN(LAMPORTS_PER_SOL / 100);  // 0.01 SOL = 10_000_000 lamports
       const minStakeForDispute = new BN(LAMPORTS_PER_SOL / 100);  // 0.01 SOL
+      const programDataPda = deriveProgramDataPda(program.programId);
       await program.methods
         .initializeProtocol(
           51,                // dispute_threshold
@@ -228,6 +230,7 @@ describe("test_1", () => {
           secondSigner: secondSigner.publicKey,  // new account (fix #556)
           systemProgram: SystemProgram.programId,
         })
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
         .signers([secondSigner])
         .rpc();
       treasuryPubkey = treasury.publicKey;
@@ -4048,6 +4051,7 @@ describe("test_1", () => {
         // The protocol is already initialized in the before() hook
         // Trying to initialize again should fail because PDA already exists
         try {
+          const programDataPda = deriveProgramDataPda(program.programId);
           await program.methods
             .initializeProtocol(51, 100, 1 * LAMPORTS_PER_SOL)
             .accountsPartial({
@@ -4056,6 +4060,7 @@ describe("test_1", () => {
               authority: provider.wallet.publicKey,
               systemProgram: SystemProgram.programId,
             })
+            .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
             .rpc();
           expect.fail("Should have failed");
         } catch (e: unknown) {

--- a/tests/test_cu_benchmarks.ts
+++ b/tests/test_cu_benchmarks.ts
@@ -26,6 +26,7 @@ import {
   deriveEscrowPda,
   deriveClaimPda,
   deriveProtocolPda,
+  deriveProgramDataPda,
   generateRunId,
   makeAgentId,
 } from "./test-utils";
@@ -131,6 +132,7 @@ describe("CU Benchmarks", () => {
           secondSigner: secondSigner.publicKey,
           systemProgram: SystemProgram.programId,
         })
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
         .signers([secondSigner])
         .rpc();
     } catch {

--- a/tests/upgrades.ts
+++ b/tests/upgrades.ts
@@ -4,6 +4,7 @@ import BN from "bn.js";
 import { expect } from "chai";
 import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { AgencCoordination } from "../target/types/agenc_coordination";
+import { deriveProgramDataPda } from "./test-utils";
 
 describe("upgrades", () => {
   const provider = anchor.AnchorProvider.env();
@@ -15,6 +16,8 @@ describe("upgrades", () => {
     [Buffer.from("protocol")],
     program.programId
   );
+
+  const programDataPda = deriveProgramDataPda(program.programId);
 
   const CURRENT_PROTOCOL_VERSION = 1;
   const FUTURE_PROTOCOL_VERSION = CURRENT_PROTOCOL_VERSION + 1;
@@ -72,10 +75,7 @@ describe("upgrades", () => {
           treasury: treasury.publicKey,
           authority: provider.wallet.publicKey,
         })
-        .remainingAccounts([
-          { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-          { pubkey: multisigSigner.publicKey, isSigner: true, isWritable: false },
-        ])
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
         .signers([multisigSigner])
         .rpc();
     } catch (e) {

--- a/tests/zk-proof-lifecycle.ts
+++ b/tests/zk-proof-lifecycle.ts
@@ -27,6 +27,7 @@ import {
   CAPABILITY_COMPUTE,
   TASK_TYPE_EXCLUSIVE,
   TASK_TYPE_COMPETITIVE,
+  deriveProgramDataPda,
 } from "./test-utils";
 
 describe("ZK Proof Verification Lifecycle", () => {
@@ -206,17 +207,18 @@ describe("ZK Proof Verification Lifecycle", () => {
 
     // Initialize protocol
     try {
+      const programDataPda = deriveProgramDataPda(program.programId);
       await program.methods
-        .initializeProtocol(51, 100, new BN(LAMPORTS_PER_SOL / 10), 1, [provider.wallet.publicKey])
+        .initializeProtocol(51, 100, new BN(LAMPORTS_PER_SOL / 10), new BN(LAMPORTS_PER_SOL / 100), 1, [provider.wallet.publicKey, treasury.publicKey])
         .accountsPartial({
           protocolConfig: protocolPda,
           treasury: treasury.publicKey,
           authority: provider.wallet.publicKey,
+          secondSigner: treasury.publicKey,
           systemProgram: SystemProgram.programId,
         })
-        .remainingAccounts([
-          { pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false },
-        ])
+        .remainingAccounts([{ pubkey: deriveProgramDataPda(program.programId), isSigner: false, isWritable: false }])
+        .signers([treasury])
         .rpc();
       treasuryPubkey = treasury.publicKey;
     } catch (e) {


### PR DESCRIPTION
## Summary

Fixes 4 critical-severity findings from the security audit:

- **#819 — Agent suspension broken**: Split suspension into dedicated `suspend_agent` and `unsuspend_agent` instructions restricted to protocol authority only. `update_agent` no longer allows setting `Suspended` status. Adds `AgentSuspended` and `AgentUnsuspended` events.

- **#823 — Stake not deposited at registration**: `register_agent` now performs `system_program::transfer` of stake SOL from authority to agent PDA. Previously only the `stake` field was set as bookkeeping, enabling fake stake inflation (20,000x) and broken slashing.

- **#828 — expire_dispute fund redirection**: Added validation requiring `worker` account when `worker_authority` is provided. Prevents attackers from providing only `worker_authority` (pointing to their wallet) to redirect expired dispute funds.

- **#839 — Protocol init takeover (first-caller-wins)**: `initialize_protocol` now validates the caller is the program's upgrade authority by verifying the BPF Loader Upgradeable ProgramData account via PDA derivation, owner check, and authority match. Passed via `remaining_accounts[0]`.

## Changes

**New files:**
- `suspend_agent.rs` — Protocol authority suspends agents
- `unsuspend_agent.rs` — Protocol authority restores suspended agents to Inactive

**Modified Rust:**
- `initialize_protocol.rs` — Upgrade authority check via ProgramData in remaining_accounts
- `register_agent.rs` — SOL transfer for stake deposit
- `expire_dispute.rs` — worker_authority requires worker validation
- `update_agent.rs` — Removed suspension path (status=3 returns InvalidInput)
- `events.rs` — AgentSuspended, AgentUnsuspended events
- `lib.rs`, `mod.rs` — New instruction registrations

**Test updates:**
- All 15 test files updated to pass ProgramData PDA via `.remainingAccounts()`
- `test-utils.ts` — Added `deriveProgramDataPda()` helper

## Test plan

- [x] `anchor build` compiles cleanly
- [x] `anchor test` — 143 passing (3 pre-existing failures from #829, unrelated)
- [ ] Manual verification: `suspend_agent` only callable by protocol authority
- [ ] Manual verification: `register_agent` actually transfers SOL
- [ ] Manual verification: `expire_dispute` rejects worker_authority without worker
- [ ] Manual verification: `initialize_protocol` rejects non-upgrade-authority callers

Closes #819, closes #823, closes #828, closes #839