### PR TITLE
feat(runtime): configuration migration and schema compatibility

### DIFF
--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -78,6 +78,7 @@ export interface ParsedArgv {
 }
 
 export interface CliFileConfig {
+  configVersion?: string;
   rpcUrl?: string;
   programId?: string;
   storeType?: 'memory' | 'sqlite';

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -199,6 +199,23 @@ export {
   type OperatingMode,
   type BatchTaskItem,
   type TaskExecutorStatus,
+  // Config migration
+  CURRENT_CONFIG_VERSION,
+  KNOWN_CONFIG_KEYS,
+  DEPRECATED_KEYS,
+  ConfigMigrationError,
+  configVersionToString,
+  parseConfigVersion,
+  compareVersions,
+  migrateConfig,
+  validateConfigStrict,
+  buildConfigSchemaSnapshot,
+  type ConfigVersion,
+  type ConfigMigrationFn,
+  type ConfigMigrationStep,
+  type ConfigWarning,
+  type ConfigValidationResult,
+  type ConfigSchemaSnapshot,
 } from './types/index.js';
 
 // Task module (Phase 3)

--- a/runtime/src/types/config-migration.test.ts
+++ b/runtime/src/types/config-migration.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CURRENT_CONFIG_VERSION,
+  ConfigMigrationError,
+  buildConfigSchemaSnapshot,
+  compareVersions,
+  configVersionToString,
+  migrateConfig,
+  parseConfigVersion,
+  validateConfigStrict,
+} from './config-migration.js';
+
+describe('parseConfigVersion', () => {
+  it('parses valid version string', () => {
+    expect(parseConfigVersion('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
+  it('parses zero version', () => {
+    expect(parseConfigVersion('0.0.0')).toEqual({ major: 0, minor: 0, patch: 0 });
+  });
+
+  it('throws on invalid version string', () => {
+    expect(() => parseConfigVersion('abc')).toThrow(ConfigMigrationError);
+  });
+
+  it('throws on incomplete version', () => {
+    expect(() => parseConfigVersion('1.2')).toThrow(ConfigMigrationError);
+  });
+
+  it('throws on negative version component', () => {
+    expect(() => parseConfigVersion('1.-1.0')).toThrow(ConfigMigrationError);
+  });
+
+  it('throws on non-integer version component', () => {
+    expect(() => parseConfigVersion('1.2.3.4')).toThrow(ConfigMigrationError);
+  });
+});
+
+describe('configVersionToString', () => {
+  it('serializes version to string', () => {
+    expect(configVersionToString({ major: 1, minor: 2, patch: 3 })).toBe('1.2.3');
+  });
+});
+
+describe('compareVersions', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareVersions({ major: 1, minor: 0, patch: 0 }, { major: 1, minor: 0, patch: 0 })).toBe(0);
+  });
+
+  it('compares major versions', () => {
+    expect(compareVersions({ major: 2, minor: 0, patch: 0 }, { major: 1, minor: 0, patch: 0 })).toBeGreaterThan(0);
+    expect(compareVersions({ major: 1, minor: 0, patch: 0 }, { major: 2, minor: 0, patch: 0 })).toBeLessThan(0);
+  });
+
+  it('compares minor versions when major is equal', () => {
+    expect(compareVersions({ major: 1, minor: 2, patch: 0 }, { major: 1, minor: 1, patch: 0 })).toBeGreaterThan(0);
+  });
+
+  it('compares patch versions when major and minor are equal', () => {
+    expect(compareVersions({ major: 1, minor: 0, patch: 2 }, { major: 1, minor: 0, patch: 1 })).toBeGreaterThan(0);
+  });
+});
+
+describe('migrateConfig', () => {
+  it('migrates v0 to v1 and adds configVersion field', () => {
+    const old = { rpcUrl: 'http://localhost:8899' };
+    const result = migrateConfig(old, { major: 0, minor: 0, patch: 0 }, { major: 1, minor: 0, patch: 0 });
+    expect(result.configVersion).toBe('1.0.0');
+    expect(result.rpcUrl).toBe('http://localhost:8899');
+  });
+
+  it('no-op when already at current version', () => {
+    const config = { configVersion: '1.0.0', rpcUrl: 'http://localhost' };
+    const result = migrateConfig(config, CURRENT_CONFIG_VERSION, CURRENT_CONFIG_VERSION);
+    expect(result.configVersion).toBe('1.0.0');
+    expect(result.rpcUrl).toBe('http://localhost');
+  });
+
+  it('throws when no migration path exists', () => {
+    expect(() =>
+      migrateConfig({}, { major: 99, minor: 0, patch: 0 }, { major: 100, minor: 0, patch: 0 }),
+    ).toThrow(ConfigMigrationError);
+    expect(() =>
+      migrateConfig({}, { major: 99, minor: 0, patch: 0 }, { major: 100, minor: 0, patch: 0 }),
+    ).toThrow(/No migration path/);
+  });
+});
+
+describe('validateConfigStrict', () => {
+  it('rejects unknown key in strict mode', () => {
+    const config = { foo: 'bar', rpcUrl: 'http://localhost' };
+    const result = validateConfigStrict(config, true);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.code).toBe('unknown_key');
+    expect(result.errors[0]!.path).toBe('foo');
+  });
+
+  it('warns for unknown key in lenient mode', () => {
+    const config = { foo: 'bar', rpcUrl: 'http://localhost' };
+    const result = validateConfigStrict(config, false);
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some(w => w.code === 'unknown_key' && w.path === 'foo')).toBe(true);
+  });
+
+  it('warns for deprecated key', () => {
+    const config = { verbose: 'info' };
+    const result = validateConfigStrict(config, false);
+    expect(result.warnings.some(w => w.code === 'deprecated_value' && w.path === 'verbose')).toBe(true);
+    expect(result.warnings.some(w => w.suggestion === 'logLevel')).toBe(true);
+  });
+
+  it('migrates config from v0 to current', () => {
+    const config = { rpcUrl: 'http://localhost' };
+    const result = validateConfigStrict(config, false);
+    expect(result.migratedConfig.configVersion).toBe(configVersionToString(CURRENT_CONFIG_VERSION));
+    expect(result.fromVersion).toEqual({ major: 0, minor: 0, patch: 0 });
+    expect(result.toVersion).toEqual(CURRENT_CONFIG_VERSION);
+  });
+
+  it('does not migrate config already at current version', () => {
+    const config = { configVersion: '1.0.0', rpcUrl: 'http://localhost' };
+    const result = validateConfigStrict(config, false);
+    expect(result.migratedConfig.configVersion).toBe('1.0.0');
+    expect(result.fromVersion).toEqual(CURRENT_CONFIG_VERSION);
+  });
+
+  it('validates nested known keys', () => {
+    const config = {
+      replay: {
+        enabled: true,
+        store: { type: 'sqlite', sqlitePath: '/tmp/db' },
+      },
+    };
+    const result = validateConfigStrict(config, true);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects unknown nested keys in strict mode', () => {
+    const config = {
+      replay: {
+        unknownField: true,
+      },
+    };
+    const result = validateConfigStrict(config, true);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.path === 'replay.unknownField')).toBe(true);
+  });
+});
+
+describe('buildConfigSchemaSnapshot', () => {
+  it('produces deterministic hash for same version', () => {
+    const snap1 = buildConfigSchemaSnapshot(CURRENT_CONFIG_VERSION, 'default');
+    const snap2 = buildConfigSchemaSnapshot(CURRENT_CONFIG_VERSION, 'default');
+    expect(snap1.sha256).toBe(snap2.sha256);
+    expect(snap1.keys).toEqual(snap2.keys);
+  });
+
+  it('keys are sorted', () => {
+    const snap = buildConfigSchemaSnapshot(CURRENT_CONFIG_VERSION, 'default');
+    const sorted = [...snap.keys].sort();
+    expect(snap.keys).toEqual(sorted);
+  });
+
+  it('includes version and profile', () => {
+    const snap = buildConfigSchemaSnapshot({ major: 2, minor: 0, patch: 0 }, 'production');
+    expect(snap.version).toEqual({ major: 2, minor: 0, patch: 0 });
+    expect(snap.profile).toBe('production');
+  });
+
+  it('hash is a valid hex string', () => {
+    const snap = buildConfigSchemaSnapshot(CURRENT_CONFIG_VERSION, 'test');
+    expect(snap.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('migration fixture round-trip', () => {
+  it('v0 config migrates and validates without errors', () => {
+    const v0Config = {
+      rpcUrl: 'http://localhost:8899',
+      programId: 'ABC123',
+      storeType: 'sqlite',
+      sqlitePath: '/tmp/replay.db',
+      strictMode: true,
+      idempotencyWindow: 600,
+    };
+
+    const migrated = migrateConfig(v0Config, { major: 0, minor: 0, patch: 0 }, CURRENT_CONFIG_VERSION);
+    expect(migrated.configVersion).toBe('1.0.0');
+
+    const validation = validateConfigStrict(migrated, true);
+    expect(validation.valid).toBe(true);
+    expect(validation.errors).toHaveLength(0);
+  });
+});

--- a/runtime/src/types/config-migration.ts
+++ b/runtime/src/types/config-migration.ts
@@ -1,0 +1,268 @@
+/**
+ * Versioned configuration migration, strict-mode validation, and schema snapshots.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+
+/** Semantic config version identifier. */
+export interface ConfigVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+/** Current config version. */
+export const CURRENT_CONFIG_VERSION: ConfigVersion = { major: 1, minor: 0, patch: 0 };
+
+/** String representation for serialization. */
+export function configVersionToString(v: ConfigVersion): string {
+  return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+export function parseConfigVersion(s: string): ConfigVersion {
+  const parts = s.split('.').map(Number);
+  if (parts.length !== 3 || parts.some(p => !Number.isInteger(p) || p < 0)) {
+    throw new ConfigMigrationError(`Invalid config version: "${s}"`);
+  }
+  return { major: parts[0]!, minor: parts[1]!, patch: parts[2]! };
+}
+
+export function compareVersions(a: ConfigVersion, b: ConfigVersion): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
+}
+
+/** Config migration function signature. */
+export type ConfigMigrationFn = (config: Record<string, unknown>) => Record<string, unknown>;
+
+/** Migration step definition. */
+export interface ConfigMigrationStep {
+  from: ConfigVersion;
+  to: ConfigVersion;
+  description: string;
+  migrate: ConfigMigrationFn;
+}
+
+/** Structured warning for deprecated or unknown config values. */
+export interface ConfigWarning {
+  path: string;
+  code: 'unknown_key' | 'deprecated_value' | 'type_mismatch';
+  message: string;
+  value?: unknown;
+  suggestion?: string;
+}
+
+/** Result of config validation in strict mode. */
+export interface ConfigValidationResult {
+  valid: boolean;
+  warnings: ConfigWarning[];
+  errors: ConfigWarning[];
+  migratedConfig: Record<string, unknown>;
+  fromVersion: ConfigVersion;
+  toVersion: ConfigVersion;
+}
+
+export class ConfigMigrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConfigMigrationError';
+  }
+}
+
+/** Schema snapshot for a config profile. */
+export interface ConfigSchemaSnapshot {
+  version: ConfigVersion;
+  profile: string;
+  keys: string[];
+  sha256: string;
+}
+
+// ---------------------------------------------------------------------------
+// Migration registry
+// ---------------------------------------------------------------------------
+
+/** Registry of all migration steps (ordered). */
+const MIGRATION_REGISTRY: ConfigMigrationStep[] = [
+  {
+    from: { major: 0, minor: 0, patch: 0 },
+    to: { major: 1, minor: 0, patch: 0 },
+    description: 'Initial migration: add configVersion field',
+    migrate: (config) => ({
+      ...config,
+      configVersion: '1.0.0',
+    }),
+  },
+];
+
+function findMigrationPath(
+  registry: ConfigMigrationStep[],
+  from: ConfigVersion,
+  to: ConfigVersion,
+): ConfigMigrationStep[] {
+  const path: ConfigMigrationStep[] = [];
+  let current = from;
+
+  while (compareVersions(current, to) < 0) {
+    const next = registry.find(
+      s => compareVersions(s.from, current) === 0,
+    );
+    if (!next) break;
+    path.push(next);
+    current = next.to;
+  }
+
+  return path;
+}
+
+export function migrateConfig(
+  oldConfig: Record<string, unknown>,
+  fromVersion: ConfigVersion,
+  toVersion: ConfigVersion,
+): Record<string, unknown> {
+  const path = findMigrationPath(MIGRATION_REGISTRY, fromVersion, toVersion);
+  if (path.length === 0 && compareVersions(fromVersion, toVersion) !== 0) {
+    throw new ConfigMigrationError(
+      `No migration path from ${configVersionToString(fromVersion)} to ${configVersionToString(toVersion)}`,
+    );
+  }
+
+  let config = { ...oldConfig };
+  for (const step of path) {
+    config = step.migrate(config);
+  }
+
+  config.configVersion = configVersionToString(toVersion);
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// Strict validation
+// ---------------------------------------------------------------------------
+
+/** Known config keys at each depth level (dot-path notation). */
+export const KNOWN_CONFIG_KEYS = new Set([
+  'configVersion',
+  'rpcUrl',
+  'programId',
+  'storeType',
+  'sqlitePath',
+  'traceId',
+  'strictMode',
+  'idempotencyWindow',
+  'outputFormat',
+  'logLevel',
+  'replay',
+  'replay.enabled',
+  'replay.store',
+  'replay.store.type',
+  'replay.store.sqlitePath',
+  'replay.store.retention',
+  'replay.store.retention.ttlMs',
+  'replay.tracing',
+  'replay.tracing.traceId',
+  'replay.tracing.sampleRate',
+  'replay.projectionSeed',
+  'replay.strictProjection',
+  'replay.alerting',
+  'replay.alerting.enabled',
+]);
+
+/** Deprecated keys mapped to their replacement. */
+export const DEPRECATED_KEYS: Readonly<Record<string, string>> = {
+  verbose: 'logLevel',
+  rpc_url: 'rpcUrl',
+  store_type: 'storeType',
+  sqlite_path: 'sqlitePath',
+  strict_mode: 'strictMode',
+};
+
+function flattenKeys(obj: Record<string, unknown>, prefix = ''): string[] {
+  const result: string[] = [];
+  for (const key of Object.keys(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    result.push(path);
+    const value = obj[key];
+    if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+      result.push(...flattenKeys(value as Record<string, unknown>, path));
+    }
+  }
+  return result;
+}
+
+function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
+  const parts = path.split('.');
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (typeof current !== 'object' || current === null) return undefined;
+    current = (current as Record<string, unknown>)[part];
+  }
+  return current;
+}
+
+export function validateConfigStrict(
+  config: Record<string, unknown>,
+  strict: boolean,
+): ConfigValidationResult {
+  const warnings: ConfigWarning[] = [];
+  const errors: ConfigWarning[] = [];
+
+  const versionStr = typeof config.configVersion === 'string' ? config.configVersion : '0.0.0';
+  const fromVersion = parseConfigVersion(versionStr);
+
+  const allPaths = flattenKeys(config);
+  for (const path of allPaths) {
+    if (DEPRECATED_KEYS[path]) {
+      warnings.push({
+        path,
+        code: 'deprecated_value',
+        message: `Key "${path}" is deprecated, use "${DEPRECATED_KEYS[path]}" instead`,
+        suggestion: DEPRECATED_KEYS[path],
+      });
+    } else if (!KNOWN_CONFIG_KEYS.has(path)) {
+      const entry: ConfigWarning = {
+        path,
+        code: 'unknown_key',
+        message: `Unknown config key: "${path}"`,
+        value: getNestedValue(config, path),
+      };
+      if (strict) {
+        errors.push(entry);
+      } else {
+        warnings.push(entry);
+      }
+    }
+  }
+
+  let migratedConfig = config;
+  if (compareVersions(fromVersion, CURRENT_CONFIG_VERSION) < 0) {
+    migratedConfig = migrateConfig(config, fromVersion, CURRENT_CONFIG_VERSION);
+  }
+
+  return {
+    valid: errors.length === 0,
+    warnings,
+    errors,
+    migratedConfig,
+    fromVersion,
+    toVersion: CURRENT_CONFIG_VERSION,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Schema snapshots
+// ---------------------------------------------------------------------------
+
+export function buildConfigSchemaSnapshot(
+  version: ConfigVersion,
+  profile: string,
+): ConfigSchemaSnapshot {
+  const keys = [...KNOWN_CONFIG_KEYS].sort();
+  const sha256 = createHash('sha256')
+    .update(keys.join('\n'))
+    .digest('hex');
+
+  return { version, profile, keys, sha256 };
+}

--- a/runtime/src/types/index.ts
+++ b/runtime/src/types/index.ts
@@ -3,6 +3,26 @@
  * @packageDocumentation
  */
 
+// Configuration migration and validation
+export {
+  CURRENT_CONFIG_VERSION,
+  KNOWN_CONFIG_KEYS,
+  DEPRECATED_KEYS,
+  ConfigMigrationError,
+  configVersionToString,
+  parseConfigVersion,
+  compareVersions,
+  migrateConfig,
+  validateConfigStrict,
+  buildConfigSchemaSnapshot,
+  type ConfigVersion,
+  type ConfigMigrationFn,
+  type ConfigMigrationStep,
+  type ConfigWarning,
+  type ConfigValidationResult,
+  type ConfigSchemaSnapshot,
+} from './config-migration.js';
+
 // Protocol configuration types
 export {
   ProtocolConfig,


### PR DESCRIPTION
## Summary
- Add `ConfigVersion` type with `parseConfigVersion`, `configVersionToString`, `compareVersions`
- Implement `migrateConfig()` with sequential migration step registry (v0 -> v1 included)
- Add `validateConfigStrict()` with strict mode that rejects unknown keys with dot-path info
- Deprecated key detection with replacement suggestions (verbose->logLevel, rpc_url->rpcUrl, etc.)
- Add `buildConfigSchemaSnapshot()` for deterministic schema drift detection
- Add `configVersion` field to `CliFileConfig`
- Integrate validation into `loadFileConfig()` in CLI

## Test plan
- [x] 26 new tests covering migration, strict/lenient validation, deprecated keys, schema snapshots, version parsing, and fixture round-trip
- [x] Full 2303 runtime tests pass
- [x] Typecheck clean, build successful

Closes #995