### PR TITLE
fix(solana): decrement disputes_as_defendant in all dispute cleanup paths

### DIFF
--- a/programs/agenc-coordination/src/instructions/dispute_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/dispute_helpers.rs
@@ -121,6 +121,9 @@ pub(crate) fn process_worker_claim_pair(
     let mut worker_reg = AgentRegistration::try_deserialize(&mut &**worker_data)?;
     // Using saturating_sub intentionally - underflow returns 0 (safe counter decrement)
     worker_reg.active_tasks = worker_reg.active_tasks.saturating_sub(1);
+    // Decrement disputes_as_defendant (fix #821)
+    // Using saturating_sub intentionally - underflow returns 0 (safe counter decrement)
+    worker_reg.disputes_as_defendant = worker_reg.disputes_as_defendant.saturating_sub(1);
     worker_reg.try_serialize(&mut &mut worker_data[8..])?;
 
     Ok(())

--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -211,6 +211,9 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
             .active_tasks
             .checked_sub(1)
             .ok_or(CoordinationError::ArithmeticOverflow)?;
+        // Decrement disputes_as_defendant (fix #821)
+        // Using saturating_sub intentionally - underflow returns 0 (safe counter decrement)
+        worker_reg.disputes_as_defendant = worker_reg.disputes_as_defendant.saturating_sub(1);
         worker_reg.try_serialize(&mut &mut worker_data[8..])?;
     }
 


### PR DESCRIPTION
## Summary
- Fixes inconsistent `disputes_as_defendant` cleanup in dispute resolution paths
- Adds decrements to `resolve_dispute`, `expire_dispute`, and `cancel_dispute` instructions
- Previously only decremented in `apply_dispute_slash`, causing worker lockup

Fixes #821

## Test plan
- [ ] Build passes with `cargo build-sbf`
- [ ] Integration tests pass with `anchor test`
- [ ] Manual testing of dispute lifecycle