### PR TITLE
test(runtime): migrate integration tests to LiteSVM

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -15,7 +15,7 @@
   "files": ["dist", "idl", "README.md"],
   "scripts": {
     "prebuild": "npm run build --prefix ../sdk && node scripts/copy-idl.js",
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis",
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token",
     "typecheck": "tsc --noEmit",
     "pretest": "npm run build --prefix ../sdk",
     "test": "vitest run",
@@ -42,15 +42,20 @@
   },
   "devDependencies": {
     "@coral-xyz/anchor": "^0.32.1",
+    "@solana/spl-token": "^0.4.0",
     "@solana/web3.js": "^1.95.0",
     "@types/better-sqlite3": "^7.0.0",
     "@types/node": "^20.0.0",
+    "anchor-litesvm": "^0.2.1",
+    "bs58": "^6.0.0",
+    "litesvm": "^0.5.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^2.0.0"
   },
   "peerDependencies": {
     "@coral-xyz/anchor": ">=0.29.0",
+    "@solana/spl-token": ">=0.4.0",
     "@solana/web3.js": ">=1.90.0"
   },
   "engines": {

--- a/runtime/src/agent/manager.ts
+++ b/runtime/src/agent/manager.ts
@@ -119,6 +119,8 @@ export interface AgentManagerConfig {
    * If not provided, uses default TTL of 5 minutes with no stale fallback.
    */
   protocolConfigCache?: ProtocolConfigCacheOptions;
+  /** Pre-built Program instance (for testing with LiteSVM). If provided, skips internal provider creation. */
+  program?: Program<AgencCoordination>;
 }
 
 /**
@@ -225,13 +227,17 @@ export class AgentManager {
       );
     }
 
-    // Create Anchor provider and program
-    const provider = new AnchorProvider(
-      this.connection,
-      this.wallet,
-      { commitment: 'confirmed' }
-    );
-    this.program = createProgram(provider, this.programId);
+    // Use injected program or create Anchor provider and program
+    if (config.program) {
+      this.program = config.program;
+    } else {
+      const provider = new AnchorProvider(
+        this.connection,
+        this.wallet,
+        { commitment: 'confirmed' }
+      );
+      this.program = createProgram(provider, this.programId);
+    }
   }
 
   // ==========================================================================

--- a/runtime/src/agent/types.test.ts
+++ b/runtime/src/agent/types.test.ts
@@ -68,12 +68,13 @@ function createValidMockData() {
     bump: 255,
     lastTaskCreated: mockBN(1700000500),
     lastDisputeInitiated: mockBN(1699990000),
-    taskCount24h: 5,
-    disputeCount24h: 1,
+    taskCount24H: 5,
+    disputeCount24H: 1,
     rateLimitWindowStart: mockBN(1699920000),
     activeDisputeVotes: 0,
     lastVoteTimestamp: mockBN(0),
     lastStateUpdate: mockBN(1700001000),
+    disputesAsDefendant: 0,
   };
 }
 
@@ -371,6 +372,7 @@ describe('parseAgentState', () => {
       expect(agent.activeDisputeVotes).toBe(0);
       expect(agent.lastVoteTimestamp).toBe(0);
       expect(agent.lastStateUpdate).toBe(1700001000);
+      expect(agent.disputesAsDefendant).toBe(0);
     });
 
     it('correctly converts u64 fields to bigint', () => {
@@ -545,14 +547,14 @@ describe('parseAgentState', () => {
 
     it('throws when taskCount24h exceeds MAX_U8', () => {
       const mockData = createValidMockData();
-      mockData.taskCount24h = 256;
+      mockData.taskCount24H = 256;
 
       expect(() => parseAgentState(mockData)).toThrow('Invalid taskCount24h: 256');
     });
 
     it('throws when disputeCount24h exceeds MAX_U8', () => {
       const mockData = createValidMockData();
-      mockData.disputeCount24h = 256;
+      mockData.disputeCount24H = 256;
 
       expect(() => parseAgentState(mockData)).toThrow('Invalid disputeCount24h: 256');
     });
@@ -629,8 +631,8 @@ describe('parseAgentState', () => {
       const mockData = createValidMockData();
       mockData.lastTaskCreated = mockBN(0);
       mockData.lastDisputeInitiated = mockBN(0);
-      mockData.taskCount24h = 0;
-      mockData.disputeCount24h = 0;
+      mockData.taskCount24H = 0;
+      mockData.disputeCount24H = 0;
       mockData.rateLimitWindowStart = mockBN(0);
       mockData.activeDisputeVotes = 0;
       mockData.lastVoteTimestamp = mockBN(0);
@@ -649,8 +651,8 @@ describe('parseAgentState', () => {
     it('handles maximum u8 values', () => {
       const mockData = createValidMockData();
       mockData.activeTasks = 255;
-      mockData.taskCount24h = 255;
-      mockData.disputeCount24h = 255;
+      mockData.taskCount24H = 255;
+      mockData.disputeCount24H = 255;
       mockData.activeDisputeVotes = 255;
       mockData.bump = 255;
 
@@ -715,6 +717,7 @@ describe('AgentState interface', () => {
       activeDisputeVotes: 0,
       lastVoteTimestamp: 0,
       lastStateUpdate: 1700001000,
+      disputesAsDefendant: 0,
     };
 
     expect(agent.authority).toBeInstanceOf(PublicKey);

--- a/runtime/src/agent/types.ts
+++ b/runtime/src/agent/types.ts
@@ -227,6 +227,10 @@ export interface AgentState {
   // === State Sync ===
   /** Timestamp of last state update (Unix seconds) */
   lastStateUpdate: number;
+
+  // === Defendant Tracking ===
+  /** Number of disputes where this agent is the defendant */
+  disputesAsDefendant: number;
 }
 
 // ============================================================================
@@ -379,12 +383,13 @@ interface RawAgentRegistrationData {
   bump: number;
   lastTaskCreated: { toNumber: () => number };
   lastDisputeInitiated: { toNumber: () => number };
-  taskCount24h: number;
-  disputeCount24h: number;
+  taskCount24H: number;
+  disputeCount24H: number;
   rateLimitWindowStart: { toNumber: () => number };
   activeDisputeVotes: number;
   lastVoteTimestamp: { toNumber: () => number };
   lastStateUpdate: { toNumber: () => number };
+  disputesAsDefendant: number;
 }
 
 /**
@@ -430,8 +435,9 @@ function isRawAgentRegistrationData(data: unknown): data is RawAgentRegistration
   if (typeof obj.reputation !== 'number') return false;
   if (typeof obj.activeTasks !== 'number') return false;
   if (typeof obj.bump !== 'number') return false;
-  if (typeof obj.taskCount24h !== 'number') return false;
-  if (typeof obj.disputeCount24h !== 'number') return false;
+  if (typeof obj.taskCount24H !== 'number') return false;
+  if (typeof obj.disputeCount24H !== 'number') return false;
+  if (typeof obj.disputesAsDefendant !== 'number') return false;
   if (typeof obj.activeDisputeVotes !== 'number') return false;
 
   // Status can be object (Anchor enum) or number
@@ -515,12 +521,17 @@ export function parseAgentState(data: unknown): AgentState {
   if (data.activeTasks > MAX_U8) {
     throw new Error(`Invalid activeTasks: ${data.activeTasks} (must be 0-${MAX_U8})`);
   }
-  if (data.taskCount24h > MAX_U8) {
-    throw new Error(`Invalid taskCount24h: ${data.taskCount24h} (must be 0-${MAX_U8})`);
+  if (data.taskCount24H > MAX_U8) {
+    throw new Error(`Invalid taskCount24h: ${data.taskCount24H} (must be 0-${MAX_U8})`);
   }
-  if (data.disputeCount24h > MAX_U8) {
+  if (data.disputeCount24H > MAX_U8) {
     throw new Error(
-      `Invalid disputeCount24h: ${data.disputeCount24h} (must be 0-${MAX_U8})`
+      `Invalid disputeCount24h: ${data.disputeCount24H} (must be 0-${MAX_U8})`
+    );
+  }
+  if (data.disputesAsDefendant > MAX_U8) {
+    throw new Error(
+      `Invalid disputesAsDefendant: ${data.disputesAsDefendant} (must be 0-${MAX_U8})`
     );
   }
   if (data.activeDisputeVotes > MAX_U8) {
@@ -574,8 +585,8 @@ export function parseAgentState(data: unknown): AgentState {
     // Rate Limiting
     lastTaskCreated: data.lastTaskCreated.toNumber(),
     lastDisputeInitiated: data.lastDisputeInitiated.toNumber(),
-    taskCount24h: data.taskCount24h,
-    disputeCount24h: data.disputeCount24h,
+    taskCount24h: data.taskCount24H,
+    disputeCount24h: data.disputeCount24H,
     rateLimitWindowStart: data.rateLimitWindowStart.toNumber(),
 
     // Dispute Activity
@@ -584,6 +595,9 @@ export function parseAgentState(data: unknown): AgentState {
 
     // State Sync
     lastStateUpdate: data.lastStateUpdate.toNumber(),
+
+    // Defendant Tracking
+    disputesAsDefendant: data.disputesAsDefendant,
   };
 }
 

--- a/runtime/src/runtime.ts
+++ b/runtime/src/runtime.ts
@@ -8,7 +8,9 @@
  */
 
 import { Connection, PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
 import { PROGRAM_ID } from '@agenc/sdk';
+import type { AgencCoordination } from './types/agenc_coordination.js';
 import { AgentManager } from './agent/manager.js';
 import { AgentState, AgentStatus, AgentRegistrationParams, AGENT_ID_LENGTH } from './agent/types.js';
 import { findAgentPda } from './agent/pda.js';
@@ -122,6 +124,7 @@ export class AgentRuntime {
       wallet: this.wallet,
       programId: this.programId,
       logger: this.logger,
+      program: config.program as Program<AgencCoordination> | undefined,
     });
 
     this.logger.debug('AgentRuntime created');

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -80,6 +80,7 @@ function serializeTask(task: OnChainTask, taskPda: PublicKey): SerializedTask {
     completions: task.completions,
     requiredCompletions: task.requiredCompletions,
     description: bytesToHex(task.description),
+    rewardMint: task.rewardMint?.toBase58() ?? null,
   };
 }
 
@@ -119,6 +120,8 @@ function serializeProtocolConfig(config: ProtocolConfig): SerializedProtocolConf
     maxDisputesPer24h: config.maxDisputesPer24h,
     minStakeForDispute: config.minStakeForDispute.toString(),
     slashPercentage: config.slashPercentage,
+    stateUpdateCooldown: config.stateUpdateCooldown,
+    votingPeriod: config.votingPeriod,
     protocolVersion: config.protocolVersion,
     minSupportedVersion: config.minSupportedVersion,
   };

--- a/runtime/src/tools/agenc/types.ts
+++ b/runtime/src/tools/agenc/types.ts
@@ -27,6 +27,7 @@ export interface SerializedTask {
   completions: number;
   requiredCompletions: number;
   description: string;
+  rewardMint: string | null;
 }
 
 /**
@@ -68,6 +69,8 @@ export interface SerializedProtocolConfig {
   maxDisputesPer24h: number;
   minStakeForDispute: string;
   slashPercentage: number;
+  stateUpdateCooldown: number;
+  votingPeriod: number;
   protocolVersion: number;
   minSupportedVersion: number;
 }

--- a/runtime/src/types/config.ts
+++ b/runtime/src/types/config.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Connection, PublicKey, Keypair } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
 import type { Wallet } from './wallet.js';
 import type { LogLevel } from '../utils/logger.js';
 
@@ -48,6 +49,9 @@ export interface AgentRuntimeConfig {
 
   /** Log level (default: no logging) */
   logLevel?: LogLevel;
+
+  /** Pre-built Program instance (for testing with LiteSVM). Passed through to AgentManager. */
+  program?: Program;
 }
 
 /**

--- a/runtime/src/types/protocol.test.ts
+++ b/runtime/src/types/protocol.test.ts
@@ -43,11 +43,13 @@ function createValidMockData() {
     multisigThreshold: 2,
     multisigOwnersLen: 3,
     taskCreationCooldown: mockBN(60),
-    maxTasksPer24h: 10,
+    maxTasksPer24H: 10,
     disputeInitiationCooldown: mockBN(300),
-    maxDisputesPer24h: 5,
+    maxDisputesPer24H: 5,
     minStakeForDispute: mockBN(500_000_000n),
     slashPercentage: 10,
+    stateUpdateCooldown: mockBN(60),
+    votingPeriod: mockBN(86400),
     protocolVersion: 1,
     minSupportedVersion: 1,
     multisigOwners: [
@@ -91,6 +93,8 @@ describe('ProtocolConfig interface', () => {
       maxDisputesPer24h: 5,
       minStakeForDispute: 500_000_000n,
       slashPercentage: 10,
+      stateUpdateCooldown: 60,
+      votingPeriod: 86400,
       protocolVersion: 1,
       minSupportedVersion: 1,
       multisigOwners: [new PublicKey(TEST_PUBKEY_3)],
@@ -129,6 +133,8 @@ describe('parseProtocolConfig', () => {
       expect(config.maxDisputesPer24h).toBe(5);
       expect(config.minStakeForDispute).toBe(500_000_000n);
       expect(config.slashPercentage).toBe(10);
+      expect(config.stateUpdateCooldown).toBe(60);
+      expect(config.votingPeriod).toBe(86400);
       expect(config.protocolVersion).toBe(1);
       expect(config.minSupportedVersion).toBe(1);
     });
@@ -356,9 +362,9 @@ describe('parseProtocolConfig', () => {
     it('handles zero values for optional fields', () => {
       const mockData = createValidMockData();
       mockData.taskCreationCooldown = mockBN(0);
-      mockData.maxTasksPer24h = 0;
+      mockData.maxTasksPer24H = 0;
       mockData.disputeInitiationCooldown = mockBN(0);
-      mockData.maxDisputesPer24h = 0;
+      mockData.maxDisputesPer24H = 0;
 
       const config = parseProtocolConfig(mockData);
 
@@ -371,8 +377,8 @@ describe('parseProtocolConfig', () => {
     it('handles maximum u8 values', () => {
       const mockData = createValidMockData();
       mockData.bump = 255;
-      mockData.maxTasksPer24h = 255;
-      mockData.maxDisputesPer24h = 255;
+      mockData.maxTasksPer24H = 255;
+      mockData.maxDisputesPer24H = 255;
       mockData.disputeThreshold = 100; // max valid
 
       const config = parseProtocolConfig(mockData);

--- a/runtime/src/types/protocol.ts
+++ b/runtime/src/types/protocol.ts
@@ -72,6 +72,12 @@ export interface ProtocolConfig {
   /** Percentage of stake slashed on losing dispute (0-100) */
   slashPercentage: number;
 
+  /** Cooldown between agent state updates (seconds, 0 = disabled) */
+  stateUpdateCooldown: number;
+
+  /** Voting period for disputes (seconds) */
+  votingPeriod: number;
+
   /** Current protocol version (for upgrades) */
   protocolVersion: number;
 
@@ -103,11 +109,13 @@ interface RawProtocolConfigData {
   multisigThreshold: number;
   multisigOwnersLen: number;
   taskCreationCooldown: { toNumber: () => number };
-  maxTasksPer24h: number;
+  maxTasksPer24H: number;
   disputeInitiationCooldown: { toNumber: () => number };
-  maxDisputesPer24h: number;
+  maxDisputesPer24H: number;
   minStakeForDispute: { toNumber?: () => number; toString: () => string };
   slashPercentage: number;
+  stateUpdateCooldown: { toNumber: () => number };
+  votingPeriod: { toNumber: () => number };
   protocolVersion: number;
   minSupportedVersion: number;
   multisigOwners: PublicKey[];
@@ -153,8 +161,8 @@ function isRawProtocolConfigData(data: unknown): data is RawProtocolConfigData {
   if (typeof obj.bump !== 'number') return false;
   if (typeof obj.multisigThreshold !== 'number') return false;
   if (typeof obj.multisigOwnersLen !== 'number') return false;
-  if (typeof obj.maxTasksPer24h !== 'number') return false;
-  if (typeof obj.maxDisputesPer24h !== 'number') return false;
+  if (typeof obj.maxTasksPer24H !== 'number') return false;
+  if (typeof obj.maxDisputesPer24H !== 'number') return false;
   if (typeof obj.slashPercentage !== 'number') return false;
   if (typeof obj.protocolVersion !== 'number') return false;
   if (typeof obj.minSupportedVersion !== 'number') return false;
@@ -173,6 +181,8 @@ function isRawProtocolConfigData(data: unknown): data is RawProtocolConfigData {
   if (!isBNLikeWithToNumber(obj.maxDisputeDuration)) return false;
   if (!isBNLikeWithToNumber(obj.taskCreationCooldown)) return false;
   if (!isBNLikeWithToNumber(obj.disputeInitiationCooldown)) return false;
+  if (!isBNLikeWithToNumber(obj.stateUpdateCooldown)) return false;
+  if (!isBNLikeWithToNumber(obj.votingPeriod)) return false;
 
   // Validate array field and its contents
   if (!Array.isArray(obj.multisigOwners)) return false;
@@ -272,11 +282,15 @@ export function parseProtocolConfig(data: unknown): ProtocolConfig {
 
     // Rate Limiting
     taskCreationCooldown: data.taskCreationCooldown.toNumber(),
-    maxTasksPer24h: data.maxTasksPer24h,
+    maxTasksPer24h: data.maxTasksPer24H,
     disputeInitiationCooldown: data.disputeInitiationCooldown.toNumber(),
-    maxDisputesPer24h: data.maxDisputesPer24h,
+    maxDisputesPer24h: data.maxDisputesPer24H,
     minStakeForDispute: toBigInt(data.minStakeForDispute),
     slashPercentage: data.slashPercentage,
+
+    // State Update & Voting
+    stateUpdateCooldown: data.stateUpdateCooldown.toNumber(),
+    votingPeriod: data.votingPeriod.toNumber(),
 
     // Versioning
     protocolVersion: data.protocolVersion,

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -3,7 +3,7 @@
 
 
 "@agenc/sdk@file:../sdk":
-  version "1.2.0"
+  version "1.3.0"
   resolved "file:../sdk"
   dependencies:
     "@coral-xyz/anchor" ">=0.29.0"
@@ -127,12 +127,29 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.2.tgz"
   integrity sha512-4BJucJBGbuGnH6q7kpPqGJGzZnYrpAzRd60HQSt3OpX/6/YVgSsJnNzR8Ot74io50SeVT4CtCWe/RYIAymFPwA==
 
-"@solana/buffer-layout@^4.0.1":
+"@solana/buffer-layout-utils@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz"
+  integrity sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/web3.js" "^1.32.0"
+    bigint-buffer "^1.1.5"
+    bignumber.js "^9.0.1"
+
+"@solana/buffer-layout@^4.0.0", "@solana/buffer-layout@^4.0.1":
   version "4.0.1"
   resolved "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz"
   integrity sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==
   dependencies:
     buffer "~6.0.3"
+
+"@solana/codecs-core@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz"
+  integrity sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==
+  dependencies:
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs-core@2.3.0":
   version "2.3.0"
@@ -140,6 +157,15 @@
   integrity sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==
   dependencies:
     "@solana/errors" "2.3.0"
+
+"@solana/codecs-data-structures@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz"
+  integrity sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
 
 "@solana/codecs-numbers@^2.1.0":
   version "2.3.0"
@@ -149,6 +175,42 @@
     "@solana/codecs-core" "2.3.0"
     "@solana/errors" "2.3.0"
 
+"@solana/codecs-numbers@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz"
+  integrity sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/codecs-strings@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz"
+  integrity sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/codecs@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz"
+  integrity sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/options" "2.0.0-rc.1"
+
+"@solana/errors@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz"
+  integrity sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==
+  dependencies:
+    chalk "^5.3.0"
+    commander "^12.1.0"
+
 "@solana/errors@2.3.0":
   version "2.3.0"
   resolved "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz"
@@ -157,7 +219,43 @@
     chalk "^5.4.1"
     commander "^14.0.0"
 
-"@solana/web3.js@^1.69.0", "@solana/web3.js@^1.95.0":
+"@solana/options@2.0.0-rc.1":
+  version "2.0.0-rc.1"
+  resolved "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz"
+  integrity sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==
+  dependencies:
+    "@solana/codecs-core" "2.0.0-rc.1"
+    "@solana/codecs-data-structures" "2.0.0-rc.1"
+    "@solana/codecs-numbers" "2.0.0-rc.1"
+    "@solana/codecs-strings" "2.0.0-rc.1"
+    "@solana/errors" "2.0.0-rc.1"
+
+"@solana/spl-token-group@^0.0.7":
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz"
+  integrity sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==
+  dependencies:
+    "@solana/codecs" "2.0.0-rc.1"
+
+"@solana/spl-token-metadata@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz"
+  integrity sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==
+  dependencies:
+    "@solana/codecs" "2.0.0-rc.1"
+
+"@solana/spl-token@^0.4.0":
+  version "0.4.14"
+  resolved "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz"
+  integrity sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    "@solana/spl-token-group" "^0.0.7"
+    "@solana/spl-token-metadata" "^0.1.6"
+    buffer "^6.0.3"
+
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.95.0", "@solana/web3.js@^1.95.3", "@solana/web3.js@^1.95.5":
   version "1.98.4"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz"
   integrity sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==
@@ -363,7 +461,19 @@ better-sqlite3@^12.0.0:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"
 
-bindings@^1.5.0:
+bigint-buffer@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz"
+  integrity sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==
+  dependencies:
+    bindings "^1.3.0"
+
+bignumber.js@^9.0.1:
+  version "9.3.1"
+  resolved "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz"
+  integrity sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==
+
+bindings@^1.3.0, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -464,7 +574,7 @@ chai@^5.1.2:
     loupe "^3.1.0"
     pathval "^2.0.0"
 
-chalk@^5.4.1:
+chalk@^5.3.0, chalk@^5.4.1:
   version "5.6.2"
   resolved "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
@@ -497,6 +607,11 @@ combined-stream@^1.0.8:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
+
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^14.0.0:
   version "14.0.2"
@@ -736,6 +851,11 @@ fast-stable-stringify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz"
   integrity sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==
+
+fastestsmallesttextencoderdecoder@^1.0.22:
+  version "1.0.22"
+  resolved "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz"
+  integrity sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==
 
 fdir@^6.5.0:
   version "6.5.0"
@@ -1478,7 +1598,7 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
-typescript@^5.0.0, typescript@>=4.5.0, typescript@>=5.3.3:
+typescript@^5.0.0, typescript@>=4.5.0, typescript@>=5, typescript@>=5.3.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==


### PR DESCRIPTION
## Summary

- Remove `RUN_INTEGRATION` env gate from runtime integration tests — all 8 tests now run in-process via LiteSVM (~125ms)
- Add optional `program` injection to `AgentManager`/`AgentRuntimeConfig` for LiteSVM compatibility
- Fix runtime type parsers to match on-chain program after PR #868 (new fields, Anchor casing)
- Create `runtime/tests/litesvm-setup.ts` with defensive `patchSendAndConfirm()` for anchor-litesvm

## Test plan

- [x] All 1886 runtime tests pass across 66 files
- [x] Typecheck clean
- [x] 8 formerly-skipped integration tests now pass with LiteSVM