### PR TITLE
docs(runtime): add observability epic plan (#920)

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -913,13 +913,15 @@ yarn build
 - [x] **Phase 1**: Core Runtime + Agent Manager
 - [x] **Phase 2**: Event Monitoring (17 protocol events)
 - [x] **Phase 3**: Task Executor (Discovery → Claim → Execute → Submit)
-- [ ] **Phase 4**: LLM Adapters (Grok, Anthropic, Ollama)
-- [ ] **Phase 5**: Tool System (MCP-compatible)
-- [ ] **Phase 6**: Memory Backends (SQLite, Redis)
-- [ ] **Phase 7**: ZK Proof Integration
-- [ ] **Phase 8**: Dispute Handling
-- [ ] **Phase 9**: Examples and Documentation ✅
-- [ ] **Phase 10**: Production Hardening
+- [ ] **Phase 4**: Deterministic Observability & Replay Pipeline (Epic #920)
+- [ ] See [observability epic plan](./docs/observability-epic-920.md) for implementation details.
+- [ ] **Phase 5**: LLM Adapters (Grok, Anthropic, Ollama)
+- [ ] **Phase 6**: Tool System (MCP-compatible)
+- [ ] **Phase 7**: Memory Backends (SQLite, Redis)
+- [ ] **Phase 8**: ZK Proof Integration
+- [ ] **Phase 9**: Dispute Handling
+- [ ] **Phase 10**: Examples and Documentation ✅
+- [ ] **Phase 11**: Production Hardening
 
 ## License
 

--- a/runtime/docs/observability-epic-920.md
+++ b/runtime/docs/observability-epic-920.md
@@ -1,0 +1,85 @@
+# Deterministic Observability and Replay Pipeline (Epic #920)
+
+This document defines the execution contract for issues `#920` → `#941`.
+
+## Objectives
+
+- Convert on-chain AgenC protocol events into canonical, deterministic timeline records.
+- Support replay, backfill, diff, and anomaly detection for incident reconstruction.
+- Keep the runtime integration optional so normal agent execution behavior is unchanged by default.
+- Preserve deterministic outputs for the same input event stream across environments.
+
+## End-to-end Runtime Architecture
+
+```
+Anchor Events
+  -> event parsers (existing runtime events)
+  -> projector (new trajectory-level canonical records)
+  -> storage/replay sink (checkpointed)
+  -> validator (transition checks)
+  -> comparator (against local trajectory replay)
+  -> reports/anomalies
+```
+
+### Canonical event stages
+
+1. **Input**
+   - Parsed on-chain runtime events with `(slot, signature, eventName)` identity.
+2. **Projection**
+   - Deterministic normalization into `taskId` / `disputeId` / `agentId` keyed records.
+   - Includes `traceType` and lifecycle context.
+3. **Persistence**
+   - Cursor checkpointed by latest `(slot, signature, eventSeq)`.
+   - Idempotent writes keyed by event tuple.
+4. **Validation**
+   - Transition integrity checks for task/dispute/speculation.
+5. **Compare**
+   - Timeline compare against local deterministic trajectory replay output.
+   - Produce mismatch, hash, and provenance details.
+
+## Deterministic contract
+
+- Stable ordering: `(slot asc, signature asc, eventSeq asc)`.
+- Stable output IDs: `traceId`/`recordId` derived from canonical JSON input only.
+- Deterministic duplicate handling: duplicate `(slot, signature, eventName)` entries are ignored with explicit telemetry.
+- Unknown event variants never crash the pipeline; they are recorded in telemetry and continue.
+
+## Issue execution chain
+
+- Baseline:
+  - `#921` Runtime event surface complete (already completed).
+  - `#922` Projection module.
+  - `#923` Persistent checkpoint + backfill.
+  - `#924` Replay comparison and anomaly reporting.
+  - `#925` Runtime integration.
+  - `#926` Quality pass.
+- Hardening:
+  - `#928` IDL drift guard.
+  - `#929` Lifecycle validation.
+  - `#927` Hardening/operations packaging.
+  - `#930` Pluggable storage.
+  - `#932` Trace propagation.
+  - `#933` Chaos/robustness tests.
+  - `#931` Structured alerts.
+  - `#934` Ops docs and runbooks.
+- Operator access:
+  - `#935` Incident replay CLI.
+  - `#936` CLI foundation.
+  - `#937` Backfill/compare/incident commands.
+  - `#938` CLI fixtures and schema tests.
+- MCP:
+  - `#939` MCP replay tools.
+  - `#940` MCP policy/security controls.
+  - `#941` MCP test + doc hardening.
+
+## Required outcomes
+
+- Deterministic replay outputs are reproducible for the same event set.
+- Incident windows can be reconstructed from signatures/cursors.
+- High-risk lifecycle violations (disputes/task transitions/speculation outcomes) are surfaced with stable anomaly records.
+
+## Operator defaults
+
+- Replay bridge is opt-in at runtime/CLI.
+- Replay services remain disabled unless explicitly enabled.
+- Alerts are optional and default to no-op.


### PR DESCRIPTION
## Summary\n- Add runtime observability epic design artifact for #920.\n- Document the full runtime replay chain and dependencies across #921-#941.\n- Add roadmap entries and implementation pointer for deterministic observability work.\n\n## Files changed\n- runtime/docs/observability-epic-920.md\n- runtime/README.md\n\n## Tests\n- npm run test --prefix runtime\n  - PASS: 112 files, 2124 tests\n- npm run typecheck\n  - PASS\n- npm run build\n  - PASS\n- npm run test:anchor\n  - FAIL: ANCHOR_PROVIDER_URL is not defined\n\n## Risks\n- No runtime code-path changes; scope is roadmap documentation only.\n- No API/behavior impact expected.\n\n## Validation\n- Build and typecheck pipelines pass from this branch for sdk/runtime/mcp packages.\n- Anchor integration tests require ANCHOR_PROVIDER_URL in environment for execution.\n\n## Docs\n- Adds an execution contract for issue sequencing and deterministic observability outputs.\n\nCloses #920