### PR TITLE
test(spl-token): add SPL token integration tests and fix existing tests

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -22,9 +22,10 @@ wallet = "~/.config/solana/id.json"
 [test]
 startup_wait = 120000
 shutdown_wait = 5000
+upgradeable = true
 
 [scripts]
-test = "npx ts-mocha -p ./tsconfig.json -t 300000 tests/test_1.ts tests/dispute-slash-logic.ts"
+test = "npx ts-mocha -p ./tsconfig.json -t 300000 tests/test_1.ts tests/dispute-slash-logic.ts tests/spl-token-tasks.ts"
 
 [workspace]
 members = ["programs/agenc-coordination"]

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@solana/web3.js": "^1.95.0"
   },
   "devDependencies": {
+    "@solana/spl-token": "0.4.6",
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.0",

--- a/tests/dispute-slash-logic.ts
+++ b/tests/dispute-slash-logic.ts
@@ -251,6 +251,7 @@ describe("dispute-slash-logic (issue #136)", () => {
       const creatorAgentPda = deriveAgentPda(creatorAgentId);
       const workerAgentPda = deriveAgentPda(workerAgentId);
       const taskPda = deriveTaskPda(creator.publicKey, taskId);
+      const escrowPda = deriveEscrowPda(taskPda);
       const claimPda = deriveClaimPda(taskPda, workerAgentPda);
       const disputePda = deriveDisputePda(disputeId);
 
@@ -266,11 +267,21 @@ describe("dispute-slash-logic (issue #136)", () => {
           TASK_TYPE_EXCLUSIVE,
           null,
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
+          task: taskPda,
+          escrow: escrowPda,
+          protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -345,6 +356,7 @@ describe("dispute-slash-logic (issue #136)", () => {
       const workerAgentPda = deriveAgentPda(workerAgentId);
       const arbiter1Pda = deriveAgentPda(arbiter1AgentId);
       const taskPda = deriveTaskPda(creator.publicKey, taskId);
+      const escrowPda = deriveEscrowPda(taskPda);
       const claimPda = deriveClaimPda(taskPda, workerAgentPda);
       const disputePda = deriveDisputePda(disputeId);
       const votePda = deriveVotePda(disputePda, arbiter1Pda);
@@ -361,11 +373,21 @@ describe("dispute-slash-logic (issue #136)", () => {
           TASK_TYPE_EXCLUSIVE,
           null,
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
+          task: taskPda,
+          escrow: escrowPda,
+          protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -424,6 +446,7 @@ describe("dispute-slash-logic (issue #136)", () => {
           dispute: disputePda,
           task: taskPda,
           workerClaim: claimPda,
+          defendantAgent: null,
           vote: votePda,
           authorityVote: authorityVotePda,
           arbiter: arbiter1Pda,
@@ -539,6 +562,7 @@ describe("dispute-slash-logic (issue #136)", () => {
       const workerAgentPda = deriveAgentPda(workerAgentId);
       const workerBPda = deriveAgentPda(workerBAgentId);
       const taskPda = deriveTaskPda(creator.publicKey, taskId);
+      const escrowPda = deriveEscrowPda(taskPda);
       const claimAPda = deriveClaimPda(taskPda, workerAgentPda);
       const claimBPda = deriveClaimPda(taskPda, workerBPda);
       const disputePda = deriveDisputePda(disputeId);
@@ -555,11 +579,21 @@ describe("dispute-slash-logic (issue #136)", () => {
           TASK_TYPE_COLLABORATIVE,
           null,
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
+          task: taskPda,
+          escrow: escrowPda,
+          protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();

--- a/tests/spl-token-tasks.ts
+++ b/tests/spl-token-tasks.ts
@@ -1,0 +1,1370 @@
+/**
+ * SPL Token Task Integration Tests (Issue #860)
+ *
+ * Tests the optional SPL token escrow support added in PR #864.
+ * Verifies token-denominated task creation, completion, cancellation,
+ * and dispute initiation across all supported task types.
+ *
+ * Test Strategy:
+ * - Happy path: create, claim, complete, cancel with SPL tokens
+ * - Edge cases: SOL regression, missing accounts, insufficient balance,
+ *   competitive/collaborative token tasks, minimum amounts, 0-decimal mints
+ * - Fee verification: protocol fees in tokens, not SOL
+ * - Dispute preconditions: initiate + vote on token tasks (resolution
+ *   requires time warp, so only preconditions are tested)
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { expect } from "chai";
+import {
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  LAMPORTS_PER_SOL,
+} from "@solana/web3.js";
+import {
+  createMint,
+  createAssociatedTokenAccount,
+  mintTo,
+  getAccount,
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from "@solana/spl-token";
+import { AgencCoordination } from "../target/types/agenc_coordination";
+import {
+  CAPABILITY_COMPUTE,
+  CAPABILITY_ARBITER,
+  TASK_TYPE_EXCLUSIVE,
+  TASK_TYPE_COLLABORATIVE,
+  TASK_TYPE_COMPETITIVE,
+  RESOLUTION_TYPE_REFUND,
+  getDefaultDeadline,
+  deriveProgramDataPda,
+} from "./test-utils";
+
+describe("spl-token-tasks (issue #860)", () => {
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  const program = anchor.workspace
+    .AgencCoordination as Program<AgencCoordination>;
+
+  const [protocolPda] = PublicKey.findProgramAddressSync(
+    [Buffer.from("protocol")],
+    program.programId
+  );
+
+  const runId =
+    Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+
+  // Wallets
+  let treasury: Keypair;
+  let treasuryPubkey: PublicKey;
+  let secondSigner: Keypair;
+  let creator: Keypair;
+  let worker: Keypair;
+  let worker2: Keypair;
+  let arbiter1: Keypair;
+  let arbiter2: Keypair;
+
+  // Agent IDs
+  let creatorAgentId: Buffer;
+  let workerAgentId: Buffer;
+  let worker2AgentId: Buffer;
+  let arbiter1AgentId: Buffer;
+  let arbiter2AgentId: Buffer;
+
+  // Token state
+  let mint: PublicKey;
+  let creatorAta: PublicKey;
+  let workerAta: PublicKey;
+  let worker2Ata: PublicKey;
+  let treasuryAta: PublicKey;
+
+  // 0-decimal mint for edge case
+  let zeroDecMint: PublicKey;
+  let zeroDecCreatorAta: PublicKey;
+  let zeroDecWorkerAta: PublicKey;
+  let zeroDecTreasuryAta: PublicKey;
+
+  // Protocol fee: 100 bps = 1%
+  const PROTOCOL_FEE_BPS = 100;
+
+  const VALID_EVIDENCE =
+    "This is valid dispute evidence that exceeds the minimum 50 character requirement for the dispute system.";
+
+  let minAgentStake: number = LAMPORTS_PER_SOL;
+  let minArbiterStake: number = LAMPORTS_PER_SOL;
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  function makeId(prefix: string): Buffer {
+    return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+  }
+
+  const deriveAgentPda = (agentId: Buffer) =>
+    PublicKey.findProgramAddressSync(
+      [Buffer.from("agent"), agentId],
+      program.programId
+    )[0];
+
+  const deriveTaskPda = (creatorKey: PublicKey, taskId: Buffer) =>
+    PublicKey.findProgramAddressSync(
+      [Buffer.from("task"), creatorKey.toBuffer(), taskId],
+      program.programId
+    )[0];
+
+  const deriveEscrowPda = (taskPda: PublicKey) =>
+    PublicKey.findProgramAddressSync(
+      [Buffer.from("escrow"), taskPda.toBuffer()],
+      program.programId
+    )[0];
+
+  const deriveClaimPda = (taskPda: PublicKey, workerPda: PublicKey) =>
+    PublicKey.findProgramAddressSync(
+      [Buffer.from("claim"), taskPda.toBuffer(), workerPda.toBuffer()],
+      program.programId
+    )[0];
+
+  const deriveDisputePda = (disputeId: Buffer) =>
+    PublicKey.findProgramAddressSync(
+      [Buffer.from("dispute"), disputeId],
+      program.programId
+    )[0];
+
+  const deriveVotePda = (disputePda: PublicKey, arbiterPda: PublicKey) =>
+    PublicKey.findProgramAddressSync(
+      [Buffer.from("vote"), disputePda.toBuffer(), arbiterPda.toBuffer()],
+      program.programId
+    )[0];
+
+  const deriveAuthorityVotePda = (
+    disputePda: PublicKey,
+    authorityPubkey: PublicKey
+  ) =>
+    PublicKey.findProgramAddressSync(
+      [
+        Buffer.from("authority_vote"),
+        disputePda.toBuffer(),
+        authorityPubkey.toBuffer(),
+      ],
+      program.programId
+    )[0];
+
+  /** Derive escrow's ATA for the given mint (allowOwnerOffCurve for PDA) */
+  const deriveEscrowAta = (tokenMint: PublicKey, escrowPda: PublicKey) =>
+    getAssociatedTokenAddressSync(tokenMint, escrowPda, true);
+
+  /** Fetch token balance as bigint */
+  async function getTokenBalance(ata: PublicKey): Promise<bigint> {
+    const acct = await getAccount(provider.connection, ata);
+    return acct.amount;
+  }
+
+  const airdrop = async (
+    wallets: Keypair[],
+    amount: number = 20 * LAMPORTS_PER_SOL
+  ) => {
+    for (const wallet of wallets) {
+      await provider.connection.confirmTransaction(
+        await provider.connection.requestAirdrop(wallet.publicKey, amount),
+        "confirmed"
+      );
+    }
+  };
+
+  const payer = (): Keypair => (provider.wallet as any).payer;
+
+  const ensureProtocol = async () => {
+    try {
+      const config =
+        await program.account.protocolConfig.fetch(protocolPda);
+      treasuryPubkey = config.treasury;
+      minAgentStake = Math.max(
+        config.minAgentStake.toNumber(),
+        LAMPORTS_PER_SOL
+      );
+      minArbiterStake = Math.max(
+        config.minArbiterStake.toNumber(),
+        minAgentStake
+      );
+    } catch {
+      const minStake = new BN(LAMPORTS_PER_SOL);
+      const minStakeForDispute = new BN(LAMPORTS_PER_SOL / 10);
+      await program.methods
+        .initializeProtocol(
+          51,
+          PROTOCOL_FEE_BPS,
+          minStake,
+          minStakeForDispute,
+          1,
+          [provider.wallet.publicKey, secondSigner.publicKey]
+        )
+        .accountsPartial({
+          protocolConfig: protocolPda,
+          treasury: treasury.publicKey,
+          authority: provider.wallet.publicKey,
+          secondSigner: secondSigner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .remainingAccounts([
+          {
+            pubkey: deriveProgramDataPda(program.programId),
+            isSigner: false,
+            isWritable: false,
+          },
+        ])
+        .signers([secondSigner])
+        .rpc();
+      treasuryPubkey = treasury.publicKey;
+      minAgentStake = LAMPORTS_PER_SOL;
+      minArbiterStake = LAMPORTS_PER_SOL;
+    }
+
+    // Disable rate limiting for tests
+    try {
+      await program.methods
+        .updateRateLimits(
+          new BN(0),
+          0,
+          new BN(0),
+          0,
+          new BN(LAMPORTS_PER_SOL / 100)
+        )
+        .accountsPartial({ protocolConfig: protocolPda })
+        .remainingAccounts([
+          {
+            pubkey: provider.wallet.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
+        ])
+        .rpc();
+    } catch {
+      // May already be configured
+    }
+  };
+
+  const registerAgent = async (
+    agentId: Buffer,
+    authority: Keypair,
+    capabilities: number,
+    stake: number = 0
+  ) => {
+    const agentPda = deriveAgentPda(agentId);
+    try {
+      await program.account.agentRegistration.fetch(agentPda);
+    } catch {
+      await program.methods
+        .registerAgent(
+          Array.from(agentId),
+          new BN(capabilities),
+          "https://example.com",
+          null,
+          new BN(stake)
+        )
+        .accountsPartial({
+          agent: agentPda,
+          protocolConfig: protocolPda,
+          authority: authority.publicKey,
+        })
+        .signers([authority])
+        .rpc();
+    }
+    return agentPda;
+  };
+
+  /** Create a token-denominated task, returning all relevant PDAs */
+  async function createTokenTask(opts: {
+    taskId: Buffer;
+    tokenMint: PublicKey;
+    creatorKp: Keypair;
+    creatorAgentPda: PublicKey;
+    creatorTokenAccount: PublicKey;
+    rewardAmount: number;
+    maxWorkers?: number;
+    taskType?: number;
+    constraintHash?: number[] | null;
+  }) {
+    const taskPda = deriveTaskPda(opts.creatorKp.publicKey, opts.taskId);
+    const escrowPda = deriveEscrowPda(taskPda);
+    const escrowAta = deriveEscrowAta(opts.tokenMint, escrowPda);
+
+    await program.methods
+      .createTask(
+        Array.from(opts.taskId),
+        new BN(CAPABILITY_COMPUTE),
+        Buffer.from("Token task description".padEnd(64, "\0")),
+        new BN(opts.rewardAmount),
+        opts.maxWorkers ?? 1,
+        getDefaultDeadline(),
+        opts.taskType ?? TASK_TYPE_EXCLUSIVE,
+        opts.constraintHash ?? null,
+        0,
+        opts.tokenMint
+      )
+      .accountsPartial({
+        task: taskPda,
+        escrow: escrowPda,
+        protocolConfig: protocolPda,
+        creatorAgent: opts.creatorAgentPda,
+        authority: opts.creatorKp.publicKey,
+        creator: opts.creatorKp.publicKey,
+        systemProgram: SystemProgram.programId,
+        rewardMint: opts.tokenMint,
+        creatorTokenAccount: opts.creatorTokenAccount,
+        tokenEscrowAta: escrowAta,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+      })
+      .signers([opts.creatorKp])
+      .rpc();
+
+    return { taskPda, escrowPda, escrowAta };
+  }
+
+  /** Claim a task (no token accounts needed) */
+  async function claimTask(
+    taskPda: PublicKey,
+    workerAgentPda: PublicKey,
+    workerKp: Keypair
+  ) {
+    const claimPda = deriveClaimPda(taskPda, workerAgentPda);
+    await program.methods
+      .claimTask()
+      .accountsPartial({
+        task: taskPda,
+        claim: claimPda,
+        protocolConfig: protocolPda,
+        worker: workerAgentPda,
+        authority: workerKp.publicKey,
+      })
+      .signers([workerKp])
+      .rpc();
+    return claimPda;
+  }
+
+  /** Complete a token-denominated task */
+  async function completeTokenTask(opts: {
+    taskPda: PublicKey;
+    claimPda: PublicKey;
+    escrowPda: PublicKey;
+    escrowAta: PublicKey;
+    workerAgentPda: PublicKey;
+    workerKp: Keypair;
+    workerTokenAccount: PublicKey;
+    tokenMint: PublicKey;
+    treasuryTokenAccount: PublicKey;
+  }) {
+    await program.methods
+      .completeTask(
+        Array.from(Buffer.from("proof-hash".padEnd(32, "\0"))),
+        Buffer.from("result-data".padEnd(64, "\0"))
+      )
+      .accountsPartial({
+        task: opts.taskPda,
+        claim: opts.claimPda,
+        escrow: opts.escrowPda,
+        creator: creator.publicKey,
+        worker: opts.workerAgentPda,
+        protocolConfig: protocolPda,
+        treasury: treasuryPubkey,
+        authority: opts.workerKp.publicKey,
+        systemProgram: SystemProgram.programId,
+        tokenEscrowAta: opts.escrowAta,
+        workerTokenAccount: opts.workerTokenAccount,
+        treasuryTokenAccount: opts.treasuryTokenAccount,
+        rewardMint: opts.tokenMint,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      })
+      .signers([opts.workerKp])
+      .rpc();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Setup
+  // ---------------------------------------------------------------------------
+
+  before(async () => {
+    treasury = Keypair.generate();
+    secondSigner = Keypair.generate();
+    creator = Keypair.generate();
+    worker = Keypair.generate();
+    worker2 = Keypair.generate();
+    arbiter1 = Keypair.generate();
+    arbiter2 = Keypair.generate();
+
+    creatorAgentId = makeId("cre");
+    workerAgentId = makeId("wrk");
+    worker2AgentId = makeId("wr2");
+    arbiter1AgentId = makeId("ar1");
+    arbiter2AgentId = makeId("ar2");
+
+    // Airdrop SOL
+    await airdrop([
+      treasury,
+      secondSigner,
+      creator,
+      worker,
+      worker2,
+      arbiter1,
+      arbiter2,
+    ]);
+
+    await ensureProtocol();
+
+    // Register agents
+    await registerAgent(creatorAgentId, creator, CAPABILITY_COMPUTE, minAgentStake);
+    await registerAgent(workerAgentId, worker, CAPABILITY_COMPUTE, minAgentStake);
+    await registerAgent(worker2AgentId, worker2, CAPABILITY_COMPUTE, minAgentStake);
+    await registerAgent(arbiter1AgentId, arbiter1, CAPABILITY_ARBITER, minArbiterStake);
+    await registerAgent(arbiter2AgentId, arbiter2, CAPABILITY_ARBITER, minArbiterStake);
+
+    // Create 9-decimal test mint
+    mint = await createMint(
+      provider.connection,
+      payer(),
+      payer().publicKey,
+      null,
+      9
+    );
+
+    // Create ATAs
+    creatorAta = await createAssociatedTokenAccount(
+      provider.connection,
+      payer(),
+      mint,
+      creator.publicKey
+    );
+    workerAta = await createAssociatedTokenAccount(
+      provider.connection,
+      payer(),
+      mint,
+      worker.publicKey
+    );
+    worker2Ata = await createAssociatedTokenAccount(
+      provider.connection,
+      payer(),
+      mint,
+      worker2.publicKey
+    );
+    treasuryAta = await createAssociatedTokenAccount(
+      provider.connection,
+      payer(),
+      mint,
+      treasuryPubkey
+    );
+
+    // Mint 100 tokens (100 * 10^9) to creator
+    await mintTo(
+      provider.connection,
+      payer(),
+      mint,
+      creatorAta,
+      payer(),
+      100_000_000_000n
+    );
+
+    // Create 0-decimal mint + ATAs for edge case
+    zeroDecMint = await createMint(
+      provider.connection,
+      payer(),
+      payer().publicKey,
+      null,
+      0
+    );
+    zeroDecCreatorAta = await createAssociatedTokenAccount(
+      provider.connection,
+      payer(),
+      zeroDecMint,
+      creator.publicKey
+    );
+    zeroDecWorkerAta = await createAssociatedTokenAccount(
+      provider.connection,
+      payer(),
+      zeroDecMint,
+      worker.publicKey
+    );
+    zeroDecTreasuryAta = await createAssociatedTokenAccount(
+      provider.connection,
+      payer(),
+      zeroDecMint,
+      treasuryPubkey
+    );
+
+    // Mint 1000 whole tokens to creator (0-decimal)
+    await mintTo(
+      provider.connection,
+      payer(),
+      zeroDecMint,
+      zeroDecCreatorAta,
+      payer(),
+      1000n
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Happy Path
+  // ---------------------------------------------------------------------------
+
+  describe("happy path", () => {
+    it("should create a token-denominated task with escrow funded", async () => {
+      const taskId = makeId("t-create");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const rewardAmount = 1_000_000_000; // 1 token
+
+      const creatorBefore = await getTokenBalance(creatorAta);
+
+      const { taskPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+      });
+
+      // Verify task has reward_mint set
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.rewardMint).to.not.be.null;
+      expect(task.rewardMint!.toBase58()).to.equal(mint.toBase58());
+
+      // Verify escrow ATA funded
+      const escrowBalance = await getTokenBalance(escrowAta);
+      expect(Number(escrowBalance)).to.equal(rewardAmount);
+
+      // Verify creator debited
+      const creatorAfter = await getTokenBalance(creatorAta);
+      expect(Number(creatorBefore - creatorAfter)).to.equal(rewardAmount);
+    });
+
+    it("should claim a token task (no token accounts needed)", async () => {
+      const taskId = makeId("t-claim");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+
+      const { taskPda } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount: 500_000_000,
+      });
+
+      const claimPda = await claimTask(taskPda, workerAgentPda, worker);
+      const claim = await program.account.taskClaim.fetch(claimPda);
+      expect(claim.task.toBase58()).to.equal(taskPda.toBase58());
+    });
+
+    it("should complete a token task with correct fee distribution", async () => {
+      const taskId = makeId("t-compl");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+      const rewardAmount = 10_000_000_000; // 10 tokens
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+      });
+
+      const claimPda = await claimTask(taskPda, workerAgentPda, worker);
+
+      const workerBefore = await getTokenBalance(workerAta);
+      const treasuryBefore = await getTokenBalance(treasuryAta);
+
+      await completeTokenTask({
+        taskPda,
+        claimPda,
+        escrowPda,
+        escrowAta,
+        workerAgentPda,
+        workerKp: worker,
+        workerTokenAccount: workerAta,
+        tokenMint: mint,
+        treasuryTokenAccount: treasuryAta,
+      });
+
+      const workerAfter = await getTokenBalance(workerAta);
+      const treasuryAfter = await getTokenBalance(treasuryAta);
+
+      // Fee: floor(10_000_000_000 * 100 / 10000) = 100_000_000 (0.1 token)
+      const expectedFee = Math.floor(
+        (rewardAmount * PROTOCOL_FEE_BPS) / 10000
+      );
+      const expectedWorkerReward = rewardAmount - expectedFee;
+
+      expect(Number(workerAfter - workerBefore)).to.equal(
+        expectedWorkerReward
+      );
+      expect(Number(treasuryAfter - treasuryBefore)).to.equal(expectedFee);
+    });
+
+    it("should cancel an unclaimed token task with full refund", async () => {
+      const taskId = makeId("t-cancel");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const rewardAmount = 2_000_000_000; // 2 tokens
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+      });
+
+      const creatorBefore = await getTokenBalance(creatorAta);
+
+      await program.methods
+        .cancelTask()
+        .accountsPartial({
+          task: taskPda,
+          escrow: escrowPda,
+          creator: creator.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+          tokenEscrowAta: escrowAta,
+          creatorTokenAccount: creatorAta,
+          rewardMint: mint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .signers([creator])
+        .rpc();
+
+      const creatorAfter = await getTokenBalance(creatorAta);
+      expect(Number(creatorAfter - creatorBefore)).to.equal(rewardAmount);
+
+      // Verify task is cancelled
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ cancelled: {} });
+    });
+
+    it("should create a dependent token task", async () => {
+      const parentTaskId = makeId("t-par");
+      const childTaskId = makeId("t-child");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+
+      // Create parent task (SOL to keep it simple)
+      const parentTaskPda = deriveTaskPda(creator.publicKey, parentTaskId);
+      const parentEscrowPda = deriveEscrowPda(parentTaskPda);
+
+      await program.methods
+        .createTask(
+          Array.from(parentTaskId),
+          new BN(CAPABILITY_COMPUTE),
+          Buffer.from("Parent task".padEnd(64, "\0")),
+          new BN(LAMPORTS_PER_SOL / 10),
+          1,
+          getDefaultDeadline(),
+          TASK_TYPE_EXCLUSIVE,
+          null,
+          0,
+          null
+        )
+        .accountsPartial({
+          task: parentTaskPda,
+          escrow: parentEscrowPda,
+          protocolConfig: protocolPda,
+          creatorAgent: creatorAgentPda,
+          authority: creator.publicKey,
+          creator: creator.publicKey,
+          systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
+        })
+        .signers([creator])
+        .rpc();
+
+      // Create dependent token task
+      const childTaskPda = deriveTaskPda(creator.publicKey, childTaskId);
+      const childEscrowPda = deriveEscrowPda(childTaskPda);
+      const childEscrowAta = deriveEscrowAta(mint, childEscrowPda);
+      const rewardAmount = 500_000_000;
+
+      await program.methods
+        .createDependentTask(
+          Array.from(childTaskId),
+          new BN(CAPABILITY_COMPUTE),
+          Buffer.from("Dependent token task".padEnd(64, "\0")),
+          new BN(rewardAmount),
+          1,
+          getDefaultDeadline(),
+          TASK_TYPE_EXCLUSIVE,
+          null,
+          1, // DependencyType::Data
+          0,
+          mint
+        )
+        .accountsPartial({
+          task: childTaskPda,
+          escrow: childEscrowPda,
+          parentTask: parentTaskPda,
+          protocolConfig: protocolPda,
+          creatorAgent: creatorAgentPda,
+          authority: creator.publicKey,
+          creator: creator.publicKey,
+          systemProgram: SystemProgram.programId,
+          rewardMint: mint,
+          creatorTokenAccount: creatorAta,
+          tokenEscrowAta: childEscrowAta,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        })
+        .signers([creator])
+        .rpc();
+
+      // Verify child task has reward_mint set
+      const childTask = await program.account.task.fetch(childTaskPda);
+      expect(childTask.rewardMint).to.not.be.null;
+      expect(childTask.rewardMint!.toBase58()).to.equal(mint.toBase58());
+
+      // Verify escrow funded
+      const escrowBalance = await getTokenBalance(childEscrowAta);
+      expect(Number(escrowBalance)).to.equal(rewardAmount);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge Cases
+  // ---------------------------------------------------------------------------
+
+  describe("edge cases", () => {
+    it("should create SOL task with reward_mint: null (regression)", async () => {
+      const taskId = makeId("t-sol");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const taskPda = deriveTaskPda(creator.publicKey, taskId);
+      const escrowPda = deriveEscrowPda(taskPda);
+
+      await program.methods
+        .createTask(
+          Array.from(taskId),
+          new BN(CAPABILITY_COMPUTE),
+          Buffer.from("SOL task regression".padEnd(64, "\0")),
+          new BN(LAMPORTS_PER_SOL / 10),
+          1,
+          getDefaultDeadline(),
+          TASK_TYPE_EXCLUSIVE,
+          null,
+          0,
+          null // No reward_mint = SOL path
+        )
+        .accountsPartial({
+          task: taskPda,
+          escrow: escrowPda,
+          protocolConfig: protocolPda,
+          creatorAgent: creatorAgentPda,
+          authority: creator.publicKey,
+          creator: creator.publicKey,
+          systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
+        })
+        .signers([creator])
+        .rpc();
+
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.rewardMint).to.be.null;
+      expect(task.rewardAmount.toNumber()).to.equal(LAMPORTS_PER_SOL / 10);
+    });
+
+    it("should fail with MissingTokenAccounts when token accounts omitted", async () => {
+      const taskId = makeId("t-miss");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const taskPda = deriveTaskPda(creator.publicKey, taskId);
+      const escrowPda = deriveEscrowPda(taskPda);
+
+      try {
+        // Pass reward_mint arg + account, but null out the other token accounts
+        // Anchor sets null optional accounts to the program ID (= not provided)
+        await program.methods
+          .createTask(
+            Array.from(taskId),
+            new BN(CAPABILITY_COMPUTE),
+            Buffer.from("Missing token accounts".padEnd(64, "\0")),
+            new BN(1_000_000_000),
+            1,
+            getDefaultDeadline(),
+            TASK_TYPE_EXCLUSIVE,
+            null,
+            0,
+            mint // reward_mint specified
+          )
+          .accountsPartial({
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            creatorAgent: creatorAgentPda,
+            authority: creator.publicKey,
+            creator: creator.publicKey,
+            systemProgram: SystemProgram.programId,
+            rewardMint: mint,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
+          })
+          .signers([creator])
+          .rpc();
+        expect.fail("Should have failed with MissingTokenAccounts");
+      } catch (e: unknown) {
+        const err = e as any;
+        expect(err.error?.errorCode?.code).to.equal("MissingTokenAccounts");
+      }
+    });
+
+    it("should fail when creator has insufficient token balance", async () => {
+      // Create a new keypair with an empty ATA
+      const poorCreator = Keypair.generate();
+      const poorAgentId = makeId("poor");
+      await airdrop([poorCreator]);
+      await registerAgent(poorAgentId, poorCreator, CAPABILITY_COMPUTE, minAgentStake);
+
+      const poorAta = await createAssociatedTokenAccount(
+        provider.connection,
+        payer(),
+        mint,
+        poorCreator.publicKey
+      );
+      // Do NOT mint any tokens to poorAta
+
+      const taskId = makeId("t-insuf");
+      const poorAgentPda = deriveAgentPda(poorAgentId);
+      const taskPda = deriveTaskPda(poorCreator.publicKey, taskId);
+      const escrowPda = deriveEscrowPda(taskPda);
+      const escrowAta = deriveEscrowAta(mint, escrowPda);
+
+      try {
+        await program.methods
+          .createTask(
+            Array.from(taskId),
+            new BN(CAPABILITY_COMPUTE),
+            Buffer.from("Insufficient balance task".padEnd(64, "\0")),
+            new BN(1_000_000_000),
+            1,
+            getDefaultDeadline(),
+            TASK_TYPE_EXCLUSIVE,
+            null,
+            0,
+            mint
+          )
+          .accountsPartial({
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            creatorAgent: poorAgentPda,
+            authority: poorCreator.publicKey,
+            creator: poorCreator.publicKey,
+            systemProgram: SystemProgram.programId,
+            rewardMint: mint,
+            creatorTokenAccount: poorAta,
+            tokenEscrowAta: escrowAta,
+            tokenProgram: TOKEN_PROGRAM_ID,
+            associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+          })
+          .signers([poorCreator])
+          .rpc();
+        expect.fail("Should have failed with insufficient balance");
+      } catch (e: unknown) {
+        // SPL token transfer fails — the exact error depends on the runtime
+        expect(e).to.exist;
+      }
+    });
+
+    it("should handle competitive token task (first completer gets tokens)", async () => {
+      const taskId = makeId("t-comp");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+      const worker2AgentPda = deriveAgentPda(worker2AgentId);
+      const rewardAmount = 5_000_000_000;
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+        maxWorkers: 2,
+        taskType: TASK_TYPE_COMPETITIVE,
+      });
+
+      // Both workers claim
+      const claimPda1 = await claimTask(taskPda, workerAgentPda, worker);
+      const claimPda2 = await claimTask(taskPda, worker2AgentPda, worker2);
+
+      // First worker completes
+      const workerBefore = await getTokenBalance(workerAta);
+
+      await completeTokenTask({
+        taskPda,
+        claimPda: claimPda1,
+        escrowPda,
+        escrowAta,
+        workerAgentPda,
+        workerKp: worker,
+        workerTokenAccount: workerAta,
+        tokenMint: mint,
+        treasuryTokenAccount: treasuryAta,
+      });
+
+      const workerAfter = await getTokenBalance(workerAta);
+      const expectedFee = Math.floor(
+        (rewardAmount * PROTOCOL_FEE_BPS) / 10000
+      );
+      expect(Number(workerAfter - workerBefore)).to.equal(
+        rewardAmount - expectedFee
+      );
+
+      // Verify task is completed — second worker cannot complete
+      const task = await program.account.task.fetch(taskPda);
+      expect(task.status).to.deep.equal({ completed: {} });
+
+      // Second worker tries to complete — should fail.
+      // For token tasks, the escrow ATA is closed after first completion,
+      // so the second attempt fails at account deserialization rather than
+      // reaching the CompetitiveTaskAlreadyWon check.
+      try {
+        await completeTokenTask({
+          taskPda,
+          claimPda: claimPda2,
+          escrowPda,
+          escrowAta,
+          workerAgentPda: worker2AgentPda,
+          workerKp: worker2,
+          workerTokenAccount: worker2Ata,
+          tokenMint: mint,
+          treasuryTokenAccount: treasuryAta,
+        });
+        expect.fail("Second completion should have failed");
+      } catch (e: unknown) {
+        // Expected: AccountNotInitialized (escrow ATA closed) or
+        // CompetitiveTaskAlreadyWon (if escrow ATA not yet closed)
+        expect(e).to.be.an("error");
+      }
+    });
+
+    it("should handle collaborative token task (multiple workers get tokens)", async () => {
+      const taskId = makeId("t-collab");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+      const worker2AgentPda = deriveAgentPda(worker2AgentId);
+      const rewardAmount = 10_000_000_000; // 10 tokens total
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+        maxWorkers: 2,
+        taskType: TASK_TYPE_COLLABORATIVE,
+      });
+
+      // Both workers claim
+      const claimPda1 = await claimTask(taskPda, workerAgentPda, worker);
+      const claimPda2 = await claimTask(taskPda, worker2AgentPda, worker2);
+
+      // Worker 1 completes
+      const worker1Before = await getTokenBalance(workerAta);
+      await completeTokenTask({
+        taskPda,
+        claimPda: claimPda1,
+        escrowPda,
+        escrowAta,
+        workerAgentPda,
+        workerKp: worker,
+        workerTokenAccount: workerAta,
+        tokenMint: mint,
+        treasuryTokenAccount: treasuryAta,
+      });
+      const worker1After = await getTokenBalance(workerAta);
+
+      // Worker 2 completes
+      const worker2Before = await getTokenBalance(worker2Ata);
+      await completeTokenTask({
+        taskPda,
+        claimPda: claimPda2,
+        escrowPda,
+        escrowAta,
+        workerAgentPda: worker2AgentPda,
+        workerKp: worker2,
+        workerTokenAccount: worker2Ata,
+        tokenMint: mint,
+        treasuryTokenAccount: treasuryAta,
+      });
+      const worker2After = await getTokenBalance(worker2Ata);
+
+      // Each worker gets reward / maxWorkers, minus fee
+      const perWorker = Math.floor(rewardAmount / 2);
+      const feePerWorker = Math.floor(
+        (perWorker * PROTOCOL_FEE_BPS) / 10000
+      );
+      const expectedPerWorker = perWorker - feePerWorker;
+
+      expect(Number(worker1After - worker1Before)).to.equal(
+        expectedPerWorker
+      );
+      expect(Number(worker2After - worker2Before)).to.equal(
+        expectedPerWorker
+      );
+    });
+
+    it("should handle minimum reward amount (1 unit, fee rounds to 0)", async () => {
+      const taskId = makeId("t-min");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+      const rewardAmount = 1; // 1 smallest unit
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+      });
+
+      const claimPda = await claimTask(taskPda, workerAgentPda, worker);
+
+      const workerBefore = await getTokenBalance(workerAta);
+      const treasuryBefore = await getTokenBalance(treasuryAta);
+
+      // fee = floor(1 * 100 / 10000) = 0, worker gets 1
+      // But the program enforces worker_reward > 0, and with fee=0, worker gets 1
+      await completeTokenTask({
+        taskPda,
+        claimPda,
+        escrowPda,
+        escrowAta,
+        workerAgentPda,
+        workerKp: worker,
+        workerTokenAccount: workerAta,
+        tokenMint: mint,
+        treasuryTokenAccount: treasuryAta,
+      });
+
+      const workerAfter = await getTokenBalance(workerAta);
+      const treasuryAfter = await getTokenBalance(treasuryAta);
+
+      expect(Number(workerAfter - workerBefore)).to.equal(1);
+      expect(Number(treasuryAfter - treasuryBefore)).to.equal(0);
+    });
+
+    it("should work with 0-decimal mint", async () => {
+      const taskId = makeId("t-0dec");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+      const rewardAmount = 100; // 100 whole tokens
+
+      const taskPda = deriveTaskPda(creator.publicKey, taskId);
+      const escrowPda = deriveEscrowPda(taskPda);
+      const escrowAta = deriveEscrowAta(zeroDecMint, escrowPda);
+
+      await program.methods
+        .createTask(
+          Array.from(taskId),
+          new BN(CAPABILITY_COMPUTE),
+          Buffer.from("Zero decimal task".padEnd(64, "\0")),
+          new BN(rewardAmount),
+          1,
+          getDefaultDeadline(),
+          TASK_TYPE_EXCLUSIVE,
+          null,
+          0,
+          zeroDecMint
+        )
+        .accountsPartial({
+          task: taskPda,
+          escrow: escrowPda,
+          protocolConfig: protocolPda,
+          creatorAgent: creatorAgentPda,
+          authority: creator.publicKey,
+          creator: creator.publicKey,
+          systemProgram: SystemProgram.programId,
+          rewardMint: zeroDecMint,
+          creatorTokenAccount: zeroDecCreatorAta,
+          tokenEscrowAta: escrowAta,
+          tokenProgram: TOKEN_PROGRAM_ID,
+          associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        })
+        .signers([creator])
+        .rpc();
+
+      const claimPda = await claimTask(taskPda, workerAgentPda, worker);
+
+      const workerBefore = await getTokenBalance(zeroDecWorkerAta);
+
+      await program.methods
+        .completeTask(
+          Array.from(Buffer.from("proof-hash-0dec".padEnd(32, "\0"))),
+          Buffer.from("result-0dec".padEnd(64, "\0"))
+        )
+        .accountsPartial({
+          task: taskPda,
+          claim: claimPda,
+          escrow: escrowPda,
+          creator: creator.publicKey,
+          worker: workerAgentPda,
+          protocolConfig: protocolPda,
+          treasury: treasuryPubkey,
+          authority: worker.publicKey,
+          systemProgram: SystemProgram.programId,
+          tokenEscrowAta: escrowAta,
+          workerTokenAccount: zeroDecWorkerAta,
+          treasuryTokenAccount: zeroDecTreasuryAta,
+          rewardMint: zeroDecMint,
+          tokenProgram: TOKEN_PROGRAM_ID,
+        })
+        .signers([worker])
+        .rpc();
+
+      const workerAfter = await getTokenBalance(zeroDecWorkerAta);
+
+      // fee = floor(100 * 100 / 10000) = 1 token
+      const expectedFee = Math.floor(
+        (rewardAmount * PROTOCOL_FEE_BPS) / 10000
+      );
+      expect(Number(workerAfter - workerBefore)).to.equal(
+        rewardAmount - expectedFee
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fee Verification
+  // ---------------------------------------------------------------------------
+
+  describe("fee verification", () => {
+    it("should collect protocol fees in tokens, not SOL", async () => {
+      const taskId = makeId("t-fee");
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+      const rewardAmount = 20_000_000_000; // 20 tokens
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+      });
+
+      const claimPda = await claimTask(taskPda, workerAgentPda, worker);
+
+      // Record SOL balances before completion
+      const workerSolBefore = await provider.connection.getBalance(
+        worker.publicKey
+      );
+      const treasurySolBefore =
+        await provider.connection.getBalance(treasuryPubkey);
+
+      // Record token balances
+      const treasuryTokenBefore = await getTokenBalance(treasuryAta);
+
+      await completeTokenTask({
+        taskPda,
+        claimPda,
+        escrowPda,
+        escrowAta,
+        workerAgentPda,
+        workerKp: worker,
+        workerTokenAccount: workerAta,
+        tokenMint: mint,
+        treasuryTokenAccount: treasuryAta,
+      });
+
+      const treasuryTokenAfter = await getTokenBalance(treasuryAta);
+      const treasurySolAfter =
+        await provider.connection.getBalance(treasuryPubkey);
+
+      // Token fee should be collected
+      const expectedFee = Math.floor(
+        (rewardAmount * PROTOCOL_FEE_BPS) / 10000
+      );
+      expect(Number(treasuryTokenAfter - treasuryTokenBefore)).to.equal(
+        expectedFee
+      );
+
+      // Treasury SOL balance should be unchanged (no SOL fees)
+      expect(treasurySolAfter).to.equal(treasurySolBefore);
+
+      // Worker SOL change should be small — no reward in SOL.
+      // Worker pays tx fee but may receive rent back from closed accounts
+      // (claim PDA and escrow PDA), so net change could be slightly positive.
+      const workerSolAfter = await provider.connection.getBalance(
+        worker.publicKey
+      );
+      const solDiff = Math.abs(workerSolBefore - workerSolAfter);
+      // The SOL change should be well under 1 SOL (just tx fees + rent refunds)
+      expect(solDiff).to.be.lessThan(LAMPORTS_PER_SOL / 10);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dispute Preconditions (token tasks)
+  // ---------------------------------------------------------------------------
+
+  describe("dispute preconditions (token tasks)", () => {
+    let disputeTaskId: Buffer;
+    let disputeTaskPda: PublicKey;
+    let disputeEscrowPda: PublicKey;
+    let disputeEscrowAta: PublicKey;
+    let disputeClaimPda: PublicKey;
+    let workerAgentPda: PublicKey;
+    let creatorAgentPda: PublicKey;
+    // Shared dispute: created in test 1, voted in test 2, resolve-rejected in test 3
+    let sharedDisputeId: Buffer;
+    let sharedDisputePda: PublicKey;
+
+    before(async () => {
+      disputeTaskId = makeId("t-disp");
+      creatorAgentPda = deriveAgentPda(creatorAgentId);
+      workerAgentPda = deriveAgentPda(workerAgentId);
+
+      const result = await createTokenTask({
+        taskId: disputeTaskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount: 5_000_000_000,
+      });
+
+      disputeTaskPda = result.taskPda;
+      disputeEscrowPda = result.escrowPda;
+      disputeEscrowAta = result.escrowAta;
+
+      disputeClaimPda = await claimTask(
+        disputeTaskPda,
+        workerAgentPda,
+        worker
+      );
+
+      sharedDisputeId = makeId("d-tok");
+      sharedDisputePda = deriveDisputePda(sharedDisputeId);
+    });
+
+    it("should initiate a dispute on a token task", async () => {
+      await program.methods
+        .initiateDispute(
+          Array.from(sharedDisputeId),
+          Array.from(disputeTaskId),
+          Array.from(Buffer.from("evidence-hash".padEnd(32, "\0"))),
+          RESOLUTION_TYPE_REFUND,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: sharedDisputePda,
+          task: disputeTaskPda,
+          agent: creatorAgentPda,
+          protocolConfig: protocolPda,
+          initiatorClaim: null,
+          workerAgent: workerAgentPda,
+          workerClaim: disputeClaimPda,
+          authority: creator.publicKey,
+        })
+        .signers([creator])
+        .rpc();
+
+      const dispute = await program.account.dispute.fetch(sharedDisputePda);
+      expect(dispute.status).to.deep.equal({ active: {} });
+      expect(dispute.task.toBase58()).to.equal(disputeTaskPda.toBase58());
+    });
+
+    it("should vote on a dispute for a token task", async () => {
+      const arbiter1Pda = deriveAgentPda(arbiter1AgentId);
+      const votePda = deriveVotePda(sharedDisputePda, arbiter1Pda);
+      const authorityVotePda = deriveAuthorityVotePda(
+        sharedDisputePda,
+        arbiter1.publicKey
+      );
+
+      // Check if voting period has already ended
+      const dispute = await program.account.dispute.fetch(sharedDisputePda);
+      const currentTime = Math.floor(Date.now() / 1000);
+      if (dispute.votingDeadline.toNumber() <= currentTime) {
+        // Voting already ended — skip but verify dispute state is valid
+        expect(dispute.status).to.deep.equal({ active: {} });
+        return;
+      }
+
+      await program.methods
+        .voteDispute(true)
+        .accountsPartial({
+          dispute: sharedDisputePda,
+          task: disputeTaskPda,
+          workerClaim: disputeClaimPda,
+          defendantAgent: workerAgentPda,
+          vote: votePda,
+          authorityVote: authorityVotePda,
+          arbiter: arbiter1Pda,
+          protocolConfig: protocolPda,
+          authority: arbiter1.publicKey,
+        })
+        .signers([arbiter1])
+        .rpc();
+
+      const disputeAfter = await program.account.dispute.fetch(
+        sharedDisputePda
+      );
+      expect(disputeAfter.votesFor.toNumber()).to.be.greaterThan(0);
+    });
+
+    it("should reject resolve before voting period ends (VotingNotEnded)", async () => {
+      // Check if voting period has already ended
+      const dispute = await program.account.dispute.fetch(sharedDisputePda);
+      const currentTime = Math.floor(Date.now() / 1000);
+      if (dispute.votingDeadline.toNumber() <= currentTime) {
+        // Voting already ended — can't test VotingNotEnded, skip
+        return;
+      }
+
+      // Use protocol authority as resolver (initiator can't resolve)
+      try {
+        await program.methods
+          .resolveDispute()
+          .accountsPartial({
+            dispute: sharedDisputePda,
+            task: disputeTaskPda,
+            escrow: disputeEscrowPda,
+            creator: creator.publicKey,
+            protocolConfig: protocolPda,
+            resolver: provider.wallet.publicKey,
+            workerClaim: null,
+            worker: null,
+            workerAuthority: null,
+            systemProgram: SystemProgram.programId,
+            tokenEscrowAta: disputeEscrowAta,
+            creatorTokenAccount: creatorAta,
+            workerTokenAccountAta: null,
+            treasuryTokenAccount: treasuryAta,
+            rewardMint: mint,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .rpc();
+        expect.fail("Should have failed with VotingNotEnded");
+      } catch (e: unknown) {
+        const err = e as any;
+        expect(err.error?.errorCode?.code).to.equal("VotingNotEnded");
+      }
+    });
+  });
+});

--- a/tests/test_1.ts
+++ b/tests/test_1.ts
@@ -379,6 +379,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -388,6 +389,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -414,6 +420,7 @@ describe("test_1", () => {
           TASK_TYPE_COLLABORATIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -423,6 +430,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -449,6 +461,7 @@ describe("test_1", () => {
           TASK_TYPE_COMPETITIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -458,6 +471,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -486,6 +504,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -495,6 +514,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -526,6 +550,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,  // constraint_hash
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -535,6 +560,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -565,6 +595,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -574,6 +605,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: unauthorized.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([unauthorized, creator])
           .rpc();
@@ -602,6 +638,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -611,6 +648,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -641,6 +683,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -650,6 +693,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -678,6 +726,7 @@ describe("test_1", () => {
             99,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -687,6 +736,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -717,6 +771,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -726,6 +781,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -766,6 +826,7 @@ describe("test_1", () => {
           TASK_TYPE_COLLABORATIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -775,6 +836,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -827,6 +893,7 @@ describe("test_1", () => {
           TASK_TYPE_COLLABORATIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -836,6 +903,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -904,6 +976,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -913,6 +986,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -966,6 +1044,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -975,6 +1054,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1021,6 +1105,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1030,6 +1115,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1074,6 +1164,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1083,6 +1174,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1111,6 +1207,11 @@ describe("test_1", () => {
           protocolConfig: protocolPda,
           treasury: treasuryPubkey,
           authority: worker1.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         })
         .signers([worker1.wallet])
         .rpc();
@@ -1154,6 +1255,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1163,6 +1265,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1175,6 +1282,10 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          creatorTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1220,6 +1331,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -1229,6 +1341,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -1259,6 +1376,7 @@ describe("test_1", () => {
           TASK_TYPE_COLLABORATIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1268,6 +1386,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1336,6 +1459,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1345,6 +1469,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1394,6 +1523,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1403,6 +1533,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1431,6 +1566,11 @@ describe("test_1", () => {
           protocolConfig: protocolPda,
           treasury: treasuryPubkey,
           authority: worker1.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         })
         .signers([worker1.wallet])
         .rpc();
@@ -1474,6 +1614,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1483,6 +1624,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1495,6 +1641,10 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          creatorTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1538,6 +1688,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1547,6 +1698,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1588,6 +1744,7 @@ describe("test_1", () => {
           TASK_TYPE_COLLABORATIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1597,6 +1754,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1666,6 +1828,7 @@ describe("test_1", () => {
           TASK_TYPE_COLLABORATIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1675,6 +1838,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1731,6 +1899,7 @@ describe("test_1", () => {
           TASK_TYPE_COLLABORATIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1740,6 +1909,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1773,6 +1947,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1782,6 +1957,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1815,6 +1995,11 @@ describe("test_1", () => {
           treasury: treasuryPubkey,
           authority: worker.wallet.publicKey,
           systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         })
         .signers([worker.wallet])
         .rpc();
@@ -1856,6 +2041,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,  // constraint_hash
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -1865,6 +2051,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -1955,6 +2146,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -1964,6 +2156,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2008,6 +2205,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2017,6 +2215,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2051,6 +2254,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: worker.wallet.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([worker.wallet])
           .rpc();
@@ -2076,6 +2284,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2085,6 +2294,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2102,6 +2316,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2134,6 +2352,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2143,6 +2362,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2188,6 +2412,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .remainingAccounts([
             { pubkey: claimPda, isSigner: false, isWritable: true },
@@ -2221,6 +2449,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2230,6 +2459,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2260,6 +2494,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: worker1.wallet.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([worker1.wallet])
           .rpc();
@@ -2307,6 +2546,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2316,6 +2556,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2345,6 +2590,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: worker.wallet.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([worker.wallet])
           .rpc();
@@ -2359,6 +2609,10 @@ describe("test_1", () => {
               creator: creator.publicKey,
               protocolConfig: protocolPda,
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              creatorTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .signers([creator])
             .rpc();
@@ -2387,6 +2641,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2396,6 +2651,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2409,6 +2669,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2456,6 +2720,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2465,6 +2730,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2508,6 +2778,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2517,6 +2788,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2530,6 +2806,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2544,6 +2824,10 @@ describe("test_1", () => {
               creator: creator.publicKey,
               protocolConfig: protocolPda,
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              creatorTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .signers([creator])
             .rpc();
@@ -2572,6 +2856,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2581,6 +2866,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2626,6 +2916,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2635,6 +2926,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2679,6 +2975,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: worker1.wallet.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([worker1.wallet])
           .rpc();
@@ -2697,6 +2998,11 @@ describe("test_1", () => {
               treasury: treasuryPubkey,
               authority: worker1.wallet.publicKey,
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              workerTokenAccount: null,
+              treasuryTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .signers([worker1.wallet])
             .rpc();
@@ -2727,6 +3033,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2736,6 +3043,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2765,6 +3077,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: worker.wallet.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([worker.wallet])
           .rpc();
@@ -2793,6 +3110,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -2802,6 +3120,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2814,6 +3137,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -2986,6 +3313,7 @@ describe("test_1", () => {
               TASK_TYPE_EXCLUSIVE,
               null,
               0, // min_reputation
+              null, // reward_mint
             )
             .accountsPartial({
               task: taskPda,
@@ -2995,6 +3323,11 @@ describe("test_1", () => {
               authority: creator.publicKey,
               creator: creator.publicKey,
               systemProgram: SystemProgram.programId,
+              rewardMint: null,
+              creatorTokenAccount: null,
+              tokenEscrowAta: null,
+              tokenProgram: null,
+              associatedTokenProgram: null,
             })
             .signers([creator])
             .rpc();
@@ -3024,6 +3357,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3033,6 +3367,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3076,6 +3415,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3085,6 +3425,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3132,6 +3477,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3141,6 +3487,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3172,6 +3523,11 @@ describe("test_1", () => {
               treasury: treasuryPubkey,
               authority: worker2.wallet.publicKey, // But worker2 signing
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              workerTokenAccount: null,
+              treasuryTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .signers([worker2.wallet])
             .rpc();
@@ -3201,6 +3557,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3210,6 +3567,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3241,6 +3603,11 @@ describe("test_1", () => {
               treasury: wrongTreasury.publicKey, // Wrong treasury
               authority: worker.wallet.publicKey,
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              workerTokenAccount: null,
+              treasuryTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .signers([worker.wallet])
             .rpc();
@@ -3270,6 +3637,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3279,6 +3647,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3325,6 +3698,11 @@ describe("test_1", () => {
               treasury: treasuryPubkey,
               authority: worker1.wallet.publicKey,
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              workerTokenAccount: null,
+              treasuryTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .signers([worker1.wallet])
             .rpc();
@@ -3360,6 +3738,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3369,6 +3748,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3383,6 +3767,10 @@ describe("test_1", () => {
               creator: nonCreator.publicKey,
               protocolConfig: protocolPda,
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              creatorTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .signers([nonCreator])
             .rpc();
@@ -3421,6 +3809,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3430,6 +3819,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3473,6 +3867,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .remainingAccounts([
             { pubkey: claimPda, isSigner: false, isWritable: true },
@@ -3585,6 +3983,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3594,6 +3993,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3629,6 +4033,8 @@ describe("test_1", () => {
               protocolConfig: protocolPda,
               systemProgram: SystemProgram.programId,
               initiatorClaim: claimPda,
+              workerAgent: null,
+              workerClaim: null,
             })
             .signers([wrongSigner])
             .rpc();
@@ -3694,6 +4100,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3703,6 +4110,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3765,6 +4177,7 @@ describe("test_1", () => {
               protocolConfig: protocolPda,
               authority: wrongSigner.publicKey, // But wrong signer
               systemProgram: SystemProgram.programId,
+              defendantAgent: null,
             })
             .signers([wrongSigner])
             .rpc();
@@ -3795,6 +4208,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3804,6 +4218,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3860,6 +4279,7 @@ describe("test_1", () => {
               protocolConfig: protocolPda,
               authority: worker.wallet.publicKey,
               systemProgram: SystemProgram.programId,
+              defendantAgent: null,
             })
             .signers([worker.wallet])
             .rpc();
@@ -3892,6 +4312,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3901,6 +4322,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -3955,6 +4381,12 @@ describe("test_1", () => {
               worker: null,
               workerAuthority: null,
               systemProgram: SystemProgram.programId,
+              tokenEscrowAta: null,
+              creatorTokenAccount: null,
+              workerTokenAccountAta: null,
+              treasuryTokenAccount: null,
+              rewardMint: null,
+              tokenProgram: null,
             })
             .rpc();
           expect.fail("Should have failed");
@@ -3987,6 +4419,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -3996,6 +4429,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4103,6 +4541,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -4112,6 +4551,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -4124,6 +4568,10 @@ describe("test_1", () => {
             creator: unauthorized.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([unauthorized])
           .rpc();
@@ -4158,6 +4606,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -4167,6 +4616,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -4194,6 +4648,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: wrongSigner.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([wrongSigner])
           .rpc();
@@ -4222,6 +4681,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -4231,6 +4691,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -4257,6 +4722,11 @@ describe("test_1", () => {
           treasury: treasuryPubkey,
           authority: worker.wallet.publicKey,
           systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         })
         .signers([worker.wallet])
         .rpc();
@@ -4269,6 +4739,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4297,6 +4771,7 @@ describe("test_1", () => {
           TASK_TYPE_EXCLUSIVE,
           null,
           0, // min_reputation
+          null, // reward_mint
         )
         .accountsPartial({
           task: taskPda,
@@ -4306,6 +4781,11 @@ describe("test_1", () => {
           authority: creator.publicKey,
           creator: creator.publicKey,
           systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -4317,6 +4797,10 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          creatorTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         })
         .signers([creator])
         .rpc();
@@ -4335,6 +4819,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: worker.wallet.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([worker.wallet])
           .rpc();
@@ -4385,6 +4874,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4394,6 +4884,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4441,6 +4936,7 @@ describe("test_1", () => {
               TASK_TYPE_EXCLUSIVE,
               null,
               0, // min_reputation
+              null, // reward_mint
             )
             .accountsPartial({
               task: taskPda,
@@ -4450,6 +4946,11 @@ describe("test_1", () => {
               authority: creator.publicKey,
               creator: creator.publicKey,
               systemProgram: SystemProgram.programId,
+              rewardMint: null,
+              creatorTokenAccount: null,
+              tokenEscrowAta: null,
+              tokenProgram: null,
+              associatedTokenProgram: null,
             })
             .signers([creator])
             .rpc();
@@ -4481,6 +4982,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4490,6 +4992,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4526,6 +5033,11 @@ describe("test_1", () => {
             treasury: treasuryPubkey,
             authority: worker.wallet.publicKey,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([worker.wallet])
           .rpc();
@@ -4579,6 +5091,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4588,6 +5101,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4628,6 +5146,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: w1.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([w1.wallet]).rpc();
         const tx1Details = await provider.connection.getTransaction(tx1, { commitment: "confirmed" });
         const tx1Fee = tx1Details?.meta?.fee || 0;
@@ -4645,6 +5168,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: w2.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([w2.wallet]).rpc();
 
         // Escrow should still exist after second completion
@@ -4657,6 +5185,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: w3.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([w3.wallet]).rpc();
 
         // Verify escrow is closed after final completion
@@ -4688,6 +5221,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4697,6 +5231,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4715,6 +5254,10 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4761,6 +5304,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4770,6 +5314,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4786,6 +5335,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker.wallet]).rpc();
 
         // Wait for deadline
@@ -4804,6 +5358,10 @@ describe("test_1", () => {
             task: taskPda, escrow: escrowPda, creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Expected cancel to fail after completion");
         } catch (e: any) {
@@ -4837,6 +5395,7 @@ describe("test_1", () => {
             TASK_TYPE_COLLABORATIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4846,6 +5405,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4871,6 +5435,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: w1.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([w1.wallet]).rpc();
 
         const escrowAfter = await provider.connection.getBalance(escrowPda);
@@ -4888,6 +5457,11 @@ describe("test_1", () => {
             creator: creator.publicKey,
             protocolConfig: protocolPda, treasury: treasuryPubkey,
             authority: w1.wallet.publicKey,
+            tokenEscrowAta: null,
+            workerTokenAccount: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           }).signers([w1.wallet]).rpc();
           expect.fail("Should have failed");
         } catch (e: unknown) {
@@ -4919,6 +5493,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4928,6 +5503,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -4944,6 +5524,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker.wallet]).rpc();
 
         // Snapshot before attempted cancel
@@ -4955,6 +5540,10 @@ describe("test_1", () => {
             task: taskPda, escrow: escrowPda, creator: creator.publicKey,
             protocolConfig: protocolPda,
             systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Should have failed");
         } catch (e: unknown) {
@@ -4989,6 +5578,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -4998,6 +5588,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5017,6 +5612,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker.wallet]).rpc();
 
         // Note: Escrow account is closed (close = creator directive) after completion
@@ -5052,6 +5652,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5061,6 +5662,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5072,6 +5678,10 @@ describe("test_1", () => {
           task: taskPda, escrow: escrowPda, creator: creator.publicKey,
           protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          creatorTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([creator]).rpc();
 
         // Note: Escrow account is closed (close = creator directive) after cancel
@@ -5121,6 +5731,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5130,6 +5741,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5151,6 +5767,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker.wallet]).rpc();
         const tx3Details = await provider.connection.getTransaction(tx3, { commitment: "confirmed" });
         totalTxFees += tx3Details?.meta?.fee || 0;
@@ -5212,6 +5833,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5221,6 +5843,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5287,6 +5914,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5296,6 +5924,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5373,6 +6006,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5382,6 +6016,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5437,11 +6076,17 @@ describe("test_1", () => {
           Buffer.from("Resolution type 0".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda0, escrow: escrowPda0, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda0 = deriveClaimPda(taskPda0, worker.agentPda);
@@ -5488,6 +6133,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5497,6 +6143,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5555,6 +6206,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5564,6 +6216,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5579,6 +6236,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker.wallet.publicKey, systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker.wallet]).rpc();
 
         // Task is Completed
@@ -5635,6 +6297,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5644,6 +6307,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5652,6 +6320,10 @@ describe("test_1", () => {
           task: taskPda, escrow: escrowPda, creator: creator.publicKey,
           protocolConfig: protocolPda,
           systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          creatorTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([creator]).rpc();
 
         // Task is Cancelled
@@ -5711,6 +6383,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5720,6 +6393,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5850,6 +6528,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5859,6 +6538,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5920,6 +6604,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -5929,6 +6614,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -5994,6 +6684,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -6003,6 +6694,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -6096,6 +6792,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,
             0, // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -6105,6 +6802,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -6173,11 +6875,17 @@ describe("test_1", () => {
           Buffer.from("Voting capability test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6233,6 +6941,7 @@ describe("test_1", () => {
             authorityVote: authorityVotePdaNonArbiter,
             arbiter: worker.agentPda, protocolConfig: protocolPda,
             authority: worker.wallet.publicKey, systemProgram: SystemProgram.programId,
+            defendantAgent: null,
           }).signers([worker.wallet]).rpc();
           expect.fail("Should have failed");
         } catch (e: unknown) {
@@ -6256,11 +6965,17 @@ describe("test_1", () => {
           Buffer.from("Stake test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6321,11 +7036,17 @@ describe("test_1", () => {
           Buffer.from("Deadline vote test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6398,11 +7119,17 @@ describe("test_1", () => {
           Buffer.from("Double vote test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6489,11 +7216,17 @@ describe("test_1", () => {
           Buffer.from("Vote count test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const workerCount = await createFreshWorker();
@@ -6533,11 +7266,17 @@ describe("test_1", () => {
           Buffer.from("Inactive voter test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6608,6 +7347,7 @@ describe("test_1", () => {
             authorityVote: authorityVotePda,
             arbiter: inactiveArbiterPda, protocolConfig: protocolPda,
             authority: inactiveArbiterOwner.publicKey,
+            defendantAgent: null,
           }).signers([inactiveArbiterOwner]).rpc();
           expect.fail("Inactive arbiter should not vote");
         } catch (e: any) {
@@ -6633,11 +7373,17 @@ describe("test_1", () => {
           Buffer.from("Early resolve test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6661,6 +7407,12 @@ describe("test_1", () => {
             dispute: disputePda, task: taskPda, escrow: escrowPda,
             protocolConfig: protocolPda, resolver: provider.wallet.publicKey, creator: creator.publicKey,
             workerClaim: null, worker: null, workerAuthority: null, systemProgram: SystemProgram.programId,
+            tokenEscrowAta: null,
+            creatorTokenAccount: null,
+            workerTokenAccountAta: null,
+            treasuryTokenAccount: null,
+            rewardMint: null,
+            tokenProgram: null,
           }).rpc();
           expect.fail("Should have failed");
         } catch (e: unknown) {
@@ -6685,11 +7437,17 @@ describe("test_1", () => {
           Buffer.from("Zero votes test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6729,11 +7487,17 @@ describe("test_1", () => {
           Buffer.from("Status change test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey, systemProgram: SystemProgram.programId,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, worker.agentPda);
@@ -6822,11 +7586,17 @@ describe("test_1", () => {
           Buffer.from("Reputation increment test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, repAgentPda);
@@ -6842,6 +7612,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: repAgentOwner.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([repAgentOwner]).rpc();
 
         // Verify reputation increased by 100
@@ -7009,11 +7784,17 @@ describe("test_1", () => {
           Buffer.from("Stats increment test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, statsAgentPda);
@@ -7029,6 +7810,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: statsAgentOwner.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([statsAgentOwner]).rpc();
 
         // Verify tasks_completed incremented
@@ -7072,11 +7858,17 @@ describe("test_1", () => {
           Buffer.from("Earnings test".padEnd(64, "\0")),
           new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, earnAgentPda);
@@ -7092,6 +7884,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: earnAgentOwner.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([earnAgentOwner]).rpc();
 
         // Verify total_earned (reward minus 1% protocol fee)
@@ -7135,11 +7932,17 @@ describe("test_1", () => {
           Buffer.from("Active tasks test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda = deriveClaimPda(taskPda, activeAgentPda);
@@ -7160,6 +7963,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: activeAgentOwner.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([activeAgentOwner]).rpc();
 
         // Verify active_tasks decremented to 0
@@ -7181,11 +7989,17 @@ describe("test_1", () => {
           Buffer.from("Multi-claim test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         // All 3 workers claim using fresh agents
@@ -7227,11 +8041,17 @@ describe("test_1", () => {
           Buffer.from("Overflow claim test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         // First 2 claims succeed using fresh workers
@@ -7277,11 +8097,17 @@ describe("test_1", () => {
           Buffer.from("PDA uniqueness test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         // First claim succeeds
@@ -7323,11 +8149,17 @@ describe("test_1", () => {
           Buffer.from("First wins test".padEnd(64, "\0")),
           new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const worker = await createFreshWorker();
@@ -7346,6 +8178,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker.wallet]).rpc();
 
         const workerAfter = await provider.connection.getBalance(worker.wallet.publicKey);
@@ -7366,11 +8203,17 @@ describe("test_1", () => {
           Buffer.from("All completions test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const worker1 = await createFreshWorker();
@@ -7396,6 +8239,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker1.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker1.wallet]).rpc();
 
         let task = await program.account.task.fetch(taskPda);
@@ -7412,6 +8260,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker2.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker2.wallet]).rpc();
 
         task = await program.account.task.fetch(taskPda);
@@ -7435,11 +8288,17 @@ describe("test_1", () => {
           Buffer.from("Worker count test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         let task = await program.account.task.fetch(taskPda);
@@ -7491,11 +8350,17 @@ describe("test_1", () => {
           Buffer.from("Completion count test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 33), 3, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const worker1 = await createFreshWorker();
@@ -7531,6 +8396,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker1.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker1.wallet]).rpc();
 
         task = await program.account.task.fetch(taskPda);
@@ -7544,6 +8414,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker2.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker2.wallet]).rpc();
 
         task = await program.account.task.fetch(taskPda);
@@ -7557,6 +8432,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker3.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker3.wallet]).rpc();
 
         task = await program.account.task.fetch(taskPda);
@@ -7599,11 +8479,17 @@ describe("test_1", () => {
           Buffer.from("Track test 1".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda1, escrow: escrowPda1, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda1 = deriveClaimPda(taskPda1, deriveAgentPda(trackAgentId));
@@ -7625,11 +8511,17 @@ describe("test_1", () => {
           Buffer.from("Track test 2".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda2, escrow: escrowPda2, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda2 = deriveClaimPda(taskPda2, deriveAgentPda(trackAgentId));
@@ -7649,6 +8541,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: trackAgentOwner.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([trackAgentOwner]).rpc();
 
         agent = await program.account.agentRegistration.fetch(trackAgentPda);
@@ -7662,6 +8559,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: trackAgentOwner.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([trackAgentOwner]).rpc();
 
         agent = await program.account.agentRegistration.fetch(trackAgentPda);
@@ -7682,11 +8584,17 @@ describe("test_1", () => {
           Buffer.from("Max workers test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 100, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const task = await program.account.task.fetch(taskPda);
@@ -7704,11 +8612,17 @@ describe("test_1", () => {
             Buffer.from("Zero workers test".padEnd(64, "\0")),
             new BN(LAMPORTS_PER_SOL / 100), 0, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
             0, // min_reputation
+            null, // reward_mint
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
             authority: creator.publicKey,
             creator: creator.publicKey,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Should have failed");
         } catch (e: any) {
@@ -7727,11 +8641,17 @@ describe("test_1", () => {
             Buffer.from("Zero reward test".padEnd(64, "\0")),
             new BN(0), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
             0, // min_reputation
+            null, // reward_mint
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
             authority: creator.publicKey,
             creator: creator.publicKey,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Should have rejected zero reward");
         } catch (e: any) {
@@ -7752,11 +8672,17 @@ describe("test_1", () => {
             new BN("18446744073709551615"), // u64::MAX
             1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
             0, // min_reputation
+            null, // reward_mint
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
             authority: creator.publicKey,
             creator: creator.publicKey,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Should have failed");
         } catch (e: unknown) {
@@ -7777,11 +8703,17 @@ describe("test_1", () => {
             Buffer.from("No deadline test".padEnd(64, "\0")),
             new BN(LAMPORTS_PER_SOL), 1, new BN(0), TASK_TYPE_EXCLUSIVE, null,
             0, // min_reputation
+            null, // reward_mint
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
             authority: creator.publicKey,
             creator: creator.publicKey,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Should have failed with deadline=0");
         } catch (e: unknown) {
@@ -7804,11 +8736,17 @@ describe("test_1", () => {
             Buffer.from("Past deadline test".padEnd(64, "\0")),
             new BN(0), 1, new BN(pastDeadline), TASK_TYPE_EXCLUSIVE, null,
             0, // min_reputation
+            null, // reward_mint
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
             authority: creator.publicKey,
             creator: creator.publicKey,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Should have failed");
         } catch (e: unknown) {
@@ -7829,11 +8767,17 @@ describe("test_1", () => {
             Buffer.from("Invalid type test".padEnd(64, "\0")),
             new BN(0), 1, new BN(0), 3, null, // Invalid: only 0, 1, 2 are valid
             0, // min_reputation
+            null, // reward_mint
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
             authority: creator.publicKey,
             creator: creator.publicKey,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           }).signers([creator]).rpc();
           expect.fail("Should have failed");
         } catch (e: any) {
@@ -7994,11 +8938,17 @@ describe("test_1", () => {
           Buffer.from("Invariant test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         // Claim up to max using fresh workers
@@ -8031,11 +8981,17 @@ describe("test_1", () => {
           Buffer.from("Completion invariant".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 50), 2, getDefaultDeadline(), TASK_TYPE_COLLABORATIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const worker1 = await createFreshWorker();
@@ -8061,6 +9017,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker1.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker1.wallet]).rpc();
 
         // Note: For exclusive tasks (max_workers=1), escrow is closed after single completion
@@ -8080,11 +9041,17 @@ describe("test_1", () => {
           Buffer.from("Escrow invariant".padEnd(64, "\0")),
           new BN(rewardAmount), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         // Check escrow invariant before completion (escrow is closed after completion)
@@ -8106,6 +9073,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: worker.wallet.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([worker.wallet]).rpc();
 
         // Escrow is closed after completion - verify task is completed
@@ -8146,11 +9118,17 @@ describe("test_1", () => {
             Buffer.from(`Busy task ${i}`.padEnd(64, "\0")),
             new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
             0, // min_reputation
+            null, // reward_mint
           ).accountsPartial({
             task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
             creatorAgent: creatorAgentPda,
             authority: creator.publicKey,
             creator: creator.publicKey,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           }).signers([creator]).rpc();
 
           const claimPda = deriveClaimPda(taskPda, deriveAgentPda(busyAgentId));
@@ -8174,11 +9152,17 @@ describe("test_1", () => {
           Buffer.from("Busy task 10".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda11, escrow: escrowPda11, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         const claimPda11 = deriveClaimPda(taskPda11, deriveAgentPda(busyAgentId));
@@ -8216,11 +9200,17 @@ describe("test_1", () => {
           Buffer.from("Stats increase test".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda, escrow: escrowPda, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         // Verify total_tasks increased
@@ -8266,6 +9256,11 @@ describe("test_1", () => {
           creator: creator.publicKey,
           protocolConfig: protocolPda, treasury: treasuryPubkey,
           authority: newAgentOwner.publicKey,
+          tokenEscrowAta: null,
+          workerTokenAccount: null,
+          treasuryTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
         }).signers([newAgentOwner]).rpc();
 
         // Verify completed_tasks increased
@@ -8287,11 +9282,17 @@ describe("test_1", () => {
           Buffer.from("Shared ID test 1".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda1, escrow: escrowPda1, protocolConfig: protocolPda,
           creatorAgent: creatorAgentPda,
           authority: creator.publicKey,
           creator: creator.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([creator]).rpc();
 
         // Creator 2 (using worker1 as different creator)
@@ -8303,11 +9304,17 @@ describe("test_1", () => {
           Buffer.from("Shared ID test 2".padEnd(64, "\0")),
           new BN(LAMPORTS_PER_SOL / 100), 1, getDefaultDeadline(), TASK_TYPE_EXCLUSIVE, null,
           0, // min_reputation
+          null, // reward_mint
         ).accountsPartial({
           task: taskPda2, escrow: escrowPda2, protocolConfig: protocolPda,
           creatorAgent: deriveAgentPda(agentId1),
           authority: worker1.publicKey,
           creator: worker1.publicKey,
+          rewardMint: null,
+          creatorTokenAccount: null,
+          tokenEscrowAta: null,
+          tokenProgram: null,
+          associatedTokenProgram: null,
         }).signers([worker1]).rpc();
 
         // Verify PDAs are different
@@ -8389,6 +9396,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,  // constraint_hash
             6000,  // min_reputation (worker has 5000)
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -8398,6 +9406,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -8441,6 +9454,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,  // constraint_hash
             5000,  // min_reputation (worker has exactly 5000)
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -8450,6 +9464,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -8491,6 +9510,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,  // constraint_hash
             0,  // min_reputation (no gate)
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -8500,6 +9520,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();
@@ -8541,6 +9566,7 @@ describe("test_1", () => {
               TASK_TYPE_EXCLUSIVE,
               null,  // constraint_hash
               10001,  // min_reputation > MAX_REPUTATION
+              null, // reward_mint
             )
             .accountsPartial({
               task: taskPda,
@@ -8550,6 +9576,11 @@ describe("test_1", () => {
               authority: creator.publicKey,
               creator: creator.publicKey,
               systemProgram: SystemProgram.programId,
+              rewardMint: null,
+              creatorTokenAccount: null,
+              tokenEscrowAta: null,
+              tokenProgram: null,
+              associatedTokenProgram: null,
             })
             .signers([creator])
             .rpc();
@@ -8575,6 +9606,7 @@ describe("test_1", () => {
             TASK_TYPE_EXCLUSIVE,
             null,  // constraint_hash
             7500,  // min_reputation
+            null, // reward_mint
           )
           .accountsPartial({
             task: taskPda,
@@ -8584,6 +9616,11 @@ describe("test_1", () => {
             authority: creator.publicKey,
             creator: creator.publicKey,
             systemProgram: SystemProgram.programId,
+            rewardMint: null,
+            creatorTokenAccount: null,
+            tokenEscrowAta: null,
+            tokenProgram: null,
+            associatedTokenProgram: null,
           })
           .signers([creator])
           .rpc();

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,135 +39,10 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
-"@esbuild/aix-ppc64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz#521cbd968dcf362094034947f76fa1b18d2d403c"
-  integrity sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==
-
-"@esbuild/android-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz#61ea550962d8aa12a9b33194394e007657a6df57"
-  integrity sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==
-
-"@esbuild/android-arm@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.2.tgz#554887821e009dd6d853f972fde6c5143f1de142"
-  integrity sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==
-
-"@esbuild/android-x64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.2.tgz#a7ce9d0721825fc578f9292a76d9e53334480ba2"
-  integrity sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==
-
-"@esbuild/darwin-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz#2cb7659bd5d109803c593cfc414450d5430c8256"
-  integrity sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==
-
-"@esbuild/darwin-x64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz#e741fa6b1abb0cd0364126ba34ca17fd5e7bf509"
-  integrity sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==
-
-"@esbuild/freebsd-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz#2b64e7116865ca172d4ce034114c21f3c93e397c"
-  integrity sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==
-
-"@esbuild/freebsd-x64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz#e5252551e66f499e4934efb611812f3820e990bb"
-  integrity sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==
-
-"@esbuild/linux-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz#dc4acf235531cd6984f5d6c3b13dbfb7ddb303cb"
-  integrity sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==
-
-"@esbuild/linux-arm@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz#56a900e39240d7d5d1d273bc053daa295c92e322"
-  integrity sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==
-
-"@esbuild/linux-ia32@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz#d4a36d473360f6870efcd19d52bbfff59a2ed1cc"
-  integrity sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==
-
-"@esbuild/linux-loong64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz#fcf0ab8c3eaaf45891d0195d4961cb18b579716a"
-  integrity sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==
-
-"@esbuild/linux-mips64el@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz#598b67d34048bb7ee1901cb12e2a0a434c381c10"
-  integrity sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==
-
-"@esbuild/linux-ppc64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz#3846c5df6b2016dab9bc95dde26c40f11e43b4c0"
-  integrity sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==
-
-"@esbuild/linux-riscv64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz#173d4475b37c8d2c3e1707e068c174bb3f53d07d"
-  integrity sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==
-
-"@esbuild/linux-s390x@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz#f7a4790105edcab8a5a31df26fbfac1aa3dacfab"
-  integrity sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==
-
 "@esbuild/linux-x64@0.27.2":
   version "0.27.2"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz"
   integrity sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==
-
-"@esbuild/netbsd-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz#e2863c2cd1501845995cb11adf26f7fe4be527b0"
-  integrity sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==
-
-"@esbuild/netbsd-x64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz#93f7609e2885d1c0b5a1417885fba8d1fcc41272"
-  integrity sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==
-
-"@esbuild/openbsd-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz#a1985604a203cdc325fd47542e106fafd698f02e"
-  integrity sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==
-
-"@esbuild/openbsd-x64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz#8209e46c42f1ffbe6e4ef77a32e1f47d404ad42a"
-  integrity sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==
-
-"@esbuild/openharmony-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz#8fade4441893d9cc44cbd7dcf3776f508ab6fb2f"
-  integrity sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==
-
-"@esbuild/sunos-x64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz#980d4b9703a16f0f07016632424fc6d9a789dfc2"
-  integrity sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==
-
-"@esbuild/win32-arm64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz#1c09a3633c949ead3d808ba37276883e71f6111a"
-  integrity sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==
-
-"@esbuild/win32-ia32@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz#1b1e3a63ad4bef82200fef4e369e0fff7009eee5"
-  integrity sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==
-
-"@esbuild/win32-x64@0.27.2":
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz#9e585ab6086bef994c6e8a5b3a0481219ada862b"
-  integrity sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==
 
 "@noble/curves@^1.4.2":
   version "1.9.7"
@@ -176,17 +51,41 @@
   dependencies:
     "@noble/hashes" "1.8.0"
 
-"@noble/hashes@1.8.0", "@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0":
+"@noble/hashes@^1.3.1", "@noble/hashes@^1.4.0", "@noble/hashes@1.8.0":
   version "1.8.0"
   resolved "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
 
-"@solana/buffer-layout@^4.0.1":
+"@solana/buffer-layout-utils@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz"
+  integrity sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/web3.js" "^1.32.0"
+    bigint-buffer "^1.1.5"
+    bignumber.js "^9.0.1"
+
+"@solana/buffer-layout@^4.0.0", "@solana/buffer-layout@^4.0.1":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz"
   integrity sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==
   dependencies:
     buffer "~6.0.3"
+
+"@solana/codecs-core@2.0.0-preview.2":
+  version "2.0.0-preview.2"
+  resolved "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-preview.2.tgz"
+  integrity sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==
+  dependencies:
+    "@solana/errors" "2.0.0-preview.2"
+
+"@solana/codecs-core@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz"
+  integrity sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==
+  dependencies:
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs-core@2.3.0":
   version "2.3.0"
@@ -194,6 +93,24 @@
   integrity sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==
   dependencies:
     "@solana/errors" "2.3.0"
+
+"@solana/codecs-data-structures@2.0.0-preview.2":
+  version "2.0.0-preview.2"
+  resolved "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-preview.2.tgz"
+  integrity sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-preview.2"
+    "@solana/codecs-numbers" "2.0.0-preview.2"
+    "@solana/errors" "2.0.0-preview.2"
+
+"@solana/codecs-data-structures@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz"
+  integrity sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs-numbers@^2.1.0":
   version "2.3.0"
@@ -203,6 +120,78 @@
     "@solana/codecs-core" "2.3.0"
     "@solana/errors" "2.3.0"
 
+"@solana/codecs-numbers@2.0.0-preview.2":
+  version "2.0.0-preview.2"
+  resolved "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-preview.2.tgz"
+  integrity sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-preview.2"
+    "@solana/errors" "2.0.0-preview.2"
+
+"@solana/codecs-numbers@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz"
+  integrity sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/codecs-strings@2.0.0-preview.2":
+  version "2.0.0-preview.2"
+  resolved "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-preview.2.tgz"
+  integrity sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-preview.2"
+    "@solana/codecs-numbers" "2.0.0-preview.2"
+    "@solana/errors" "2.0.0-preview.2"
+
+"@solana/codecs-strings@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz"
+  integrity sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/codecs@2.0.0-preview.2":
+  version "2.0.0-preview.2"
+  resolved "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-preview.2.tgz"
+  integrity sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-preview.2"
+    "@solana/codecs-data-structures" "2.0.0-preview.2"
+    "@solana/codecs-numbers" "2.0.0-preview.2"
+    "@solana/codecs-strings" "2.0.0-preview.2"
+    "@solana/options" "2.0.0-preview.2"
+
+"@solana/codecs@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz"
+  integrity sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/options" "2.0.0-rc.1"
+
+"@solana/errors@2.0.0-preview.2":
+  version "2.0.0-preview.2"
+  resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-preview.2.tgz"
+  integrity sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==
+  dependencies:
+    chalk "^5.3.0"
+    commander "^12.0.0"
+
+"@solana/errors@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz"
+  integrity sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==
+  dependencies:
+    chalk "^5.3.0"
+    commander "^12.1.0"
+
 "@solana/errors@2.3.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz"
@@ -211,7 +200,59 @@
     chalk "^5.4.1"
     commander "^14.0.0"
 
-"@solana/web3.js@^1.69.0", "@solana/web3.js@^1.95.0":
+"@solana/options@2.0.0-preview.2":
+  version "2.0.0-preview.2"
+  resolved "https://registry.npmjs.org/@solana/options/-/options-2.0.0-preview.2.tgz"
+  integrity sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-preview.2"
+    "@solana/codecs-numbers" "2.0.0-preview.2"
+
+"@solana/options@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz"
+  integrity sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/spl-token-group@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.4.tgz"
+  integrity sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==
+  dependencies:
+    "@solana/codecs" "2.0.0-preview.2"
+    "@solana/spl-type-length-value" "0.1.0"
+
+"@solana/spl-token-metadata@^0.1.4":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz"
+  integrity sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==
+  dependencies:
+    "@solana/codecs" "2.0.0-rc.1"
+
+"@solana/spl-token@0.4.6":
+  version "0.4.6"
+  resolved "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.6.tgz"
+  integrity sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    "@solana/spl-token-group" "^0.0.4"
+    "@solana/spl-token-metadata" "^0.1.4"
+    buffer "^6.0.3"
+
+"@solana/spl-type-length-value@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/@solana/spl-type-length-value/-/spl-type-length-value-0.1.0.tgz"
+  integrity sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==
+  dependencies:
+    buffer "^6.0.3"
+
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.91.6", "@solana/web3.js@^1.95.0", "@solana/web3.js@^1.95.3":
   version "1.98.4"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz"
   integrity sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==
@@ -356,10 +397,29 @@ base64-js@^1.3.1:
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+bigint-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz"
+  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
+  dependencies:
+    bindings "^1.3.0"
+
+bignumber.js@^9.0.1:
+  version "9.3.1"
+  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz"
   integrity sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==
+
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
 
 bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1, bn.js@^5.2.2:
   version "5.2.2"
@@ -411,7 +471,7 @@ buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   resolved "https://registry.npmjs.org/buffer-layout/-/buffer-layout-1.2.2.tgz"
   integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==
 
-buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
+buffer@^6.0.3, buffer@~6.0.3, buffer@6.0.3:
   version "6.0.3"
   resolved "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz"
   integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
@@ -438,7 +498,7 @@ chai-as-promised@^7.1.2:
   dependencies:
     check-error "^1.0.2"
 
-chai@^4.3.0:
+chai@^4.3.0, "chai@>= 2.1.2 < 6":
   version "4.5.0"
   resolved "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz"
   integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
@@ -459,7 +519,7 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.4.1:
+chalk@^5.3.0, chalk@^5.4.1:
   version "5.6.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
@@ -506,6 +566,16 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+commander@^12.0.0:
+  version "12.1.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^14.0.0:
   version "14.0.2"
@@ -637,6 +707,16 @@ fast-stable-stringify@^1.0.0:
   resolved "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz"
   integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
 
+fastestsmallesttextencoderdecoder@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz"
+  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz"
@@ -661,11 +741,6 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
-fsevents@~2.3.2, fsevents@~2.3.3:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -864,7 +939,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.6"
 
-mocha@^10.0.0:
+mocha@^10.0.0, "mocha@^3.X.X || ^4.X.X || ^5.X.X || ^6.X.X || ^7.X.X || ^8.X.X || ^9.X.X || ^10.X.X || ^11.X.X":
   version "10.8.2"
   resolved "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz"
   integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==
@@ -1155,12 +1230,12 @@ type-detect@^4.0.0, type-detect@^4.1.0:
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz"
   integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
 
-typescript@^5.0.0:
+typescript@^5.0.0, typescript@>=5, typescript@>=5.3.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
-utf-8-validate@^5.0.2:
+utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
   version "5.0.10"
   resolved "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz"
   integrity sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==
@@ -1204,7 +1279,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^7.5.10:
+ws@*, ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==


### PR DESCRIPTION
## Summary

- Adds 16 new integration tests for SPL token task flows in `tests/spl-token-tasks.ts`
- Fixes all 114 existing test failures in `test_1.ts` and `dispute-slash-logic.ts` caused by PR #864 adding `reward_mint` as a new instruction argument

## Root Cause of Failures

PR #864 added `reward_mint: Option<Pubkey>` as the 10th argument to `create_task` (and 11th to `create_dependent_task`). Anchor's `splitArgsAndCtx` only pops the context object when `args.length > inputLen`. With the old arg count, the accounts object was silently consumed as an instruction argument, leaving all accounts empty.

## Changes

- **`tests/spl-token-tasks.ts`** (new): 16 tests covering token create, claim, complete, cancel, dependent tasks, competitive/collaborative modes, fee verification, dispute preconditions, edge cases (0-decimal mint, minimum amount, insufficient balance)
- **`tests/test_1.ts`**: Added `null, // reward_mint` as 10th arg to all 123 `createTask` calls + null optional token accounts
- **`tests/dispute-slash-logic.ts`**: Added `null, // reward_mint` arg + restored required accounts + added `escrowPda` derivations
- **`package.json`**: Added `@solana/spl-token` 0.4.6 devDependency
- **`Anchor.toml`**: Updated test script to run all 3 test files

## Test plan

- [x] All 163 tests pass (`anchor test --skip-build`): 141 test_1.ts + 6 dispute-slash-logic.ts + 16 spl-token-tasks.ts
- [x] No program changes required (skip-build verified)

Closes #860