### PR TITLE
fix(solana): prevent self-task claim to block reputation farming (#831)

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -452,4 +452,7 @@ pub enum CoordinationError {
     // Security errors (7700-7799)
     #[msg("Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use.")]
     DevelopmentKeyNotAllowed,
+
+    #[msg("Cannot claim own task: worker authority matches task creator")]
+    SelfTaskNotAllowed,
 }


### PR DESCRIPTION
Fixes #831

## Summary
Prevents reputation farming via self-task loop by adding a check in  that rejects claims where the worker's authority wallet matches the task creator.

## Changes
- Added  error to 
- Added validation in  to compare  against  before allowing claim
- Without this check, the same wallet could create, claim, and complete its own task, gaining +100 reputation per cycle at near-zero cost

## Testing
- Compiled successfully with 