### PR TITLE
feat(runtime): replay anomaly and alert schema stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ obj/
 !package.json
 !tsconfig.json
 !runtime/idl/*.json
+!runtime/src/replay/alert-schema-lockfile.json
 id.json
 deploy/
 keys/

--- a/mcp/src/tools/replay-types.ts
+++ b/mcp/src/tools/replay-types.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 
+/**
+ * Alert schema version referenced by replay tools.
+ * Must match REPLAY_ALERT_SCHEMA_VERSION in @agenc/runtime.
+ */
+export const REPLAY_ALERT_SCHEMA_VERSION = 'replay.alert.v1';
+
 export const REPLAY_BACKFILL_OUTPUT_SCHEMA = 'replay.backfill.output.v1';
 export const REPLAY_COMPARE_OUTPUT_SCHEMA = 'replay.compare.output.v1';
 export const REPLAY_INCIDENT_OUTPUT_SCHEMA = 'replay.incident.output.v1';
@@ -97,6 +103,7 @@ export const ReplayIncidentValidationSchema = z.object({
     replay_task_count: z.number().nonnegative(),
   }),
   anomaly_ids: z.array(z.string()),
+  deterministic_hash: z.string().optional(),
 });
 
 export const ReplayIncidentSummarySchema = z.object({
@@ -116,6 +123,7 @@ export const ReplayIncidentSummarySchema = z.object({
 export const ReplayIncidentNarrativeSchema = z.object({
   lines: z.array(z.string()),
   anomaly_ids: z.array(z.string()),
+  deterministic_hash: z.string().optional(),
 });
 
 export const ReplayBackfillOutputSchema = z.object({

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -698,6 +698,15 @@ export {
   type ReplayAlertKind,
   type ReplayAlertSeverity,
   ReplayAlertDispatcher,
+  REPLAY_ALERT_SCHEMA_VERSION,
+  type ReplayAlertSchemaV1,
+  REPLAY_ALERT_V1_REQUIRED_FIELDS,
+  REPLAY_ALERT_V1_VALID_SEVERITIES,
+  REPLAY_ALERT_V1_VALID_KINDS,
+  type SchemaCompatibilityResult,
+  validateAlertSchema,
+  computeAnomalySetHash,
+  computeAnomalySetHashFromContexts,
 } from './replay/index.js';
 
 // Policy and Safety Engine

--- a/runtime/src/replay/alert-schema-lockfile.json
+++ b/runtime/src/replay/alert-schema-lockfile.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "replay.alert.v1",
+  "requiredFields": ["code", "emittedAtMs", "id", "kind", "message", "severity"],
+  "optionalFields": [
+    "disputePda", "metadata", "occurredAtMs", "repeatCount",
+    "signature", "slot", "sourceEventName", "sourceEventSequence",
+    "taskPda", "traceId"
+  ],
+  "validSeverities": ["error", "info", "warning"],
+  "validKinds": [
+    "replay_anomaly_repeat", "replay_hash_mismatch",
+    "replay_ingestion_lag", "transition_validation"
+  ],
+  "fieldTypes": {
+    "id": "string",
+    "code": "string",
+    "severity": "string",
+    "kind": "string",
+    "message": "string",
+    "emittedAtMs": "number",
+    "taskPda": "string?",
+    "disputePda": "string?",
+    "sourceEventName": "string?",
+    "signature": "string?",
+    "slot": "number?",
+    "sourceEventSequence": "number?",
+    "traceId": "string?",
+    "metadata": "Record<string, string | number | boolean | null>?",
+    "occurredAtMs": "number?",
+    "repeatCount": "number?"
+  }
+}

--- a/runtime/src/replay/alerting.test.ts
+++ b/runtime/src/replay/alerting.test.ts
@@ -1,6 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import type { Logger } from '../utils/logger.js';
-import { createReplayAlertDispatcher, type ReplayAnomalyAlert } from './alerting.js';
+import {
+  computeAnomalySetHash,
+  computeAnomalySetHashFromContexts,
+  createReplayAlertDispatcher,
+  REPLAY_ALERT_SCHEMA_VERSION,
+  REPLAY_ALERT_V1_REQUIRED_FIELDS,
+  REPLAY_ALERT_V1_VALID_KINDS,
+  REPLAY_ALERT_V1_VALID_SEVERITIES,
+  validateAlertSchema,
+  type ReplayAnomalyAlert,
+} from './alerting.js';
+
+const __dirname = resolve(fileURLToPath(import.meta.url), '..');
 
 interface LoggerCapture {
   callCount: number;
@@ -202,5 +217,190 @@ describe('ReplayAlertDispatcher', () => {
       severity: 'error',
       message: 'deterministic test alert',
     } satisfies Partial<ReplayAnomalyAlert>);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation (#967)
+// ---------------------------------------------------------------------------
+
+describe('validateAlertSchema (#967)', () => {
+  it('validates a complete alert payload', () => {
+    const alert = {
+      id: 'test-id',
+      code: 'replay.test',
+      severity: 'warning',
+      kind: 'transition_validation',
+      message: 'test',
+      emittedAtMs: Date.now(),
+    };
+    const result = validateAlertSchema(alert);
+    expect(result.compatible).toBe(true);
+    expect(result.missingFields).toHaveLength(0);
+    expect(result.invalidFields).toHaveLength(0);
+  });
+
+  it('detects missing required fields', () => {
+    const result = validateAlertSchema({ id: 'test', code: 'test' });
+    expect(result.compatible).toBe(false);
+    expect(result.missingFields).toContain('severity');
+    expect(result.missingFields).toContain('kind');
+    expect(result.missingFields).toContain('message');
+    expect(result.missingFields).toContain('emittedAtMs');
+  });
+
+  it('detects invalid field types', () => {
+    const result = validateAlertSchema({
+      id: '',
+      code: '',
+      severity: 'critical',
+      kind: 'unknown_kind',
+      message: 123,
+      emittedAtMs: NaN,
+    });
+    expect(result.compatible).toBe(false);
+    expect(result.invalidFields.length).toBeGreaterThan(0);
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateAlertSchema(null).compatible).toBe(false);
+    expect(validateAlertSchema(undefined).compatible).toBe(false);
+    expect(validateAlertSchema('string').compatible).toBe(false);
+    expect(validateAlertSchema(42).compatible).toBe(false);
+    expect(validateAlertSchema([]).compatible).toBe(false);
+  });
+
+  it('accepts optional fields without complaint', () => {
+    const alert = {
+      id: 'test-id',
+      code: 'replay.test',
+      severity: 'info',
+      kind: 'replay_hash_mismatch',
+      message: 'test',
+      emittedAtMs: 1700000000000,
+      taskPda: 'TASK_1',
+      slot: 42,
+      traceId: 'trace-1',
+    };
+    const result = validateAlertSchema(alert);
+    expect(result.compatible).toBe(true);
+  });
+
+  it('reports schema version in result', () => {
+    const result = validateAlertSchema({});
+    expect(result.schemaVersion).toBe(REPLAY_ALERT_SCHEMA_VERSION);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Anomaly set hash (#967)
+// ---------------------------------------------------------------------------
+
+describe('computeAnomalySetHash (#967)', () => {
+  it('produces same hash for same anomaly set', () => {
+    const alerts: ReplayAnomalyAlert[] = [
+      { id: 'a', code: 'c1', severity: 'warning', kind: 'transition_validation', message: 'm1', emittedAtMs: 1 },
+      { id: 'b', code: 'c2', severity: 'error', kind: 'replay_hash_mismatch', message: 'm2', emittedAtMs: 2 },
+    ];
+    const hash1 = computeAnomalySetHash(alerts);
+    const hash2 = computeAnomalySetHash([alerts[1]!, alerts[0]!]);
+    expect(hash1).toBe(hash2);
+  });
+
+  it('empty anomaly set produces consistent hash', () => {
+    const hash1 = computeAnomalySetHash([]);
+    const hash2 = computeAnomalySetHash([]);
+    expect(hash1).toBe(hash2);
+    expect(hash1.length).toBe(64);
+  });
+
+  it('different sets produce different hashes', () => {
+    const alert1: ReplayAnomalyAlert = { id: 'a', code: 'c1', severity: 'warning', kind: 'transition_validation', message: 'm1', emittedAtMs: 1 };
+    const alert2: ReplayAnomalyAlert = { id: 'b', code: 'c2', severity: 'error', kind: 'replay_hash_mismatch', message: 'm2', emittedAtMs: 2 };
+    const hash1 = computeAnomalySetHash([alert1]);
+    const hash2 = computeAnomalySetHash([alert2]);
+    expect(hash1).not.toBe(hash2);
+  });
+});
+
+describe('computeAnomalySetHashFromContexts (#967)', () => {
+  it('produces same hash for same contexts regardless of order', () => {
+    const ctx1 = {
+      code: 'replay.test.1',
+      severity: 'warning' as const,
+      kind: 'transition_validation' as const,
+      message: 'msg1',
+    };
+    const ctx2 = {
+      code: 'replay.test.2',
+      severity: 'error' as const,
+      kind: 'replay_hash_mismatch' as const,
+      message: 'msg2',
+    };
+    const hash1 = computeAnomalySetHashFromContexts([ctx1, ctx2]);
+    const hash2 = computeAnomalySetHashFromContexts([ctx2, ctx1]);
+    expect(hash1).toBe(hash2);
+    expect(hash1.length).toBe(64);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Golden schema and lockfile (#967)
+// ---------------------------------------------------------------------------
+
+describe('replay.alert.v1 golden schema (#967)', () => {
+  it('schema version is replay.alert.v1', () => {
+    expect(REPLAY_ALERT_SCHEMA_VERSION).toBe('replay.alert.v1');
+  });
+
+  it('required fields list matches expected set', () => {
+    const fields = [...REPLAY_ALERT_V1_REQUIRED_FIELDS].sort();
+    expect(fields).toEqual(['code', 'emittedAtMs', 'id', 'kind', 'message', 'severity']);
+  });
+
+  it('valid severities match expected set', () => {
+    expect([...REPLAY_ALERT_V1_VALID_SEVERITIES].sort()).toEqual(['error', 'info', 'warning']);
+  });
+
+  it('valid kinds match expected set', () => {
+    expect([...REPLAY_ALERT_V1_VALID_KINDS].sort()).toEqual([
+      'replay_anomaly_repeat',
+      'replay_hash_mismatch',
+      'replay_ingestion_lag',
+      'transition_validation',
+    ]);
+  });
+
+  it('sample alert passes schema validation', () => {
+    const sampleAlert = {
+      id: 'abc123',
+      code: 'replay.projection.transition_invalid',
+      severity: 'warning',
+      kind: 'transition_validation',
+      message: 'test alert message',
+      emittedAtMs: 1700000000000,
+      taskPda: 'TASK_1',
+      slot: 42,
+      signature: 'SIG_1',
+      sourceEventName: 'taskCompleted',
+      sourceEventSequence: 3,
+      traceId: 'trace-123',
+    };
+
+    const result = validateAlertSchema(sampleAlert);
+    expect(result.compatible).toBe(true);
+    expect(result.missingFields).toEqual([]);
+    expect(result.invalidFields).toEqual([]);
+  });
+
+  it('alert schema matches lockfile', () => {
+    const lockfile = JSON.parse(
+      readFileSync(resolve(__dirname, './alert-schema-lockfile.json'), 'utf8'),
+    );
+
+    expect(lockfile.schemaVersion).toBe(REPLAY_ALERT_SCHEMA_VERSION);
+    expect(lockfile.requiredFields).toEqual([...REPLAY_ALERT_V1_REQUIRED_FIELDS].sort());
+    expect(lockfile.validSeverities).toEqual([...REPLAY_ALERT_V1_VALID_SEVERITIES].sort());
+    expect(lockfile.validKinds).toEqual([...REPLAY_ALERT_V1_VALID_KINDS].sort());
   });
 });

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -70,4 +70,13 @@ export {
   type ReplayAlertSeverity,
   type ReplayAlertKind,
   ReplayAlertDispatcher,
+  REPLAY_ALERT_SCHEMA_VERSION,
+  type ReplayAlertSchemaV1,
+  REPLAY_ALERT_V1_REQUIRED_FIELDS,
+  REPLAY_ALERT_V1_VALID_SEVERITIES,
+  REPLAY_ALERT_V1_VALID_KINDS,
+  type SchemaCompatibilityResult,
+  validateAlertSchema,
+  computeAnomalySetHash,
+  computeAnomalySetHashFromContexts,
 } from './alerting.js';


### PR DESCRIPTION
## Summary
- Add `replay.alert.v1` schema versioning with `REPLAY_ALERT_SCHEMA_VERSION` constant
- `validateAlertSchema()` checks required fields, types, and enum values
- `computeAnomalySetHash()` / `computeAnomalySetHashFromContexts()` for deterministic incident evidence
- Schema lockfile (`alert-schema-lockfile.json`) pins field shapes for consumers
- MCP incident schemas extended with optional `deterministic_hash` field

## Test plan
- [x] 21 tests in alerting.test.ts (5 existing + 16 new)
- [x] Golden-schema test locks field names and lockfile validation
- [x] Full runtime suite passes (2341 tests)
- [x] Typecheck clean (runtime + MCP)
- [x] Build successful

Closes #967