### PR TITLE
fix(runtime): add adaptive verification budget guardrails

### DIFF
--- a/runtime/src/autonomous/index.ts
+++ b/runtime/src/autonomous/index.ts
@@ -28,6 +28,18 @@ export {
 } from './risk-scoring.js';
 export {
   allocateVerificationBudget,
+  BudgetAdjustmentInput,
+  BudgetAdjustmentResult,
+  BudgetAuditEntry,
+  BudgetAuditTrail,
+  BudgetGuardrail,
+  clampBudget,
+  calculateNextBudget,
+  countConsecutiveFromEnd,
+  DEFAULT_BUDGET_GUARDRAIL,
+  DEFAULT_INITIAL_BUDGET_LAMPORTS,
+  resolveBudgetGuardrail,
+  validateBudgetGuardrail,
   type VerificationBudgetDecision,
 } from './verification-budget.js';
 export {

--- a/runtime/src/autonomous/types.ts
+++ b/runtime/src/autonomous/types.ts
@@ -15,6 +15,7 @@ import type { PolicyEngine } from '../policy/engine.js';
 import type { PolicyViolation } from '../policy/types.js';
 import type { TrajectoryRecorderSink } from '../eval/types.js';
 import type { WorkflowOptimizerRuntimeConfig } from '../workflow/optimizer.js';
+import type { BudgetGuardrail } from './verification-budget.js';
 
 /**
  * On-chain task data
@@ -268,6 +269,12 @@ export interface VerifierAdaptiveRiskConfig {
   hardMaxVerificationRetries?: number;
   hardMaxVerificationDurationMs?: number;
   hardMaxVerificationCostLamports?: bigint;
+  /** Guardrail bounds for adaptive budget changes. */
+  budgetGuardrail?: Partial<BudgetGuardrail>;
+  /** Maximum number of budget adjustment audit entries kept in memory. */
+  auditTrailMaxEntries?: number;
+  /** Initial verification budget in lamports before adjustments. */
+  initialBudgetLamports?: bigint;
 }
 
 export interface MultiCandidateArbitrationWeights {

--- a/runtime/src/autonomous/verification-budget.test.ts
+++ b/runtime/src/autonomous/verification-budget.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import { Keypair } from '@solana/web3.js';
 import { TaskStatus, type Task, type VerifierLaneConfig } from './types.js';
-import { allocateVerificationBudget } from './verification-budget.js';
+import {
+  allocateVerificationBudget,
+  BudgetAuditTrail,
+  BudgetAuditEntry,
+  BudgetGuardrail,
+  BudgetAdjustmentInput,
+  calculateNextBudget,
+  DEFAULT_BUDGET_GUARDRAIL,
+  validateBudgetGuardrail,
+} from './verification-budget.js';
 import { scoreTaskRisk } from './risk-scoring.js';
 
 function makeTask(overrides: Partial<Task> = {}): Task {
@@ -124,5 +133,317 @@ describe('allocateVerificationBudget', () => {
     expect(lowRisk.score).toBeLessThan(0.8);
     expect(budget.enabled).toBe(false);
     expect(budget.metadata.reason).toBe('below_risk_threshold');
+  });
+
+  it('clamps negative max allowed spend to zero', () => {
+    const task = makeTask({ reward: 100n });
+    const config = makeVerifierConfig({
+      policy: {
+        enabled: true,
+        adaptiveRisk: {
+          enabled: true,
+          hardMaxVerificationCostLamports: -1n,
+        },
+      },
+    });
+
+    const risk = scoreTaskRisk(task, {
+      verifierDisagreementRate: 0.95,
+      rollbackRate: 0.95,
+    });
+
+    const budget = allocateVerificationBudget(task, risk, config);
+    expect(budget.maxAllowedSpendLamports).toBe(0n);
+  });
+});
+
+describe('calculateNextBudget', () => {
+  const guardrail: BudgetGuardrail = {
+    ...DEFAULT_BUDGET_GUARDRAIL,
+    cooldownMs: 1_000,
+  };
+
+  const baseInput = (overrides: Partial<BudgetAdjustmentInput>): BudgetAdjustmentInput => ({
+    currentBudgetLamports: 100_000n,
+    success: true,
+    history: [],
+    guardrail,
+    lastAdjustmentTimestampMs: 0,
+    nowMs: 5_000,
+    ...overrides,
+  });
+
+  it('returns identical results for identical inputs', () => {
+    const input = baseInput({
+      history: [true, true],
+      nowMs: 2_000,
+      lastAdjustmentTimestampMs: 0,
+    });
+    const first = calculateNextBudget(input);
+    const second = calculateNextBudget(input);
+
+    expect(second.nextBudgetLamports).toBe(first.nextBudgetLamports);
+    expect(second.adjustmentFraction).toBe(first.adjustmentFraction);
+    expect(second.reason).toBe(first.reason);
+  });
+
+  it('increases budget on success streak', () => {
+    const result = calculateNextBudget(baseInput({
+      success: true,
+      history: [true, true, true, true],
+      nowMs: 6_000,
+      lastAdjustmentTimestampMs: 0,
+    }));
+
+    expect(result.adjusted).toBe(true);
+    expect(result.nextBudgetLamports).toBeGreaterThan(100_000n);
+    expect(result.reason).toBe('increased_on_success');
+  });
+
+  it('decreases budget on failure streak', () => {
+    const result = calculateNextBudget(baseInput({
+      success: false,
+      history: [false, false],
+      nowMs: 6_000,
+      lastAdjustmentTimestampMs: 0,
+    }));
+
+    expect(result.adjusted).toBe(true);
+    expect(result.nextBudgetLamports).toBeLessThan(100_000n);
+    expect(result.reason).toBe('decreased_on_failure');
+  });
+
+  it('respects cooldown and avoids changing budget', () => {
+    const result = calculateNextBudget(baseInput({
+      success: true,
+      history: [true],
+      nowMs: 4_500,
+      lastAdjustmentTimestampMs: 4_000,
+    }));
+
+    expect(result.adjusted).toBe(false);
+    expect(result.reason).toBe('cooldown_active');
+    expect(result.nextBudgetLamports).toBe(100_000n);
+  });
+
+  it('clamps to minimum budget on extreme failure', () => {
+    const result = calculateNextBudget({
+      currentBudgetLamports: 1_500n,
+      success: false,
+      history: [false, false, false, false],
+      guardrail: {
+        ...guardrail,
+        minBudgetLamports: 1_300n,
+      },
+      lastAdjustmentTimestampMs: 0,
+      nowMs: 6_000,
+    });
+    expect(result.nextBudgetLamports).toBe(1_300n);
+  });
+
+  it('clamps to maximum budget on extreme success', () => {
+    const result = calculateNextBudget({
+      currentBudgetLamports: 950_000n,
+      success: true,
+      history: [true, true, true, true, true],
+      guardrail: {
+        ...guardrail,
+        maxBudgetLamports: 1_000_000n,
+      },
+      lastAdjustmentTimestampMs: 0,
+      nowMs: 6_000,
+    });
+    expect(result.nextBudgetLamports).toBe(1_000_000n);
+  });
+
+  it('never produces a negative budget', () => {
+    const result = calculateNextBudget({
+      currentBudgetLamports: 0n,
+      success: false,
+      history: [false],
+      guardrail: {
+        ...guardrail,
+        minBudgetLamports: 0n,
+      },
+      lastAdjustmentTimestampMs: 0,
+      nowMs: 6_000,
+    });
+    expect(result.nextBudgetLamports).toBeGreaterThanOrEqual(0n);
+  });
+});
+
+describe('BudgetGuardrail validation', () => {
+  it('rejects negative minBudgetLamports', () => {
+    expect(() => validateBudgetGuardrail({
+      minBudgetLamports: -1n,
+      maxBudgetLamports: 100n,
+      adjustmentRate: 0.2,
+      cooldownMs: 1_000,
+    })).toThrow('minBudgetLamports must be non-negative');
+  });
+
+  it('rejects maxBudgetLamports < minBudgetLamports', () => {
+    expect(() => validateBudgetGuardrail({
+      minBudgetLamports: 200n,
+      maxBudgetLamports: 100n,
+      adjustmentRate: 0.2,
+      cooldownMs: 1_000,
+    })).toThrow('maxBudgetLamports must be >= minBudgetLamports');
+  });
+
+  it('rejects adjustmentRate > 1', () => {
+    expect(() => validateBudgetGuardrail({
+      minBudgetLamports: 0n,
+      maxBudgetLamports: 100n,
+      adjustmentRate: 1.5,
+      cooldownMs: 1_000,
+    })).toThrow('adjustmentRate must be in [0, 1]');
+  });
+
+  it('rejects negative cooldownMs', () => {
+    expect(() => validateBudgetGuardrail({
+      minBudgetLamports: 0n,
+      maxBudgetLamports: 100n,
+      adjustmentRate: 0.2,
+      cooldownMs: -1,
+    })).toThrow('cooldownMs must be non-negative');
+  });
+});
+
+describe('BudgetAuditTrail', () => {
+  it('records entries with incrementing sequence values', () => {
+    const trail = new BudgetAuditTrail(5);
+    trail.record({
+      timestampMs: 1000,
+      previousBudgetLamports: 100n,
+      nextBudgetLamports: 120n,
+      adjustmentFraction: 0.2,
+      reason: 'increased_on_success',
+      riskTier: 'low',
+      success: true,
+      consecutiveStreak: 1,
+    });
+    const entries = trail.getEntries();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].seq).toBe(0);
+  });
+
+  it('evicts the oldest entries when capacity is exceeded', () => {
+    const trail = new BudgetAuditTrail(2);
+    for (let i = 0; i < 4; i += 1) {
+      trail.record({
+        timestampMs: i * 1_000,
+        previousBudgetLamports: BigInt(i * 100),
+        nextBudgetLamports: BigInt((i + 1) * 100),
+        adjustmentFraction: 0.1,
+        reason: 'decreased_on_failure',
+        riskTier: 'high',
+        success: false,
+        consecutiveStreak: 2,
+      });
+    }
+
+    const entries = trail.getEntries();
+    expect(entries).toHaveLength(2);
+    expect(entries[0].seq).toBe(2);
+    expect(entries[1].seq).toBe(3);
+  });
+
+  it('supports bounded slice access', () => {
+    const trail = new BudgetAuditTrail(10);
+    for (let i = 0; i < 3; i += 1) {
+      trail.record({
+        timestampMs: i * 100,
+        previousBudgetLamports: BigInt(i * 100),
+        nextBudgetLamports: BigInt((i + 1) * 100),
+        adjustmentFraction: 0.1,
+        riskTier: 'low',
+        reason: 'increased_on_success',
+        success: true,
+        consecutiveStreak: i + 1,
+      });
+    }
+
+    const last: BudgetAuditEntry[] = [...trail.getLastN(2)] as BudgetAuditEntry[];
+    expect(last).toHaveLength(2);
+    expect(last[0].seq).toBe(1);
+  });
+});
+
+describe('deterministic budget simulations', () => {
+  it('keeps budget within configured bounds over alternating outcomes', () => {
+    const guardrail: BudgetGuardrail = {
+      minBudgetLamports: 1_000n,
+      maxBudgetLamports: 1_000_000n,
+      adjustmentRate: 0.1,
+      cooldownMs: 0,
+    };
+
+    let budget = 100_000n;
+    let lastAdjustment = 0;
+    const history: boolean[] = [];
+
+    for (let step = 0; step < 100; step++) {
+      const success = step % 2 === 0;
+      history.push(success);
+      const result = calculateNextBudget({
+        currentBudgetLamports: budget,
+        success,
+        history,
+        guardrail,
+        lastAdjustmentTimestampMs: lastAdjustment,
+        nowMs: step * 1_000,
+      });
+
+      if (result.adjusted) {
+        lastAdjustment = result.adjustedAtMs;
+      }
+      budget = result.nextBudgetLamports;
+    }
+
+    expect(budget).toBeGreaterThanOrEqual(guardrail.minBudgetLamports);
+    expect(budget).toBeLessThanOrEqual(guardrail.maxBudgetLamports);
+  });
+
+  it('produces identical traces for identical simulation inputs', () => {
+    const guardrail: BudgetGuardrail = {
+      minBudgetLamports: 1_000n,
+      maxBudgetLamports: 1_000_000n,
+      adjustmentRate: 0.15,
+      cooldownMs: 500,
+    };
+    const outcomes = [true, true, false, true, false, false, true, true, true, false];
+
+    const run = (): bigint[] => {
+      let budget = 50_000n;
+      let lastAdjustment = 0;
+      const history: boolean[] = [];
+      const trace: bigint[] = [];
+
+      for (let i = 0; i < outcomes.length; i++) {
+        const success = outcomes[i]!;
+        history.push(success);
+        const result = calculateNextBudget({
+          currentBudgetLamports: budget,
+          success,
+          history,
+          guardrail,
+          lastAdjustmentTimestampMs: lastAdjustment,
+          nowMs: i * 1000,
+        });
+
+        if (result.adjusted) {
+          lastAdjustment = result.adjustedAtMs;
+        }
+        budget = result.nextBudgetLamports;
+        trace.push(budget);
+      }
+
+      return trace;
+    };
+
+    const first = run();
+    const second = run();
+    expect(first).toEqual(second);
   });
 });


### PR DESCRIPTION
## Summary
- Added budget guardrail configuration, validation, and defaults for adaptive verifier budgeting.
- Introduced deterministic budget stepping with cooldown, clamping, and overflow/underflow protection.
- Added bounded budget audit trail and verifier integration for outcome-based budget evolution.
- Expanded deterministic unit tests for policy guardrails, streak behavior, cooldown, and audit-log capacity.

## Test plan
- [x] 
 RUN  v2.1.9 /home/tetsuo/git/AgenC/runtime

 ✓ src/autonomous/verification-budget.test.ts (20 tests) 45ms

 Test Files  1 passed (1)
      Tests  20 passed (20)
   Start at  19:22:46
   Duration  436ms (transform 60ms, setup 0ms, collect 111ms, tests 45ms, environment 0ms, prepare 34ms)

Closes #970
