### PR TITLE
feat(runtime): add policy safety engine with circuit breakers

### DIFF
--- a/runtime/src/autonomous/agent.policy.test.ts
+++ b/runtime/src/autonomous/agent.policy.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Keypair } from '@solana/web3.js';
+import type { Task, TaskExecutor } from './types.js';
+import { TaskStatus } from './types.js';
+import { AutonomousAgent } from './agent.js';
+import { PolicyEngine } from '../policy/engine.js';
+import { PolicyViolationError } from '../policy/types.js';
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    pda: Keypair.generate().publicKey,
+    taskId: new Uint8Array(32).fill(1),
+    creator: Keypair.generate().publicKey,
+    requiredCapabilities: 1n,
+    reward: 100n,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    deadline: 0,
+    maxWorkers: 1,
+    currentClaims: 0,
+    status: TaskStatus.Open,
+    rewardMint: null,
+    ...overrides,
+  };
+}
+
+function createAgent(
+  executor: TaskExecutor,
+  policyEngine: PolicyEngine,
+): AutonomousAgent {
+  return new AutonomousAgent({
+    connection: {} as any,
+    wallet: Keypair.generate(),
+    capabilities: 1n,
+    executor,
+    policyEngine,
+  });
+}
+
+describe('AutonomousAgent policy integration', () => {
+  it('pause_discovery mode blocks polling without errors', async () => {
+    const policyEngine = new PolicyEngine({ policy: { enabled: true } });
+    policyEngine.setMode('pause_discovery', 'test');
+    const executor = {
+      execute: vi.fn(async () => [1n]),
+    };
+
+    const agent = createAgent(executor, policyEngine);
+    const scanner = {
+      scan: vi.fn(async () => [createTask()]),
+      isTaskAvailable: vi.fn(async () => true),
+      subscribeToNewTasks: vi.fn(),
+    };
+
+    const agentAny = agent as any;
+    agentAny.scanner = scanner;
+    agentAny.scanLoopRunning = true;
+
+    await agentAny.pollAndProcess();
+    expect(scanner.scan).not.toHaveBeenCalled();
+  });
+
+  it('halt_submissions mode blocks completion submission', async () => {
+    const policyEngine = new PolicyEngine({ policy: { enabled: true } });
+    policyEngine.setMode('halt_submissions', 'incident');
+    const executor = {
+      execute: vi.fn(async () => [1n, 2n]),
+    };
+
+    const agent = createAgent(executor, policyEngine);
+    const agentAny = agent as any;
+    agentAny.completeTaskWithRetry = vi.fn(async () => 'complete-tx');
+
+    const task = createTask();
+    await expect(
+      agentAny.executeSequential(task, {
+        task,
+        claimedAt: Date.now(),
+        claimTx: 'claim-tx',
+        retryCount: 0,
+      }, task.pda.toBase58()),
+    ).rejects.toBeInstanceOf(PolicyViolationError);
+
+    expect(agentAny.completeTaskWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('disabled policy preserves legacy execution behavior', async () => {
+    const policyEngine = new PolicyEngine({ policy: { enabled: false } });
+    const executor = {
+      execute: vi.fn(async () => [9n]),
+    };
+
+    const agent = createAgent(executor, policyEngine);
+    const agentAny = agent as any;
+    agentAny.completeTaskWithRetry = vi.fn(async () => 'complete-tx');
+
+    const task = createTask();
+    const result = await agentAny.executeSequential(task, {
+      task,
+      claimedAt: Date.now(),
+      claimTx: 'claim-tx',
+      retryCount: 0,
+    }, task.pda.toBase58());
+
+    expect(result.success).toBe(true);
+    expect(result.completionTx).toBe('complete-tx');
+    expect(agentAny.completeTaskWithRetry).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/runtime/src/autonomous/types.ts
+++ b/runtime/src/autonomous/types.ts
@@ -11,6 +11,8 @@ import type { MemoryBackend } from '../memory/types.js';
 import type { MetricsProvider } from '../task/types.js';
 import type { DependencyType } from '../task/dependency-graph.js';
 import type { ProofPipelineConfig } from '../task/proof-pipeline.js';
+import type { PolicyEngine } from '../policy/engine.js';
+import type { PolicyViolation } from '../policy/types.js';
 
 /**
  * On-chain task data
@@ -442,6 +444,16 @@ export interface AutonomousAgentConfig extends AgentRuntimeConfig {
    * Optional callback fired when verifier lane escalates a task failure.
    */
   onTaskEscalated?: (task: Task, metadata: VerifierEscalationMetadata) => void;
+
+  /**
+   * Optional policy/safety engine for runtime action enforcement.
+   */
+  policyEngine?: PolicyEngine;
+
+  /**
+   * Optional callback fired on policy violations.
+   */
+  onPolicyViolation?: (violation: PolicyViolation) => void;
 }
 
 /**

--- a/runtime/src/builder.test.ts
+++ b/runtime/src/builder.test.ts
@@ -256,6 +256,7 @@ describe('AgentBuilder', () => {
       expect(builder.withMaxConcurrentTasks(2)).toBe(builder);
       expect(builder.withSystemPrompt('hello')).toBe(builder);
       expect(builder.withVerifier({ verifier: { verify: vi.fn() } } as any)).toBe(builder);
+      expect(builder.withPolicy({ enabled: true })).toBe(builder);
       expect(builder.withCallbacks({})).toBe(builder);
     });
   });
@@ -555,6 +556,7 @@ describe('AgentBuilder', () => {
         onEarnings: vi.fn(),
         onVerifierVerdict: vi.fn(),
         onTaskEscalated: vi.fn(),
+        onPolicyViolation: vi.fn(),
       };
 
       await new AgentBuilder(mockConnection, mockKeypair)
@@ -570,6 +572,7 @@ describe('AgentBuilder', () => {
         .withScanInterval(3000)
         .withMaxConcurrentTasks(2)
         .withVerifier(verifierConfig as any)
+        .withPolicy({ enabled: true })
         .withCallbacks(callbacks)
         .build();
 
@@ -585,10 +588,12 @@ describe('AgentBuilder', () => {
       expect(config.scanIntervalMs).toBe(3000);
       expect(config.maxConcurrentTasks).toBe(2);
       expect(config.verifier).toBe(verifierConfig);
+      expect(config.policyEngine).toBeDefined();
       expect(config.onTaskCompleted).toBe(callbacks.onTaskCompleted);
       expect(config.onEarnings).toBe(callbacks.onEarnings);
       expect(config.onVerifierVerdict).toBe(callbacks.onVerifierVerdict);
       expect(config.onTaskEscalated).toBe(callbacks.onTaskEscalated);
+      expect(config.onPolicyViolation).toBe(callbacks.onPolicyViolation);
     });
 
     it('passes agentId when configured', async () => {

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -431,6 +431,24 @@ export {
   DefaultClaimStrategy,
 } from './autonomous/index.js';
 
+// Policy and Safety Engine
+export {
+  PolicyEngine,
+  PolicyViolationError,
+  type PolicyActionType,
+  type PolicyAccess,
+  type CircuitBreakerMode,
+  type PolicyAction,
+  type PolicyBudgetRule,
+  type SpendBudgetRule,
+  type CircuitBreakerConfig,
+  type RuntimePolicyConfig,
+  type PolicyViolation,
+  type PolicyDecision,
+  type PolicyEngineState,
+  type PolicyEngineConfig,
+} from './policy/index.js';
+
 // Tool System (Phase 5)
 export {
   // Core types

--- a/runtime/src/policy/engine.test.ts
+++ b/runtime/src/policy/engine.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { PolicyEngine } from './engine.js';
+import { PolicyViolationError } from './types.js';
+
+describe('PolicyEngine', () => {
+  it('allows everything when policy is disabled', () => {
+    const engine = new PolicyEngine({
+      policy: { enabled: false },
+    });
+
+    const decision = engine.evaluate({
+      type: 'tool_call',
+      name: 'agenc.createTask',
+      access: 'write',
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.violations).toEqual([]);
+  });
+
+  it('blocks denied tools deterministically', () => {
+    const engine = new PolicyEngine({
+      policy: {
+        enabled: true,
+        toolDenyList: ['agenc.createTask'],
+      },
+    });
+
+    const decision = engine.evaluate({
+      type: 'tool_call',
+      name: 'agenc.createTask',
+      access: 'write',
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.violations[0].code).toBe('tool_denied');
+  });
+
+  it('enforces action budgets', () => {
+    let nowMs = 1_000;
+    const engine = new PolicyEngine({
+      now: () => nowMs,
+      policy: {
+        enabled: true,
+        actionBudgets: {
+          'task_execution:*': {
+            limit: 1,
+            windowMs: 10_000,
+          },
+        },
+      },
+    });
+
+    const first = engine.evaluate({
+      type: 'task_execution',
+      name: 'execute_task',
+      access: 'write',
+    });
+    expect(first.allowed).toBe(true);
+
+    const second = engine.evaluate({
+      type: 'task_execution',
+      name: 'execute_task',
+      access: 'write',
+    });
+    expect(second.allowed).toBe(false);
+    expect(second.violations[0].code).toBe('action_budget_exceeded');
+
+    nowMs += 11_000;
+    const third = engine.evaluate({
+      type: 'task_execution',
+      name: 'execute_task',
+      access: 'write',
+    });
+    expect(third.allowed).toBe(true);
+  });
+
+  it('enforces spend budgets', () => {
+    const engine = new PolicyEngine({
+      policy: {
+        enabled: true,
+        spendBudget: {
+          limitLamports: 1_000n,
+          windowMs: 60_000,
+        },
+      },
+    });
+
+    const first = engine.evaluate({
+      type: 'tx_submission',
+      name: 'complete_task_submission',
+      access: 'write',
+      spendLamports: 700n,
+    });
+    expect(first.allowed).toBe(true);
+
+    const second = engine.evaluate({
+      type: 'tx_submission',
+      name: 'complete_task_submission',
+      access: 'write',
+      spendLamports: 400n,
+    });
+    expect(second.allowed).toBe(false);
+    expect(second.violations[0].code).toBe('spend_budget_exceeded');
+  });
+
+  it('auto-trips circuit breaker on repeated violations', () => {
+    let nowMs = 1_000;
+    const engine = new PolicyEngine({
+      now: () => nowMs,
+      policy: {
+        enabled: true,
+        denyActions: ['execute_task'],
+        circuitBreaker: {
+          enabled: true,
+          threshold: 2,
+          windowMs: 60_000,
+          mode: 'pause_discovery',
+        },
+      },
+    });
+
+    engine.evaluate({
+      type: 'task_execution',
+      name: 'execute_task',
+      access: 'write',
+    });
+    nowMs += 100;
+    engine.evaluate({
+      type: 'task_execution',
+      name: 'execute_task',
+      access: 'write',
+    });
+
+    const state = engine.getState();
+    expect(state.mode).toBe('pause_discovery');
+    expect(state.circuitBreakerReason).toBe('auto_threshold');
+  });
+
+  it('safe mode allows reads but blocks writes', () => {
+    const engine = new PolicyEngine({
+      policy: { enabled: true },
+    });
+    engine.setMode('safe_mode', 'manual-test');
+
+    const readDecision = engine.evaluate({
+      type: 'tool_call',
+      name: 'agenc.listTasks',
+      access: 'read',
+    });
+    expect(readDecision.allowed).toBe(true);
+
+    const writeDecision = engine.evaluate({
+      type: 'tool_call',
+      name: 'agenc.createTask',
+      access: 'write',
+    });
+    expect(writeDecision.allowed).toBe(false);
+    expect(writeDecision.violations[0].code).toBe('circuit_breaker_active');
+  });
+
+  it('evaluateOrThrow throws structured violation errors', () => {
+    const engine = new PolicyEngine({
+      policy: {
+        enabled: true,
+        denyActions: ['execute_task'],
+      },
+    });
+
+    expect(() =>
+      engine.evaluateOrThrow({
+        type: 'task_execution',
+        name: 'execute_task',
+        access: 'write',
+      }),
+    ).toThrow(PolicyViolationError);
+  });
+});
+

--- a/runtime/src/policy/engine.ts
+++ b/runtime/src/policy/engine.ts
@@ -1,0 +1,338 @@
+/**
+ * Deterministic runtime policy/safety engine with circuit breakers.
+ *
+ * @module
+ */
+
+import { TELEMETRY_METRIC_NAMES } from '../telemetry/metric-names.js';
+import type {
+  CircuitBreakerMode,
+  PolicyAction,
+  PolicyDecision,
+  PolicyEngineConfig,
+  PolicyEngineState,
+  PolicyViolation,
+  RuntimePolicyConfig,
+} from './types.js';
+import { PolicyViolationError } from './types.js';
+import { silentLogger } from '../utils/logger.js';
+
+const DEFAULT_POLICY: RuntimePolicyConfig = {
+  enabled: false,
+};
+
+export class PolicyEngine {
+  private policy: RuntimePolicyConfig;
+  private mode: CircuitBreakerMode = 'normal';
+  private circuitBreakerReason?: string;
+  private trippedAtMs?: number;
+
+  private readonly logger;
+  private readonly metrics;
+  private readonly now: () => number;
+
+  private readonly actionEvents = new Map<string, number[]>();
+  private spendEvents: Array<{ atMs: number; amount: bigint }> = [];
+  private violationEvents: number[] = [];
+
+  onViolation?: (violation: PolicyViolation) => void;
+
+  constructor(config: PolicyEngineConfig = {}) {
+    this.policy = { ...DEFAULT_POLICY, ...(config.policy ?? {}) };
+    this.logger = config.logger ?? silentLogger;
+    this.metrics = config.metrics;
+    this.now = config.now ?? Date.now;
+  }
+
+  getPolicy(): RuntimePolicyConfig {
+    return { ...this.policy };
+  }
+
+  setPolicy(policy: RuntimePolicyConfig): void {
+    this.policy = { ...DEFAULT_POLICY, ...policy };
+  }
+
+  setMode(mode: Exclude<CircuitBreakerMode, 'normal'>, reason = 'manual'): void {
+    this.mode = mode;
+    this.circuitBreakerReason = reason;
+    this.trippedAtMs = this.now();
+  }
+
+  clearMode(): void {
+    this.mode = 'normal';
+    this.circuitBreakerReason = undefined;
+    this.trippedAtMs = undefined;
+  }
+
+  getState(): PolicyEngineState {
+    this.pruneViolations();
+    return {
+      mode: this.mode,
+      circuitBreakerReason: this.circuitBreakerReason,
+      trippedAtMs: this.trippedAtMs,
+      recentViolations: this.violationEvents.length,
+    };
+  }
+
+  evaluate(action: PolicyAction): PolicyDecision {
+    this.pruneViolations();
+    const violations: PolicyViolation[] = [];
+
+    const modeViolation = this.checkCircuitMode(action);
+    if (modeViolation) {
+      violations.push(modeViolation);
+    }
+
+    if (this.policy.enabled) {
+      const toolViolation = this.checkToolRules(action);
+      if (toolViolation) violations.push(toolViolation);
+
+      const actionViolation = this.checkActionRules(action);
+      if (actionViolation) violations.push(actionViolation);
+
+      const riskViolation = this.checkRisk(action);
+      if (riskViolation) violations.push(riskViolation);
+
+      const actionBudgetViolation = this.checkAndConsumeActionBudget(action);
+      if (actionBudgetViolation) violations.push(actionBudgetViolation);
+
+      const spendViolation = this.checkAndConsumeSpendBudget(action);
+      if (spendViolation) violations.push(spendViolation);
+    }
+
+    const allowed = violations.length === 0;
+    if (!allowed) {
+      this.recordViolation(violations[0]);
+      this.maybeAutoTripCircuitBreaker();
+    } else {
+      this.metrics?.counter(TELEMETRY_METRIC_NAMES.POLICY_DECISIONS_TOTAL, 1, {
+        outcome: 'allow',
+        action_type: action.type,
+      });
+    }
+
+    return {
+      allowed,
+      mode: this.mode,
+      violations,
+    };
+  }
+
+  evaluateOrThrow(action: PolicyAction): void {
+    const decision = this.evaluate(action);
+    if (!decision.allowed) {
+      throw new PolicyViolationError(action, decision);
+    }
+  }
+
+  private checkCircuitMode(action: PolicyAction): PolicyViolation | null {
+    if (this.mode === 'normal') {
+      return null;
+    }
+
+    if (this.mode === 'pause_discovery' && action.type === 'task_discovery') {
+      return this.buildViolation(
+        'circuit_breaker_active',
+        action,
+        'Discovery is paused by circuit breaker',
+      );
+    }
+
+    if (this.mode === 'halt_submissions' && action.type === 'tx_submission') {
+      return this.buildViolation(
+        'circuit_breaker_active',
+        action,
+        'Submissions are halted by circuit breaker',
+      );
+    }
+
+    if (this.mode === 'safe_mode' && action.access === 'write') {
+      return this.buildViolation(
+        'circuit_breaker_active',
+        action,
+        'Safe mode blocks write actions',
+      );
+    }
+
+    return null;
+  }
+
+  private checkToolRules(action: PolicyAction): PolicyViolation | null {
+    if (action.type !== 'tool_call') {
+      return null;
+    }
+
+    if (this.policy.toolDenyList?.includes(action.name)) {
+      return this.buildViolation(
+        'tool_denied',
+        action,
+        `Tool "${action.name}" is denied by policy`,
+      );
+    }
+
+    const allowList = this.policy.toolAllowList;
+    if (allowList && allowList.length > 0 && !allowList.includes(action.name)) {
+      return this.buildViolation(
+        'tool_denied',
+        action,
+        `Tool "${action.name}" is not in allow-list`,
+      );
+    }
+
+    return null;
+  }
+
+  private checkActionRules(action: PolicyAction): PolicyViolation | null {
+    if (this.policy.denyActions?.includes(action.name)) {
+      return this.buildViolation(
+        'action_denied',
+        action,
+        `Action "${action.name}" is denied by policy`,
+      );
+    }
+
+    const allowActions = this.policy.allowActions;
+    if (allowActions && allowActions.length > 0 && !allowActions.includes(action.name)) {
+      return this.buildViolation(
+        'action_denied',
+        action,
+        `Action "${action.name}" is not in allow-list`,
+      );
+    }
+
+    return null;
+  }
+
+  private checkRisk(action: PolicyAction): PolicyViolation | null {
+    const maxRisk = this.policy.maxRiskScore;
+    if (maxRisk === undefined || action.riskScore === undefined) {
+      return null;
+    }
+    if (action.riskScore <= maxRisk) {
+      return null;
+    }
+    return this.buildViolation(
+      'risk_threshold_exceeded',
+      action,
+      `Risk score ${action.riskScore.toFixed(3)} exceeds max ${maxRisk.toFixed(3)}`,
+      {
+        maxRiskScore: maxRisk,
+        riskScore: action.riskScore,
+      },
+    );
+  }
+
+  private checkAndConsumeActionBudget(action: PolicyAction): PolicyViolation | null {
+    const budgets = this.policy.actionBudgets;
+    if (!budgets) return null;
+
+    const exactKey = `${action.type}:${action.name}`;
+    const wildcardKey = `${action.type}:*`;
+    const hasExact = budgets[exactKey] !== undefined;
+    const budget = hasExact ? budgets[exactKey] : budgets[wildcardKey];
+    if (!budget) return null;
+
+    const now = this.now();
+    const cutoff = now - budget.windowMs;
+    const bucketKey = hasExact ? exactKey : wildcardKey;
+    const bucket = this.actionEvents.get(bucketKey) ?? [];
+    const recent = bucket.filter((timestamp) => timestamp >= cutoff);
+    if (recent.length >= budget.limit) {
+      this.actionEvents.set(bucketKey, recent);
+      return this.buildViolation(
+        'action_budget_exceeded',
+        action,
+        `Action budget exceeded for "${action.name}"`,
+        {
+          limit: budget.limit,
+          windowMs: budget.windowMs,
+          observed: recent.length,
+        },
+      );
+    }
+    recent.push(now);
+    this.actionEvents.set(bucketKey, recent);
+    return null;
+  }
+
+  private checkAndConsumeSpendBudget(action: PolicyAction): PolicyViolation | null {
+    if (!this.policy.spendBudget || action.spendLamports === undefined) {
+      return null;
+    }
+
+    const now = this.now();
+    const cutoff = now - this.policy.spendBudget.windowMs;
+    this.spendEvents = this.spendEvents.filter((event) => event.atMs >= cutoff);
+
+    const currentSpend = this.spendEvents.reduce((sum, event) => sum + event.amount, 0n);
+    const projected = currentSpend + action.spendLamports;
+    if (projected > this.policy.spendBudget.limitLamports) {
+      return this.buildViolation(
+        'spend_budget_exceeded',
+        action,
+        'Spend budget exceeded',
+        {
+          limitLamports: this.policy.spendBudget.limitLamports.toString(),
+          currentLamports: currentSpend.toString(),
+          attemptedLamports: action.spendLamports.toString(),
+        },
+      );
+    }
+
+    this.spendEvents.push({ atMs: now, amount: action.spendLamports });
+    return null;
+  }
+
+  private maybeAutoTripCircuitBreaker(): void {
+    const cfg = this.policy.circuitBreaker;
+    if (!cfg?.enabled) return;
+    if (this.mode !== 'normal') return;
+
+    this.pruneViolations();
+    if (this.violationEvents.length < cfg.threshold) return;
+
+    this.mode = cfg.mode;
+    this.circuitBreakerReason = 'auto_threshold';
+    this.trippedAtMs = this.now();
+
+    this.logger.warn(`Policy circuit breaker tripped: mode=${cfg.mode}`);
+  }
+
+  private recordViolation(violation: PolicyViolation): void {
+    this.violationEvents.push(this.now());
+    this.onViolation?.(violation);
+    this.metrics?.counter(TELEMETRY_METRIC_NAMES.POLICY_VIOLATIONS_TOTAL, 1, {
+      code: violation.code,
+      action_type: violation.actionType,
+    });
+    this.metrics?.counter(TELEMETRY_METRIC_NAMES.POLICY_DECISIONS_TOTAL, 1, {
+      outcome: 'deny',
+      action_type: violation.actionType,
+    });
+  }
+
+  private pruneViolations(): void {
+    const cfg = this.policy.circuitBreaker;
+    if (!cfg) {
+      this.violationEvents = [];
+      return;
+    }
+    const cutoff = this.now() - cfg.windowMs;
+    this.violationEvents = this.violationEvents.filter((timestamp) => timestamp >= cutoff);
+  }
+
+  private buildViolation(
+    code: PolicyViolation['code'],
+    action: PolicyAction,
+    message: string,
+    details?: Record<string, unknown>,
+  ): PolicyViolation {
+    return {
+      code,
+      message,
+      actionType: action.type,
+      actionName: action.name,
+      details,
+    };
+  }
+}

--- a/runtime/src/policy/index.ts
+++ b/runtime/src/policy/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Policy and safety engine exports.
+ *
+ * @module
+ */
+
+export { PolicyEngine } from './engine.js';
+export {
+  PolicyViolationError,
+  type PolicyActionType,
+  type PolicyAccess,
+  type CircuitBreakerMode,
+  type PolicyAction,
+  type PolicyBudgetRule,
+  type SpendBudgetRule,
+  type CircuitBreakerConfig,
+  type RuntimePolicyConfig,
+  type PolicyViolation,
+  type PolicyDecision,
+  type PolicyEngineState,
+  type PolicyEngineConfig,
+} from './types.js';
+

--- a/runtime/src/policy/types.ts
+++ b/runtime/src/policy/types.ts
@@ -1,0 +1,132 @@
+/**
+ * Core policy/safety engine types.
+ *
+ * @module
+ */
+
+import type { MetricsProvider } from '../task/types.js';
+import type { Logger } from '../utils/logger.js';
+
+export type PolicyActionType =
+  | 'tool_call'
+  | 'task_discovery'
+  | 'task_claim'
+  | 'task_execution'
+  | 'tx_submission'
+  | 'custom';
+
+export type PolicyAccess = 'read' | 'write';
+
+export type CircuitBreakerMode =
+  | 'normal'
+  | 'pause_discovery'
+  | 'halt_submissions'
+  | 'safe_mode';
+
+export interface PolicyAction {
+  type: PolicyActionType;
+  name: string;
+  access: PolicyAccess;
+  /** Optional risk score in [0, 1]. */
+  riskScore?: number;
+  /** Optional spend value for budget tracking. */
+  spendLamports?: bigint;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PolicyBudgetRule {
+  /** Max allowed actions in the rolling window. */
+  limit: number;
+  /** Rolling window size in ms. */
+  windowMs: number;
+}
+
+export interface SpendBudgetRule {
+  /** Max allowed spend in lamports for the rolling window. */
+  limitLamports: bigint;
+  /** Rolling window size in ms. */
+  windowMs: number;
+}
+
+export interface CircuitBreakerConfig {
+  enabled?: boolean;
+  /** Violations required before auto-trip. */
+  threshold: number;
+  /** Violation counting window in ms. */
+  windowMs: number;
+  /** Mode entered when auto-tripped. */
+  mode: Exclude<CircuitBreakerMode, 'normal'>;
+}
+
+export interface RuntimePolicyConfig {
+  /** Default-safe: disabled unless explicitly enabled. */
+  enabled?: boolean;
+  /** Explicit allow-list for action names. Empty/undefined means allow all. */
+  allowActions?: string[];
+  /** Explicit deny-list for action names. */
+  denyActions?: string[];
+  /** Tool-specific allow-list. Empty/undefined means allow all tools. */
+  toolAllowList?: string[];
+  /** Tool-specific deny-list. */
+  toolDenyList?: string[];
+  /**
+   * Action budget rules keyed by:
+   * - `${type}:*` for all actions of a type
+   * - `${type}:${name}` for exact action name
+   */
+  actionBudgets?: Record<string, PolicyBudgetRule>;
+  /** Optional rolling spend budget. */
+  spendBudget?: SpendBudgetRule;
+  /** Block actions with risk score above this threshold. */
+  maxRiskScore?: number;
+  /** Auto-trip configuration on repeated policy violations. */
+  circuitBreaker?: CircuitBreakerConfig;
+}
+
+export interface PolicyViolation {
+  code:
+    | 'circuit_breaker_active'
+    | 'tool_denied'
+    | 'action_denied'
+    | 'action_budget_exceeded'
+    | 'spend_budget_exceeded'
+    | 'risk_threshold_exceeded';
+  message: string;
+  actionType: PolicyActionType;
+  actionName: string;
+  details?: Record<string, unknown>;
+}
+
+export interface PolicyDecision {
+  allowed: boolean;
+  mode: CircuitBreakerMode;
+  violations: PolicyViolation[];
+}
+
+export interface PolicyEngineState {
+  mode: CircuitBreakerMode;
+  circuitBreakerReason?: string;
+  trippedAtMs?: number;
+  recentViolations: number;
+}
+
+export interface PolicyEngineConfig {
+  policy?: RuntimePolicyConfig;
+  logger?: Logger;
+  metrics?: MetricsProvider;
+  now?: () => number;
+}
+
+export class PolicyViolationError extends Error {
+  readonly action: PolicyAction;
+  readonly decision: PolicyDecision;
+
+  constructor(action: PolicyAction, decision: PolicyDecision) {
+    const reason = decision.violations[0]?.message ?? 'Policy blocked action';
+    super(reason);
+    this.name = 'PolicyViolationError';
+    this.action = action;
+    this.decision = decision;
+  }
+}
+

--- a/runtime/src/telemetry/metric-names.ts
+++ b/runtime/src/telemetry/metric-names.ts
@@ -32,4 +32,7 @@ export const TELEMETRY_METRIC_NAMES = {
   // Dispute
   DISPUTE_OPS_TOTAL: 'agenc.dispute.ops.total',
   DISPUTE_OP_DURATION: 'agenc.dispute.op.duration_ms',
+  // Policy
+  POLICY_VIOLATIONS_TOTAL: 'agenc.policy.violations.total',
+  POLICY_DECISIONS_TOTAL: 'agenc.policy.decisions.total',
 } as const;

--- a/runtime/src/tools/types.ts
+++ b/runtime/src/tools/types.ts
@@ -12,6 +12,7 @@ import type { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
 import type { Wallet } from '../types/wallet.js';
 import type { Logger } from '../utils/logger.js';
+import type { PolicyEngine } from '../policy/engine.js';
 
 /**
  * JSON Schema type alias.
@@ -75,6 +76,8 @@ export interface ToolContext {
 export interface ToolRegistryConfig {
   /** Logger for registry operations */
   logger?: Logger;
+  /** Optional policy engine for tool call enforcement. */
+  policyEngine?: PolicyEngine;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a deterministic `PolicyEngine` with action/tool allow-deny rules, action and spend budgets, violation model, and auto/manual circuit breaker modes (`pause_discovery`, `halt_submissions`, `safe_mode`)
- wire policy enforcement into `AutonomousAgent` discovery/claim/execution/submission paths with structured violation callbacks and journaling
- enforce policy at tool dispatch in `ToolRegistry` so disallowed tool calls are blocked with machine-readable reasons
- add builder/runtime integration (`AgentBuilder.withPolicy(...)`, `BuiltAgent.policyEngine`) and telemetry metric names for policy decisions/violations
- add docs and comprehensive unit/integration tests for policy behavior, safe-mode semantics, and regression when policy is disabled

## Testing
- npm run test --prefix runtime
- npm run typecheck --prefix runtime
- npm run build --prefix runtime

Closes #878
