### PR TITLE
fix(mcp): install dependencies before typecheck

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "prebuild": "npm run build --prefix ../sdk && npm run build --prefix ../runtime",
     "build": "tsup",
+    "pretypecheck": "npm install --no-save --no-package-lock --no-audit --no-fund",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
## Summary
- ensure `mcp` typecheck is self-sufficient on fresh environments
- add `pretypecheck` hook in `mcp/package.json` to install required dependencies without mutating lockfiles

## Changes
- `mcp/package.json`
  - add:
    - `"pretypecheck": "npm install --no-save --no-package-lock --no-audit --no-fund"`

## Why
- root `npm run typecheck` was failing in `mcp` on machines without preinstalled `mcp/node_modules`
- unresolved module errors (`@modelcontextprotocol/sdk`, `zod`, `@agenc/runtime`, `@agenc/sdk`) cascaded into many strict-type diagnostics

## Testing
- `npm run typecheck --prefix mcp`
- `npm run typecheck`
