### PR TITLE
fix(security): harden dispute defendant lifecycle and path validation

### DIFF
--- a/mcp/src/tools/circuits.ts
+++ b/mcp/src/tools/circuits.ts
@@ -44,11 +44,17 @@ function validatePath(inputPath: string | undefined, defaultDir: string): string
     throw new Error('Invalid characters in path');
   }
 
-  // Resolve relative to project root
-  if (path.isAbsolute(inputPath)) {
-    return inputPath;
+  const candidate = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(PROJECT_ROOT, inputPath);
+
+  // Enforce project-root confinement for both absolute and relative input.
+  const projectRoot = path.resolve(PROJECT_ROOT);
+  if (candidate !== projectRoot && !candidate.startsWith(projectRoot + path.sep)) {
+    throw new Error('Path must be inside project root');
   }
-  return path.resolve(PROJECT_ROOT, inputPath);
+
+  return candidate;
 }
 
 /**

--- a/programs/agenc-coordination/src/instructions/cancel_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_dispute.rs
@@ -12,7 +12,8 @@
 
 use crate::errors::CoordinationError;
 use crate::events::DisputeCancelled;
-use crate::state::{Dispute, DisputeStatus, Task, TaskStatus};
+use crate::instructions::validation::validate_account_owner;
+use crate::state::{AgentRegistration, Dispute, DisputeStatus, Task, TaskStatus};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
@@ -46,10 +47,7 @@ pub fn handler(ctx: Context<CancelDispute>) -> Result<()> {
     let clock = Clock::get()?;
 
     // Can only cancel if no votes have been cast
-    require!(
-        dispute.total_voters == 0,
-        CoordinationError::VotingEnded
-    );
+    require!(dispute.total_voters == 0, CoordinationError::VotingEnded);
 
     // Update dispute status
     dispute.status = DisputeStatus::Cancelled;
@@ -59,6 +57,26 @@ pub fn handler(ctx: Context<CancelDispute>) -> Result<()> {
     if task.status == TaskStatus::Disputed {
         task.status = TaskStatus::InProgress;
     }
+
+    // Decrement defendant dispute counter (fix #544, #842)
+    // remaining_accounts must include exactly one account: dispute.defendant
+    require!(
+        ctx.remaining_accounts.len() == 1,
+        CoordinationError::InvalidInput
+    );
+    let defendant_info = &ctx.remaining_accounts[0];
+    validate_account_owner(defendant_info)?;
+    require!(defendant_info.is_writable, CoordinationError::InvalidInput);
+    require!(
+        defendant_info.key() == dispute.defendant,
+        CoordinationError::WorkerNotInDispute
+    );
+
+    let mut defendant_data = defendant_info.try_borrow_mut_data()?;
+    let mut defendant = AgentRegistration::try_deserialize(&mut &**defendant_data)?;
+    // Saturating decrement preserves recoverability for legacy stale counters.
+    defendant.disputes_as_defendant = defendant.disputes_as_defendant.saturating_sub(1);
+    defendant.try_serialize(&mut &mut defendant_data[8..])?;
 
     emit!(DisputeCancelled {
         dispute_id: dispute.dispute_id,

--- a/runtime/src/dispute/operations.ts
+++ b/runtime/src/dispute/operations.ts
@@ -449,6 +449,14 @@ export class DisputeOperations {
     this.logger.info(`Cancelling dispute ${disputePda.toBase58()}`);
 
     try {
+      const dispute = await this.fetchDispute(disputePda);
+      if (!dispute) {
+        throw new DisputeResolutionError(
+          disputePda.toBase58(),
+          'Dispute not found',
+        );
+      }
+
       const signature = await this.program.methods
         .cancelDispute()
         .accountsPartial({
@@ -456,6 +464,9 @@ export class DisputeOperations {
           task: taskPda,
           authority: this.program.provider.publicKey,
         })
+        .remainingAccounts([
+          { pubkey: dispute.defendant, isSigner: false, isWritable: true },
+        ])
         .rpc();
 
       this.logger.info(`Dispute cancelled: ${signature}`);


### PR DESCRIPTION
## Summary
- harden dispute defendant lifecycle bookkeeping
- enforce deterministic worker cleanup in dispute resolution/expiry
- block claim expiry during active disputes
- tighten MCP circuit path confinement to repository root