### PR TITLE
fix(program): make dispute paths deterministic and replay-aligned

### DIFF
--- a/programs/agenc-coordination/src/instructions/cancel_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_dispute.rs
@@ -76,7 +76,9 @@ pub fn handler(ctx: Context<CancelDispute>) -> Result<()> {
     let mut defendant = AgentRegistration::try_deserialize(&mut &**defendant_data)?;
     // Saturating decrement preserves recoverability for legacy stale counters.
     defendant.disputes_as_defendant = defendant.disputes_as_defendant.saturating_sub(1);
-    defendant.try_serialize(&mut &mut defendant_data[8..])?;
+    // Use AnchorSerialize::serialize (Borsh only) — see dispute_helpers.rs comment (fix #960).
+    AnchorSerialize::serialize(&defendant, &mut &mut defendant_data[8..])
+        .map_err(|_| anchor_lang::error::ErrorCode::AccountDidNotSerialize)?;
 
     emit!(DisputeCancelled {
         dispute_id: dispute.dispute_id,

--- a/programs/agenc-coordination/src/instructions/initialize_protocol.rs
+++ b/programs/agenc-coordination/src/instructions/initialize_protocol.rs
@@ -227,6 +227,7 @@ pub fn handler(
     config.max_disputes_per_24h = 10; // 10 disputes per 24h window
     config.min_stake_for_dispute = min_stake_for_dispute;
     config.slash_percentage = ProtocolConfig::DEFAULT_SLASH_PERCENTAGE;
+    config.voting_period = ProtocolConfig::DEFAULT_VOTING_PERIOD;
     // Versioning
     config.protocol_version = CURRENT_PROTOCOL_VERSION;
     config.min_supported_version = MIN_SUPPORTED_VERSION;

--- a/runtime/src/eval/index.ts
+++ b/runtime/src/eval/index.ts
@@ -39,6 +39,7 @@ export {
 
 export {
   projectOnChainEvents,
+  type DisputeReplayState,
   type OnChainProjectionInput,
   type ProjectionOptions,
   type ProjectionResult,


### PR DESCRIPTION
## Summary
- Fix critical serialization bug: `AccountSerialize::try_serialize` double-writes discriminator when called on `data[8..]`, corrupting accounts modified via `remaining_accounts` pattern. Changed to `AnchorSerialize::serialize` (Borsh only) in `dispute_helpers.rs`, `cancel_dispute.rs`, and `cancel_task.rs`
- Fix `initialize_protocol` missing `voting_period` initialization (was zero, breaking vote window logic)
- Add 13 LiteSVM dispute tests: vote window boundaries, slash idempotency, deterministic outcome parametrics, split payout correctness
- Add `DisputeReplayState` to runtime projector with 3 replay determinism tests

## Test plan
- [x] 185 LiteSVM integration tests pass (22 new)
- [x] 2202 runtime vitest tests pass
- [x] Typecheck clean
- [x] Build succeeds (sdk + runtime + mcp)

Closes #960