### PR TITLE
feat(runtime): add SPL token support across runtime modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,11 @@ circuits/**/*.gz
 CLAUDE.md
 .mcp.json
 
+# Codex (local AI assistant config)
+.codex/
+CODEX.md
+codex.md
+
 # Cursor IDE
 .cursor/
 .cursorrules

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -449,6 +449,37 @@
         {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account to receive refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -751,6 +782,45 @@
         {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account",
+          "docs": [
+            "Worker's token account to receive reward (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury's token account for protocol fees (optional, must pre-exist)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": [
@@ -965,6 +1035,45 @@
         {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account",
+          "docs": [
+            "Worker's token account to receive reward (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury's token account for protocol fees (optional, must pre-exist)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": [
@@ -1062,11 +1171,15 @@
         {
           "name": "parent_task",
           "docs": [
-            "The parent task this new task depends on"
+            "The parent task this new task depends on",
+            "Note: Uses Box to reduce stack usage for this large account"
           ]
         },
         {
           "name": "protocol_config",
+          "docs": [
+            "Note: Uses Box to reduce stack usage for this large account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -1134,6 +1247,45 @@
         {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint for reward denomination (optional)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Escrow's associated token account for holding reward tokens (optional)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Account program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         }
       ],
       "args": [
@@ -1193,6 +1345,12 @@
         {
           "name": "min_reputation",
           "type": "u16"
+        },
+        {
+          "name": "reward_mint",
+          "type": {
+            "option": "pubkey"
+          }
         }
       ]
     },
@@ -1341,6 +1499,46 @@
         {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint for reward denomination (optional)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Escrow's associated token account for holding reward tokens (optional).",
+            "Created via ATA CPI during handler if token task."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Account program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         }
       ],
       "args": [
@@ -1396,6 +1594,12 @@
         {
           "name": "min_reputation",
           "type": "u16"
+        },
+        {
+          "name": "reward_mint",
+          "type": {
+            "option": "pubkey"
+          }
         }
       ]
     },
@@ -1785,6 +1989,45 @@
           ],
           "writable": true,
           "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account for refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account_ata",
+          "docs": [
+            "Worker's token account for payment (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -2413,6 +2656,53 @@
         {
           "name": "system_program",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account for refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account_ata",
+          "docs": [
+            "Worker's token account for payment (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury's token account for protocol fees (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -3026,6 +3316,34 @@
                 "kind": "account",
                 "path": "worker_claim.worker",
                 "account": "TaskClaim"
+              }
+            ]
+          }
+        },
+        {
+          "name": "defendant_agent",
+          "docs": [
+            "Optional: Defendant's agent registration (for authority-level participant check, fix #824)",
+            "If provided, validates arbiter's authority is not the defendant worker's authority.",
+            "Must match the dispute's defendant field."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "defendant_agent.agent_id",
+                "account": "AgentRegistration"
               }
             ]
           }
@@ -4392,6 +4710,31 @@
       "code": 6141,
       "name": "DevelopmentKeyNotAllowed",
       "msg": "Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use."
+    },
+    {
+      "code": 6142,
+      "name": "SelfTaskNotAllowed",
+      "msg": "Cannot claim own task: worker authority matches task creator"
+    },
+    {
+      "code": 6143,
+      "name": "MissingTokenAccounts",
+      "msg": "Token accounts not provided for token-denominated task"
+    },
+    {
+      "code": 6144,
+      "name": "InvalidTokenEscrow",
+      "msg": "Token escrow ATA does not match expected derivation"
+    },
+    {
+      "code": 6145,
+      "name": "InvalidTokenMint",
+      "msg": "Provided mint does not match task's reward_mint"
+    },
+    {
+      "code": 6146,
+      "name": "TokenTransferFailed",
+      "msg": "SPL token transfer CPI failed"
     }
   ],
   "types": [
@@ -5092,6 +5435,15 @@
           {
             "name": "dependency_type",
             "type": "u8"
+          },
+          {
+            "name": "reward_mint",
+            "docs": [
+              "SPL token mint for reward denomination (None = SOL)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
           },
           {
             "name": "timestamp",
@@ -6493,15 +6845,14 @@
             "type": "u16"
           },
           {
-            "name": "_reserved",
+            "name": "reward_mint",
             "docs": [
-              "Reserved"
+              "Optional SPL token mint for reward denomination.",
+              "None = SOL rewards (default, backward compatible).",
+              "Some(mint) = SPL token rewards using the specified mint."
             ],
             "type": {
-              "array": [
-                "u8",
-                30
-              ]
+              "option": "pubkey"
             }
           }
         ]
@@ -6764,6 +7115,15 @@
           {
             "name": "min_reputation",
             "type": "u16"
+          },
+          {
+            "name": "reward_mint",
+            "docs": [
+              "SPL token mint for reward denomination (None = SOL)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
           },
           {
             "name": "timestamp",

--- a/runtime/src/autonomous/scanner.ts
+++ b/runtime/src/autonomous/scanner.ts
@@ -261,6 +261,16 @@ export class TaskScanner {
       return false;
     }
 
+    // Mint filter
+    if (f.acceptedMints !== undefined) {
+      const taskMintKey = task.rewardMint?.toBase58() ?? null;
+      const accepted = f.acceptedMints.some((m) => {
+        if (m === null) return taskMintKey === null;
+        return taskMintKey === m.toBase58();
+      });
+      if (!accepted) return false;
+    }
+
     // Deadline filter - skip expired tasks
     if (task.deadline > 0 && task.deadline < Math.floor(Date.now() / 1000)) {
       return false;
@@ -291,6 +301,7 @@ export class TaskScanner {
       status:
         | { open?: unknown; inProgress?: unknown; completed?: unknown; cancelled?: unknown; disputed?: unknown }
         | number;
+      rewardMint: PublicKey | null;
     };
 
     return {
@@ -305,6 +316,7 @@ export class TaskScanner {
       maxWorkers: data.maxWorkers,
       currentClaims: data.currentClaims,
       status: this.parseStatus(data.status),
+      rewardMint: data.rewardMint ?? null,
     };
   }
 

--- a/runtime/src/autonomous/speculation-adapter.ts
+++ b/runtime/src/autonomous/speculation-adapter.ts
@@ -101,6 +101,7 @@ export function autonomousTaskToOnChainTask(task: Task): OnChainTask {
     completions: 0,
     requiredCompletions: 1,
     bump: 0,
+    rewardMint: task.rewardMint ?? null,
   };
 }
 
@@ -126,6 +127,7 @@ export function onChainTaskToAutonomousTask(task: OnChainTask, pda: PublicKey): 
     maxWorkers: task.maxWorkers,
     currentClaims: task.currentWorkers,
     status: mapOnChainTaskStatus(task.status),
+    rewardMint: task.rewardMint ?? null,
   };
 }
 

--- a/runtime/src/autonomous/types.ts
+++ b/runtime/src/autonomous/types.ts
@@ -38,6 +38,8 @@ export interface Task {
   currentClaims: number;
   /** Task status */
   status: TaskStatus;
+  /** SPL token mint for reward denomination (null = SOL) */
+  rewardMint: PublicKey | null;
 }
 
 export enum TaskStatus {
@@ -66,6 +68,11 @@ export interface TaskFilter {
   privateOnly?: boolean;
   /** Only public tasks (zero constraint hash) */
   publicOnly?: boolean;
+  /**
+   * Accepted reward mints. null means SOL, PublicKey means that mint.
+   * Undefined (or omitted) means accept all mints.
+   */
+  acceptedMints?: (PublicKey | null)[];
   /** Custom filter function */
   custom?: (task: Task) => boolean;
 }
@@ -270,8 +277,10 @@ export interface AutonomousAgentStats {
   tasksCompleted: number;
   /** Total tasks failed */
   tasksFailed: number;
-  /** Total earnings in lamports */
+  /** Total earnings in lamports (across all mints) */
   totalEarnings: bigint;
+  /** Earnings broken down by mint (key = mint base58, "SOL" for native) */
+  earningsByMint: Record<string, bigint>;
   /** Currently active tasks */
   activeTasks: number;
   /** Average task completion time (ms) */

--- a/runtime/src/builder.ts
+++ b/runtime/src/builder.ts
@@ -250,6 +250,14 @@ export class AgentBuilder {
     return this;
   }
 
+  withAcceptedMints(mints: (PublicKey | null)[]): this {
+    if (!this.taskFilter) {
+      this.taskFilter = {};
+    }
+    this.taskFilter.acceptedMints = mints;
+    return this;
+  }
+
   withClaimStrategy(strategy: ClaimStrategy): this {
     this.claimStrategy = strategy;
     return this;

--- a/runtime/src/dispute/operations.test.ts
+++ b/runtime/src/dispute/operations.test.ts
@@ -110,6 +110,9 @@ function createMockProgram(overrides: Record<string, any> = {}) {
       protocolConfig: {
         fetch: vi.fn().mockResolvedValue({ treasury: randomPubkey() }),
       },
+      task: {
+        fetch: vi.fn().mockResolvedValue({ rewardMint: null }),
+      },
     },
     methods: {
       initiateDispute: vi.fn().mockReturnValue(methodBuilder),

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -235,6 +235,17 @@ export {
   toAnchorBytes,
 } from './utils/index.js';
 
+// SPL Token utilities
+export {
+  isTokenTask,
+  buildCompleteTaskTokenAccounts,
+  buildResolveDisputeTokenAccounts,
+  buildExpireDisputeTokenAccounts,
+  buildCreateTaskTokenAccounts,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from './utils/index.js';
+
 // Event monitoring (Phase 2)
 export {
   // Shared types

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -28,6 +28,7 @@ import {
 import { deriveTaskPda, deriveClaimPda, deriveEscrowPda } from './pda.js';
 import { deriveAgentPda, findProtocolPda } from '../agent/pda.js';
 import { fetchTreasury } from '../utils/treasury.js';
+import { buildCompleteTaskTokenAccounts } from '../utils/token.js';
 import {
   isAnchorError,
   parseAnchorError,
@@ -345,6 +346,12 @@ export class TaskOperations {
     const { address: escrowPda } = deriveEscrowPda(taskPda, this.program.programId);
     const protocolPda = findProtocolPda(this.program.programId);
     const treasury = await this.getProtocolTreasury();
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      this.program.provider.publicKey!,
+      treasury,
+    );
 
     this.logger.info(`Completing task ${taskPda.toBase58()}`);
 
@@ -363,6 +370,7 @@ export class TaskOperations {
           treasury,
           authority: this.program.provider.publicKey,
           systemProgram: SystemProgram.programId,
+          ...tokenAccounts,
         })
         .rpc();
 
@@ -404,6 +412,12 @@ export class TaskOperations {
     const { address: escrowPda } = deriveEscrowPda(taskPda, this.program.programId);
     const protocolPda = findProtocolPda(this.program.programId);
     const treasury = await this.getProtocolTreasury();
+    const tokenAccounts = buildCompleteTaskTokenAccounts(
+      task.rewardMint,
+      escrowPda,
+      this.program.provider.publicKey!,
+      treasury,
+    );
 
     this.logger.info(`Completing task privately ${taskPda.toBase58()}`);
 
@@ -430,6 +444,7 @@ export class TaskOperations {
           treasury,
           authority: this.program.provider.publicKey,
           systemProgram: SystemProgram.programId,
+          ...tokenAccounts,
         })
         .rpc();
 

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -87,6 +87,8 @@ export interface OnChainTask {
   requiredCompletions: number;
   /** PDA bump seed */
   bump: number;
+  /** SPL token mint for reward denomination (null = SOL) */
+  rewardMint: PublicKey | null;
 }
 
 /**
@@ -146,6 +148,7 @@ export interface RawOnChainTask {
   completions: number;
   requiredCompletions: number;
   bump: number;
+  rewardMint: PublicKey | null;
 }
 
 /**
@@ -229,6 +232,11 @@ export function isRawOnChainTask(data: unknown): data is RawOnChainTask {
   // Status and taskType can be object (Anchor enum) or number
   if (typeof obj.status !== 'object' && typeof obj.status !== 'number') return false;
   if (typeof obj.taskType !== 'object' && typeof obj.taskType !== 'number') return false;
+
+  // rewardMint is optional: null (SOL) or PublicKey-like
+  if (obj.rewardMint !== null && obj.rewardMint !== undefined) {
+    if (!(obj.rewardMint instanceof Object) || typeof (obj.rewardMint as Record<string, unknown>).toBuffer !== 'function') return false;
+  }
 
   return true;
 }
@@ -376,6 +384,7 @@ export function parseOnChainTask(data: unknown): OnChainTask {
     completions: data.completions,
     requiredCompletions: data.requiredCompletions,
     bump: data.bump,
+    rewardMint: data.rewardMint ?? null,
   };
 }
 

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -461,6 +461,37 @@ export type AgencCoordination = {
         {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creatorTokenAccount",
+          "docs": [
+            "Creator's token account to receive refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -763,6 +794,45 @@ export type AgencCoordination = {
         {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "workerTokenAccount",
+          "docs": [
+            "Worker's token account to receive reward (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasuryTokenAccount",
+          "docs": [
+            "Treasury's token account for protocol fees (optional, must pre-exist)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": [
@@ -977,6 +1047,45 @@ export type AgencCoordination = {
         {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "workerTokenAccount",
+          "docs": [
+            "Worker's token account to receive reward (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasuryTokenAccount",
+          "docs": [
+            "Treasury's token account for protocol fees (optional, must pre-exist)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": [
@@ -1074,11 +1183,15 @@ export type AgencCoordination = {
         {
           "name": "parentTask",
           "docs": [
-            "The parent task this new task depends on"
+            "The parent task this new task depends on",
+            "Note: Uses Box to reduce stack usage for this large account"
           ]
         },
         {
           "name": "protocolConfig",
+          "docs": [
+            "Note: Uses Box to reduce stack usage for this large account"
+          ],
           "writable": true,
           "pda": {
             "seeds": [
@@ -1146,6 +1259,45 @@ export type AgencCoordination = {
         {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL token mint for reward denomination (optional)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "creatorTokenAccount",
+          "docs": [
+            "Creator's token account holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Escrow's associated token account for holding reward tokens (optional)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associatedTokenProgram",
+          "docs": [
+            "Associated Token Account program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         }
       ],
       "args": [
@@ -1205,6 +1357,12 @@ export type AgencCoordination = {
         {
           "name": "minReputation",
           "type": "u16"
+        },
+        {
+          "name": "rewardMint",
+          "type": {
+            "option": "pubkey"
+          }
         }
       ]
     },
@@ -1353,6 +1511,46 @@ export type AgencCoordination = {
         {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL token mint for reward denomination (optional)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "creatorTokenAccount",
+          "docs": [
+            "Creator's token account holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Escrow's associated token account for holding reward tokens (optional).",
+            "Created via ATA CPI during handler if token task."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associatedTokenProgram",
+          "docs": [
+            "Associated Token Account program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         }
       ],
       "args": [
@@ -1408,6 +1606,12 @@ export type AgencCoordination = {
         {
           "name": "minReputation",
           "type": "u16"
+        },
+        {
+          "name": "rewardMint",
+          "type": {
+            "option": "pubkey"
+          }
         }
       ]
     },
@@ -1797,6 +2001,45 @@ export type AgencCoordination = {
           ],
           "writable": true,
           "optional": true
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creatorTokenAccount",
+          "docs": [
+            "Creator's token account for refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "workerTokenAccountAta",
+          "docs": [
+            "Worker's token account for payment (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -2425,6 +2668,53 @@ export type AgencCoordination = {
         {
           "name": "systemProgram",
           "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creatorTokenAccount",
+          "docs": [
+            "Creator's token account for refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "workerTokenAccountAta",
+          "docs": [
+            "Worker's token account for payment (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasuryTokenAccount",
+          "docs": [
+            "Treasury's token account for protocol fees (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -3038,6 +3328,34 @@ export type AgencCoordination = {
                 "kind": "account",
                 "path": "worker_claim.worker",
                 "account": "taskClaim"
+              }
+            ]
+          }
+        },
+        {
+          "name": "defendantAgent",
+          "docs": [
+            "Optional: Defendant's agent registration (for authority-level participant check, fix #824)",
+            "If provided, validates arbiter's authority is not the defendant worker's authority.",
+            "Must match the dispute's defendant field."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "defendant_agent.agent_id",
+                "account": "agentRegistration"
               }
             ]
           }
@@ -4404,6 +4722,31 @@ export type AgencCoordination = {
       "code": 6141,
       "name": "developmentKeyNotAllowed",
       "msg": "Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use."
+    },
+    {
+      "code": 6142,
+      "name": "selfTaskNotAllowed",
+      "msg": "Cannot claim own task: worker authority matches task creator"
+    },
+    {
+      "code": 6143,
+      "name": "missingTokenAccounts",
+      "msg": "Token accounts not provided for token-denominated task"
+    },
+    {
+      "code": 6144,
+      "name": "invalidTokenEscrow",
+      "msg": "Token escrow ATA does not match expected derivation"
+    },
+    {
+      "code": 6145,
+      "name": "invalidTokenMint",
+      "msg": "Provided mint does not match task's reward_mint"
+    },
+    {
+      "code": 6146,
+      "name": "tokenTransferFailed",
+      "msg": "SPL token transfer CPI failed"
     }
   ],
   "types": [
@@ -5104,6 +5447,15 @@ export type AgencCoordination = {
           {
             "name": "dependencyType",
             "type": "u8"
+          },
+          {
+            "name": "rewardMint",
+            "docs": [
+              "SPL token mint for reward denomination (None = SOL)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
           },
           {
             "name": "timestamp",
@@ -6505,15 +6857,14 @@ export type AgencCoordination = {
             "type": "u16"
           },
           {
-            "name": "reserved",
+            "name": "rewardMint",
             "docs": [
-              "Reserved"
+              "Optional SPL token mint for reward denomination.",
+              "None = SOL rewards (default, backward compatible).",
+              "Some(mint) = SPL token rewards using the specified mint."
             ],
             "type": {
-              "array": [
-                "u8",
-                30
-              ]
+              "option": "pubkey"
             }
           }
         ]
@@ -6776,6 +7127,15 @@ export type AgencCoordination = {
           {
             "name": "minReputation",
             "type": "u16"
+          },
+          {
+            "name": "rewardMint",
+            "docs": [
+              "SPL token mint for reward denomination (None = SOL)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
           },
           {
             "name": "timestamp",

--- a/runtime/src/utils/index.ts
+++ b/runtime/src/utils/index.ts
@@ -28,3 +28,13 @@ export { encodeStatusByte, queryWithFallback } from './query.js';
 export { fetchTreasury } from './treasury.js';
 
 export { ensureLazyModule } from './lazy-import.js';
+
+export {
+  isTokenTask,
+  buildCompleteTaskTokenAccounts,
+  buildResolveDisputeTokenAccounts,
+  buildExpireDisputeTokenAccounts,
+  buildCreateTaskTokenAccounts,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from './token.js';

--- a/runtime/src/utils/token.test.ts
+++ b/runtime/src/utils/token.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
+import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import {
+  isTokenTask,
+  buildCompleteTaskTokenAccounts,
+  buildResolveDisputeTokenAccounts,
+  buildExpireDisputeTokenAccounts,
+  buildCreateTaskTokenAccounts,
+} from './token.js';
+
+// ============================================================================
+// Fixtures
+// Use Keypair.generate().publicKey for on-curve keys (required by
+// getAssociatedTokenAddressSync for non-PDA owners).
+// Use PublicKey.unique() only for PDA-like addresses (escrow) where
+// allowOwnerOffCurve=true is passed.
+// ============================================================================
+
+const MINT = Keypair.generate().publicKey;
+const ESCROW_PDA = PublicKey.unique(); // off-curve (PDA)
+const WORKER = Keypair.generate().publicKey;
+const CREATOR = Keypair.generate().publicKey;
+const TREASURY = Keypair.generate().publicKey;
+
+// ============================================================================
+// isTokenTask
+// ============================================================================
+
+describe('isTokenTask', () => {
+  it('returns false for null', () => {
+    expect(isTokenTask(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isTokenTask(undefined)).toBe(false);
+  });
+
+  it('returns true for a PublicKey', () => {
+    expect(isTokenTask(MINT)).toBe(true);
+  });
+});
+
+// ============================================================================
+// buildCompleteTaskTokenAccounts
+// ============================================================================
+
+describe('buildCompleteTaskTokenAccounts', () => {
+  it('returns all nulls for SOL task (null mint)', () => {
+    const result = buildCompleteTaskTokenAccounts(null, ESCROW_PDA, WORKER, TREASURY);
+
+    expect(result.tokenEscrowAta).toBeNull();
+    expect(result.workerTokenAccount).toBeNull();
+    expect(result.treasuryTokenAccount).toBeNull();
+    expect(result.rewardMint).toBeNull();
+    expect(result.tokenProgram).toBeNull();
+  });
+
+  it('returns all nulls for SOL task (undefined mint)', () => {
+    const result = buildCompleteTaskTokenAccounts(undefined, ESCROW_PDA, WORKER, TREASURY);
+
+    expect(result.tokenEscrowAta).toBeNull();
+    expect(result.rewardMint).toBeNull();
+  });
+
+  it('returns correct ATAs for token task', () => {
+    const result = buildCompleteTaskTokenAccounts(MINT, ESCROW_PDA, WORKER, TREASURY);
+
+    expect(result.tokenEscrowAta).toEqual(
+      getAssociatedTokenAddressSync(MINT, ESCROW_PDA, true),
+    );
+    expect(result.workerTokenAccount).toEqual(
+      getAssociatedTokenAddressSync(MINT, WORKER),
+    );
+    expect(result.treasuryTokenAccount).toEqual(
+      getAssociatedTokenAddressSync(MINT, TREASURY),
+    );
+    expect(result.rewardMint).toEqual(MINT);
+    expect(result.tokenProgram).toEqual(TOKEN_PROGRAM_ID);
+  });
+
+  it('escrow ATA uses allowOwnerOffCurve', () => {
+    const result = buildCompleteTaskTokenAccounts(MINT, ESCROW_PDA, WORKER, TREASURY);
+    // PDA-owned ATAs require allowOwnerOffCurve=true
+    const expected = getAssociatedTokenAddressSync(MINT, ESCROW_PDA, true);
+    expect(result.tokenEscrowAta).toEqual(expected);
+  });
+});
+
+// ============================================================================
+// buildResolveDisputeTokenAccounts
+// ============================================================================
+
+describe('buildResolveDisputeTokenAccounts', () => {
+  it('returns all nulls for SOL task', () => {
+    const result = buildResolveDisputeTokenAccounts(null, ESCROW_PDA, CREATOR, WORKER, TREASURY);
+
+    expect(result.tokenEscrowAta).toBeNull();
+    expect(result.creatorTokenAccount).toBeNull();
+    expect(result.workerTokenAccountAta).toBeNull();
+    expect(result.treasuryTokenAccount).toBeNull();
+    expect(result.rewardMint).toBeNull();
+    expect(result.tokenProgram).toBeNull();
+  });
+
+  it('returns correct ATAs for token task with worker', () => {
+    const result = buildResolveDisputeTokenAccounts(MINT, ESCROW_PDA, CREATOR, WORKER, TREASURY);
+
+    expect(result.tokenEscrowAta).toEqual(
+      getAssociatedTokenAddressSync(MINT, ESCROW_PDA, true),
+    );
+    expect(result.creatorTokenAccount).toEqual(
+      getAssociatedTokenAddressSync(MINT, CREATOR),
+    );
+    expect(result.workerTokenAccountAta).toEqual(
+      getAssociatedTokenAddressSync(MINT, WORKER),
+    );
+    expect(result.treasuryTokenAccount).toEqual(
+      getAssociatedTokenAddressSync(MINT, TREASURY),
+    );
+    expect(result.rewardMint).toEqual(MINT);
+    expect(result.tokenProgram).toEqual(TOKEN_PROGRAM_ID);
+  });
+
+  it('returns null workerTokenAccountAta when worker is null', () => {
+    const result = buildResolveDisputeTokenAccounts(MINT, ESCROW_PDA, CREATOR, null, TREASURY);
+
+    expect(result.workerTokenAccountAta).toBeNull();
+    // Other fields should still be set
+    expect(result.tokenEscrowAta).not.toBeNull();
+    expect(result.creatorTokenAccount).not.toBeNull();
+    expect(result.treasuryTokenAccount).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// buildExpireDisputeTokenAccounts
+// ============================================================================
+
+describe('buildExpireDisputeTokenAccounts', () => {
+  it('returns all nulls for SOL task', () => {
+    const result = buildExpireDisputeTokenAccounts(null, ESCROW_PDA, CREATOR, WORKER);
+
+    expect(result.tokenEscrowAta).toBeNull();
+    expect(result.creatorTokenAccount).toBeNull();
+    expect(result.workerTokenAccountAta).toBeNull();
+    expect(result.rewardMint).toBeNull();
+    expect(result.tokenProgram).toBeNull();
+  });
+
+  it('does NOT include treasuryTokenAccount', () => {
+    const result = buildExpireDisputeTokenAccounts(MINT, ESCROW_PDA, CREATOR, WORKER);
+
+    expect(result).not.toHaveProperty('treasuryTokenAccount');
+  });
+
+  it('returns correct ATAs for token task', () => {
+    const result = buildExpireDisputeTokenAccounts(MINT, ESCROW_PDA, CREATOR, WORKER);
+
+    expect(result.tokenEscrowAta).toEqual(
+      getAssociatedTokenAddressSync(MINT, ESCROW_PDA, true),
+    );
+    expect(result.creatorTokenAccount).toEqual(
+      getAssociatedTokenAddressSync(MINT, CREATOR),
+    );
+    expect(result.workerTokenAccountAta).toEqual(
+      getAssociatedTokenAddressSync(MINT, WORKER),
+    );
+    expect(result.rewardMint).toEqual(MINT);
+    expect(result.tokenProgram).toEqual(TOKEN_PROGRAM_ID);
+  });
+
+  it('returns null workerTokenAccountAta when worker is null', () => {
+    const result = buildExpireDisputeTokenAccounts(MINT, ESCROW_PDA, CREATOR, null);
+
+    expect(result.workerTokenAccountAta).toBeNull();
+    expect(result.tokenEscrowAta).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// buildCreateTaskTokenAccounts
+// ============================================================================
+
+describe('buildCreateTaskTokenAccounts', () => {
+  it('returns all nulls for SOL task', () => {
+    const result = buildCreateTaskTokenAccounts(null, ESCROW_PDA, CREATOR);
+
+    expect(result.rewardMint).toBeNull();
+    expect(result.creatorTokenAccount).toBeNull();
+    expect(result.tokenEscrowAta).toBeNull();
+    expect(result.tokenProgram).toBeNull();
+    expect(result.associatedTokenProgram).toBeNull();
+  });
+
+  it('returns correct ATAs and programs for token task', () => {
+    const result = buildCreateTaskTokenAccounts(MINT, ESCROW_PDA, CREATOR);
+
+    expect(result.rewardMint).toEqual(MINT);
+    expect(result.creatorTokenAccount).toEqual(
+      getAssociatedTokenAddressSync(MINT, CREATOR),
+    );
+    expect(result.tokenEscrowAta).toEqual(
+      getAssociatedTokenAddressSync(MINT, ESCROW_PDA, true),
+    );
+    expect(result.tokenProgram).toEqual(TOKEN_PROGRAM_ID);
+    expect(result.associatedTokenProgram).toEqual(ASSOCIATED_TOKEN_PROGRAM_ID);
+  });
+
+  it('includes associatedTokenProgram (unlike other builders)', () => {
+    const result = buildCreateTaskTokenAccounts(MINT, ESCROW_PDA, CREATOR);
+    expect(result.associatedTokenProgram).toEqual(ASSOCIATED_TOKEN_PROGRAM_ID);
+  });
+});

--- a/runtime/src/utils/token.ts
+++ b/runtime/src/utils/token.ts
@@ -1,0 +1,151 @@
+/**
+ * Shared SPL token account helpers for task and dispute operations.
+ *
+ * Each builder returns all-null when rewardMint is null (SOL task),
+ * or computed ATAs when non-null (SPL token task).
+ *
+ * @module
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+
+export { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID };
+
+/**
+ * Check if a task uses SPL tokens (non-null rewardMint).
+ */
+export function isTokenTask(rewardMint: PublicKey | null | undefined): boolean {
+  return rewardMint != null;
+}
+
+/**
+ * Token accounts for completeTask / completeTaskPrivate.
+ *
+ * On-chain account names (camelCase via Anchor):
+ *   tokenEscrowAta, workerTokenAccount, treasuryTokenAccount, rewardMint, tokenProgram
+ */
+export function buildCompleteTaskTokenAccounts(
+  rewardMint: PublicKey | null | undefined,
+  escrowPda: PublicKey,
+  workerAuthority: PublicKey,
+  treasury: PublicKey,
+): Record<string, PublicKey | null> {
+  if (!rewardMint) {
+    return {
+      tokenEscrowAta: null,
+      workerTokenAccount: null,
+      treasuryTokenAccount: null,
+      rewardMint: null,
+      tokenProgram: null,
+    };
+  }
+  return {
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    workerTokenAccount: getAssociatedTokenAddressSync(rewardMint, workerAuthority),
+    treasuryTokenAccount: getAssociatedTokenAddressSync(rewardMint, treasury),
+    rewardMint,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  };
+}
+
+/**
+ * Token accounts for resolveDispute.
+ *
+ * On-chain account names:
+ *   tokenEscrowAta, creatorTokenAccount, workerTokenAccountAta, treasuryTokenAccount,
+ *   rewardMint, tokenProgram
+ */
+export function buildResolveDisputeTokenAccounts(
+  rewardMint: PublicKey | null | undefined,
+  escrowPda: PublicKey,
+  creatorPubkey: PublicKey,
+  workerAuthority: PublicKey | null,
+  treasury: PublicKey,
+): Record<string, PublicKey | null> {
+  if (!rewardMint) {
+    return {
+      tokenEscrowAta: null,
+      creatorTokenAccount: null,
+      workerTokenAccountAta: null,
+      treasuryTokenAccount: null,
+      rewardMint: null,
+      tokenProgram: null,
+    };
+  }
+  return {
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    creatorTokenAccount: getAssociatedTokenAddressSync(rewardMint, creatorPubkey),
+    workerTokenAccountAta: workerAuthority
+      ? getAssociatedTokenAddressSync(rewardMint, workerAuthority)
+      : null,
+    treasuryTokenAccount: getAssociatedTokenAddressSync(rewardMint, treasury),
+    rewardMint,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  };
+}
+
+/**
+ * Token accounts for expireDispute (like resolveDispute but NO treasuryTokenAccount).
+ *
+ * On-chain account names:
+ *   tokenEscrowAta, creatorTokenAccount, workerTokenAccountAta, rewardMint, tokenProgram
+ */
+export function buildExpireDisputeTokenAccounts(
+  rewardMint: PublicKey | null | undefined,
+  escrowPda: PublicKey,
+  creatorPubkey: PublicKey,
+  workerAuthority: PublicKey | null,
+): Record<string, PublicKey | null> {
+  if (!rewardMint) {
+    return {
+      tokenEscrowAta: null,
+      creatorTokenAccount: null,
+      workerTokenAccountAta: null,
+      rewardMint: null,
+      tokenProgram: null,
+    };
+  }
+  return {
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    creatorTokenAccount: getAssociatedTokenAddressSync(rewardMint, creatorPubkey),
+    workerTokenAccountAta: workerAuthority
+      ? getAssociatedTokenAddressSync(rewardMint, workerAuthority)
+      : null,
+    rewardMint,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  };
+}
+
+/**
+ * Token accounts for createTask / createDependentTask.
+ *
+ * On-chain account names:
+ *   rewardMint, creatorTokenAccount, tokenEscrowAta, tokenProgram, associatedTokenProgram
+ */
+export function buildCreateTaskTokenAccounts(
+  rewardMint: PublicKey | null | undefined,
+  escrowPda: PublicKey,
+  creatorPubkey: PublicKey,
+): Record<string, PublicKey | null> {
+  if (!rewardMint) {
+    return {
+      rewardMint: null,
+      creatorTokenAccount: null,
+      tokenEscrowAta: null,
+      tokenProgram: null,
+      associatedTokenProgram: null,
+    };
+  }
+  return {
+    rewardMint,
+    creatorTokenAccount: getAssociatedTokenAddressSync(rewardMint, creatorPubkey),
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    tokenProgram: TOKEN_PROGRAM_ID,
+    associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+  };
+}

--- a/runtime/src/workflow/submitter.ts
+++ b/runtime/src/workflow/submitter.ts
@@ -17,6 +17,7 @@ import { generateAgentId, toAnchorBytes } from '../utils/encoding.js';
 import { findAgentPda, findProtocolPda } from '../agent/pda.js';
 import { findTaskPda, findEscrowPda } from '../task/pda.js';
 import { isAnchorError, AnchorErrorCodes } from '../types/errors.js';
+import { buildCreateTaskTokenAccounts } from '../utils/token.js';
 import type { WorkflowState, WorkflowEdge } from './types.js';
 import { WorkflowNodeStatus, OnChainDependencyType } from './types.js';
 import { WorkflowSubmissionError } from './errors.js';
@@ -193,6 +194,8 @@ export class DAGSubmitter {
     const constraintHash = template.constraintHash
       ? Array.from(template.constraintHash)
       : null;
+    const mint = template.rewardMint ?? null;
+    const tokenAccounts = buildCreateTaskTokenAccounts(mint, escrowPda, creator);
 
     return this.program.methods
       .createTask(
@@ -205,6 +208,7 @@ export class DAGSubmitter {
         template.taskType,
         constraintHash,
         template.minReputation ?? 0,
+        mint,
       )
       .accountsPartial({
         task: taskPda,
@@ -214,6 +218,7 @@ export class DAGSubmitter {
         authority: creator,
         creator,
         systemProgram: SystemProgram.programId,
+        ...tokenAccounts,
       })
       .rpc();
   }
@@ -233,6 +238,8 @@ export class DAGSubmitter {
     const constraintHash = template.constraintHash
       ? Array.from(template.constraintHash)
       : null;
+    const mint = template.rewardMint ?? null;
+    const tokenAccounts = buildCreateTaskTokenAccounts(mint, escrowPda, creator);
 
     return this.program.methods
       .createDependentTask(
@@ -246,6 +253,7 @@ export class DAGSubmitter {
         constraintHash,
         dependencyType,
         template.minReputation ?? 0,
+        mint,
       )
       .accountsPartial({
         task: taskPda,
@@ -256,6 +264,7 @@ export class DAGSubmitter {
         authority: creator,
         creator,
         systemProgram: SystemProgram.programId,
+        ...tokenAccounts,
       })
       .rpc();
   }

--- a/runtime/src/workflow/types.ts
+++ b/runtime/src/workflow/types.ts
@@ -56,6 +56,8 @@ export interface TaskTemplate {
   constraintHash?: Uint8Array;
   /** Minimum reputation score (0-10000). Default 0. */
   minReputation?: number;
+  /** SPL token mint for reward denomination (null/undefined = SOL) */
+  rewardMint?: PublicKey | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `runtime/src/utils/token.ts` with helpers to build token account metas (ATA derivation, conditional inclusion for SOL vs SPL tasks)
- Wire SPL token escrow support (program PR #864) into TaskOperations, AutonomousAgent, DisputeOperations, DAGSubmitter, and SpeculationAdapter
- Track `earningsByMint` in autonomous agent stats, support `acceptedMints` filter in TaskScanner
- Update IDL and generated types for SPL token program changes

## Test plan

- [x] 1886 runtime tests pass across 66 files
- [x] Typecheck clean
- [x] New `token.test.ts` covers ATA derivation and account building helpers