### PR TITLE
feat(runtime): add replay trace correlation across ingestion and replay (#932)

### DIFF
--- a/runtime/docs/observability-epic-920.md
+++ b/runtime/docs/observability-epic-920.md
@@ -44,6 +44,20 @@ Anchor Events
 - Deterministic duplicate handling: duplicate `(slot, signature, eventName)` entries are ignored with explicit telemetry.
 - Unknown event variants never crash the pipeline; they are recorded in telemetry and continue.
 
+## Trace propagation behavior (#932)
+
+- Replay bridge events now ensure each ingested input has a deterministic `traceContext` for projection and persistence.
+- Missing trace context is synthesized from `(slot, signature, eventName, sourceEventSequence)` using `buildReplayTraceContext`.
+- Backfill writes trace identifiers into both `ReplayTimelineRecord` rows and cursor checkpoints to preserve resume continuity.
+- `ReplayComparisonService` emits an optional internal span around comparison and can attach anomaly reporting/metrics under `replay.compare`.
+- Optional OpenTelemetry output is controlled by `replay.tracing.emitOtel` and uses best-effort loading of `@opentelemetry/api`; when unavailable, operations remain no-op without changing runtime behavior.
+- Span names follow deterministic patterns:
+  - `replay.intake[slot=...,signature=...]`
+  - `replay.projector[slot=...,signature=...]`
+  - `replay.store.save[slot=...,signature=...]`
+  - `replay.backfill.page[slot=...,signature=...]`
+  - `replay.compare[slot=...,signature=...]`
+
 ## Issue execution chain
 
 - Baseline:

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -49,6 +49,9 @@ export {
 
 export {
   buildReplayTraceContext,
+  buildReplaySpanEvent,
+  buildReplaySpanName,
+  startReplaySpan,
   toReplayTraceEnvelope,
   type ReplayTraceContext,
   type ReplayTraceEnvelope,

--- a/runtime/src/replay/sqlite-store.test.ts
+++ b/runtime/src/replay/sqlite-store.test.ts
@@ -243,7 +243,7 @@ sqliteStoreDescribe('SqliteReplayTimelineStore', () => {
     await expect(service.runBackfill()).rejects.toThrow('simulated rpc failure');
 
     const cursor = await store.getCursor();
-    expect(stableReplayCursorString(cursor)).toBe('1:A:taskCreated');
+    expect(stableReplayCursorString(cursor)).toMatch(/^1:A:taskCreated:replay-backfill:/);
 
     const completed = await service.runBackfill();
     const fullTimeline = await store.query();

--- a/runtime/src/replay/trace.ts
+++ b/runtime/src/replay/trace.ts
@@ -9,6 +9,7 @@
  */
 
 import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
 
 export interface ReplayTraceContext {
   traceId: string;
@@ -33,7 +34,84 @@ export interface ReplayTraceEnvelope {
   sampled: boolean;
 }
 
+export interface ReplaySpanEvent {
+  code: string;
+  slot?: number;
+  signature?: string;
+  sourceEventSequence?: number;
+  taskPda?: string;
+  disputePda?: string;
+}
+
+export interface ReplaySpanContext {
+  name: string;
+  trace: ReplayTraceContext;
+  attributes?: ReplaySpanEvent;
+  emitOtel?: boolean;
+}
+
+interface ReplaySpanHandle {
+  end: (error?: unknown) => void;
+}
+
+interface ReplayOtelSpan {
+  setAttribute: (name: string, value: unknown) => void;
+  recordException?: (error: unknown) => void;
+  setStatus?: (status: { code: number; message?: string }) => void;
+  end: () => void;
+}
+
+interface ReplayOtelModule {
+  trace: {
+    getTracer: (name: string, version?: string) => {
+      startSpan: (
+        name: string,
+        options: {
+          attributes?: Record<string, string | number | boolean>;
+        }
+      ) => ReplayOtelSpan;
+    };
+  };
+}
+
+type OtelLoadState = ReplayOtelModule | false;
+
 export const DEFAULT_TRACE_SAMPLE_RATE = 1;
+
+const otelRequire = createRequire(`${process.cwd()}/`);
+const otelCache = new Map<string, OtelLoadState>();
+
+function resolveOtelModule(cacheKey: string): ReplayOtelModule | null {
+  const cached = otelCache.get(cacheKey);
+  if (cached === false) {
+    return null;
+  }
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  try {
+    const module = otelRequire('@opentelemetry/api') as { trace?: unknown };
+    const tracerApi = module?.trace as { getTracer?: unknown } | undefined;
+    if (tracerApi?.getTracer !== undefined) {
+      otelCache.set(cacheKey, {
+        trace: {
+          getTracer: tracerApi.getTracer as ReplayOtelModule['trace']['getTracer'],
+        },
+      });
+      return {
+        trace: {
+          getTracer: tracerApi.getTracer as ReplayOtelModule['trace']['getTracer'],
+        },
+      };
+    }
+  } catch {
+    // Optional dependency unavailable.
+  }
+
+  otelCache.set(cacheKey, false);
+  return null;
+}
 
 function normalizeSampleRate(sampleRate: number | undefined): number {
   if (sampleRate === undefined || Number.isNaN(sampleRate)) {
@@ -113,5 +191,76 @@ export function toReplayTraceEnvelope(context: ReplayTraceContext | undefined): 
     spanId: context.spanId,
     parentSpanId: context.parentSpanId,
     sampled: context.sampled,
+  };
+}
+
+export function buildReplaySpanEvent(
+  code: string,
+  details: {
+    slot?: number;
+    signature?: string;
+    sourceEventSequence?: number;
+    taskPda?: string;
+    disputePda?: string;
+  },
+): ReplaySpanEvent {
+  return {
+    code,
+    slot: details.slot,
+    signature: details.signature,
+    sourceEventSequence: details.sourceEventSequence,
+    taskPda: details.taskPda,
+    disputePda: details.disputePda,
+  };
+}
+
+export function buildReplaySpanName(
+  code: string,
+  event: {
+    slot?: number;
+    signature?: string;
+  },
+): string {
+  if (event.slot !== undefined && event.signature !== undefined) {
+    return `${code}[slot=${event.slot},signature=${event.signature}]`;
+  }
+  return code;
+}
+
+export function startReplaySpan(context: ReplaySpanContext): ReplaySpanHandle {
+  if (!context.emitOtel || !context.trace.sampled) {
+    return { end: () => undefined };
+  }
+
+  const otel = resolveOtelModule('default');
+  if (!otel) {
+    return { end: () => undefined };
+  }
+
+  const attributes = {
+    ...context.attributes,
+    'agenc.replay.trace_id': context.trace.traceId,
+    'agenc.replay.span_id': context.trace.spanId,
+    'agenc.replay.sampled': context.trace.sampled,
+  } as const;
+  if (context.trace.parentSpanId !== undefined) {
+    (attributes as { 'agenc.replay.parent_span_id'?: string })['agenc.replay.parent_span_id'] = context.trace.parentSpanId;
+  }
+
+  const span = otel.trace
+    .getTracer('agenc-runtime-replay', '0.1.0')
+    .startSpan(context.name, { attributes });
+
+  return {
+    end(error?: unknown): void {
+      if (error !== undefined) {
+        span.recordException?.(error);
+        const message = error instanceof Error
+          ? error.message
+          : String(error);
+        span.setStatus?.({ code: 2, message });
+      }
+      span.end();
+    },
   };
 }


### PR DESCRIPTION
## Summary
- add trace context propagation through replay event bridge and backfill
- add OpenTelemetry span scaffolding in replay module with optional runtime loading
- add deterministic trace IDs to backfill checkpoints and mismatch records
- update docs with observed trace propagation behavior

## Files changed
- runtime/src/replay/trace.ts
- runtime/src/replay/bridge.ts
- runtime/src/replay/backfill.ts
- runtime/src/eval/replay-comparison.ts
- runtime/src/replay/index.ts
- runtime/src/replay/replay-storage.test.ts
- runtime/src/replay/sqlite-store.test.ts
- runtime/docs/observability-epic-920.md

## Tests run
- npm run test --prefix runtime -- replay-storage.test.ts replay-comparison.test.ts sqlite-store.test.ts

## Risks
- optional OpenTelemetry loading path relies on dynamic require and no-op fallback when missing

## Validation
- issue #932
