### PR TITLE
fix(program,runtime): close high-risk task lifecycle gaps

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -25,7 +25,7 @@ shutdown_wait = 5000
 upgradeable = true
 
 [scripts]
-test = "npx ts-mocha -p ./tsconfig.json -t 300000 tests/test_1.ts tests/dispute-slash-logic.ts tests/spl-token-tasks.ts"
+test = "npx ts-mocha -p ./tsconfig.json -t 300000 tests/test_1.ts tests/dispute-slash-logic.ts tests/spl-token-tasks.ts tests/lifecycle-guards.ts"
 
 [workspace]
 members = ["programs/agenc-coordination"]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run build:sdk && npm run build:runtime && npm run test --prefix sdk && npm run test --prefix runtime",
     "typecheck": "npm run typecheck --prefix sdk && npm run typecheck --prefix runtime && npm run typecheck --prefix mcp",
     "test:anchor": "ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts",
-    "test:fast": "ts-mocha -p ./tsconfig.json -t 60000 tests/test_1.ts tests/dispute-slash-logic.ts tests/spl-token-tasks.ts",
+    "test:fast": "ts-mocha -p ./tsconfig.json -t 60000 tests/test_1.ts tests/dispute-slash-logic.ts tests/spl-token-tasks.ts tests/lifecycle-guards.ts",
     "demo": "npx tsx demo/private_task_demo.ts",
     "demo:mainnet": "HELIUS_API_KEY=$HELIUS_API_KEY npx tsx demo/private_task_demo.ts"
   },

--- a/programs/agenc-coordination/src/instructions/completion_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/completion_helpers.rs
@@ -263,6 +263,16 @@ pub fn validate_completion_prereqs(
     claim: &TaskClaim,
     clock: &Clock,
 ) -> Result<()> {
+    // Defense-in-depth: reject terminal states with specific error codes (#959)
+    require!(
+        task.status != TaskStatus::Completed,
+        CoordinationError::TaskAlreadyCompleted
+    );
+    require!(
+        task.status != TaskStatus::Cancelled,
+        CoordinationError::TaskCannotBeCancelled
+    );
+
     require!(
         task.status == TaskStatus::InProgress,
         CoordinationError::TaskNotInProgress

--- a/runtime/src/eval/index.ts
+++ b/runtime/src/eval/index.ts
@@ -47,6 +47,7 @@ export {
 } from './projector.js';
 
 export {
+  ANOMALY_CODES,
   validateTransition,
   transitionViolationMessage,
   type ReplayLifecycleType,

--- a/tests/lifecycle-guards.ts
+++ b/tests/lifecycle-guards.ts
@@ -1,0 +1,629 @@
+/**
+ * Task lifecycle guard tests (#959)
+ *
+ * Verifies that on-chain guards reject invalid state transitions:
+ * - Double completion on competitive tasks
+ * - Dispute initiation on completed tasks
+ * - Claim after task deadline
+ * - Cancel on completed tasks
+ * - Deregister with active tasks or disputes
+ * - Completion of cancelled tasks
+ * - Claim on cancelled tasks
+ */
+
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import BN from "bn.js";
+import { expect } from "chai";
+import { Keypair, PublicKey, SystemProgram, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { AgencCoordination } from "../target/types/agenc_coordination";
+import {
+  CAPABILITY_COMPUTE,
+  CAPABILITY_ARBITER,
+  TASK_TYPE_EXCLUSIVE,
+  TASK_TYPE_COMPETITIVE,
+  VALID_EVIDENCE,
+  generateRunId,
+  deriveAgentPda as _deriveAgentPda,
+  deriveTaskPda as _deriveTaskPda,
+  deriveEscrowPda as _deriveEscrowPda,
+  deriveClaimPda as _deriveClaimPda,
+  deriveDisputePda as _deriveDisputePda,
+  deriveProgramDataPda,
+  getErrorCode,
+} from "./test-utils";
+import { createLiteSVMContext, fundAccount, advanceClock, getClockTimestamp } from "./litesvm-helpers";
+
+describe("Task lifecycle guards (#959)", () => {
+  const { svm, provider, program } = createLiteSVMContext();
+
+  const [protocolPda] = PublicKey.findProgramAddressSync(
+    [Buffer.from("protocol")],
+    program.programId
+  );
+
+  const runId = generateRunId();
+
+  let treasury: Keypair;
+  let treasuryPubkey: PublicKey;
+  let secondSigner: Keypair;
+  let creator: Keypair;
+  let creatorAgentId: Buffer;
+  let creatorAgentPda: PublicKey;
+
+  let agentCounter = 0;
+  let taskCounter = 0;
+
+  function deriveAgentPda(agentId: Buffer): PublicKey {
+    return _deriveAgentPda(agentId, program.programId);
+  }
+  function deriveTaskPda(creatorPubkey: PublicKey, taskId: Buffer): PublicKey {
+    return _deriveTaskPda(creatorPubkey, taskId, program.programId);
+  }
+  function deriveEscrowPda(taskPda: PublicKey): PublicKey {
+    return _deriveEscrowPda(taskPda, program.programId);
+  }
+  function deriveClaimPda(taskPda: PublicKey, workerPda: PublicKey): PublicKey {
+    return _deriveClaimPda(taskPda, workerPda, program.programId);
+  }
+  function deriveDisputePda(disputeId: Buffer): PublicKey {
+    return _deriveDisputePda(disputeId, program.programId);
+  }
+
+  function makeAgentId(prefix: string): Buffer {
+    return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+  }
+  function makeTaskId(prefix: string): Buffer {
+    return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+  }
+  function makeDisputeId(prefix: string): Buffer {
+    return Buffer.from(`${prefix}-${runId}`.slice(0, 32).padEnd(32, "\0"));
+  }
+
+  async function createFreshWorker(capabilities: number = CAPABILITY_COMPUTE): Promise<{
+    wallet: Keypair;
+    agentId: Buffer;
+    agentPda: PublicKey;
+  }> {
+    agentCounter++;
+    const wallet = Keypair.generate();
+    const agentId = makeAgentId(`lw${agentCounter}`);
+    const agentPda = deriveAgentPda(agentId);
+    fundAccount(svm, wallet.publicKey, 5 * LAMPORTS_PER_SOL);
+    await program.methods
+      .registerAgent(
+        Array.from(agentId),
+        new BN(capabilities),
+        `https://lifecycle-worker-${agentCounter}.example.com`,
+        null,
+        new BN(LAMPORTS_PER_SOL / 10)
+      )
+      .accountsPartial({
+        agent: agentPda,
+        protocolConfig: protocolPda,
+        authority: wallet.publicKey,
+      })
+      .signers([wallet])
+      .rpc({ skipPreflight: true });
+    return { wallet, agentId, agentPda };
+  }
+
+  function nextTaskId(): Buffer {
+    taskCounter++;
+    return makeTaskId(`lt${taskCounter}`);
+  }
+
+  async function createExclusiveTask(
+    creatorWallet: Keypair,
+    creatorAgent: PublicKey,
+    taskId: Buffer,
+    deadline?: BN,
+  ): Promise<{ taskPda: PublicKey; escrowPda: PublicKey }> {
+    const taskPda = deriveTaskPda(creatorWallet.publicKey, taskId);
+    const escrowPda = deriveEscrowPda(taskPda);
+    const dl = deadline ?? new BN(getClockTimestamp(svm) + 3600);
+    await program.methods
+      .createTask(
+        Array.from(taskId),
+        new BN(CAPABILITY_COMPUTE),
+        Buffer.from("lifecycle guard test".padEnd(64, "\0")),
+        new BN(LAMPORTS_PER_SOL / 100),
+        1,
+        dl,
+        TASK_TYPE_EXCLUSIVE,
+        null,
+        0,
+        null,
+      )
+      .accountsPartial({
+        task: taskPda,
+        escrow: escrowPda,
+        protocolConfig: protocolPda,
+        creatorAgent,
+        authority: creatorWallet.publicKey,
+        creator: creatorWallet.publicKey,
+        systemProgram: SystemProgram.programId,
+        rewardMint: null,
+        creatorTokenAccount: null,
+        tokenEscrowAta: null,
+        tokenProgram: null,
+        associatedTokenProgram: null,
+      })
+      .signers([creatorWallet])
+      .rpc();
+    return { taskPda, escrowPda };
+  }
+
+  async function createCompetitiveTask(
+    creatorWallet: Keypair,
+    creatorAgent: PublicKey,
+    taskId: Buffer,
+    maxWorkers: number,
+  ): Promise<{ taskPda: PublicKey; escrowPda: PublicKey }> {
+    const taskPda = deriveTaskPda(creatorWallet.publicKey, taskId);
+    const escrowPda = deriveEscrowPda(taskPda);
+    await program.methods
+      .createTask(
+        Array.from(taskId),
+        new BN(CAPABILITY_COMPUTE),
+        Buffer.from("competitive guard test".padEnd(64, "\0")),
+        new BN(LAMPORTS_PER_SOL / 100),
+        maxWorkers,
+        new BN(getClockTimestamp(svm) + 3600),
+        TASK_TYPE_COMPETITIVE,
+        null,
+        0,
+        null,
+      )
+      .accountsPartial({
+        task: taskPda,
+        escrow: escrowPda,
+        protocolConfig: protocolPda,
+        creatorAgent,
+        authority: creatorWallet.publicKey,
+        creator: creatorWallet.publicKey,
+        systemProgram: SystemProgram.programId,
+        rewardMint: null,
+        creatorTokenAccount: null,
+        tokenEscrowAta: null,
+        tokenProgram: null,
+        associatedTokenProgram: null,
+      })
+      .signers([creatorWallet])
+      .rpc();
+    return { taskPda, escrowPda };
+  }
+
+  async function claimTask(
+    taskPda: PublicKey,
+    worker: { wallet: Keypair; agentPda: PublicKey },
+  ): Promise<PublicKey> {
+    const claimPda = deriveClaimPda(taskPda, worker.agentPda);
+    await program.methods
+      .claimTask()
+      .accountsPartial({
+        task: taskPda,
+        claim: claimPda,
+        worker: worker.agentPda,
+        authority: worker.wallet.publicKey,
+        protocolConfig: protocolPda,
+      })
+      .signers([worker.wallet])
+      .rpc();
+    return claimPda;
+  }
+
+  async function completeTask(
+    taskPda: PublicKey,
+    escrowPda: PublicKey,
+    claimPda: PublicKey,
+    worker: { wallet: Keypair; agentPda: PublicKey },
+    creatorPubkey: PublicKey,
+  ): Promise<void> {
+    await program.methods
+      .completeTask(Array.from(Buffer.from("proof".padEnd(32, "\0"))), null)
+      .accountsPartial({
+        task: taskPda,
+        claim: claimPda,
+        escrow: escrowPda,
+        creator: creatorPubkey,
+        worker: worker.agentPda,
+        protocolConfig: protocolPda,
+        treasury: treasuryPubkey,
+        authority: worker.wallet.publicKey,
+        tokenEscrowAta: null,
+        workerTokenAccount: null,
+        treasuryTokenAccount: null,
+        rewardMint: null,
+        tokenProgram: null,
+      })
+      .signers([worker.wallet])
+      .rpc();
+  }
+
+  before(async () => {
+    treasury = Keypair.generate();
+    secondSigner = Keypair.generate();
+    creator = Keypair.generate();
+
+    creatorAgentId = makeAgentId("lcr");
+    creatorAgentPda = deriveAgentPda(creatorAgentId);
+
+    const wallets = [treasury, secondSigner, creator];
+    for (const wallet of wallets) {
+      fundAccount(svm, wallet.publicKey, 100 * LAMPORTS_PER_SOL);
+    }
+
+    // Initialize protocol
+    try {
+      const programDataPda = deriveProgramDataPda(program.programId);
+      await program.methods
+        .initializeProtocol(
+          51, 100,
+          new BN(LAMPORTS_PER_SOL / 100),
+          new BN(LAMPORTS_PER_SOL / 100),
+          1,
+          [provider.wallet.publicKey, secondSigner.publicKey]
+        )
+        .accountsPartial({
+          protocolConfig: protocolPda,
+          treasury: treasury.publicKey,
+          authority: provider.wallet.publicKey,
+          secondSigner: secondSigner.publicKey,
+          systemProgram: SystemProgram.programId,
+        })
+        .remainingAccounts([{ pubkey: programDataPda, isSigner: false, isWritable: false }])
+        .signers([secondSigner])
+        .rpc();
+      treasuryPubkey = treasury.publicKey;
+    } catch {
+      const protocolConfig = await program.account.protocolConfig.fetch(protocolPda);
+      treasuryPubkey = protocolConfig.treasury;
+    }
+
+    // Disable rate limiting for tests
+    try {
+      await program.methods
+        .updateRateLimits(new BN(0), 0, new BN(0), 0, new BN(0))
+        .accountsPartial({ protocolConfig: protocolPda })
+        .remainingAccounts([{ pubkey: provider.wallet.publicKey, isSigner: true, isWritable: false }])
+        .rpc({ skipPreflight: true });
+    } catch {
+      // May already be configured
+    }
+
+    // Register creator agent
+    try {
+      await program.methods
+        .registerAgent(
+          Array.from(creatorAgentId),
+          new BN(CAPABILITY_COMPUTE),
+          "https://lifecycle-creator.example.com",
+          null,
+          new BN(LAMPORTS_PER_SOL / 10)
+        )
+        .accountsPartial({
+          agent: creatorAgentPda,
+          protocolConfig: protocolPda,
+          authority: creator.publicKey,
+        })
+        .signers([creator])
+        .rpc({ skipPreflight: true });
+    } catch (e: any) {
+      if (!e.message?.includes("already in use")) throw e;
+    }
+  });
+
+  it("rejects double completion on competitive task (CompetitiveTaskAlreadyWon)", async () => {
+    const taskId = nextTaskId();
+    const { taskPda, escrowPda } = await createCompetitiveTask(
+      creator, creatorAgentPda, taskId, 2
+    );
+
+    const workerA = await createFreshWorker();
+    const workerB = await createFreshWorker();
+
+    const claimA = await claimTask(taskPda, workerA);
+    const claimB = await claimTask(taskPda, workerB);
+
+    // Worker A completes successfully
+    await completeTask(taskPda, escrowPda, claimA, workerA, creator.publicKey);
+
+    // Worker B's completion should fail. After first competitive completion the escrow
+    // is closed (zeroed), so Anchor rejects at account deserialization. Both
+    // AccountNotInitialized (escrow gone) and CompetitiveTaskAlreadyWon (guard) are valid.
+    try {
+      await completeTask(taskPda, escrowPda, claimB, workerB, creator.publicKey);
+      expect.fail("Should have rejected double completion on competitive task");
+    } catch (e: unknown) {
+      const code = getErrorCode(e);
+      const msg = (e as { message?: string })?.message ?? "";
+      expect(
+        code === "CompetitiveTaskAlreadyWon" ||
+        code === "TaskAlreadyCompleted" ||
+        code === "AccountNotInitialized" ||
+        msg.includes("AccountNotInitialized") ||
+        msg.includes("Error processing Instruction")
+      ).to.be.true;
+    }
+  });
+
+  it("rejects dispute initiation on completed task (TaskNotInProgress)", async () => {
+    const taskId = nextTaskId();
+    const { taskPda, escrowPda } = await createExclusiveTask(creator, creatorAgentPda, taskId);
+
+    const worker = await createFreshWorker();
+    const claimPda = await claimTask(taskPda, worker);
+    await completeTask(taskPda, escrowPda, claimPda, worker, creator.publicKey);
+
+    // Attempt dispute on completed task (worker-initiated path to avoid
+    // optional account deserialization issues with the creator path)
+    const disputeId = makeDisputeId(`dac${taskCounter}`);
+    const disputePda = deriveDisputePda(disputeId);
+    try {
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.from("evidence".padEnd(32, "\0"))),
+          0,
+          VALID_EVIDENCE
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+          initiatorClaim: claimPda,
+          workerAgent: null,
+          workerClaim: null,
+        })
+        .signers([worker.wallet])
+        .rpc();
+      expect.fail("Should have rejected dispute on completed task");
+    } catch (e: unknown) {
+      // TaskNotInProgress fires before ClaimAlreadyCompleted in the handler.
+      // In some cases Anchor rejects at account deserialization level if claim
+      // state is affected by completion; both outcomes block the dispute.
+      const code = getErrorCode(e);
+      const msg = (e as { message?: string })?.message ?? "";
+      expect(
+        code === "TaskNotInProgress" ||
+        code === "AccountNotInitialized" ||
+        msg.includes("Error processing Instruction")
+      ).to.be.true;
+    }
+  });
+
+  it("rejects claim after task deadline (TaskExpired)", async () => {
+    const taskId = nextTaskId();
+    const deadline = new BN(getClockTimestamp(svm) + 60);
+    const { taskPda } = await createExclusiveTask(creator, creatorAgentPda, taskId, deadline);
+
+    // Advance clock past deadline
+    advanceClock(svm, 61);
+
+    const worker = await createFreshWorker();
+    const claimPda = deriveClaimPda(taskPda, worker.agentPda);
+
+    try {
+      await program.methods
+        .claimTask()
+        .accountsPartial({
+          task: taskPda,
+          claim: claimPda,
+          worker: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+        })
+        .signers([worker.wallet])
+        .rpc();
+      expect.fail("Should have rejected claim after deadline");
+    } catch (e: unknown) {
+      const code = getErrorCode(e);
+      expect(code).to.equal("TaskExpired");
+    }
+  });
+
+  it("rejects cancel on completed task (InvalidStatusTransition)", async () => {
+    const taskId = nextTaskId();
+    const { taskPda, escrowPda } = await createExclusiveTask(creator, creatorAgentPda, taskId);
+
+    const worker = await createFreshWorker();
+    const claimPda = await claimTask(taskPda, worker);
+    await completeTask(taskPda, escrowPda, claimPda, worker, creator.publicKey);
+
+    try {
+      await program.methods
+        .cancelTask()
+        .accountsPartial({
+          task: taskPda,
+          escrow: escrowPda,
+          creator: creator.publicKey,
+          protocolConfig: protocolPda,
+          systemProgram: SystemProgram.programId,
+          tokenEscrowAta: null,
+          creatorTokenAccount: null,
+          rewardMint: null,
+          tokenProgram: null,
+        })
+        .signers([creator])
+        .rpc();
+      expect.fail("Should have rejected cancel on completed task");
+    } catch (e: unknown) {
+      // Escrow is already closed after completion, so Anchor account constraint
+      // will fail before status check. Either error is acceptable.
+      const code = getErrorCode(e);
+      const msg = (e as { message?: string })?.message ?? "";
+      expect(
+        code === "InvalidStatusTransition" ||
+        msg.includes("AccountNotInitialized") ||
+        msg.includes("does not exist") ||
+        msg.includes("Error processing Instruction")
+      ).to.be.true;
+    }
+  });
+
+  it("rejects deregister with active tasks (AgentHasActiveTasks)", async () => {
+    const worker = await createFreshWorker();
+    const taskId = nextTaskId();
+    const { taskPda } = await createExclusiveTask(creator, creatorAgentPda, taskId);
+
+    await claimTask(taskPda, worker);
+
+    try {
+      await program.methods
+        .deregisterAgent()
+        .accountsPartial({
+          agent: worker.agentPda,
+          protocolConfig: protocolPda,
+          authority: worker.wallet.publicKey,
+        })
+        .signers([worker.wallet])
+        .rpc();
+      expect.fail("Should have rejected deregister with active tasks");
+    } catch (e: unknown) {
+      const code = getErrorCode(e);
+      expect(code).to.equal("AgentHasActiveTasks");
+    }
+  });
+
+  it("rejects deregister with disputes_as_defendant > 0 (ActiveDisputesExist)", async () => {
+    const worker = await createFreshWorker();
+    const taskId = nextTaskId();
+    const { taskPda } = await createExclusiveTask(creator, creatorAgentPda, taskId);
+
+    const claimPda = await claimTask(taskPda, worker);
+
+    // Initiate dispute against the worker (creator-initiated)
+    const disputeId = makeDisputeId(`dd${taskCounter}`);
+    const disputePda = deriveDisputePda(disputeId);
+    await program.methods
+      .initiateDispute(
+        Array.from(disputeId),
+        Array.from(taskId),
+        Array.from(Buffer.from("evidence".padEnd(32, "\0"))),
+        0,
+        VALID_EVIDENCE
+      )
+      .accountsPartial({
+        dispute: disputePda,
+        task: taskPda,
+        agent: creatorAgentPda,
+        authority: creator.publicKey,
+        protocolConfig: protocolPda,
+        systemProgram: SystemProgram.programId,
+        initiatorClaim: null,
+        workerAgent: worker.agentPda,
+        workerClaim: claimPda,
+      })
+      .signers([creator])
+      .rpc();
+
+    try {
+      await program.methods
+        .deregisterAgent()
+        .accountsPartial({
+          agent: worker.agentPda,
+          protocolConfig: protocolPda,
+          authority: worker.wallet.publicKey,
+        })
+        .signers([worker.wallet])
+        .rpc();
+      expect.fail("Should have rejected deregister with active disputes");
+    } catch (e: unknown) {
+      const code = getErrorCode(e);
+      // Worker has both active tasks and disputes; either error is valid
+      expect(
+        code === "ActiveDisputesExist" || code === "AgentHasActiveTasks"
+      ).to.be.true;
+    }
+  });
+
+  it("rejects completion of cancelled task (TaskCannotBeCancelled or TaskNotInProgress)", async () => {
+    const taskId = nextTaskId();
+    const { taskPda, escrowPda } = await createExclusiveTask(creator, creatorAgentPda, taskId);
+
+    // Cancel the task before any claims
+    await program.methods
+      .cancelTask()
+      .accountsPartial({
+        task: taskPda,
+        escrow: escrowPda,
+        creator: creator.publicKey,
+        protocolConfig: protocolPda,
+        systemProgram: SystemProgram.programId,
+        tokenEscrowAta: null,
+        creatorTokenAccount: null,
+        rewardMint: null,
+        tokenProgram: null,
+      })
+      .signers([creator])
+      .rpc();
+
+    // Attempt completion on cancelled task — escrow is closed so Anchor will reject
+    const worker = await createFreshWorker();
+    const claimPda = deriveClaimPda(taskPda, worker.agentPda);
+    try {
+      await completeTask(taskPda, escrowPda, claimPda, worker, creator.publicKey);
+      expect.fail("Should have rejected completion of cancelled task");
+    } catch (e: unknown) {
+      // Task is cancelled and escrow is closed — any error is expected
+      const code = getErrorCode(e);
+      const msg = (e as { message?: string })?.message ?? "";
+      expect(
+        code === "TaskCannotBeCancelled" ||
+        code === "TaskNotInProgress" ||
+        code === "TaskAlreadyCompleted" ||
+        msg.includes("AccountNotInitialized") ||
+        msg.includes("does not exist") ||
+        msg.includes("Error processing Instruction")
+      ).to.be.true;
+    }
+  });
+
+  it("rejects claim on cancelled task (TaskNotOpen)", async () => {
+    const taskId = nextTaskId();
+    const { taskPda, escrowPda } = await createExclusiveTask(creator, creatorAgentPda, taskId);
+
+    // Cancel the task
+    await program.methods
+      .cancelTask()
+      .accountsPartial({
+        task: taskPda,
+        escrow: escrowPda,
+        creator: creator.publicKey,
+        protocolConfig: protocolPda,
+        systemProgram: SystemProgram.programId,
+        tokenEscrowAta: null,
+        creatorTokenAccount: null,
+        rewardMint: null,
+        tokenProgram: null,
+      })
+      .signers([creator])
+      .rpc();
+
+    // Attempt claim on cancelled task
+    const worker = await createFreshWorker();
+    const claimPda = deriveClaimPda(taskPda, worker.agentPda);
+    try {
+      await program.methods
+        .claimTask()
+        .accountsPartial({
+          task: taskPda,
+          claim: claimPda,
+          worker: worker.agentPda,
+          authority: worker.wallet.publicKey,
+          protocolConfig: protocolPda,
+        })
+        .signers([worker.wallet])
+        .rpc();
+      expect.fail("Should have rejected claim on cancelled task");
+    } catch (e: unknown) {
+      const code = getErrorCode(e);
+      expect(code).to.equal("TaskNotOpen");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #959.

- Add terminal-state defense-in-depth guards to `validate_completion_prereqs()` — reject completed tasks with `TaskAlreadyCompleted` and cancelled tasks with `TaskCannotBeCancelled` before the generic `TaskNotInProgress` check
- Add `disputed` state to runtime transition validator's task lifecycle state machine with secondary projection from `disputeInitiated` events (guarded to only fire when task is in `claimed` state, matching on-chain `initiate_dispute` requirements)
- Add `anomalyCode` field to `TransitionValidationViolation` with stable codes (`TASK_DOUBLE_COMPLETE`, `TASK_TERMINAL_TRANSITION`, `DISPUTE_INVALID_START`, etc.) for deterministic anomaly classification
- 8 new LiteSVM integration tests covering lifecycle guard edge cases (double completion, dispute after completion, claim after deadline, cancel after completion, deregister with active tasks/disputes, completion of cancelled task, claim on cancelled task)
- 4 new runtime transition validator unit tests for anomaly codes

## Test plan

- [x] `anchor build` passes
- [x] `npm run test:fast` — 172 LiteSVM tests pass (8 new)
- [x] `npm run test` — 2199 runtime tests pass (4 new)
- [x] `npm run typecheck` — clean across sdk, runtime, mcp
- [x] `npm run build` — all packages build