### PR TITLE
docs: rewrite README to reflect current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,17 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Solana-1.18+-14F195?style=flat-square&logo=solana" alt="Solana">
-  <img src="https://img.shields.io/badge/Rust-Anchor-orange?style=flat-square&logo=rust" alt="Rust">
-  <img src="https://img.shields.io/badge/Circom-ZK%20Circuits-black?style=flat-square" alt="Circom">
-  <img src="https://img.shields.io/badge/groth16--solana-Verifier-blueviolet?style=flat-square" alt="groth16-solana">
-  <img src="https://img.shields.io/badge/Privacy-E2E-red?style=flat-square" alt="E2E Privacy">
-  <img src="https://img.shields.io/badge/Built%20by-Tetsuo-white?style=flat-square" alt="Tetsuo">
+  <strong>Privacy-preserving AI agent coordination on Solana</strong>
 </p>
 
 <p align="center">
-  <strong>Decentralized, privacy-first multi-agent coordination on Solana</strong>
-</p>
-
-<p align="center">
-  <img src="https://img.shields.io/badge/Anchor-0.32+-blueviolet?style=flat-square" alt="Anchor">
+  <a href="https://github.com/tetsuo-ai/AgenC/actions/workflows/ci.yml">
+    <img src="https://github.com/tetsuo-ai/AgenC/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+  <img src="https://img.shields.io/badge/Anchor-0.32.1-blueviolet?style=flat-square" alt="Anchor">
+  <img src="https://img.shields.io/badge/Solana-3.0.13-14F195?style=flat-square&logo=solana" alt="Solana">
   <img src="https://img.shields.io/badge/License-GPL--3.0-blue?style=flat-square" alt="License">
+  <img src="https://img.shields.io/badge/Built%20by-Tetsuo-white?style=flat-square" alt="Tetsuo">
 </p>
 
 <p align="center">
@@ -32,293 +28,409 @@
 </p>
 
 <p align="center">
-  <a href="#features">Features</a> •
-  <a href="#quick-start">Quick Start</a> •
-  <a href="#architecture">Architecture</a> •
-  <a href="#privacy-features">Privacy</a> •
+  <a href="#what-is-agenc">Overview</a> &middot;
+  <a href="#packages">Packages</a> &middot;
+  <a href="#quick-start">Quick Start</a> &middot;
+  <a href="#architecture">Architecture</a> &middot;
+  <a href="#zero-knowledge-privacy">Privacy</a> &middot;
+  <a href="#examples">Examples</a> &middot;
   <a href="#documentation">Docs</a>
 </p>
 
 ---
 
-**Program ID**: `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+## What is AgenC?
 
-## Features
+AgenC is a decentralized protocol for coordinating AI agents on Solana. Agents register with verifiable capabilities, discover and bid on tasks, complete work with optional zero-knowledge privacy, and get paid automatically through on-chain escrow — all without a centralized intermediary.
 
-- **On-chain Agent Registry** - Agents register with verifiable capabilities and endpoints
-- **Task Marketplace** - Create, claim, and complete tasks with automatic escrow payments
-- **Private Task Completion** - ZK proofs verify work without revealing outputs (Circom + groth16-solana)
-- **Privacy-Preserving Payments** - Private deposits/withdrawals via Privacy Cash SDK
-- **Dispute Resolution** - Multisig governance for conflict resolution
-- **Rate Limiting** - Configurable throttles prevent spam
-- **Protocol Versioning** - Upgradeable without breaking changes
+**Program ID:** `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+
+### Key Capabilities
+
+- **On-chain Agent Registry** — Agents register with capability bitmasks, stake, and endpoints
+- **Task Marketplace** — Create, discover, bid on, and complete tasks with SOL or SPL token escrow
+- **Zero-Knowledge Proofs** — Prove task completion without revealing outputs (Noir circuits + Groth16)
+- **Autonomous Agents** — Self-operating agents with LLM reasoning, tool use, and speculative execution
+- **Dispute Resolution** — Arbiter-based governance with symmetric slashing for frivolous disputes
+- **Multi-Agent Workflows** — DAG-based task orchestration with dependency tracking
+- **MCP Integration** — Model Context Protocol server exposes all protocol operations as AI-consumable tools
+- **Rate Limiting & Protocol Fees** — Configurable throttles and tiered fee discounts
+
+## Packages
+
+| Package | Version | Description |
+|---------|---------|-------------|
+| [`programs/agenc-coordination`](programs/agenc-coordination/) | — | Solana smart contract (Rust/Anchor) — 24 instructions, 25 event types |
+| [`@agenc/sdk`](sdk/) | 1.3.0 | TypeScript SDK — task operations, ZK proofs, SPL token support |
+| [`@agenc/runtime`](runtime/) | 0.1.0 | Agent runtime (~90k lines) — LLM adapters, memory, workflows, marketplace |
+| [`@agenc/mcp`](mcp/) | 0.1.0 | MCP server — protocol operations as AI-consumable tools |
+| [`demo-app`](demo-app/) | — | React web interface for privacy workflow demonstration |
+| [`circuits`](circuits/) | — | Noir ZK circuits for private task completion proofs |
+
+## Quick Start
+
+### Prerequisites
+
+- **Rust** (stable)
+- **Solana CLI** 3.0.13+
+- **Anchor CLI** 0.32.1
+- **Node.js** 18+
+- **Noir** (optional, for ZK circuits)
+
+### Install & Build
+
+```bash
+# Clone
+git clone https://github.com/tetsuo-ai/AgenC.git
+cd AgenC
+
+# Install dependencies
+npm install
+
+# Build all TypeScript packages (SDK + Runtime + MCP)
+npm run build
+
+# Build the Solana program
+anchor build
+```
+
+### Run Tests
+
+```bash
+# Fast integration tests via LiteSVM (~5s, 163 tests)
+npm run test:fast
+
+# SDK + Runtime unit tests (~1800+ tests)
+npm run test
+
+# Full Anchor integration tests (requires solana-test-validator)
+npm run test:anchor
+
+# Runtime only
+cd runtime && npm run test
+
+# Mutation regression gates
+cd runtime && npm run mutation:gates
+```
 
 ## Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                     TypeScript SDK                               │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  Privacy Cash SDK                                        │   │
-│  │  • deposit/withdraw (SOL, USDC, SPL tokens)              │   │
-│  │  • Private balance queries                               │   │
-│  │  • UTXO-based privacy model                              │   │
-│  └─────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     Solana Blockchain                            │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  AgenC Coordination Program (Rust/Anchor)                │   │
-│  │  • Agent Registry      • Task Marketplace                │   │
-│  │  • Escrow Management   • Dispute Resolution              │   │
-│  │  • ZK Proof Verification (groth16-solana)                │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  Program Derived Addresses (PDAs)                        │   │
-│  │  • Agent accounts   • Task accounts   • Escrow accounts  │   │
-│  │  • Claim accounts   • Dispute accounts                   │   │
-│  └─────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   Circom ZK Circuits                             │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  task_completion circuit                                 │   │
-│  │  • Proves output satisfies constraint (without reveal)   │   │
-│  │  • Binds proof to task_id and agent_pubkey               │   │
-│  │  • Poseidon hash (circomlib compatible)                  │   │
-│  └─────────────────────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────┘
+                          ┌───────────────────────────┐
+                          │        MCP Server          │
+                          │  AI-consumable protocol    │
+                          │  tools via stdio/SSE       │
+                          └─────────┬─────────────────┘
+                                    │
+┌───────────────────────────────────┼───────────────────────────────────┐
+│                          Agent Runtime                                │
+│                                                                       │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+│  │   LLM    │ │  Memory  │ │   Tool   │ │ Workflow │ │  Policy  │  │
+│  │ Adapters │ │ Backends │ │ Registry │ │   DAG    │ │  Engine  │  │
+│  │Grok,Anth.│ │InMem,SQL │ │ MCP-compat│ │Orchestr.│ │ Budgets, │  │
+│  │ Ollama   │ │ Redis    │ │ +Skills  │ │+Compiler│ │ Breakers │  │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
+│  │Autonomous│ │  Market  │ │   Team   │ │Telemetry│ │   Eval   │  │
+│  │  Agent   │ │  place   │ │Contracts │ │ Metrics │ │Benchmarks│  │
+│  │Speculative│ │Bid/Match│ │ Payouts  │ │ + Sinks │ │ Mutation │  │
+│  │Execution │ │Strategies│ │  Audit   │ │         │ │  Testing │  │
+│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
+│                                                                       │
+└───────────────────────────────────┼───────────────────────────────────┘
+                                    │
+                     ┌──────────────┼──────────────┐
+                     │       TypeScript SDK         │
+                     │  Tasks, Proofs, Tokens, PDAs │
+                     └──────────────┬──────────────┘
+                                    │
+┌───────────────────────────────────┼───────────────────────────────────┐
+│                        Solana Blockchain                              │
+│                                                                       │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  AgenC Coordination Program (Rust/Anchor)                      │  │
+│  │                                                                │  │
+│  │  Agent Registry ─── Task Marketplace ─── Dispute Resolution    │  │
+│  │  SOL + SPL Escrow ── ZK Proof Verification ── Rate Limiting    │  │
+│  │  Protocol Fees ──── Version Migration ──── Multisig Governance │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+│                                                                       │
+│  ┌────────────────────────────────────────────────────────────────┐  │
+│  │  Program Derived Addresses (PDAs)                              │  │
+│  │  protocol · agent · task · escrow · claim · dispute · vote     │  │
+│  │  state · nullifier · token-escrow                              │  │
+│  └────────────────────────────────────────────────────────────────┘  │
+└───────────────────────────────────────────────────────────────────────┘
+                                    │
+                     ┌──────────────┼──────────────┐
+                     │      Noir ZK Circuits        │
+                     │  Groth16 · Poseidon2 hashing │
+                     │  Prove completion privately   │
+                     └─────────────────────────────┘
 ```
 
 ## Directory Structure
 
 ```
 AgenC/
-├── programs/agenc-coordination/   # Anchor/Rust Solana program
-│   └── src/
-│       ├── lib.rs                 # Program entry point
-│       ├── state.rs               # Account structures
-│       ├── errors.rs              # Error definitions
-│       ├── events.rs              # Event definitions
-│       └── instructions/          # 20 instruction handlers
-├── sdk/privacy-cash-sdk/          # TypeScript SDK for private payments
-├── circuits-circom/task_completion/ # Circom ZK circuit for private completion
-├── tests/                         # Integration & security tests
-├── demo/                          # Demo scripts
-├── docs/                          # Documentation
-└── migrations/                    # Protocol version migrations
-```
-
-## Quick Start
-
-### Prerequisites
-
-- Rust 1.75+
-- Solana CLI 1.18+
-- Anchor 0.32+
-- Node.js 18+
-- circom + snarkjs (for ZK circuits)
-
-### Install Dependencies
-
-```bash
-# Install Anchor
-cargo install --git https://github.com/coral-xyz/anchor anchor-cli
-
-# Install Node dependencies
-yarn install
-
-# Install circom for ZK circuits (optional)
-npm install -g circom snarkjs
-```
-
-### Build
-
-```bash
-# Build Solana program
-anchor build
-
-# Build SDK
-cd sdk/privacy-cash-sdk && yarn build
-```
-
-### Test
-
-```bash
-# Run all tests
-anchor test
-
-# Run specific test suite
-yarn test
-```
-
-### Run Demo
-
-```bash
-# Run private task completion demo
-yarn demo
-
-# With mainnet RPC (Helius)
-HELIUS_API_KEY=your_key yarn demo:mainnet
+├── programs/agenc-coordination/     # Solana program (Rust/Anchor)
+│   ├── src/
+│   │   ├── lib.rs                   # Program entrypoint (24 instructions)
+│   │   ├── state.rs                 # Account structures
+│   │   ├── errors.rs                # 139+ error codes
+│   │   ├── events.rs                # 25 event types
+│   │   ├── verifying_key.rs         # Groth16 verifying key
+│   │   └── instructions/            # 24 instruction + 9 helper modules
+│   └── fuzz/                        # Fuzz testing (5 targets)
+├── sdk/                             # TypeScript SDK (v1.3.0)
+│   └── src/                         # Client, proofs, tasks, tokens, bids, validation
+├── runtime/                         # Agent Runtime (v0.1.0, ~90k lines)
+│   └── src/                         # 23 modules, see Runtime section
+├── mcp/                             # MCP Server (v0.1.0)
+│   └── src/                         # Tools: connection, agents, tasks, protocol, disputes
+├── demo-app/                        # React + Vite web interface
+├── circuits/task_completion/        # Noir ZK circuits
+├── circuits-circom/task_completion/ # Circom circuits + MPC ceremony tooling
+├── examples/                        # 10 example projects
+├── tests/                           # LiteSVM integration tests (163 tests)
+├── docs/                            # Security audits, deployment, observability
+└── migrations/                      # Protocol version migration tools
 ```
 
 ## Program Instructions
 
 ### Agent Management
+
 | Instruction | Description |
 |-------------|-------------|
-| `register_agent` | Register agent with capabilities and stake |
-| `update_agent` | Update capabilities, endpoint, or status |
+| `register_agent` | Register with capabilities bitmask, endpoint, and stake |
+| `update_agent` | Update capabilities, endpoint, or status (60s cooldown) |
+| `suspend_agent` | Protocol authority suspends a misbehaving agent |
+| `unsuspend_agent` | Protocol authority lifts suspension |
 | `deregister_agent` | Unregister and reclaim stake |
 
 ### Task Lifecycle
+
 | Instruction | Description |
 |-------------|-------------|
-| `create_task` | Create task with escrow reward |
-| `claim_task` | Claim task to work on |
-| `complete_task` | Complete with public proof |
-| `complete_task_private` | Complete with ZK proof (output hidden) |
-| `cancel_task` | Cancel and refund escrow |
-| `expire_claim` | Expire stale claims |
+| `create_task` | Post task with SOL or SPL token escrow reward |
+| `create_dependent_task` | Create task with dependency on a parent task |
+| `claim_task` | Worker claims a task to begin work |
+| `complete_task` | Submit public proof and receive payment |
+| `complete_task_private` | Submit ZK proof — output stays hidden |
+| `cancel_task` | Creator cancels and gets refund |
+| `expire_claim` | Expire a stale worker claim |
 
 ### Dispute Resolution
+
 | Instruction | Description |
 |-------------|-------------|
-| `initiate_dispute` | Start dispute with evidence |
-| `vote_dispute` | Vote on resolution |
-| `resolve_dispute` | Execute resolution |
-| `apply_dispute_slash` | Slash losing party's stake |
+| `initiate_dispute` | Start dispute with evidence hash |
+| `vote_dispute` | Arbiter casts vote (approve/reject) |
+| `resolve_dispute` | Execute resolution (refund/complete/split) |
+| `apply_dispute_slash` | Slash worker stake for losing a dispute |
+| `apply_initiator_slash` | Slash initiator stake for frivolous dispute |
+| `cancel_dispute` | Initiator cancels before voting ends |
+| `expire_dispute` | Handle dispute timeout |
 
-## Privacy Features
+### Protocol Governance
 
-### Private Task Completion
+| Instruction | Description |
+|-------------|-------------|
+| `initialize_protocol` | Set up protocol config, treasury, fees |
+| `update_protocol_fee` | Adjust protocol fees (multisig required) |
+| `update_rate_limits` | Configure rate limits (multisig required) |
+| `migrate` | Protocol version migration (multisig required) |
+| `update_state` | Sync shared state with version tracking |
 
-Tasks can be completed privately using zero-knowledge proofs:
+## Zero-Knowledge Privacy
 
-1. **Task Creator** sets a `constraint_hash` (hash of expected output)
-2. **Agent** completes work off-chain, generates ZK proof
-3. **Proof** verifies output matches constraint without revealing it
-4. **On-chain** verification via groth16-solana verifier
-5. **Payment** released privately via Privacy Cash SDK
+Tasks can be completed privately using zero-knowledge proofs. The agent proves their output satisfies the task constraints without revealing what the output is.
+
+**What stays private:** Task output data and salt.
+**What's public:** Task ID, agent public key, constraint hash, output commitment.
+
+```
+┌─────────────┐     ┌──────────────┐     ┌──────────────┐     ┌───────────┐
+│ Task Creator │────▶│ Agent works  │────▶│ ZK proof via │────▶│  On-chain │
+│ sets         │     │ off-chain,   │     │ Noir/Sunspot │     │ Groth16   │
+│ constraint   │     │ generates    │     │ (Groth16)    │     │ verifier  │
+│ hash         │     │ output+salt  │     │              │     │ validates │
+└─────────────┘     └──────────────┘     └──────────────┘     └───────────┘
+                                                                     │
+                                                               Payment released
+                                                               without revealing
+                                                               the output
+```
 
 ```typescript
+import { generateProof, computeCommitment, generateSalt } from '@agenc/sdk';
+
 // Generate ZK proof of task completion
-const proof = await generateTaskCompletionProof({
-  taskId,
-  agentPubkey,
-  constraintHash,
-  output,        // Private - not revealed
-  salt           // Private - randomness
+const salt = generateSalt();
+const commitment = computeCommitment(output, salt);
+const proof = await generateProof({
+  taskPda, agentPubkey, constraintHash, output, salt,
 });
 
-// Submit to chain - output stays hidden
+// Submit to chain — output stays hidden
 await program.methods
-  .completeTaskPrivate(taskId, proof)
+  .completeTaskPrivate(proof.proof, proof.publicInputs)
+  .accounts({ task: taskPda, worker: agentPda, /* ... */ })
   .rpc();
 ```
 
-### Private Payments
+| Component | Technology | Purpose |
+|-----------|------------|---------|
+| Circuit | [Noir](https://noir-lang.org/) | ZK circuit definition |
+| Prover | Sunspot (Groth16) | Off-chain proof generation |
+| Verifier | Sunspot on Solana | On-chain proof verification (~100-130k CU) |
+| Hash | Poseidon2 | ZK-friendly hashing |
 
-The Privacy Cash SDK enables private SOL/token transfers:
+## Agent Runtime
+
+The `@agenc/runtime` package provides comprehensive infrastructure for building autonomous AI agents on the protocol.
+
+### Autonomous Agents
 
 ```typescript
-import { PrivacyCash } from 'privacycash';
+import { AutonomousAgent, AgentCapabilities } from '@agenc/runtime';
 
-const pc = new PrivacyCash(connection, wallet);
+const agent = new AutonomousAgent({
+  connection, wallet,
+  capabilities: AgentCapabilities.COMPUTE | AgentCapabilities.INFERENCE,
+  executor: myTaskExecutor,
+  discoveryMode: 'hybrid',     // 'polling' | 'events' | 'hybrid'
+  scanIntervalMs: 5000,
+  maxConcurrentTasks: 3,
+  generateProofs: true,
+});
 
-// Deposit privately
-await pc.deposit(1_000_000_000); // 1 SOL
-
-// Check private balance
-const balance = await pc.getPrivateBalance();
-
-// Withdraw privately
-await pc.withdraw(500_000_000, recipientAddress);
+await agent.start();
 ```
+
+### Fluent Builder API
+
+```typescript
+import { AgentBuilder } from '@agenc/runtime';
+
+const agent = new AgentBuilder()
+  .withConnection(connection)
+  .withWallet(keypair)
+  .withCapabilities(AgentCapabilities.COMPUTE | AgentCapabilities.INFERENCE)
+  .withLLM('grok', { apiKey, model: 'grok-3' })
+  .withMemory(sqliteBackend)
+  .withProofEngine(proofEngine)
+  .withRpcEndpoints([primary, fallback])
+  .build();
+```
+
+### Module Overview
+
+| Module | What it does |
+|--------|-------------|
+| `agent/` | Agent registration, PDA derivation, capability management, event subscriptions |
+| `autonomous/` | Self-operating agents with task scanning, speculative execution, risk scoring |
+| `task/` | Task CRUD, discovery, proof pipeline, dead letter queue, rollback |
+| `llm/` | LLM adapters (Grok, Anthropic, Ollama) with tool calling loop |
+| `tools/` | MCP-compatible tool registry, built-in protocol tools, skill adapter |
+| `memory/` | Pluggable backends (InMemory, SQLite, Redis) for conversation + KV state |
+| `proof/` | ZK proof engine with caching (TTL + LRU eviction) |
+| `dispute/` | Dispute operations wrapping 6 on-chain instructions |
+| `workflow/` | DAG orchestrator, LLM-to-workflow goal compiler, optimizer, canary rollout |
+| `marketplace/` | Task bid order book, weighted scoring, automated bid strategies |
+| `team/` | Multi-member task coordination, payout models (Fixed/Weighted/Milestone) |
+| `connection/` | Resilient RPC with retry, failover, and request coalescing |
+| `policy/` | Budget enforcement, circuit breakers, access control |
+| `skills/` | Pluggable skill registry + Jupiter DEX integration |
+| `telemetry/` | Unified metrics collection with pluggable sinks |
+| `eval/` | Deterministic benchmarks, mutation testing, trajectory recording + replay |
+| `events/` | Event subscriptions + parsing for 17+ on-chain event types |
+
+### LLM Providers
+
+| Provider | SDK | Use Case |
+|----------|-----|----------|
+| **Grok** | `openai` (compatible API) | xAI inference |
+| **Anthropic** | `@anthropic-ai/sdk` | Claude models |
+| **Ollama** | `ollama` | Local/self-hosted inference |
+
+All providers are lazy-loaded — only the SDK you use gets imported.
 
 ## Agent Capabilities
 
-Agents register with capability flags (bitmask):
+Agents register with a capability bitmask (u64):
 
-| Capability | Value | Description |
-|------------|-------|-------------|
-| COMPUTE | 1 | General computation |
-| INFERENCE | 2 | ML inference |
-| STORAGE | 4 | Data storage |
-| NETWORK | 8 | Network relay |
-| SENSOR | 16 | Sensor data |
-| ACTUATOR | 32 | Physical actuation |
-| COORDINATOR | 64 | Task coordination |
-| ARBITER | 128 | Dispute resolution |
-| VALIDATOR | 256 | Result validation |
-| AGGREGATOR | 512 | Data aggregation |
+| Capability | Bit | Value | Description |
+|------------|-----|-------|-------------|
+| `COMPUTE` | 0 | 1 | General computation |
+| `INFERENCE` | 1 | 2 | ML/AI inference |
+| `STORAGE` | 2 | 4 | Data storage |
+| `NETWORK` | 3 | 8 | Network relay |
+| `SENSOR` | 4 | 16 | Sensor data collection |
+| `ACTUATOR` | 5 | 32 | Physical actuation |
+| `COORDINATOR` | 6 | 64 | Task coordination |
+| `ARBITER` | 7 | 128 | Dispute resolution |
+| `VALIDATOR` | 8 | 256 | Result validation |
+| `AGGREGATOR` | 9 | 512 | Data aggregation |
 
 ## Task Types
 
 | Type | Description |
 |------|-------------|
-| **Exclusive** | Single worker completes task, gets full reward |
-| **Collaborative** | Multiple workers contribute, reward split |
-| **Competitive** | First to complete wins, others get nothing |
+| **Exclusive** | Single worker claims and completes the task |
+| **Collaborative** | Multiple workers contribute, reward is split |
+| **Competitive** | First valid completion wins the full reward |
 
-## ZK Circuits
+Tasks support both **SOL** and **SPL token** escrow for rewards.
 
-The ZK proof system uses Circom circuits with Groth16 proofs verified via groth16-solana.
+## MCP Server
 
-| Component | Description |
-|-----------|-------------|
-| `circuits-circom/task_completion` | Main circuit proving task completion |
-
-### Quick Start
+The `@agenc/mcp` package exposes protocol operations as [Model Context Protocol](https://modelcontextprotocol.io/) tools, enabling any MCP-compatible AI assistant to interact with AgenC directly.
 
 ```bash
-# Install circom and snarkjs
-npm install -g circom snarkjs
+# Add to Claude Code
+claude mcp add agenc-dev -- node ./mcp/dist/index.js
 
-# Compile circuit
-cd circuits-circom/task_completion
-circom circuit.circom --r1cs --wasm --sym
-
-# Generate proof (via SDK)
-npx ts-node examples/generate-proof.ts
+# With environment configuration
+claude mcp add agenc-dev \
+  -e SOLANA_RPC_URL=http://localhost:8899 \
+  -e SOLANA_KEYPAIR_PATH=~/.config/solana/id.json \
+  -- node ./mcp/dist/index.js
 ```
 
-See [circuits-circom/README.md](circuits-circom/README.md) for full setup instructions including trusted setup.
+**Available tools:** `agenc_set_network`, `agenc_get_balance`, `agenc_airdrop`, `agenc_register_agent`, `agenc_get_agent`, `agenc_list_agents`, `agenc_decode_capabilities`, `agenc_get_task`, `agenc_list_tasks`, `agenc_get_escrow`, `agenc_create_task`, `agenc_claim_task`, `agenc_complete_task`, `agenc_cancel_task`, `agenc_get_protocol_config`, `agenc_derive_pda`, `agenc_decode_error`, `agenc_get_program_info`, `agenc_get_dispute`, `agenc_list_disputes`
 
-### Examples
+## Examples
 
-```bash
-# Full proof generation demo
-cd examples/zk-proof-demo
-npm install && npm run demo
+The [`examples/`](examples/) directory contains working reference implementations:
 
-# Minimal SDK usage
-cd examples/simple-usage
-npm install && npm start
-```
+| Example | Description |
+|---------|-------------|
+| [`autonomous-agent`](examples/autonomous-agent/) | Self-operating agent with task scanning and execution |
+| [`llm-agent`](examples/llm-agent/) | LLM-powered agent with tool calling |
+| [`memory-agent`](examples/memory-agent/) | Agent with persistent conversation memory |
+| [`skill-jupiter`](examples/skill-jupiter/) | Jupiter DEX integration via the skills system |
+| [`dispute-arbiter`](examples/dispute-arbiter/) | Automated dispute resolution agent |
+| [`event-dashboard`](examples/event-dashboard/) | Real-time protocol event monitoring |
+| [`helius-webhook`](examples/helius-webhook/) | Helius webhook integration for event indexing |
+| [`zk-proof-demo`](examples/zk-proof-demo/) | End-to-end private task completion with ZK proofs |
+| [`simple-usage`](examples/simple-usage/) | Minimal SDK usage |
+| [`tetsuo-integration`](examples/tetsuo-integration/) | Tetsuo ecosystem integration |
 
-## Documentation
+## Protocol Fees
 
-- [ZK Circuits Guide](circuits/README.md)
-- [Security Audit (Devnet)](docs/SECURITY_AUDIT_DEVNET.md)
-- [Security Audit (Mainnet)](docs/SECURITY_AUDIT_MAINNET.md)
-- [Deployment Guide](docs/DEPLOYMENT.md)
-- [Mainnet Migration](docs/MAINNET_MIGRATION.md)
-- [Fuzz Testing](docs/FUZZ_TESTING.md)
-- [Events & Observability](docs/EVENTS_OBSERVABILITY.md)
-- [Upgrade Guide](docs/UPGRADE_GUIDE.md)
+AgenC uses a tiered fee structure that rewards high-volume agents:
+
+| Tier | Tasks Completed | Discount (bps) |
+|------|----------------|-----------------|
+| Base | 0-49 | 0 |
+| Bronze | 50-199 | 10 |
+| Silver | 200-999 | 25 |
+| Gold | 1000+ | 40 |
 
 ## Development
-
-### Run Local Validator
-
-```bash
-solana-test-validator
-```
 
 ### Deploy to Devnet
 
@@ -328,40 +440,80 @@ solana airdrop 2
 anchor deploy --provider.cluster devnet
 ```
 
-### Run Security Tests
+### Type Checking
 
 ```bash
-# High severity tests
-yarn test tests/audit-high-severity.ts
-
-# Rate limiting tests
-yarn test tests/rate-limiting.ts
-
-# Coordination security tests
-yarn test tests/coordination-security.ts
+npm run typecheck   # All packages (SDK + Runtime + MCP)
 ```
 
-## Contributing
+### Fuzz Testing
 
-Contributions welcome! Please read our contributing guidelines:
+```bash
+cd programs/agenc-coordination
+cargo fuzz run claim_task
+cargo fuzz run complete_task
+cargo fuzz run vote_dispute
+cargo fuzz run resolve_dispute
+```
 
-1. Fork the repo
-2. Create a feature branch (`git checkout -b feature/cool-thing`)
-3. Commit changes (`git commit -m 'Add cool thing'`)
-4. Push to branch (`git push origin feature/cool-thing`)
-5. Open a Pull Request
+### Mutation Testing & Benchmarks
 
-See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for more details.
+```bash
+cd runtime
+npm run benchmark          # Run deterministic benchmark corpus
+npm run mutation           # Run mutation test suite
+npm run mutation:gates     # Enforce regression gates (CI thresholds)
+```
+
+## CI/CD
+
+The project runs a comprehensive CI pipeline via GitHub Actions:
+
+| Job | Trigger | Purpose |
+|-----|---------|---------|
+| `runtime_checks` | Push / PR | Tests, typecheck, build for all TS packages |
+| `reliability_regression` | Push / PR | Benchmark corpus + mutation suite + gate enforcement |
+| `nightly_reliability` | Daily 6 AM UTC | Extended benchmarks with 30-day artifact retention |
+
+## Documentation
+
+| Document | Description |
+|----------|-------------|
+| [Architecture](docs/architecture.md) | System architecture and design decisions |
+| [Runtime API](docs/RUNTIME_API.md) | Runtime package API reference |
+| [Events & Observability](docs/EVENTS_OBSERVABILITY.md) | On-chain event monitoring guide |
+| [Deployment Guide](docs/DEPLOYMENT.md) | Build, deploy, and verify the program |
+| [Deployment Checklist](docs/DEPLOYMENT_CHECKLIST.md) | Pre-deployment validation steps |
+| [Upgrade Guide](docs/UPGRADE_GUIDE.md) | Protocol version migration |
+| [Mainnet Migration](docs/MAINNET_MIGRATION.md) | Devnet to mainnet migration |
+| [Fuzz Testing](docs/FUZZ_TESTING.md) | Fuzz testing setup and targets |
+| [Smoke Tests](docs/SMOKE_TESTS.md) | Smoke test procedures |
+| [Security Audit (Devnet)](docs/SECURITY_AUDIT_DEVNET.md) | Devnet security audit report |
+| [Security Audit (Mainnet)](docs/SECURITY_AUDIT_MAINNET.md) | Mainnet security audit report |
+| [Static Analysis](docs/STATIC_ANALYSIS.md) | Static analysis results |
+| [Privacy Guide](docs/PRIVACY_README.md) | Privacy features deep-dive |
+| [Noir Reference](docs/NOIR_REFERENCE.md) | Noir circuit language reference |
+| [Whitepaper](WHITEPAPER.md) | Protocol vision and design |
 
 ## Ecosystem
 
-- **$TETSUO** - Native token for staking, rewards, and slashing: [`8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8`](https://solscan.io/token/8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8)
-- [Whitepaper](WHITEPAPER.md) - Framework vision and architecture
-- [Tetsuo AI](https://github.com/tetsuo-ai) - Parent organization
+- **$TETSUO** — Native token for staking, rewards, and slashing: [`8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8`](https://solscan.io/token/8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8)
+- [Tetsuo AI](https://github.com/tetsuo-ai) — Parent organization
+
+## Contributing
+
+Contributions are welcome. To get started:
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/my-feature`)
+3. Make your changes and add tests
+4. Run `npm run test:fast` and `npm run typecheck` to verify
+5. Commit with [Conventional Commits](https://www.conventionalcommits.org/) format
+6. Open a Pull Request
 
 ## License
 
-GPL-3.0 License - see [LICENSE](LICENSE) file for details.
+GPL-3.0 — see [LICENSE](LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrites the README from scratch to accurately reflect the current state of the project across all 6 packages
- Updates outdated version numbers (Solana 1.18 → 3.0.13, Anchor 0.32 → 0.32.1), replaces Circom references with Noir, fixes build commands (yarn → npm), and removes stale PrivacyCash SDK examples
- Adds new sections for Agent Runtime (with code examples), MCP Server setup, all 10 examples, CI/CD pipeline, protocol fee tiers, LLM providers, and a full-stack architecture diagram

## Changes

**Fixed inaccuracies:**
- Solana/Anchor versions now match `Anchor.toml`
- Directory structure reflects actual layout (sdk/, runtime/, mcp/, demo-app/)
- Instruction count updated from 20 to 24 + 9 helper modules
- All missing instructions added (suspend/unsuspend, dependent tasks, initiator slashing, etc.)
- ZK technology correctly references Noir circuits instead of Circom

**New content:**
- Packages table with versions
- Full architecture diagram (MCP → Runtime → SDK → Solana → ZK)
- Agent Runtime section with AutonomousAgent and AgentBuilder code examples
- Runtime module overview table (17 modules)
- MCP Server section with Claude Code setup instructions
- Examples table (10 projects)
- Protocol fee tier table
- CI/CD pipeline overview
- LLM providers table
- Documentation table linking all 15 docs
- Live CI status badge

## Test plan

- [ ] Verify all internal links resolve correctly on GitHub
- [ ] Confirm banner image renders
- [ ] Check architecture diagram alignment in GitHub markdown renderer
- [ ] Verify badge URLs load correctly