### PR TITLE
feat(sdk): add SPL token helpers and rewrite task functions

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agenc/sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "TypeScript SDK for AgenC - Privacy-preserving agent coordination on Solana",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
@@ -20,7 +20,7 @@
     "README.md"
   ],
   "scripts": {
-    "build": "tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash",
+    "build": "tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token",
     "prepublishOnly": "npm run build",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -58,6 +58,7 @@
     "snarkjs": "^0.7.0"
   },
   "devDependencies": {
+    "@solana/spl-token": "^0.4.0",
     "@types/node": "^20.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
@@ -65,7 +66,8 @@
   },
   "peerDependencies": {
     "@coral-xyz/anchor": ">=0.29.0",
-    "@solana/web3.js": ">=1.90.0"
+    "@solana/web3.js": ">=1.90.0",
+    "@solana/spl-token": ">=0.4.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/sdk/src/__tests__/tokens.test.ts
+++ b/sdk/src/__tests__/tokens.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for SPL token helpers.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PublicKey, Connection, Keypair } from '@solana/web3.js';
+
+// Mock @solana/spl-token before importing tokens module
+vi.mock('@solana/spl-token', () => {
+  const mockGetAssociatedTokenAddressSync = vi.fn();
+  const mockGetAccount = vi.fn();
+  const mockGetMint = vi.fn();
+  return {
+    getAssociatedTokenAddressSync: mockGetAssociatedTokenAddressSync,
+    getAccount: mockGetAccount,
+    getMint: mockGetMint,
+    TOKEN_PROGRAM_ID: new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA'),
+    ASSOCIATED_TOKEN_PROGRAM_ID: new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'),
+  };
+});
+
+import {
+  deriveTokenEscrowAddress,
+  isTokenTask,
+  getEscrowTokenBalance,
+  formatTokenAmount,
+  getMintDecimals,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from '../tokens';
+
+import {
+  getAssociatedTokenAddressSync,
+  getAccount as getTokenAccount,
+  getMint,
+} from '@solana/spl-token';
+
+const makeTestPubkey = (seed: number): PublicKey => {
+  const bytes = new Uint8Array(32);
+  bytes.fill(seed);
+  return new PublicKey(bytes);
+};
+
+describe('deriveTokenEscrowAddress', () => {
+  it('calls getAssociatedTokenAddressSync with correct args', () => {
+    const mint = makeTestPubkey(1);
+    const escrowPda = makeTestPubkey(2);
+    const expectedAta = makeTestPubkey(3);
+
+    vi.mocked(getAssociatedTokenAddressSync).mockReturnValue(expectedAta);
+
+    const result = deriveTokenEscrowAddress(mint, escrowPda);
+
+    expect(getAssociatedTokenAddressSync).toHaveBeenCalledWith(mint, escrowPda, true);
+    expect(result.equals(expectedAta)).toBe(true);
+  });
+
+  it('uses allowOwnerOffCurve=true for PDA owner', () => {
+    const mint = makeTestPubkey(4);
+    const escrowPda = makeTestPubkey(5);
+
+    vi.mocked(getAssociatedTokenAddressSync).mockReturnValue(makeTestPubkey(6));
+
+    deriveTokenEscrowAddress(mint, escrowPda);
+
+    const call = vi.mocked(getAssociatedTokenAddressSync).mock.calls[0];
+    expect(call[2]).toBe(true); // allowOwnerOffCurve
+  });
+
+  it('is deterministic', () => {
+    const mint = makeTestPubkey(7);
+    const escrowPda = makeTestPubkey(8);
+    const ata = makeTestPubkey(9);
+
+    vi.mocked(getAssociatedTokenAddressSync).mockReturnValue(ata);
+
+    const result1 = deriveTokenEscrowAddress(mint, escrowPda);
+    const result2 = deriveTokenEscrowAddress(mint, escrowPda);
+
+    expect(result1.equals(result2)).toBe(true);
+  });
+});
+
+describe('isTokenTask', () => {
+  it('returns true when rewardMint is set', () => {
+    expect(isTokenTask({ rewardMint: makeTestPubkey(1) })).toBe(true);
+  });
+
+  it('returns false when rewardMint is null', () => {
+    expect(isTokenTask({ rewardMint: null })).toBe(false);
+  });
+
+  it('returns false when rewardMint is undefined', () => {
+    expect(isTokenTask({})).toBe(false);
+  });
+
+  it('returns false when rewardMint is explicitly undefined', () => {
+    expect(isTokenTask({ rewardMint: undefined })).toBe(false);
+  });
+});
+
+describe('getEscrowTokenBalance', () => {
+  let mockConnection: Connection;
+
+  beforeEach(() => {
+    mockConnection = {} as unknown as Connection;
+    vi.clearAllMocks();
+  });
+
+  it('returns token balance from escrow ATA', async () => {
+    const taskPda = makeTestPubkey(1);
+    const mint = makeTestPubkey(2);
+    const ata = makeTestPubkey(3);
+
+    vi.mocked(getAssociatedTokenAddressSync).mockReturnValue(ata);
+    vi.mocked(getTokenAccount).mockResolvedValue({
+      amount: 1000000000n,
+    } as never);
+
+    const balance = await getEscrowTokenBalance(mockConnection, taskPda, mint);
+
+    expect(balance).toBe(1000000000n);
+  });
+});
+
+describe('formatTokenAmount', () => {
+  it('formats amount with 9 decimals', async () => {
+    const result = await formatTokenAmount(1000000000n, 9);
+    expect(result).toBe('1.000000000');
+  });
+
+  it('formats amount with 6 decimals (USDC-like)', async () => {
+    const result = await formatTokenAmount(1500000n, 6);
+    expect(result).toBe('1.500000');
+  });
+
+  it('formats amount with 0 decimals', async () => {
+    const result = await formatTokenAmount(42n, 0);
+    expect(result).toBe('42');
+  });
+
+  it('formats zero amount', async () => {
+    const result = await formatTokenAmount(0n, 9);
+    expect(result).toBe('0.000000000');
+  });
+
+  it('formats fractional amount', async () => {
+    const result = await formatTokenAmount(500000000n, 9);
+    expect(result).toBe('0.500000000');
+  });
+
+  it('fetches decimals from mint when not provided', async () => {
+    const mint = makeTestPubkey(1);
+    const mockConnection = {} as unknown as Connection;
+
+    vi.mocked(getMint).mockResolvedValue({ decimals: 6 } as never);
+
+    const result = await formatTokenAmount(1000000n, undefined, mockConnection, mint);
+    expect(result).toBe('1.000000');
+    expect(getMint).toHaveBeenCalledWith(mockConnection, mint);
+  });
+
+  it('throws when decimals not provided and no connection', async () => {
+    await expect(formatTokenAmount(100n)).rejects.toThrow(
+      'connection and mint are required when decimals is not provided'
+    );
+  });
+});
+
+describe('getMintDecimals', () => {
+  it('returns decimals from mint', async () => {
+    const mint = makeTestPubkey(1);
+    const mockConnection = {} as unknown as Connection;
+
+    vi.mocked(getMint).mockResolvedValue({ decimals: 9 } as never);
+
+    const decimals = await getMintDecimals(mockConnection, mint);
+    expect(decimals).toBe(9);
+  });
+
+  it('propagates errors', async () => {
+    const mint = makeTestPubkey(1);
+    const mockConnection = {} as unknown as Connection;
+
+    vi.mocked(getMint).mockRejectedValue(new Error('Account not found'));
+
+    await expect(getMintDecimals(mockConnection, mint)).rejects.toThrow('Account not found');
+  });
+});
+
+describe('re-exports', () => {
+  it('exports TOKEN_PROGRAM_ID', () => {
+    expect(TOKEN_PROGRAM_ID).toBeDefined();
+    expect(TOKEN_PROGRAM_ID).toBeInstanceOf(PublicKey);
+  });
+
+  it('exports ASSOCIATED_TOKEN_PROGRAM_ID', () => {
+    expect(ASSOCIATED_TOKEN_PROGRAM_ID).toBeDefined();
+    expect(ASSOCIATED_TOKEN_PROGRAM_ID).toBeInstanceOf(PublicKey);
+  });
+});

--- a/sdk/src/anchor-utils.ts
+++ b/sdk/src/anchor-utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Internal Anchor utilities shared across SDK modules.
+ *
+ * Provides type-safe dynamic account access for Anchor programs,
+ * since Program<T> doesn't expose individual account types at the
+ * type level when using the generic Idl.
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+
+/**
+ * Dynamic account accessor returned by Anchor's `program.account[name]`.
+ */
+export type AccountFetcher = {
+  fetch: (key: PublicKey) => Promise<unknown>;
+  all: (
+    filters?: Array<{ memcmp: { offset: number; bytes: string } }>
+  ) => Promise<Array<{ account: unknown; publicKey: PublicKey }>>;
+};
+
+/**
+ * Retrieve an account accessor from an Anchor program by name.
+ * Throws with a helpful message listing available accounts if the name is invalid.
+ */
+export function getAccount(program: Program, name: string): AccountFetcher {
+  const accounts = program.account as Record<string, AccountFetcher | undefined>;
+  const account = accounts[name];
+  if (!account) {
+    throw new Error(
+      `Account "${name}" not found in program. ` +
+      `Available accounts: ${Object.keys(accounts).join(', ') || 'none'}`
+    );
+  }
+  return account;
+}

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -103,6 +103,20 @@ export const RECOMMENDED_CU_VOTE_DISPUTE = 30_000;
 /** CU budget for resolve_dispute instruction */
 export const RECOMMENDED_CU_RESOLVE_DISPUTE = 60_000;
 
+// Token-path CU budgets (higher due to ATA creation/CPI overhead)
+
+/** CU budget for create_task with SPL token escrow */
+export const RECOMMENDED_CU_CREATE_TASK_TOKEN = 100_000;
+
+/** CU budget for complete_task with SPL token payment */
+export const RECOMMENDED_CU_COMPLETE_TASK_TOKEN = 100_000;
+
+/** CU budget for complete_task_private with SPL token payment */
+export const RECOMMENDED_CU_COMPLETE_TASK_PRIVATE_TOKEN = 250_000;
+
+/** CU budget for cancel_task with SPL token refund */
+export const RECOMMENDED_CU_CANCEL_TASK_TOKEN = 80_000;
+
 // ============================================================================
 // Fee Constants
 // ============================================================================
@@ -162,4 +176,5 @@ export const SEEDS = {
   DISPUTE: Buffer.from('dispute'),
   VOTE: Buffer.from('vote'),
   AUTHORITY_VOTE: Buffer.from('authority_vote'),
+  NULLIFIER: Buffer.from('nullifier'),
 } as const;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -40,6 +40,7 @@ export {
   claimTask,
   completeTask,
   completeTaskPrivate,
+  cancelTask,
   getTask,
   getTasksByCreator,
   deriveTaskPda,
@@ -52,6 +53,16 @@ export {
   TaskStatus,
   PrivateCompletionProof,
 } from './tasks';
+
+export {
+  deriveTokenEscrowAddress,
+  isTokenTask,
+  getEscrowTokenBalance,
+  formatTokenAmount,
+  getMintDecimals,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from './tokens';
 
 export {
   PROGRAM_ID,
@@ -86,6 +97,11 @@ export {
   RECOMMENDED_CU_INITIATE_DISPUTE,
   RECOMMENDED_CU_VOTE_DISPUTE,
   RECOMMENDED_CU_RESOLVE_DISPUTE,
+  // Token-path CU constants
+  RECOMMENDED_CU_CREATE_TASK_TOKEN,
+  RECOMMENDED_CU_COMPLETE_TASK_TOKEN,
+  RECOMMENDED_CU_COMPLETE_TASK_PRIVATE_TOKEN,
+  RECOMMENDED_CU_CANCEL_TASK_TOKEN,
   // PDA seeds
   SEEDS,
 } from './constants';
@@ -113,4 +129,4 @@ export {
 } from './logger';
 
 // Version info
-export const VERSION = '1.0.0';
+export const VERSION = '1.3.0';

--- a/sdk/src/tokens.ts
+++ b/sdk/src/tokens.ts
@@ -1,0 +1,114 @@
+/**
+ * SPL Token Helpers for AgenC
+ *
+ * Utilities for working with SPL token-denominated tasks.
+ */
+
+import { Connection, PublicKey } from '@solana/web3.js';
+import {
+  getAssociatedTokenAddressSync,
+  getAccount as getTokenAccount,
+  getMint,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import { SEEDS, PROGRAM_ID } from './constants';
+
+export { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID };
+
+/**
+ * Derive the Associated Token Account address for a task's escrow PDA.
+ *
+ * @param mint - SPL token mint address
+ * @param escrowPda - The escrow PDA (owner of the token account)
+ * @returns The ATA address for the escrow
+ */
+export function deriveTokenEscrowAddress(
+  mint: PublicKey,
+  escrowPda: PublicKey,
+): PublicKey {
+  return getAssociatedTokenAddressSync(mint, escrowPda, true);
+}
+
+/**
+ * Check whether a task uses SPL tokens (vs native SOL).
+ *
+ * @param task - Object with an optional rewardMint field
+ * @returns true if the task has a non-null rewardMint
+ */
+export function isTokenTask(task: { rewardMint?: PublicKey | null }): boolean {
+  return task.rewardMint != null;
+}
+
+/**
+ * Get the token balance of a task's escrow ATA.
+ *
+ * @param connection - Solana RPC connection
+ * @param taskPda - The task PDA
+ * @param mint - SPL token mint
+ * @param programId - AgenC program ID (defaults to PROGRAM_ID)
+ * @returns Token balance as bigint
+ */
+export async function getEscrowTokenBalance(
+  connection: Connection,
+  taskPda: PublicKey,
+  mint: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): Promise<bigint> {
+  const [escrowPda] = PublicKey.findProgramAddressSync(
+    [SEEDS.ESCROW, taskPda.toBuffer()],
+    programId,
+  );
+  const ata = getAssociatedTokenAddressSync(mint, escrowPda, true);
+  const account = await getTokenAccount(connection, ata);
+  return account.amount;
+}
+
+/**
+ * Format a raw token amount using the mint's decimals.
+ *
+ * @param amount - Raw token amount (smallest unit)
+ * @param decimals - Number of decimal places. If omitted, fetched from the mint.
+ * @param connection - Required when decimals is not provided
+ * @param mint - Required when decimals is not provided
+ * @returns Formatted string (e.g. "1.000000000" for 1 SOL-equivalent with 9 decimals)
+ */
+export async function formatTokenAmount(
+  amount: bigint,
+  decimals?: number,
+  connection?: Connection,
+  mint?: PublicKey,
+): Promise<string> {
+  let dec = decimals;
+  if (dec === undefined) {
+    if (!connection || !mint) {
+      throw new Error('connection and mint are required when decimals is not provided');
+    }
+    dec = await getMintDecimals(connection, mint);
+  }
+
+  if (dec === 0) {
+    return amount.toString();
+  }
+
+  const divisor = 10n ** BigInt(dec);
+  const whole = amount / divisor;
+  const fractional = amount % divisor;
+  const fracStr = fractional.toString().padStart(dec, '0');
+  return `${whole}.${fracStr}`;
+}
+
+/**
+ * Get the number of decimals for an SPL token mint.
+ *
+ * @param connection - Solana RPC connection
+ * @param mint - SPL token mint address
+ * @returns Number of decimals
+ */
+export async function getMintDecimals(
+  connection: Connection,
+  mint: PublicKey,
+): Promise<number> {
+  const mintInfo = await getMint(connection, mint);
+  return mintInfo.decimals;
+}

--- a/sdk/yarn.lock
+++ b/sdk/yarn.lock
@@ -112,12 +112,29 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz"
   integrity sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==
 
-"@solana/buffer-layout@^4.0.1":
+"@solana/buffer-layout-utils@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz"
+  integrity sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/web3.js" "^1.32.0"
+    bigint-buffer "^1.1.5"
+    bignumber.js "^9.0.1"
+
+"@solana/buffer-layout@^4.0.0", "@solana/buffer-layout@^4.0.1":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz"
   integrity sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==
   dependencies:
     buffer "~6.0.3"
+
+"@solana/codecs-core@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz"
+  integrity sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==
+  dependencies:
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs-core@2.3.0":
   version "2.3.0"
@@ -125,6 +142,15 @@
   integrity sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==
   dependencies:
     "@solana/errors" "2.3.0"
+
+"@solana/codecs-data-structures@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz"
+  integrity sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs-numbers@^2.1.0":
   version "2.3.0"
@@ -134,6 +160,42 @@
     "@solana/codecs-core" "2.3.0"
     "@solana/errors" "2.3.0"
 
+"@solana/codecs-numbers@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz"
+  integrity sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/codecs-strings@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz"
+  integrity sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/codecs@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz"
+  integrity sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/options" "2.0.0-rc.1"
+
+"@solana/errors@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz"
+  integrity sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==
+  dependencies:
+    chalk "^5.3.0"
+    commander "^12.1.0"
+
 "@solana/errors@2.3.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz"
@@ -142,7 +204,43 @@
     chalk "^5.4.1"
     commander "^14.0.0"
 
-"@solana/web3.js@^1.68.0", "@solana/web3.js@>=1.90.0":
+"@solana/options@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz"
+  integrity sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/spl-token-group@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz"
+  integrity sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==
+  dependencies:
+    "@solana/codecs" "2.0.0-rc.1"
+
+"@solana/spl-token-metadata@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz"
+  integrity sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==
+  dependencies:
+    "@solana/codecs" "2.0.0-rc.1"
+
+"@solana/spl-token@^0.4.0":
+  version "0.4.14"
+  resolved "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz"
+  integrity sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    "@solana/spl-token-group" "^0.0.7"
+    "@solana/spl-token-metadata" "^0.1.6"
+    buffer "^6.0.3"
+
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.95.3", "@solana/web3.js@^1.95.5", "@solana/web3.js@>=1.90.0":
   version "1.98.4"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz"
   integrity sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==
@@ -339,6 +437,25 @@ bfj@^7.0.2:
     jsonpath "^1.1.1"
     tryer "^1.0.1"
 
+bigint-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz"
+  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
+  dependencies:
+    bindings "^1.3.0"
+
+bignumber.js@^9.0.1:
+  version "9.3.1"
+  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
+bindings@^1.3.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bl@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz"
@@ -445,6 +562,11 @@ chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.3.0:
+  version "5.6.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
 chalk@^5.4.1:
   version "5.6.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
@@ -503,7 +625,7 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-commander@^12.0.0:
+commander@^12.0.0, commander@^12.1.0:
   version "12.1.0"
   resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
   integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
@@ -725,6 +847,11 @@ fast-stable-stringify@^1.0.0:
   resolved "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz"
   integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
 
+fastestsmallesttextencoderdecoder@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz"
+  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
+
 fastfile@0.0.20:
   version "0.0.20"
   resolved "https://registry.npmjs.org/fastfile/-/fastfile-0.0.20.tgz"
@@ -752,6 +879,11 @@ ffjavascript@0.3.0:
     wasmbuilder "0.0.16"
     wasmcurves "0.2.2"
     web-worker "1.2.0"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filelist@^1.0.4:
   version "1.0.4"
@@ -1375,7 +1507,7 @@ tsup@^8.0.0:
     tinyglobby "^0.2.11"
     tree-kill "^1.2.2"
 
-typescript@^5.0.0, typescript@>=4.5.0, typescript@>=5.3.3:
+typescript@^5.0.0, typescript@>=4.5.0, typescript@>=5, typescript@>=5.3.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## Summary

- Rewrite all SDK task functions (`createTask`, `claimTask`, `completeTask`, `completeTaskPrivate`) to match current on-chain program — fixes wrong PDA seeds, account names, and arg format
- Add `cancelTask` with `remaining_accounts` worker pair support
- Create `tokens.ts` with SPL token helpers: `deriveTokenEscrowAddress`, `isTokenTask`, `getEscrowTokenBalance`, `formatTokenAmount`, `getMintDecimals`
- Fix stale byte offsets in `queries.ts` (`protocol_fee_bps` shifted `depends_on` and downstream fields by 2 bytes)
- Add `protocolFeeBps`, `minReputation`, `rewardMint` to `DependentTask` type
- Extract shared `AccountFetcher`/`getAccount` to `anchor-utils.ts` (was duplicated in tasks.ts + queries.ts)
- Add `@solana/spl-token` as peer/dev dependency, bump SDK to v1.3.0

## Test plan

- [x] SDK build clean (`npm run build`)
- [x] TypeScript typecheck clean (`npm run typecheck`)
- [x] 108 SDK unit tests pass (`npm run test`) — 4 test files including new tokens.test.ts
- [x] 163 LiteSVM integration tests pass (`npm run test:fast`)

Closes #861