### PR TITLE
fix(solana): enforce system-program ownership for init multisig signers (#840)

### DIFF
--- a/programs/agenc-coordination/src/instructions/initialize_protocol.rs
+++ b/programs/agenc-coordination/src/instructions/initialize_protocol.rs
@@ -174,7 +174,11 @@ pub fn handler(
 
     // Add any additional signers from remaining_accounts (skip [0] which is ProgramData)
     for acc in ctx.remaining_accounts.iter().skip(1) {
+        // Fix #840: Match require_multisig validation — only system-owned accounts
+        // can be valid multisig signers. This prevents PDAs that are signers via CPI
+        // from being counted during initialization but rejected during runtime operations.
         if acc.is_signer
+            && acc.owner == &anchor_lang::system_program::ID
             && multisig_owners.contains(acc.key)
             && acc.key != &ctx.accounts.authority.key()
             && acc.key != &ctx.accounts.second_signer.key()


### PR DESCRIPTION
Fixes #840

## Problem

Protocol initialization counted signers by checking `acc.is_signer` only. The runtime `require_multisig` function additionally checks `account.owner == system_program::ID`, rejecting non-wallet accounts. This meant a PDA that is a signer via CPI context could count as a valid multisig signer during initialization but would be rejected during any subsequent multisig operation.

## Solution

Added the same `account.owner == system_program::ID` check in `initialize_protocol` that `require_multisig` uses. This ensures only system-owned (wallet) accounts can be counted as valid multisig signers during initialization, maintaining consistency with runtime validation.

## Changes

- Updated signer validation loop in `initialize_protocol.rs` to check `acc.owner == &anchor_lang::system_program::ID`
- Added comment explaining the fix and its purpose

## Testing

- Program builds successfully with `cargo build-sbf`
- Validation logic now matches `require_multisig` behavior exactly