### PR TITLE
fix(dispute): finalize token slash settlement flow

### DIFF
--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -147,6 +147,45 @@
         {
           "name": "treasury",
           "writable": true
+        },
+        {
+          "name": "escrow",
+          "docs": [
+            "Escrow PDA for the disputed task (kept open until slash for token disputes)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding deferred slash amount"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury token ATA receiving slashed tokens"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL mint for task rewards (must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -1952,6 +1991,7 @@
             "Optional - when provided, allows decrementing worker's active_tasks",
             "and enables fair refund distribution (fix #418)"
           ],
+          "writable": true,
           "optional": true,
           "pda": {
             "seeds": [
@@ -1979,6 +2019,9 @@
         },
         {
           "name": "worker",
+          "docs": [
+            "Worker's AgentRegistration PDA (must be dispute defendant)."
+          ],
           "writable": true,
           "optional": true
         },
@@ -2273,6 +2316,7 @@
           "docs": [
             "Optional: Worker agent to be disputed (required when initiator is task creator)"
           ],
+          "writable": true,
           "optional": true
         },
         {
@@ -2645,6 +2689,9 @@
         },
         {
           "name": "worker",
+          "docs": [
+            "Worker agent account for the dispute defendant."
+          ],
           "writable": true,
           "optional": true
         },

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -241,6 +241,7 @@ export {
   buildCompleteTaskTokenAccounts,
   buildResolveDisputeTokenAccounts,
   buildExpireDisputeTokenAccounts,
+  buildApplyDisputeSlashTokenAccounts,
   buildCreateTaskTokenAccounts,
   TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID,

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -159,6 +159,45 @@ export type AgencCoordination = {
         {
           "name": "treasury",
           "writable": true
+        },
+        {
+          "name": "escrow",
+          "docs": [
+            "Escrow PDA for the disputed task (kept open until slash for token disputes)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "tokenEscrowAta",
+          "docs": [
+            "Token escrow ATA holding deferred slash amount"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasuryTokenAccount",
+          "docs": [
+            "Treasury token ATA receiving slashed tokens"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "rewardMint",
+          "docs": [
+            "SPL mint for task rewards (must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "tokenProgram",
+          "docs": [
+            "SPL Token program"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": []
@@ -1964,6 +2003,7 @@ export type AgencCoordination = {
             "Optional - when provided, allows decrementing worker's active_tasks",
             "and enables fair refund distribution (fix #418)"
           ],
+          "writable": true,
           "optional": true,
           "pda": {
             "seeds": [
@@ -1991,6 +2031,9 @@ export type AgencCoordination = {
         },
         {
           "name": "worker",
+          "docs": [
+            "Worker's AgentRegistration PDA (must be dispute defendant)."
+          ],
           "writable": true,
           "optional": true
         },
@@ -2285,6 +2328,7 @@ export type AgencCoordination = {
           "docs": [
             "Optional: Worker agent to be disputed (required when initiator is task creator)"
           ],
+          "writable": true,
           "optional": true
         },
         {
@@ -2657,6 +2701,9 @@ export type AgencCoordination = {
         },
         {
           "name": "worker",
+          "docs": [
+            "Worker agent account for the dispute defendant."
+          ],
           "writable": true,
           "optional": true
         },

--- a/runtime/src/utils/index.ts
+++ b/runtime/src/utils/index.ts
@@ -34,6 +34,7 @@ export {
   buildCompleteTaskTokenAccounts,
   buildResolveDisputeTokenAccounts,
   buildExpireDisputeTokenAccounts,
+  buildApplyDisputeSlashTokenAccounts,
   buildCreateTaskTokenAccounts,
   TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID,

--- a/runtime/src/utils/token.test.ts
+++ b/runtime/src/utils/token.test.ts
@@ -6,6 +6,7 @@ import {
   buildCompleteTaskTokenAccounts,
   buildResolveDisputeTokenAccounts,
   buildExpireDisputeTokenAccounts,
+  buildApplyDisputeSlashTokenAccounts,
   buildCreateTaskTokenAccounts,
 } from './token.js';
 
@@ -175,6 +176,36 @@ describe('buildExpireDisputeTokenAccounts', () => {
 
     expect(result.workerTokenAccountAta).toBeNull();
     expect(result.tokenEscrowAta).not.toBeNull();
+  });
+});
+
+// ============================================================================
+// buildApplyDisputeSlashTokenAccounts
+// ============================================================================
+
+describe('buildApplyDisputeSlashTokenAccounts', () => {
+  it('returns all nulls for SOL task', () => {
+    const result = buildApplyDisputeSlashTokenAccounts(null, ESCROW_PDA, TREASURY);
+
+    expect(result.escrow).toBeNull();
+    expect(result.tokenEscrowAta).toBeNull();
+    expect(result.treasuryTokenAccount).toBeNull();
+    expect(result.rewardMint).toBeNull();
+    expect(result.tokenProgram).toBeNull();
+  });
+
+  it('returns escrow + ATAs for token task', () => {
+    const result = buildApplyDisputeSlashTokenAccounts(MINT, ESCROW_PDA, TREASURY);
+
+    expect(result.escrow).toEqual(ESCROW_PDA);
+    expect(result.tokenEscrowAta).toEqual(
+      getAssociatedTokenAddressSync(MINT, ESCROW_PDA, true),
+    );
+    expect(result.treasuryTokenAccount).toEqual(
+      getAssociatedTokenAddressSync(MINT, TREASURY),
+    );
+    expect(result.rewardMint).toEqual(MINT);
+    expect(result.tokenProgram).toEqual(TOKEN_PROGRAM_ID);
   });
 });
 

--- a/runtime/src/utils/token.ts
+++ b/runtime/src/utils/token.ts
@@ -122,6 +122,35 @@ export function buildExpireDisputeTokenAccounts(
 }
 
 /**
+ * Token accounts for applyDisputeSlash.
+ *
+ * On-chain account names:
+ *   escrow, tokenEscrowAta, treasuryTokenAccount, rewardMint, tokenProgram
+ */
+export function buildApplyDisputeSlashTokenAccounts(
+  rewardMint: PublicKey | null | undefined,
+  escrowPda: PublicKey,
+  treasury: PublicKey,
+): Record<string, PublicKey | null> {
+  if (!rewardMint) {
+    return {
+      escrow: null,
+      tokenEscrowAta: null,
+      treasuryTokenAccount: null,
+      rewardMint: null,
+      tokenProgram: null,
+    };
+  }
+  return {
+    escrow: escrowPda,
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    treasuryTokenAccount: getAssociatedTokenAddressSync(rewardMint, treasury),
+    rewardMint,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  };
+}
+
+/**
  * Token accounts for createTask / createDependentTask.
  *
  * On-chain account names:


### PR DESCRIPTION
# Summary
Finalize token-denominated dispute slashing so slash reserves are handled consistently between `resolve_dispute` and `apply_dispute_slash`.

# Changes
- Added shared slash math helper `calculate_slash_amount` and reused it in dispute slash flows.
- Updated `resolve_dispute` to reserve token slash amounts for losing workers, defer escrow close when slash is pending, and defer worker-claim close when slash still needs to execute.
- Updated `apply_dispute_slash` to:
  - support token slash settlement accounts,
  - enforce token account set when required for token disputes,
  - transfer reserved tokens to treasury,
  - close token escrow ATA + escrow PDA,
  - apply lamport slash transfer after token CPIs.
- Updated runtime dispute ops to auto-wire token accounts for `applySlash` based on task `rewardMint`.
- Added runtime token-account builder + exports and tests.
- Added integration test coverage for token dispute resolve + slash end-to-end.
- Hardened one dispute slash test assertion path for error-shape variance.

# Testing
- [ ] anchor test
- [x] cargo fmt --check
- [ ] cargo clippy
- [ ] cargo test
- [x] runtime vitest (`src/utils/token.test.ts`, `src/dispute/operations.test.ts`)
- [x] ts-mocha (`tests/dispute-slash-logic.ts`, `tests/spl-token-tasks.ts`)

# Security / Risk
- [x] PDA seeds/constraints reviewed (if applicable)
- [x] No authority bypass introduced
- [x] Escrow/funds safety considered (if applicable)

# Checklist
- [x] Tests added/updated (or N/A)
- [ ] Docs updated (if needed)

# Issue link(s)
Closes #858
Closes #859
