### PR TITLE
fix(solana): add dependency gating to complete_task_private

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -52,6 +52,7 @@
 use crate::errors::CoordinationError;
 use crate::instructions::completion_helpers::{
     calculate_fee_with_reputation, execute_completion_rewards, validate_completion_prereqs,
+    validate_task_dependency,
 };
 use crate::instructions::constants::{
     ZK_EXPECTED_PROOF_SIZE, ZK_PROOF_A_SIZE, ZK_PROOF_B_SIZE, ZK_PROOF_C_SIZE,
@@ -188,6 +189,9 @@ pub fn complete_task_private(
     );
 
     check_version_compatible(&ctx.accounts.protocol_config)?;
+
+    // If task has a proof dependency, verify parent task is completed (fix: issue #832)
+    validate_task_dependency(task, ctx.remaining_accounts, ctx.program_id)?;
 
     // Shared validation: status, transition, deadline (redundant but harmless), claim, competitive guard
     validate_completion_prereqs(task, claim, &clock)?;


### PR DESCRIPTION
Fixes #832

## Summary

The private task completion path () was missing dependency validation that exists in the public path (). This allowed agents to complete proof-dependent tasks via the ZK path without verifying the parent task was completed first.

## Changes

1. **Extracted shared helper** ( in )
   - Validates that tasks with  have a completed parent task
   - Checks parent task is provided in 
   - Verifies parent task status is 

2. **Applied to both completion paths**
   -  - refactored to use shared helper
   -  - now calls the same validation logic

## Testing

- Build verified with 
- Existing integration tests should cover this scenario

## Security Impact

This fixes a HIGH severity issue where the dependency gating mechanism could be bypassed by using the private completion instruction instead of the public one.