### PR TITLE
fix(runtime): harden LLM adapter resilience paths

### DIFF
--- a/runtime/src/llm/fallback.test.ts
+++ b/runtime/src/llm/fallback.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  LLMAuthenticationError,
+  LLMServerError,
+  LLMTimeoutError,
+} from './errors.js';
+import { FallbackLLMProvider } from './fallback.js';
+import type { LLMMessage, LLMProvider, LLMResponse } from './types.js';
+
+function makeResponse(content: string): LLMResponse {
+  return {
+    content,
+    toolCalls: [],
+    usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    model: 'mock-model',
+    finishReason: 'stop',
+  };
+}
+
+function createMockProvider(
+  name: string,
+  chatImpl?: (messages: LLMMessage[]) => Promise<LLMResponse>,
+): LLMProvider {
+  return {
+    name,
+    chat: vi.fn(chatImpl ?? (async () => makeResponse(`response from ${name}`))),
+    chatStream: vi.fn(async () => makeResponse(`stream response from ${name}`)),
+    healthCheck: vi.fn(async () => true),
+  };
+}
+
+describe('FallbackLLMProvider', () => {
+  it('uses primary provider when it succeeds', async () => {
+    const primary = createMockProvider('primary');
+    const secondary = createMockProvider('secondary');
+    const provider = new FallbackLLMProvider({ providers: [primary, secondary] });
+
+    const result = await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    expect(result.content).toBe('response from primary');
+    expect(primary.chat).toHaveBeenCalledTimes(1);
+    expect(secondary.chat).not.toHaveBeenCalled();
+  });
+
+  it('falls back to secondary on timeout errors', async () => {
+    const primary = createMockProvider('primary', async () => {
+      throw new LLMTimeoutError('primary', 5000);
+    });
+    const secondary = createMockProvider('secondary');
+    const provider = new FallbackLLMProvider({ providers: [primary, secondary] });
+
+    const result = await provider.chat([{ role: 'user', content: 'hello' }]);
+
+    expect(result.content).toBe('response from secondary');
+    expect(primary.chat).toHaveBeenCalledTimes(1);
+    expect(secondary.chat).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fall back on authentication errors by default', async () => {
+    const primary = createMockProvider('primary', async () => {
+      throw new LLMAuthenticationError('primary', 401);
+    });
+    const secondary = createMockProvider('secondary');
+    const provider = new FallbackLLMProvider({ providers: [primary, secondary] });
+
+    await expect(
+      provider.chat([{ role: 'user', content: 'hello' }]),
+    ).rejects.toThrow(LLMAuthenticationError);
+    expect(secondary.chat).not.toHaveBeenCalled();
+  });
+
+  it('throws when all providers fail', async () => {
+    const primary = createMockProvider('primary', async () => {
+      throw new LLMServerError('primary', 500, 'down');
+    });
+    const secondary = createMockProvider('secondary', async () => {
+      throw new LLMServerError('secondary', 500, 'also down');
+    });
+    const provider = new FallbackLLMProvider({ providers: [primary, secondary] });
+
+    await expect(
+      provider.chat([{ role: 'user', content: 'hello' }]),
+    ).rejects.toThrow(LLMServerError);
+  });
+
+  it('healthCheck returns true if any provider is healthy', async () => {
+    const primary = createMockProvider('primary');
+    const secondary = createMockProvider('secondary');
+
+    (primary.healthCheck as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (secondary.healthCheck as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const provider = new FallbackLLMProvider({ providers: [primary, secondary] });
+    await expect(provider.healthCheck()).resolves.toBe(true);
+  });
+});

--- a/runtime/src/llm/fallback.ts
+++ b/runtime/src/llm/fallback.ts
@@ -1,0 +1,114 @@
+/**
+ * Fallback LLM provider chain.
+ *
+ * @module
+ */
+
+import {
+  LLMProviderError,
+  LLMServerError,
+  LLMTimeoutError,
+} from './errors.js';
+import type {
+  LLMMessage,
+  LLMProvider,
+  LLMResponse,
+  StreamProgressCallback,
+} from './types.js';
+
+export interface FallbackChainConfig {
+  providers: LLMProvider[];
+  fallbackOnErrors?: Array<'timeout' | 'server' | 'provider'>;
+}
+
+/**
+ * Provider wrapper that retries against secondary providers when allowed.
+ */
+export class FallbackLLMProvider implements LLMProvider {
+  readonly name: string;
+
+  private readonly providers: LLMProvider[];
+  private readonly fallbackErrors: Set<'timeout' | 'server' | 'provider'>;
+
+  constructor(config: FallbackChainConfig) {
+    if (!config.providers || config.providers.length === 0) {
+      throw new Error('FallbackLLMProvider requires at least one provider');
+    }
+    this.providers = [...config.providers];
+    this.fallbackErrors = new Set(
+      config.fallbackOnErrors ?? ['timeout', 'server', 'provider'],
+    );
+    this.name = `fallback(${this.providers.map((provider) => provider.name).join(',')})`;
+  }
+
+  async chat(messages: LLMMessage[]): Promise<LLMResponse> {
+    let lastError: Error | undefined;
+
+    for (const provider of this.providers) {
+      try {
+        const response = await provider.chat(messages);
+        if (response.finishReason === 'error' && response.error) {
+          throw response.error;
+        }
+        return response;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (!this.shouldFallback(lastError)) {
+          throw lastError;
+        }
+      }
+    }
+
+    throw lastError ?? new LLMProviderError(this.name, 'All providers failed');
+  }
+
+  async chatStream(
+    messages: LLMMessage[],
+    onChunk: StreamProgressCallback,
+  ): Promise<LLMResponse> {
+    let lastError: Error | undefined;
+
+    for (const provider of this.providers) {
+      try {
+        const response = await provider.chatStream(messages, onChunk);
+        if (response.finishReason === 'error' && response.error) {
+          throw response.error;
+        }
+        return response;
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error(String(err));
+        if (!this.shouldFallback(lastError)) {
+          throw lastError;
+        }
+      }
+    }
+
+    throw lastError ?? new LLMProviderError(this.name, 'All providers failed');
+  }
+
+  async healthCheck(): Promise<boolean> {
+    for (const provider of this.providers) {
+      try {
+        if (await provider.healthCheck()) {
+          return true;
+        }
+      } catch {
+        // Ignore and continue to next provider.
+      }
+    }
+    return false;
+  }
+
+  private shouldFallback(err: Error): boolean {
+    if (err instanceof LLMTimeoutError) {
+      return this.fallbackErrors.has('timeout');
+    }
+    if (err instanceof LLMServerError) {
+      return this.fallbackErrors.has('server');
+    }
+    if (err instanceof LLMProviderError) {
+      return this.fallbackErrors.has('provider');
+    }
+    return false;
+  }
+}

--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -21,12 +21,15 @@ export type {
   StreamProgressCallback,
   ToolHandler,
 } from './types.js';
+export { validateToolCall } from './types.js';
 
 // Error classes
 export {
+  LLMAuthenticationError,
   LLMProviderError,
   LLMRateLimitError,
   LLMResponseConversionError,
+  LLMServerError,
   LLMToolCallError,
   LLMTimeoutError,
   mapLLMError,
@@ -37,6 +40,7 @@ export { responseToOutput } from './response-converter.js';
 
 // LLM Task Executor
 export { LLMTaskExecutor, type LLMTaskExecutorConfig } from './executor.js';
+export { FallbackLLMProvider, type FallbackChainConfig } from './fallback.js';
 
 // Provider adapters
 export { GrokProvider, type GrokProviderConfig } from './grok/index.js';

--- a/runtime/src/llm/timeout.ts
+++ b/runtime/src/llm/timeout.ts
@@ -1,0 +1,44 @@
+/**
+ * Timeout helper for LLM provider calls.
+ *
+ * @module
+ */
+
+function createAbortTimeoutError(providerName: string, timeoutMs: number): Error {
+  const err = new Error(`${providerName} request aborted after ${timeoutMs}ms`);
+  (err as any).name = 'AbortError';
+  (err as any).code = 'ABORT_ERR';
+  return err;
+}
+
+/**
+ * Execute an async provider call with an explicit AbortController timeout.
+ */
+export async function withTimeout<T>(
+  fn: (signal: AbortSignal) => Promise<T>,
+  timeoutMs: number | undefined,
+  providerName: string,
+): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) {
+    const controller = new AbortController();
+    return fn(controller.signal);
+  }
+
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(createAbortTimeoutError(providerName, timeoutMs));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([fn(controller.signal), timeoutPromise]);
+  } finally {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/runtime/src/llm/types.test.ts
+++ b/runtime/src/llm/types.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { validateToolCall } from './types.js';
+
+describe('validateToolCall', () => {
+  it('accepts a valid tool call payload', () => {
+    const result = validateToolCall({
+      id: 'call_1',
+      name: 'lookup',
+      arguments: '{"q":"hello"}',
+    });
+
+    expect(result).toEqual({
+      id: 'call_1',
+      name: 'lookup',
+      arguments: '{"q":"hello"}',
+    });
+  });
+
+  it('rejects missing ids', () => {
+    expect(
+      validateToolCall({
+        name: 'lookup',
+        arguments: '{}',
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects empty names', () => {
+    expect(
+      validateToolCall({
+        id: 'call_1',
+        name: '',
+        arguments: '{}',
+      }),
+    ).toBeNull();
+  });
+
+  it('rejects non-JSON argument strings', () => {
+    expect(
+      validateToolCall({
+        id: 'call_1',
+        name: 'lookup',
+        arguments: '{bad-json',
+      }),
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- expanded LLM error taxonomy with `LLMAuthenticationError` and `LLMServerError`, and updated `mapLLMError()` classification for abort/auth/rate-limit/server cases
- added `withTimeout()` AbortController guard and applied it across Grok/Anthropic/Ollama `chat()` + `chatStream()` entry calls
- added partial streaming recovery in all three adapters (`finishReason: error`, `partial: true`, `error`) when content was accumulated before failure
- added strict tool-call shape validation (`validateToolCall`) and applied it in all three adapter parse paths
- updated `LLMTaskExecutor` to reject `finishReason: error` responses and to return tool-argument parse errors to the model instead of silently using `{}`
- added `FallbackLLMProvider` chain wrapper with configurable fallback-on-error behavior
- added/updated adapter, executor, fallback, and types tests for resilience paths

## Test plan
- [x] `cd runtime && npm run typecheck`
- [x] `cd runtime && npx vitest run src/llm/types.test.ts src/llm/fallback.test.ts src/llm/grok/adapter.test.ts src/llm/anthropic/adapter.test.ts src/llm/ollama/adapter.test.ts src/llm/executor.test.ts`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:fast`
- [x] `npm run typecheck`

Closes #973