### PR TITLE
feat(runtime): backfill reliability and cursor correctness

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -647,6 +647,7 @@ export {
   ReplayStorageWriteResult,
   BackfillFetcher,
   BackfillResult,
+  type BackfillDuplicateReport,
   type ReplayBridgeConfig,
   type ReplayBridgeBackfillOptions,
   type ReplayBridgeHandle,

--- a/runtime/src/replay/backfill.test.ts
+++ b/runtime/src/replay/backfill.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it } from 'vitest';
+import { PublicKey } from '@solana/web3.js';
+import { ReplayBackfillService } from './backfill.js';
+import { InMemoryReplayTimelineStore } from './in-memory-store.js';
+import type {
+  BackfillFetcher,
+  BackfillFetcherPage,
+  ProjectedTimelineInput,
+  ReplayEventCursor,
+} from './types.js';
+
+function pubkey(seed: number): PublicKey {
+  const buf = new Uint8Array(32);
+  buf.fill(seed);
+  return new PublicKey(buf);
+}
+
+function bytes(seed = 0, length = 32): Uint8Array {
+  const buf = new Uint8Array(length);
+  buf.fill(seed);
+  return buf;
+}
+
+function event(slot: number, signature: string, eventName: string): ProjectedTimelineInput {
+  return {
+    slot,
+    signature,
+    eventName,
+    event: {
+      taskId: bytes(slot),
+      creator: pubkey(slot),
+      requiredCapabilities: 1n,
+      rewardAmount: 1n,
+      taskType: 0,
+      deadline: 0,
+      minReputation: 0,
+      rewardMint: null,
+      timestamp: slot * 100,
+    },
+    timestampMs: slot * 100,
+  };
+}
+
+function createMockFetcher(
+  pages: BackfillFetcherPage[],
+): BackfillFetcher {
+  let pageIndex = 0;
+  return {
+    async fetchPage(
+      _cursor: ReplayEventCursor | null,
+      _toSlot: number,
+      _pageSize: number,
+    ): Promise<BackfillFetcherPage> {
+      const page = pages[pageIndex];
+      if (!page) {
+        return { events: [], nextCursor: null, done: true };
+      }
+      pageIndex++;
+      return page;
+    },
+  };
+}
+
+describe('ReplayBackfillService', () => {
+  it('cursor reflects last processed page boundary', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    const fetcher = createMockFetcher([
+      {
+        events: [event(1, 'SIG_1', 'taskCreated')],
+        nextCursor: { slot: 1, signature: 'SIG_1' },
+        done: false,
+      },
+      {
+        events: [event(2, 'SIG_2', 'taskClaimed')],
+        nextCursor: null,
+        done: true,
+      },
+    ]);
+
+    const service = new ReplayBackfillService(store, { toSlot: 100, fetcher });
+    const result = await service.runBackfill();
+
+    // done=true with nextCursor=null → saveCursor(null) is called
+    const cursor = await store.getCursor();
+    expect(cursor).toBeNull();
+    expect(result.processed).toBe(2);
+    expect(result.duplicates).toBe(0);
+  });
+
+  it('reports duplicate events deterministically', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    const duplicateEvent = event(1, 'SIG_1', 'taskCreated');
+    const fetcher = createMockFetcher([
+      {
+        events: [duplicateEvent],
+        nextCursor: { slot: 1, signature: 'SIG_1' },
+        done: false,
+      },
+      {
+        events: [duplicateEvent],
+        nextCursor: null,
+        done: true,
+      },
+    ]);
+
+    const service = new ReplayBackfillService(store, { toSlot: 100, fetcher });
+    const result = await service.runBackfill();
+
+    expect(result.duplicates).toBeGreaterThan(0);
+    expect(result.duplicateReport).toBeDefined();
+    expect(result.duplicateReport!.count).toBe(result.duplicates);
+    expect(result.duplicateReport!.keys).toEqual(
+      [...result.duplicateReport!.keys].sort(),
+    );
+  });
+
+  it('resume from partial cursor produces no event gaps', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    // First run: process first event
+    const fetcher1 = createMockFetcher([
+      {
+        events: [event(1, 'SIG_1', 'taskCreated')],
+        nextCursor: { slot: 1, signature: 'SIG_1' },
+        done: true,
+      },
+    ]);
+
+    const service1 = new ReplayBackfillService(store, { toSlot: 100, fetcher: fetcher1 });
+    await service1.runBackfill();
+
+    // Set cursor at the midpoint for resume
+    await store.saveCursor({ slot: 1, signature: 'SIG_1' });
+
+    // Second run: resume from cursor
+    const fetcher2 = createMockFetcher([
+      {
+        events: [event(2, 'SIG_2', 'taskClaimed')],
+        nextCursor: null,
+        done: true,
+      },
+    ]);
+
+    const service2 = new ReplayBackfillService(store, { toSlot: 100, fetcher: fetcher2 });
+    await service2.runBackfill();
+
+    const allRecords = await store.query();
+    expect(allRecords.length).toBe(2);
+    // Verify monotonic slot ordering
+    for (let i = 1; i < allRecords.length; i++) {
+      expect(allRecords[i]!.slot).toBeGreaterThanOrEqual(allRecords[i - 1]!.slot);
+    }
+  });
+
+  it('survives interruption mid-page and resumes correctly', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    let callCount = 0;
+
+    const fetcher: BackfillFetcher = {
+      async fetchPage(): Promise<BackfillFetcherPage> {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            events: [event(1, 'SIG_1', 'taskCreated'), event(2, 'SIG_2', 'taskClaimed')],
+            nextCursor: { slot: 2, signature: 'SIG_2' },
+            done: false,
+          };
+        }
+        if (callCount === 2) {
+          // Simulate crash after first page saved
+          throw new Error('simulated crash');
+        }
+        // Resume call (callCount >= 3)
+        return {
+          events: [event(3, 'SIG_3', 'taskCompleted')],
+          nextCursor: null,
+          done: true,
+        };
+      },
+    };
+
+    // First run -- crashes on page 2 fetch
+    const service1 = new ReplayBackfillService(store, { toSlot: 100, fetcher });
+    await expect(service1.runBackfill()).rejects.toThrow('simulated crash');
+
+    // Events from page 1 should be persisted
+    const recordsAfterCrash = await store.query();
+    expect(recordsAfterCrash.length).toBe(2);
+
+    // Resume -- should pick up and add page 3 events
+    const service2 = new ReplayBackfillService(store, { toSlot: 100, fetcher });
+    const result = await service2.runBackfill();
+
+    const allRecords = await store.query();
+    expect(allRecords.length).toBe(3);
+    expect(result.processed).toBe(1);
+  });
+
+  it('repeat backfill with same inputs produces identical store state', async () => {
+    const events = [
+      event(1, 'SIG_1', 'taskCreated'),
+      event(2, 'SIG_2', 'taskClaimed'),
+      event(3, 'SIG_3', 'taskCompleted'),
+    ];
+
+    // First run
+    const store1 = new InMemoryReplayTimelineStore();
+    const service1 = new ReplayBackfillService(store1, {
+      toSlot: 100,
+      fetcher: createMockFetcher([{ events, nextCursor: null, done: true }]),
+    });
+    await service1.runBackfill();
+    const records1 = await store1.query();
+
+    // Second run (same inputs, fresh store)
+    const store2 = new InMemoryReplayTimelineStore();
+    const service2 = new ReplayBackfillService(store2, {
+      toSlot: 100,
+      fetcher: createMockFetcher([{ events, nextCursor: null, done: true }]),
+    });
+    await service2.runBackfill();
+    const records2 = await store2.query();
+
+    // Store state must be identical
+    expect(records1.length).toBe(records2.length);
+    for (let i = 0; i < records1.length; i++) {
+      expect(records1[i]!.projectionHash).toBe(records2[i]!.projectionHash);
+      expect(records1[i]!.slot).toBe(records2[i]!.slot);
+      expect(records1[i]!.signature).toBe(records2[i]!.signature);
+      expect(records1[i]!.sourceEventName).toBe(records2[i]!.sourceEventName);
+    }
+
+    // Third run into SAME store -- duplicates only, no new inserts
+    const service3 = new ReplayBackfillService(store1, {
+      toSlot: 100,
+      fetcher: createMockFetcher([{ events, nextCursor: null, done: true }]),
+    });
+    const result3 = await service3.runBackfill();
+    expect(result3.processed).toBe(0);
+    expect(result3.duplicates).toBe(events.length);
+    expect(result3.duplicateReport).toBeDefined();
+    expect(result3.duplicateReport!.count).toBe(events.length);
+  });
+
+  it('resets invalid cursor and emits alert', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    // Set invalid cursor (negative slot)
+    await store.saveCursor({ slot: -1, signature: '' });
+
+    const alerts: { code: string; message: string }[] = [];
+    const alertDispatcher = {
+      emit: async (ctx: { code: string; message: string }) => {
+        alerts.push(ctx);
+      },
+    };
+
+    const fetcher = createMockFetcher([
+      {
+        events: [event(1, 'SIG_1', 'taskCreated')],
+        nextCursor: null,
+        done: true,
+      },
+    ]);
+
+    const service = new ReplayBackfillService(store, {
+      toSlot: 100,
+      fetcher,
+      alertDispatcher: alertDispatcher as any,
+    });
+    await service.runBackfill();
+
+    // Cursor should have been reset (backfill starts from scratch)
+    const records = await store.query();
+    expect(records.length).toBe(1);
+    // Alert should have been emitted for invalid cursor
+    expect(alerts.some(a => a.code === 'replay.backfill.invalid_cursor')).toBe(true);
+  });
+
+  it('resets cursor with empty signature and emits alert', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    await store.saveCursor({ slot: 5, signature: '' });
+
+    const alerts: { code: string }[] = [];
+    const alertDispatcher = {
+      emit: async (ctx: { code: string }) => {
+        alerts.push(ctx);
+      },
+    };
+
+    const fetcher = createMockFetcher([
+      {
+        events: [event(1, 'SIG_1', 'taskCreated')],
+        nextCursor: null,
+        done: true,
+      },
+    ]);
+
+    const service = new ReplayBackfillService(store, {
+      toSlot: 100,
+      fetcher,
+      alertDispatcher: alertDispatcher as any,
+    });
+    await service.runBackfill();
+
+    expect(alerts.some(a => a.code === 'replay.backfill.invalid_cursor')).toBe(true);
+  });
+
+  it('no duplicate report when no duplicates detected', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    const fetcher = createMockFetcher([
+      {
+        events: [event(1, 'SIG_1', 'taskCreated'), event(2, 'SIG_2', 'taskClaimed')],
+        nextCursor: null,
+        done: true,
+      },
+    ]);
+
+    const service = new ReplayBackfillService(store, { toSlot: 100, fetcher });
+    const result = await service.runBackfill();
+
+    expect(result.duplicates).toBe(0);
+    expect(result.duplicateReport).toBeUndefined();
+  });
+});

--- a/runtime/src/replay/file-store.ts
+++ b/runtime/src/replay/file-store.ts
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, rename } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
@@ -100,6 +100,9 @@ export class FileReplayTimelineStore implements ReplayTimelineStore {
       cursor: state.cursor,
       records: state.records,
     });
-    await writeFile(this.filePath, payload);
+    // Write to temp file then rename for crash-safe persistence
+    const tmpPath = `${this.filePath}.tmp`;
+    await writeFile(tmpPath, payload);
+    await rename(tmpPath, this.filePath);
   }
 }

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -40,6 +40,7 @@ export {
   ReplayTimelineStoreConfig,
   BackfillFetcher,
   BackfillResult,
+  type BackfillDuplicateReport,
   ProjectedTimelineInput,
   BackfillFetcherPage,
   buildReplayKey,

--- a/runtime/src/replay/sqlite-store.ts
+++ b/runtime/src/replay/sqlite-store.ts
@@ -221,6 +221,15 @@ export class SqliteReplayTimelineStore implements ReplayTimelineStore {
     };
   }
 
+  /**
+   * Cursor persistence is atomic within a single SQLite statement.
+   * If the process crashes during saveCursor(), the cursor row either
+   * has the old value or the new value -- never a partial write.
+   *
+   * Combined with INSERT OR IGNORE for events, this guarantees:
+   * - Events from a partially-processed page can be safely re-inserted
+   * - The cursor always points to the last fully-processed page boundary
+   */
   async saveCursor(cursor: ReplayEventCursor | null): Promise<void> {
     const db = await this.getDb();
     const statement = db.prepare(`

--- a/runtime/src/replay/types.ts
+++ b/runtime/src/replay/types.ts
@@ -108,10 +108,19 @@ export interface ProjectedTimelineInput {
   traceContext?: ReplayTraceContext;
 }
 
+export interface BackfillDuplicateReport {
+  /** Total duplicate events detected across all pages */
+  count: number;
+  /** Deterministic list of duplicate event keys (slot|signature|sourceEventType) */
+  keys: string[];
+}
+
 export interface BackfillResult {
   processed: number;
   duplicates: number;
   cursor: ReplayEventCursor | null;
+  /** Deterministic duplicate report for auditing */
+  duplicateReport?: BackfillDuplicateReport;
 }
 
 export interface ReplayHealth {


### PR DESCRIPTION
## Summary

Closes #965

- Add `BackfillDuplicateReport` interface to `runtime/src/replay/types.ts` with deterministic sorted key tracking
- Extend `BackfillResult` with optional `duplicateReport` field
- Add cursor validation on resume in `backfill.ts` — resets invalid cursors (negative slot, empty signature) with alert emission
- Track duplicate keys during paginated backfill and emit `replay.backfill.duplicates` alerts
- Document cursor persistence contract (exactly-once semantics via save-then-cursor ordering)
- Document SQLite cursor atomicity guarantee in `sqlite-store.ts`
- Implement write-then-rename in `file-store.ts` for crash-safe persistence
- Add 8 new tests: cursor boundary, duplicate reporting, resume from partial, crash interruption/recovery, idempotency proof, invalid cursor reset (2 variants), no-duplicate baseline

## Test plan

- [x] All 2236 runtime tests pass (123 files)
- [x] Typecheck clean across sdk + runtime + mcp
- [x] Build succeeds
- [x] Existing tests unaffected (backward compatible)
- [x] New backfill tests cover chaos, idempotency, and invalid cursor scenarios