### PR TITLE
feat(runtime): add pluggable sqlite replay storage (#930)

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -296,6 +296,19 @@ const runtime = new AgentRuntime({
       sampleRate: 1,
     },
     store: { type: 'sqlite', sqlitePath: '.agenc/replay-events.sqlite' },
+    // Optional retention and compaction for replay state.
+    // TTL and per-scope caps prevent unbounded growth.
+    // SQLite VACUUM compaction runs on a configurable save cadence.
+    retention: {
+      ttlMs: 86_400_000,
+      maxEventsPerTask: 10_000,
+      maxEventsPerDispute: 1_000,
+      maxEventsTotal: 100_000,
+    },
+    compaction: {
+      enabled: true,
+      compactAfterWrites: 250,
+    },
     backfill: {
       toSlot: 9_000_000,
       pageSize: 200,

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -13,6 +13,10 @@ export {
 } from './file-store.js';
 
 export {
+  SqliteReplayTimelineStore,
+} from './sqlite-store.js';
+
+export {
   ReplayBackfillService,
 } from './backfill.js';
 
@@ -31,6 +35,9 @@ export {
   ReplayTimelineRecord,
   ReplayEventCursor,
   ReplayStorageWriteResult,
+  ReplayTimelineRetentionPolicy,
+  ReplayTimelineCompactionPolicy,
+  ReplayTimelineStoreConfig,
   BackfillFetcher,
   BackfillResult,
   ProjectedTimelineInput,

--- a/runtime/src/replay/sqlite-store.test.ts
+++ b/runtime/src/replay/sqlite-store.test.ts
@@ -1,0 +1,256 @@
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  BackfillFetcher,
+  computeProjectionHash,
+  type ReplayTimelineRecord,
+  ReplayBackfillService,
+  SqliteReplayTimelineStore,
+  stableReplayCursorString,
+} from './index.js';
+
+const hasSqliteDependency = (() => {
+  try {
+    createRequire(import.meta.url).resolve('better-sqlite3');
+    return true;
+  } catch (_error) {
+    return false;
+  }
+})();
+
+const sqliteStoreDescribe = hasSqliteDependency ? describe : describe.skip;
+
+function makeRecord(
+  seq: number,
+  type: string,
+  slot: number,
+  signature: string,
+): ReplayTimelineRecord {
+  const record = {
+    seq,
+    type,
+    taskPda: 'task-1',
+    timestampMs: slot * 10 + seq,
+    payload: { value: seq, onchain: { signature, slot, eventType: type } },
+    slot,
+    signature,
+    sourceEventName: type === 'discovered' ? 'taskCreated' : 'taskClaimed',
+    sourceEventSequence: seq - 1,
+    sourceEventType: type,
+    disputePda: undefined,
+    projectionHash: '',
+  };
+
+  return {
+    ...record,
+    projectionHash: computeProjectionHash({
+      seq,
+      type: record.type,
+      taskPda: record.taskPda,
+      timestampMs: record.timestampMs,
+      payload: record.payload,
+      slot,
+      signature,
+      sourceEventName: record.sourceEventName,
+      sourceEventSequence: record.sourceEventSequence,
+    }),
+  };
+}
+
+sqliteStoreDescribe('SqliteReplayTimelineStore', () => {
+  it('persists replay records and cursor deterministically', async () => {
+    const path = join(tmpdir(), `replay-store-${randomUUID()}.sqlite`);
+    const store = new SqliteReplayTimelineStore(path);
+
+    await store.save([
+      makeRecord(2, 'claimed', 2, 'SIG_B'),
+      makeRecord(1, 'discovered', 1, 'SIG_A'),
+      makeRecord(3, 'claimed', 3, 'SIG_C'),
+    ]);
+
+    await store.saveCursor({
+      slot: 3,
+      signature: 'SIG_C',
+      eventName: 'taskClaimed',
+      traceId: 'trace-930',
+      traceSpanId: 'span-2',
+    });
+
+    const reopened = new SqliteReplayTimelineStore(path);
+    const timeline = await reopened.query({ taskPda: 'task-1' });
+    const cursor = await reopened.getCursor();
+
+    expect(timeline.map((entry) => entry.signature)).toEqual(['SIG_A', 'SIG_B', 'SIG_C']);
+    expect(timeline.map((entry) => entry.seq)).toEqual([1, 2, 3]);
+    expect(stableReplayCursorString(cursor)).toBe('3:SIG_C:taskClaimed:trace-930:span-2');
+
+    await reopened.clear();
+    const cleared = await reopened.query();
+    const clearedCursor = await reopened.getCursor();
+    expect(cleared).toHaveLength(0);
+    expect(clearedCursor).toBeNull();
+  });
+
+  it('applies ttl retention and drops old events', async () => {
+    const path = join(tmpdir(), `replay-store-ttl-${randomUUID()}.sqlite`);
+    const store = new SqliteReplayTimelineStore(path, {
+      retention: {
+        ttlMs: 1_000,
+      },
+    });
+
+    const baseTime = Date.now();
+    await store.save([
+      { ...makeRecord(1, 'discovered', 1, 'SIG_OLD'), timestampMs: baseTime - 5_000 },
+      { ...makeRecord(2, 'claimed', 2, 'SIG_NEW'), timestampMs: baseTime + 1 },
+    ]);
+
+    const timeline = await store.query({ taskPda: 'task-1' });
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]?.signature).toBe('SIG_NEW');
+  });
+
+  it('applies max events per task and preserves deterministic ordering', async () => {
+    const path = join(tmpdir(), `replay-store-task-limit-${randomUUID()}.sqlite`);
+    const store = new SqliteReplayTimelineStore(path, {
+      retention: {
+        maxEventsPerTask: 2,
+      },
+    });
+
+    await store.save([
+      makeRecord(1, 'taskA', 10, 'SIG_A'),
+      makeRecord(2, 'taskA', 11, 'SIG_B'),
+      makeRecord(3, 'taskA', 12, 'SIG_C'),
+      makeRecord(4, 'taskA', 13, 'SIG_D'),
+    ]);
+
+    const timeline = await store.query({ taskPda: 'task-1' });
+    expect(timeline.map((entry) => entry.signature)).toEqual(['SIG_C', 'SIG_D']);
+    expect(timeline.map((entry) => entry.seq)).toEqual([3, 4]);
+  });
+
+  it('applies max events per dispute', async () => {
+    const path = join(tmpdir(), `replay-store-dispute-limit-${randomUUID()}.sqlite`);
+    const store = new SqliteReplayTimelineStore(path, {
+      retention: {
+        maxEventsPerDispute: 1,
+      },
+    });
+
+    await store.save([
+      { ...makeRecord(1, 'taskA', 10, 'SIG_A'), disputePda: 'dispute-1' },
+      { ...makeRecord(2, 'taskA', 11, 'SIG_B'), disputePda: 'dispute-1' },
+      { ...makeRecord(3, 'taskA', 12, 'SIG_C'), disputePda: 'dispute-2' },
+    ]);
+
+    const disputeTimeline = await store.query({ disputePda: 'dispute-1' });
+    expect(disputeTimeline).toHaveLength(1);
+    expect(disputeTimeline[0]?.signature).toBe('SIG_B');
+  });
+
+  it('applies max total event cap', async () => {
+    const path = join(tmpdir(), `replay-store-total-limit-${randomUUID()}.sqlite`);
+    const store = new SqliteReplayTimelineStore(path, {
+      retention: {
+        maxEventsTotal: 3,
+      },
+    });
+
+    await store.save([
+      { ...makeRecord(1, 'taskA', 10, 'SIG_A'), taskPda: 'task-1' },
+      { ...makeRecord(2, 'taskA', 11, 'SIG_B'), taskPda: 'task-1' },
+      { ...makeRecord(3, 'taskA', 12, 'SIG_C'), taskPda: 'task-1' },
+      { ...makeRecord(4, 'taskA', 13, 'SIG_D'), taskPda: 'task-1' },
+      { ...makeRecord(5, 'taskA', 14, 'SIG_E'), taskPda: 'task-1' },
+    ]);
+
+    const timeline = await store.query();
+    expect(timeline).toHaveLength(3);
+    expect(timeline.map((entry) => entry.signature)).toEqual(['SIG_C', 'SIG_D', 'SIG_E']);
+  });
+
+  it('compacts deterministically when compaction is enabled', async () => {
+    const path = join(tmpdir(), `replay-store-compaction-${randomUUID()}.sqlite`);
+    const store = new SqliteReplayTimelineStore(path, {
+      compaction: {
+        enabled: true,
+        compactAfterWrites: 2,
+      },
+    });
+
+    await store.save([makeRecord(1, 'taskA', 1, 'SIG_A'), makeRecord(2, 'taskA', 2, 'SIG_B')]);
+    await store.save([makeRecord(3, 'taskA', 3, 'SIG_C')]);
+
+    const timeline = await store.query({ taskPda: 'task-1' });
+    expect(timeline.map((entry) => entry.signature)).toEqual(['SIG_A', 'SIG_B', 'SIG_C']);
+  });
+  it('resumes backfill from persisted cursor for sqlite store', async () => {
+    const file = join(tmpdir(), `replay-store-backfill-${randomUUID()}.sqlite`);
+    const store = new SqliteReplayTimelineStore(file);
+
+    const pageOne = [
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'A',
+        event: { taskId: new Uint8Array(32).fill(1), creator: new Uint8Array(32).fill(1), requiredCapabilities: 1n, rewardAmount: 1n, taskType: 0, deadline: 1, minReputation: 0, rewardMint: null, timestamp: 1 },
+      },
+    ];
+    const pageTwo = [
+      {
+        eventName: 'taskClaimed',
+        slot: 2,
+        signature: 'B',
+        event: { taskId: new Uint8Array(32).fill(1), worker: new Uint8Array(32).fill(2), currentWorkers: 1, maxWorkers: 1, timestamp: 2 },
+      },
+    ];
+
+    const fetcher: BackfillFetcher & { failOnce: boolean } = {
+      async fetchPage(cursor, toSlot) {
+        expect(toSlot).toBe(9);
+
+        if (!cursor) {
+          return {
+            events: pageOne,
+            nextCursor: { slot: 1, signature: 'A', eventName: 'taskCreated' },
+            done: false,
+          };
+        }
+
+        if (cursor.signature === 'A' && !this.failOnce) {
+          this.failOnce = true;
+          throw new Error('simulated rpc failure');
+        }
+
+        return {
+          events: pageTwo,
+          nextCursor: null,
+          done: true,
+        };
+      },
+      failOnce: false,
+    };
+
+    const service = new ReplayBackfillService(store, {
+      toSlot: 9,
+      fetcher,
+    });
+
+    await expect(service.runBackfill()).rejects.toThrow('simulated rpc failure');
+
+    const cursor = await store.getCursor();
+    expect(stableReplayCursorString(cursor)).toBe('1:A:taskCreated');
+
+    const completed = await service.runBackfill();
+    const fullTimeline = await store.query();
+
+    expect(completed.processed).toBe(1);
+    expect(completed.duplicates).toBe(0);
+    expect(stableReplayCursorString(completed.cursor)).toBe('');
+    expect(fullTimeline).toHaveLength(2);
+  });
+});

--- a/runtime/src/replay/sqlite-store.ts
+++ b/runtime/src/replay/sqlite-store.ts
@@ -1,0 +1,442 @@
+/**
+ * SQLite-backed replay timeline store for production persistence.
+ *
+ * @module
+ */
+
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { ensureLazyBackend } from '../memory/lazy-import.js';
+import {
+  ReplayEventCursor,
+  ReplayTimelineCompactionPolicy,
+  ReplayTimelineQuery,
+  ReplayTimelineRecord,
+  ReplayTimelineRetentionPolicy,
+  ReplayTimelineStore,
+  ReplayStorageWriteResult,
+  type ReplayTimelineStoreConfig,
+} from './types.js';
+
+interface ReplayTimelineRow {
+  id: number;
+  slot: number;
+  signature: string;
+  source_event_name: string;
+  source_event_type: string;
+  source_event_sequence: number;
+  seq: number;
+  task_pda: string | null;
+  dispute_pda: string | null;
+  timestamp_ms: number;
+  projection_hash: string;
+  trace_id: string | null;
+  trace_span_id: string | null;
+  trace_parent_span_id: string | null;
+  trace_sampled: number;
+  payload: string;
+}
+
+interface ReplayTimelineCursorRow {
+  slot: number | null;
+  signature: string | null;
+  event_name: string | null;
+  trace_id: string | null;
+  trace_span_id: string | null;
+}
+
+const SQL_SCHEMA_VERSION = 1;
+
+export class SqliteReplayTimelineStore implements ReplayTimelineStore {
+  private readonly dbPath: string;
+  private readonly retention: ReplayTimelineRetentionPolicy | undefined;
+  private readonly compaction: ReplayTimelineCompactionPolicy | undefined;
+  private db: any = null;
+  private writeCounter = 0;
+
+  constructor(dbPath: string, config: ReplayTimelineStoreConfig = {}) {
+    this.dbPath = dbPath;
+    this.retention = config.retention;
+    this.compaction = config.compaction;
+  }
+
+  async save(records: readonly ReplayTimelineRecord[]): Promise<ReplayStorageWriteResult> {
+    const db = await this.getDb();
+    const insert = db.prepare(`
+      INSERT OR IGNORE INTO replay_timeline_events (
+        slot,
+        signature,
+        source_event_name,
+        source_event_type,
+        source_event_sequence,
+        seq,
+        task_pda,
+        dispute_pda,
+        timestamp_ms,
+        projection_hash,
+        trace_id,
+        trace_span_id,
+        trace_parent_span_id,
+        trace_sampled,
+        payload
+      )
+      VALUES (
+        @slot,
+        @signature,
+        @sourceEventName,
+        @sourceEventType,
+        @sourceEventSequence,
+        @seq,
+        @taskPda,
+        @disputePda,
+        @timestampMs,
+        @projectionHash,
+        @traceId,
+        @traceSpanId,
+        @traceParentSpanId,
+        @traceSampled,
+        @payload
+      )
+    `);
+
+    let inserted = 0;
+    let duplicates = 0;
+
+    for (const event of records) {
+      const result = insert.run({
+        slot: event.slot,
+        signature: event.signature,
+        sourceEventName: event.sourceEventName,
+        sourceEventType: event.sourceEventType,
+        sourceEventSequence: event.sourceEventSequence,
+        seq: event.seq,
+        taskPda: event.taskPda,
+        disputePda: event.disputePda ?? null,
+        timestampMs: event.timestampMs,
+        projectionHash: event.projectionHash,
+        traceId: event.traceId ?? null,
+        traceSpanId: event.traceSpanId ?? null,
+        traceParentSpanId: event.traceParentSpanId ?? null,
+        traceSampled: event.traceSampled === true ? 1 : 0,
+        payload: JSON.stringify(event.payload),
+      });
+
+      if (result.changes === 1) {
+        inserted += 1;
+      } else {
+        duplicates += 1;
+      }
+    }
+
+    await this.applyRetentionPolicy(db);
+
+    this.writeCounter += 1;
+    await this.compact(db);
+
+    return {
+      inserted,
+      duplicates,
+    };
+  }
+
+  async query(filter: ReplayTimelineQuery = {}): Promise<ReadonlyArray<ReplayTimelineRecord>> {
+    const db = await this.getDb();
+
+    const queryParts = ['1 = 1'];
+    const params: Record<string, string | number | null> = {};
+
+    if (filter.taskPda !== undefined) {
+      queryParts.push('task_pda = @taskPda');
+      params.taskPda = filter.taskPda;
+    }
+
+    if (filter.disputePda !== undefined) {
+      queryParts.push('dispute_pda = @disputePda');
+      params.disputePda = filter.disputePda;
+    }
+
+    if (filter.fromSlot !== undefined) {
+      queryParts.push('slot >= @fromSlot');
+      params.fromSlot = filter.fromSlot;
+    }
+
+    if (filter.toSlot !== undefined) {
+      queryParts.push('slot <= @toSlot');
+      params.toSlot = filter.toSlot;
+    }
+
+    if (filter.fromTimestampMs !== undefined) {
+      queryParts.push('timestamp_ms >= @fromTimestampMs');
+      params.fromTimestampMs = filter.fromTimestampMs;
+    }
+
+    if (filter.toTimestampMs !== undefined) {
+      queryParts.push('timestamp_ms <= @toTimestampMs');
+      params.toTimestampMs = filter.toTimestampMs;
+    }
+
+    const orderBy =
+      'slot ASC, signature ASC, seq ASC, source_event_type ASC';
+
+    const limitClause =
+      filter.limit !== undefined && filter.limit > 0
+        ? ' LIMIT @limit OFFSET @offset'
+        : '';
+
+    if (filter.limit === undefined || filter.limit > 0) {
+      params.offset = filter.offset ?? 0;
+    }
+    if (filter.limit !== undefined && filter.limit > 0) {
+      params.limit = filter.limit;
+    }
+
+    const sql = `
+      SELECT *
+      FROM replay_timeline_events
+      WHERE ${queryParts.join(' AND ')}
+      ORDER BY ${orderBy}${limitClause}
+    `;
+
+    const rows = db.prepare(sql).all(params);
+
+    return rows.map((row: ReplayTimelineRow) => this.rowToRecord(row));
+  }
+
+  async getCursor(): Promise<ReplayEventCursor | null> {
+    const db = await this.getDb();
+    const cursor = db
+      .prepare('SELECT slot, signature, event_name, trace_id, trace_span_id FROM replay_timeline_cursor WHERE id = 1')
+      .get() as ReplayTimelineCursorRow | undefined;
+
+    if (!cursor || cursor.slot === null || cursor.signature === null) {
+      return null;
+    }
+
+    return {
+      slot: cursor.slot,
+      signature: cursor.signature,
+      eventName: cursor.event_name ?? undefined,
+      traceId: cursor.trace_id ?? undefined,
+      traceSpanId: cursor.trace_span_id ?? undefined,
+    };
+  }
+
+  async saveCursor(cursor: ReplayEventCursor | null): Promise<void> {
+    const db = await this.getDb();
+    const statement = db.prepare(`
+      INSERT OR REPLACE INTO replay_timeline_cursor (
+        id,
+        slot,
+        signature,
+        event_name,
+        trace_id,
+        trace_span_id
+      ) VALUES (1, @slot, @signature, @eventName, @traceId, @traceSpanId)
+    `);
+
+    statement.run({
+      slot: cursor?.slot ?? null,
+      signature: cursor?.signature ?? null,
+      eventName: cursor?.eventName ?? null,
+      traceId: cursor?.traceId ?? null,
+      traceSpanId: cursor?.traceSpanId ?? null,
+    });
+  }
+
+  async clear(): Promise<void> {
+    const db = await this.getDb();
+    db.prepare('DELETE FROM replay_timeline_events').run();
+    await this.saveCursor(null);
+  }
+
+  private async getDb(): Promise<any> {
+    if (this.db) {
+      return this.db;
+    }
+
+    if (this.dbPath !== ':memory:') {
+      await mkdir(dirname(this.dbPath), { recursive: true });
+    }
+
+    this.db = await ensureLazyBackend('better-sqlite3', 'sqlite', (mod) => {
+      const Database = (mod.default ?? mod) as new (...args: unknown[]) => any;
+      return new Database(this.dbPath);
+    });
+
+    if (this.dbPath !== ':memory:') {
+      this.db.pragma('journal_mode = WAL');
+    }
+
+    await this.ensureSchema(this.db);
+    return this.db;
+  }
+
+  private ensureSchema(db: any): void {
+    const versionRow = db.pragma('user_version', { simple: true }) as number;
+    if (versionRow > SQL_SCHEMA_VERSION) {
+      throw new Error(`Replay timeline schema version ${versionRow} is newer than supported ${SQL_SCHEMA_VERSION}`);
+    }
+
+    if (versionRow > 0 && versionRow !== SQL_SCHEMA_VERSION) {
+      throw new Error(`Unsupported replay timeline schema version: ${versionRow}`);
+    }
+
+    if (versionRow === SQL_SCHEMA_VERSION) {
+      return;
+    }
+
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS replay_timeline_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        slot INTEGER NOT NULL,
+        signature TEXT NOT NULL,
+        source_event_name TEXT NOT NULL,
+        source_event_type TEXT NOT NULL,
+        source_event_sequence INTEGER NOT NULL,
+        seq INTEGER NOT NULL,
+        task_pda TEXT,
+        dispute_pda TEXT,
+        timestamp_ms INTEGER NOT NULL,
+        projection_hash TEXT NOT NULL,
+        trace_id TEXT,
+        trace_span_id TEXT,
+        trace_parent_span_id TEXT,
+        trace_sampled INTEGER NOT NULL DEFAULT 0,
+        payload TEXT NOT NULL
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_replay_timeline_events_uniq
+        ON replay_timeline_events(slot, signature, source_event_type);
+
+      CREATE INDEX IF NOT EXISTS idx_replay_timeline_events_task_lookup
+        ON replay_timeline_events(task_pda, slot, signature, seq, source_event_type);
+
+      CREATE INDEX IF NOT EXISTS idx_replay_timeline_events_dispute_lookup
+        ON replay_timeline_events(dispute_pda, slot, signature, seq, source_event_type);
+
+      CREATE INDEX IF NOT EXISTS idx_replay_timeline_events_slot_signature_seq
+        ON replay_timeline_events(slot, signature, seq, source_event_type);
+
+      CREATE TABLE IF NOT EXISTS replay_timeline_cursor (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        slot INTEGER,
+        signature TEXT,
+        event_name TEXT,
+        trace_id TEXT,
+        trace_span_id TEXT
+      );
+    `);
+
+    db.prepare(
+      'INSERT OR IGNORE INTO replay_timeline_cursor (id, slot, signature, event_name, trace_id, trace_span_id) VALUES (1, NULL, NULL, NULL, NULL, NULL)',
+    ).run();
+
+    db.pragma(`user_version = ${SQL_SCHEMA_VERSION}`);
+  }
+
+  private rowToRecord(row: ReplayTimelineRow): ReplayTimelineRecord {
+    return {
+      seq: row.seq,
+      type: row.source_event_type,
+      taskPda: row.task_pda ?? undefined,
+      timestampMs: row.timestamp_ms,
+      payload: JSON.parse(row.payload),
+      slot: row.slot,
+      signature: row.signature,
+      sourceEventName: row.source_event_name,
+      sourceEventSequence: row.source_event_sequence,
+      sourceEventType: row.source_event_type,
+      disputePda: row.dispute_pda ?? undefined,
+      projectionHash: row.projection_hash,
+      traceId: row.trace_id ?? undefined,
+      traceSpanId: row.trace_span_id ?? undefined,
+      traceParentSpanId: row.trace_parent_span_id ?? undefined,
+      traceSampled: row.trace_sampled === 1,
+    };
+  }
+
+  private async applyRetentionPolicy(db: any): Promise<void> {
+    if (!this.retention) {
+      return;
+    }
+
+    const now = Date.now();
+
+    if (this.retention.ttlMs !== undefined && this.retention.ttlMs > 0) {
+      const cutoff = now - this.retention.ttlMs;
+      db.prepare('DELETE FROM replay_timeline_events WHERE timestamp_ms < ?').run(cutoff);
+    }
+
+    if (this.retention.maxEventsPerTask !== undefined && this.retention.maxEventsPerTask > 0) {
+      const limit = this.retention.maxEventsPerTask;
+      db.exec(`
+        DELETE FROM replay_timeline_events
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY task_pda
+                     ORDER BY slot DESC, signature DESC, seq DESC, source_event_type DESC
+                   ) AS seq_num
+            FROM replay_timeline_events
+            WHERE task_pda IS NOT NULL
+          )
+          WHERE seq_num > ${limit}
+        );
+      `);
+    }
+
+    if (this.retention.maxEventsPerDispute !== undefined && this.retention.maxEventsPerDispute > 0) {
+      const limit = this.retention.maxEventsPerDispute;
+      db.exec(`
+        DELETE FROM replay_timeline_events
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY dispute_pda
+                     ORDER BY slot DESC, signature DESC, seq DESC, source_event_type DESC
+                   ) AS seq_num
+            FROM replay_timeline_events
+            WHERE dispute_pda IS NOT NULL
+          )
+          WHERE seq_num > ${limit}
+        );
+      `);
+    }
+
+    if (this.retention.maxEventsTotal !== undefined && this.retention.maxEventsTotal > 0) {
+      const limit = this.retention.maxEventsTotal;
+      db.exec(`
+        DELETE FROM replay_timeline_events
+        WHERE id IN (
+          SELECT id FROM (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     ORDER BY slot DESC, signature DESC, seq DESC, source_event_type DESC
+                   ) AS seq_num
+            FROM replay_timeline_events
+          )
+          WHERE seq_num > ${limit}
+        );
+      `);
+    }
+  }
+
+  private async compact(db: any): Promise<void> {
+    if (this.compaction?.enabled !== true) {
+      return;
+    }
+
+    const compactAfterWrites = this.compaction.compactAfterWrites ?? 0;
+    if (compactAfterWrites <= 0) {
+      return;
+    }
+
+    if (this.writeCounter % compactAfterWrites !== 0) {
+      return;
+    }
+
+    db.exec('VACUUM');
+  }
+}

--- a/runtime/src/replay/types.ts
+++ b/runtime/src/replay/types.ts
@@ -61,6 +61,29 @@ export interface ReplayTimelineStore {
   clear(): Promise<void>;
 }
 
+export interface ReplayTimelineRetentionPolicy {
+  /** Retain events newer than this TTL in milliseconds. */
+  ttlMs?: number;
+  /** Keep only the most recent N events for a task. */
+  maxEventsPerTask?: number;
+  /** Keep only the most recent N events for a dispute timeline. */
+  maxEventsPerDispute?: number;
+  /** Keep only the most recent N events overall in the store. */
+  maxEventsTotal?: number;
+}
+
+export interface ReplayTimelineCompactionPolicy {
+  /** Run compacting operations when enabled. Defaults to `false`. */
+  enabled?: boolean;
+  /** Number of save operations between SQLite VACUUM calls. */
+  compactAfterWrites?: number;
+}
+
+export interface ReplayTimelineStoreConfig {
+  retention?: ReplayTimelineRetentionPolicy;
+  compaction?: ReplayTimelineCompactionPolicy;
+}
+
 export interface BackfillFetcher {
   fetchPage(
     cursor: ReplayEventCursor | null,

--- a/runtime/src/types/config.ts
+++ b/runtime/src/types/config.ts
@@ -13,6 +13,22 @@ export type ReplayBridgeStoreType = 'memory' | 'sqlite';
 export interface ReplayBridgeStoreConfig {
   type: ReplayBridgeStoreType;
   sqlitePath?: string;
+  retention?: {
+    /** Retain events newer than this TTL in milliseconds. */
+    ttlMs?: number;
+    /** Keep only the most recent N events for a task. */
+    maxEventsPerTask?: number;
+    /** Keep only the most recent N events for a dispute timeline. */
+    maxEventsPerDispute?: number;
+    /** Keep only the most recent N events in the store. */
+    maxEventsTotal?: number;
+  };
+  compaction?: {
+    /** Run compacting operations when enabled. */
+    enabled?: boolean;
+    /** Number of save operations between SQLite VACUUM calls. */
+    compactAfterWrites?: number;
+  };
 }
 
 export interface ReplayBackfillConfig {


### PR DESCRIPTION
## Summary
- Add SQLite-backed replay timeline store with retention and compaction policy support.
- Wire sqlite store selection through replay config and runtime bridge.
- Export sqlite store and new config/policy types.
- Add persistence/retention/compaction/backfill cursor tests.
- Update replay docs with sqlite + retention/compaction examples.

## Files Changed
- runtime/src/replay/sqlite-store.ts
- runtime/src/replay/sqlite-store.test.ts
- runtime/src/replay/bridge.ts
- runtime/src/replay/index.ts
- runtime/src/replay/types.ts
- runtime/src/types/config.ts
- runtime/README.md

## Tests
- npm run test (pass)
- npm run test:anchor (environment-dependent failure: ANCHOR_PROVIDER_URL is not defined)
- npm run typecheck (pass)
- npm run build (pass)

## Risks
- SQLite dependency remains optional; missing dependency throws install guidance.
- test:anchor requires ANCHOR_PROVIDER_URL and will still fail in this local environment.

## How to Validate Locally
- npm run test
- npm run typecheck
- npm run build

Closes #930