### PR TITLE
feat(sdk): harden private completion preconditions

### DIFF
--- a/sdk/src/__tests__/proof-validation.test.ts
+++ b/sdk/src/__tests__/proof-validation.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import {
+  validateProofPreconditions,
+  DEFAULT_MAX_PROOF_AGE_MS,
+} from '../proof-validation';
+import { NullifierCache } from '../nullifier-cache';
+import {
+  completeTaskPrivateSafe,
+  type PrivateCompletionProof,
+  ProofPreconditionError,
+} from '../tasks';
+import { PROGRAM_ID } from '../constants';
+
+function bnLike(value: number) {
+  return {
+    toNumber: () => value,
+    toString: () => String(value),
+  };
+}
+
+function makeBytes(length: number, fill: number): Uint8Array {
+  return new Uint8Array(length).fill(fill);
+}
+
+function makeProof(overrides: Partial<PrivateCompletionProof> = {}): PrivateCompletionProof {
+  return {
+    proofData: makeBytes(256, 7),
+    constraintHash: makeBytes(32, 1),
+    outputCommitment: makeBytes(32, 2),
+    expectedBinding: makeBytes(32, 3),
+    nullifier: makeBytes(32, 4),
+    ...overrides,
+  };
+}
+
+function makeValidationHarness(options?: {
+  taskMissing?: boolean;
+  taskState?: unknown;
+  privateTask?: boolean;
+  constraintHash?: Uint8Array;
+  deadline?: number;
+  taskType?: number;
+  completions?: number;
+  claimMissing?: boolean;
+  claimCompleted?: boolean;
+  claimExpiresAt?: number;
+  nullifierSpent?: boolean;
+}) {
+  const now = Math.floor(Date.now() / 1000);
+  const creator = Keypair.generate().publicKey;
+
+  const taskFetch = options?.taskMissing
+    ? vi.fn().mockRejectedValue(new Error('Account does not exist'))
+    : vi.fn().mockResolvedValue({
+        taskId: makeBytes(32, 9),
+        status: options?.taskState ?? { inProgress: {} },
+        creator,
+        rewardAmount: { toString: () => '1000' },
+        deadline: bnLike(options?.deadline ?? now + 600),
+        constraintHash: options?.privateTask === false
+          ? makeBytes(32, 0)
+          : (options?.constraintHash ?? makeBytes(32, 1)),
+        currentWorkers: 1,
+        maxWorkers: 1,
+        completedAt: null,
+        rewardMint: null,
+        createdAt: bnLike(now - 120),
+        taskType: options?.taskType ?? 1,
+        completions: options?.completions ?? 0,
+      });
+
+  const claimFetch = options?.claimMissing
+    ? vi.fn().mockRejectedValue(new Error('claim missing'))
+    : vi.fn().mockResolvedValue({
+        isCompleted: options?.claimCompleted ?? false,
+        expiresAt: bnLike(options?.claimExpiresAt ?? now + 120),
+      });
+
+  const program = {
+    programId: PROGRAM_ID,
+    account: {
+      task: { fetch: taskFetch },
+      taskClaim: { fetch: claimFetch },
+      protocolConfig: {
+        fetch: vi.fn().mockResolvedValue({
+          treasury: Keypair.generate().publicKey,
+        }),
+      },
+    },
+    methods: {
+      completeTaskPrivate: vi.fn().mockReturnValue({
+        accountsPartial: vi.fn().mockReturnValue({
+          signers: vi.fn().mockReturnValue({
+            rpc: vi.fn().mockResolvedValue('tx-sig'),
+          }),
+        }),
+      }),
+    },
+  } as unknown as Program;
+
+  const connection = {
+    getAccountInfo: vi.fn().mockResolvedValue(options?.nullifierSpent ? { data: Buffer.alloc(0) } : null),
+    confirmTransaction: vi.fn().mockResolvedValue(undefined),
+  };
+
+  return {
+    program,
+    connection,
+    taskPda: Keypair.generate().publicKey,
+    workerAgentPda: Keypair.generate().publicKey,
+  };
+}
+
+describe('validateProofPreconditions', () => {
+  it('passes all checks for valid proof/task/claim/nullifier state', async () => {
+    const harness = makeValidationHarness();
+    const proof = makeProof();
+
+    const result = await validateProofPreconditions(
+      harness.connection as any,
+      harness.program,
+      {
+        taskPda: harness.taskPda,
+        workerAgentPda: harness.workerAgentPda,
+        proof,
+        proofGeneratedAtMs: Date.now() - 30_000,
+      },
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.failures).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('fails proof_size when proofData length is invalid', async () => {
+    const harness = makeValidationHarness();
+    const proof = makeProof({ proofData: makeBytes(10, 1) });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof,
+    });
+    expect(result.failures.some((f) => f.check === 'proof_size')).toBe(true);
+  });
+
+  it('fails binding_nonzero when expectedBinding is all zeros', async () => {
+    const harness = makeValidationHarness();
+    const proof = makeProof({ expectedBinding: makeBytes(32, 0) });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof,
+    });
+    expect(result.failures.some((f) => f.check === 'binding_nonzero')).toBe(true);
+  });
+
+  it('fails commitment_nonzero when outputCommitment is all zeros', async () => {
+    const harness = makeValidationHarness();
+    const proof = makeProof({ outputCommitment: makeBytes(32, 0) });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof,
+    });
+    expect(result.failures.some((f) => f.check === 'commitment_nonzero')).toBe(true);
+  });
+
+  it('fails nullifier_nonzero when nullifier is all zeros', async () => {
+    const harness = makeValidationHarness();
+    const proof = makeProof({ nullifier: makeBytes(32, 0) });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof,
+    });
+    expect(result.failures.some((f) => f.check === 'nullifier_nonzero')).toBe(true);
+  });
+
+  it('fails proof_freshness when proof is stale', async () => {
+    const harness = makeValidationHarness();
+    const proof = makeProof();
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof,
+      proofGeneratedAtMs: Date.now() - DEFAULT_MAX_PROOF_AGE_MS - 1000,
+      maxProofAgeMs: DEFAULT_MAX_PROOF_AGE_MS,
+    });
+    expect(result.failures.some((f) => f.check === 'proof_freshness')).toBe(true);
+  });
+
+  it('emits proof_freshness warning when nearing expiry', async () => {
+    const harness = makeValidationHarness();
+    const proof = makeProof();
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof,
+      proofGeneratedAtMs: Date.now() - Math.floor(DEFAULT_MAX_PROOF_AGE_MS * 0.81),
+      maxProofAgeMs: DEFAULT_MAX_PROOF_AGE_MS,
+    });
+    expect(result.warnings.some((w) => w.check === 'proof_freshness')).toBe(true);
+  });
+
+  it('fails task_exists and returns early when task is missing', async () => {
+    const harness = makeValidationHarness({ taskMissing: true });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'task_exists')).toBe(true);
+  });
+
+  it('fails task_in_progress when task is not in progress', async () => {
+    const harness = makeValidationHarness({ taskState: { open: {} } });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'task_in_progress')).toBe(true);
+  });
+
+  it('fails task_is_private when task has no private constraint hash', async () => {
+    const harness = makeValidationHarness({ privateTask: false });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'task_is_private')).toBe(true);
+  });
+
+  it('fails constraint_hash_match when proof hash differs from task hash', async () => {
+    const harness = makeValidationHarness({ constraintHash: makeBytes(32, 9) });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof({ constraintHash: makeBytes(32, 1) }),
+    });
+    expect(result.failures.some((f) => f.check === 'constraint_hash_match')).toBe(true);
+  });
+
+  it('fails task_deadline when deadline has passed', async () => {
+    const harness = makeValidationHarness({ deadline: Math.floor(Date.now() / 1000) - 1 });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'task_deadline')).toBe(true);
+  });
+
+  it('fails competitive_not_won when competitive task already has completion', async () => {
+    const harness = makeValidationHarness({ taskType: 2, completions: 1 });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'competitive_not_won')).toBe(true);
+  });
+
+  it('fails claim_exists when claim account is missing', async () => {
+    const harness = makeValidationHarness({ claimMissing: true });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'claim_exists')).toBe(true);
+  });
+
+  it('fails claim_not_expired when claim is expired', async () => {
+    const harness = makeValidationHarness({ claimExpiresAt: Math.floor(Date.now() / 1000) - 10 });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'claim_not_expired')).toBe(true);
+  });
+
+  it('fails nullifier_not_spent when nullifier account exists', async () => {
+    const harness = makeValidationHarness({ nullifierSpent: true });
+    const result = await validateProofPreconditions(harness.connection as any, harness.program, {
+      taskPda: harness.taskPda,
+      workerAgentPda: harness.workerAgentPda,
+      proof: makeProof(),
+    });
+    expect(result.failures.some((f) => f.check === 'nullifier_not_spent')).toBe(true);
+  });
+});
+
+describe('NullifierCache', () => {
+  it('isUsed returns false for unseen nullifier', () => {
+    const cache = new NullifierCache();
+    expect(cache.isUsed(makeBytes(32, 1))).toBe(false);
+  });
+
+  it('markUsed then isUsed returns true', () => {
+    const cache = new NullifierCache();
+    const n = makeBytes(32, 2);
+    cache.markUsed(n);
+    expect(cache.isUsed(n)).toBe(true);
+  });
+
+  it('evicts least recently used entry at maxSize', () => {
+    const cache = new NullifierCache(2);
+    const a = makeBytes(32, 1);
+    const b = makeBytes(32, 2);
+    const c = makeBytes(32, 3);
+
+    cache.markUsed(a);
+    cache.markUsed(b);
+    expect(cache.isUsed(a)).toBe(true); // touch a, b becomes LRU
+
+    cache.markUsed(c); // evict b
+
+    expect(cache.isUsed(a)).toBe(true);
+    expect(cache.isUsed(b)).toBe(false);
+    expect(cache.isUsed(c)).toBe(true);
+  });
+
+  it('clear removes all entries', () => {
+    const cache = new NullifierCache();
+    cache.markUsed(makeBytes(32, 8));
+    cache.clear();
+    expect(cache.size).toBe(0);
+  });
+});
+
+describe('completeTaskPrivateSafe', () => {
+  it('rejects when nullifier was already submitted in local cache', async () => {
+    const cache = new NullifierCache();
+    const proof = makeProof();
+    cache.markUsed(proof.nullifier);
+
+    await expect(
+      completeTaskPrivateSafe(
+        { confirmTransaction: vi.fn(), getAccountInfo: vi.fn() } as any,
+        {} as Program,
+        Keypair.generate(),
+        makeBytes(32, 5),
+        Keypair.generate().publicKey,
+        proof,
+        { nullifierCache: cache, validatePreconditions: false },
+      ),
+    ).rejects.toThrow('Nullifier already submitted in this session');
+  });
+
+  it('throws ProofPreconditionError when validation fails', async () => {
+    const harness = makeValidationHarness({ taskMissing: true });
+
+    await expect(
+      completeTaskPrivateSafe(
+        harness.connection as any,
+        harness.program,
+        Keypair.generate(),
+        makeBytes(32, 5),
+        harness.taskPda,
+        makeProof(),
+      ),
+    ).rejects.toBeInstanceOf(ProofPreconditionError);
+  });
+
+  it('submits successfully with validatePreconditions=false and marks cache', async () => {
+    const harness = makeValidationHarness();
+    const cache = new NullifierCache();
+    const proof = makeProof();
+
+    const result = await completeTaskPrivateSafe(
+      harness.connection as any,
+      harness.program,
+      Keypair.generate(),
+      makeBytes(32, 5),
+      harness.taskPda,
+      proof,
+      {
+        validatePreconditions: false,
+        nullifierCache: cache,
+      },
+    );
+
+    expect(result.txSignature).toBe('tx-sig');
+    expect(cache.isUsed(proof.nullifier)).toBe(true);
+  });
+});

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -42,6 +42,7 @@ export {
   expireClaim,
   completeTask,
   completeTaskPrivate,
+  completeTaskPrivateSafe,
   cancelTask,
   getTask,
   getTasksByCreator,
@@ -58,6 +59,8 @@ export {
   TaskLifecycleEvent,
   TaskLifecycleSummary,
   PrivateCompletionProof,
+  CompleteTaskPrivateSafeOptions,
+  ProofPreconditionError,
 } from './tasks';
 
 export {
@@ -201,6 +204,19 @@ export {
   type CoordinationErrorEntry,
   type DecodedError,
 } from './errors';
+
+export {
+  validateProofPreconditions,
+  DEFAULT_MAX_PROOF_AGE_MS,
+  type ProofPreconditionResult,
+  type ProofPreconditionFailure,
+  type ProofPreconditionWarning,
+  type ValidateProofParams,
+} from './proof-validation';
+
+export {
+  NullifierCache,
+} from './nullifier-cache';
 
 export {
   // Query functions

--- a/sdk/src/nullifier-cache.ts
+++ b/sdk/src/nullifier-cache.ts
@@ -1,0 +1,53 @@
+/**
+ * Session-scoped nullifier usage tracking with LRU eviction.
+ */
+export class NullifierCache {
+  private readonly used = new Map<string, true>();
+  private readonly maxSize: number;
+
+  constructor(maxSize: number = 10_000) {
+    if (!Number.isInteger(maxSize) || maxSize <= 0) {
+      throw new Error('maxSize must be a positive integer');
+    }
+    this.maxSize = maxSize;
+  }
+
+  private toKey(nullifier: Uint8Array | Buffer): string {
+    return Buffer.from(nullifier).toString('hex');
+  }
+
+  isUsed(nullifier: Uint8Array | Buffer): boolean {
+    const key = this.toKey(nullifier);
+    const exists = this.used.has(key);
+    if (!exists) return false;
+
+    this.used.delete(key);
+    this.used.set(key, true);
+    return true;
+  }
+
+  markUsed(nullifier: Uint8Array | Buffer): void {
+    const key = this.toKey(nullifier);
+
+    if (this.used.has(key)) {
+      this.used.delete(key);
+    }
+
+    this.used.set(key, true);
+
+    if (this.used.size > this.maxSize) {
+      const oldest = this.used.keys().next().value;
+      if (oldest !== undefined) {
+        this.used.delete(oldest);
+      }
+    }
+  }
+
+  clear(): void {
+    this.used.clear();
+  }
+
+  get size(): number {
+    return this.used.size;
+  }
+}

--- a/sdk/src/proof-validation.ts
+++ b/sdk/src/proof-validation.ts
@@ -1,0 +1,250 @@
+import { Connection, PublicKey } from '@solana/web3.js';
+import { type Program } from '@coral-xyz/anchor';
+import { PROOF_SIZE_BYTES, SEEDS } from './constants';
+import { getTask, deriveClaimPda, TaskState, type PrivateCompletionProof } from './tasks';
+import { getAccount } from './anchor-utils';
+
+export interface ProofPreconditionResult {
+  valid: boolean;
+  failures: ProofPreconditionFailure[];
+  warnings: ProofPreconditionWarning[];
+}
+
+export interface ProofPreconditionFailure {
+  check: string;
+  message: string;
+  retriable: boolean;
+}
+
+export interface ProofPreconditionWarning {
+  check: string;
+  message: string;
+}
+
+export interface ValidateProofParams {
+  taskPda: PublicKey;
+  workerAgentPda: PublicKey;
+  proof: Pick<
+    PrivateCompletionProof,
+    'constraintHash' | 'outputCommitment' | 'expectedBinding' | 'nullifier' | 'proofData'
+  >;
+  proofGeneratedAtMs?: number;
+  maxProofAgeMs?: number;
+}
+
+export const DEFAULT_MAX_PROOF_AGE_MS = 5 * 60 * 1_000;
+
+function toBytes(value: Uint8Array | Buffer): Uint8Array {
+  return value instanceof Uint8Array ? value : new Uint8Array(value);
+}
+
+function isAllZeros(value: Uint8Array | Buffer): boolean {
+  return toBytes(value).every((b) => b === 0);
+}
+
+function bytesEqual(a: Uint8Array | Buffer, b: Uint8Array | Buffer): boolean {
+  const ab = toBytes(a);
+  const bb = toBytes(b);
+  if (ab.length !== bb.length) return false;
+  for (let i = 0; i < ab.length; i++) {
+    if (ab[i] !== bb[i]) return false;
+  }
+  return true;
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'bigint') return Number(value);
+  if (value && typeof value === 'object' && 'toNumber' in value) {
+    return (value as { toNumber: () => number }).toNumber();
+  }
+  return 0;
+}
+
+export async function validateProofPreconditions(
+  connection: Connection,
+  program: Program,
+  params: ValidateProofParams,
+): Promise<ProofPreconditionResult> {
+  const failures: ProofPreconditionFailure[] = [];
+  const warnings: ProofPreconditionWarning[] = [];
+
+  const proofData = toBytes(params.proof.proofData);
+  const expectedBinding = toBytes(params.proof.expectedBinding);
+  const outputCommitment = toBytes(params.proof.outputCommitment);
+  const nullifier = toBytes(params.proof.nullifier);
+  const constraintHash = toBytes(params.proof.constraintHash);
+
+  if (proofData.length !== PROOF_SIZE_BYTES) {
+    failures.push({
+      check: 'proof_size',
+      message: `Proof data must be ${PROOF_SIZE_BYTES} bytes, got ${proofData.length}`,
+      retriable: false,
+    });
+  }
+
+  if (isAllZeros(expectedBinding)) {
+    failures.push({
+      check: 'binding_nonzero',
+      message: 'expectedBinding cannot be all zeros',
+      retriable: false,
+    });
+  }
+
+  if (isAllZeros(outputCommitment)) {
+    failures.push({
+      check: 'commitment_nonzero',
+      message: 'outputCommitment cannot be all zeros',
+      retriable: false,
+    });
+  }
+
+  if (isAllZeros(nullifier)) {
+    failures.push({
+      check: 'nullifier_nonzero',
+      message: 'nullifier cannot be all zeros',
+      retriable: false,
+    });
+  }
+
+  if (params.proofGeneratedAtMs !== undefined) {
+    const maxAge = params.maxProofAgeMs ?? DEFAULT_MAX_PROOF_AGE_MS;
+    const age = Date.now() - params.proofGeneratedAtMs;
+
+    if (age > maxAge) {
+      failures.push({
+        check: 'proof_freshness',
+        message: `Proof is ${Math.floor(age / 1000)}s old, max allowed is ${Math.floor(maxAge / 1000)}s`,
+        retriable: false,
+      });
+    } else if (age > maxAge * 0.8) {
+      warnings.push({
+        check: 'proof_freshness',
+        message: `Proof is ${Math.floor(age / 1000)}s old, approaching expiry at ${Math.floor(maxAge / 1000)}s`,
+      });
+    }
+  }
+
+  const task = await getTask(program, params.taskPda);
+  if (!task) {
+    failures.push({
+      check: 'task_exists',
+      message: 'Task account not found',
+      retriable: false,
+    });
+
+    return { valid: false, failures, warnings };
+  }
+
+  if (task.state !== TaskState.InProgress) {
+    failures.push({
+      check: 'task_in_progress',
+      message: `Task is in state ${task.state}, expected InProgress (1)`,
+      retriable: false,
+    });
+  }
+
+  if (!task.constraintHash || isAllZeros(task.constraintHash)) {
+    failures.push({
+      check: 'task_is_private',
+      message: 'Task has no constraint hash and is not private',
+      retriable: false,
+    });
+  } else if (!bytesEqual(task.constraintHash, constraintHash)) {
+    failures.push({
+      check: 'constraint_hash_match',
+      message: 'Proof constraint hash does not match task constraint hash',
+      retriable: false,
+    });
+  }
+
+  if (task.deadline > 0) {
+    const now = Math.floor(Date.now() / 1000);
+
+    if (now > task.deadline) {
+      failures.push({
+        check: 'task_deadline',
+        message: `Task deadline passed (${task.deadline}), current time is ${now}`,
+        retriable: false,
+      });
+    } else if (task.deadline - now < 60) {
+      warnings.push({
+        check: 'task_deadline',
+        message: `Task deadline is in ${task.deadline - now}s and may expire before confirmation`,
+      });
+    }
+  }
+
+  const rawTask = await getAccount(program, 'task').fetch(params.taskPda) as {
+    taskType?: number;
+    task_type?: number;
+    completions?: number;
+  };
+
+  const taskType = toNumber(rawTask.taskType ?? rawTask.task_type);
+  const completions = toNumber(rawTask.completions);
+  if (taskType === 2 && completions > 0) {
+    failures.push({
+      check: 'competitive_not_won',
+      message: 'Competitive task already completed by another worker',
+      retriable: false,
+    });
+  }
+
+  const claimPda = deriveClaimPda(params.taskPda, params.workerAgentPda, program.programId);
+  try {
+    const claim = await getAccount(program, 'taskClaim').fetch(claimPda) as {
+      completed?: boolean;
+      isCompleted?: boolean;
+      is_completed?: boolean;
+      expiresAt?: { toNumber: () => number };
+      expires_at?: { toNumber: () => number };
+    };
+
+    const isCompleted = Boolean(claim.completed ?? claim.isCompleted ?? claim.is_completed ?? false);
+    if (isCompleted) {
+      failures.push({
+        check: 'claim_not_completed',
+        message: 'Claim is already completed',
+        retriable: false,
+      });
+    }
+
+    const expiresAt = toNumber(claim.expiresAt ?? claim.expires_at);
+    if (expiresAt > 0) {
+      const now = Math.floor(Date.now() / 1000);
+      if (now > expiresAt) {
+        failures.push({
+          check: 'claim_not_expired',
+          message: `Claim expired at ${expiresAt}, current time is ${now}`,
+          retriable: false,
+        });
+      }
+    }
+  } catch {
+    failures.push({
+      check: 'claim_exists',
+      message: 'Claim account not found for worker/task pair',
+      retriable: false,
+    });
+  }
+
+  const [nullifierPda] = PublicKey.findProgramAddressSync(
+    [SEEDS.NULLIFIER, nullifier],
+    program.programId,
+  );
+  const nullifierInfo = await connection.getAccountInfo(nullifierPda);
+  if (nullifierInfo !== null) {
+    failures.push({
+      check: 'nullifier_not_spent',
+      message: 'Nullifier has already been spent',
+      retriable: false,
+    });
+  }
+
+  return {
+    valid: failures.length === 0,
+    failures,
+    warnings,
+  };
+}


### PR DESCRIPTION
## Summary
- added `validateProofPreconditions()` with local proof checks plus on-chain task/claim/nullifier gating before private completion submission
- added `NullifierCache` with session-scoped LRU eviction to prevent duplicate nullifier submissions in one client session
- added `completeTaskPrivateSafe()` and `ProofPreconditionError` to integrate precondition validation and nullifier cache enforcement without changing existing `completeTaskPrivate()` behavior
- added focused tests covering each validation failure mode, cache behavior, and safe wrapper flows

## Test plan
- [x] `cd sdk && npm run typecheck`
- [x] `cd sdk && npm test`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:fast`
- [x] `npm run typecheck`

Closes #976