### PR TITLE
feat(mcp): add replay risk caps and audit entries

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -76,8 +76,10 @@ Add to `~/.codeium/windsurf/mcp_config.json`:
 | `MCP_REPLAY_TOOL_TIMEOUT_MS` | `180000` | Per-call tool timeout in milliseconds |
 | `MCP_REPLAY_ALLOWLIST` | `""` | Comma-separated allowlisted MCP actor IDs |
 | `MCP_REPLAY_DENYLIST` | `""` | Comma-separated denied MCP actor IDs |
+| `MCP_REPLAY_REQUIRE_AUTH_FOR_HIGH_RISK` | `false` | Require authenticated actors for high-risk replay tools |
 | `MCP_REPLAY_DEFAULT_REDACTIONS` | `signature` | Comma-separated field names to redact from output |
 | `MCP_REPLAY_AUDIT_ENABLED` | `false` | Emit replay audit logs to stdout |
+| `MCP_REPLAY_CAPS_<TOOL>_<FIELD>` | `""` | Per-tool replay caps override (example: `MCP_REPLAY_CAPS_BACKFILL_MAX_EVENT_COUNT=5000`) |
 
 ## Tools
 
@@ -210,6 +212,7 @@ MCP_REPLAY_MAX_EVENT_COUNT=2000
 MCP_REPLAY_MAX_CONCURRENT_JOBS=2
 MCP_REPLAY_TOOL_TIMEOUT_MS=180000
 MCP_REPLAY_ALLOWLIST=incident-bot,security-operator
+MCP_REPLAY_REQUIRE_AUTH_FOR_HIGH_RISK=true
 MCP_REPLAY_AUDIT_ENABLED=true
 ```
 
@@ -217,12 +220,29 @@ Policy behavior:
 
 - `MCP_REPLAY_DENYLIST` blocks matching actors first.
 - If `MCP_REPLAY_ALLOWLIST` is set, only matching actors can run replay tools.
+- If `MCP_REPLAY_REQUIRE_AUTH_FOR_HIGH_RISK=true`, high-risk tools require actors resolved via `authInfo.clientId` (not sessions/anonymous).
 - Actor identity is resolved from MCP auth context in this order:
   1. `authInfo.clientId`
   2. `session:<sessionId>`
   3. `anonymous`
 
 Any actor that is denied gets a `replay.access_denied` response with `retriable: false`.
+
+Per-tool caps can be overridden via environment variables in this format:
+
+- `MCP_REPLAY_CAPS_<TOOL>_<FIELD>=<positive integer>`
+
+Where:
+
+- `<TOOL>` is one of: `BACKFILL`, `COMPARE`, `INCIDENT`, `STATUS`
+- `<FIELD>` is one of: `MAX_WINDOW_SLOTS`, `MAX_EVENT_COUNT`, `TIMEOUT_MS`, `MAX_PAYLOAD_BYTES`
+
+Example:
+
+```bash
+MCP_REPLAY_CAPS_BACKFILL_MAX_WINDOW_SLOTS=500000
+MCP_REPLAY_CAPS_COMPARE_TIMEOUT_MS=60000
+```
 
 See also:
 

--- a/mcp/src/tools/replay-actor.ts
+++ b/mcp/src/tools/replay-actor.ts
@@ -1,0 +1,60 @@
+import type { ReplayPolicy } from './replay.js';
+import type { ReplayToolRequestExtra } from './replay-internal-types.js';
+import { getToolRiskProfile } from './replay-risk.js';
+
+export interface ResolvedActor {
+  id: string;
+  source: 'auth_client_id' | 'session_id' | 'anonymous';
+  authenticated: boolean;
+}
+
+export function resolveActor(extra: ReplayToolRequestExtra): ResolvedActor {
+  const authInfo = extra?.authInfo;
+
+  if (authInfo?.clientId) {
+    return {
+      id: authInfo.clientId,
+      source: 'auth_client_id',
+      authenticated: true,
+    };
+  }
+
+  if (extra?.sessionId) {
+    return {
+      id: `session:${extra.sessionId}`,
+      source: 'session_id',
+      authenticated: false,
+    };
+  }
+
+  return {
+    id: 'anonymous',
+    source: 'anonymous',
+    authenticated: false,
+  };
+}
+
+export function checkActorPermission(
+  actor: ResolvedActor,
+  policy: ReplayPolicy,
+  toolName: string,
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  if (policy.denylist.size > 0 && policy.denylist.has(actor.id)) {
+    return `actor ${actor.id} is denylisted for replay tools`;
+  }
+
+  if (policy.allowlist.size > 0 && !policy.allowlist.has(actor.id)) {
+    return `actor ${actor.id} is not allowlisted for replay tools`;
+  }
+
+  const profile = getToolRiskProfile(toolName);
+  if (profile.riskLevel === 'high' && !actor.authenticated) {
+    const requireAuth = env.MCP_REPLAY_REQUIRE_AUTH_FOR_HIGH_RISK === 'true';
+    if (requireAuth) {
+      return `tool ${toolName} requires authenticated actor (risk level: high)`;
+    }
+  }
+
+  return null;
+}

--- a/mcp/src/tools/replay-audit.ts
+++ b/mcp/src/tools/replay-audit.ts
@@ -1,0 +1,21 @@
+import type { ResolvedActor } from './replay-actor.js';
+import type { RiskLevel, ToolRiskCaps } from './replay-risk.js';
+
+export interface ReplayAuditEntry {
+  timestamp: string;
+  tool: string;
+  actor: ResolvedActor;
+  requestId: string;
+  status: 'start' | 'success' | 'failure' | 'denied';
+  durationMs: number;
+  reason?: string;
+  violationCode?: string;
+  riskLevel: RiskLevel;
+  mutatedState: boolean;
+  effectiveCaps: ToolRiskCaps;
+}
+
+export function emitAuditEntry(entry: ReplayAuditEntry): void {
+  const clean = JSON.parse(JSON.stringify(entry)) as ReplayAuditEntry;
+  console.info(`mcp.replay.audit ${JSON.stringify(clean)}`);
+}

--- a/mcp/src/tools/replay-internal-types.ts
+++ b/mcp/src/tools/replay-internal-types.ts
@@ -1,0 +1,4 @@
+import { type ServerNotification, type ServerRequest } from '@modelcontextprotocol/sdk/types.js';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+
+export type ReplayToolRequestExtra = RequestHandlerExtra<ServerRequest, ServerNotification> | undefined;

--- a/mcp/src/tools/replay-policy-controls.test.ts
+++ b/mcp/src/tools/replay-policy-controls.test.ts
@@ -1,0 +1,230 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { checkActorPermission, resolveActor } from './replay-actor.js';
+import { emitAuditEntry } from './replay-audit.js';
+import { getToolRiskProfile, loadToolCapsFromEnv, resolveToolCaps } from './replay-risk.js';
+import type { ReplayPolicy } from './replay.js';
+
+function buildReplayPolicy(): ReplayPolicy {
+  return {
+    maxSlotWindow: 2_000_000,
+    maxEventCount: 250_000,
+    maxConcurrentJobs: 2,
+    maxToolRuntimeMs: 180_000,
+    allowlist: new Set<string>(),
+    denylist: new Set<string>(),
+    defaultRedactions: ['signature'],
+    auditEnabled: false,
+  };
+}
+
+test('actor resolution: clientId present', () => {
+  const actor = resolveActor({
+    authInfo: { clientId: 'actor-001' },
+  } as any);
+  assert.deepEqual(actor, {
+    id: 'actor-001',
+    source: 'auth_client_id',
+    authenticated: true,
+  });
+});
+
+test('actor resolution: sessionId only', () => {
+  const actor = resolveActor({
+    sessionId: 'session-001',
+  } as any);
+  assert.deepEqual(actor, {
+    id: 'session:session-001',
+    source: 'session_id',
+    authenticated: false,
+  });
+});
+
+test('actor resolution: anonymous', () => {
+  const actor = resolveActor(undefined);
+  assert.deepEqual(actor, {
+    id: 'anonymous',
+    source: 'anonymous',
+    authenticated: false,
+  });
+});
+
+test('permission: denylisted actor', () => {
+  const policy = buildReplayPolicy();
+  policy.denylist.add('denylisted');
+  const error = checkActorPermission(
+    { id: 'denylisted', source: 'auth_client_id', authenticated: true },
+    policy,
+    'agenc_replay_compare',
+  );
+  assert.equal(error?.includes('denylisted'), true);
+});
+
+test('permission: not in allowlist', () => {
+  const policy = buildReplayPolicy();
+  policy.allowlist.add('allowlisted');
+  const error = checkActorPermission(
+    { id: 'anonymous', source: 'anonymous', authenticated: false },
+    policy,
+    'agenc_replay_compare',
+  );
+  assert.equal(error?.includes('not allowlisted'), true);
+});
+
+test('permission: high-risk tool unauthenticated', () => {
+  const policy = buildReplayPolicy();
+  const error = checkActorPermission(
+    { id: 'anonymous', source: 'anonymous', authenticated: false },
+    policy,
+    'agenc_replay_backfill',
+    { MCP_REPLAY_REQUIRE_AUTH_FOR_HIGH_RISK: 'true' },
+  );
+  assert.equal(error?.includes('requires authenticated actor'), true);
+});
+
+test('permission: allowed actor', () => {
+  const policy = buildReplayPolicy();
+  policy.allowlist.add('actor-123');
+  const error = checkActorPermission(
+    { id: 'actor-123', source: 'auth_client_id', authenticated: true },
+    policy,
+    'agenc_replay_backfill',
+  );
+  assert.equal(error, null);
+});
+
+test('risk profile: known tool', () => {
+  const profile = getToolRiskProfile('agenc_replay_backfill');
+  assert.equal(profile.riskLevel, 'high');
+  assert.equal(profile.mutatesState, true);
+  assert.equal(profile.toolName, 'agenc_replay_backfill');
+  assert.equal(profile.defaultCaps.maxPayloadBytes > 0, true);
+});
+
+test('risk profile: unknown tool', () => {
+  const profile = getToolRiskProfile('unknown_tool');
+  assert.equal(profile.riskLevel, 'high');
+  assert.equal(profile.toolName, 'unknown_tool');
+  assert.equal(profile.defaultCaps.maxWindowSlots, 500_000);
+});
+
+test('cap resolution: global only', () => {
+  const policy: ReplayPolicy = {
+    ...buildReplayPolicy(),
+    maxSlotWindow: 12_345,
+    maxEventCount: 234,
+    maxToolRuntimeMs: 56_789,
+  };
+  const caps = resolveToolCaps('agenc_replay_compare', { globalPolicy: policy });
+  assert.equal(caps.maxWindowSlots, 12_345);
+  assert.equal(caps.maxEventCount, 234);
+  assert.equal(caps.timeoutMs, 56_789);
+  assert.equal(caps.maxPayloadBytes, getToolRiskProfile('agenc_replay_compare').defaultCaps.maxPayloadBytes);
+});
+
+test('cap resolution: tool override', () => {
+  const policy = buildReplayPolicy();
+  const caps = resolveToolCaps('agenc_replay_compare', {
+    globalPolicy: policy,
+    toolOverrides: {
+      agenc_replay_compare: {
+        maxEventCount: 123,
+        maxPayloadBytes: 456,
+      },
+    },
+  });
+  assert.equal(caps.maxEventCount, 123);
+  assert.equal(caps.maxPayloadBytes, 456);
+});
+
+test('cap resolution: env var override', () => {
+  const overrides = loadToolCapsFromEnv({
+    MCP_REPLAY_CAPS_COMPARE_MAX_WINDOW_SLOTS: '500000',
+    MCP_REPLAY_CAPS_COMPARE_MAX_EVENT_COUNT: '250',
+    MCP_REPLAY_CAPS_COMPARE_TIMEOUT_MS: '1000',
+    MCP_REPLAY_CAPS_COMPARE_MAX_PAYLOAD_BYTES: '2048',
+  });
+
+  assert.deepEqual(overrides.agenc_replay_compare, {
+    maxWindowSlots: 500000,
+    maxEventCount: 250,
+    timeoutMs: 1000,
+    maxPayloadBytes: 2048,
+  });
+});
+
+test('audit entry: success', () => {
+  const calls: string[] = [];
+  const original = console.info;
+  console.info = (...args: unknown[]) => {
+    calls.push(String(args[0]));
+  };
+
+  try {
+    emitAuditEntry({
+      timestamp: new Date(0).toISOString(),
+      tool: 'agenc_replay_status',
+      actor: { id: 'actor', source: 'auth_client_id', authenticated: true },
+      requestId: 'req-1',
+      status: 'success',
+      durationMs: 10,
+      riskLevel: 'low',
+      mutatedState: false,
+      effectiveCaps: {
+        maxWindowSlots: 0,
+        maxEventCount: 1,
+        timeoutMs: 1,
+        maxPayloadBytes: 1,
+      },
+    });
+  } finally {
+    console.info = original;
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].startsWith('mcp.replay.audit '), true);
+
+  const json = calls[0].slice('mcp.replay.audit '.length);
+  const parsed = JSON.parse(json) as Record<string, unknown>;
+  assert.equal(parsed.status, 'success');
+  assert.equal(parsed.tool, 'agenc_replay_status');
+  assert.equal(typeof parsed.timestamp, 'string');
+  assert.equal(typeof parsed.durationMs, 'number');
+});
+
+test('audit entry: denied', () => {
+  const calls: string[] = [];
+  const original = console.info;
+  console.info = (...args: unknown[]) => {
+    calls.push(String(args[0]));
+  };
+
+  try {
+    emitAuditEntry({
+      timestamp: new Date(0).toISOString(),
+      tool: 'agenc_replay_backfill',
+      actor: { id: 'anonymous', source: 'anonymous', authenticated: false },
+      requestId: 'req-2',
+      status: 'denied',
+      durationMs: 1,
+      reason: 'denied',
+      violationCode: 'replay.access_denied',
+      riskLevel: 'high',
+      mutatedState: true,
+      effectiveCaps: {
+        maxWindowSlots: 1,
+        maxEventCount: 1,
+        timeoutMs: 1,
+        maxPayloadBytes: 1,
+      },
+    });
+  } finally {
+    console.info = original;
+  }
+
+  const json = calls[0].slice('mcp.replay.audit '.length);
+  const parsed = JSON.parse(json) as Record<string, unknown>;
+  assert.equal(parsed.status, 'denied');
+  assert.equal(parsed.violationCode, 'replay.access_denied');
+  assert.equal(parsed.reason, 'denied');
+});

--- a/mcp/src/tools/replay-risk.ts
+++ b/mcp/src/tools/replay-risk.ts
@@ -1,0 +1,142 @@
+import type { ReplayPolicy } from './replay.js';
+
+export type RiskLevel = 'low' | 'medium' | 'high';
+
+export interface ToolRiskCaps {
+  maxWindowSlots: number;
+  maxEventCount: number;
+  timeoutMs: number;
+  maxPayloadBytes: number;
+}
+
+export interface ToolRiskProfile {
+  toolName: string;
+  riskLevel: RiskLevel;
+  rationale: string;
+  mutatesState: boolean;
+  readsSensitiveData: boolean;
+  defaultCaps: ToolRiskCaps;
+}
+
+const DEFAULT_TOOL_CAPS: ToolRiskCaps = {
+  maxWindowSlots: 2_000_000,
+  maxEventCount: 250_000,
+  timeoutMs: 180_000,
+  maxPayloadBytes: 120_000,
+};
+
+export const REPLAY_TOOL_RISK_PROFILES: Record<string, ToolRiskProfile> = {
+  agenc_replay_backfill: {
+    toolName: 'agenc_replay_backfill',
+    riskLevel: 'high',
+    rationale: 'Fetches on-chain transactions and writes to replay store. High RPC cost and store mutation.',
+    mutatesState: true,
+    readsSensitiveData: false,
+    defaultCaps: DEFAULT_TOOL_CAPS,
+  },
+  agenc_replay_compare: {
+    toolName: 'agenc_replay_compare',
+    riskLevel: 'medium',
+    rationale: 'Reads from store and local filesystem. Comparison logic is CPU-bound.',
+    mutatesState: false,
+    readsSensitiveData: true,
+    defaultCaps: DEFAULT_TOOL_CAPS,
+  },
+  agenc_replay_incident: {
+    toolName: 'agenc_replay_incident',
+    riskLevel: 'medium',
+    rationale: 'Reads from store and replays events. May expose sensitive event payloads.',
+    mutatesState: false,
+    readsSensitiveData: true,
+    defaultCaps: DEFAULT_TOOL_CAPS,
+  },
+  agenc_replay_status: {
+    toolName: 'agenc_replay_status',
+    riskLevel: 'low',
+    rationale: 'Read-only aggregate query. Minimal resource usage.',
+    mutatesState: false,
+    readsSensitiveData: false,
+    defaultCaps: {
+      maxWindowSlots: 0,
+      maxEventCount: 250_000,
+      timeoutMs: 30_000,
+      maxPayloadBytes: 50_000,
+    },
+  },
+};
+
+export function getToolRiskProfile(toolName: string): ToolRiskProfile {
+  return REPLAY_TOOL_RISK_PROFILES[toolName] ?? {
+    toolName,
+    riskLevel: 'high',
+    rationale: 'Unknown tool — defaulting to high risk',
+    mutatesState: true,
+    readsSensitiveData: true,
+    defaultCaps: {
+      maxWindowSlots: 500_000,
+      maxEventCount: 50_000,
+      timeoutMs: 60_000,
+      maxPayloadBytes: 50_000,
+    },
+  };
+}
+
+export interface ReplayRiskConfig {
+  globalPolicy: ReplayPolicy;
+  toolOverrides?: Record<string, Partial<ToolRiskCaps>>;
+}
+
+export function resolveToolCaps(toolName: string, config: ReplayRiskConfig): ToolRiskCaps {
+  const profile = getToolRiskProfile(toolName);
+  const override = config.toolOverrides?.[toolName] ?? {};
+
+  return {
+    maxWindowSlots: override.maxWindowSlots
+      ?? (config.globalPolicy.maxSlotWindow > 0 ? config.globalPolicy.maxSlotWindow : profile.defaultCaps.maxWindowSlots),
+    maxEventCount: override.maxEventCount
+      ?? (config.globalPolicy.maxEventCount > 0 ? config.globalPolicy.maxEventCount : profile.defaultCaps.maxEventCount),
+    timeoutMs: override.timeoutMs
+      ?? (config.globalPolicy.maxToolRuntimeMs > 0 ? config.globalPolicy.maxToolRuntimeMs : profile.defaultCaps.timeoutMs),
+    maxPayloadBytes: override.maxPayloadBytes ?? profile.defaultCaps.maxPayloadBytes,
+  };
+}
+
+function parsePositiveInt(value: string | undefined): number | null {
+  if (value === undefined) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+export function loadToolCapsFromEnv(
+  env: Record<string, string | undefined> = process.env,
+): Record<string, Partial<ToolRiskCaps>> {
+  const overrides: Record<string, Partial<ToolRiskCaps>> = {};
+  const tools = ['backfill', 'compare', 'incident', 'status'];
+  const fields: Array<[string, keyof ToolRiskCaps]> = [
+    ['MAX_WINDOW_SLOTS', 'maxWindowSlots'],
+    ['MAX_EVENT_COUNT', 'maxEventCount'],
+    ['TIMEOUT_MS', 'timeoutMs'],
+    ['MAX_PAYLOAD_BYTES', 'maxPayloadBytes'],
+  ];
+
+  for (const tool of tools) {
+    const toolName = `agenc_replay_${tool}`;
+    const prefix = `MCP_REPLAY_CAPS_${tool.toUpperCase()}_`;
+    for (const [envSuffix, field] of fields) {
+      const parsed = parsePositiveInt(env[`${prefix}${envSuffix}`]);
+      if (parsed !== null) {
+        if (!overrides[toolName]) {
+          overrides[toolName] = {};
+        }
+        overrides[toolName][field] = parsed;
+      }
+    }
+  }
+
+  return overrides;
+}


### PR DESCRIPTION
## Summary
- Added per-tool replay risk profiles and effective cap resolution (global policy + per-tool + env overrides)
- Added structured actor resolution with optional auth requirement for high-risk tools
- Added structured replay audit entries and policy control tests

## Test plan
- [x] `cd mcp && npm test`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:fast`
- [x] `npm run typecheck`

Closes #979