### PR TITLE
feat(runtime): add replay timeline storage and backfill persistence (#923)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -621,6 +621,25 @@ export {
   type CalibrationReport,
 } from './eval/index.js';
 
+export {
+  InMemoryReplayTimelineStore,
+  FileReplayTimelineStore,
+  ReplayBackfillService,
+  ReplayHealth,
+  ReplayTimelineQuery,
+  ReplayTimelineStore,
+  ReplayTimelineRecord,
+  ReplayEventCursor,
+  ReplayStorageWriteResult,
+  BackfillFetcher,
+  BackfillResult,
+  ProjectedTimelineInput,
+  BackfillFetcherPage,
+  buildReplayKey,
+  computeProjectionHash,
+  stableReplayCursorString,
+} from './replay/index.js';
+
 // Policy and Safety Engine
 export {
   PolicyEngine,

--- a/runtime/src/replay/backfill.ts
+++ b/runtime/src/replay/backfill.ts
@@ -1,0 +1,92 @@
+/**
+ * Replay timeline backfill service with cursor resume behavior.
+ *
+ * @module
+ */
+
+import { projectOnChainEvents } from '../eval/projector.js';
+import type { ProjectedTimelineEvent } from '../eval/projector.js';
+import {
+  computeProjectionHash,
+  stableReplayCursorString,
+  type BackfillFetcher,
+  type BackfillResult,
+  type ReplayTimelineRecord,
+  type ReplayTimelineStore,
+} from './types.js';
+
+const DEFAULT_BACKFILL_PAGE_SIZE = 100;
+
+export class ReplayBackfillService {
+  constructor(
+    private readonly store: ReplayTimelineStore,
+    private readonly options: {
+      toSlot: number;
+      pageSize?: number;
+      fetcher: BackfillFetcher;
+    },
+  ) {}
+
+  async runBackfill(): Promise<BackfillResult> {
+    const pageSize = this.options.pageSize ?? DEFAULT_BACKFILL_PAGE_SIZE;
+    let cursor = await this.store.getCursor();
+    let processed = 0;
+    let duplicates = 0;
+    let previousCursor = stableReplayCursorString(cursor);
+
+    while (true) {
+      const page = await this.options.fetcher.fetchPage(cursor, this.options.toSlot, pageSize);
+      if (page.events.length > 0) {
+        const projection = projectOnChainEvents(page.events, { traceId: 'replay-backfill' });
+        const records = projection.events.map(toReplayStoreRecord);
+        const writeResult = await this.store.save(records);
+        processed += writeResult.inserted;
+        duplicates += writeResult.duplicates;
+      }
+
+      await this.store.saveCursor(page.nextCursor);
+      cursor = page.nextCursor;
+
+      if (page.done) {
+        return {
+          processed,
+          duplicates,
+          cursor,
+        };
+      }
+
+      if (page.events.length === 0) {
+        const nextCursor = stableReplayCursorString(cursor);
+        if (nextCursor === previousCursor) {
+          throw new Error('replay backfill stalled: cursor did not advance');
+        }
+      }
+
+      previousCursor = stableReplayCursorString(cursor);
+    }
+  }
+}
+
+function toReplayStoreRecord(event: ProjectedTimelineEvent): ReplayTimelineRecord {
+  const recordEvent = {
+    seq: event.seq,
+    type: event.type,
+    taskPda: event.taskPda,
+    timestampMs: event.timestampMs,
+    payload: event.payload,
+    slot: event.slot,
+    signature: event.signature,
+    sourceEventName: event.sourceEventName,
+    sourceEventSequence: event.sourceEventSequence,
+    sourceEventType: event.type,
+  } as Omit<ReplayTimelineRecord, 'projectionHash'>;
+
+  return {
+    ...recordEvent,
+    projectionHash: computeProjectionHash({
+      ...recordEvent,
+      sourceEventName: event.sourceEventName,
+      sourceEventSequence: event.sourceEventSequence,
+    } as ReturnType<typeof projectOnChainEvents>['events'][number]),
+  };
+}

--- a/runtime/src/replay/file-store.ts
+++ b/runtime/src/replay/file-store.ts
@@ -1,0 +1,104 @@
+/**
+ * File-backed replay timeline store for deterministic checkpointed replay.
+ *
+ * @module
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { InMemoryReplayTimelineStore } from './in-memory-store.js';
+import { type ReplayEventCursor, type ReplayStorageWriteResult, type ReplayTimelineQuery, type ReplayTimelineRecord, type ReplayTimelineStore } from './types.js';
+
+interface StoredTimelineState {
+  cursor: ReplayEventCursor | null;
+  records: Array<ReplayTimelineRecord>;
+}
+
+export class FileReplayTimelineStore implements ReplayTimelineStore {
+  private readonly fallback = new InMemoryReplayTimelineStore();
+  private loaded = false;
+
+  constructor(private readonly filePath: string) {
+  }
+
+  async save(records: readonly ReplayTimelineRecord[]): Promise<ReplayStorageWriteResult> {
+    const state = await this.getState();
+    const result = await this.fallback.save(records);
+    state.records = [...(await this.fallback.query())];
+    await this.persist(state);
+    return result;
+  }
+
+  async query(filter: ReplayTimelineQuery = {}): Promise<ReadonlyArray<ReplayTimelineRecord>> {
+    await this.getState();
+    return this.fallback.query(filter);
+  }
+
+  async getCursor(): Promise<ReplayEventCursor | null> {
+    const state = await this.getState();
+    return state.cursor;
+  }
+
+  async saveCursor(cursor: ReplayEventCursor | null): Promise<void> {
+    const state = await this.getState();
+    state.cursor = cursor;
+    await this.persist(state);
+  }
+
+  async clear(): Promise<void> {
+    await this.persist({ cursor: null, records: [] });
+    await this.fallback.clear();
+  }
+
+  private async getState(): Promise<StoredTimelineState> {
+    if (this.loaded) {
+      return {
+        cursor: await this.fallback.getCursor(),
+        records: [...(await this.fallback.query())],
+      };
+    }
+
+    await this.fallback.clear();
+    if (!existsSync(this.filePath)) {
+      const empty: StoredTimelineState = { cursor: null, records: [] };
+      await this.persist(empty);
+      this.loaded = true;
+      return empty;
+    }
+
+    try {
+      const raw = await readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as StoredTimelineState | null;
+      const cursor = parsed?.cursor ?? null;
+      const records = Array.isArray(parsed?.records) ? [...parsed.records] : [];
+      await this.fallback.clear();
+      if (records.length > 0) {
+        await this.fallback.save(records);
+      }
+      await this.fallback.saveCursor(cursor);
+      this.loaded = true;
+      return {
+        cursor,
+        records,
+      };
+    } catch (error) {
+      if ((error as { code?: string }).code === 'ENOENT') {
+        const empty: StoredTimelineState = { cursor: null, records: [] };
+        this.loaded = true;
+        return empty;
+      }
+      throw error;
+    }
+  }
+
+  private async persist(state: StoredTimelineState): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const payload = JSON.stringify({
+      cursor: state.cursor,
+      records: state.records,
+    });
+    await writeFile(this.filePath, payload);
+  }
+}

--- a/runtime/src/replay/in-memory-store.ts
+++ b/runtime/src/replay/in-memory-store.ts
@@ -1,0 +1,97 @@
+/**
+ * In-memory replay timeline store used for tests and single-process development.
+ *
+ * @module
+ */
+
+import { buildReplayKey } from './types.js';
+import type {
+  ReplayEventCursor,
+  ReplayStorageWriteResult,
+  ReplayTimelineRecord,
+  ReplayTimelineQuery,
+  ReplayTimelineStore,
+} from './types.js';
+
+function sortReplayEvents(events: readonly ReplayTimelineRecord[]): ReplayTimelineRecord[] {
+  return [...events].sort((left, right) => {
+    if (left.slot !== right.slot) {
+      return left.slot - right.slot;
+    }
+    if (left.signature !== right.signature) {
+      return left.signature.localeCompare(right.signature);
+    }
+    if (left.seq !== right.seq) {
+      return left.seq - right.seq;
+    }
+    return left.sourceEventType.localeCompare(right.sourceEventType);
+  });
+}
+
+function passesFilter(event: ReplayTimelineRecord, filter: ReplayTimelineQuery): boolean {
+  if (filter.taskPda && event.taskPda !== filter.taskPda) {
+    return false;
+  }
+  if (filter.disputePda && event.disputePda !== filter.disputePda) {
+    return false;
+  }
+  if (filter.fromSlot !== undefined && event.slot < filter.fromSlot) {
+    return false;
+  }
+  if (filter.toSlot !== undefined && event.slot > filter.toSlot) {
+    return false;
+  }
+  if (filter.fromTimestampMs !== undefined && event.timestampMs < filter.fromTimestampMs) {
+    return false;
+  }
+  if (filter.toTimestampMs !== undefined && event.timestampMs > filter.toTimestampMs) {
+    return false;
+  }
+  return true;
+}
+
+export class InMemoryReplayTimelineStore implements ReplayTimelineStore {
+  private readonly events: ReplayTimelineRecord[] = [];
+  private readonly ids = new Set<string>();
+  private cursor: ReplayEventCursor | null = null;
+
+  async save(records: readonly ReplayTimelineRecord[]): Promise<ReplayStorageWriteResult> {
+    let inserted = 0;
+    let duplicates = 0;
+
+    for (const event of records) {
+      const key = buildReplayKey(event.slot, event.signature, event.sourceEventType);
+      if (this.ids.has(key)) {
+        duplicates += 1;
+        continue;
+      }
+
+      this.ids.add(key);
+      this.events.push(event);
+      inserted += 1;
+    }
+
+    return { inserted, duplicates };
+  }
+
+  async query(filter: ReplayTimelineQuery = {}): Promise<ReadonlyArray<ReplayTimelineRecord>> {
+    const all = sortReplayEvents(this.events.filter((event) => passesFilter(event, filter)));
+    const start = filter.offset ?? 0;
+    const end = filter.limit === undefined ? all.length : start + filter.limit;
+    return all.slice(start, end);
+  }
+
+  async getCursor(): Promise<ReplayEventCursor | null> {
+    return this.cursor;
+  }
+
+  async saveCursor(cursor: ReplayEventCursor | null): Promise<void> {
+    this.cursor = cursor;
+  }
+
+  async clear(): Promise<void> {
+    this.events.length = 0;
+    this.ids.clear();
+    this.cursor = null;
+  }
+}

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -1,0 +1,33 @@
+/**
+ * Replay storage and backfill subsystem.
+ *
+ * @module
+ */
+
+export {
+  InMemoryReplayTimelineStore,
+} from './in-memory-store.js';
+
+export {
+  FileReplayTimelineStore,
+} from './file-store.js';
+
+export {
+  ReplayBackfillService,
+} from './backfill.js';
+
+export {
+  ReplayHealth,
+  ReplayTimelineQuery,
+  ReplayTimelineStore,
+  ReplayTimelineRecord,
+  ReplayEventCursor,
+  ReplayStorageWriteResult,
+  BackfillFetcher,
+  BackfillResult,
+  ProjectedTimelineInput,
+  BackfillFetcherPage,
+  buildReplayKey,
+  computeProjectionHash,
+  stableReplayCursorString,
+} from './types.js';

--- a/runtime/src/replay/replay-storage.test.ts
+++ b/runtime/src/replay/replay-storage.test.ts
@@ -1,0 +1,151 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  BackfillFetcher,
+  computeProjectionHash,
+  FileReplayTimelineStore,
+  InMemoryReplayTimelineStore,
+  ReplayBackfillService,
+  type ReplayTimelineRecord,
+  stableReplayCursorString,
+} from './index.js';
+
+function makeRecord(
+  seq: number,
+  type: string,
+  slot: number,
+  signature: string,
+): ReplayTimelineRecord {
+  const event = {
+    seq,
+    type,
+    taskPda: 'task-1',
+    timestampMs: slot * 10,
+    payload: { value: seq, onchain: { signature, slot, eventType: type } },
+    slot,
+    signature,
+    sourceEventName: type === 'discovered' ? 'taskCreated' : 'taskClaimed',
+    sourceEventSequence: seq - 1,
+    sourceEventType: type,
+    disputePda: undefined,
+    projectionHash: '',
+  };
+
+  return {
+    ...event,
+    projectionHash: computeProjectionHash({
+      seq,
+      type: event.type,
+      taskPda: event.taskPda,
+      timestampMs: event.timestampMs,
+      payload: event.payload,
+      slot,
+      signature,
+      sourceEventName: event.sourceEventName,
+      sourceEventSequence: event.sourceEventSequence,
+    }),
+  };
+}
+
+describe('replay storage', () => {
+  it('stores deterministic timeline and deduplicates duplicate stream entries', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    await store.save([makeRecord(1, 'discovered', 1, 'AAA')]);
+    await store.save([makeRecord(1, 'discovered', 1, 'AAA'), makeRecord(2, 'claimed', 1, 'AAA')]);
+
+    const timeline = await store.query({ taskPda: 'task-1' });
+    expect(timeline).toHaveLength(2);
+    expect(timeline[0].sourceEventType).toBe('discovered');
+    expect(timeline[1].sourceEventType).toBe('claimed');
+  });
+
+  it('persists and restores cursor and events from disk', async () => {
+    const file = join(tmpdir(), `replay-store-${randomUUID()}.json`);
+    const first = new FileReplayTimelineStore(file);
+    const records = [makeRecord(1, 'discovered', 3, 'SIG_A'), makeRecord(2, 'claimed', 3, 'SIG_B')];
+
+    await first.save(records);
+    await first.saveCursor({ slot: 10, signature: 'SIG_CURSOR', eventName: 'taskClaimed' });
+    expect(existsSync(file)).toBe(true);
+    const raw = readFileSync(file, 'utf8');
+    expect(raw.length).toBeGreaterThan(0);
+    expect(JSON.parse(raw).records).toHaveLength(2);
+
+    const second = new FileReplayTimelineStore(file);
+    const restored = await second.query();
+    const restoredCursor = await second.getCursor();
+
+    expect(restoredCursor).toEqual({ slot: 10, signature: 'SIG_CURSOR', eventName: 'taskClaimed' });
+    expect(restored).toHaveLength(2);
+    expect(restored.map((entry) => entry.seq)).toEqual([1, 2]);
+    expect(restored.map((entry) => entry.slot)).toEqual([3, 3]);
+  });
+
+  it('resumes backfill using persisted cursor after a fetch failure', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    const pageOne = [
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'A',
+        event: { taskId: new Uint8Array(32).fill(1), creator: new Uint8Array(32).fill(1), requiredCapabilities: 1n, rewardAmount: 1n, taskType: 0, deadline: 1, minReputation: 0, rewardMint: null, timestamp: 1 },
+      },
+    ];
+    const pageTwo = [
+      {
+        eventName: 'taskClaimed',
+        slot: 2,
+        signature: 'B',
+        event: { taskId: new Uint8Array(32).fill(1), worker: new Uint8Array(32).fill(2), currentWorkers: 1, maxWorkers: 1, timestamp: 2 },
+      },
+    ];
+
+    const fetcher: BackfillFetcher = {
+      async fetchPage(cursor, toSlot) {
+        expect(toSlot).toBe(9);
+
+        if (!cursor) {
+          return {
+            events: pageOne,
+            nextCursor: { slot: 1, signature: 'A', eventName: 'taskCreated' },
+            done: false,
+          };
+        }
+
+        if (cursor.signature === 'A' && !this.failOnce) {
+          this.failOnce = true;
+          throw new Error('simulated rpc failure');
+        }
+
+        return {
+          events: pageTwo,
+          nextCursor: null,
+          done: true,
+        };
+      },
+      failOnce: false,
+    };
+
+    const service = new ReplayBackfillService(store, {
+      toSlot: 9,
+      fetcher,
+    });
+
+    await expect(service.runBackfill()).rejects.toThrow('simulated rpc failure');
+
+    const partiallyIngested = await store.query();
+    const savedCursor = await store.getCursor();
+    expect(partiallyIngested).toHaveLength(1);
+    expect(stableReplayCursorString(savedCursor)).toBe('1:A:taskCreated');
+
+    const completed = await service.runBackfill();
+    const fullTimeline = await store.query();
+    expect(completed.processed).toBe(1);
+    expect(completed.duplicates).toBe(0);
+    expect(stableReplayCursorString(completed.cursor)).toBe('');
+    expect(fullTimeline).toHaveLength(2);
+  });
+});

--- a/runtime/src/replay/types.ts
+++ b/runtime/src/replay/types.ts
@@ -1,0 +1,125 @@
+/**
+ * Replay persistence primitives and backfill contracts.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+import { stableStringifyJson, type JsonValue } from '../eval/types.js';
+import type { ProjectedTimelineEvent } from '../eval/projector.js';
+
+export interface ReplayEventCursor {
+  slot: number;
+  signature: string;
+  eventName?: string;
+}
+
+export interface ReplayTimelineRecord extends Omit<ProjectedTimelineEvent, 'payload'> {
+  sourceEventName: string;
+  sourceEventType: string;
+  disputePda?: string;
+  projectionHash: string;
+  payload: ProjectedTimelineEvent['payload'];
+}
+
+export interface ReplayTimelineRecordInput {
+  slot: number;
+  signature: string;
+  sourceEventName: string;
+  sourceEventType: string;
+  event: ProjectedTimelineEvent;
+}
+
+export interface ReplayTimelineQuery {
+  taskPda?: string;
+  disputePda?: string;
+  fromSlot?: number;
+  toSlot?: number;
+  fromTimestampMs?: number;
+  toTimestampMs?: number;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ReplayStorageWriteResult {
+  inserted: number;
+  duplicates: number;
+}
+
+export interface ReplayTimelineStore {
+  save(records: readonly ReplayTimelineRecord[]): Promise<ReplayStorageWriteResult>;
+  query(filter?: ReplayTimelineQuery): Promise<ReadonlyArray<ReplayTimelineRecord>>;
+  getCursor(): Promise<ReplayEventCursor | null>;
+  saveCursor(cursor: ReplayEventCursor | null): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export interface BackfillFetcher {
+  fetchPage(
+    cursor: ReplayEventCursor | null,
+    toSlot: number,
+    pageSize: number
+  ): Promise<BackfillFetcherPage>;
+}
+
+export interface BackfillFetcherPage {
+  events: ReadonlyArray<ProjectedTimelineInput>;
+  nextCursor: ReplayEventCursor | null;
+  done: boolean;
+}
+
+export interface ProjectedTimelineInput {
+  eventName: string;
+  event: unknown;
+  slot: number;
+  signature: string;
+  timestampMs?: number;
+}
+
+export interface BackfillResult {
+  processed: number;
+  duplicates: number;
+  cursor: ReplayEventCursor | null;
+}
+
+export interface ReplayHealth {
+  totalEvents: number;
+  uniqueEvents: number;
+  lastCursor: ReplayEventCursor | null;
+  taskCount: number;
+}
+
+export interface ReplayComparatorInput {
+  events: ReadonlyArray<ReplayTimelineRecord>;
+  traceTaskIds?: ReadonlyArray<string>;
+}
+
+export function stableReplayCursorString(cursor: ReplayEventCursor | null): string {
+  if (!cursor) {
+    return '';
+  }
+  return `${cursor.slot}:${cursor.signature}:${cursor.eventName ?? ''}`;
+}
+
+export function computeProjectionHash(event: ProjectedTimelineEvent): string {
+  const payload = {
+    seq: event.seq,
+    type: event.type,
+    taskPda: event.taskPda,
+    timestampMs: event.timestampMs,
+    payload: event.payload,
+    slot: event.slot,
+    signature: event.signature,
+    sourceEventName: event.sourceEventName,
+    sourceEventSequence: event.sourceEventSequence,
+  };
+  return createHash('sha256').update(stableStringifyJson(payload as JsonValue)).digest('hex');
+}
+
+export function buildReplayKey(
+  slot: number,
+  signature: string,
+  sourceEventType: string,
+): string {
+  return `${slot}|${signature}|${sourceEventType}`;
+}


### PR DESCRIPTION
## Summary
- add replay timeline persistence primitives and file-backed/in-memory store implementations
- add resume-aware backfill service with dedupe and cursor persistence semantics
- expose replay storage/replay types through runtime exports
- add replay storage tests for dedupe ordering, disk cursor recovery, and backfill resume behavior

## Files changed
- runtime/src/replay/index.ts
- runtime/src/replay/types.ts
- runtime/src/replay/in-memory-store.ts
- runtime/src/replay/file-store.ts
- runtime/src/replay/backfill.ts
- runtime/src/replay/replay-storage.test.ts
- runtime/src/index.ts

## Tests
- npm run test --prefix runtime -- src/replay/replay-storage.test.ts
- npm run test
- npm run typecheck (fails in current branch on unrelated declaration issues)
- npm run build
- npm run test:anchor (fails: ANCHOR_PROVIDER_URL is not defined in this environment)

## Risks
- file-backed store hydrates records into memory on first load; long-lived stores may incur startup overhead proportional to persisted timeline size
- replay cursor and records are unencrypted local JSON and should be protected accordingly in operator environments

## How to validate locally
- rerun the same commands above; after starting a fresh FileReplayTimelineStore, call query/getCursor to verify restored state

Closes #923