### PR TITLE
fix(solana): defer escrow closure until final collaborative completion (#829)

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -161,7 +161,7 @@ pub fn handler(
 
     log_compute_units("complete_task_validated");
 
-    // Execute reward transfer, state updates, and event emissions
+    // Execute reward transfer, state updates, event emissions, and conditional escrow closure
     execute_completion_rewards(
         task,
         claim,
@@ -170,17 +170,11 @@ pub fn handler(
         &mut ctx.accounts.protocol_config,
         &ctx.accounts.authority.to_account_info(),
         &ctx.accounts.treasury.to_account_info(),
+        &ctx.accounts.creator.to_account_info(),
         protocol_fee_bps,
         Some(claim_result_data),
         &clock,
     )?;
-
-    // Only close escrow when task is fully completed (all required completions done).
-    // For collaborative tasks with max_workers > 1, this keeps the escrow open
-    // for subsequent workers to complete and receive their share.
-    if task.status == TaskStatus::Completed {
-        escrow.close(ctx.accounts.creator.to_account_info())?;
-    }
 
     log_compute_units("complete_task_done");
 


### PR DESCRIPTION
Fixes #829

## Problem

Both `complete_task` and `complete_task_private` used Anchor's `close = creator` constraint on the escrow account, which unconditionally drained the escrow after the first completion. On collaborative tasks requiring multiple completions (`required_completions > 1`), the second worker's completion failed with `AccountNotInitialized` because the escrow was already closed.

## Solution

- Removed the `close = creator` constraint from both instruction handlers
- Implemented manual escrow closure in `close_escrow_to_creator()` helper function
- Made escrow closure conditional in `execute_completion_rewards()` - only closes when `task_completed` is true (i.e., `task.completions >= task.required_completions`)
- For intermediate completions on collaborative tasks, the escrow stays open and only transfers the worker's share

## Changes

- `complete_task.rs`: Removed `close = creator` constraint, added `creator_info` parameter to `execute_completion_rewards()`
- `complete_task_private.rs`: Same changes as `complete_task.rs`
- `completion_helpers.rs`: Added `close_escrow_to_creator()` function and conditional closure logic

## Testing

- Program builds successfully with `cargo build-sbf`
- The fix preserves the escrow for intermediate completions while properly closing it on the final completion