### PR TITLE
feat(runtime): add replay trace propagation and identifiers (#932)

### DIFF
--- a/runtime/src/eval/replay-comparison.ts
+++ b/runtime/src/eval/replay-comparison.ts
@@ -37,6 +37,10 @@ export interface ReplayComparisonContext {
   signature?: string;
   seq?: number;
   eventType?: string;
+  traceId?: string;
+  traceSpanId?: string;
+  traceParentSpanId?: string;
+  traceSampled?: boolean;
 }
 
 export type ReplayAnomalyCode =
@@ -132,16 +136,27 @@ function replayReplayContextFromProjected(event: ReplayTimelineRecord): ReplayCo
     sourceEventSequence: event.sourceEventSequence,
     signature: event.signature,
     eventType: event.type,
+    traceId: event.traceId,
+    traceSpanId: event.traceSpanId,
+    traceParentSpanId: event.traceParentSpanId,
+    traceSampled: event.traceSampled,
   };
 }
 
 function replayContextFromLocal(event: TrajectoryEvent): ReplayComparisonContext {
+  const onchainTrace = event.payload.onchain as Record<string, unknown> | undefined;
+  const trace = onchainTrace && typeof onchainTrace === 'object' ? (onchainTrace.trace as Record<string, unknown> | undefined) : undefined;
+
   return {
     seq: event.seq,
     taskPda: event.taskPda,
     disputePda: extractDisputeIdFromPayload(event.payload),
     eventType: event.type,
     signature: extractSignatureFromPayload(event.payload),
+    traceId: typeof trace?.traceId === 'string' ? trace.traceId : undefined,
+    traceSpanId: typeof trace?.spanId === 'string' ? trace.spanId : undefined,
+    traceParentSpanId: typeof trace?.parentSpanId === 'string' ? trace.parentSpanId : undefined,
+    traceSampled: trace?.sampled === true,
   };
 }
 

--- a/runtime/src/replay/backfill.ts
+++ b/runtime/src/replay/backfill.ts
@@ -5,7 +5,7 @@
  */
 
 import { projectOnChainEvents } from '../eval/projector.js';
-import type { ProjectedTimelineEvent } from '../eval/projector.js';
+import type { OnChainProjectionInput, ProjectedTimelineEvent } from '../eval/projector.js';
 import {
   computeProjectionHash,
   stableReplayCursorString,
@@ -13,6 +13,7 @@ import {
   type BackfillResult,
   type ReplayTimelineRecord,
   type ReplayTimelineStore,
+  type ProjectedTimelineInput,
 } from './types.js';
 
 const DEFAULT_BACKFILL_PAGE_SIZE = 100;
@@ -24,6 +25,10 @@ export class ReplayBackfillService {
       toSlot: number;
       pageSize?: number;
       fetcher: BackfillFetcher;
+      tracePolicy?: {
+        traceId?: string;
+        sampleRate?: number;
+      };
     },
   ) {}
 
@@ -37,14 +42,25 @@ export class ReplayBackfillService {
     while (true) {
       const page = await this.options.fetcher.fetchPage(cursor, this.options.toSlot, pageSize);
       if (page.events.length > 0) {
-        const projection = projectOnChainEvents(page.events, { traceId: 'replay-backfill' });
+        const pageEvents: OnChainProjectionInput[] = page.events.map((event, index) => ({
+          ...(event as ProjectedTimelineInput),
+          sourceEventSequence: event.sourceEventSequence ?? index,
+          traceContext: (event as ProjectedTimelineInput).traceContext,
+        }));
+
+        const projection = projectOnChainEvents(pageEvents, {
+          traceId: this.options.tracePolicy?.traceId ?? 'replay-backfill',
+          seed: 0,
+        });
         const records = projection.events.map(toReplayStoreRecord);
         const writeResult = await this.store.save(records);
         processed += writeResult.inserted;
         duplicates += writeResult.duplicates;
       }
 
-      await this.store.saveCursor(page.nextCursor);
+      await this.store.saveCursor(page.nextCursor
+        ? { ...page.nextCursor, traceId: this.options.tracePolicy?.traceId }
+        : null);
       cursor = page.nextCursor;
 
       if (page.done) {
@@ -68,6 +84,10 @@ export class ReplayBackfillService {
 }
 
 function toReplayStoreRecord(event: ProjectedTimelineEvent): ReplayTimelineRecord {
+  const trace = (event.payload.onchain as Record<string, unknown> | undefined)?.trace as
+    | undefined
+    | { traceId?: string; spanId?: string; parentSpanId?: string; sampled?: boolean };
+
   const recordEvent = {
     seq: event.seq,
     type: event.type,
@@ -79,6 +99,10 @@ function toReplayStoreRecord(event: ProjectedTimelineEvent): ReplayTimelineRecor
     sourceEventName: event.sourceEventName,
     sourceEventSequence: event.sourceEventSequence,
     sourceEventType: event.type,
+    traceId: trace?.traceId,
+    traceSpanId: trace?.spanId,
+    traceParentSpanId: trace?.parentSpanId,
+    traceSampled: trace?.sampled === true,
   } as Omit<ReplayTimelineRecord, 'projectionHash'>;
 
   return {

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -39,3 +39,12 @@ export {
   computeProjectionHash,
   stableReplayCursorString,
 } from './types.js';
+
+export {
+  buildReplayTraceContext,
+  toReplayTraceEnvelope,
+  type ReplayTraceContext,
+  type ReplayTraceEnvelope,
+  type ReplayTracingPolicy,
+  DEFAULT_TRACE_SAMPLE_RATE,
+} from './trace.js';

--- a/runtime/src/replay/trace.ts
+++ b/runtime/src/replay/trace.ts
@@ -1,0 +1,117 @@
+/**
+ * Replay trace helpers for deterministic trace context and optional sampling.
+ *
+ * This module provides trace IDs and span identifiers without hard-coding a
+ * specific tracing backend. Callers can enable `emitOtel` when the optional
+ * OpenTelemetry package is available.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+
+export interface ReplayTraceContext {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  sampled: boolean;
+}
+
+export interface ReplayTracingPolicy {
+  /** Optional override trace identifier for a run */
+  traceId?: string;
+  /** Deterministic sample rate in [0, 1]. Defaults to 1 (always sample). */
+  sampleRate?: number;
+  /** Emit OpenTelemetry shape/metadata when a backend is available */
+  emitOtel?: boolean;
+}
+
+export interface ReplayTraceEnvelope {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  sampled: boolean;
+}
+
+export const DEFAULT_TRACE_SAMPLE_RATE = 1;
+
+function normalizeSampleRate(sampleRate: number | undefined): number {
+  if (sampleRate === undefined || Number.isNaN(sampleRate)) {
+    return DEFAULT_TRACE_SAMPLE_RATE;
+  }
+  if (sampleRate <= 0) return 0;
+  if (sampleRate >= 1) return 1;
+  return sampleRate;
+}
+
+function hashHex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function deterministicSample(key: string, sampleRate: number): boolean {
+  if (sampleRate >= 1) {
+    return true;
+  }
+  if (sampleRate <= 0) {
+    return false;
+  }
+  const value = Number.parseInt(hashHex(key).slice(0, 8), 16);
+  return (value / 0xFFFF_FFFF) < sampleRate;
+}
+
+function deriveTraceId(base: string | undefined, slot: number, signature: string, eventName: string, eventSequence?: number): string {
+  if (base && base.length > 0) {
+    return base;
+  }
+  return hashHex(`agenc-runtime:${slot}:${signature}:${eventName}:${eventSequence ?? 0}`).slice(0, 32);
+}
+
+function deriveSpanId(
+  traceId: string,
+  eventName: string,
+  slot: number,
+  signature: string,
+  eventSequence: number,
+): string {
+  return hashHex(`${traceId}:${eventName}:${slot}:${signature}:${eventSequence}`).slice(0, 16);
+}
+
+/**
+ * Build a deterministic trace context for a single event stream item.
+ */
+export function buildReplayTraceContext(
+  args: {
+    traceId?: string;
+    eventName: string;
+    slot: number;
+    signature: string;
+    eventSequence: number;
+    parentSpanId?: string;
+    sampleRate?: number;
+  },
+): ReplayTraceContext {
+  const normalizedSampleRate = normalizeSampleRate(args.sampleRate);
+  const traceId = deriveTraceId(args.traceId, args.slot, args.signature, args.eventName, args.eventSequence);
+  const spanIdSeed = `${traceId}:${args.eventName}:${args.slot}:${args.signature}:${args.eventSequence}`;
+  const spanId = deriveSpanId(traceId, args.eventName, args.slot, args.signature, args.eventSequence);
+  const sampled = deterministicSample(spanIdSeed, normalizedSampleRate);
+
+  return {
+    traceId,
+    spanId,
+    parentSpanId: args.parentSpanId,
+    sampled,
+  };
+}
+
+export function toReplayTraceEnvelope(context: ReplayTraceContext | undefined): ReplayTraceEnvelope | undefined {
+  if (!context) {
+    return undefined;
+  }
+  return {
+    traceId: context.traceId,
+    spanId: context.spanId,
+    parentSpanId: context.parentSpanId,
+    sampled: context.sampled,
+  };
+}

--- a/runtime/src/runtime.ts
+++ b/runtime/src/runtime.ts
@@ -81,6 +81,7 @@ export class AgentRuntime {
   private shutdownHandlersRegistered = false;
   private readonly replayBridge: ReplayBridgeHandle | null;
   private readonly replayBackfillDefaults?: ReplayBackfillConfig;
+  private readonly replayTraceId?: string;
 
   /**
    * Create a new AgentRuntime instance.
@@ -132,8 +133,14 @@ export class AgentRuntime {
     });
 
     const replayConfig = config.replay;
+    const tracing = replayConfig?.tracing;
     this.replayBackfillDefaults = replayConfig?.backfill;
-    this.replayBridge = this.createReplayBridge(replayConfig);
+    this.replayTraceId = tracing?.traceId ?? replayConfig?.traceId;
+    this.replayBridge = this.createReplayBridge(replayConfig ? {
+      ...replayConfig,
+      tracing,
+      traceId: replayConfig?.traceId,
+    } : undefined);
 
     this.logger.debug('AgentRuntime created');
   }
@@ -420,6 +427,7 @@ export class AgentRuntime {
       fetcher: options.fetcher,
       toSlot,
       pageSize: options.pageSize ?? this.replayBackfillDefaults?.pageSize,
+      traceId: this.replayTraceId,
     });
   }
 
@@ -436,6 +444,7 @@ export class AgentRuntime {
 
     const options: ReplayBridgeConfig = {
       traceId: replayConfig.traceId,
+      tracing: replayConfig.tracing,
       projectionSeed: replayConfig.projectionSeed,
       strictProjection: replayConfig.strictProjection,
       store: replayConfig.store,

--- a/runtime/src/types/config.ts
+++ b/runtime/src/types/config.ts
@@ -27,6 +27,15 @@ export interface RuntimeReplayConfig {
   enabled?: boolean;
   /** Optional store configuration for replay timeline persistence */
   store?: ReplayBridgeStoreConfig;
+  /** Optional tracing and sampling policy for replay pipeline observability */
+  tracing?: {
+    /** Optional override trace identifier for replay activities */
+    traceId?: string;
+    /** Deterministic sample ratio in [0, 1], defaults to 1 */
+    sampleRate?: number;
+    /** Emit OpenTelemetry span names/fields (best-effort when deps are available) */
+    emitOtel?: boolean;
+  };
   /** Projection seed used to generate deterministic trace hashes */
   projectionSeed?: number;
   /** Propagate projection errors in strict mode */


### PR DESCRIPTION
## Summary
- Added replay trace context plumbing across capture, backfill, storage, and comparison.
- Added deterministic trace/sampler helpers and replay trace metadata persistence.
- Extended replay config with tracing policy and wired into runtime backfill.
- Updated tests for backfill cursor persistence and mismatch context trace IDs.

## Files changed
- runtime/src/replay/trace.ts
- runtime/src/replay/types.ts
- runtime/src/replay/index.ts
- runtime/src/eval/projector.ts
- runtime/src/replay/bridge.ts
- runtime/src/replay/backfill.ts
- runtime/src/replay/replay-storage.test.ts
- runtime/src/eval/replay-comparison.ts
- runtime/src/eval/replay-comparison.test.ts
- runtime/src/runtime.ts
- runtime/src/types/config.ts

## Tests
- npm run test --prefix runtime -- src/replay/replay-storage.test.ts src/eval/replay-comparison.test.ts src/eval/projector.test.ts
- npm run test --prefix runtime
- npm run typecheck
- npm run build
- npm run test:anchor (blocked: ANCHOR_PROVIDER_URL is not defined)

## Risks
- Full determinism depends on optional trace payload propagation from projection inputs.

## Validation
- Comparison and storage tests now assert trace fields are preserved through persistence and mismatch diagnostics.
