### PR TITLE
fix(sdk,runtime): remove protocol-critical edge leaks

### DIFF
--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -25,6 +25,9 @@ import {
   getAnchorErrorName,
   getAnchorErrorMessage,
   isRuntimeError,
+  // Validation helpers (#963)
+  validateByteLength,
+  validateNonZeroBytes,
 } from './errors';
 
 describe('RuntimeErrorCodes', () => {
@@ -53,17 +56,17 @@ describe('RuntimeErrorCodes', () => {
 });
 
 describe('AnchorErrorCodes', () => {
-  it('has exactly 78 error codes (6000-6077)', () => {
-    expect(Object.keys(AnchorErrorCodes)).toHaveLength(78);
+  it('has exactly 147 error codes (6000-6146)', () => {
+    expect(Object.keys(AnchorErrorCodes)).toHaveLength(147);
   });
 
-  it('has codes in range 6000-6077', () => {
+  it('has codes in range 6000-6146', () => {
     const codes = Object.values(AnchorErrorCodes);
     const minCode = Math.min(...codes);
     const maxCode = Math.max(...codes);
 
     expect(minCode).toBe(6000);
-    expect(maxCode).toBe(6077);
+    expect(maxCode).toBe(6146);
   });
 
   it('has sequential codes (no gaps)', () => {
@@ -73,109 +76,171 @@ describe('AnchorErrorCodes', () => {
     }
   });
 
-  it('has correct agent error codes (6000-6007)', () => {
+  it('has correct agent error codes (6000-6012)', () => {
     expect(AnchorErrorCodes.AgentAlreadyRegistered).toBe(6000);
     expect(AnchorErrorCodes.AgentNotFound).toBe(6001);
     expect(AnchorErrorCodes.AgentNotActive).toBe(6002);
     expect(AnchorErrorCodes.InsufficientCapabilities).toBe(6003);
-    expect(AnchorErrorCodes.MaxActiveTasksReached).toBe(6004);
-    expect(AnchorErrorCodes.AgentHasActiveTasks).toBe(6005);
-    expect(AnchorErrorCodes.UnauthorizedAgent).toBe(6006);
-    expect(AnchorErrorCodes.AgentRegistrationRequired).toBe(6007);
+    expect(AnchorErrorCodes.InvalidCapabilities).toBe(6004);
+    expect(AnchorErrorCodes.MaxActiveTasksReached).toBe(6005);
+    expect(AnchorErrorCodes.AgentHasActiveTasks).toBe(6006);
+    expect(AnchorErrorCodes.UnauthorizedAgent).toBe(6007);
+    expect(AnchorErrorCodes.CreatorAuthorityMismatch).toBe(6008);
+    expect(AnchorErrorCodes.InvalidAgentId).toBe(6009);
+    expect(AnchorErrorCodes.AgentRegistrationRequired).toBe(6010);
+    expect(AnchorErrorCodes.AgentSuspended).toBe(6011);
+    expect(AnchorErrorCodes.AgentBusyWithTasks).toBe(6012);
   });
 
-  it('has correct task error codes (6008-6023)', () => {
-    expect(AnchorErrorCodes.TaskNotFound).toBe(6008);
-    expect(AnchorErrorCodes.TaskNotOpen).toBe(6009);
-    expect(AnchorErrorCodes.TaskFullyClaimed).toBe(6010);
-    expect(AnchorErrorCodes.TaskExpired).toBe(6011);
-    expect(AnchorErrorCodes.TaskNotExpired).toBe(6012);
-    expect(AnchorErrorCodes.DeadlinePassed).toBe(6013);
-    expect(AnchorErrorCodes.TaskNotInProgress).toBe(6014);
-    expect(AnchorErrorCodes.TaskAlreadyCompleted).toBe(6015);
-    expect(AnchorErrorCodes.TaskCannotBeCancelled).toBe(6016);
-    expect(AnchorErrorCodes.UnauthorizedTaskAction).toBe(6017);
-    expect(AnchorErrorCodes.InvalidCreator).toBe(6018);
-    expect(AnchorErrorCodes.InvalidTaskType).toBe(6019);
-    expect(AnchorErrorCodes.CompetitiveTaskAlreadyWon).toBe(6020);
-    expect(AnchorErrorCodes.NoWorkers).toBe(6021);
-    expect(AnchorErrorCodes.ConstraintHashMismatch).toBe(6022);
-    expect(AnchorErrorCodes.NotPrivateTask).toBe(6023);
+  it('has correct task error codes (6013-6034)', () => {
+    expect(AnchorErrorCodes.TaskNotFound).toBe(6013);
+    expect(AnchorErrorCodes.TaskNotOpen).toBe(6014);
+    expect(AnchorErrorCodes.TaskFullyClaimed).toBe(6015);
+    expect(AnchorErrorCodes.TaskExpired).toBe(6016);
+    expect(AnchorErrorCodes.TaskNotExpired).toBe(6017);
+    expect(AnchorErrorCodes.DeadlinePassed).toBe(6018);
+    expect(AnchorErrorCodes.TaskNotInProgress).toBe(6019);
+    expect(AnchorErrorCodes.TaskAlreadyCompleted).toBe(6020);
+    expect(AnchorErrorCodes.TaskCannotBeCancelled).toBe(6021);
+    expect(AnchorErrorCodes.UnauthorizedTaskAction).toBe(6022);
+    expect(AnchorErrorCodes.InvalidCreator).toBe(6023);
+    expect(AnchorErrorCodes.InvalidTaskId).toBe(6024);
+    expect(AnchorErrorCodes.InvalidDescription).toBe(6025);
+    expect(AnchorErrorCodes.InvalidMaxWorkers).toBe(6026);
+    expect(AnchorErrorCodes.InvalidTaskType).toBe(6027);
+    expect(AnchorErrorCodes.InvalidDeadline).toBe(6028);
+    expect(AnchorErrorCodes.InvalidReward).toBe(6029);
+    expect(AnchorErrorCodes.InvalidRequiredCapabilities).toBe(6030);
+    expect(AnchorErrorCodes.CompetitiveTaskAlreadyWon).toBe(6031);
+    expect(AnchorErrorCodes.NoWorkers).toBe(6032);
+    expect(AnchorErrorCodes.ConstraintHashMismatch).toBe(6033);
+    expect(AnchorErrorCodes.NotPrivateTask).toBe(6034);
   });
 
-  it('has correct claim error codes (6024-6032)', () => {
-    expect(AnchorErrorCodes.AlreadyClaimed).toBe(6024);
-    expect(AnchorErrorCodes.NotClaimed).toBe(6025);
-    expect(AnchorErrorCodes.ClaimAlreadyCompleted).toBe(6026);
-    expect(AnchorErrorCodes.ClaimNotExpired).toBe(6027);
-    expect(AnchorErrorCodes.InvalidProof).toBe(6028);
-    expect(AnchorErrorCodes.ZkVerificationFailed).toBe(6029);
-    expect(AnchorErrorCodes.InvalidProofSize).toBe(6030);
-    expect(AnchorErrorCodes.InvalidProofBinding).toBe(6031);
-    expect(AnchorErrorCodes.InvalidOutputCommitment).toBe(6032);
+  it('has correct claim error codes (6035-6049)', () => {
+    expect(AnchorErrorCodes.AlreadyClaimed).toBe(6035);
+    expect(AnchorErrorCodes.NotClaimed).toBe(6036);
+    expect(AnchorErrorCodes.ClaimAlreadyCompleted).toBe(6037);
+    expect(AnchorErrorCodes.ClaimNotExpired).toBe(6038);
+    expect(AnchorErrorCodes.ClaimExpired).toBe(6039);
+    expect(AnchorErrorCodes.InvalidExpiration).toBe(6040);
+    expect(AnchorErrorCodes.InvalidProof).toBe(6041);
+    expect(AnchorErrorCodes.ZkVerificationFailed).toBe(6042);
+    expect(AnchorErrorCodes.InvalidProofSize).toBe(6043);
+    expect(AnchorErrorCodes.InvalidProofBinding).toBe(6044);
+    expect(AnchorErrorCodes.InvalidOutputCommitment).toBe(6045);
+    expect(AnchorErrorCodes.InvalidRentRecipient).toBe(6046);
+    expect(AnchorErrorCodes.GracePeriodNotPassed).toBe(6047);
+    expect(AnchorErrorCodes.InvalidProofHash).toBe(6048);
+    expect(AnchorErrorCodes.InvalidResultData).toBe(6049);
   });
 
-  it('has correct dispute error codes (6033-6047)', () => {
-    expect(AnchorErrorCodes.DisputeNotActive).toBe(6033);
-    expect(AnchorErrorCodes.VotingEnded).toBe(6034);
-    expect(AnchorErrorCodes.VotingNotEnded).toBe(6035);
-    expect(AnchorErrorCodes.AlreadyVoted).toBe(6036);
-    expect(AnchorErrorCodes.NotArbiter).toBe(6037);
-    expect(AnchorErrorCodes.InsufficientVotes).toBe(6038);
-    expect(AnchorErrorCodes.DisputeAlreadyResolved).toBe(6039);
-    expect(AnchorErrorCodes.UnauthorizedResolver).toBe(6040);
-    expect(AnchorErrorCodes.ActiveDisputeVotes).toBe(6041);
-    expect(AnchorErrorCodes.RecentVoteActivity).toBe(6042);
-    expect(AnchorErrorCodes.InsufficientEvidence).toBe(6043);
-    expect(AnchorErrorCodes.EvidenceTooLong).toBe(6044);
-    expect(AnchorErrorCodes.DisputeNotExpired).toBe(6045);
-    expect(AnchorErrorCodes.SlashAlreadyApplied).toBe(6046);
-    expect(AnchorErrorCodes.DisputeNotResolved).toBe(6047);
+  it('has correct dispute error codes (6050-6075)', () => {
+    expect(AnchorErrorCodes.DisputeNotActive).toBe(6050);
+    expect(AnchorErrorCodes.VotingEnded).toBe(6051);
+    expect(AnchorErrorCodes.VotingNotEnded).toBe(6052);
+    expect(AnchorErrorCodes.AlreadyVoted).toBe(6053);
+    expect(AnchorErrorCodes.NotArbiter).toBe(6054);
+    expect(AnchorErrorCodes.InsufficientVotes).toBe(6055);
+    expect(AnchorErrorCodes.DisputeAlreadyResolved).toBe(6056);
+    expect(AnchorErrorCodes.UnauthorizedResolver).toBe(6057);
+    expect(AnchorErrorCodes.ActiveDisputeVotes).toBe(6058);
+    expect(AnchorErrorCodes.RecentVoteActivity).toBe(6059);
+    expect(AnchorErrorCodes.AuthorityAlreadyVoted).toBe(6060);
+    expect(AnchorErrorCodes.InsufficientEvidence).toBe(6061);
+    expect(AnchorErrorCodes.EvidenceTooLong).toBe(6062);
+    expect(AnchorErrorCodes.DisputeNotExpired).toBe(6063);
+    expect(AnchorErrorCodes.SlashAlreadyApplied).toBe(6064);
+    expect(AnchorErrorCodes.SlashWindowExpired).toBe(6065);
+    expect(AnchorErrorCodes.DisputeNotResolved).toBe(6066);
+    expect(AnchorErrorCodes.NotTaskParticipant).toBe(6067);
+    expect(AnchorErrorCodes.InvalidEvidenceHash).toBe(6068);
+    expect(AnchorErrorCodes.ArbiterIsDisputeParticipant).toBe(6069);
+    expect(AnchorErrorCodes.InsufficientQuorum).toBe(6070);
+    expect(AnchorErrorCodes.ActiveDisputesExist).toBe(6071);
+    expect(AnchorErrorCodes.WorkerAgentRequired).toBe(6072);
+    expect(AnchorErrorCodes.WorkerClaimRequired).toBe(6073);
+    expect(AnchorErrorCodes.WorkerNotInDispute).toBe(6074);
+    expect(AnchorErrorCodes.InitiatorCannotResolve).toBe(6075);
   });
 
-  it('has correct state error codes (6048-6050)', () => {
-    expect(AnchorErrorCodes.VersionMismatch).toBe(6048);
-    expect(AnchorErrorCodes.StateKeyExists).toBe(6049);
-    expect(AnchorErrorCodes.StateNotFound).toBe(6050);
+  it('has correct state error codes (6076-6081)', () => {
+    expect(AnchorErrorCodes.VersionMismatch).toBe(6076);
+    expect(AnchorErrorCodes.StateKeyExists).toBe(6077);
+    expect(AnchorErrorCodes.StateNotFound).toBe(6078);
+    expect(AnchorErrorCodes.InvalidStateValue).toBe(6079);
+    expect(AnchorErrorCodes.StateOwnershipViolation).toBe(6080);
+    expect(AnchorErrorCodes.InvalidStateKey).toBe(6081);
   });
 
-  it('has correct protocol error codes (6051-6061)', () => {
-    expect(AnchorErrorCodes.ProtocolAlreadyInitialized).toBe(6051);
-    expect(AnchorErrorCodes.ProtocolNotInitialized).toBe(6052);
-    expect(AnchorErrorCodes.InvalidProtocolFee).toBe(6053);
-    expect(AnchorErrorCodes.InvalidDisputeThreshold).toBe(6054);
-    expect(AnchorErrorCodes.InsufficientStake).toBe(6055);
-    expect(AnchorErrorCodes.MultisigInvalidThreshold).toBe(6056);
-    expect(AnchorErrorCodes.MultisigInvalidSigners).toBe(6057);
-    expect(AnchorErrorCodes.MultisigNotEnoughSigners).toBe(6058);
-    expect(AnchorErrorCodes.MultisigDuplicateSigner).toBe(6059);
-    expect(AnchorErrorCodes.MultisigDefaultSigner).toBe(6060);
-    expect(AnchorErrorCodes.MultisigSignerNotSystemOwned).toBe(6061);
+  it('has correct protocol error codes (6082-6093)', () => {
+    expect(AnchorErrorCodes.ProtocolAlreadyInitialized).toBe(6082);
+    expect(AnchorErrorCodes.ProtocolNotInitialized).toBe(6083);
+    expect(AnchorErrorCodes.InvalidProtocolFee).toBe(6084);
+    expect(AnchorErrorCodes.InvalidTreasury).toBe(6085);
+    expect(AnchorErrorCodes.InvalidDisputeThreshold).toBe(6086);
+    expect(AnchorErrorCodes.InsufficientStake).toBe(6087);
+    expect(AnchorErrorCodes.MultisigInvalidThreshold).toBe(6088);
+    expect(AnchorErrorCodes.MultisigInvalidSigners).toBe(6089);
+    expect(AnchorErrorCodes.MultisigNotEnoughSigners).toBe(6090);
+    expect(AnchorErrorCodes.MultisigDuplicateSigner).toBe(6091);
+    expect(AnchorErrorCodes.MultisigDefaultSigner).toBe(6092);
+    expect(AnchorErrorCodes.MultisigSignerNotSystemOwned).toBe(6093);
   });
 
-  it('has correct general error codes (6062-6068)', () => {
-    expect(AnchorErrorCodes.InvalidInput).toBe(6062);
-    expect(AnchorErrorCodes.ArithmeticOverflow).toBe(6063);
-    expect(AnchorErrorCodes.VoteOverflow).toBe(6064);
-    expect(AnchorErrorCodes.InsufficientFunds).toBe(6065);
-    expect(AnchorErrorCodes.CorruptedData).toBe(6066);
-    expect(AnchorErrorCodes.StringTooLong).toBe(6067);
-    expect(AnchorErrorCodes.InvalidAccountOwner).toBe(6068);
+  it('has correct general error codes (6094-6101)', () => {
+    expect(AnchorErrorCodes.InvalidInput).toBe(6094);
+    expect(AnchorErrorCodes.ArithmeticOverflow).toBe(6095);
+    expect(AnchorErrorCodes.VoteOverflow).toBe(6096);
+    expect(AnchorErrorCodes.InsufficientFunds).toBe(6097);
+    expect(AnchorErrorCodes.RewardTooSmall).toBe(6098);
+    expect(AnchorErrorCodes.CorruptedData).toBe(6099);
+    expect(AnchorErrorCodes.StringTooLong).toBe(6100);
+    expect(AnchorErrorCodes.InvalidAccountOwner).toBe(6101);
   });
 
-  it('has correct rate limiting error codes (6069-6071)', () => {
-    expect(AnchorErrorCodes.RateLimitExceeded).toBe(6069);
-    expect(AnchorErrorCodes.CooldownNotElapsed).toBe(6070);
-    expect(AnchorErrorCodes.InsufficientStakeForDispute).toBe(6071);
+  it('has correct rate limiting error codes (6102-6110)', () => {
+    expect(AnchorErrorCodes.RateLimitExceeded).toBe(6102);
+    expect(AnchorErrorCodes.CooldownNotElapsed).toBe(6103);
+    expect(AnchorErrorCodes.UpdateTooFrequent).toBe(6104);
+    expect(AnchorErrorCodes.InvalidCooldown).toBe(6105);
+    expect(AnchorErrorCodes.CooldownTooLarge).toBe(6106);
+    expect(AnchorErrorCodes.RateLimitTooHigh).toBe(6107);
+    expect(AnchorErrorCodes.CooldownTooLong).toBe(6108);
+    expect(AnchorErrorCodes.InsufficientStakeForDispute).toBe(6109);
+    expect(AnchorErrorCodes.InsufficientStakeForCreatorDispute).toBe(6110);
   });
 
-  it('has correct version/upgrade error codes (6072-6077)', () => {
-    expect(AnchorErrorCodes.VersionMismatchProtocol).toBe(6072);
-    expect(AnchorErrorCodes.AccountVersionTooOld).toBe(6073);
-    expect(AnchorErrorCodes.AccountVersionTooNew).toBe(6074);
-    expect(AnchorErrorCodes.InvalidMigrationSource).toBe(6075);
-    expect(AnchorErrorCodes.InvalidMigrationTarget).toBe(6076);
-    expect(AnchorErrorCodes.UnauthorizedUpgrade).toBe(6077);
+  it('has correct version/upgrade error codes (6111-6118)', () => {
+    expect(AnchorErrorCodes.VersionMismatchProtocol).toBe(6111);
+    expect(AnchorErrorCodes.AccountVersionTooOld).toBe(6112);
+    expect(AnchorErrorCodes.AccountVersionTooNew).toBe(6113);
+    expect(AnchorErrorCodes.InvalidMigrationSource).toBe(6114);
+    expect(AnchorErrorCodes.InvalidMigrationTarget).toBe(6115);
+    expect(AnchorErrorCodes.UnauthorizedUpgrade).toBe(6116);
+    expect(AnchorErrorCodes.InvalidMinVersion).toBe(6117);
+    expect(AnchorErrorCodes.ProtocolConfigRequired).toBe(6118);
+  });
+
+  it('has correct dependency error codes (6119-6124)', () => {
+    expect(AnchorErrorCodes.ParentTaskCancelled).toBe(6119);
+    expect(AnchorErrorCodes.ParentTaskDisputed).toBe(6120);
+    expect(AnchorErrorCodes.InvalidDependencyType).toBe(6121);
+    expect(AnchorErrorCodes.ParentTaskNotCompleted).toBe(6122);
+    expect(AnchorErrorCodes.ParentTaskAccountRequired).toBe(6123);
+    expect(AnchorErrorCodes.UnauthorizedCreator).toBe(6124);
+  });
+
+  it('has correct nullifier error codes (6125-6126)', () => {
+    expect(AnchorErrorCodes.NullifierAlreadySpent).toBe(6125);
+    expect(AnchorErrorCodes.InvalidNullifier).toBe(6126);
+  });
+
+  it('has correct SPL token error codes (6143-6146)', () => {
+    expect(AnchorErrorCodes.MissingTokenAccounts).toBe(6143);
+    expect(AnchorErrorCodes.InvalidTokenEscrow).toBe(6144);
+    expect(AnchorErrorCodes.InvalidTokenMint).toBe(6145);
+    expect(AnchorErrorCodes.TokenTransferFailed).toBe(6146);
   });
 });
 
@@ -361,7 +426,7 @@ describe('isAnchorError', () => {
       error: {
         errorCode: {
           code: 'TaskNotOpen',
-          number: 6009,
+          number: AnchorErrorCodes.TaskNotOpen,
         },
       },
     };
@@ -389,7 +454,7 @@ describe('isAnchorError', () => {
 
   it('handles decimal error code in message', () => {
     const error = {
-      message: 'Error Number: 6024',
+      message: `Error Number: ${AnchorErrorCodes.AlreadyClaimed}`,
     };
     expect(isAnchorError(error, AnchorErrorCodes.AlreadyClaimed)).toBe(true);
   });
@@ -427,13 +492,13 @@ describe('parseAnchorError', () => {
     const error = {
       errorCode: {
         code: 'TaskExpired',
-        number: 6011,
+        number: AnchorErrorCodes.TaskExpired,
       },
     };
     const parsed = parseAnchorError(error);
 
     expect(parsed).not.toBeNull();
-    expect(parsed?.code).toBe(6011);
+    expect(parsed?.code).toBe(AnchorErrorCodes.TaskExpired);
     expect(parsed?.name).toBe('TaskExpired');
     expect(parsed?.message).toBe('Task has expired');
   });
@@ -443,49 +508,49 @@ describe('parseAnchorError', () => {
       error: {
         errorCode: {
           code: 'ZkVerificationFailed',
-          number: 6029,
+          number: AnchorErrorCodes.ZkVerificationFailed,
         },
       },
     };
     const parsed = parseAnchorError(error);
 
     expect(parsed).not.toBeNull();
-    expect(parsed?.code).toBe(6029);
+    expect(parsed?.code).toBe(AnchorErrorCodes.ZkVerificationFailed);
     expect(parsed?.name).toBe('ZkVerificationFailed');
   });
 
   it('parses transaction logs', () => {
     const error = {
       logs: [
-        'Program log: Error Code: DisputeNotActive. Error Number: 6033. Some message',
+        `Program log: Error Code: DisputeNotActive. Error Number: ${AnchorErrorCodes.DisputeNotActive}. Some message`,
       ],
     };
     const parsed = parseAnchorError(error);
 
     expect(parsed).not.toBeNull();
-    expect(parsed?.code).toBe(6033);
+    expect(parsed?.code).toBe(AnchorErrorCodes.DisputeNotActive);
     expect(parsed?.name).toBe('DisputeNotActive');
   });
 
   it('parses hex error code in message', () => {
     const error = {
-      message: 'custom program error: 0x17b5', // 6069
+      message: `custom program error: 0x${AnchorErrorCodes.RateLimitExceeded.toString(16)}`,
     };
     const parsed = parseAnchorError(error);
 
     expect(parsed).not.toBeNull();
-    expect(parsed?.code).toBe(6069);
+    expect(parsed?.code).toBe(AnchorErrorCodes.RateLimitExceeded);
     expect(parsed?.name).toBe('RateLimitExceeded');
   });
 
   it('parses decimal error code in message', () => {
     const error = {
-      message: 'Error Number: 6055',
+      message: `Error Number: ${AnchorErrorCodes.InsufficientStake}`,
     };
     const parsed = parseAnchorError(error);
 
     expect(parsed).not.toBeNull();
-    expect(parsed?.code).toBe(6055);
+    expect(parsed?.code).toBe(AnchorErrorCodes.InsufficientStake);
     expect(parsed?.name).toBe('InsufficientStake');
   });
 
@@ -498,7 +563,7 @@ describe('parseAnchorError', () => {
 
   it('returns null for code outside range', () => {
     expect(parseAnchorError({ code: 5999 })).toBeNull();
-    expect(parseAnchorError({ code: 6078 })).toBeNull();
+    expect(parseAnchorError({ code: 6147 })).toBeNull();
   });
 
   it('returns null for null/undefined', () => {
@@ -515,9 +580,10 @@ describe('parseAnchorError', () => {
     // Test a sampling of error codes to ensure messages are mapped
     const testCases = [
       { code: 6000, expected: 'Agent is already registered' },
-      { code: 6029, expected: 'ZK proof verification failed' },
-      { code: 6055, expected: 'Insufficient stake for arbiter registration' },
-      { code: 6077, expected: 'Only upgrade authority can perform this action' },
+      { code: AnchorErrorCodes.ZkVerificationFailed, expected: 'ZK proof verification failed' },
+      { code: AnchorErrorCodes.InsufficientStake, expected: 'Insufficient stake for arbiter registration' },
+      { code: AnchorErrorCodes.UnauthorizedUpgrade, expected: 'Only upgrade authority can perform this action' },
+      { code: AnchorErrorCodes.TokenTransferFailed, expected: 'SPL token transfer CPI failed' },
     ];
 
     for (const { code, expected } of testCases) {
@@ -530,18 +596,19 @@ describe('parseAnchorError', () => {
 describe('getAnchorErrorName', () => {
   it('returns correct name for valid code', () => {
     expect(getAnchorErrorName(6000)).toBe('AgentAlreadyRegistered');
-    expect(getAnchorErrorName(6029)).toBe('ZkVerificationFailed');
-    expect(getAnchorErrorName(6077)).toBe('UnauthorizedUpgrade');
+    expect(getAnchorErrorName(AnchorErrorCodes.ZkVerificationFailed)).toBe('ZkVerificationFailed');
+    expect(getAnchorErrorName(AnchorErrorCodes.UnauthorizedUpgrade)).toBe('UnauthorizedUpgrade');
+    expect(getAnchorErrorName(AnchorErrorCodes.TokenTransferFailed)).toBe('TokenTransferFailed');
   });
 
   it('returns undefined for invalid code', () => {
     expect(getAnchorErrorName(5999)).toBeUndefined();
-    expect(getAnchorErrorName(6078)).toBeUndefined();
+    expect(getAnchorErrorName(6147)).toBeUndefined();
     expect(getAnchorErrorName(0)).toBeUndefined();
   });
 
-  it('returns name for all 78 codes', () => {
-    for (let code = 6000; code <= 6077; code++) {
+  it('returns name for all 147 codes', () => {
+    for (let code = 6000; code <= 6146; code++) {
       const name = getAnchorErrorName(code);
       expect(name).toBeDefined();
       expect(typeof name).toBe('string');
@@ -552,11 +619,12 @@ describe('getAnchorErrorName', () => {
 describe('getAnchorErrorMessage', () => {
   it('returns correct message for valid code', () => {
     expect(getAnchorErrorMessage(6000)).toBe('Agent is already registered');
-    expect(getAnchorErrorMessage(6029)).toBe('ZK proof verification failed');
+    expect(getAnchorErrorMessage(AnchorErrorCodes.ZkVerificationFailed)).toBe('ZK proof verification failed');
+    expect(getAnchorErrorMessage(AnchorErrorCodes.TokenTransferFailed)).toBe('SPL token transfer CPI failed');
   });
 
-  it('returns message for all 78 codes', () => {
-    for (let code = 6000; code <= 6077; code++) {
+  it('returns message for all 147 codes', () => {
+    for (let code = 6000; code <= 6146; code++) {
       const message = getAnchorErrorMessage(code as AnchorErrorCode);
       expect(message).toBeDefined();
       expect(typeof message).toBe('string');
@@ -668,5 +736,29 @@ describe('Type exports', () => {
     expect(parsed.code).toBe(6000);
     expect(parsed.name).toBe('AgentAlreadyRegistered');
     expect(parsed.message).toBe('Agent is already registered');
+  });
+});
+
+describe('validateByteLength', () => {
+  it('returns Uint8Array for valid input', () => {
+    const input = new Uint8Array(32);
+    const result = validateByteLength(input, 32, 'testParam');
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(result.length).toBe(32);
+  });
+
+  it('throws ValidationError for wrong length', () => {
+    expect(() => validateByteLength(new Uint8Array(16), 32, 'testParam')).toThrow(ValidationError);
+  });
+});
+
+describe('validateNonZeroBytes', () => {
+  it('passes for non-zero bytes', () => {
+    const input = new Uint8Array([1, 2, 3, 4]);
+    expect(() => validateNonZeroBytes(input, 'testParam')).not.toThrow();
+  });
+
+  it('throws ValidationError for all-zero bytes', () => {
+    expect(() => validateNonZeroBytes(new Uint8Array(32), 'testParam')).toThrow(ValidationError);
   });
 });

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -114,15 +114,16 @@ export const RuntimeErrorCodes = {
 export type RuntimeErrorCode = (typeof RuntimeErrorCodes)[keyof typeof RuntimeErrorCodes];
 
 // ============================================================================
-// Anchor Error Codes (78 codes: 6000-6077)
+// Anchor Error Codes (147 codes: 6000-6146)
 // ============================================================================
 
 /**
  * Numeric error codes matching the Anchor program's CoordinationError enum.
- * Codes are organized by category as defined in programs/agenc-coordination/src/errors.rs
+ * Codes are assigned sequentially starting from 6000 based on enum variant order
+ * in programs/agenc-coordination/src/errors.rs
  */
 export const AnchorErrorCodes = {
-  // Agent errors (6000-6007)
+  // Agent errors (6000-6012)
   /** Agent is already registered */
   AgentAlreadyRegistered: 6000,
   /** Agent not found */
@@ -131,170 +132,330 @@ export const AnchorErrorCodes = {
   AgentNotActive: 6002,
   /** Agent has insufficient capabilities */
   InsufficientCapabilities: 6003,
+  /** Agent capabilities bitmask cannot be zero */
+  InvalidCapabilities: 6004,
   /** Agent has reached maximum active tasks */
-  MaxActiveTasksReached: 6004,
+  MaxActiveTasksReached: 6005,
   /** Agent has active tasks and cannot be deregistered */
-  AgentHasActiveTasks: 6005,
+  AgentHasActiveTasks: 6006,
   /** Only the agent authority can perform this action */
-  UnauthorizedAgent: 6006,
+  UnauthorizedAgent: 6007,
+  /** Creator must match authority to prevent social engineering */
+  CreatorAuthorityMismatch: 6008,
+  /** Invalid agent ID: agent_id cannot be all zeros */
+  InvalidAgentId: 6009,
   /** Agent registration required to create tasks */
-  AgentRegistrationRequired: 6007,
+  AgentRegistrationRequired: 6010,
+  /** Agent is suspended and cannot change status */
+  AgentSuspended: 6011,
+  /** Agent cannot set status to Active while having active tasks */
+  AgentBusyWithTasks: 6012,
 
-  // Task errors (6008-6023)
+  // Task errors (6013-6034)
   /** Task not found */
-  TaskNotFound: 6008,
+  TaskNotFound: 6013,
   /** Task is not open for claims */
-  TaskNotOpen: 6009,
+  TaskNotOpen: 6014,
   /** Task has reached maximum workers */
-  TaskFullyClaimed: 6010,
+  TaskFullyClaimed: 6015,
   /** Task has expired */
-  TaskExpired: 6011,
+  TaskExpired: 6016,
   /** Task deadline has not passed */
-  TaskNotExpired: 6012,
+  TaskNotExpired: 6017,
   /** Task deadline has passed */
-  DeadlinePassed: 6013,
+  DeadlinePassed: 6018,
   /** Task is not in progress */
-  TaskNotInProgress: 6014,
+  TaskNotInProgress: 6019,
   /** Task is already completed */
-  TaskAlreadyCompleted: 6015,
+  TaskAlreadyCompleted: 6020,
   /** Task cannot be cancelled */
-  TaskCannotBeCancelled: 6016,
+  TaskCannotBeCancelled: 6021,
   /** Only the task creator can perform this action */
-  UnauthorizedTaskAction: 6017,
+  UnauthorizedTaskAction: 6022,
   /** Invalid creator */
-  InvalidCreator: 6018,
+  InvalidCreator: 6023,
+  /** Invalid task ID: cannot be zero */
+  InvalidTaskId: 6024,
+  /** Invalid description: cannot be empty */
+  InvalidDescription: 6025,
+  /** Invalid max workers: must be between 1 and 100 */
+  InvalidMaxWorkers: 6026,
   /** Invalid task type */
-  InvalidTaskType: 6019,
+  InvalidTaskType: 6027,
+  /** Invalid deadline: deadline must be greater than zero */
+  InvalidDeadline: 6028,
+  /** Invalid reward: reward must be greater than zero */
+  InvalidReward: 6029,
+  /** Invalid required capabilities: required_capabilities cannot be zero */
+  InvalidRequiredCapabilities: 6030,
   /** Competitive task already completed by another worker */
-  CompetitiveTaskAlreadyWon: 6020,
+  CompetitiveTaskAlreadyWon: 6031,
   /** Task has no workers */
-  NoWorkers: 6021,
+  NoWorkers: 6032,
   /** Proof constraint hash does not match task's stored constraint hash */
-  ConstraintHashMismatch: 6022,
+  ConstraintHashMismatch: 6033,
   /** Task is not a private task (no constraint hash set) */
-  NotPrivateTask: 6023,
+  NotPrivateTask: 6034,
 
-  // Claim errors (6024-6032)
+  // Claim errors (6035-6049)
   /** Worker has already claimed this task */
-  AlreadyClaimed: 6024,
+  AlreadyClaimed: 6035,
   /** Worker has not claimed this task */
-  NotClaimed: 6025,
+  NotClaimed: 6036,
   /** Claim has already been completed */
-  ClaimAlreadyCompleted: 6026,
+  ClaimAlreadyCompleted: 6037,
   /** Claim has not expired yet */
-  ClaimNotExpired: 6027,
+  ClaimNotExpired: 6038,
+  /** Claim has expired */
+  ClaimExpired: 6039,
+  /** Invalid expiration: expires_at cannot be zero */
+  InvalidExpiration: 6040,
   /** Invalid proof of work */
-  InvalidProof: 6028,
+  InvalidProof: 6041,
   /** ZK proof verification failed */
-  ZkVerificationFailed: 6029,
-  /** Invalid proof size - expected 388 bytes for Groth16 */
-  InvalidProofSize: 6030,
+  ZkVerificationFailed: 6042,
+  /** Invalid proof size - expected 256 bytes for Groth16 */
+  InvalidProofSize: 6043,
   /** Invalid proof binding: expected_binding cannot be all zeros */
-  InvalidProofBinding: 6031,
+  InvalidProofBinding: 6044,
   /** Invalid output commitment: output_commitment cannot be all zeros */
-  InvalidOutputCommitment: 6032,
+  InvalidOutputCommitment: 6045,
+  /** Invalid rent recipient: must be worker authority */
+  InvalidRentRecipient: 6046,
+  /** Grace period not passed: only worker authority can expire claim within 60 seconds of expiry */
+  GracePeriodNotPassed: 6047,
+  /** Invalid proof hash: proof_hash cannot be all zeros */
+  InvalidProofHash: 6048,
+  /** Invalid result data: result_data cannot be all zeros when provided */
+  InvalidResultData: 6049,
 
-  // Dispute errors (6033-6047)
+  // Dispute errors (6050-6075)
   /** Dispute is not active */
-  DisputeNotActive: 6033,
+  DisputeNotActive: 6050,
   /** Voting period has ended */
-  VotingEnded: 6034,
+  VotingEnded: 6051,
   /** Voting period has not ended */
-  VotingNotEnded: 6035,
+  VotingNotEnded: 6052,
   /** Already voted on this dispute */
-  AlreadyVoted: 6036,
+  AlreadyVoted: 6053,
   /** Not authorized to vote (not an arbiter) */
-  NotArbiter: 6037,
+  NotArbiter: 6054,
   /** Insufficient votes to resolve */
-  InsufficientVotes: 6038,
+  InsufficientVotes: 6055,
   /** Dispute has already been resolved */
-  DisputeAlreadyResolved: 6039,
+  DisputeAlreadyResolved: 6056,
   /** Only protocol authority or dispute initiator can resolve disputes */
-  UnauthorizedResolver: 6040,
+  UnauthorizedResolver: 6057,
   /** Agent has active dispute votes pending resolution */
-  ActiveDisputeVotes: 6041,
+  ActiveDisputeVotes: 6058,
   /** Agent must wait 24 hours after voting before deregistering */
-  RecentVoteActivity: 6042,
+  RecentVoteActivity: 6059,
+  /** Authority has already voted on this dispute */
+  AuthorityAlreadyVoted: 6060,
   /** Insufficient dispute evidence provided */
-  InsufficientEvidence: 6043,
+  InsufficientEvidence: 6061,
   /** Dispute evidence exceeds maximum allowed length */
-  EvidenceTooLong: 6044,
+  EvidenceTooLong: 6062,
   /** Dispute has not expired */
-  DisputeNotExpired: 6045,
+  DisputeNotExpired: 6063,
   /** Dispute slashing already applied */
-  SlashAlreadyApplied: 6046,
+  SlashAlreadyApplied: 6064,
+  /** Slash window expired: must apply slashing within 7 days of resolution */
+  SlashWindowExpired: 6065,
   /** Dispute has not been resolved */
-  DisputeNotResolved: 6047,
+  DisputeNotResolved: 6066,
+  /** Only task creator or workers can initiate disputes */
+  NotTaskParticipant: 6067,
+  /** Invalid evidence hash: cannot be all zeros */
+  InvalidEvidenceHash: 6068,
+  /** Arbiter cannot vote on disputes they are a participant in */
+  ArbiterIsDisputeParticipant: 6069,
+  /** Insufficient quorum: minimum number of voters not reached */
+  InsufficientQuorum: 6070,
+  /** Agent has active disputes as defendant and cannot deregister */
+  ActiveDisputesExist: 6071,
+  /** Worker agent account required when creator initiates dispute */
+  WorkerAgentRequired: 6072,
+  /** Worker claim account required when creator initiates dispute */
+  WorkerClaimRequired: 6073,
+  /** Worker was not involved in this dispute */
+  WorkerNotInDispute: 6074,
+  /** Dispute initiator cannot resolve their own dispute */
+  InitiatorCannotResolve: 6075,
 
-  // State errors (6048-6050)
+  // State errors (6076-6081)
   /** State version mismatch (concurrent modification) */
-  VersionMismatch: 6048,
+  VersionMismatch: 6076,
   /** State key already exists */
-  StateKeyExists: 6049,
+  StateKeyExists: 6077,
   /** State not found */
-  StateNotFound: 6050,
+  StateNotFound: 6078,
+  /** Invalid state value: state_value cannot be all zeros */
+  InvalidStateValue: 6079,
+  /** State ownership violation: only the creator agent can update this state */
+  StateOwnershipViolation: 6080,
+  /** Invalid state key: state_key cannot be all zeros */
+  InvalidStateKey: 6081,
 
-  // Protocol errors (6051-6061)
+  // Protocol errors (6082-6093)
   /** Protocol is already initialized */
-  ProtocolAlreadyInitialized: 6051,
+  ProtocolAlreadyInitialized: 6082,
   /** Protocol is not initialized */
-  ProtocolNotInitialized: 6052,
+  ProtocolNotInitialized: 6083,
   /** Invalid protocol fee (must be <= 1000 bps) */
-  InvalidProtocolFee: 6053,
-  /** Invalid dispute threshold */
-  InvalidDisputeThreshold: 6054,
+  InvalidProtocolFee: 6084,
+  /** Invalid treasury: treasury account cannot be default pubkey */
+  InvalidTreasury: 6085,
+  /** Invalid dispute threshold: must be 1-100 (percentage of votes required) */
+  InvalidDisputeThreshold: 6086,
   /** Insufficient stake for arbiter registration */
-  InsufficientStake: 6055,
+  InsufficientStake: 6087,
   /** Invalid multisig threshold */
-  MultisigInvalidThreshold: 6056,
+  MultisigInvalidThreshold: 6088,
   /** Invalid multisig signer configuration */
-  MultisigInvalidSigners: 6057,
+  MultisigInvalidSigners: 6089,
   /** Not enough multisig signers */
-  MultisigNotEnoughSigners: 6058,
+  MultisigNotEnoughSigners: 6090,
   /** Duplicate multisig signer provided */
-  MultisigDuplicateSigner: 6059,
+  MultisigDuplicateSigner: 6091,
   /** Multisig signer cannot be default pubkey */
-  MultisigDefaultSigner: 6060,
+  MultisigDefaultSigner: 6092,
   /** Multisig signer account not owned by System Program */
-  MultisigSignerNotSystemOwned: 6061,
+  MultisigSignerNotSystemOwned: 6093,
 
-  // General errors (6062-6068)
+  // General errors (6094-6101)
   /** Invalid input parameter */
-  InvalidInput: 6062,
+  InvalidInput: 6094,
   /** Arithmetic overflow */
-  ArithmeticOverflow: 6063,
+  ArithmeticOverflow: 6095,
   /** Vote count overflow */
-  VoteOverflow: 6064,
+  VoteOverflow: 6096,
   /** Insufficient funds */
-  InsufficientFunds: 6065,
+  InsufficientFunds: 6097,
+  /** Reward too small: worker must receive at least 1 lamport */
+  RewardTooSmall: 6098,
   /** Account data is corrupted */
-  CorruptedData: 6066,
+  CorruptedData: 6099,
   /** String too long */
-  StringTooLong: 6067,
+  StringTooLong: 6100,
   /** Account owner validation failed: account not owned by this program */
-  InvalidAccountOwner: 6068,
+  InvalidAccountOwner: 6101,
 
-  // Rate limiting errors (6069-6071)
+  // Rate limiting errors (6102-6110)
   /** Rate limit exceeded: maximum actions per 24h window reached */
-  RateLimitExceeded: 6069,
+  RateLimitExceeded: 6102,
   /** Cooldown period has not elapsed since last action */
-  CooldownNotElapsed: 6070,
+  CooldownNotElapsed: 6103,
+  /** Agent update too frequent: must wait cooldown period */
+  UpdateTooFrequent: 6104,
+  /** Cooldown value cannot be negative */
+  InvalidCooldown: 6105,
+  /** Cooldown value exceeds maximum (24 hours) */
+  CooldownTooLarge: 6106,
+  /** Rate limit value exceeds maximum allowed (1000) */
+  RateLimitTooHigh: 6107,
+  /** Cooldown value exceeds maximum allowed (1 week) */
+  CooldownTooLong: 6108,
   /** Insufficient stake to initiate dispute */
-  InsufficientStakeForDispute: 6071,
+  InsufficientStakeForDispute: 6109,
+  /** Creator-initiated disputes require 2x the minimum stake */
+  InsufficientStakeForCreatorDispute: 6110,
 
-  // Version/upgrade errors (6072-6077)
+  // Version/upgrade errors (6111-6118)
   /** Protocol version mismatch: account version incompatible with current program */
-  VersionMismatchProtocol: 6072,
+  VersionMismatchProtocol: 6111,
   /** Account version too old: migration required */
-  AccountVersionTooOld: 6073,
+  AccountVersionTooOld: 6112,
   /** Account version too new: program upgrade required */
-  AccountVersionTooNew: 6074,
+  AccountVersionTooNew: 6113,
   /** Migration not allowed: invalid source version */
-  InvalidMigrationSource: 6075,
+  InvalidMigrationSource: 6114,
   /** Migration not allowed: invalid target version */
-  InvalidMigrationTarget: 6076,
+  InvalidMigrationTarget: 6115,
   /** Only upgrade authority can perform this action */
-  UnauthorizedUpgrade: 6077,
+  UnauthorizedUpgrade: 6116,
+  /** Minimum version cannot exceed current protocol version */
+  InvalidMinVersion: 6117,
+  /** Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts */
+  ProtocolConfigRequired: 6118,
+
+  // Dependency errors (6119-6124)
+  /** Parent task has been cancelled */
+  ParentTaskCancelled: 6119,
+  /** Parent task is in disputed state */
+  ParentTaskDisputed: 6120,
+  /** Invalid dependency type */
+  InvalidDependencyType: 6121,
+  /** Parent task must be completed before completing a proof-dependent task */
+  ParentTaskNotCompleted: 6122,
+  /** Parent task account required for proof-dependent task completion */
+  ParentTaskAccountRequired: 6123,
+  /** Parent task does not belong to the same creator */
+  UnauthorizedCreator: 6124,
+
+  // Nullifier errors (6125-6126)
+  /** Nullifier has already been spent - proof/knowledge reuse detected */
+  NullifierAlreadySpent: 6125,
+  /** Invalid nullifier: nullifier value cannot be all zeros */
+  InvalidNullifier: 6126,
+
+  // Cancel task errors (6127-6128)
+  /** All worker accounts must be provided when cancelling a task with active claims */
+  IncompleteWorkerAccounts: 6127,
+  /** Worker accounts required when task has active workers */
+  WorkerAccountsRequired: 6128,
+
+  // Duplicate account errors (6129)
+  /** Duplicate arbiter provided in remaining_accounts */
+  DuplicateArbiter: 6129,
+
+  // Escrow errors (6130)
+  /** Escrow has insufficient balance for reward transfer */
+  InsufficientEscrowBalance: 6130,
+
+  // Status transition errors (6131)
+  /** Invalid task status transition */
+  InvalidStatusTransition: 6131,
+
+  // Stake validation errors (6132-6134)
+  /** Stake value is below minimum required (0.001 SOL) */
+  StakeTooLow: 6132,
+  /** min_stake_for_dispute must be greater than zero */
+  InvalidMinStake: 6133,
+  /** Slash amount must be greater than zero */
+  InvalidSlashAmount: 6134,
+
+  // Speculation Bond errors (6135-6138)
+  /** Bond amount too low */
+  BondAmountTooLow: 6135,
+  /** Bond already exists */
+  BondAlreadyExists: 6136,
+  /** Bond not found */
+  BondNotFound: 6137,
+  /** Bond not yet matured */
+  BondNotMatured: 6138,
+
+  // Reputation errors (6139-6140)
+  /** Agent reputation below task minimum requirement */
+  InsufficientReputation: 6139,
+  /** Invalid minimum reputation: must be <= 10000 */
+  InvalidMinReputation: 6140,
+
+  // Security errors (6141-6142)
+  /** Development verifying key detected (gamma == delta). ZK proofs are forgeable. */
+  DevelopmentKeyNotAllowed: 6141,
+  /** Cannot claim own task: worker authority matches task creator */
+  SelfTaskNotAllowed: 6142,
+
+  // SPL Token errors (6143-6146)
+  /** Token accounts not provided for token-denominated task */
+  MissingTokenAccounts: 6143,
+  /** Token escrow ATA does not match expected derivation */
+  InvalidTokenEscrow: 6144,
+  /** Provided mint does not match task's reward_mint */
+  InvalidTokenMint: 6145,
+  /** SPL token transfer CPI failed */
+  TokenTransferFailed: 6146,
 } as const;
 
 /** Union type of all Anchor error code values */
@@ -309,85 +470,206 @@ export type AnchorErrorName = keyof typeof AnchorErrorCodes;
 
 /** Human-readable messages for each Anchor error code */
 const AnchorErrorMessages: Record<AnchorErrorCode, string> = {
+  // Agent errors (6000-6012)
   6000: 'Agent is already registered',
   6001: 'Agent not found',
   6002: 'Agent is not active',
   6003: 'Agent has insufficient capabilities',
-  6004: 'Agent has reached maximum active tasks',
-  6005: 'Agent has active tasks and cannot be deregistered',
-  6006: 'Only the agent authority can perform this action',
-  6007: 'Agent registration required to create tasks',
-  6008: 'Task not found',
-  6009: 'Task is not open for claims',
-  6010: 'Task has reached maximum workers',
-  6011: 'Task has expired',
-  6012: 'Task deadline has not passed',
-  6013: 'Task deadline has passed',
-  6014: 'Task is not in progress',
-  6015: 'Task is already completed',
-  6016: 'Task cannot be cancelled',
-  6017: 'Only the task creator can perform this action',
-  6018: 'Invalid creator',
-  6019: 'Invalid task type',
-  6020: 'Competitive task already completed by another worker',
-  6021: 'Task has no workers',
-  6022: "Proof constraint hash does not match task's stored constraint hash",
-  6023: 'Task is not a private task (no constraint hash set)',
-  6024: 'Worker has already claimed this task',
-  6025: 'Worker has not claimed this task',
-  6026: 'Claim has already been completed',
-  6027: 'Claim has not expired yet',
-  6028: 'Invalid proof of work',
-  6029: 'ZK proof verification failed',
-  6030: 'Invalid proof size - expected 388 bytes for Groth16',
-  6031: 'Invalid proof binding: expected_binding cannot be all zeros',
-  6032: 'Invalid output commitment: output_commitment cannot be all zeros',
-  6033: 'Dispute is not active',
-  6034: 'Voting period has ended',
-  6035: 'Voting period has not ended',
-  6036: 'Already voted on this dispute',
-  6037: 'Not authorized to vote (not an arbiter)',
-  6038: 'Insufficient votes to resolve',
-  6039: 'Dispute has already been resolved',
-  6040: 'Only protocol authority or dispute initiator can resolve disputes',
-  6041: 'Agent has active dispute votes pending resolution',
-  6042: 'Agent must wait 24 hours after voting before deregistering',
-  6043: 'Insufficient dispute evidence provided',
-  6044: 'Dispute evidence exceeds maximum allowed length',
-  6045: 'Dispute has not expired',
-  6046: 'Dispute slashing already applied',
-  6047: 'Dispute has not been resolved',
-  6048: 'State version mismatch (concurrent modification)',
-  6049: 'State key already exists',
-  6050: 'State not found',
-  6051: 'Protocol is already initialized',
-  6052: 'Protocol is not initialized',
-  6053: 'Invalid protocol fee (must be <= 1000 bps)',
-  6054: 'Invalid dispute threshold',
-  6055: 'Insufficient stake for arbiter registration',
-  6056: 'Invalid multisig threshold',
-  6057: 'Invalid multisig signer configuration',
-  6058: 'Not enough multisig signers',
-  6059: 'Duplicate multisig signer provided',
-  6060: 'Multisig signer cannot be default pubkey',
-  6061: 'Multisig signer account not owned by System Program',
-  6062: 'Invalid input parameter',
-  6063: 'Arithmetic overflow',
-  6064: 'Vote count overflow',
-  6065: 'Insufficient funds',
-  6066: 'Account data is corrupted',
-  6067: 'String too long',
-  6068: 'Account owner validation failed: account not owned by this program',
-  6069: 'Rate limit exceeded: maximum actions per 24h window reached',
-  6070: 'Cooldown period has not elapsed since last action',
-  6071: 'Insufficient stake to initiate dispute',
-  6072: 'Protocol version mismatch: account version incompatible with current program',
-  6073: 'Account version too old: migration required',
-  6074: 'Account version too new: program upgrade required',
-  6075: 'Migration not allowed: invalid source version',
-  6076: 'Migration not allowed: invalid target version',
-  6077: 'Only upgrade authority can perform this action',
+  6004: 'Agent capabilities bitmask cannot be zero',
+  6005: 'Agent has reached maximum active tasks',
+  6006: 'Agent has active tasks and cannot be deregistered',
+  6007: 'Only the agent authority can perform this action',
+  6008: 'Creator must match authority to prevent social engineering',
+  6009: 'Invalid agent ID: agent_id cannot be all zeros',
+  6010: 'Agent registration required to create tasks',
+  6011: 'Agent is suspended and cannot change status',
+  6012: 'Agent cannot set status to Active while having active tasks',
+  // Task errors (6013-6034)
+  6013: 'Task not found',
+  6014: 'Task is not open for claims',
+  6015: 'Task has reached maximum workers',
+  6016: 'Task has expired',
+  6017: 'Task deadline has not passed',
+  6018: 'Task deadline has passed',
+  6019: 'Task is not in progress',
+  6020: 'Task is already completed',
+  6021: 'Task cannot be cancelled',
+  6022: 'Only the task creator can perform this action',
+  6023: 'Invalid creator',
+  6024: 'Invalid task ID: cannot be zero',
+  6025: 'Invalid description: cannot be empty',
+  6026: 'Invalid max workers: must be between 1 and 100',
+  6027: 'Invalid task type',
+  6028: 'Invalid deadline: deadline must be greater than zero',
+  6029: 'Invalid reward: reward must be greater than zero',
+  6030: 'Invalid required capabilities: required_capabilities cannot be zero',
+  6031: 'Competitive task already completed by another worker',
+  6032: 'Task has no workers',
+  6033: "Proof constraint hash does not match task's stored constraint hash",
+  6034: 'Task is not a private task (no constraint hash set)',
+  // Claim errors (6035-6049)
+  6035: 'Worker has already claimed this task',
+  6036: 'Worker has not claimed this task',
+  6037: 'Claim has already been completed',
+  6038: 'Claim has not expired yet',
+  6039: 'Claim has expired',
+  6040: 'Invalid expiration: expires_at cannot be zero',
+  6041: 'Invalid proof of work',
+  6042: 'ZK proof verification failed',
+  6043: 'Invalid proof size - expected 256 bytes for Groth16',
+  6044: 'Invalid proof binding: expected_binding cannot be all zeros',
+  6045: 'Invalid output commitment: output_commitment cannot be all zeros',
+  6046: 'Invalid rent recipient: must be worker authority',
+  6047: 'Grace period not passed: only worker authority can expire claim within 60 seconds of expiry',
+  6048: 'Invalid proof hash: proof_hash cannot be all zeros',
+  6049: 'Invalid result data: result_data cannot be all zeros when provided',
+  // Dispute errors (6050-6075)
+  6050: 'Dispute is not active',
+  6051: 'Voting period has ended',
+  6052: 'Voting period has not ended',
+  6053: 'Already voted on this dispute',
+  6054: 'Not authorized to vote (not an arbiter)',
+  6055: 'Insufficient votes to resolve',
+  6056: 'Dispute has already been resolved',
+  6057: 'Only protocol authority or dispute initiator can resolve disputes',
+  6058: 'Agent has active dispute votes pending resolution',
+  6059: 'Agent must wait 24 hours after voting before deregistering',
+  6060: 'Authority has already voted on this dispute',
+  6061: 'Insufficient dispute evidence provided',
+  6062: 'Dispute evidence exceeds maximum allowed length',
+  6063: 'Dispute has not expired',
+  6064: 'Dispute slashing already applied',
+  6065: 'Slash window expired: must apply slashing within 7 days of resolution',
+  6066: 'Dispute has not been resolved',
+  6067: 'Only task creator or workers can initiate disputes',
+  6068: 'Invalid evidence hash: cannot be all zeros',
+  6069: 'Arbiter cannot vote on disputes they are a participant in',
+  6070: 'Insufficient quorum: minimum number of voters not reached',
+  6071: 'Agent has active disputes as defendant and cannot deregister',
+  6072: 'Worker agent account required when creator initiates dispute',
+  6073: 'Worker claim account required when creator initiates dispute',
+  6074: 'Worker was not involved in this dispute',
+  6075: 'Dispute initiator cannot resolve their own dispute',
+  // State errors (6076-6081)
+  6076: 'State version mismatch (concurrent modification)',
+  6077: 'State key already exists',
+  6078: 'State not found',
+  6079: 'Invalid state value: state_value cannot be all zeros',
+  6080: 'State ownership violation: only the creator agent can update this state',
+  6081: 'Invalid state key: state_key cannot be all zeros',
+  // Protocol errors (6082-6093)
+  6082: 'Protocol is already initialized',
+  6083: 'Protocol is not initialized',
+  6084: 'Invalid protocol fee (must be <= 1000 bps)',
+  6085: 'Invalid treasury: treasury account cannot be default pubkey',
+  6086: 'Invalid dispute threshold: must be 1-100 (percentage of votes required)',
+  6087: 'Insufficient stake for arbiter registration',
+  6088: 'Invalid multisig threshold',
+  6089: 'Invalid multisig signer configuration',
+  6090: 'Not enough multisig signers',
+  6091: 'Duplicate multisig signer provided',
+  6092: 'Multisig signer cannot be default pubkey',
+  6093: 'Multisig signer account not owned by System Program',
+  // General errors (6094-6101)
+  6094: 'Invalid input parameter',
+  6095: 'Arithmetic overflow',
+  6096: 'Vote count overflow',
+  6097: 'Insufficient funds',
+  6098: 'Reward too small: worker must receive at least 1 lamport',
+  6099: 'Account data is corrupted',
+  6100: 'String too long',
+  6101: 'Account owner validation failed: account not owned by this program',
+  // Rate limiting errors (6102-6110)
+  6102: 'Rate limit exceeded: maximum actions per 24h window reached',
+  6103: 'Cooldown period has not elapsed since last action',
+  6104: 'Agent update too frequent: must wait cooldown period',
+  6105: 'Cooldown value cannot be negative',
+  6106: 'Cooldown value exceeds maximum (24 hours)',
+  6107: 'Rate limit value exceeds maximum allowed (1000)',
+  6108: 'Cooldown value exceeds maximum allowed (1 week)',
+  6109: 'Insufficient stake to initiate dispute',
+  6110: 'Creator-initiated disputes require 2x the minimum stake',
+  // Version/upgrade errors (6111-6118)
+  6111: 'Protocol version mismatch: account version incompatible with current program',
+  6112: 'Account version too old: migration required',
+  6113: 'Account version too new: program upgrade required',
+  6114: 'Migration not allowed: invalid source version',
+  6115: 'Migration not allowed: invalid target version',
+  6116: 'Only upgrade authority can perform this action',
+  6117: 'Minimum version cannot exceed current protocol version',
+  6118: 'Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts',
+  // Dependency errors (6119-6124)
+  6119: 'Parent task has been cancelled',
+  6120: 'Parent task is in disputed state',
+  6121: 'Invalid dependency type',
+  6122: 'Parent task must be completed before completing a proof-dependent task',
+  6123: 'Parent task account required for proof-dependent task completion',
+  6124: 'Parent task does not belong to the same creator',
+  // Nullifier errors (6125-6126)
+  6125: 'Nullifier has already been spent - proof/knowledge reuse detected',
+  6126: 'Invalid nullifier: nullifier value cannot be all zeros',
+  // Cancel task errors (6127-6128)
+  6127: 'All worker accounts must be provided when cancelling a task with active claims',
+  6128: 'Worker accounts required when task has active workers',
+  // Duplicate account errors (6129)
+  6129: 'Duplicate arbiter provided in remaining_accounts',
+  // Escrow errors (6130)
+  6130: 'Escrow has insufficient balance for reward transfer',
+  // Status transition errors (6131)
+  6131: 'Invalid task status transition',
+  // Stake validation errors (6132-6134)
+  6132: 'Stake value is below minimum required (0.001 SOL)',
+  6133: 'min_stake_for_dispute must be greater than zero',
+  6134: 'Slash amount must be greater than zero',
+  // Speculation Bond errors (6135-6138)
+  6135: 'Bond amount too low',
+  6136: 'Bond already exists',
+  6137: 'Bond not found',
+  6138: 'Bond not yet matured',
+  // Reputation errors (6139-6140)
+  6139: 'Agent reputation below task minimum requirement',
+  6140: 'Invalid minimum reputation: must be <= 10000',
+  // Security errors (6141-6142)
+  6141: 'Development verifying key detected (gamma == delta). ZK proofs are forgeable.',
+  6142: 'Cannot claim own task: worker authority matches task creator',
+  // SPL Token errors (6143-6146)
+  6143: 'Token accounts not provided for token-denominated task',
+  6144: 'Token escrow ATA does not match expected derivation',
+  6145: 'Provided mint does not match task\'s reward_mint',
+  6146: 'SPL token transfer CPI failed',
 };
+
+// ============================================================================
+// Validation Helpers
+// ============================================================================
+
+/**
+ * Validates that a byte array has the expected length.
+ * @throws ValidationError if length doesn't match
+ */
+export function validateByteLength(
+  value: Uint8Array | number[],
+  expectedLength: number,
+  paramName: string,
+): Uint8Array {
+  const bytes = value instanceof Uint8Array ? value : new Uint8Array(value);
+  if (bytes.length !== expectedLength) {
+    throw new ValidationError(
+      `Invalid ${paramName}: expected ${expectedLength} bytes, got ${bytes.length}`
+    );
+  }
+  return bytes;
+}
+
+/**
+ * Validates that a byte array is not all zeros.
+ * @throws ValidationError if all bytes are zero
+ */
+export function validateNonZeroBytes(value: Uint8Array, paramName: string): void {
+  if (value.every(b => b === 0)) {
+    throw new ValidationError(`Invalid ${paramName}: cannot be all zeros`);
+  }
+}
 
 // ============================================================================
 // Base Runtime Error Class
@@ -1002,7 +1284,7 @@ export function parseAnchorError(error: unknown): ParsedAnchorError | null {
   }
 
   // Validate code is in our known range
-  if (code === undefined || code < 6000 || code > 6077) {
+  if (code === undefined || code < 6000 || code > 6146) {
     return null;
   }
 

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -44,6 +44,9 @@ export {
   getAnchorErrorName,
   getAnchorErrorMessage,
   isRuntimeError,
+  // Validation helpers
+  validateByteLength,
+  validateNonZeroBytes,
 } from './errors.js';
 
 // Agent types and utilities

--- a/sdk/src/__tests__/client.test.ts
+++ b/sdk/src/__tests__/client.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { PrivacyClient } from '../client';
+
+describe('PrivacyClient input validation (#963)', () => {
+  it('rejects invalid RPC URL', () => {
+    expect(() => new PrivacyClient({ rpcUrl: 'not-a-url' })).toThrow('Invalid RPC URL');
+  });
+
+  it('rejects non-http RPC URL', () => {
+    expect(() => new PrivacyClient({ rpcUrl: 'ftp://example.com' })).toThrow('http or https');
+  });
+
+  it('accepts valid HTTP RPC URL', () => {
+    expect(() => new PrivacyClient({ rpcUrl: 'http://localhost:8899' })).not.toThrow();
+  });
+
+  it('accepts valid HTTPS RPC URL', () => {
+    expect(() => new PrivacyClient({ rpcUrl: 'https://api.mainnet-beta.solana.com' })).not.toThrow();
+  });
+
+  it('accepts no RPC URL (defaults)', () => {
+    expect(() => new PrivacyClient()).not.toThrow();
+  });
+
+  describe('completeTaskPrivate validation', () => {
+    it('rejects when not initialized', async () => {
+      const client = new PrivacyClient({ rpcUrl: 'http://localhost:8899' });
+      await expect(
+        client.completeTaskPrivate({
+          taskId: 1,
+          output: [1n, 2n, 3n, 4n],
+          salt: 123n,
+          recipientWallet: {} as any,
+          escrowLamports: 1000,
+        })
+      ).rejects.toThrow('not initialized');
+    });
+  });
+});

--- a/sdk/src/__tests__/validation.test.ts
+++ b/sdk/src/__tests__/validation.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { validateCircuitPath } from '../validation';
+
+describe('validateCircuitPath (#963)', () => {
+  it('rejects empty string', () => {
+    expect(() => validateCircuitPath('')).toThrow('cannot be empty');
+  });
+
+  it('rejects whitespace-only string', () => {
+    expect(() => validateCircuitPath('   ')).toThrow('cannot be empty');
+  });
+
+  it('rejects path exceeding 512 characters', () => {
+    expect(() => validateCircuitPath('a'.repeat(513))).toThrow('maximum length');
+  });
+
+  it('rejects absolute path', () => {
+    expect(() => validateCircuitPath('/etc/passwd')).toThrow('Absolute');
+  });
+
+  it('rejects path traversal', () => {
+    expect(() => validateCircuitPath('../../../etc/passwd')).toThrow('traversal');
+  });
+
+  it('rejects shell metacharacters', () => {
+    expect(() => validateCircuitPath('path; rm -rf /')).toThrow('disallowed characters');
+    expect(() => validateCircuitPath('path$(cmd)')).toThrow('disallowed characters');
+    expect(() => validateCircuitPath('path`cmd`')).toThrow('disallowed characters');
+  });
+
+  it('accepts valid relative path', () => {
+    expect(() => validateCircuitPath('./circuits/task_completion')).not.toThrow();
+  });
+
+  it('accepts path with hyphens and underscores', () => {
+    expect(() => validateCircuitPath('my-circuits/task_completion')).not.toThrow();
+  });
+});

--- a/sdk/src/validation.ts
+++ b/sdk/src/validation.ts
@@ -16,6 +16,16 @@ import * as path from 'path';
  * @throws Error if the path is invalid
  */
 export function validateCircuitPath(circuitPath: string): void {
+  // Disallow empty paths
+  if (!circuitPath || circuitPath.trim().length === 0) {
+    throw new Error('Security: Circuit path cannot be empty');
+  }
+
+  // Length limit to prevent abuse
+  if (circuitPath.length > 512) {
+    throw new Error('Security: Circuit path exceeds maximum length (512 characters)');
+  }
+
   // Disallow absolute paths
   if (path.isAbsolute(circuitPath)) {
     throw new Error('Security: Absolute circuit paths are not allowed');


### PR DESCRIPTION
## Summary
- Expand `AnchorErrorCodes` from 78→147 entries to match the Rust `CoordinationError` enum exactly (6000-6146), fixing incorrect code assignments that caused silent error drops above code 6077
- Add client-side input validation to SDK (`PrivacyClient` RPC URL, `validateCircuitPath` empty/length, `completeTaskPrivate` BN254 bounds) and runtime operations (`completeTask`, `completeTaskPrivate`, `initiateDispute`) to catch invalid inputs before they reach the chain
- Add `validateByteLength()` and `validateNonZeroBytes()` helpers exported from `types/errors`
- Update all tests to use `AnchorErrorCodes.X` constants instead of hardcoded numbers

Closes #963

## Test plan
- [x] SDK validation tests (8 tests) — circuit path edge cases
- [x] SDK client tests (6 tests) — RPC URL validation, completeTaskPrivate validation
- [x] Runtime errors tests (75 tests) — all 147 AnchorErrorCodes verified, validation helpers tested
- [x] Runtime task operations tests (35 tests) — input validation, error mapping with correct codes
- [x] Runtime dispute operations tests (63 tests) — initiateDispute validation, error mapping
- [x] Full runtime suite: 2220 tests passing
- [x] Typecheck clean across sdk + runtime + mcp
- [x] Build successful