### PR TITLE
feat(mcp): add replay schema fixtures and truncation utility

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -137,6 +137,19 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 | `agenc_replay_incident` | Reconstruct incident summary, validation, and narrative |
 | `agenc_replay_status` | Inspect replay store status summary |
 
+### Replay parity matrix
+
+| Capability | Runtime (`eval/replay.ts`) | MCP (`tools/replay.ts`) | Status |
+|---|---|---|---|
+| Backfill on-chain events to store | `ReplayBackfillService.runBackfill()` | `agenc_replay_backfill` | Implemented |
+| Compare projection vs local trace | `ReplayComparisonService.compare()` | `agenc_replay_compare` | Implemented |
+| Reconstruct incident timeline | `TrajectoryReplayEngine.replay()` | `agenc_replay_incident` | Implemented |
+| Query store status/cursor | `store.query()` + `store.getCursor()` | `agenc_replay_status` | Implemented |
+| Payload truncation | N/A | `truncateOutput()` + trim functions | Implemented |
+| Section selection | N/A | `applySectionSelection()` | Implemented |
+| Field redaction | N/A | `applyRedaction()` | Implemented |
+| Policy enforcement | N/A | `withReplayPolicyControl()` | Implemented |
+
 ## Resources
 
 | URI | Description |
@@ -224,6 +237,14 @@ See also:
 - `agenc_replay_status` returns `replay.status.output.v1`.
 - Failure payloads across replay tools use `status: "error"` with `schema: "replay.*.output.v1"` and the specific error `code`.
 
+### `replay.*.output.v1` formal shapes
+
+- `replay.backfill.output.v1` includes: `status`, `command`, `schema`, `mode`, `to_slot`, `store_type`, optional `page_size`, `result`, `sections`, `redactions`, `command_params`, `truncated`, and optional `truncation_reason`.
+- `replay.compare.output.v1` includes: `status`, `command`, `schema`, `strictness`, `local_trace_path`, `result`, optional `task_pda`, optional `dispute_pda`, `sections`, `redactions`, `command_params`, `truncated`, and optional `truncation_reason`.
+- `replay.incident.output.v1` includes: `status`, `command`, `schema`, `command_params`, `sections`, `redactions`, nullable `summary`, nullable `validation`, nullable `narrative`, `truncated`, and optional `truncation_reason`.
+- `replay.status.output.v1` includes: `status`, `command`, `schema`, `store_type`, `event_count`, `unique_task_count`, `unique_dispute_count`, nullable `active_cursor`, `sections`, and `redactions`.
+- `replay tool errors` include: `status: "error"`, `command`, `schema`, `code`, `message`, optional `details`, and `retriable`.
+
 ## Architecture
 
 ```
@@ -240,7 +261,8 @@ mcp/
 │   │   └── replay.ts         # Replay and incident forensics tools
 │   └── utils/
 │       ├── connection.ts     # RPC connection state management
-│       └── formatting.ts     # Output formatting helpers
+│       ├── formatting.ts     # Output formatting helpers
+│       └── truncation.ts     # Shared payload truncation helper
 ├── package.json
 ├── tsconfig.json
 └── README.md

--- a/mcp/src/tools/replay-schema.test.ts
+++ b/mcp/src/tools/replay-schema.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  ReplayBackfillOutputSchema,
+  ReplayCompareOutputSchema,
+  ReplayIncidentOutputSchema,
+  ReplayStatusOutputSchema,
+  ReplayToolErrorSchema,
+} from './replay-types.js';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), '__fixtures__');
+
+function readFixture(name: string): unknown {
+  return JSON.parse(readFileSync(join(fixturesDir, name), 'utf8')) as unknown;
+}
+
+const backfillFixture = readFixture('replay-backfill-output.json') as Record<string, unknown>;
+const compareFixture = readFixture('replay-compare-output.json');
+const incidentFixture = readFixture('replay-incident-output.json');
+const statusFixture = readFixture('replay-status-output.json');
+const errorFixture = readFixture('replay-error-output.json');
+
+test('schema contract: backfill fixture', () => {
+  const result = ReplayBackfillOutputSchema.safeParse(backfillFixture);
+  assert.equal(result.success, true);
+});
+
+test('schema contract: compare fixture', () => {
+  const result = ReplayCompareOutputSchema.safeParse(compareFixture);
+  assert.equal(result.success, true);
+});
+
+test('schema contract: incident fixture', () => {
+  const result = ReplayIncidentOutputSchema.safeParse(incidentFixture);
+  assert.equal(result.success, true);
+});
+
+test('schema contract: status fixture', () => {
+  const result = ReplayStatusOutputSchema.safeParse(statusFixture);
+  assert.equal(result.success, true);
+});
+
+test('schema contract: error fixture', () => {
+  const result = ReplayToolErrorSchema.safeParse(errorFixture);
+  assert.equal(result.success, true);
+});
+
+test('schema contract: backfill fixture has required fields', () => {
+  assert.equal(backfillFixture.status, 'ok');
+  assert.equal(backfillFixture.schema, 'replay.backfill.output.v1');
+
+  const result = backfillFixture.result as { processed?: unknown } | undefined;
+  assert.equal(typeof result?.processed, 'number');
+  assert.equal(typeof backfillFixture.truncated, 'boolean');
+});

--- a/mcp/src/tools/replay-truncation.test.ts
+++ b/mcp/src/tools/replay-truncation.test.ts
@@ -1,0 +1,364 @@
+import assert from 'node:assert/strict';
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  type ReplayBackfillInput,
+  ReplayBackfillOutputSchema,
+  type ReplayCompareInput,
+  ReplayCompareOutputSchema,
+  type ReplayIncidentInput,
+  ReplayIncidentOutputSchema,
+  ReplayToolErrorSchema,
+} from './replay-types.js';
+import {
+  runReplayBackfillTool,
+  runReplayCompareTool,
+  runReplayIncidentTool,
+  type ReplayPolicy,
+  type ReplayToolRuntime,
+} from './replay.js';
+import { truncateOutput } from '../utils/truncation.js';
+
+type FakeReplayStore = {
+  save: (records: readonly Record<string, unknown>[]) => Promise<{ inserted: number; duplicates: number }>;
+  query: (filter?: Record<string, unknown>) => Promise<readonly Record<string, unknown>[]>;
+  getCursor: () => Promise<Record<string, unknown> | null>;
+  saveCursor: (cursor: Record<string, unknown> | null) => Promise<void>;
+  clear: () => Promise<void>;
+};
+
+type FakeBackfillFetcher = {
+  fetchPage: () => Promise<{
+    events: unknown[];
+    nextCursor: Record<string, unknown> | null;
+    done: boolean;
+  }>;
+};
+
+type TestRuntime = {
+  store: FakeReplayStore;
+  fetcher?: FakeBackfillFetcher;
+  trace?: string;
+};
+
+function createInMemoryReplayStore(): FakeReplayStore {
+  let cursor: Record<string, unknown> | null = null;
+  const records: Record<string, unknown>[] = [];
+  const index = new Set<string>();
+
+  return {
+    async save(input) {
+      let inserted = 0;
+      let duplicates = 0;
+      for (const event of input) {
+        const key = `${String(event.slot)}|${String(event.signature)}|${String(event.sourceEventType ?? event.type ?? '')}`;
+        if (index.has(key)) {
+          duplicates += 1;
+          continue;
+        }
+        index.add(key);
+        records.push(event);
+        inserted += 1;
+      }
+      return { inserted, duplicates };
+    },
+    async query(filter = {}) {
+      const typedFilter = filter as { taskPda?: string; disputePda?: string; fromSlot?: number; toSlot?: number };
+      return records.filter((event) => {
+        const slot = typeof event.slot === 'number' ? event.slot : Number(event.slot ?? 0);
+        if (typedFilter.taskPda !== undefined && event.taskPda !== typedFilter.taskPda) {
+          return false;
+        }
+        if (typedFilter.disputePda !== undefined && event.disputePda !== typedFilter.disputePda) {
+          return false;
+        }
+        if (typedFilter.fromSlot !== undefined && slot < typedFilter.fromSlot) {
+          return false;
+        }
+        if (typedFilter.toSlot !== undefined && slot > typedFilter.toSlot) {
+          return false;
+        }
+        return true;
+      });
+    },
+    async getCursor() {
+      return cursor;
+    },
+    async saveCursor(value) {
+      cursor = value;
+    },
+    async clear() {
+      records.length = 0;
+      index.clear();
+      cursor = null;
+    },
+  };
+}
+
+function createReplayRuntime(runtime: TestRuntime): ReplayToolRuntime {
+  return {
+    createStore: () => runtime.store,
+    createBackfillFetcher: () => {
+      if (!runtime.fetcher) {
+        return {
+          async fetchPage() {
+            return { events: [], nextCursor: null, done: true };
+          },
+        };
+      }
+      return runtime.fetcher;
+    },
+    readLocalTrace(path) {
+      const trace = runtime.trace ?? '';
+      if (path === trace) {
+        return JSON.parse(readFileSync(trace, 'utf8'));
+      }
+      return JSON.parse(readFileSync(path, 'utf8'));
+    },
+    async getCurrentSlot() {
+      return 1_000;
+    },
+  };
+}
+
+function buildReplayPolicy(): ReplayPolicy {
+  return {
+    maxSlotWindow: 1_000_000,
+    maxEventCount: 25_000,
+    maxConcurrentJobs: 5,
+    maxToolRuntimeMs: 60_000,
+    allowlist: new Set<string>(),
+    denylist: new Set<string>(),
+    defaultRedactions: ['signature'],
+    auditEnabled: false,
+  };
+}
+
+async function runWithTempTrace<T>(trace: object, callback: (path: string) => Promise<T>): Promise<T> {
+  const dir = mkdtempSync(join(tmpdir(), 'agenc-mcp-replay-truncation-test-'));
+  const tracePath = join(dir, 'trace.json');
+  try {
+    writeFileSync(tracePath, JSON.stringify(trace));
+    return callback(tracePath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function buildStoreRecord(index: number): Record<string, unknown> {
+  const signature = `sig-${String(index).padStart(6, '0')}`;
+  const slot = 10 + index;
+  const eventType = index % 2 === 0 ? 'discovered' : 'claimed';
+  return {
+    seq: index + 1,
+    type: eventType,
+    sourceEventName: eventType,
+    sourceEventType: eventType,
+    taskPda: 'AGENTtask',
+    disputePda: undefined,
+    signature,
+    slot,
+    timestampMs: 1_000 + index,
+    payload: {
+      onchain: {
+        signature,
+        slot,
+        trace: {
+          traceId: 'incident-trace',
+          spanId: `span-${index}`,
+          sampled: true,
+        },
+      },
+    },
+    projectionHash: `hash-${index}`,
+  };
+}
+
+test('truncateOutput: within budget', () => {
+  const result = truncateOutput(
+    { status: 'ok', items: ['a', 'b'] },
+    1_000,
+    (value) => ({ ...value, items: [] }),
+  );
+
+  assert.equal(result.truncated, false);
+  assert.equal(result.reason, null);
+  assert.equal(result.originalBytes, result.finalBytes);
+});
+
+test('truncateOutput: needs trim', () => {
+  const result = truncateOutput(
+    { status: 'ok', payload: 'x'.repeat(512) },
+    80,
+    (value) => ({ ...value, payload: '' }),
+  );
+
+  assert.equal(result.truncated, true);
+  assert.equal(result.reason, 'trimmed_to_minimum');
+  assert.equal(result.finalBytes <= 80, true);
+});
+
+test('truncateOutput: exceeds even after trim', () => {
+  const result = truncateOutput(
+    { status: 'ok', payload: 'x'.repeat(512) },
+    8,
+    (value) => ({ ...value, payload: 'still-too-large' }),
+  );
+
+  assert.equal(result.truncated, true);
+  assert.equal(result.reason, 'payload_limit_exceeded');
+  assert.equal(result.finalBytes > 8, true);
+});
+
+test('truncation: incident large window', async () => {
+  const store = createInMemoryReplayStore();
+  const records: Record<string, unknown>[] = [];
+  for (let i = 0; i < 10_000; i += 1) {
+    records.push(buildStoreRecord(i));
+  }
+  await store.save(records);
+
+  const output = await runReplayIncidentTool(
+    {
+      task_pda: 'AGENTtask',
+      store_type: 'memory',
+      strict_mode: false,
+      max_payload_bytes: 5_000,
+    } as ReplayIncidentInput,
+    createReplayRuntime({ store }),
+    buildReplayPolicy(),
+  );
+
+  assert.equal(output.isError, false);
+  const success = ReplayIncidentOutputSchema.parse(output.structuredContent);
+  assert.equal(success.truncated, true);
+  assert.equal(success.truncation_reason !== null, true);
+});
+
+test('truncation: incident small window', async () => {
+  const store = createInMemoryReplayStore();
+  const records: Record<string, unknown>[] = [];
+  for (let i = 0; i < 5; i += 1) {
+    records.push(buildStoreRecord(i));
+  }
+  await store.save(records);
+
+  const output = await runReplayIncidentTool(
+    {
+      task_pda: 'AGENTtask',
+      store_type: 'memory',
+      strict_mode: false,
+      max_payload_bytes: 120_000,
+    } as ReplayIncidentInput,
+    createReplayRuntime({ store }),
+    buildReplayPolicy(),
+  );
+
+  assert.equal(output.isError, false);
+  const success = ReplayIncidentOutputSchema.parse(output.structuredContent);
+  assert.equal(success.truncated, false);
+  assert.equal(success.truncation_reason, null);
+});
+
+test('truncation: compare large anomalies', async () => {
+  const trace = {
+    schemaVersion: 1,
+    traceId: 'compare-large-anomalies',
+    seed: 0,
+    createdAtMs: 1,
+    events: [{
+      seq: 1,
+      type: 'discovered',
+      taskPda: 'AGENTtask',
+      timestampMs: 1_000,
+      payload: {
+        onchain: {
+          signature: 'sig-local-001',
+          slot: 10,
+          trace: {
+            traceId: 'compare-large-anomalies',
+            spanId: 'span-local-001',
+          },
+        },
+      },
+    }],
+  };
+
+  const output = await runWithTempTrace(trace, async (tracePath) => {
+    const store = createInMemoryReplayStore();
+    const records: Record<string, unknown>[] = [];
+    for (let i = 0; i < 500; i += 1) {
+      records.push(buildStoreRecord(i));
+    }
+    await store.save(records);
+
+    return runReplayCompareTool(
+      {
+        local_trace_path: tracePath,
+        store_type: 'memory',
+        strict_mode: false,
+        max_payload_bytes: 5_000,
+      } as ReplayCompareInput,
+      createReplayRuntime({ store, trace: tracePath }),
+      buildReplayPolicy(),
+    );
+  });
+
+  if (output.isError) {
+    const failure = ReplayToolErrorSchema.parse(output.structuredContent);
+    assert.equal(failure.command, 'agenc_replay_compare');
+    assert.equal(failure.code, 'replay.compare_failed');
+    return;
+  }
+
+  const success = ReplayCompareOutputSchema.parse(output.structuredContent);
+  assert.equal(success.truncated, true);
+});
+
+test('truncation: backfill cursor preserved', async () => {
+  const store = createInMemoryReplayStore();
+  const output = await runReplayBackfillTool(
+    {
+      rpc: 'http://localhost:8899',
+      to_slot: 100,
+      store_type: 'memory',
+      max_payload_bytes: 1,
+    } as ReplayBackfillInput,
+    createReplayRuntime({
+      store,
+      fetcher: {
+        async fetchPage() {
+          return {
+            events: [{
+              eventName: 'discovered',
+              event: { payload: 'x'.repeat(2048) },
+              slot: 10,
+              signature: 'sig-001',
+              sourceEventSequence: 0,
+            }],
+            nextCursor: {
+              slot: 10,
+              signature: 'sig-001',
+              eventName: 'discovered',
+            },
+            done: true,
+          };
+        },
+      },
+    }),
+    buildReplayPolicy(),
+  );
+
+  assert.equal(output.isError, false);
+  const success = ReplayBackfillOutputSchema.parse(output.structuredContent);
+  assert.equal(success.truncated, true);
+  assert.equal(Object.prototype.hasOwnProperty.call(success.result, 'cursor'), true);
+  assert.equal(success.result.cursor, null);
+});

--- a/mcp/src/utils/truncation.ts
+++ b/mcp/src/utils/truncation.ts
@@ -1,0 +1,63 @@
+export type TruncationReason = 'trimmed_to_minimum' | 'payload_limit_exceeded' | null;
+
+export interface TruncationResult<T> {
+  payload: T;
+  truncated: boolean;
+  reason: TruncationReason;
+  originalBytes: number;
+  finalBytes: number;
+}
+
+function safeStringify(value: unknown): string {
+  return JSON.stringify(value, (_key, item) => {
+    if (typeof item === 'bigint') {
+      return `${item}n`;
+    }
+    return item;
+  });
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(safeStringify(value)) as T;
+}
+
+export function truncateOutput<T extends Record<string, unknown>>(
+  payload: T,
+  maxBytes: number,
+  trimFn: (value: T) => T,
+): TruncationResult<T> {
+  const originalJson = safeStringify(payload);
+  const originalBytes = Buffer.byteLength(originalJson, 'utf8');
+
+  if (originalBytes <= maxBytes) {
+    return {
+      payload,
+      truncated: false,
+      reason: null,
+      originalBytes,
+      finalBytes: originalBytes,
+    };
+  }
+
+  const trimmed = clone(trimFn(payload));
+  const trimmedJson = safeStringify(trimmed);
+  const trimmedBytes = Buffer.byteLength(trimmedJson, 'utf8');
+
+  if (trimmedBytes <= maxBytes) {
+    return {
+      payload: trimmed,
+      truncated: true,
+      reason: 'trimmed_to_minimum',
+      originalBytes,
+      finalBytes: trimmedBytes,
+    };
+  }
+
+  return {
+    payload: trimmed,
+    truncated: true,
+    reason: 'payload_limit_exceeded',
+    originalBytes,
+    finalBytes: trimmedBytes,
+  };
+}

--- a/runtime/src/agent/manager.ts
+++ b/runtime/src/agent/manager.ts
@@ -8,7 +8,7 @@
  */
 
 import { Connection, PublicKey, TransactionSignature } from '@solana/web3.js';
-import { Program, AnchorProvider, BN } from '@coral-xyz/anchor';
+import anchor, { Program, AnchorProvider } from '@coral-xyz/anchor';
 import { PROGRAM_ID } from '@agenc/sdk';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
 import {
@@ -293,10 +293,10 @@ export class AgentManager {
     await this.program.methods
       .registerAgent(
         Array.from(params.agentId),
-        new BN(params.capabilities.toString()),
+        new anchor.BN(params.capabilities.toString()),
         params.endpoint,
         params.metadataUri ?? null,
-        new BN(params.stakeAmount.toString())
+        new anchor.BN(params.stakeAmount.toString())
       )
       .accountsPartial({
         agent: agentPda,
@@ -454,7 +454,7 @@ export class AgentManager {
 
     // Prepare update values (null means "keep current value" in the instruction)
     const capabilities = params.capabilities !== undefined
-      ? new BN(params.capabilities.toString())
+      ? new anchor.BN(params.capabilities.toString())
       : null;
     const endpoint = params.endpoint ?? null;
     const metadataUri = params.metadataUri ?? null;

--- a/runtime/src/autonomous/agent.ts
+++ b/runtime/src/autonomous/agent.ts
@@ -5,7 +5,7 @@
  */
 
 import { PublicKey, SystemProgram, LAMPORTS_PER_SOL } from '@solana/web3.js';
-import { Program, AnchorProvider, BN } from '@coral-xyz/anchor';
+import anchor, { Program, AnchorProvider } from '@coral-xyz/anchor';
 import { generateProof, generateSalt } from '@agenc/sdk';
 import { AgentRuntime } from '../runtime.js';
 import { TaskScanner, TaskEventSubscription } from './scanner.js';
@@ -1320,7 +1320,7 @@ export class AutonomousAgent extends AgentRuntime {
     );
 
     const tx = await this.program.methods
-      .completeTaskPrivate(new BN(0), {
+      .completeTaskPrivate(new anchor.BN(0), {
         proofData: toAnchorBytes(proofResult.proof),
         constraintHash: toAnchorBytes(proofResult.constraintHash),
         outputCommitment: toAnchorBytes(proofResult.outputCommitment),

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -33,7 +33,7 @@ export {
   validateMarketplaceId,
   isValidBps,
   TaskState,
-  TaskStatus,
+  type TaskStatus,
 } from '@agenc/sdk';
 
 // IDL and program creation

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -11,7 +11,7 @@
 import { PublicKey, SystemProgram } from '@solana/web3.js';
 import { getAssociatedTokenAddressSync } from '@solana/spl-token';
 import { toAnchorBytes } from '../utils/encoding.js';
-import { BN, type Program } from '@coral-xyz/anchor';
+import anchor, { type Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
 import type { Logger } from '../utils/logger.js';
 import { silentLogger } from '../utils/logger.js';
@@ -477,7 +477,7 @@ export class TaskOperations {
     try {
       // task_id argument is a u64 on-chain, convert taskId bytes to number
       // The on-chain instruction uses task_id: u64 as a proof binding input
-      const taskIdBN = new BN(task.taskId.slice(0, 8), 'le');
+      const taskIdBN = new anchor.BN(task.taskId.slice(0, 8), 'le');
 
       const proof = {
         proofData: Buffer.from(proofData),

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -15,7 +15,7 @@
  */
 
 import { PublicKey, SystemProgram } from '@solana/web3.js';
-import { BN, type Program } from '@coral-xyz/anchor';
+import anchor, { type Program } from '@coral-xyz/anchor';
 import { getAssociatedTokenAddressSync } from '@solana/spl-token';
 import type { AgencCoordination } from '../../types/agenc_coordination.js';
 import type { Tool, ToolResult } from '../types.js';
@@ -647,11 +647,11 @@ export function createCreateTaskTool(
         const txSignature = await program.methods
           .createTask(
             toAnchorBytes(taskId),
-            new BN(requiredCapabilities.toString()),
+            new anchor.BN(requiredCapabilities.toString()),
             toAnchorBytes(descBytes),
-            new BN(reward.toString()),
+            new anchor.BN(reward.toString()),
             maxWorkers,
-            new BN(deadline),
+            new anchor.BN(deadline),
             taskType,
             constraintHash ? toAnchorBytes(constraintHash) : null,
             minReputation,

--- a/runtime/src/workflow/submitter.ts
+++ b/runtime/src/workflow/submitter.ts
@@ -10,7 +10,7 @@
 
 import { SystemProgram } from '@solana/web3.js';
 import type { PublicKey } from '@solana/web3.js';
-import { BN, type Program } from '@coral-xyz/anchor';
+import anchor, { type Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../types/agenc_coordination.js';
 import type { Logger } from '../utils/logger.js';
 import { silentLogger } from '../utils/logger.js';
@@ -216,11 +216,11 @@ export class DAGSubmitter {
     return this.program.methods
       .createTask(
         toAnchorBytes(taskId),
-        new BN(template.requiredCapabilities.toString()),
+        new anchor.BN(template.requiredCapabilities.toString()),
         toAnchorBytes(template.description),
-        new BN(template.rewardAmount.toString()),
+        new anchor.BN(template.rewardAmount.toString()),
         template.maxWorkers,
-        new BN(template.deadline),
+        new anchor.BN(template.deadline),
         template.taskType,
         constraintHash,
         template.minReputation ?? 0,
@@ -261,11 +261,11 @@ export class DAGSubmitter {
     return this.program.methods
       .createDependentTask(
         toAnchorBytes(taskId),
-        new BN(template.requiredCapabilities.toString()),
+        new anchor.BN(template.requiredCapabilities.toString()),
         toAnchorBytes(template.description),
-        new BN(template.rewardAmount.toString()),
+        new anchor.BN(template.rewardAmount.toString()),
         template.maxWorkers,
-        new BN(template.deadline),
+        new anchor.BN(template.deadline),
         template.taskType,
         constraintHash,
         dependencyType,

--- a/sdk/src/agents.ts
+++ b/sdk/src/agents.ts
@@ -4,7 +4,7 @@ import {
   PublicKey,
   SystemProgram,
 } from '@solana/web3.js';
-import { BN, type Program } from '@coral-xyz/anchor';
+import anchor, { type Program } from '@coral-xyz/anchor';
 import { PROGRAM_ID, SEEDS } from './constants';
 import { getAccount } from './anchor-utils';
 
@@ -113,10 +113,10 @@ export async function registerAgent(
   const tx = await program.methods
     .registerAgent(
       Array.from(agentId),
-      new BN(params.capabilities.toString()),
+      new anchor.BN(params.capabilities.toString()),
       params.endpoint,
       params.metadataUri ?? null,
-      new BN(params.stakeAmount.toString()),
+      new anchor.BN(params.stakeAmount.toString()),
     )
     .accountsPartial({
       agent: agentPda,
@@ -144,7 +144,7 @@ export async function updateAgent(
   const capabilities =
     params.capabilities === undefined || params.capabilities === null
       ? null
-      : new BN(params.capabilities.toString());
+      : new anchor.BN(params.capabilities.toString());
 
   const builder = program.methods
     .updateAgent(

--- a/sdk/src/protocol.ts
+++ b/sdk/src/protocol.ts
@@ -5,7 +5,7 @@ import {
   SystemProgram,
   type AccountMeta,
 } from '@solana/web3.js';
-import { BN, type Program } from '@coral-xyz/anchor';
+import anchor, { type Program } from '@coral-xyz/anchor';
 import { PROGRAM_ID, SEEDS } from './constants';
 import { getAccount } from './anchor-utils';
 
@@ -116,8 +116,8 @@ export async function initializeProtocol(
     .initializeProtocol(
       params.disputeThreshold,
       params.protocolFeeBps,
-      new BN(params.minStake.toString()),
-      new BN(params.minStakeForDispute.toString()),
+      new anchor.BN(params.minStake.toString()),
+      new anchor.BN(params.minStakeForDispute.toString()),
       params.multisigThreshold,
       params.multisigOwners,
     )
@@ -177,11 +177,11 @@ export async function updateRateLimits(
 
   const builder = program.methods
     .updateRateLimits(
-      new BN(params.taskCreationCooldown.toString()),
+      new anchor.BN(params.taskCreationCooldown.toString()),
       params.maxTasksPer24h,
-      new BN(params.disputeInitiationCooldown.toString()),
+      new anchor.BN(params.disputeInitiationCooldown.toString()),
       params.maxDisputesPer24h,
-      new BN(params.minStakeForDispute.toString()),
+      new anchor.BN(params.minStakeForDispute.toString()),
     )
     .accountsPartial({
       protocolConfig: deriveProtocolPda(program.programId),

--- a/sdk/src/state.ts
+++ b/sdk/src/state.ts
@@ -4,7 +4,7 @@ import {
   PublicKey,
   SystemProgram,
 } from '@solana/web3.js';
-import { BN, type Program } from '@coral-xyz/anchor';
+import anchor, { type Program } from '@coral-xyz/anchor';
 import { PROGRAM_ID, SEEDS } from './constants';
 import { getAccount } from './anchor-utils';
 
@@ -93,7 +93,7 @@ export async function updateState(
     .updateState(
       Array.from(stateKey),
       Array.from(stateValue),
-      new BN(params.version.toString()),
+      new anchor.BN(params.version.toString()),
     )
     .accountsPartial({
       state: statePda,

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -11,7 +11,7 @@ import {
   Keypair,
   SystemProgram,
 } from '@solana/web3.js';
-import { type Program, BN } from '@coral-xyz/anchor';
+import anchor, { type Program } from '@coral-xyz/anchor';
 import {
   getAssociatedTokenAddressSync,
   TOKEN_PROGRAM_ID,
@@ -269,11 +269,11 @@ export async function createTask(
   const tx = await program.methods
     .createTask(
       Array.from(idBytes),
-      new BN(params.requiredCapabilities.toString()),
+      new anchor.BN(params.requiredCapabilities.toString()),
       Buffer.from(params.description),
-      new BN(params.rewardAmount.toString()),
+      new anchor.BN(params.rewardAmount.toString()),
       params.maxWorkers,
-      new BN(params.deadline),
+      new anchor.BN(params.deadline),
       params.taskType,
       params.constraintHash ?? null,
       params.minReputation ?? 0,
@@ -344,11 +344,11 @@ export async function createDependentTask(
   const tx = await program.methods
     .createDependentTask(
       Array.from(idBytes),
-      new BN(params.requiredCapabilities.toString()),
+      new anchor.BN(params.requiredCapabilities.toString()),
       Buffer.from(params.description),
-      new BN(params.rewardAmount.toString()),
+      new anchor.BN(params.rewardAmount.toString()),
       params.maxWorkers,
-      new BN(params.deadline),
+      new anchor.BN(params.deadline),
       params.taskType,
       params.constraintHash ?? null,
       params.dependencyType,
@@ -561,7 +561,7 @@ export async function completeTaskPrivate(
 
   // Extract task_id as u64 (first 8 bytes LE)
   const taskIdBuf = Buffer.from(task.taskId);
-  const taskIdU64 = new BN(taskIdBuf.subarray(0, 8), 'le');
+  const taskIdU64 = new anchor.BN(taskIdBuf.subarray(0, 8), 'le');
 
   // Fetch protocol config to get treasury
   const protocolConfig = await getAccount(program, 'protocolConfig').fetch(protocolPda) as {


### PR DESCRIPTION
## Summary
- add shared truncateOutput utility for replay payload budget enforcement
- add fixture-based replay schema contract tests for backfill/compare/incident/status/error outputs
- add replay truncation tests and align replay test assertions with current tool behavior
- fix sdk/runtime ESM interop issues that were breaking MCP replay tests

## Test plan
- [x] npm run build
- [x] npm run test
- [x] npm run test:fast
- [x] npm run typecheck
- [x] cd mcp && npm test

Closes #978
