### PR TITLE
fix(solana): return claim rent to worker authority on dispute resolution (#838)

### DIFF
--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -314,10 +314,15 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
     dispute.resolved_at = clock.unix_timestamp;
     escrow.is_closed = true;
 
-    // Close worker_claim account and return lamports to creator (fix #439)
-    // The claim is no longer needed once the dispute is resolved
+    // Close worker_claim account and return rent lamports to worker authority (fix #838)
+    // The claim rent was paid by worker authority at creation, so return it there
     if let Some(claim) = ctx.accounts.worker_claim.as_ref() {
-        claim.close(ctx.accounts.creator.to_account_info())?;
+        if let Some(worker_authority) = &ctx.accounts.worker_authority {
+            claim.close(worker_authority.to_account_info())?;
+        } else {
+            // No worker authority provided (refund-only resolution) - return to creator as fallback
+            claim.close(ctx.accounts.creator.to_account_info())?;
+        }
     }
 
     emit!(DisputeResolved {


### PR DESCRIPTION
Fixes #838

## Summary

The claim account rent was being incorrectly returned to the task creator on dispute resolution, even though the worker's authority paid for the claim account creation.

## Changes

Updated  to return claim rent lamports to the worker's authority wallet instead of the creator:
- When closing the claim account, the rent now goes to  (the original payer)
- Falls back to creator only when no worker authority is provided (refund-only resolutions)

## Verification

- Confirmed  shows  for claim account creation
- Program compiles successfully with 