### PR TITLE
feat(runtime): persistent memory graph with provenance-aware retrieval

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -206,6 +206,33 @@ const agent = await new AgentBuilder(connection, wallet)
 agent.policyEngine?.setMode('halt_submissions', 'manual_incident');
 ```
 
+### Provenance-Aware Memory Graph
+
+Persist reusable facts with source traceability and confidence-aware retrieval:
+
+```typescript
+import { MemoryGraph, InMemoryBackend } from '@agenc/runtime';
+
+const backend = new InMemoryBackend();
+const graph = new MemoryGraph(backend);
+
+await graph.upsertNode({
+  content: 'Treasury key rotated on Feb 10',
+  sessionId: 'ops',
+  baseConfidence: 0.92,
+  provenance: [
+    { type: 'onchain_event', sourceId: '5uW...txsig' },
+  ],
+});
+
+const facts = await graph.query({
+  sessionId: 'ops',
+  requireProvenance: true,
+  minConfidence: 0.8,
+  includeContradicted: false,
+});
+```
+
 ## Core Modules
 
 ### AgentRuntime

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -529,6 +529,19 @@ export {
   // Redis backend
   RedisBackend,
   type RedisBackendConfig,
+  // Memory graph
+  MemoryGraph,
+  type ProvenanceSourceType,
+  type ProvenanceSource,
+  type MemoryEdgeType,
+  type MemoryGraphNode,
+  type MemoryGraphEdge,
+  type UpsertMemoryNodeInput,
+  type AddMemoryEdgeInput,
+  type MemoryGraphQuery,
+  type MemoryGraphResult,
+  type MemoryGraphConfig,
+  type CompactOptions,
 } from './memory/index.js';
 
 // Dispute Operations (Phase 8)

--- a/runtime/src/memory/graph.test.ts
+++ b/runtime/src/memory/graph.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryBackend } from './in-memory/backend.js';
+import { SqliteBackend } from './sqlite/backend.js';
+import { MemoryGraph } from './graph.js';
+import type { MemoryBackend } from './types.js';
+
+describe('MemoryGraph', () => {
+  it('requires provenance on writes', async () => {
+    const backend = new InMemoryBackend();
+    const graph = new MemoryGraph(backend);
+
+    await expect(
+      graph.upsertNode({
+        content: 'fact without source',
+        provenance: [],
+      }),
+    ).rejects.toThrow('provenance');
+  });
+
+  it('supports provenance-aware retrieval filters', async () => {
+    const backend = new InMemoryBackend();
+    const graph = new MemoryGraph(backend);
+
+    await graph.upsertNode({
+      id: 'n1',
+      content: 'Task payout is 10 SOL',
+      sessionId: 's1',
+      baseConfidence: 0.95,
+      provenance: [{ type: 'onchain_event', sourceId: 'tx-1' }],
+    });
+    await graph.upsertNode({
+      id: 'n2',
+      content: 'Unverified rumor',
+      sessionId: 's1',
+      baseConfidence: 0.4,
+      provenance: [{ type: 'manual', sourceId: 'note-1' }],
+    });
+
+    const strict = await graph.query({
+      sessionId: 's1',
+      minConfidence: 0.7,
+      provenanceTypes: ['onchain_event'],
+      requireProvenance: true,
+    });
+
+    expect(strict).toHaveLength(1);
+    expect(strict[0].node.id).toBe('n1');
+  });
+
+  it('applies freshness decay to confidence', async () => {
+    const clock = { now: 1_000_000 };
+    const backend = new InMemoryBackend();
+    const graph = new MemoryGraph(backend, {
+      now: () => clock.now,
+      confidenceHalfLifeMs: 1_000,
+    });
+
+    await graph.upsertNode({
+      id: 'n1',
+      content: 'decaying fact',
+      baseConfidence: 1,
+      provenance: [{ type: 'manual', sourceId: 'seed' }],
+    });
+
+    clock.now += 1_000;
+    const results = await graph.query({ nowMs: clock.now });
+    expect(results).toHaveLength(1);
+    expect(results[0].effectiveConfidence).toBeGreaterThan(0.49);
+    expect(results[0].effectiveConfidence).toBeLessThan(0.51);
+  });
+
+  it('models contradiction and supersession edges in retrieval policy', async () => {
+    const backend = new InMemoryBackend();
+    const graph = new MemoryGraph(backend);
+
+    await graph.upsertNode({
+      id: 'base',
+      content: 'Model A is best',
+      provenance: [{ type: 'manual', sourceId: 'opinion-a' }],
+    });
+    await graph.upsertNode({
+      id: 'contra',
+      content: 'Model A fails benchmark X',
+      provenance: [{ type: 'external_doc', sourceId: 'paper-1' }],
+    });
+    await graph.upsertNode({
+      id: 'newer',
+      content: 'Model B supersedes Model A',
+      provenance: [{ type: 'external_doc', sourceId: 'paper-2' }],
+    });
+
+    await graph.addEdge({
+      fromId: 'contra',
+      toId: 'base',
+      type: 'contradicts',
+    });
+    await graph.addEdge({
+      fromId: 'newer',
+      toId: 'base',
+      type: 'supersedes',
+    });
+
+    const strict = await graph.query({
+      includeContradicted: false,
+      includeSuperseded: false,
+    });
+    expect(strict.some((r) => r.node.id === 'base')).toBe(false);
+
+    const relaxed = await graph.query({
+      includeContradicted: true,
+      includeSuperseded: true,
+    });
+    expect(relaxed.some((r) => r.node.id === 'base')).toBe(true);
+  });
+
+  it('materializes session summaries from thread history', async () => {
+    const backend = new InMemoryBackend();
+    await backend.addEntry({
+      sessionId: 's1',
+      role: 'user',
+      content: 'Need a plan for token launch',
+    });
+    await backend.addEntry({
+      sessionId: 's1',
+      role: 'assistant',
+      content: 'Drafting 3-step launch plan',
+    });
+
+    const graph = new MemoryGraph(backend);
+    const summaryNode = await graph.materializeSessionSummary('s1');
+    expect(summaryNode.content).toContain('Need a plan');
+    expect(summaryNode.provenance[0].type).toBe('materialization');
+  });
+
+  it('keeps in-memory and sqlite behavior aligned for core graph queries', async () => {
+    const runScenario = async (backend: MemoryBackend) => {
+      const graph = new MemoryGraph(backend);
+      await graph.upsertNode({
+        id: 'a',
+        content: 'Primary fact',
+        sessionId: 'shared',
+        baseConfidence: 0.9,
+        provenance: [{ type: 'tx_signature', sourceId: 'sig-a' }],
+      });
+      await graph.upsertNode({
+        id: 'b',
+        content: 'Derived fact',
+        sessionId: 'shared',
+        baseConfidence: 0.8,
+        provenance: [{ type: 'tool_output', sourceId: 'tool-b' }],
+      });
+      await graph.addEdge({
+        id: 'e1',
+        fromId: 'b',
+        toId: 'a',
+        type: 'derived_from',
+      });
+
+      const results = await graph.query({
+        sessionId: 'shared',
+        minConfidence: 0.5,
+      });
+      return results.map((r) => r.node.id);
+    };
+
+    const inMemory = new InMemoryBackend();
+    const sqlite = new SqliteBackend({ dbPath: ':memory:' });
+    const inMemoryResults = await runScenario(inMemory);
+    const sqliteResults = await runScenario(sqlite);
+
+    expect(sqliteResults).toEqual(inMemoryResults);
+    await sqlite.close();
+  });
+});
+

--- a/runtime/src/memory/graph.ts
+++ b/runtime/src/memory/graph.ts
@@ -1,0 +1,435 @@
+/**
+ * Provenance-aware persistent memory graph built on top of MemoryBackend.
+ *
+ * @module
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { MemoryBackend } from './types.js';
+
+const NODE_PREFIX = 'graph:node:';
+const EDGE_PREFIX = 'graph:edge:';
+const SESSION_INDEX_PREFIX = 'graph:index:session:';
+
+const DEFAULT_CONFIDENCE_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export type ProvenanceSourceType =
+  | 'onchain_event'
+  | 'tool_output'
+  | 'tx_signature'
+  | 'external_doc'
+  | 'materialization'
+  | 'manual';
+
+export interface ProvenanceSource {
+  type: ProvenanceSourceType;
+  sourceId: string;
+  description?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export type MemoryEdgeType =
+  | 'derived_from'
+  | 'supports'
+  | 'contradicts'
+  | 'supersedes';
+
+export interface MemoryGraphNode {
+  id: string;
+  content: string;
+  sessionId?: string;
+  taskPda?: string;
+  createdAt: number;
+  updatedAt: number;
+  baseConfidence: number;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  provenance: ProvenanceSource[];
+}
+
+export interface MemoryGraphEdge {
+  id: string;
+  fromId: string;
+  toId: string;
+  type: MemoryEdgeType;
+  createdAt: number;
+  weight?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface UpsertMemoryNodeInput {
+  id?: string;
+  content: string;
+  sessionId?: string;
+  taskPda?: string;
+  baseConfidence?: number;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  provenance: ProvenanceSource[];
+}
+
+export interface AddMemoryEdgeInput {
+  id?: string;
+  fromId: string;
+  toId: string;
+  type: MemoryEdgeType;
+  weight?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface MemoryGraphQuery {
+  sessionId?: string;
+  taskPda?: string;
+  textContains?: string;
+  tagsAny?: string[];
+  provenanceTypes?: ProvenanceSourceType[];
+  requireProvenance?: boolean;
+  minConfidence?: number;
+  includeContradicted?: boolean;
+  includeSuperseded?: boolean;
+  limit?: number;
+  nowMs?: number;
+}
+
+export interface MemoryGraphResult {
+  node: MemoryGraphNode;
+  effectiveConfidence: number;
+  contradicted: boolean;
+  superseded: boolean;
+  sources: ProvenanceSource[];
+}
+
+export interface MemoryGraphConfig {
+  confidenceHalfLifeMs?: number;
+  now?: () => number;
+}
+
+export interface CompactOptions {
+  retentionMs?: number;
+  minBaseConfidence?: number;
+}
+
+export class MemoryGraph {
+  private readonly backend: MemoryBackend;
+  private readonly confidenceHalfLifeMs: number;
+  private readonly now: () => number;
+
+  constructor(backend: MemoryBackend, config: MemoryGraphConfig = {}) {
+    this.backend = backend;
+    this.confidenceHalfLifeMs = config.confidenceHalfLifeMs ?? DEFAULT_CONFIDENCE_HALF_LIFE_MS;
+    this.now = config.now ?? Date.now;
+  }
+
+  async upsertNode(input: UpsertMemoryNodeInput): Promise<MemoryGraphNode> {
+    this.assertProvenance(input.provenance);
+
+    const timestamp = this.now();
+    const existing = input.id ? await this.getNode(input.id) : null;
+    const node: MemoryGraphNode = existing
+      ? {
+        ...existing,
+        content: input.content,
+        sessionId: input.sessionId ?? existing.sessionId,
+        taskPda: input.taskPda ?? existing.taskPda,
+        baseConfidence: this.normalizeConfidence(input.baseConfidence ?? existing.baseConfidence),
+        tags: input.tags ?? existing.tags,
+        metadata: input.metadata ?? existing.metadata,
+        provenance: this.mergeProvenance(existing.provenance, input.provenance),
+        updatedAt: timestamp,
+      }
+      : {
+        id: input.id ?? randomUUID(),
+        content: input.content,
+        sessionId: input.sessionId,
+        taskPda: input.taskPda,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        baseConfidence: this.normalizeConfidence(input.baseConfidence ?? 0.75),
+        tags: input.tags,
+        metadata: input.metadata,
+        provenance: [...input.provenance],
+      };
+
+    await this.backend.set(this.nodeKey(node.id), node);
+    if (node.sessionId) {
+      await this.addSessionIndex(node.sessionId, node.id);
+    }
+    return node;
+  }
+
+  async addEdge(input: AddMemoryEdgeInput): Promise<MemoryGraphEdge> {
+    if (!(await this.getNode(input.fromId))) {
+      throw new Error(`Source node not found: ${input.fromId}`);
+    }
+    if (!(await this.getNode(input.toId))) {
+      throw new Error(`Target node not found: ${input.toId}`);
+    }
+
+    const edge: MemoryGraphEdge = {
+      id: input.id ?? randomUUID(),
+      fromId: input.fromId,
+      toId: input.toId,
+      type: input.type,
+      createdAt: this.now(),
+      weight: input.weight,
+      metadata: input.metadata,
+    };
+    await this.backend.set(this.edgeKey(edge.id), edge);
+    return edge;
+  }
+
+  async getNode(id: string): Promise<MemoryGraphNode | null> {
+    const node = await this.backend.get<MemoryGraphNode>(this.nodeKey(id));
+    return node ?? null;
+  }
+
+  async getEdge(id: string): Promise<MemoryGraphEdge | null> {
+    const edge = await this.backend.get<MemoryGraphEdge>(this.edgeKey(id));
+    return edge ?? null;
+  }
+
+  async listNodes(sessionId?: string): Promise<MemoryGraphNode[]> {
+    if (sessionId) {
+      const ids = await this.backend.get<string[]>(this.sessionIndexKey(sessionId));
+      if (!ids || ids.length === 0) return [];
+      const nodes = await Promise.all(ids.map((id) => this.getNode(id)));
+      return nodes.filter((node): node is MemoryGraphNode => node !== null);
+    }
+
+    const keys = await this.backend.listKeys(NODE_PREFIX);
+    const nodes = await Promise.all(
+      keys.map((key) => this.backend.get<MemoryGraphNode>(key)),
+    );
+    return nodes.filter((node): node is MemoryGraphNode => node !== undefined);
+  }
+
+  async listEdges(): Promise<MemoryGraphEdge[]> {
+    const keys = await this.backend.listKeys(EDGE_PREFIX);
+    const edges = await Promise.all(
+      keys.map((key) => this.backend.get<MemoryGraphEdge>(key)),
+    );
+    return edges.filter((edge): edge is MemoryGraphEdge => edge !== undefined);
+  }
+
+  async query(query: MemoryGraphQuery = {}): Promise<MemoryGraphResult[]> {
+    const now = query.nowMs ?? this.now();
+    const nodes = await this.listNodes(query.sessionId);
+    const edges = await this.listEdges();
+
+    const contradictedIds = new Set(
+      edges.filter((edge) => edge.type === 'contradicts').map((edge) => edge.toId),
+    );
+    const supersededIds = new Set(
+      edges.filter((edge) => edge.type === 'supersedes').map((edge) => edge.toId),
+    );
+
+    const results: MemoryGraphResult[] = [];
+    for (const node of nodes) {
+      if (query.taskPda && node.taskPda !== query.taskPda) continue;
+      if (query.textContains && !node.content.toLowerCase().includes(query.textContains.toLowerCase())) continue;
+      if (query.tagsAny && query.tagsAny.length > 0) {
+        const tags = node.tags ?? [];
+        if (!query.tagsAny.some((tag) => tags.includes(tag))) continue;
+      }
+
+      const sources = node.provenance ?? [];
+      if (query.requireProvenance && sources.length === 0) continue;
+      if (query.provenanceTypes && query.provenanceTypes.length > 0) {
+        if (!sources.some((source) => query.provenanceTypes!.includes(source.type))) continue;
+      }
+
+      const contradicted = contradictedIds.has(node.id);
+      const superseded = supersededIds.has(node.id);
+      if (contradicted && query.includeContradicted === false) continue;
+      if (superseded && query.includeSuperseded === false) continue;
+
+      const effectiveConfidence = this.computeEffectiveConfidence(node, now);
+      if (query.minConfidence !== undefined && effectiveConfidence < query.minConfidence) continue;
+
+      results.push({
+        node,
+        effectiveConfidence,
+        contradicted,
+        superseded,
+        sources,
+      });
+    }
+
+    results.sort((a, b) => {
+      if (b.effectiveConfidence !== a.effectiveConfidence) {
+        return b.effectiveConfidence - a.effectiveConfidence;
+      }
+      return b.node.updatedAt - a.node.updatedAt;
+    });
+
+    if (query.limit !== undefined && query.limit > 0) {
+      return results.slice(0, query.limit);
+    }
+    return results;
+  }
+
+  async materializeSessionSummary(sessionId: string, limit = 50): Promise<MemoryGraphNode> {
+    const entries = await this.backend.getThread(sessionId, limit);
+    const summaryLines = entries.slice(-5).map((entry) => `${entry.role}: ${entry.content}`);
+    const summary = summaryLines.join('\n');
+
+    return await this.upsertNode({
+      content: summary.length > 0 ? summary : 'No session history available',
+      sessionId,
+      tags: ['summary', 'materialized'],
+      baseConfidence: 0.65,
+      provenance: [{
+        type: 'materialization',
+        sourceId: `session:${sessionId}`,
+        description: `Materialized from ${entries.length} thread entries`,
+      }],
+    });
+  }
+
+  async ingestToolOutput(options: {
+    sessionId: string;
+    toolName: string;
+    output: string;
+    taskPda?: string;
+    confidence?: number;
+    metadata?: Record<string, unknown>;
+  }): Promise<MemoryGraphNode> {
+    return await this.upsertNode({
+      content: options.output,
+      sessionId: options.sessionId,
+      taskPda: options.taskPda,
+      tags: ['tool-output', options.toolName],
+      baseConfidence: options.confidence ?? 0.8,
+      metadata: options.metadata,
+      provenance: [{
+        type: 'tool_output',
+        sourceId: `${options.toolName}:${this.now()}`,
+        description: `Tool output from ${options.toolName}`,
+        metadata: options.metadata,
+      }],
+    });
+  }
+
+  async ingestOnChainEvent(options: {
+    eventName: string;
+    txSignature: string;
+    payload: string;
+    sessionId?: string;
+    taskPda?: string;
+    confidence?: number;
+    metadata?: Record<string, unknown>;
+  }): Promise<MemoryGraphNode> {
+    return await this.upsertNode({
+      content: options.payload,
+      sessionId: options.sessionId,
+      taskPda: options.taskPda,
+      tags: ['onchain-event', options.eventName],
+      baseConfidence: options.confidence ?? 0.9,
+      metadata: options.metadata,
+      provenance: [{
+        type: 'onchain_event',
+        sourceId: options.txSignature,
+        description: options.eventName,
+        metadata: options.metadata,
+      }],
+    });
+  }
+
+  async compact(options: CompactOptions = {}): Promise<{ removedNodes: number; removedEdges: number }> {
+    const now = this.now();
+    const nodes = await this.listNodes();
+    const retentionMs = options.retentionMs;
+    const minBaseConfidence = options.minBaseConfidence;
+
+    const toRemove = new Set<string>();
+    for (const node of nodes) {
+      const stale = retentionMs !== undefined && now - node.updatedAt > retentionMs;
+      const weak = minBaseConfidence !== undefined && node.baseConfidence < minBaseConfidence;
+      if (stale || weak) {
+        toRemove.add(node.id);
+      }
+    }
+
+    for (const nodeId of toRemove) {
+      await this.backend.delete(this.nodeKey(nodeId));
+    }
+
+    const edges = await this.listEdges();
+    let removedEdges = 0;
+    for (const edge of edges) {
+      if (toRemove.has(edge.fromId) || toRemove.has(edge.toId)) {
+        await this.backend.delete(this.edgeKey(edge.id));
+        removedEdges++;
+      }
+    }
+
+    return { removedNodes: toRemove.size, removedEdges };
+  }
+
+  private computeEffectiveConfidence(node: MemoryGraphNode, nowMs: number): number {
+    if (this.confidenceHalfLifeMs <= 0) {
+      return node.baseConfidence;
+    }
+    const ageMs = Math.max(0, nowMs - node.updatedAt);
+    const decay = Math.exp((-Math.log(2) * ageMs) / this.confidenceHalfLifeMs);
+    return node.baseConfidence * decay;
+  }
+
+  private async addSessionIndex(sessionId: string, nodeId: string): Promise<void> {
+    const key = this.sessionIndexKey(sessionId);
+    const ids = (await this.backend.get<string[]>(key)) ?? [];
+    if (!ids.includes(nodeId)) {
+      ids.push(nodeId);
+      await this.backend.set(key, ids);
+    }
+  }
+
+  private mergeProvenance(
+    existing: ProvenanceSource[],
+    incoming: ProvenanceSource[],
+  ): ProvenanceSource[] {
+    const merged = [...existing];
+    for (const source of incoming) {
+      const exists = merged.some(
+        (current) =>
+          current.type === source.type
+          && current.sourceId === source.sourceId,
+      );
+      if (!exists) {
+        merged.push(source);
+      }
+    }
+    return merged;
+  }
+
+  private assertProvenance(provenance: ProvenanceSource[]): void {
+    if (!Array.isArray(provenance) || provenance.length === 0) {
+      throw new Error('Memory graph writes require provenance metadata');
+    }
+    for (const source of provenance) {
+      if (!source.type || !source.sourceId) {
+        throw new Error('Invalid provenance entry: type and sourceId are required');
+      }
+    }
+  }
+
+  private normalizeConfidence(confidence: number): number {
+    if (!Number.isFinite(confidence)) return 0;
+    if (confidence < 0) return 0;
+    if (confidence > 1) return 1;
+    return confidence;
+  }
+
+  private nodeKey(id: string): string {
+    return `${NODE_PREFIX}${id}`;
+  }
+
+  private edgeKey(id: string): string {
+    return `${EDGE_PREFIX}${id}`;
+  }
+
+  private sessionIndexKey(sessionId: string): string {
+    return `${SESSION_INDEX_PREFIX}${sessionId}`;
+  }
+}
+

--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -35,3 +35,19 @@ export { SqliteBackend, type SqliteBackendConfig } from './sqlite/index.js';
 
 // Redis backend (optional ioredis)
 export { RedisBackend, type RedisBackendConfig } from './redis/index.js';
+
+// Provenance-aware graph layer
+export {
+  MemoryGraph,
+  type ProvenanceSourceType,
+  type ProvenanceSource,
+  type MemoryEdgeType,
+  type MemoryGraphNode,
+  type MemoryGraphEdge,
+  type UpsertMemoryNodeInput,
+  type AddMemoryEdgeInput,
+  type MemoryGraphQuery,
+  type MemoryGraphResult,
+  type MemoryGraphConfig,
+  type CompactOptions,
+} from './graph.js';


### PR DESCRIPTION
## Summary
- add a provenance-aware `MemoryGraph` over existing memory backends
- support confidence/freshness weighted retrieval with contradiction and supersession policies
- integrate graph retrieval and ingestion hooks into `LLMTaskExecutor`
- expose the graph through runtime exports and document usage

## Changes
- new `runtime/src/memory/graph.ts` with node/edge modeling, retrieval scoring, ingestion helpers, summaries, and compaction
- new `runtime/src/memory/graph.test.ts` for provenance enforcement, retrieval policies, and backend parity
- update `runtime/src/llm/executor.ts` to optionally inject graph context and ingest tool output memory
- update `runtime/src/llm/executor.test.ts` for graph context + ingestion flows
- export graph APIs from `runtime/src/memory/index.ts` and `runtime/src/index.ts`
- document the feature in `runtime/README.md`

Closes #877

## Testing
- `npm run test --prefix runtime`
- `npm run typecheck --prefix runtime`
- `npm run build --prefix runtime`
