### PR TITLE
fix(program): add dev key feature flag and deployment hardening

### DIFF
--- a/programs/agenc-coordination/Cargo.toml
+++ b/programs/agenc-coordination/Cargo.toml
@@ -19,6 +19,10 @@ no-idl = []
 no-log-ix-name = []
 idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
 init-if-needed = []
+# Allow development verifying key for integration testing.
+# BYPASSES the unconditional dev key rejection in complete_task_private.
+# NEVER enable this in production builds.
+allow-dev-key = []
 
 [dependencies]
 anchor-lang = { version = "0.32.1", features = ["init-if-needed"] }

--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -390,9 +390,19 @@ fn verify_zk_proof(proof: &PrivateCompletionProof, task_key: Pubkey, agent: Pubk
     // Security check: block ZK proofs with development verifying key (issues #356, #358)
     // Development keys (gamma == delta) make proofs forgeable.
     // The key must be replaced via MPC ceremony before use.
-    require!(
-        !crate::verifying_key::is_development_key(),
-        CoordinationError::DevelopmentKeyNotAllowed
+    // The allow-dev-key feature bypasses this check for integration testing ONLY.
+    #[cfg(not(feature = "allow-dev-key"))]
+    {
+        require!(
+            !crate::verifying_key::is_development_key(),
+            CoordinationError::DevelopmentKeyNotAllowed
+        );
+    }
+
+    msg!(
+        "ZK verification using VK version {} (dev={})",
+        crate::verifying_key::VK_VERSION,
+        crate::verifying_key::is_development_key()
     );
 
     let public_inputs = build_public_inputs(&task_key, &agent, proof);

--- a/programs/agenc-coordination/src/verifying_key.rs
+++ b/programs/agenc-coordination/src/verifying_key.rs
@@ -552,6 +552,18 @@ pub const VK_IC: [[u8; 64]; 68] = [
     ],
 ];
 
+/// SHA-256 fingerprint of the concatenated verifying key components for version tracking.
+/// Allows off-chain systems to verify they are using the expected key.
+///
+/// Computed as: SHA256(VK_ALPHA_G1 || VK_BETA_G2 || VK_GAMMA_G2 || VK_DELTA_G2)
+///
+/// NOTE: Placeholder until MPC ceremony produces a production key.
+pub const VK_FINGERPRINT: [u8; 32] = [0u8; 32];
+
+/// Verifying key version. Increment after each MPC ceremony key rotation.
+/// 0 = development key, 1+ = production keys from MPC ceremony.
+pub const VK_VERSION: u8 = 0;
+
 /// Returns true if the verifying key is a development-only key (issues #356, #358).
 ///
 /// A development key has VK_GAMMA_G2 == VK_DELTA_G2, which means proofs are
@@ -635,5 +647,16 @@ mod tests {
     fn test_ic_length_matches() {
         assert_eq!(VK_IC.len(), VK_IC_LENGTH);
         assert_eq!(VK_IC_LENGTH, PUBLIC_INPUTS_COUNT + 1);
+    }
+
+    #[test]
+    fn test_vk_version_is_zero_for_dev_key() {
+        assert_eq!(VK_VERSION, 0);
+    }
+
+    #[test]
+    fn test_vk_fingerprint_is_placeholder() {
+        // Until MPC ceremony, fingerprint is all zeros
+        assert_eq!(VK_FINGERPRINT, [0u8; 32]);
     }
 }

--- a/scripts/check-deployment-readiness.sh
+++ b/scripts/check-deployment-readiness.sh
@@ -57,6 +57,28 @@ else
             pass "VK_GAMMA_G2 != VK_DELTA_G2: MPC ceremony key detected"
         fi
     fi
+
+    # Check VK_VERSION (fix #962)
+    VK_VERSION=$(grep 'pub const VK_VERSION' "$VK_FILE" | grep -oP '= \K\d+' | head -1 || echo "")
+    if [ -n "$VK_VERSION" ]; then
+        if [ "$VK_VERSION" = "0" ]; then
+            if [ "$NETWORK" = "mainnet" ]; then
+                fail "VK_VERSION is 0 (development key)"
+            else
+                warn "VK_VERSION is 0 (development key, acceptable for $NETWORK)"
+            fi
+        else
+            pass "VK_VERSION is $VK_VERSION"
+        fi
+    fi
+
+    # Check allow-dev-key not in default features (fix #962)
+    CARGO_FILE="programs/agenc-coordination/Cargo.toml"
+    if grep -q 'default.*allow-dev-key' "$CARGO_FILE" 2>/dev/null; then
+        fail "'allow-dev-key' is in default Cargo features"
+    else
+        pass "'allow-dev-key' not in default features"
+    fi
 fi
 echo ""
 


### PR DESCRIPTION
## Summary
- Add `allow-dev-key` Cargo feature flag (not in default features) to bypass dev key rejection in `complete_task_private`, enabling ZK integration testing
- Add `VK_VERSION` (0 = dev) and `VK_FINGERPRINT` (placeholder) metadata constants to `verifying_key.rs` for deployment tracking
- Gate existing dev key check with `#[cfg(not(feature = "allow-dev-key"))]` and add VK version logging
- Enhance `validate-verifying-key.sh` with version, fingerprint, and feature flag checks (`--mainnet` fails on dev key)
- Enhance `check-deployment-readiness.sh` with VK version and feature flag checks

## Test plan
- [x] 85 Rust unit tests pass (2 new for VK metadata)
- [x] SBF binary builds without `allow-dev-key` (default behavior preserved)
- [x] 185 LiteSVM integration tests pass
- [x] `validate-verifying-key.sh` warns on dev key, `--mainnet` fails
- [x] `allow-dev-key` NOT in default features

Closes #962