### PR TITLE
feat(runtime): add deterministic trajectory replay module (#892)

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -233,6 +233,42 @@ const facts = await graph.query({
 });
 ```
 
+### Deterministic Trajectory Replay
+
+Capture autonomous lifecycle traces and replay them offline for reproducible reliability debugging:
+
+```typescript
+import {
+  AutonomousAgent,
+  TrajectoryRecorder,
+  TrajectoryReplayEngine,
+} from '@agenc/runtime';
+
+const recorder = new TrajectoryRecorder({
+  traceId: 'run-2026-02-12',
+  seed: 42,
+});
+
+const agent = new AutonomousAgent({
+  connection,
+  wallet,
+  capabilities,
+  executor,
+  trajectoryRecorder: recorder, // optional, default disabled
+});
+
+// ... run agent workload ...
+
+const trace = recorder.createTrace();
+const replay = new TrajectoryReplayEngine({ strictMode: true, seed: 42 }).replay(trace);
+console.log(replay.deterministicHash, replay.summary);
+```
+
+Notes:
+- Replay is fully offline and does not perform chain writes.
+- Hash stability is guaranteed for the same trace + seed + replay config.
+- Legacy traces are migrated through `migrateTrajectoryTrace(...)`.
+
 ### Team Contracts (Role-Based Agent Runs)
 
 Coordinate planner/worker/reviewer teams with deterministic role checks, checkpoint gating, and payout splitting:

--- a/runtime/src/autonomous/types.ts
+++ b/runtime/src/autonomous/types.ts
@@ -13,6 +13,7 @@ import type { DependencyType } from '../task/dependency-graph.js';
 import type { ProofPipelineConfig } from '../task/proof-pipeline.js';
 import type { PolicyEngine } from '../policy/engine.js';
 import type { PolicyViolation } from '../policy/types.js';
+import type { TrajectoryRecorderSink } from '../eval/types.js';
 
 /**
  * On-chain task data
@@ -454,6 +455,12 @@ export interface AutonomousAgentConfig extends AgentRuntimeConfig {
    * Optional callback fired on policy violations.
    */
   onPolicyViolation?: (violation: PolicyViolation) => void;
+
+  /**
+   * Optional trajectory recorder for deterministic replay/evaluation.
+   * When omitted, no trace events are recorded.
+   */
+  trajectoryRecorder?: TrajectoryRecorderSink;
 }
 
 /**

--- a/runtime/src/eval/index.ts
+++ b/runtime/src/eval/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Evaluation and deterministic replay module.
+ *
+ * @module
+ */
+
+export {
+  EVAL_TRACE_SCHEMA_VERSION,
+  parseTrajectoryTrace,
+  migrateTrajectoryTrace,
+  canonicalizeTrajectoryTrace,
+  stableStringifyJson,
+  type JsonPrimitive,
+  type JsonValue,
+  type JsonObject,
+  type KnownTrajectoryEventType,
+  type TrajectoryEventType,
+  type TrajectoryRecordInput,
+  type TrajectoryRecorderSink,
+  type TrajectoryEvent,
+  type TrajectoryTrace,
+  type LegacyTrajectoryEventV0,
+  type LegacyTrajectoryTraceV0,
+} from './types.js';
+
+export {
+  TrajectoryRecorder,
+  type TrajectoryRecorderConfig,
+} from './recorder.js';
+
+export {
+  TrajectoryReplayEngine,
+  type ReplayTaskStatus,
+  type ReplayTaskState,
+  type ReplaySummary,
+  type TrajectoryReplayResult,
+  type TrajectoryReplayConfig,
+} from './replay.js';

--- a/runtime/src/eval/recorder.test.ts
+++ b/runtime/src/eval/recorder.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { Keypair } from '@solana/web3.js';
+import { TrajectoryRecorder } from './recorder.js';
+
+describe('TrajectoryRecorder', () => {
+  it('records deterministic sequence and timestamp ordering', () => {
+    let now = 1000;
+    const recorder = new TrajectoryRecorder({
+      traceId: 'trace-recorder',
+      seed: 123,
+      now: () => now++,
+    });
+
+    recorder.record({
+      type: 'discovered',
+      taskPda: 'task-1',
+      payload: { rewardLamports: '100' },
+    });
+    recorder.record({
+      type: 'claimed',
+      taskPda: 'task-1',
+      payload: { claimTx: 'tx-1' },
+    });
+
+    const trace = recorder.createTrace();
+    expect(trace.traceId).toBe('trace-recorder');
+    expect(trace.seed).toBe(123);
+    expect(trace.events).toHaveLength(2);
+    expect(trace.events[0].seq).toBe(1);
+    expect(trace.events[1].seq).toBe(2);
+    expect(trace.events[0].timestampMs).toBe(1001);
+    expect(trace.events[1].timestampMs).toBe(1002);
+  });
+
+  it('sanitizes non-JSON payload values', () => {
+    const recorder = new TrajectoryRecorder({ traceId: 'sanitize' });
+    const publicKey = Keypair.generate().publicKey;
+
+    recorder.record({
+      type: 'executed',
+      taskPda: 'task-2',
+      payload: {
+        amount: 9n,
+        bytes: new Uint8Array([1, 2, 3]),
+        account: publicKey,
+      },
+    });
+
+    const event = recorder.createTrace().events[0];
+    expect(event.payload.amount).toBe('9');
+    expect(event.payload.bytes).toEqual([1, 2, 3]);
+    expect(event.payload.account).toBe(publicKey.toBase58());
+  });
+
+  it('enforces max event limit', () => {
+    const recorder = new TrajectoryRecorder({
+      traceId: 'limit',
+      maxEvents: 1,
+    });
+
+    recorder.record({ type: 'discovered', taskPda: 'task-1' });
+    expect(() => recorder.record({ type: 'claimed', taskPda: 'task-1' })).toThrow('limit');
+  });
+
+  it('returns deep copies from createTrace/getEvents', () => {
+    const recorder = new TrajectoryRecorder({ traceId: 'copy-check' });
+    recorder.record({
+      type: 'discovered',
+      taskPda: 'task-1',
+      payload: { rewardLamports: '100' },
+    });
+
+    const events = recorder.getEvents();
+    events[0].payload.rewardLamports = '999';
+
+    const trace = recorder.createTrace();
+    expect(trace.events[0].payload.rewardLamports).toBe('100');
+  });
+
+  it('supports disabled mode without recording side effects', () => {
+    const recorder = new TrajectoryRecorder({
+      traceId: 'disabled',
+      enabled: false,
+    });
+
+    const result = recorder.record({ type: 'discovered', taskPda: 'task-1' });
+    expect(result).toBeNull();
+    expect(recorder.size()).toBe(0);
+    expect(recorder.createTrace().events).toHaveLength(0);
+  });
+});

--- a/runtime/src/eval/recorder.ts
+++ b/runtime/src/eval/recorder.ts
@@ -1,0 +1,160 @@
+/**
+ * In-memory trajectory recorder for deterministic agent replay.
+ *
+ * @module
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  EVAL_TRACE_SCHEMA_VERSION,
+  canonicalizeTrajectoryTrace,
+  type JsonObject,
+  type JsonValue,
+  type TrajectoryEvent,
+  type TrajectoryRecordInput,
+  type TrajectoryTrace,
+} from './types.js';
+
+const DEFAULT_MAX_EVENTS = 10_000;
+
+export interface TrajectoryRecorderConfig {
+  traceId?: string;
+  seed?: number;
+  metadata?: JsonObject;
+  now?: () => number;
+  maxEvents?: number;
+  enabled?: boolean;
+}
+
+function sanitizeValue(value: unknown): JsonValue {
+  if (value === null) return null;
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return value;
+    case 'number':
+      return Number.isFinite(value) ? value : String(value);
+    case 'bigint':
+      return value.toString();
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return String(value);
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Uint8Array) {
+    return Array.from(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeValue(entry));
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    if ('toBase58' in value && typeof (value as { toBase58?: unknown }).toBase58 === 'function') {
+      return (value as { toBase58: () => string }).toBase58();
+    }
+
+    const output: JsonObject = {};
+    const entries = Object.entries(value as Record<string, unknown>);
+    for (const [key, entry] of entries) {
+      output[key] = sanitizeValue(entry);
+    }
+    return output;
+  }
+
+  return String(value);
+}
+
+function sanitizePayload(payload: Record<string, unknown> | undefined): JsonObject {
+  if (!payload) {
+    return {};
+  }
+
+  const sanitized = sanitizeValue(payload);
+  if (typeof sanitized === 'object' && sanitized !== null && !Array.isArray(sanitized)) {
+    return sanitized as JsonObject;
+  }
+
+  return { value: sanitized };
+}
+
+/**
+ * Records ordered trajectory events in-memory.
+ */
+export class TrajectoryRecorder {
+  private readonly traceId: string;
+  private readonly seed: number;
+  private readonly now: () => number;
+  private readonly maxEvents: number;
+  private readonly enabled: boolean;
+  private readonly createdAtMs: number;
+  private readonly metadata?: JsonObject;
+
+  private readonly events: TrajectoryEvent[] = [];
+
+  constructor(config: TrajectoryRecorderConfig = {}) {
+    this.traceId = config.traceId ?? randomUUID();
+    this.seed = config.seed ?? 0;
+    this.now = config.now ?? Date.now;
+    this.maxEvents = config.maxEvents ?? DEFAULT_MAX_EVENTS;
+    this.enabled = config.enabled ?? true;
+    this.metadata = config.metadata;
+    this.createdAtMs = this.now();
+  }
+
+  record(input: TrajectoryRecordInput): TrajectoryEvent | null {
+    if (!this.enabled) {
+      return null;
+    }
+
+    if (this.events.length >= this.maxEvents) {
+      throw new Error(`trajectory event limit reached (${this.maxEvents})`);
+    }
+
+    const event: TrajectoryEvent = {
+      seq: this.events.length + 1,
+      type: input.type,
+      taskPda: input.taskPda,
+      timestampMs: input.timestampMs ?? this.now(),
+      payload: sanitizePayload(input.payload),
+    };
+
+    this.events.push(event);
+    return {
+      ...event,
+      payload: { ...event.payload },
+    };
+  }
+
+  size(): number {
+    return this.events.length;
+  }
+
+  reset(): void {
+    this.events.length = 0;
+  }
+
+  getEvents(): TrajectoryEvent[] {
+    return this.events.map((event) => ({
+      ...event,
+      payload: { ...event.payload },
+    }));
+  }
+
+  createTrace(): TrajectoryTrace {
+    return canonicalizeTrajectoryTrace({
+      schemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+      traceId: this.traceId,
+      seed: this.seed,
+      createdAtMs: this.createdAtMs,
+      metadata: this.metadata ? { ...this.metadata } : undefined,
+      events: this.getEvents(),
+    });
+  }
+}

--- a/runtime/src/eval/replay.test.ts
+++ b/runtime/src/eval/replay.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { EVAL_TRACE_SCHEMA_VERSION, type TrajectoryTrace } from './types.js';
+import { TrajectoryReplayEngine } from './replay.js';
+
+function baseTrace(events: TrajectoryTrace['events']): TrajectoryTrace {
+  return {
+    schemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+    traceId: 'trace-replay',
+    seed: 77,
+    createdAtMs: 100,
+    events,
+  };
+}
+
+describe('TrajectoryReplayEngine', () => {
+  it('produces stable deterministic hash for identical trace + config', () => {
+    const trace = baseTrace([
+      { seq: 1, type: 'discovered', taskPda: 'task-a', timestampMs: 101, payload: {} },
+      { seq: 2, type: 'claimed', taskPda: 'task-a', timestampMs: 102, payload: {} },
+      { seq: 3, type: 'executed', taskPda: 'task-a', timestampMs: 103, payload: { outputLength: 1 } },
+      { seq: 4, type: 'completed', taskPda: 'task-a', timestampMs: 104, payload: { completionTx: 'tx-1' } },
+    ]);
+
+    const engine = new TrajectoryReplayEngine({ strictMode: true, seed: 999 });
+    const first = engine.replay(trace);
+    const second = engine.replay(trace);
+
+    expect(first.deterministicHash).toBe(second.deterministicHash);
+    expect(first.summary.completedTasks).toBe(1);
+    expect(first.tasks['task-a'].status).toBe('completed');
+  });
+
+  it('reports invalid transitions in strict mode', () => {
+    const trace = baseTrace([
+      { seq: 1, type: 'completed', taskPda: 'task-b', timestampMs: 101, payload: {} },
+    ]);
+
+    const result = new TrajectoryReplayEngine({ strictMode: true }).replay(trace);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors.join(' ')).toContain('invalid completion transition');
+  });
+
+  it('captures escalation, policy violations, and speculation aborts', () => {
+    const trace = baseTrace([
+      { seq: 1, type: 'discovered', taskPda: 'task-c', timestampMs: 101, payload: {} },
+      { seq: 2, type: 'claimed', taskPda: 'task-c', timestampMs: 102, payload: {} },
+      {
+        seq: 3,
+        type: 'policy_violation',
+        taskPda: 'task-c',
+        timestampMs: 103,
+        payload: { code: 'risk_threshold_exceeded' },
+      },
+      {
+        seq: 4,
+        type: 'speculation_aborted',
+        taskPda: 'task-c',
+        timestampMs: 104,
+        payload: { reason: 'parent_failed' },
+      },
+      {
+        seq: 5,
+        type: 'escalated',
+        taskPda: 'task-c',
+        timestampMs: 105,
+        payload: { reason: 'verifier_failed' },
+      },
+    ]);
+
+    const result = new TrajectoryReplayEngine({ strictMode: false }).replay(trace);
+    expect(result.summary.policyViolations).toBe(1);
+    expect(result.summary.speculationAborts).toBe(1);
+    expect(result.summary.escalatedTasks).toBe(1);
+    expect(result.tasks['task-c'].status).toBe('escalated');
+  });
+
+  it('migrates legacy traces during replay', () => {
+    const legacy = {
+      traceId: 'legacy-trace',
+      createdAtMs: 10,
+      events: [
+        {
+          type: 'claimed',
+          taskPda: 'task-legacy',
+          timestampMs: 11,
+          payload: {},
+        },
+      ],
+    };
+
+    const result = new TrajectoryReplayEngine().replay(legacy);
+    expect(result.trace.schemaVersion).toBe(EVAL_TRACE_SCHEMA_VERSION);
+    expect(result.trace.events[0].seq).toBe(1);
+  });
+});

--- a/runtime/src/eval/replay.ts
+++ b/runtime/src/eval/replay.ts
@@ -1,0 +1,340 @@
+/**
+ * Deterministic trajectory replay engine.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+import {
+  canonicalizeTrajectoryTrace,
+  parseTrajectoryTrace,
+  stableStringifyJson,
+  type JsonValue,
+  type TrajectoryEvent,
+  type TrajectoryTrace,
+} from './types.js';
+
+export type ReplayTaskStatus =
+  | 'unknown'
+  | 'discovered'
+  | 'claimed'
+  | 'executed'
+  | 'completed'
+  | 'failed'
+  | 'escalated';
+
+export interface ReplayTaskState {
+  taskPda: string;
+  status: ReplayTaskStatus;
+  eventCount: number;
+  verifierVerdicts: number;
+  policyViolations: number;
+  speculationAborts: number;
+  lastEventType: string;
+  lastTimestampMs: number;
+}
+
+export interface ReplaySummary {
+  totalEvents: number;
+  taskCount: number;
+  completedTasks: number;
+  failedTasks: number;
+  escalatedTasks: number;
+  policyViolations: number;
+  verifierVerdicts: number;
+  speculationAborts: number;
+}
+
+export interface TrajectoryReplayResult {
+  trace: TrajectoryTrace;
+  deterministicHash: string;
+  summary: ReplaySummary;
+  tasks: Record<string, ReplayTaskState>;
+  warnings: string[];
+  errors: string[];
+}
+
+export interface TrajectoryReplayConfig {
+  strictMode?: boolean;
+  seed?: number;
+}
+
+interface MutableReplayTaskState extends ReplayTaskState {
+  terminal: boolean;
+}
+
+const TASK_REQUIRED_EVENTS = new Set<string>([
+  'discovered',
+  'claimed',
+  'executed',
+  'executed_speculative',
+  'completed',
+  'completed_speculative',
+  'failed',
+  'proof_failed',
+  'escalated',
+  'speculation_started',
+  'speculation_confirmed',
+  'speculation_aborted',
+]);
+
+function isLifecycleStatus(status: ReplayTaskStatus): boolean {
+  return status === 'discovered'
+    || status === 'claimed'
+    || status === 'executed'
+    || status === 'completed'
+    || status === 'failed'
+    || status === 'escalated';
+}
+
+/**
+ * Replays trace events deterministically and produces a stable replay hash.
+ */
+export class TrajectoryReplayEngine {
+  private readonly strictMode: boolean;
+  private readonly seed?: number;
+
+  constructor(config: TrajectoryReplayConfig = {}) {
+    this.strictMode = config.strictMode ?? true;
+    this.seed = config.seed;
+  }
+
+  replay(input: unknown): TrajectoryReplayResult {
+    const parsed = parseTrajectoryTrace(input);
+    const trace = canonicalizeTrajectoryTrace(parsed);
+
+    const warnings: string[] = [];
+    const errors: string[] = [];
+    const tasks = new Map<string, MutableReplayTaskState>();
+
+    let previousSeq = 0;
+    for (const event of trace.events) {
+      if (event.seq <= previousSeq) {
+        warnings.push(`non-monotonic sequence at event seq=${event.seq}`);
+      }
+      previousSeq = event.seq;
+      this.applyEvent(event, tasks, warnings, errors);
+    }
+
+    const finalizedTasks: Record<string, ReplayTaskState> = {};
+    for (const [taskPda, taskState] of tasks) {
+      finalizedTasks[taskPda] = {
+        taskPda: taskState.taskPda,
+        status: taskState.status,
+        eventCount: taskState.eventCount,
+        verifierVerdicts: taskState.verifierVerdicts,
+        policyViolations: taskState.policyViolations,
+        speculationAborts: taskState.speculationAborts,
+        lastEventType: taskState.lastEventType,
+        lastTimestampMs: taskState.lastTimestampMs,
+      };
+    }
+
+    const summary = this.buildSummary(trace, finalizedTasks);
+
+    const replaySeed = this.seed ?? trace.seed;
+    const deterministicHash = this.computeHash(trace, finalizedTasks, summary, replaySeed);
+
+    return {
+      trace,
+      deterministicHash,
+      summary,
+      tasks: finalizedTasks,
+      warnings,
+      errors,
+    };
+  }
+
+  private applyEvent(
+    event: TrajectoryEvent,
+    tasks: Map<string, MutableReplayTaskState>,
+    warnings: string[],
+    errors: string[],
+  ): void {
+    const eventType = event.type;
+
+    if (TASK_REQUIRED_EVENTS.has(eventType) && !event.taskPda) {
+      const message = `event "${event.type}" at seq=${event.seq} requires taskPda`;
+      if (this.strictMode) {
+        errors.push(message);
+      } else {
+        warnings.push(message);
+      }
+      return;
+    }
+
+    if (!event.taskPda) {
+      return;
+    }
+
+    const task = this.getOrCreateTask(tasks, event.taskPda, event);
+    task.eventCount++;
+    task.lastEventType = event.type;
+    task.lastTimestampMs = event.timestampMs;
+
+    if (event.type === 'verifier_verdict') {
+      task.verifierVerdicts++;
+      return;
+    }
+
+    if (event.type === 'policy_violation') {
+      task.policyViolations++;
+      return;
+    }
+
+    if (event.type === 'speculation_aborted') {
+      task.speculationAborts++;
+    }
+
+    const previousStatus = task.status;
+
+    switch (event.type) {
+      case 'discovered':
+        task.status = 'discovered';
+        break;
+      case 'claimed':
+        task.status = 'claimed';
+        break;
+      case 'executed':
+      case 'executed_speculative':
+      case 'speculation_started':
+      case 'speculation_confirmed':
+      case 'proof_generated':
+      case 'sequential_enforcement_bypass':
+      case 'verifier_verdict':
+        task.status = isLifecycleStatus(previousStatus) ? previousStatus : 'executed';
+        if (task.status === 'discovered' || task.status === 'claimed') {
+          task.status = 'executed';
+        }
+        break;
+      case 'completed':
+      case 'completed_speculative':
+        task.status = 'completed';
+        task.terminal = true;
+        break;
+      case 'failed':
+      case 'proof_failed':
+      case 'speculation_aborted':
+        task.status = 'failed';
+        task.terminal = true;
+        break;
+      case 'escalated':
+        task.status = 'escalated';
+        task.terminal = true;
+        break;
+      default:
+        warnings.push(`unknown event type "${event.type}" at seq=${event.seq}`);
+        break;
+    }
+
+    this.validateTransition(previousStatus, task.status, event, warnings, errors);
+  }
+
+  private validateTransition(
+    previous: ReplayTaskStatus,
+    next: ReplayTaskStatus,
+    event: TrajectoryEvent,
+    warnings: string[],
+    errors: string[],
+  ): void {
+    const invalidCompletion =
+      (event.type === 'completed' || event.type === 'completed_speculative')
+      && !(previous === 'executed' || previous === 'claimed');
+
+    const invalidExecution =
+      (event.type === 'executed' || event.type === 'executed_speculative')
+      && !(previous === 'claimed' || previous === 'discovered');
+
+    const invalidClaim = event.type === 'claimed' && previous === 'completed';
+
+    const messages: string[] = [];
+    if (invalidCompletion) {
+      messages.push(`invalid completion transition ${previous} -> ${next} at seq=${event.seq}`);
+    }
+    if (invalidExecution) {
+      messages.push(`invalid execution transition ${previous} -> ${next} at seq=${event.seq}`);
+    }
+    if (invalidClaim) {
+      messages.push(`invalid claim transition ${previous} -> ${next} at seq=${event.seq}`);
+    }
+
+    for (const message of messages) {
+      if (this.strictMode) {
+        errors.push(message);
+      } else {
+        warnings.push(message);
+      }
+    }
+  }
+
+  private getOrCreateTask(
+    tasks: Map<string, MutableReplayTaskState>,
+    taskPda: string,
+    event: TrajectoryEvent,
+  ): MutableReplayTaskState {
+    const existing = tasks.get(taskPda);
+    if (existing) {
+      return existing;
+    }
+
+    const created: MutableReplayTaskState = {
+      taskPda,
+      status: 'unknown',
+      eventCount: 0,
+      verifierVerdicts: 0,
+      policyViolations: 0,
+      speculationAborts: 0,
+      lastEventType: event.type,
+      lastTimestampMs: event.timestampMs,
+      terminal: false,
+    };
+    tasks.set(taskPda, created);
+    return created;
+  }
+
+  private buildSummary(
+    trace: TrajectoryTrace,
+    tasks: Record<string, ReplayTaskState>,
+  ): ReplaySummary {
+    const taskValues = Object.values(tasks);
+
+    return {
+      totalEvents: trace.events.length,
+      taskCount: taskValues.length,
+      completedTasks: taskValues.filter((task) => task.status === 'completed').length,
+      failedTasks: taskValues.filter((task) => task.status === 'failed').length,
+      escalatedTasks: taskValues.filter((task) => task.status === 'escalated').length,
+      policyViolations: taskValues.reduce((acc, task) => acc + task.policyViolations, 0),
+      verifierVerdicts: taskValues.reduce((acc, task) => acc + task.verifierVerdicts, 0),
+      speculationAborts: taskValues.reduce((acc, task) => acc + task.speculationAborts, 0),
+    };
+  }
+
+  private computeHash(
+    trace: TrajectoryTrace,
+    tasks: Record<string, ReplayTaskState>,
+    summary: ReplaySummary,
+    seed: number,
+  ): string {
+    const sortedTaskEntries = Object.entries(tasks)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .reduce<Record<string, ReplayTaskState>>((acc, [taskPda, state]) => {
+        acc[taskPda] = state;
+        return acc;
+      }, {});
+
+    const payload = {
+      schemaVersion: trace.schemaVersion,
+      traceId: trace.traceId,
+      seed,
+      strictMode: this.strictMode,
+      events: trace.events,
+      summary,
+      tasks: sortedTaskEntries,
+    };
+
+    return createHash('sha256')
+      .update(stableStringifyJson(payload as unknown as JsonValue))
+      .digest('hex');
+  }
+}

--- a/runtime/src/eval/types.test.ts
+++ b/runtime/src/eval/types.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EVAL_TRACE_SCHEMA_VERSION,
+  canonicalizeTrajectoryTrace,
+  migrateTrajectoryTrace,
+  parseTrajectoryTrace,
+  stableStringifyJson,
+  type LegacyTrajectoryTraceV0,
+  type TrajectoryTrace,
+} from './types.js';
+
+describe('eval/types', () => {
+  it('parses v1 traces', () => {
+    const trace: TrajectoryTrace = {
+      schemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+      traceId: 'trace-v1',
+      seed: 7,
+      createdAtMs: 100,
+      events: [{
+        seq: 1,
+        type: 'discovered',
+        taskPda: 'task-1',
+        timestampMs: 101,
+        payload: { reward: '100' },
+      }],
+    };
+
+    const parsed = parseTrajectoryTrace(trace);
+    expect(parsed).toEqual(trace);
+  });
+
+  it('migrates legacy v0 traces', () => {
+    const legacy: LegacyTrajectoryTraceV0 = {
+      traceId: 'legacy',
+      createdAtMs: 1,
+      events: [{
+        type: 'claimed',
+        taskPda: 'task-1',
+        timestampMs: 2,
+      }],
+    };
+
+    const migrated = migrateTrajectoryTrace(legacy);
+    expect(migrated.schemaVersion).toBe(EVAL_TRACE_SCHEMA_VERSION);
+    expect(migrated.seed).toBe(0);
+    expect(migrated.events).toHaveLength(1);
+    expect(migrated.events[0].seq).toBe(1);
+    expect(migrated.events[0].payload).toEqual({});
+  });
+
+  it('rejects malformed events', () => {
+    expect(() =>
+      parseTrajectoryTrace({
+        schemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+        traceId: 'bad',
+        seed: 1,
+        createdAtMs: 10,
+        events: [{
+          seq: 0,
+          type: 'claimed',
+          timestampMs: 11,
+          payload: {},
+        }],
+      }),
+    ).toThrow('seq');
+  });
+
+  it('canonicalizes trace event ordering by sequence number', () => {
+    const trace: TrajectoryTrace = {
+      schemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+      traceId: 'sort-check',
+      seed: 9,
+      createdAtMs: 1,
+      events: [
+        {
+          seq: 2,
+          type: 'completed',
+          taskPda: 'task-1',
+          timestampMs: 20,
+          payload: { b: 1, a: 2 },
+        },
+        {
+          seq: 1,
+          type: 'claimed',
+          taskPda: 'task-1',
+          timestampMs: 10,
+          payload: { z: 3, y: 4 },
+        },
+      ],
+    };
+
+    const canonical = canonicalizeTrajectoryTrace(trace);
+    expect(canonical.events.map((event) => event.seq)).toEqual([1, 2]);
+  });
+
+  it('stable-stringifies JSON with key-order independence', () => {
+    const left = stableStringifyJson({
+      b: 2,
+      a: {
+        d: 4,
+        c: 3,
+      },
+    });
+
+    const right = stableStringifyJson({
+      a: {
+        c: 3,
+        d: 4,
+      },
+      b: 2,
+    });
+
+    expect(left).toBe(right);
+  });
+});

--- a/runtime/src/eval/types.ts
+++ b/runtime/src/eval/types.ts
@@ -1,0 +1,282 @@
+/**
+ * Eval trajectory trace schema, parsing, and canonicalization helpers.
+ *
+ * @module
+ */
+
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+export interface JsonObject {
+  [key: string]: JsonValue;
+}
+
+export const EVAL_TRACE_SCHEMA_VERSION = 1 as const;
+
+export type KnownTrajectoryEventType =
+  | 'discovered'
+  | 'claimed'
+  | 'executed'
+  | 'executed_speculative'
+  | 'completed'
+  | 'completed_speculative'
+  | 'failed'
+  | 'escalated'
+  | 'proof_failed'
+  | 'proof_generated'
+  | 'verifier_verdict'
+  | 'policy_violation'
+  | 'sequential_enforcement_bypass'
+  | 'speculation_started'
+  | 'speculation_confirmed'
+  | 'speculation_aborted';
+
+export type TrajectoryEventType = KnownTrajectoryEventType | (string & {});
+
+export interface TrajectoryRecordInput {
+  type: TrajectoryEventType;
+  payload?: Record<string, unknown>;
+  taskPda?: string;
+  timestampMs?: number;
+}
+
+export interface TrajectoryRecorderSink {
+  record(input: TrajectoryRecordInput): TrajectoryEvent | null;
+}
+
+export interface TrajectoryEvent {
+  seq: number;
+  type: TrajectoryEventType;
+  taskPda?: string;
+  timestampMs: number;
+  payload: JsonObject;
+}
+
+export interface TrajectoryTrace {
+  schemaVersion: typeof EVAL_TRACE_SCHEMA_VERSION;
+  traceId: string;
+  seed: number;
+  createdAtMs: number;
+  metadata?: JsonObject;
+  events: TrajectoryEvent[];
+}
+
+export interface LegacyTrajectoryEventV0 {
+  type: string;
+  taskPda?: string;
+  timestampMs: number;
+  payload?: JsonObject;
+}
+
+export interface LegacyTrajectoryTraceV0 {
+  traceId: string;
+  seed?: number;
+  createdAtMs: number;
+  metadata?: JsonObject;
+  events: LegacyTrajectoryEventV0[];
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null) return true;
+
+  const valueType = typeof value;
+  if (valueType === 'string' || valueType === 'boolean') return true;
+
+  if (valueType === 'number') {
+    return Number.isFinite(value as number);
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((entry) => isJsonValue(entry));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.values(value).every((entry) => isJsonValue(entry));
+  }
+
+  return false;
+}
+
+function parseJsonObject(value: unknown, path: string): JsonObject {
+  assert(isPlainObject(value), `${path} must be a plain object`);
+  assert(isJsonValue(value), `${path} contains non-JSON values`);
+  return value;
+}
+
+function parseTrajectoryEvent(value: unknown, index: number): TrajectoryEvent {
+  const path = `events[${index}]`;
+  assert(isPlainObject(value), `${path} must be an object`);
+
+  const seq = value.seq;
+  const type = value.type;
+  const taskPda = value.taskPda;
+  const timestampMs = value.timestampMs;
+  const payload = value.payload;
+
+  assert(Number.isInteger(seq) && (seq as number) > 0, `${path}.seq must be a positive integer`);
+  assert(typeof type === 'string' && type.length > 0, `${path}.type must be a non-empty string`);
+  if (taskPda !== undefined) {
+    assert(typeof taskPda === 'string' && taskPda.length > 0, `${path}.taskPda must be a non-empty string`);
+  }
+  assert(Number.isInteger(timestampMs) && (timestampMs as number) >= 0, `${path}.timestampMs must be a non-negative integer`);
+
+  return {
+    seq: seq as number,
+    type,
+    taskPda: taskPda as string | undefined,
+    timestampMs: timestampMs as number,
+    payload: parseJsonObject(payload ?? {}, `${path}.payload`),
+  };
+}
+
+function parseV1Trace(value: unknown): TrajectoryTrace {
+  assert(isPlainObject(value), 'trace must be an object');
+
+  const schemaVersion = value.schemaVersion;
+  const traceId = value.traceId;
+  const seed = value.seed;
+  const createdAtMs = value.createdAtMs;
+  const metadata = value.metadata;
+  const events = value.events;
+
+  assert(schemaVersion === EVAL_TRACE_SCHEMA_VERSION, `unsupported schemaVersion: ${String(schemaVersion)}`);
+  assert(typeof traceId === 'string' && traceId.length > 0, 'traceId must be a non-empty string');
+  assert(Number.isInteger(seed), 'seed must be an integer');
+  assert(Number.isInteger(createdAtMs) && (createdAtMs as number) >= 0, 'createdAtMs must be a non-negative integer');
+  assert(Array.isArray(events), 'events must be an array');
+
+  const parsedEvents = events.map((event, idx) => parseTrajectoryEvent(event, idx));
+  const parsedMetadata = metadata !== undefined
+    ? parseJsonObject(metadata, 'metadata')
+    : undefined;
+
+  return {
+    schemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+    traceId,
+    seed: seed as number,
+    createdAtMs: createdAtMs as number,
+    metadata: parsedMetadata,
+    events: parsedEvents,
+  };
+}
+
+function parseLegacyV0Trace(value: unknown): TrajectoryTrace {
+  assert(isPlainObject(value), 'legacy trace must be an object');
+
+  const traceId = value.traceId;
+  const seed = value.seed;
+  const createdAtMs = value.createdAtMs;
+  const metadata = value.metadata;
+  const events = value.events;
+
+  assert(typeof traceId === 'string' && traceId.length > 0, 'legacy traceId must be a non-empty string');
+  assert(seed === undefined || Number.isInteger(seed), 'legacy seed must be an integer when provided');
+  assert(Number.isInteger(createdAtMs) && (createdAtMs as number) >= 0, 'legacy createdAtMs must be a non-negative integer');
+  assert(Array.isArray(events), 'legacy events must be an array');
+
+  const migratedEvents = events.map((event, idx) => {
+    const path = `legacy.events[${idx}]`;
+    assert(isPlainObject(event), `${path} must be an object`);
+
+    const type = event.type;
+    const taskPda = event.taskPda;
+    const timestampMs = event.timestampMs;
+    const payload = event.payload;
+
+    assert(typeof type === 'string' && type.length > 0, `${path}.type must be a non-empty string`);
+    if (taskPda !== undefined) {
+      assert(typeof taskPda === 'string' && taskPda.length > 0, `${path}.taskPda must be a non-empty string`);
+    }
+    assert(Number.isInteger(timestampMs) && (timestampMs as number) >= 0, `${path}.timestampMs must be a non-negative integer`);
+
+    return {
+      seq: idx + 1,
+      type,
+      taskPda: taskPda as string | undefined,
+      timestampMs: timestampMs as number,
+      payload: parseJsonObject(payload ?? {}, `${path}.payload`),
+    } satisfies TrajectoryEvent;
+  });
+
+  return {
+    schemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+    traceId,
+    seed: (seed as number | undefined) ?? 0,
+    createdAtMs: createdAtMs as number,
+    metadata: metadata !== undefined ? parseJsonObject(metadata, 'legacy.metadata') : undefined,
+    events: migratedEvents,
+  };
+}
+
+/**
+ * Parse a trajectory trace, including migration from legacy v0 format.
+ */
+export function parseTrajectoryTrace(value: unknown): TrajectoryTrace {
+  if (isPlainObject(value) && value.schemaVersion === EVAL_TRACE_SCHEMA_VERSION) {
+    return parseV1Trace(value);
+  }
+
+  return parseLegacyV0Trace(value);
+}
+
+/**
+ * Explicit migration helper for callers that already distinguish source versions.
+ */
+export function migrateTrajectoryTrace(
+  trace: TrajectoryTrace | LegacyTrajectoryTraceV0,
+): TrajectoryTrace {
+  return parseTrajectoryTrace(trace);
+}
+
+function canonicalizeJson(value: JsonValue): JsonValue {
+  if (Array.isArray(value)) {
+    return value.map((entry) => canonicalizeJson(entry));
+  }
+
+  if (isPlainObject(value)) {
+    const output: JsonObject = {};
+    for (const key of Object.keys(value).sort()) {
+      output[key] = canonicalizeJson(value[key] as JsonValue);
+    }
+    return output;
+  }
+
+  return value;
+}
+
+/**
+ * Canonicalize trace for deterministic hashing/serialization.
+ * Event order is normalized by `seq` ascending.
+ */
+export function canonicalizeTrajectoryTrace(trace: TrajectoryTrace): TrajectoryTrace {
+  const events = [...trace.events]
+    .sort((a, b) => a.seq - b.seq)
+    .map((event) => ({
+      ...event,
+      payload: canonicalizeJson(event.payload) as JsonObject,
+    }));
+
+  return {
+    ...trace,
+    metadata: trace.metadata
+      ? (canonicalizeJson(trace.metadata) as JsonObject)
+      : undefined,
+    events,
+  };
+}
+
+/**
+ * Stable stringify for JSON-compatible values using canonical key ordering.
+ */
+export function stableStringifyJson(value: JsonValue): string {
+  return JSON.stringify(canonicalizeJson(value));
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -438,6 +438,34 @@ export {
   DefaultClaimStrategy,
 } from './autonomous/index.js';
 
+// Eval and deterministic replay
+export {
+  EVAL_TRACE_SCHEMA_VERSION,
+  parseTrajectoryTrace,
+  migrateTrajectoryTrace,
+  canonicalizeTrajectoryTrace,
+  stableStringifyJson,
+  TrajectoryRecorder,
+  TrajectoryReplayEngine,
+  type JsonPrimitive,
+  type JsonValue,
+  type JsonObject,
+  type KnownTrajectoryEventType,
+  type TrajectoryEventType,
+  type TrajectoryRecordInput,
+  type TrajectoryRecorderSink,
+  type TrajectoryEvent,
+  type TrajectoryTrace,
+  type LegacyTrajectoryEventV0,
+  type LegacyTrajectoryTraceV0,
+  type TrajectoryRecorderConfig,
+  type ReplayTaskStatus,
+  type ReplayTaskState,
+  type ReplaySummary,
+  type TrajectoryReplayResult,
+  type TrajectoryReplayConfig,
+} from './eval/index.js';
+
 // Policy and Safety Engine
 export {
   PolicyEngine,

--- a/runtime/tests/eval-replay.integration.test.ts
+++ b/runtime/tests/eval-replay.integration.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { Keypair } from '@solana/web3.js';
+import { AutonomousAgent } from '../src/autonomous/agent.js';
+import { TaskStatus, type Task } from '../src/autonomous/types.js';
+import { TrajectoryRecorder } from '../src/eval/recorder.js';
+import { TrajectoryReplayEngine } from '../src/eval/replay.js';
+import {
+  createRuntimeTestContext,
+  initializeProtocol,
+  type RuntimeTestContext,
+} from './litesvm-setup.js';
+
+function createTask(overrides: Partial<Task> = {}): Task {
+  return {
+    pda: Keypair.generate().publicKey,
+    taskId: new Uint8Array(32).fill(1),
+    creator: Keypair.generate().publicKey,
+    requiredCapabilities: 1n,
+    reward: 100n,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    deadline: 0,
+    maxWorkers: 1,
+    currentClaims: 0,
+    status: TaskStatus.Open,
+    rewardMint: null,
+    ...overrides,
+  };
+}
+
+describe('eval replay integration (LiteSVM)', () => {
+  let ctx: RuntimeTestContext;
+
+  beforeAll(async () => {
+    ctx = createRuntimeTestContext();
+    await initializeProtocol(ctx);
+  });
+
+  it('captures lifecycle trajectory and replays deterministically', async () => {
+    const recorder = new TrajectoryRecorder({
+      traceId: 'integration-trace-1',
+      seed: 321,
+    });
+
+    const agent = new AutonomousAgent({
+      connection: ctx.connection,
+      wallet: ctx.payer,
+      capabilities: 1n,
+      executor: {
+        execute: async () => [1n],
+      },
+      trajectoryRecorder: recorder,
+    });
+
+    const task = createTask();
+    const agentAny = agent as any;
+
+    // Capture through existing autonomous journaling hooks.
+    agentAny.handleDiscoveredTask(task);
+    await agentAny.journalEvent(task, 'claimed', { claimTx: 'claim-1' });
+    await agentAny.journalEvent(task, 'executed', {
+      outputLength: 1,
+      verifier: null,
+    });
+    await agentAny.journalEvent(task, 'completed', {
+      completionTx: 'complete-1',
+      durationMs: 55,
+      reward: '100',
+    });
+
+    const trace = recorder.createTrace();
+    const engine = new TrajectoryReplayEngine({ strictMode: true, seed: 321 });
+
+    const first = engine.replay(trace);
+    const second = engine.replay(trace);
+
+    expect(first.deterministicHash).toBe(second.deterministicHash);
+    expect(first.summary.completedTasks).toBe(1);
+    expect(first.tasks[task.pda.toBase58()].status).toBe('completed');
+    expect(first.errors).toHaveLength(0);
+  });
+
+  it('replays failure paths for verifier escalation, policy denial, and speculation abort', async () => {
+    const recorder = new TrajectoryRecorder({
+      traceId: 'integration-trace-failure',
+      seed: 654,
+    });
+
+    const agent = new AutonomousAgent({
+      connection: ctx.connection,
+      wallet: ctx.payer,
+      capabilities: 1n,
+      executor: {
+        execute: async () => [1n],
+      },
+      trajectoryRecorder: recorder,
+    });
+
+    const task = createTask();
+    const agentAny = agent as any;
+
+    await agentAny.journalEvent(task, 'claimed', { claimTx: 'claim-fail' });
+    await agentAny.journalEvent(task, 'policy_violation', {
+      violation: { code: 'risk_threshold_exceeded' },
+      mode: 'safe_mode',
+    });
+    agentAny.recordTrajectoryByPda(task.pda, 'speculation_aborted', { reason: 'parent_failed' });
+    await agentAny.journalEvent(task, 'escalated', {
+      escalation: { reason: 'verifier_failed', attempts: 1, revisions: 0, durationMs: 100 },
+      verifierHistory: [],
+    });
+
+    const trace = recorder.createTrace();
+    const replay = new TrajectoryReplayEngine({ strictMode: false, seed: 654 }).replay(trace);
+
+    expect(replay.summary.policyViolations).toBe(1);
+    expect(replay.summary.speculationAborts).toBe(1);
+    expect(replay.summary.escalatedTasks).toBe(1);
+    expect(replay.tasks[task.pda.toBase58()].status).toBe('escalated');
+  });
+});


### PR DESCRIPTION
# Summary
Implement deterministic trajectory capture/replay primitives for runtime reliability evaluation.

# Changes
- Added new eval module under `runtime/src/eval/`:
  - `types.ts`: trace schema v1, legacy migration support, canonicalization, stable stringify.
  - `recorder.ts`: in-memory `TrajectoryRecorder` with deterministic sequencing and payload sanitization.
  - `replay.ts`: `TrajectoryReplayEngine` with strict transition validation, per-task summaries, deterministic replay hash.
  - `index.ts`: public exports.
- Integrated optional recorder hook into autonomous runtime:
  - Added `trajectoryRecorder?: TrajectoryRecorderSink` to `AutonomousAgentConfig`.
  - Wired trace events from existing lifecycle/journaling paths (discovery, journaling events, proof generation, speculation events).
  - Default behavior unchanged when recorder is not configured.
- Exported eval APIs from `runtime/src/index.ts`.
- Added documentation section in `runtime/README.md` for deterministic trajectory replay usage.
- Added tests:
  - `runtime/src/eval/types.test.ts`
  - `runtime/src/eval/recorder.test.ts`
  - `runtime/src/eval/replay.test.ts`
  - `runtime/tests/eval-replay.integration.test.ts` (LiteSVM harness)

# Testing
- [ ] anchor test
- [ ] cargo fmt --check
- [ ] cargo clippy
- [ ] cargo test
- [x] `npm run test --prefix runtime`
- [x] `npm run typecheck --prefix runtime`
- [x] `npm run typecheck`

# Security / Risk
- [x] PDA seeds/constraints reviewed (if applicable)
- [x] No authority bypass introduced
- [x] Escrow/funds safety considered (if applicable)

# Checklist
- [x] Tests added/updated (or N/A)
- [x] Docs updated (if needed)

# Issue link(s)
- Closes #892
