### PR TITLE
feat(sdk): align wrappers and errors with full IDL

### DIFF
--- a/sdk/src/__tests__/agents.test.ts
+++ b/sdk/src/__tests__/agents.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import { deriveAgentPda, registerAgent } from '../agents';
+import { PROGRAM_ID, SEEDS } from '../constants';
+
+describe('agents', () => {
+  it('deriveAgentPda matches manual seed derivation', () => {
+    const agentId = new Uint8Array(32).fill(7);
+    const derived = deriveAgentPda(agentId, PROGRAM_ID);
+
+    const [expected] = PublicKey.findProgramAddressSync(
+      [SEEDS.AGENT, agentId],
+      PROGRAM_ID,
+    );
+
+    expect(derived.equals(expected)).toBe(true);
+  });
+
+  it('registerAgent converts numeric params to BN and submits expected accounts', async () => {
+    const rpc = vi.fn().mockResolvedValue('tx-signature');
+    const signers = vi.fn().mockReturnValue({ rpc });
+    const accountsPartial = vi.fn().mockReturnValue({ signers });
+    const registerAgentMethod = vi.fn().mockReturnValue({ accountsPartial });
+
+    const program = {
+      programId: PROGRAM_ID,
+      methods: {
+        registerAgent: registerAgentMethod,
+      },
+    } as unknown as Program;
+
+    const confirmTransaction = vi.fn().mockResolvedValue(undefined);
+    const connection = {
+      confirmTransaction,
+    } as unknown as Connection;
+
+    const authority = Keypair.generate();
+    const params = {
+      agentId: new Uint8Array(32).fill(3),
+      capabilities: 42,
+      endpoint: 'https://agent.example.com',
+      stakeAmount: 1_000_000,
+    };
+
+    const result = await registerAgent(connection, program, authority, params);
+
+    expect(registerAgentMethod).toHaveBeenCalledOnce();
+    const args = registerAgentMethod.mock.calls[0];
+    expect(args[1].toString()).toBe('42');
+    expect(args[4].toString()).toBe('1000000');
+
+    expect(accountsPartial).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authority: authority.publicKey,
+      }),
+    );
+
+    expect(confirmTransaction).toHaveBeenCalledWith('tx-signature', 'confirmed');
+    expect(result.txSignature).toBe('tx-signature');
+  });
+});

--- a/sdk/src/__tests__/disputes.test.ts
+++ b/sdk/src/__tests__/disputes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { deriveDisputePda, deriveVotePda } from '../disputes';
+import { PROGRAM_ID, SEEDS } from '../constants';
+
+describe('disputes PDA helpers', () => {
+  it('deriveDisputePda uses ["dispute", disputeId] seeds', () => {
+    const disputeId = new Uint8Array(32).fill(11);
+    const pda = deriveDisputePda(disputeId, PROGRAM_ID);
+
+    const [expected] = PublicKey.findProgramAddressSync(
+      [SEEDS.DISPUTE, disputeId],
+      PROGRAM_ID,
+    );
+
+    expect(pda.equals(expected)).toBe(true);
+  });
+
+  it('deriveVotePda uses ["vote", disputePda, voterAgentPda] seeds', () => {
+    const disputePda = Keypair.generate().publicKey;
+    const voterAgentPda = Keypair.generate().publicKey;
+    const pda = deriveVotePda(disputePda, voterAgentPda, PROGRAM_ID);
+
+    const [expected] = PublicKey.findProgramAddressSync(
+      [SEEDS.VOTE, disputePda.toBuffer(), voterAgentPda.toBuffer()],
+      PROGRAM_ID,
+    );
+
+    expect(pda.equals(expected)).toBe(true);
+  });
+});

--- a/sdk/src/__tests__/errors.test.ts
+++ b/sdk/src/__tests__/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { decodeAnchorError, decodeError } from '../errors';
+
+describe('errors', () => {
+  it('decodeError returns known coordination errors', () => {
+    const decoded = decodeError(6000);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.name).toBe('AgentAlreadyRegistered');
+    expect(decoded?.category).toBe('agent');
+  });
+
+  it('decodeError returns null for unknown code', () => {
+    expect(decodeError(9999)).toBeNull();
+  });
+
+  it('decodeAnchorError handles direct Anchor errorCode shape', () => {
+    const decoded = decodeAnchorError({ errorCode: { number: 6001 } });
+    expect(decoded?.name).toBe('AgentNotFound');
+  });
+
+  it('decodeAnchorError handles nested Anchor error shape', () => {
+    const decoded = decodeAnchorError({ error: { errorCode: { number: 6014 } } });
+    expect(decoded?.name).toBe('TaskNotOpen');
+  });
+
+  it('decodeAnchorError handles log/message formats', () => {
+    const fromLogs = decodeAnchorError({ logs: ['Program log: Error Number: 6050'] });
+    expect(fromLogs?.name).toBe('DisputeNotActive');
+
+    const fromHex = decodeAnchorError({ message: 'custom program error: 0x1770' });
+    expect(fromHex?.name).toBe('AgentAlreadyRegistered');
+  });
+});

--- a/sdk/src/__tests__/idl-alignment.test.ts
+++ b/sdk/src/__tests__/idl-alignment.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import * as agents from '../agents';
+import * as tasks from '../tasks';
+import * as disputes from '../disputes';
+import * as protocol from '../protocol';
+import * as state from '../state';
+import { COORDINATION_ERROR_MAP, decodeError } from '../errors';
+
+const idl = JSON.parse(
+  readFileSync(new URL('../../../target/idl/agenc_coordination.json', import.meta.url), 'utf8'),
+) as {
+  instructions: Array<{ name: string }>;
+  errors?: Array<{ code: number; name: string }>;
+};
+
+const EXPECTED_INSTRUCTIONS = [
+  'register_agent',
+  'update_agent',
+  'suspend_agent',
+  'unsuspend_agent',
+  'deregister_agent',
+  'create_task',
+  'create_dependent_task',
+  'claim_task',
+  'expire_claim',
+  'complete_task',
+  'complete_task_private',
+  'cancel_task',
+  'update_state',
+  'initiate_dispute',
+  'vote_dispute',
+  'resolve_dispute',
+  'apply_dispute_slash',
+  'apply_initiator_slash',
+  'cancel_dispute',
+  'expire_dispute',
+  'initialize_protocol',
+  'update_protocol_fee',
+  'update_rate_limits',
+  'migrate_protocol',
+  'update_min_version',
+] as const;
+
+describe('IDL instruction alignment', () => {
+  it('instruction set matches expected list exactly', () => {
+    const idlNames = idl.instructions.map((ix) => ix.name).sort();
+    const expected = [...EXPECTED_INSTRUCTIONS].sort();
+    expect(idlNames).toEqual(expected);
+  });
+
+  it('every instruction has a matching camelCase SDK wrapper export', () => {
+    const sdkExports = new Set<string>([
+      ...Object.keys(agents),
+      ...Object.keys(tasks),
+      ...Object.keys(disputes),
+      ...Object.keys(protocol),
+      ...Object.keys(state),
+    ]);
+
+    for (const instructionName of EXPECTED_INSTRUCTIONS) {
+      const camelCase = instructionName.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+      expect(sdkExports.has(camelCase)).toBe(true);
+    }
+  });
+
+  it('error map covers every IDL error variant', () => {
+    const idlErrors = idl.errors ?? [];
+    expect(Object.keys(COORDINATION_ERROR_MAP)).toHaveLength(idlErrors.length);
+
+    for (const err of idlErrors) {
+      const decoded = decodeError(err.code);
+      expect(decoded).not.toBeNull();
+      expect(decoded?.name).toBe(err.name);
+    }
+  });
+});

--- a/sdk/src/__tests__/protocol.test.ts
+++ b/sdk/src/__tests__/protocol.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Connection, Keypair } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import { initializeProtocol } from '../protocol';
+import { PROGRAM_ID } from '../constants';
+
+describe('protocol wrappers', () => {
+  it('initializeProtocol validates multisig threshold against owner count', async () => {
+    const authority = Keypair.generate();
+    const secondSigner = Keypair.generate();
+
+    const program = {
+      programId: PROGRAM_ID,
+      methods: {
+        initializeProtocol: vi.fn(),
+      },
+    } as unknown as Program;
+
+    const connection = {
+      confirmTransaction: vi.fn(),
+    } as unknown as Connection;
+
+    await expect(
+      initializeProtocol(
+        connection,
+        program,
+        authority,
+        secondSigner,
+        Keypair.generate().publicKey,
+        {
+          disputeThreshold: 51,
+          protocolFeeBps: 100,
+          minStake: 1_000_000,
+          minStakeForDispute: 500_000,
+          multisigThreshold: 3,
+          multisigOwners: [authority.publicKey, secondSigner.publicKey],
+        },
+      ),
+    ).rejects.toThrow('multisigThreshold cannot exceed multisigOwners length');
+  });
+
+  it('initializeProtocol submits expected args and confirms transaction', async () => {
+    const authority = Keypair.generate();
+    const secondSigner = Keypair.generate();
+    const treasury = Keypair.generate().publicKey;
+
+    const rpc = vi.fn().mockResolvedValue('protocol-init-sig');
+    const signers = vi.fn().mockReturnValue({ rpc });
+    const remainingAccounts = vi.fn().mockReturnValue({ signers });
+    const accountsPartial = vi.fn().mockReturnValue({ remainingAccounts });
+    const initializeProtocolMethod = vi.fn().mockReturnValue({ accountsPartial });
+
+    const program = {
+      programId: PROGRAM_ID,
+      methods: {
+        initializeProtocol: initializeProtocolMethod,
+      },
+    } as unknown as Program;
+
+    const confirmTransaction = vi.fn().mockResolvedValue(undefined);
+    const connection = {
+      confirmTransaction,
+    } as unknown as Connection;
+
+    const params = {
+      disputeThreshold: 51,
+      protocolFeeBps: 100,
+      minStake: 1_000_000,
+      minStakeForDispute: 500_000,
+      multisigThreshold: 2,
+      multisigOwners: [authority.publicKey, secondSigner.publicKey, Keypair.generate().publicKey],
+    };
+
+    const result = await initializeProtocol(
+      connection,
+      program,
+      authority,
+      secondSigner,
+      treasury,
+      params,
+    );
+
+    expect(initializeProtocolMethod).toHaveBeenCalledOnce();
+    const args = initializeProtocolMethod.mock.calls[0];
+    expect(args[0]).toBe(51);
+    expect(args[1]).toBe(100);
+    expect(args[2].toString()).toBe('1000000');
+    expect(args[3].toString()).toBe('500000');
+    expect(args[4]).toBe(2);
+
+    expect(confirmTransaction).toHaveBeenCalledWith('protocol-init-sig', 'confirmed');
+    expect(result.txSignature).toBe('protocol-init-sig');
+  });
+});

--- a/sdk/src/agents.ts
+++ b/sdk/src/agents.ts
@@ -1,0 +1,281 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+} from '@solana/web3.js';
+import { BN, type Program } from '@coral-xyz/anchor';
+import { PROGRAM_ID, SEEDS } from './constants';
+import { getAccount } from './anchor-utils';
+
+export interface RegisterAgentParams {
+  agentId: Uint8Array | number[];
+  capabilities: number | bigint;
+  endpoint: string;
+  metadataUri?: string | null;
+  stakeAmount: number | bigint;
+}
+
+export interface UpdateAgentParams {
+  capabilities?: number | bigint | null;
+  endpoint?: string | null;
+  metadataUri?: string | null;
+  status?: number | null;
+}
+
+export enum AgentStatus {
+  Inactive = 0,
+  Active = 1,
+  Busy = 2,
+  Suspended = 3,
+}
+
+export interface AgentState {
+  agentId: Uint8Array;
+  authority: PublicKey;
+  capabilities: bigint;
+  status: AgentStatus;
+  endpoint: string;
+  metadataUri: string | null;
+  stakeAmount: bigint;
+  activeTasks: number;
+  reputation: number;
+  registeredAt: number;
+}
+
+function toAgentIdBytes(agentId: Uint8Array | number[]): Uint8Array {
+  const bytes = agentId instanceof Uint8Array ? agentId : Uint8Array.from(agentId);
+  if (bytes.length !== 32) {
+    throw new Error(`Invalid agentId length: ${bytes.length}. Expected 32 bytes.`);
+  }
+  return bytes;
+}
+
+function parseAgentStatus(raw: unknown): AgentStatus {
+  if (typeof raw === 'number') {
+    return raw as AgentStatus;
+  }
+
+  if (raw && typeof raw === 'object') {
+    const enumObj = raw as Record<string, unknown>;
+    if ('inactive' in enumObj) return AgentStatus.Inactive;
+    if ('active' in enumObj) return AgentStatus.Active;
+    if ('busy' in enumObj) return AgentStatus.Busy;
+    if ('suspended' in enumObj) return AgentStatus.Suspended;
+  }
+
+  return AgentStatus.Inactive;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object' && 'toNumber' in value) {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+  if (typeof value === 'bigint') return Number(value);
+  return 0;
+}
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return BigInt(value);
+  if (value && typeof value === 'object' && 'toString' in value) {
+    return BigInt((value as { toString: () => string }).toString());
+  }
+  return 0n;
+}
+
+function deriveProtocolPda(programId: PublicKey): PublicKey {
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.PROTOCOL], programId);
+  return pda;
+}
+
+export function deriveAgentPda(
+  agentId: Uint8Array | number[],
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  const idBytes = toAgentIdBytes(agentId);
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.AGENT, idBytes], programId);
+  return pda;
+}
+
+export async function registerAgent(
+  connection: Connection,
+  program: Program,
+  authority: Keypair,
+  params: RegisterAgentParams,
+): Promise<{ agentPda: PublicKey; txSignature: string }> {
+  const programId = program.programId;
+  const agentId = toAgentIdBytes(params.agentId);
+  const agentPda = deriveAgentPda(agentId, programId);
+  const protocolPda = deriveProtocolPda(programId);
+
+  const tx = await program.methods
+    .registerAgent(
+      Array.from(agentId),
+      new BN(params.capabilities.toString()),
+      params.endpoint,
+      params.metadataUri ?? null,
+      new BN(params.stakeAmount.toString()),
+    )
+    .accountsPartial({
+      agent: agentPda,
+      protocolConfig: protocolPda,
+      authority: authority.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([authority])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { agentPda, txSignature: tx };
+}
+
+export async function updateAgent(
+  connection: Connection,
+  program: Program,
+  authority: Keypair,
+  agentId: Uint8Array | number[],
+  params: UpdateAgentParams,
+): Promise<{ txSignature: string }> {
+  const programId = program.programId;
+  const agentPda = deriveAgentPda(agentId, programId);
+
+  const capabilities =
+    params.capabilities === undefined || params.capabilities === null
+      ? null
+      : new BN(params.capabilities.toString());
+
+  const builder = program.methods
+    .updateAgent(
+      capabilities,
+      params.endpoint ?? null,
+      params.metadataUri ?? null,
+      params.status ?? null,
+    )
+    .accountsPartial({
+      agent: agentPda,
+      authority: authority.publicKey,
+    })
+    .signers([authority]);
+
+  if (params.status === AgentStatus.Suspended) {
+    builder.remainingAccounts([
+      {
+        pubkey: deriveProtocolPda(programId),
+        isSigner: false,
+        isWritable: false,
+      },
+    ]);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+
+  return { txSignature: tx };
+}
+
+export async function suspendAgent(
+  connection: Connection,
+  program: Program,
+  protocolAuthority: Keypair,
+  agentId: Uint8Array | number[],
+): Promise<{ txSignature: string }> {
+  const programId = program.programId;
+  const agentPda = deriveAgentPda(agentId, programId);
+  const protocolPda = deriveProtocolPda(programId);
+
+  const tx = await program.methods
+    .suspendAgent()
+    .accountsPartial({
+      agent: agentPda,
+      protocolConfig: protocolPda,
+      authority: protocolAuthority.publicKey,
+    })
+    .signers([protocolAuthority])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function unsuspendAgent(
+  connection: Connection,
+  program: Program,
+  protocolAuthority: Keypair,
+  agentId: Uint8Array | number[],
+): Promise<{ txSignature: string }> {
+  const programId = program.programId;
+  const agentPda = deriveAgentPda(agentId, programId);
+  const protocolPda = deriveProtocolPda(programId);
+
+  const tx = await program.methods
+    .unsuspendAgent()
+    .accountsPartial({
+      agent: agentPda,
+      protocolConfig: protocolPda,
+      authority: protocolAuthority.publicKey,
+    })
+    .signers([protocolAuthority])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function deregisterAgent(
+  connection: Connection,
+  program: Program,
+  authority: Keypair,
+  agentId: Uint8Array | number[],
+): Promise<{ txSignature: string }> {
+  const programId = program.programId;
+  const agentPda = deriveAgentPda(agentId, programId);
+  const protocolPda = deriveProtocolPda(programId);
+
+  const tx = await program.methods
+    .deregisterAgent()
+    .accountsPartial({
+      agent: agentPda,
+      protocolConfig: protocolPda,
+      authority: authority.publicKey,
+    })
+    .signers([authority])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function getAgent(
+  program: Program,
+  agentPda: PublicKey,
+): Promise<AgentState | null> {
+  try {
+    const account = (await getAccount(program, 'agentRegistration').fetch(agentPda)) as Record<string, unknown>;
+
+    const metadataUriRaw = account.metadataUri ?? account.metadata_uri;
+    const metadataUri = typeof metadataUriRaw === 'string' && metadataUriRaw.length > 0
+      ? metadataUriRaw
+      : null;
+
+    return {
+      agentId: new Uint8Array((account.agentId ?? account.agent_id ?? []) as number[]),
+      authority: account.authority as PublicKey,
+      capabilities: toBigInt(account.capabilities),
+      status: parseAgentStatus(account.status),
+      endpoint: (account.endpoint ?? '') as string,
+      metadataUri,
+      stakeAmount: toBigInt(account.stake),
+      activeTasks: toNumber(account.activeTasks ?? account.active_tasks),
+      reputation: toNumber(account.reputation),
+      registeredAt: toNumber(account.registeredAt ?? account.registered_at),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('Account does not exist') || message.includes('could not find account')) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -14,6 +14,9 @@ export const PROGRAM_ID = new PublicKey('EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jG
 /** Privacy Cash Program ID */
 export const PRIVACY_CASH_PROGRAM_ID = new PublicKey('9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD');
 
+/** AgenC verifier program ID */
+export const VERIFIER_PROGRAM_ID = new PublicKey('8fHUGmjNzSh76r78v1rPt7BhWmAu2gXrvW9A2XXonwQQ');
+
 // ============================================================================
 // RPC Endpoints
 // ============================================================================

--- a/sdk/src/disputes.ts
+++ b/sdk/src/disputes.ts
@@ -1,0 +1,617 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  type AccountMeta,
+} from '@solana/web3.js';
+import { type Program } from '@coral-xyz/anchor';
+import {
+  getAssociatedTokenAddressSync,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token';
+import { PROGRAM_ID, SEEDS } from './constants';
+import { getAccount } from './anchor-utils';
+import { deriveClaimPda, deriveEscrowPda } from './tasks';
+
+export enum DisputeStatus {
+  Active = 0,
+  Resolved = 1,
+  Expired = 2,
+  Cancelled = 3,
+}
+
+export enum ResolutionType {
+  Refund = 0,
+  Complete = 1,
+  Split = 2,
+}
+
+export interface InitiateDisputeParams {
+  disputeId: Uint8Array | number[];
+  taskPda: PublicKey;
+  taskId: Uint8Array | number[];
+  evidenceHash: Uint8Array | number[];
+  resolutionType: number;
+  evidence: string;
+  initiatorClaimPda?: PublicKey | null;
+  workerAgentPda?: PublicKey | null;
+  workerClaimPda?: PublicKey | null;
+  defendantWorkers?: Array<{ claimPda: PublicKey; workerPda: PublicKey }>;
+}
+
+export interface VoteDisputeParams {
+  disputePda: PublicKey;
+  taskPda: PublicKey;
+  approve: boolean;
+  workerClaimPda?: PublicKey | null;
+  defendantAgentPda?: PublicKey | null;
+}
+
+export interface ResolveDisputeParams {
+  disputePda: PublicKey;
+  taskPda: PublicKey;
+  creatorPubkey: PublicKey;
+  workerClaimPda?: PublicKey | null;
+  workerAgentPda?: PublicKey | null;
+  workerAuthority?: PublicKey | null;
+  arbiterPairs?: Array<{ votePda: PublicKey; agentPda: PublicKey }>;
+  workerPairs?: Array<{ claimPda: PublicKey; agentPda: PublicKey }>;
+}
+
+export interface ApplyDisputeSlashParams {
+  disputePda: PublicKey;
+  taskPda: PublicKey;
+  workerClaimPda: PublicKey;
+  workerAgentPda: PublicKey;
+}
+
+export interface ApplyInitiatorSlashParams {
+  disputePda: PublicKey;
+  taskPda: PublicKey;
+  initiatorAgentPda: PublicKey;
+}
+
+export interface ExpireDisputeParams {
+  disputePda: PublicKey;
+  taskPda: PublicKey;
+  creatorPubkey: PublicKey;
+  workerClaimPda?: PublicKey | null;
+  workerAgentPda?: PublicKey | null;
+  workerAuthority?: PublicKey | null;
+  arbiterPairs?: Array<{ votePda: PublicKey; agentPda: PublicKey }>;
+  workerPairs?: Array<{ claimPda: PublicKey; agentPda: PublicKey }>;
+}
+
+export interface DisputeState {
+  disputeId: Uint8Array;
+  task: PublicKey;
+  initiator: PublicKey;
+  initiatorAuthority: PublicKey;
+  evidenceHash: Uint8Array;
+  resolutionType: ResolutionType;
+  status: DisputeStatus;
+  createdAt: number;
+  resolvedAt: number;
+  votesFor: bigint;
+  votesAgainst: bigint;
+  totalVoters: number;
+  votingDeadline: number;
+  expiresAt: number;
+  slashApplied: boolean;
+  initiatorSlashApplied: boolean;
+  workerStakeAtDispute: bigint;
+  initiatedByCreator: boolean;
+  bump: number;
+  defendant: PublicKey;
+}
+
+function toFixedBytes(value: Uint8Array | number[], length: number, fieldName: string): Uint8Array {
+  const bytes = value instanceof Uint8Array ? value : Uint8Array.from(value);
+  if (bytes.length !== length) {
+    throw new Error(`Invalid ${fieldName} length: ${bytes.length}. Expected ${length} bytes.`);
+  }
+  return bytes;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object' && 'toNumber' in value) {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+  if (typeof value === 'bigint') return Number(value);
+  return 0;
+}
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return BigInt(value);
+  if (value && typeof value === 'object' && 'toString' in value) {
+    return BigInt((value as { toString: () => string }).toString());
+  }
+  return 0n;
+}
+
+function parseResolutionType(raw: unknown): ResolutionType {
+  if (typeof raw === 'number') return raw as ResolutionType;
+  if (raw && typeof raw === 'object') {
+    const enumObj = raw as Record<string, unknown>;
+    if ('refund' in enumObj) return ResolutionType.Refund;
+    if ('complete' in enumObj) return ResolutionType.Complete;
+    if ('split' in enumObj) return ResolutionType.Split;
+  }
+  return ResolutionType.Refund;
+}
+
+function parseDisputeStatus(raw: unknown): DisputeStatus {
+  if (typeof raw === 'number') return raw as DisputeStatus;
+  if (raw && typeof raw === 'object') {
+    const enumObj = raw as Record<string, unknown>;
+    if ('active' in enumObj) return DisputeStatus.Active;
+    if ('resolved' in enumObj) return DisputeStatus.Resolved;
+    if ('expired' in enumObj) return DisputeStatus.Expired;
+    if ('cancelled' in enumObj) return DisputeStatus.Cancelled;
+  }
+  return DisputeStatus.Active;
+}
+
+function deriveProtocolPda(programId: PublicKey): PublicKey {
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.PROTOCOL], programId);
+  return pda;
+}
+
+function deriveAgentPda(agentId: Uint8Array | number[], programId: PublicKey): PublicKey {
+  const idBytes = toFixedBytes(agentId, 32, 'agentId');
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.AGENT, idBytes], programId);
+  return pda;
+}
+
+function deriveAuthorityVotePda(
+  disputePda: PublicKey,
+  authority: PublicKey,
+  programId: PublicKey,
+): PublicKey {
+  const [pda] = PublicKey.findProgramAddressSync(
+    [SEEDS.AUTHORITY_VOTE, disputePda.toBuffer(), authority.toBuffer()],
+    programId,
+  );
+  return pda;
+}
+
+function buildRemainingAccounts(
+  arbiterPairs?: Array<{ votePda: PublicKey; agentPda: PublicKey }>,
+  workerPairs?: Array<{ claimPda: PublicKey; agentPda: PublicKey }>,
+): AccountMeta[] {
+  const metas: AccountMeta[] = [];
+  for (const pair of arbiterPairs ?? []) {
+    metas.push({ pubkey: pair.votePda, isSigner: false, isWritable: true });
+    metas.push({ pubkey: pair.agentPda, isSigner: false, isWritable: true });
+  }
+  for (const pair of workerPairs ?? []) {
+    metas.push({ pubkey: pair.claimPda, isSigner: false, isWritable: true });
+    metas.push({ pubkey: pair.agentPda, isSigner: false, isWritable: true });
+  }
+  return metas;
+}
+
+function buildResolveTokenAccounts(
+  rewardMint: PublicKey | null,
+  escrowPda: PublicKey,
+  creator: PublicKey,
+  workerAuthority: PublicKey | null,
+  treasury: PublicKey,
+): Record<string, PublicKey | undefined> {
+  if (!rewardMint) {
+    return {
+      tokenEscrowAta: undefined,
+      creatorTokenAccount: undefined,
+      workerTokenAccountAta: undefined,
+      treasuryTokenAccount: undefined,
+      rewardMint: undefined,
+      tokenProgram: undefined,
+    };
+  }
+
+  return {
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    creatorTokenAccount: getAssociatedTokenAddressSync(rewardMint, creator),
+    workerTokenAccountAta: workerAuthority
+      ? getAssociatedTokenAddressSync(rewardMint, workerAuthority)
+      : undefined,
+    treasuryTokenAccount: getAssociatedTokenAddressSync(rewardMint, treasury),
+    rewardMint,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  };
+}
+
+function buildExpireTokenAccounts(
+  rewardMint: PublicKey | null,
+  escrowPda: PublicKey,
+  creator: PublicKey,
+  workerAuthority: PublicKey | null,
+): Record<string, PublicKey | undefined> {
+  if (!rewardMint) {
+    return {
+      tokenEscrowAta: undefined,
+      creatorTokenAccount: undefined,
+      workerTokenAccountAta: undefined,
+      rewardMint: undefined,
+      tokenProgram: undefined,
+    };
+  }
+
+  return {
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    creatorTokenAccount: getAssociatedTokenAddressSync(rewardMint, creator),
+    workerTokenAccountAta: workerAuthority
+      ? getAssociatedTokenAddressSync(rewardMint, workerAuthority)
+      : undefined,
+    rewardMint,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  };
+}
+
+function buildApplySlashTokenAccounts(
+  rewardMint: PublicKey | null,
+  escrowPda: PublicKey,
+  treasury: PublicKey,
+): Record<string, PublicKey | undefined> {
+  if (!rewardMint) {
+    return {
+      escrow: undefined,
+      tokenEscrowAta: undefined,
+      treasuryTokenAccount: undefined,
+      rewardMint: undefined,
+      tokenProgram: undefined,
+    };
+  }
+
+  return {
+    escrow: escrowPda,
+    tokenEscrowAta: getAssociatedTokenAddressSync(rewardMint, escrowPda, true),
+    treasuryTokenAccount: getAssociatedTokenAddressSync(rewardMint, treasury),
+    rewardMint,
+    tokenProgram: TOKEN_PROGRAM_ID,
+  };
+}
+
+export function deriveDisputePda(
+  disputeId: Uint8Array | number[],
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  const idBytes = toFixedBytes(disputeId, 32, 'disputeId');
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.DISPUTE, idBytes], programId);
+  return pda;
+}
+
+export function deriveVotePda(
+  disputePda: PublicKey,
+  voterAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  const [pda] = PublicKey.findProgramAddressSync(
+    [SEEDS.VOTE, disputePda.toBuffer(), voterAgentPda.toBuffer()],
+    programId,
+  );
+  return pda;
+}
+
+export async function initiateDispute(
+  connection: Connection,
+  program: Program,
+  initiator: Keypair,
+  initiatorAgentId: Uint8Array | number[],
+  params: InitiateDisputeParams,
+): Promise<{ disputePda: PublicKey; txSignature: string }> {
+  const programId = program.programId;
+  const disputeId = toFixedBytes(params.disputeId, 32, 'disputeId');
+  const taskId = toFixedBytes(params.taskId, 32, 'taskId');
+  const evidenceHash = toFixedBytes(params.evidenceHash, 32, 'evidenceHash');
+
+  const disputePda = deriveDisputePda(disputeId, programId);
+  const protocolPda = deriveProtocolPda(programId);
+  const initiatorAgentPda = deriveAgentPda(initiatorAgentId, programId);
+  const derivedClaimPda = deriveClaimPda(params.taskPda, initiatorAgentPda, programId);
+
+  const builder = program.methods
+    .initiateDispute(
+      Array.from(disputeId),
+      Array.from(taskId),
+      Array.from(evidenceHash),
+      params.resolutionType,
+      params.evidence,
+    )
+    .accountsPartial({
+      dispute: disputePda,
+      task: params.taskPda,
+      agent: initiatorAgentPda,
+      protocolConfig: protocolPda,
+      initiatorClaim:
+        params.initiatorClaimPda === undefined
+          ? derivedClaimPda
+          : params.initiatorClaimPda ?? undefined,
+      workerAgent: params.workerAgentPda ?? undefined,
+      workerClaim: params.workerClaimPda ?? undefined,
+      authority: initiator.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([initiator]);
+
+  const remainingAccounts = buildRemainingAccounts(
+    undefined,
+    params.defendantWorkers?.map((pair) => ({ claimPda: pair.claimPda, agentPda: pair.workerPda })),
+  );
+
+  if (remainingAccounts.length > 0) {
+    builder.remainingAccounts(remainingAccounts);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+
+  return { disputePda, txSignature: tx };
+}
+
+export async function voteDispute(
+  connection: Connection,
+  program: Program,
+  voter: Keypair,
+  voterAgentId: Uint8Array | number[],
+  params: VoteDisputeParams,
+): Promise<{ votePda: PublicKey; txSignature: string }> {
+  const programId = program.programId;
+  const protocolPda = deriveProtocolPda(programId);
+  const voterAgentPda = deriveAgentPda(voterAgentId, programId);
+  const votePda = deriveVotePda(params.disputePda, voterAgentPda, programId);
+  const authorityVotePda = deriveAuthorityVotePda(params.disputePda, voter.publicKey, programId);
+
+  const tx = await program.methods
+    .voteDispute(params.approve)
+    .accountsPartial({
+      dispute: params.disputePda,
+      task: params.taskPda,
+      workerClaim: params.workerClaimPda ?? undefined,
+      defendantAgent: params.defendantAgentPda ?? undefined,
+      vote: votePda,
+      authorityVote: authorityVotePda,
+      arbiter: voterAgentPda,
+      protocolConfig: protocolPda,
+      authority: voter.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([voter])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+
+  return { votePda, txSignature: tx };
+}
+
+export async function resolveDispute(
+  connection: Connection,
+  program: Program,
+  resolver: Keypair,
+  params: ResolveDisputeParams,
+): Promise<{ txSignature: string }> {
+  const programId = program.programId;
+  const protocolPda = deriveProtocolPda(programId);
+  const escrowPda = deriveEscrowPda(params.taskPda, programId);
+
+  const task = (await getAccount(program, 'task').fetch(params.taskPda)) as { rewardMint: PublicKey | null };
+  const protocolConfig = (await getAccount(program, 'protocolConfig').fetch(protocolPda)) as {
+    treasury: PublicKey;
+  };
+
+  const tokenAccounts = buildResolveTokenAccounts(
+    task.rewardMint ?? null,
+    escrowPda,
+    params.creatorPubkey,
+    params.workerAuthority ?? null,
+    protocolConfig.treasury,
+  );
+
+  const builder = program.methods
+    .resolveDispute()
+    .accountsPartial({
+      dispute: params.disputePda,
+      task: params.taskPda,
+      escrow: escrowPda,
+      protocolConfig: protocolPda,
+      resolver: resolver.publicKey,
+      creator: params.creatorPubkey,
+      workerClaim: params.workerClaimPda ?? undefined,
+      worker: params.workerAgentPda ?? undefined,
+      workerAuthority: params.workerAuthority ?? undefined,
+      systemProgram: SystemProgram.programId,
+      ...tokenAccounts,
+    })
+    .signers([resolver]);
+
+  const remainingAccounts = buildRemainingAccounts(params.arbiterPairs, params.workerPairs);
+  if (remainingAccounts.length > 0) {
+    builder.remainingAccounts(remainingAccounts);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+
+  return { txSignature: tx };
+}
+
+export async function applyDisputeSlash(
+  connection: Connection,
+  program: Program,
+  payer: Keypair,
+  params: ApplyDisputeSlashParams,
+): Promise<{ txSignature: string }> {
+  const programId = program.programId;
+  const protocolPda = deriveProtocolPda(programId);
+  const escrowPda = deriveEscrowPda(params.taskPda, programId);
+
+  const task = (await getAccount(program, 'task').fetch(params.taskPda)) as { rewardMint: PublicKey | null };
+  const protocolConfig = (await getAccount(program, 'protocolConfig').fetch(protocolPda)) as {
+    treasury: PublicKey;
+  };
+
+  const tokenAccounts = buildApplySlashTokenAccounts(
+    task.rewardMint ?? null,
+    escrowPda,
+    protocolConfig.treasury,
+  );
+
+  const tx = await program.methods
+    .applyDisputeSlash()
+    .accountsPartial({
+      dispute: params.disputePda,
+      task: params.taskPda,
+      workerClaim: params.workerClaimPda,
+      workerAgent: params.workerAgentPda,
+      protocolConfig: protocolPda,
+      treasury: protocolConfig.treasury,
+      ...tokenAccounts,
+    })
+    .signers([payer])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function applyInitiatorSlash(
+  connection: Connection,
+  program: Program,
+  payer: Keypair,
+  params: ApplyInitiatorSlashParams,
+): Promise<{ txSignature: string }> {
+  const protocolPda = deriveProtocolPda(program.programId);
+  const protocolConfig = (await getAccount(program, 'protocolConfig').fetch(protocolPda)) as {
+    treasury: PublicKey;
+  };
+
+  const tx = await program.methods
+    .applyInitiatorSlash()
+    .accountsPartial({
+      dispute: params.disputePda,
+      task: params.taskPda,
+      initiatorAgent: params.initiatorAgentPda,
+      protocolConfig: protocolPda,
+      treasury: protocolConfig.treasury,
+    })
+    .signers([payer])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function cancelDispute(
+  connection: Connection,
+  program: Program,
+  authority: Keypair,
+  disputePda: PublicKey,
+  taskPda: PublicKey,
+  defendantAgentPda?: PublicKey,
+): Promise<{ txSignature: string }> {
+  const builder = program.methods
+    .cancelDispute()
+    .accountsPartial({
+      dispute: disputePda,
+      task: taskPda,
+      authority: authority.publicKey,
+    })
+    .signers([authority]);
+
+  if (defendantAgentPda) {
+    builder.remainingAccounts([
+      {
+        pubkey: defendantAgentPda,
+        isSigner: false,
+        isWritable: true,
+      },
+    ]);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function expireDispute(
+  connection: Connection,
+  program: Program,
+  caller: Keypair,
+  params: ExpireDisputeParams,
+): Promise<{ txSignature: string }> {
+  const protocolPda = deriveProtocolPda(program.programId);
+  const escrowPda = deriveEscrowPda(params.taskPda, program.programId);
+
+  const task = (await getAccount(program, 'task').fetch(params.taskPda)) as { rewardMint: PublicKey | null };
+  const tokenAccounts = buildExpireTokenAccounts(
+    task.rewardMint ?? null,
+    escrowPda,
+    params.creatorPubkey,
+    params.workerAuthority ?? null,
+  );
+
+  const builder = program.methods
+    .expireDispute()
+    .accountsPartial({
+      dispute: params.disputePda,
+      task: params.taskPda,
+      escrow: escrowPda,
+      protocolConfig: protocolPda,
+      creator: params.creatorPubkey,
+      workerClaim: params.workerClaimPda ?? undefined,
+      worker: params.workerAgentPda ?? undefined,
+      workerAuthority: params.workerAuthority ?? undefined,
+      ...tokenAccounts,
+    })
+    .signers([caller]);
+
+  const remainingAccounts = buildRemainingAccounts(params.arbiterPairs, params.workerPairs);
+  if (remainingAccounts.length > 0) {
+    builder.remainingAccounts(remainingAccounts);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function getDispute(
+  program: Program,
+  disputePda: PublicKey,
+): Promise<DisputeState | null> {
+  try {
+    const raw = (await getAccount(program, 'dispute').fetch(disputePda)) as Record<string, unknown>;
+
+    return {
+      disputeId: new Uint8Array((raw.disputeId ?? raw.dispute_id ?? []) as number[]),
+      task: raw.task as PublicKey,
+      initiator: raw.initiator as PublicKey,
+      initiatorAuthority: (raw.initiatorAuthority ?? raw.initiator_authority) as PublicKey,
+      evidenceHash: new Uint8Array((raw.evidenceHash ?? raw.evidence_hash ?? []) as number[]),
+      resolutionType: parseResolutionType(raw.resolutionType ?? raw.resolution_type),
+      status: parseDisputeStatus(raw.status),
+      createdAt: toNumber(raw.createdAt ?? raw.created_at),
+      resolvedAt: toNumber(raw.resolvedAt ?? raw.resolved_at),
+      votesFor: toBigInt(raw.votesFor ?? raw.votes_for),
+      votesAgainst: toBigInt(raw.votesAgainst ?? raw.votes_against),
+      totalVoters: toNumber(raw.totalVoters ?? raw.total_voters),
+      votingDeadline: toNumber(raw.votingDeadline ?? raw.voting_deadline),
+      expiresAt: toNumber(raw.expiresAt ?? raw.expires_at),
+      slashApplied: Boolean(raw.slashApplied ?? raw.slash_applied),
+      initiatorSlashApplied: Boolean(raw.initiatorSlashApplied ?? raw.initiator_slash_applied),
+      workerStakeAtDispute: toBigInt(raw.workerStakeAtDispute ?? raw.worker_stake_at_dispute),
+      initiatedByCreator: Boolean(raw.initiatedByCreator ?? raw.initiated_by_creator),
+      bump: toNumber(raw.bump),
+      defendant: raw.defendant as PublicKey,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('Account does not exist') || message.includes('could not find account')) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -1,0 +1,249 @@
+/**
+ * Full AgenC coordination-program error map (6000-6146).
+ */
+
+export type ErrorCategory =
+  | 'agent'
+  | 'task'
+  | 'claim'
+  | 'dispute'
+  | 'state'
+  | 'protocol'
+  | 'general'
+  | 'rate_limit'
+  | 'version'
+  | 'dependency'
+  | 'nullifier'
+  | 'cancel'
+  | 'duplicate'
+  | 'escrow'
+  | 'status'
+  | 'stake'
+  | 'bond'
+  | 'reputation'
+  | 'security'
+  | 'token';
+
+export interface CoordinationErrorEntry {
+  name: string;
+  message: string;
+  category: ErrorCategory;
+}
+
+/**
+ * Complete mapping of on-chain error codes to typed metadata.
+ * Generated from target/idl/agenc_coordination.json.
+ */
+export const COORDINATION_ERROR_MAP: Record<number, CoordinationErrorEntry> = {
+  6000: { name: 'AgentAlreadyRegistered', message: 'Agent is already registered', category: 'agent' },
+  6001: { name: 'AgentNotFound', message: 'Agent not found', category: 'agent' },
+  6002: { name: 'AgentNotActive', message: 'Agent is not active', category: 'agent' },
+  6003: { name: 'InsufficientCapabilities', message: 'Agent has insufficient capabilities', category: 'agent' },
+  6004: { name: 'InvalidCapabilities', message: 'Agent capabilities bitmask cannot be zero', category: 'agent' },
+  6005: { name: 'MaxActiveTasksReached', message: 'Agent has reached maximum active tasks', category: 'agent' },
+  6006: { name: 'AgentHasActiveTasks', message: 'Agent has active tasks and cannot be deregistered', category: 'agent' },
+  6007: { name: 'UnauthorizedAgent', message: 'Only the agent authority can perform this action', category: 'agent' },
+  6008: { name: 'CreatorAuthorityMismatch', message: 'Creator must match authority to prevent social engineering', category: 'agent' },
+  6009: { name: 'InvalidAgentId', message: 'Invalid agent ID: agent_id cannot be all zeros', category: 'agent' },
+  6010: { name: 'AgentRegistrationRequired', message: 'Agent registration required to create tasks', category: 'agent' },
+  6011: { name: 'AgentSuspended', message: 'Agent is suspended and cannot change status', category: 'agent' },
+  6012: { name: 'AgentBusyWithTasks', message: 'Agent cannot set status to Active while having active tasks', category: 'agent' },
+  6013: { name: 'TaskNotFound', message: 'Task not found', category: 'task' },
+  6014: { name: 'TaskNotOpen', message: 'Task is not open for claims', category: 'task' },
+  6015: { name: 'TaskFullyClaimed', message: 'Task has reached maximum workers', category: 'task' },
+  6016: { name: 'TaskExpired', message: 'Task has expired', category: 'task' },
+  6017: { name: 'TaskNotExpired', message: 'Task deadline has not passed', category: 'task' },
+  6018: { name: 'DeadlinePassed', message: 'Task deadline has passed', category: 'task' },
+  6019: { name: 'TaskNotInProgress', message: 'Task is not in progress', category: 'task' },
+  6020: { name: 'TaskAlreadyCompleted', message: 'Task is already completed', category: 'task' },
+  6021: { name: 'TaskCannotBeCancelled', message: 'Task cannot be cancelled', category: 'task' },
+  6022: { name: 'UnauthorizedTaskAction', message: 'Only the task creator can perform this action', category: 'task' },
+  6023: { name: 'InvalidCreator', message: 'Invalid creator', category: 'task' },
+  6024: { name: 'InvalidTaskId', message: 'Invalid task ID: cannot be zero', category: 'task' },
+  6025: { name: 'InvalidDescription', message: 'Invalid description: cannot be empty', category: 'task' },
+  6026: { name: 'InvalidMaxWorkers', message: 'Invalid max workers: must be between 1 and 100', category: 'task' },
+  6027: { name: 'InvalidTaskType', message: 'Invalid task type', category: 'task' },
+  6028: { name: 'InvalidDeadline', message: 'Invalid deadline: deadline must be greater than zero', category: 'task' },
+  6029: { name: 'InvalidReward', message: 'Invalid reward: reward must be greater than zero', category: 'task' },
+  6030: { name: 'InvalidRequiredCapabilities', message: 'Invalid required capabilities: required_capabilities cannot be zero', category: 'task' },
+  6031: { name: 'CompetitiveTaskAlreadyWon', message: 'Competitive task already completed by another worker', category: 'task' },
+  6032: { name: 'NoWorkers', message: 'Task has no workers', category: 'task' },
+  6033: { name: 'ConstraintHashMismatch', message: 'Proof constraint hash does not match task\'s stored constraint hash', category: 'task' },
+  6034: { name: 'NotPrivateTask', message: 'Task is not a private task (no constraint hash set)', category: 'task' },
+  6035: { name: 'AlreadyClaimed', message: 'Worker has already claimed this task', category: 'claim' },
+  6036: { name: 'NotClaimed', message: 'Worker has not claimed this task', category: 'claim' },
+  6037: { name: 'ClaimAlreadyCompleted', message: 'Claim has already been completed', category: 'claim' },
+  6038: { name: 'ClaimNotExpired', message: 'Claim has not expired yet', category: 'claim' },
+  6039: { name: 'ClaimExpired', message: 'Claim has expired', category: 'claim' },
+  6040: { name: 'InvalidExpiration', message: 'Invalid expiration: expires_at cannot be zero', category: 'claim' },
+  6041: { name: 'InvalidProof', message: 'Invalid proof of work', category: 'claim' },
+  6042: { name: 'ZkVerificationFailed', message: 'ZK proof verification failed', category: 'claim' },
+  6043: { name: 'InvalidProofSize', message: 'Invalid proof size - expected 256 bytes for Groth16', category: 'claim' },
+  6044: { name: 'InvalidProofBinding', message: 'Invalid proof binding: expected_binding cannot be all zeros', category: 'claim' },
+  6045: { name: 'InvalidOutputCommitment', message: 'Invalid output commitment: output_commitment cannot be all zeros', category: 'claim' },
+  6046: { name: 'InvalidRentRecipient', message: 'Invalid rent recipient: must be worker authority', category: 'claim' },
+  6047: { name: 'GracePeriodNotPassed', message: 'Grace period not passed: only worker authority can expire claim within 60 seconds of expiry', category: 'claim' },
+  6048: { name: 'InvalidProofHash', message: 'Invalid proof hash: proof_hash cannot be all zeros', category: 'claim' },
+  6049: { name: 'InvalidResultData', message: 'Invalid result data: result_data cannot be all zeros when provided', category: 'claim' },
+  6050: { name: 'DisputeNotActive', message: 'Dispute is not active', category: 'dispute' },
+  6051: { name: 'VotingEnded', message: 'Voting period has ended', category: 'dispute' },
+  6052: { name: 'VotingNotEnded', message: 'Voting period has not ended', category: 'dispute' },
+  6053: { name: 'AlreadyVoted', message: 'Already voted on this dispute', category: 'dispute' },
+  6054: { name: 'NotArbiter', message: 'Not authorized to vote (not an arbiter)', category: 'dispute' },
+  6055: { name: 'InsufficientVotes', message: 'Insufficient votes to resolve', category: 'dispute' },
+  6056: { name: 'DisputeAlreadyResolved', message: 'Dispute has already been resolved', category: 'dispute' },
+  6057: { name: 'UnauthorizedResolver', message: 'Only protocol authority or dispute initiator can resolve disputes', category: 'dispute' },
+  6058: { name: 'ActiveDisputeVotes', message: 'Agent has active dispute votes pending resolution', category: 'dispute' },
+  6059: { name: 'RecentVoteActivity', message: 'Agent must wait 24 hours after voting before deregistering', category: 'dispute' },
+  6060: { name: 'AuthorityAlreadyVoted', message: 'Authority has already voted on this dispute', category: 'dispute' },
+  6061: { name: 'InsufficientEvidence', message: 'Insufficient dispute evidence provided', category: 'dispute' },
+  6062: { name: 'EvidenceTooLong', message: 'Dispute evidence exceeds maximum allowed length', category: 'dispute' },
+  6063: { name: 'DisputeNotExpired', message: 'Dispute has not expired', category: 'dispute' },
+  6064: { name: 'SlashAlreadyApplied', message: 'Dispute slashing already applied', category: 'dispute' },
+  6065: { name: 'SlashWindowExpired', message: 'Slash window expired: must apply slashing within 7 days of resolution', category: 'dispute' },
+  6066: { name: 'DisputeNotResolved', message: 'Dispute has not been resolved', category: 'dispute' },
+  6067: { name: 'NotTaskParticipant', message: 'Only task creator or workers can initiate disputes', category: 'dispute' },
+  6068: { name: 'InvalidEvidenceHash', message: 'Invalid evidence hash: cannot be all zeros', category: 'dispute' },
+  6069: { name: 'ArbiterIsDisputeParticipant', message: 'Arbiter cannot vote on disputes they are a participant in', category: 'dispute' },
+  6070: { name: 'InsufficientQuorum', message: 'Insufficient quorum: minimum number of voters not reached', category: 'dispute' },
+  6071: { name: 'ActiveDisputesExist', message: 'Agent has active disputes as defendant and cannot deregister', category: 'dispute' },
+  6072: { name: 'WorkerAgentRequired', message: 'Worker agent account required when creator initiates dispute', category: 'dispute' },
+  6073: { name: 'WorkerClaimRequired', message: 'Worker claim account required when creator initiates dispute', category: 'dispute' },
+  6074: { name: 'WorkerNotInDispute', message: 'Worker was not involved in this dispute', category: 'dispute' },
+  6075: { name: 'InitiatorCannotResolve', message: 'Dispute initiator cannot resolve their own dispute', category: 'dispute' },
+  6076: { name: 'VersionMismatch', message: 'State version mismatch (concurrent modification)', category: 'state' },
+  6077: { name: 'StateKeyExists', message: 'State key already exists', category: 'state' },
+  6078: { name: 'StateNotFound', message: 'State not found', category: 'state' },
+  6079: { name: 'InvalidStateValue', message: 'Invalid state value: state_value cannot be all zeros', category: 'state' },
+  6080: { name: 'StateOwnershipViolation', message: 'State ownership violation: only the creator agent can update this state', category: 'state' },
+  6081: { name: 'InvalidStateKey', message: 'Invalid state key: state_key cannot be all zeros', category: 'state' },
+  6082: { name: 'ProtocolAlreadyInitialized', message: 'Protocol is already initialized', category: 'protocol' },
+  6083: { name: 'ProtocolNotInitialized', message: 'Protocol is not initialized', category: 'protocol' },
+  6084: { name: 'InvalidProtocolFee', message: 'Invalid protocol fee (must be <= 1000 bps)', category: 'protocol' },
+  6085: { name: 'InvalidTreasury', message: 'Invalid treasury: treasury account cannot be default pubkey', category: 'protocol' },
+  6086: { name: 'InvalidDisputeThreshold', message: 'Invalid dispute threshold: must be 1-100 (percentage of votes required)', category: 'protocol' },
+  6087: { name: 'InsufficientStake', message: 'Insufficient stake for arbiter registration', category: 'protocol' },
+  6088: { name: 'MultisigInvalidThreshold', message: 'Invalid multisig threshold', category: 'protocol' },
+  6089: { name: 'MultisigInvalidSigners', message: 'Invalid multisig signer configuration', category: 'protocol' },
+  6090: { name: 'MultisigNotEnoughSigners', message: 'Not enough multisig signers', category: 'protocol' },
+  6091: { name: 'MultisigDuplicateSigner', message: 'Duplicate multisig signer provided', category: 'protocol' },
+  6092: { name: 'MultisigDefaultSigner', message: 'Multisig signer cannot be default pubkey', category: 'protocol' },
+  6093: { name: 'MultisigSignerNotSystemOwned', message: 'Multisig signer account not owned by System Program', category: 'protocol' },
+  6094: { name: 'InvalidInput', message: 'Invalid input parameter', category: 'general' },
+  6095: { name: 'ArithmeticOverflow', message: 'Arithmetic overflow', category: 'general' },
+  6096: { name: 'VoteOverflow', message: 'Vote count overflow', category: 'general' },
+  6097: { name: 'InsufficientFunds', message: 'Insufficient funds', category: 'general' },
+  6098: { name: 'RewardTooSmall', message: 'Reward too small: worker must receive at least 1 lamport', category: 'general' },
+  6099: { name: 'CorruptedData', message: 'Account data is corrupted', category: 'general' },
+  6100: { name: 'StringTooLong', message: 'String too long', category: 'general' },
+  6101: { name: 'InvalidAccountOwner', message: 'Account owner validation failed: account not owned by this program', category: 'general' },
+  6102: { name: 'RateLimitExceeded', message: 'Rate limit exceeded: maximum actions per 24h window reached', category: 'rate_limit' },
+  6103: { name: 'CooldownNotElapsed', message: 'Cooldown period has not elapsed since last action', category: 'rate_limit' },
+  6104: { name: 'UpdateTooFrequent', message: 'Agent update too frequent: must wait cooldown period', category: 'rate_limit' },
+  6105: { name: 'InvalidCooldown', message: 'Cooldown value cannot be negative', category: 'rate_limit' },
+  6106: { name: 'CooldownTooLarge', message: 'Cooldown value exceeds maximum (24 hours)', category: 'rate_limit' },
+  6107: { name: 'RateLimitTooHigh', message: 'Rate limit value exceeds maximum allowed (1000)', category: 'rate_limit' },
+  6108: { name: 'CooldownTooLong', message: 'Cooldown value exceeds maximum allowed (1 week)', category: 'rate_limit' },
+  6109: { name: 'InsufficientStakeForDispute', message: 'Insufficient stake to initiate dispute', category: 'rate_limit' },
+  6110: { name: 'InsufficientStakeForCreatorDispute', message: 'Creator-initiated disputes require 2x the minimum stake', category: 'rate_limit' },
+  6111: { name: 'VersionMismatchProtocol', message: 'Protocol version mismatch: account version incompatible with current program', category: 'version' },
+  6112: { name: 'AccountVersionTooOld', message: 'Account version too old: migration required', category: 'version' },
+  6113: { name: 'AccountVersionTooNew', message: 'Account version too new: program upgrade required', category: 'version' },
+  6114: { name: 'InvalidMigrationSource', message: 'Migration not allowed: invalid source version', category: 'version' },
+  6115: { name: 'InvalidMigrationTarget', message: 'Migration not allowed: invalid target version', category: 'version' },
+  6116: { name: 'UnauthorizedUpgrade', message: 'Only upgrade authority can perform this action', category: 'version' },
+  6117: { name: 'InvalidMinVersion', message: 'Minimum version cannot exceed current protocol version', category: 'version' },
+  6118: { name: 'ProtocolConfigRequired', message: 'Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts', category: 'version' },
+  6119: { name: 'ParentTaskCancelled', message: 'Parent task has been cancelled', category: 'dependency' },
+  6120: { name: 'ParentTaskDisputed', message: 'Parent task is in disputed state', category: 'dependency' },
+  6121: { name: 'InvalidDependencyType', message: 'Invalid dependency type', category: 'dependency' },
+  6122: { name: 'ParentTaskNotCompleted', message: 'Parent task must be completed before completing a proof-dependent task', category: 'dependency' },
+  6123: { name: 'ParentTaskAccountRequired', message: 'Parent task account required for proof-dependent task completion', category: 'dependency' },
+  6124: { name: 'UnauthorizedCreator', message: 'Parent task does not belong to the same creator', category: 'dependency' },
+  6125: { name: 'NullifierAlreadySpent', message: 'Nullifier has already been spent - proof/knowledge reuse detected', category: 'nullifier' },
+  6126: { name: 'InvalidNullifier', message: 'Invalid nullifier: nullifier value cannot be all zeros', category: 'nullifier' },
+  6127: { name: 'IncompleteWorkerAccounts', message: 'All worker accounts must be provided when cancelling a task with active claims', category: 'cancel' },
+  6128: { name: 'WorkerAccountsRequired', message: 'Worker accounts required when task has active workers', category: 'cancel' },
+  6129: { name: 'DuplicateArbiter', message: 'Duplicate arbiter provided in remaining_accounts', category: 'duplicate' },
+  6130: { name: 'InsufficientEscrowBalance', message: 'Escrow has insufficient balance for reward transfer', category: 'escrow' },
+  6131: { name: 'InvalidStatusTransition', message: 'Invalid task status transition', category: 'status' },
+  6132: { name: 'StakeTooLow', message: 'Stake value is below minimum required (0.001 SOL)', category: 'stake' },
+  6133: { name: 'InvalidMinStake', message: 'min_stake_for_dispute must be greater than zero', category: 'stake' },
+  6134: { name: 'InvalidSlashAmount', message: 'Slash amount must be greater than zero', category: 'stake' },
+  6135: { name: 'BondAmountTooLow', message: 'Bond amount too low', category: 'bond' },
+  6136: { name: 'BondAlreadyExists', message: 'Bond already exists', category: 'bond' },
+  6137: { name: 'BondNotFound', message: 'Bond not found', category: 'bond' },
+  6138: { name: 'BondNotMatured', message: 'Bond not yet matured', category: 'bond' },
+  6139: { name: 'InsufficientReputation', message: 'Agent reputation below task minimum requirement', category: 'reputation' },
+  6140: { name: 'InvalidMinReputation', message: 'Invalid minimum reputation: must be <= 10000', category: 'reputation' },
+  6141: { name: 'DevelopmentKeyNotAllowed', message: 'Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use.', category: 'security' },
+  6142: { name: 'SelfTaskNotAllowed', message: 'Cannot claim own task: worker authority matches task creator', category: 'security' },
+  6143: { name: 'MissingTokenAccounts', message: 'Token accounts not provided for token-denominated task', category: 'token' },
+  6144: { name: 'InvalidTokenEscrow', message: 'Token escrow ATA does not match expected derivation', category: 'token' },
+  6145: { name: 'InvalidTokenMint', message: 'Provided mint does not match task\'s reward_mint', category: 'token' },
+  6146: { name: 'TokenTransferFailed', message: 'SPL token transfer CPI failed', category: 'token' },
+};
+
+export interface DecodedError extends CoordinationErrorEntry {
+  code: number;
+}
+
+/**
+ * Decode a numeric Anchor error code.
+ */
+export function decodeError(code: number): DecodedError | null {
+  const entry = COORDINATION_ERROR_MAP[code];
+  if (!entry) return null;
+  return { code, ...entry };
+}
+
+function extractCode(error: unknown): number | null {
+  if (!error || typeof error !== 'object') return null;
+
+  const err = error as Record<string, unknown>;
+
+  if (typeof err.code === 'number') {
+    return err.code;
+  }
+
+  const directErrorCode = err.errorCode as Record<string, unknown> | undefined;
+  if (directErrorCode && typeof directErrorCode.number === 'number') {
+    return directErrorCode.number;
+  }
+
+  const nested = err.error as Record<string, unknown> | undefined;
+  const nestedErrorCode = nested?.errorCode as Record<string, unknown> | undefined;
+  if (nestedErrorCode && typeof nestedErrorCode.number === 'number') {
+    return nestedErrorCode.number;
+  }
+
+  if (Array.isArray(err.logs)) {
+    for (const line of err.logs) {
+      if (typeof line !== 'string') continue;
+      const match = line.match(/Error Number: (\d+)/);
+      if (match) return Number.parseInt(match[1], 10);
+    }
+  }
+
+  if (typeof err.message === 'string') {
+    const hexMatch = err.message.match(/custom program error: 0x([0-9a-fA-F]+)/);
+    if (hexMatch) {
+      return Number.parseInt(hexMatch[1], 16);
+    }
+    const decimalMatch = err.message.match(/Error Number: (\d+)/);
+    if (decimalMatch) {
+      return Number.parseInt(decimalMatch[1], 10);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Decode common Anchor error object shapes.
+ */
+export function decodeAnchorError(error: unknown): DecodedError | null {
+  const code = extractCode(error);
+  if (code === null) return null;
+  return decodeError(code);
+}

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -37,7 +37,9 @@ export {
 
 export {
   createTask,
+  createDependentTask,
   claimTask,
+  expireClaim,
   completeTask,
   completeTaskPrivate,
   cancelTask,
@@ -49,6 +51,7 @@ export {
   formatTaskState,
   calculateEscrowFee,
   TaskParams,
+  DependentTaskParams,
   TaskState,
   TaskStatus,
   PrivateCompletionProof,
@@ -127,7 +130,74 @@ export {
   RECOMMENDED_CU_CANCEL_TASK_TOKEN,
   // PDA seeds
   SEEDS,
+  VERIFIER_PROGRAM_ID,
 } from './constants';
+
+export {
+  registerAgent,
+  updateAgent,
+  suspendAgent,
+  unsuspendAgent,
+  deregisterAgent,
+  getAgent,
+  deriveAgentPda,
+  AgentStatus,
+  type RegisterAgentParams,
+  type UpdateAgentParams,
+  type AgentState,
+} from './agents';
+
+export {
+  initiateDispute,
+  voteDispute,
+  resolveDispute,
+  applyDisputeSlash,
+  applyInitiatorSlash,
+  cancelDispute,
+  expireDispute,
+  getDispute,
+  deriveDisputePda,
+  deriveVotePda,
+  DisputeStatus,
+  ResolutionType,
+  type InitiateDisputeParams,
+  type VoteDisputeParams,
+  type ResolveDisputeParams,
+  type ApplyDisputeSlashParams,
+  type ApplyInitiatorSlashParams,
+  type ExpireDisputeParams,
+  type DisputeState,
+} from './disputes';
+
+export {
+  updateState,
+  getState,
+  deriveStatePda,
+  type CoordinationState,
+  type UpdateStateParams,
+} from './state';
+
+export {
+  initializeProtocol,
+  updateProtocolFee,
+  updateRateLimits,
+  migrateProtocol,
+  updateMinVersion,
+  getProtocolConfig,
+  deriveProtocolPda,
+  type InitializeProtocolParams,
+  type UpdateRateLimitsParams,
+  type ProtocolConfigState,
+} from './protocol';
+
+export {
+  COORDINATION_ERROR_MAP,
+  decodeError,
+  decodeAnchorError,
+  type ErrorCategory,
+  type CoordinationErrorEntry,
+  type DecodedError,
+} from './errors';
 
 export {
   // Query functions

--- a/sdk/src/protocol.ts
+++ b/sdk/src/protocol.ts
@@ -1,0 +1,276 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  type AccountMeta,
+} from '@solana/web3.js';
+import { BN, type Program } from '@coral-xyz/anchor';
+import { PROGRAM_ID, SEEDS } from './constants';
+import { getAccount } from './anchor-utils';
+
+const BPF_LOADER_UPGRADEABLE_PROGRAM_ID = new PublicKey(
+  'BPFLoaderUpgradeab1e11111111111111111111111',
+);
+
+export interface InitializeProtocolParams {
+  disputeThreshold: number;
+  protocolFeeBps: number;
+  minStake: number | bigint;
+  minStakeForDispute: number | bigint;
+  multisigThreshold: number;
+  multisigOwners: PublicKey[];
+}
+
+export interface UpdateRateLimitsParams {
+  taskCreationCooldown: number;
+  maxTasksPer24h: number;
+  disputeInitiationCooldown: number;
+  maxDisputesPer24h: number;
+  minStakeForDispute: number | bigint;
+}
+
+export interface ProtocolConfigState {
+  authority: PublicKey;
+  treasury: PublicKey;
+  disputeThreshold: number;
+  protocolFeeBps: number;
+  minAgentStake: bigint;
+  minStakeForDispute: bigint;
+  multisigThreshold: number;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object' && 'toNumber' in value) {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+  if (typeof value === 'bigint') return Number(value);
+  return 0;
+}
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return BigInt(value);
+  if (value && typeof value === 'object' && 'toString' in value) {
+    return BigInt((value as { toString: () => string }).toString());
+  }
+  return 0n;
+}
+
+function buildMultisigRemainingAccounts(signers: Keypair[]): AccountMeta[] {
+  const unique = new Set<string>();
+  const accounts: AccountMeta[] = [];
+
+  for (const signer of signers) {
+    const key = signer.publicKey.toBase58();
+    if (unique.has(key)) continue;
+    unique.add(key);
+    accounts.push({ pubkey: signer.publicKey, isSigner: true, isWritable: false });
+  }
+
+  return accounts;
+}
+
+function validateInitializeParams(params: InitializeProtocolParams): void {
+  if (params.multisigThreshold < 1) {
+    throw new Error('multisigThreshold must be >= 1');
+  }
+
+  if (params.multisigOwners.length === 0) {
+    throw new Error('multisigOwners must contain at least one owner');
+  }
+
+  if (params.multisigThreshold > params.multisigOwners.length) {
+    throw new Error('multisigThreshold cannot exceed multisigOwners length');
+  }
+
+  const owners = new Set(params.multisigOwners.map((owner) => owner.toBase58()));
+  if (owners.size !== params.multisigOwners.length) {
+    throw new Error('multisigOwners cannot contain duplicates');
+  }
+}
+
+export function deriveProtocolPda(programId: PublicKey = PROGRAM_ID): PublicKey {
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.PROTOCOL], programId);
+  return pda;
+}
+
+export async function initializeProtocol(
+  connection: Connection,
+  program: Program,
+  authority: Keypair,
+  secondSigner: Keypair,
+  treasury: PublicKey,
+  params: InitializeProtocolParams,
+): Promise<{ protocolPda: PublicKey; txSignature: string }> {
+  validateInitializeParams(params);
+
+  const protocolPda = deriveProtocolPda(program.programId);
+  const [programDataPda] = PublicKey.findProgramAddressSync(
+    [program.programId.toBuffer()],
+    BPF_LOADER_UPGRADEABLE_PROGRAM_ID,
+  );
+
+  const tx = await program.methods
+    .initializeProtocol(
+      params.disputeThreshold,
+      params.protocolFeeBps,
+      new BN(params.minStake.toString()),
+      new BN(params.minStakeForDispute.toString()),
+      params.multisigThreshold,
+      params.multisigOwners,
+    )
+    .accountsPartial({
+      protocolConfig: protocolPda,
+      treasury,
+      authority: authority.publicKey,
+      secondSigner: secondSigner.publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .remainingAccounts([
+      { pubkey: programDataPda, isSigner: false, isWritable: false },
+    ])
+    .signers([authority, secondSigner])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { protocolPda, txSignature: tx };
+}
+
+export async function updateProtocolFee(
+  connection: Connection,
+  program: Program,
+  multisigSigners: Keypair[],
+  newFeeBps: number,
+): Promise<{ txSignature: string }> {
+  if (multisigSigners.length === 0) {
+    throw new Error('updateProtocolFee requires at least one multisig signer');
+  }
+
+  const builder = program.methods
+    .updateProtocolFee(newFeeBps)
+    .accountsPartial({
+      protocolConfig: deriveProtocolPda(program.programId),
+    })
+    .signers(multisigSigners);
+
+  const remainingAccounts = buildMultisigRemainingAccounts(multisigSigners);
+  if (remainingAccounts.length > 0) {
+    builder.remainingAccounts(remainingAccounts);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function updateRateLimits(
+  connection: Connection,
+  program: Program,
+  multisigSigners: Keypair[],
+  params: UpdateRateLimitsParams,
+): Promise<{ txSignature: string }> {
+  if (multisigSigners.length === 0) {
+    throw new Error('updateRateLimits requires at least one multisig signer');
+  }
+
+  const builder = program.methods
+    .updateRateLimits(
+      new BN(params.taskCreationCooldown.toString()),
+      params.maxTasksPer24h,
+      new BN(params.disputeInitiationCooldown.toString()),
+      params.maxDisputesPer24h,
+      new BN(params.minStakeForDispute.toString()),
+    )
+    .accountsPartial({
+      protocolConfig: deriveProtocolPda(program.programId),
+    })
+    .signers(multisigSigners);
+
+  const remainingAccounts = buildMultisigRemainingAccounts(multisigSigners);
+  if (remainingAccounts.length > 0) {
+    builder.remainingAccounts(remainingAccounts);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function migrateProtocol(
+  connection: Connection,
+  program: Program,
+  multisigSigners: Keypair[],
+  targetVersion: number,
+): Promise<{ txSignature: string }> {
+  if (multisigSigners.length === 0) {
+    throw new Error('migrateProtocol requires at least one multisig signer');
+  }
+
+  const builder = program.methods
+    .migrateProtocol(targetVersion)
+    .accountsPartial({
+      protocolConfig: deriveProtocolPda(program.programId),
+    })
+    .signers(multisigSigners);
+
+  const remainingAccounts = buildMultisigRemainingAccounts(multisigSigners);
+  if (remainingAccounts.length > 0) {
+    builder.remainingAccounts(remainingAccounts);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function updateMinVersion(
+  connection: Connection,
+  program: Program,
+  multisigSigners: Keypair[],
+  newMinVersion: number,
+): Promise<{ txSignature: string }> {
+  if (multisigSigners.length === 0) {
+    throw new Error('updateMinVersion requires at least one multisig signer');
+  }
+
+  const builder = program.methods
+    .updateMinVersion(newMinVersion)
+    .accountsPartial({
+      protocolConfig: deriveProtocolPda(program.programId),
+    })
+    .signers(multisigSigners);
+
+  const remainingAccounts = buildMultisigRemainingAccounts(multisigSigners);
+  if (remainingAccounts.length > 0) {
+    builder.remainingAccounts(remainingAccounts);
+  }
+
+  const tx = await builder.rpc();
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { txSignature: tx };
+}
+
+export async function getProtocolConfig(program: Program): Promise<ProtocolConfigState | null> {
+  try {
+    const protocolPda = deriveProtocolPda(program.programId);
+    const raw = (await getAccount(program, 'protocolConfig').fetch(protocolPda)) as Record<string, unknown>;
+
+    return {
+      authority: raw.authority as PublicKey,
+      treasury: raw.treasury as PublicKey,
+      disputeThreshold: toNumber(raw.disputeThreshold ?? raw.dispute_threshold),
+      protocolFeeBps: toNumber(raw.protocolFeeBps ?? raw.protocol_fee_bps),
+      minAgentStake: toBigInt(raw.minAgentStake ?? raw.min_agent_stake),
+      minStakeForDispute: toBigInt(raw.minStakeForDispute ?? raw.min_stake_for_dispute),
+      multisigThreshold: toNumber(raw.multisigThreshold ?? raw.multisig_threshold),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('Account does not exist') || message.includes('could not find account')) {
+      return null;
+    }
+    throw error;
+  }
+}

--- a/sdk/src/state.ts
+++ b/sdk/src/state.ts
@@ -1,0 +1,135 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+} from '@solana/web3.js';
+import { BN, type Program } from '@coral-xyz/anchor';
+import { PROGRAM_ID, SEEDS } from './constants';
+import { getAccount } from './anchor-utils';
+
+export interface CoordinationState {
+  owner: PublicKey;
+  stateKey: Uint8Array;
+  stateValue: Uint8Array;
+  lastUpdater: PublicKey;
+  version: bigint;
+  updatedAt: number;
+  bump: number;
+}
+
+export interface UpdateStateParams {
+  agentId: Uint8Array | number[];
+  stateKey: Uint8Array | number[];
+  stateValue: Uint8Array | number[];
+  version: number | bigint;
+}
+
+function toFixedBytes(value: Uint8Array | number[], length: number, fieldName: string): Uint8Array {
+  const bytes = value instanceof Uint8Array ? value : Uint8Array.from(value);
+  if (bytes.length !== length) {
+    throw new Error(`Invalid ${fieldName} length: ${bytes.length}. Expected ${length} bytes.`);
+  }
+  return bytes;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object' && 'toNumber' in value) {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+  if (typeof value === 'bigint') return Number(value);
+  return 0;
+}
+
+function toBigInt(value: unknown): bigint {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return BigInt(value);
+  if (value && typeof value === 'object' && 'toString' in value) {
+    return BigInt((value as { toString: () => string }).toString());
+  }
+  return 0n;
+}
+
+function deriveAgentPda(agentId: Uint8Array | number[], programId: PublicKey): PublicKey {
+  const idBytes = toFixedBytes(agentId, 32, 'agentId');
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.AGENT, idBytes], programId);
+  return pda;
+}
+
+function deriveProtocolPda(programId: PublicKey): PublicKey {
+  const [pda] = PublicKey.findProgramAddressSync([SEEDS.PROTOCOL], programId);
+  return pda;
+}
+
+export function deriveStatePda(
+  authority: PublicKey,
+  stateKey: Uint8Array | number[],
+  programId: PublicKey = PROGRAM_ID,
+): PublicKey {
+  const keyBytes = toFixedBytes(stateKey, 32, 'stateKey');
+  const [pda] = PublicKey.findProgramAddressSync(
+    [Buffer.from('state'), authority.toBuffer(), keyBytes],
+    programId,
+  );
+  return pda;
+}
+
+export async function updateState(
+  connection: Connection,
+  program: Program,
+  authority: Keypair,
+  params: UpdateStateParams,
+): Promise<{ statePda: PublicKey; txSignature: string }> {
+  const programId = program.programId;
+  const stateKey = toFixedBytes(params.stateKey, 32, 'stateKey');
+  const stateValue = toFixedBytes(params.stateValue, 64, 'stateValue');
+
+  const statePda = deriveStatePda(authority.publicKey, stateKey, programId);
+  const agentPda = deriveAgentPda(params.agentId, programId);
+  const protocolPda = deriveProtocolPda(programId);
+
+  const tx = await program.methods
+    .updateState(
+      Array.from(stateKey),
+      Array.from(stateValue),
+      new BN(params.version.toString()),
+    )
+    .accountsPartial({
+      state: statePda,
+      agent: agentPda,
+      authority: authority.publicKey,
+      protocolConfig: protocolPda,
+      systemProgram: SystemProgram.programId,
+    })
+    .signers([authority])
+    .rpc();
+
+  await connection.confirmTransaction(tx, 'confirmed');
+  return { statePda, txSignature: tx };
+}
+
+export async function getState(
+  program: Program,
+  statePda: PublicKey,
+): Promise<CoordinationState | null> {
+  try {
+    const raw = (await getAccount(program, 'coordinationState').fetch(statePda)) as Record<string, unknown>;
+
+    return {
+      owner: raw.owner as PublicKey,
+      stateKey: new Uint8Array((raw.stateKey ?? raw.state_key ?? []) as number[]),
+      stateValue: new Uint8Array((raw.stateValue ?? raw.state_value ?? []) as number[]),
+      lastUpdater: (raw.lastUpdater ?? raw.last_updater) as PublicKey,
+      version: toBigInt(raw.version),
+      updatedAt: toNumber(raw.updatedAt ?? raw.updated_at),
+      bump: toNumber(raw.bump),
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message.includes('Account does not exist') || message.includes('could not find account')) {
+      return null;
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- added typed SDK wrappers for all missing on-chain instructions (agents, disputes, protocol, state, and task gaps)
- added `COORDINATION_ERROR_MAP` + `decodeError`/`decodeAnchorError` covering the full 6000-6146 range
- exported `VERIFIER_PROGRAM_ID` and expanded `sdk/src/index.ts` API exports
- added IDL drift tests plus focused unit tests for error decoding, PDA derivations, and protocol param validation

## Test plan
- [x] `cd sdk && npm run typecheck`
- [x] `cd sdk && npm test`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:fast`
- [x] `npm run typecheck`

Closes #974