### PR TITLE
feat(mcp): add replay schema hash and changelog

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -256,14 +256,16 @@ See also:
 - `agenc_replay_incident` returns `replay.incident.output.v1`.
 - `agenc_replay_status` returns `replay.status.output.v1`.
 - Failure payloads across replay tools use `status: "error"` with `schema: "replay.*.output.v1"` and the specific error `code`.
+- Replay tool payloads may include `schema_hash` for schema drift detection.
 
 ### `replay.*.output.v1` formal shapes
 
+- All `replay.*.output.v1` payloads include optional `schema_hash`.
 - `replay.backfill.output.v1` includes: `status`, `command`, `schema`, `mode`, `to_slot`, `store_type`, optional `page_size`, `result`, `sections`, `redactions`, `command_params`, `truncated`, and optional `truncation_reason`.
 - `replay.compare.output.v1` includes: `status`, `command`, `schema`, `strictness`, `local_trace_path`, `result`, optional `task_pda`, optional `dispute_pda`, `sections`, `redactions`, `command_params`, `truncated`, and optional `truncation_reason`.
 - `replay.incident.output.v1` includes: `status`, `command`, `schema`, `command_params`, `sections`, `redactions`, nullable `summary`, nullable `validation`, nullable `narrative`, `truncated`, and optional `truncation_reason`.
 - `replay.status.output.v1` includes: `status`, `command`, `schema`, `store_type`, `event_count`, `unique_task_count`, `unique_dispute_count`, nullable `active_cursor`, `sections`, and `redactions`.
-- `replay tool errors` include: `status: "error"`, `command`, `schema`, `code`, `message`, optional `details`, and `retriable`.
+- `replay tool errors` include: `status: "error"`, `command`, `schema`, optional `schema_hash`, `code`, `message`, optional `details`, and `retriable`.
 
 ## Architecture
 

--- a/mcp/src/tools/replay-changelog-lint.test.ts
+++ b/mcp/src/tools/replay-changelog-lint.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  REPLAY_SCHEMA_CHANGELOG,
+  getSchemaChanges,
+  hasBreakingChanges,
+} from './replay-changelog.js';
+import {
+  REPLAY_BACKFILL_OUTPUT_SCHEMA,
+  REPLAY_COMPARE_OUTPUT_SCHEMA,
+  REPLAY_INCIDENT_OUTPUT_SCHEMA,
+  REPLAY_STATUS_OUTPUT_SCHEMA,
+} from './replay-types.js';
+
+const VALID_SCHEMAS = [
+  REPLAY_BACKFILL_OUTPUT_SCHEMA,
+  REPLAY_COMPARE_OUTPUT_SCHEMA,
+  REPLAY_INCIDENT_OUTPUT_SCHEMA,
+  REPLAY_STATUS_OUTPUT_SCHEMA,
+];
+
+test('schema changelog lint: valid schema names', () => {
+  for (const entry of REPLAY_SCHEMA_CHANGELOG) {
+    assert.ok(
+      VALID_SCHEMAS.includes(entry.schema),
+      `Invalid schema name: ${entry.schema}`,
+    );
+  }
+});
+
+test('schema changelog lint: valid dates', () => {
+  for (const entry of REPLAY_SCHEMA_CHANGELOG) {
+    assert.ok(
+      /^\d{4}-\d{2}-\d{2}$/.test(entry.date),
+      `Invalid date format: ${entry.date}`,
+    );
+  }
+});
+
+test('schema changelog lint: valid change types', () => {
+  for (const entry of REPLAY_SCHEMA_CHANGELOG) {
+    assert.ok(
+      ['breaking', 'additive', 'deprecation'].includes(entry.changeType),
+      `Invalid changeType: ${entry.changeType}`,
+    );
+  }
+});
+
+test('schema changelog lint: breaking changes require migration', () => {
+  for (const entry of REPLAY_SCHEMA_CHANGELOG) {
+    if (entry.changeType === 'breaking') {
+      assert.ok(
+        entry.migration !== undefined && entry.migration.length > 0,
+        `Breaking change in ${entry.schema} at ${entry.version} missing migration instructions`,
+      );
+    }
+  }
+});
+
+test('schema changelog lint: entries are chronological per schema', () => {
+  for (const schema of VALID_SCHEMAS) {
+    const entries = REPLAY_SCHEMA_CHANGELOG.filter((entry) => entry.schema === schema);
+    for (let i = 1; i < entries.length; i += 1) {
+      assert.ok(
+        entries[i].date >= entries[i - 1].date,
+        `Changelog entries for ${schema} are not in chronological order`,
+      );
+    }
+  }
+});
+
+test('getSchemaChanges: filter by schema', () => {
+  const entries = getSchemaChanges(REPLAY_BACKFILL_OUTPUT_SCHEMA);
+  assert.ok(entries.length > 0);
+  for (const entry of entries) {
+    assert.equal(entry.schema, REPLAY_BACKFILL_OUTPUT_SCHEMA);
+  }
+});
+
+test('hasBreakingChanges: no breaking', () => {
+  assert.equal(hasBreakingChanges(REPLAY_BACKFILL_OUTPUT_SCHEMA, '0.1.0', '0.1.1'), false);
+});
+

--- a/mcp/src/tools/replay-changelog.ts
+++ b/mcp/src/tools/replay-changelog.ts
@@ -1,0 +1,122 @@
+export interface SchemaChangeEntry {
+  schema: string;
+  version: string;
+  date: string;
+  changeType: 'breaking' | 'additive' | 'deprecation';
+  description: string;
+  affectedFields: string[];
+  migration?: string;
+}
+
+export const REPLAY_SCHEMA_CHANGELOG: SchemaChangeEntry[] = [
+  {
+    schema: 'replay.backfill.output.v1',
+    version: '0.1.0',
+    date: '2026-02-01',
+    changeType: 'additive',
+    description: 'Initial schema release',
+    affectedFields: ['*'],
+  },
+  {
+    schema: 'replay.compare.output.v1',
+    version: '0.1.0',
+    date: '2026-02-01',
+    changeType: 'additive',
+    description: 'Initial schema release',
+    affectedFields: ['*'],
+  },
+  {
+    schema: 'replay.incident.output.v1',
+    version: '0.1.0',
+    date: '2026-02-01',
+    changeType: 'additive',
+    description: 'Initial schema release',
+    affectedFields: ['*'],
+  },
+  {
+    schema: 'replay.status.output.v1',
+    version: '0.1.0',
+    date: '2026-02-01',
+    changeType: 'additive',
+    description: 'Initial schema release',
+    affectedFields: ['*'],
+  },
+  {
+    schema: 'replay.backfill.output.v1',
+    version: '0.1.1',
+    date: '2026-02-14',
+    changeType: 'additive',
+    description: 'Added schema_hash field for drift detection',
+    affectedFields: ['schema_hash'],
+  },
+  {
+    schema: 'replay.compare.output.v1',
+    version: '0.1.1',
+    date: '2026-02-14',
+    changeType: 'additive',
+    description: 'Added schema_hash field for drift detection',
+    affectedFields: ['schema_hash'],
+  },
+  {
+    schema: 'replay.incident.output.v1',
+    version: '0.1.1',
+    date: '2026-02-14',
+    changeType: 'additive',
+    description: 'Added schema_hash field for drift detection',
+    affectedFields: ['schema_hash'],
+  },
+  {
+    schema: 'replay.status.output.v1',
+    version: '0.1.1',
+    date: '2026-02-14',
+    changeType: 'additive',
+    description: 'Added schema_hash field for drift detection',
+    affectedFields: ['schema_hash'],
+  },
+];
+
+function parseSemver(version: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    return null;
+  }
+  return [Number(match[1]), Number(match[2]), Number(match[3])];
+}
+
+function compareVersions(left: string, right: string): number {
+  const leftParsed = parseSemver(left);
+  const rightParsed = parseSemver(right);
+
+  if (!leftParsed || !rightParsed) {
+    return left.localeCompare(right);
+  }
+
+  for (let i = 0; i < leftParsed.length; i += 1) {
+    const delta = leftParsed[i] - rightParsed[i];
+    if (delta !== 0) {
+      return delta;
+    }
+  }
+
+  return 0;
+}
+
+export function getSchemaChanges(schema: string, fromVersion?: string, toVersion?: string): SchemaChangeEntry[] {
+  return REPLAY_SCHEMA_CHANGELOG.filter((entry) => {
+    if (entry.schema !== schema) {
+      return false;
+    }
+    if (fromVersion && compareVersions(entry.version, fromVersion) < 0) {
+      return false;
+    }
+    if (toVersion && compareVersions(entry.version, toVersion) > 0) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function hasBreakingChanges(schema: string, fromVersion: string, toVersion: string): boolean {
+  return getSchemaChanges(schema, fromVersion, toVersion).some((entry) => entry.changeType === 'breaking');
+}
+

--- a/mcp/src/tools/replay-schema-stability.test.ts
+++ b/mcp/src/tools/replay-schema-stability.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { z } from 'zod';
+import { computeSchemaHash } from '../utils/schema-hash.js';
+import {
+  ReplayBackfillOutputSchema,
+  ReplayCompareOutputSchema,
+  ReplayIncidentOutputSchema,
+  ReplayStatusOutputSchema,
+  REPLAY_BACKFILL_OUTPUT_SCHEMA,
+  REPLAY_COMPARE_OUTPUT_SCHEMA,
+  REPLAY_INCIDENT_OUTPUT_SCHEMA,
+  REPLAY_STATUS_OUTPUT_SCHEMA,
+  REPLAY_SCHEMA_HASHES,
+} from './replay-types.js';
+
+const PINNED_HASHES = {
+  [REPLAY_BACKFILL_OUTPUT_SCHEMA]: 'a98f92cd016e3338',
+  [REPLAY_COMPARE_OUTPUT_SCHEMA]: '6827a16d81fa9dbb',
+  [REPLAY_INCIDENT_OUTPUT_SCHEMA]: 'c237bc370cdd5241',
+  [REPLAY_STATUS_OUTPUT_SCHEMA]: '7fbe5363088b59e7',
+} as const;
+
+test('schema hash: deterministic', () => {
+  const hash1 = computeSchemaHash(ReplayBackfillOutputSchema);
+  const hash2 = computeSchemaHash(ReplayBackfillOutputSchema);
+  assert.equal(hash1, hash2);
+});
+
+test('schema hash: different schemas', () => {
+  const backfillHash = computeSchemaHash(ReplayBackfillOutputSchema);
+  const statusHash = computeSchemaHash(ReplayStatusOutputSchema);
+  assert.notEqual(backfillHash, statusHash);
+});
+
+test('schema hash: pinned backfill', () => {
+  const hash = computeSchemaHash(ReplayBackfillOutputSchema);
+  assert.equal(
+    hash,
+    PINNED_HASHES[REPLAY_BACKFILL_OUTPUT_SCHEMA],
+    'Backfill schema changed. Update PINNED_HASHES and add a changelog entry.',
+  );
+});
+
+test('schema hash: pinned compare', () => {
+  const hash = computeSchemaHash(ReplayCompareOutputSchema);
+  assert.equal(
+    hash,
+    PINNED_HASHES[REPLAY_COMPARE_OUTPUT_SCHEMA],
+    'Compare schema changed. Update PINNED_HASHES and add a changelog entry.',
+  );
+});
+
+test('schema hash: pinned incident', () => {
+  const hash = computeSchemaHash(ReplayIncidentOutputSchema);
+  assert.equal(
+    hash,
+    PINNED_HASHES[REPLAY_INCIDENT_OUTPUT_SCHEMA],
+    'Incident schema changed. Update PINNED_HASHES and add a changelog entry.',
+  );
+});
+
+test('schema hash: pinned status', () => {
+  const hash = computeSchemaHash(ReplayStatusOutputSchema);
+  assert.equal(
+    hash,
+    PINNED_HASHES[REPLAY_STATUS_OUTPUT_SCHEMA],
+    'Status schema changed. Update PINNED_HASHES and add a changelog entry.',
+  );
+});
+
+test('schema hash: field addition detected', () => {
+  const base = z.object({ a: z.string() });
+  const extended = base.extend({ b: z.number() });
+  assert.notEqual(computeSchemaHash(base), computeSchemaHash(extended));
+});
+
+test('schema hash: field removal detected', () => {
+  const base = z.object({ a: z.string(), b: z.number() });
+  const removed = base.omit({ b: true });
+  assert.notEqual(computeSchemaHash(base), computeSchemaHash(removed));
+});
+
+test('schema hash: module hashes match pinned values', () => {
+  assert.deepEqual(REPLAY_SCHEMA_HASHES, PINNED_HASHES);
+});
+

--- a/mcp/src/tools/replay-types.ts
+++ b/mcp/src/tools/replay-types.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { computeSchemaHash } from '../utils/schema-hash.js';
 
 /**
  * Alert schema version referenced by replay tools.
@@ -130,6 +131,7 @@ export const ReplayBackfillOutputSchema = z.object({
   status: z.literal('ok'),
   command: z.literal('agenc_replay_backfill'),
   schema: z.literal(REPLAY_BACKFILL_OUTPUT_SCHEMA),
+  schema_hash: z.string().optional(),
   mode: z.literal('backfill'),
   to_slot: z.number().int().positive(),
   store_type: z.enum(['memory', 'sqlite']),
@@ -146,6 +148,7 @@ export const ReplayCompareOutputSchema = z.object({
   status: z.literal('ok'),
   command: z.literal('agenc_replay_compare'),
   schema: z.literal(REPLAY_COMPARE_OUTPUT_SCHEMA),
+  schema_hash: z.string().optional(),
   strictness: z.enum(['strict', 'lenient']),
   local_trace_path: z.string(),
   result: ReplayCompareResultSchema,
@@ -162,6 +165,7 @@ export const ReplayIncidentOutputSchema = z.object({
   status: z.literal('ok'),
   command: z.literal('agenc_replay_incident'),
   schema: z.literal(REPLAY_INCIDENT_OUTPUT_SCHEMA),
+  schema_hash: z.string().optional(),
   command_params: z.record(z.unknown()),
   sections: z.array(z.string()),
   redactions: z.array(z.string()),
@@ -176,6 +180,7 @@ export const ReplayStatusOutputSchema = z.object({
   status: z.literal('ok'),
   command: z.literal('agenc_replay_status'),
   schema: z.literal(REPLAY_STATUS_OUTPUT_SCHEMA),
+  schema_hash: z.string().optional(),
   store_type: z.enum(['memory', 'sqlite']),
   event_count: z.number().nonnegative(),
   unique_task_count: z.number().nonnegative(),
@@ -189,8 +194,18 @@ export const ReplayToolErrorSchema = z.object({
   status: z.literal('error'),
   command: z.string(),
   schema: z.string(),
+  schema_hash: z.string().optional(),
   code: z.string(),
   message: z.string(),
   details: z.record(z.unknown()).optional(),
   retriable: z.boolean(),
 });
+
+export const REPLAY_SCHEMA_HASHES = {
+  [REPLAY_BACKFILL_OUTPUT_SCHEMA]: computeSchemaHash(ReplayBackfillOutputSchema),
+  [REPLAY_COMPARE_OUTPUT_SCHEMA]: computeSchemaHash(ReplayCompareOutputSchema),
+  [REPLAY_INCIDENT_OUTPUT_SCHEMA]: computeSchemaHash(ReplayIncidentOutputSchema),
+  [REPLAY_STATUS_OUTPUT_SCHEMA]: computeSchemaHash(ReplayStatusOutputSchema),
+} as const;
+
+export const REPLAY_TOOL_ERROR_SCHEMA_HASH = computeSchemaHash(ReplayToolErrorSchema);

--- a/mcp/src/tools/replay.ts
+++ b/mcp/src/tools/replay.ts
@@ -40,6 +40,8 @@ import {
   ReplayIncidentValidationSchema,
   ReplayIncidentSummarySchema,
   ReplayIncidentNarrativeSchema,
+  REPLAY_SCHEMA_HASHES,
+  REPLAY_TOOL_ERROR_SCHEMA_HASH,
   REPLAY_BACKFILL_OUTPUT_SCHEMA,
   REPLAY_COMPARE_OUTPUT_SCHEMA,
   REPLAY_INCIDENT_OUTPUT_SCHEMA,
@@ -397,6 +399,7 @@ function createToolError(
     status: 'error',
     command,
     schema,
+    schema_hash: REPLAY_TOOL_ERROR_SCHEMA_HASH,
     code,
     message,
     details,
@@ -425,10 +428,16 @@ function createToolOutput<T extends z.ZodTypeAny>(
     );
   }
 
+  const data = parsed.data as Record<string, unknown>;
+  const schemaName = typeof data.schema === 'string' ? data.schema : null;
+  if (schemaName && schemaName in REPLAY_SCHEMA_HASHES) {
+    data.schema_hash = REPLAY_SCHEMA_HASHES[schemaName as keyof typeof REPLAY_SCHEMA_HASHES];
+  }
+
   return {
     isError: false,
-    content: [{ type: 'text', text: safeStringify(parsed.data) }],
-    structuredContent: parsed.data as JsonObject,
+    content: [{ type: 'text', text: safeStringify(data) }],
+    structuredContent: data as JsonObject,
   };
 }
 

--- a/mcp/src/utils/schema-hash.ts
+++ b/mcp/src/utils/schema-hash.ts
@@ -1,0 +1,126 @@
+import { createHash } from 'node:crypto';
+import type { ZodTypeAny } from 'zod';
+
+type JsonLike =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonLike[]
+  | { readonly [key: string]: JsonLike };
+
+function normalizeLiteral(value: unknown): JsonLike {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (typeof value === 'bigint') {
+    return `${value}n`;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeLiteral(entry));
+  }
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const out: Record<string, JsonLike> = {};
+    for (const key of Object.keys(record).sort()) {
+      out[key] = normalizeLiteral(record[key]);
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(normalizeLiteral(value));
+}
+
+function stripCheckMessages(checks: unknown): unknown {
+  if (!Array.isArray(checks)) {
+    return [];
+  }
+  return checks.map((check) => {
+    if (check === null || typeof check !== 'object' || Array.isArray(check)) {
+      return check;
+    }
+    const record = check as Record<string, unknown>;
+    // Message changes are not meaningful schema shape changes.
+    const { message: _message, ...rest } = record;
+    return rest;
+  });
+}
+
+function extractSchemaDescription(schema: ZodTypeAny): unknown {
+  const def = (schema as unknown as { _def?: Record<string, unknown> })._def ?? {};
+  const typeName = def.typeName;
+
+  switch (typeName) {
+    case 'ZodObject': {
+      const shapeFn = def.shape as (() => Record<string, ZodTypeAny>) | undefined;
+      const shape = shapeFn ? shapeFn() : {};
+      const fields: Record<string, unknown> = {};
+      for (const key of Object.keys(shape).sort()) {
+        fields[key] = extractSchemaDescription(shape[key]);
+      }
+      return {
+        type: 'object',
+        fields,
+        unknownKeys: def.unknownKeys,
+        catchall: def.catchall ? extractSchemaDescription(def.catchall as ZodTypeAny) : undefined,
+      };
+    }
+    case 'ZodArray':
+      return { type: 'array', element: extractSchemaDescription(def.type as ZodTypeAny) };
+    case 'ZodString':
+      return { type: 'string', checks: stripCheckMessages(def.checks) };
+    case 'ZodNumber':
+      return { type: 'number', checks: stripCheckMessages(def.checks), coerce: def.coerce };
+    case 'ZodBoolean':
+      return { type: 'boolean' };
+    case 'ZodLiteral':
+      return { type: 'literal', value: normalizeLiteral(def.value) };
+    case 'ZodEnum':
+      return { type: 'enum', values: normalizeLiteral(def.values) };
+    case 'ZodNativeEnum':
+      return { type: 'nativeEnum', values: normalizeLiteral(def.values) };
+    case 'ZodOptional':
+      return { type: 'optional', inner: extractSchemaDescription(def.innerType as ZodTypeAny) };
+    case 'ZodNullable':
+      return { type: 'nullable', inner: extractSchemaDescription(def.innerType as ZodTypeAny) };
+    case 'ZodDefault':
+      return { type: 'default', inner: extractSchemaDescription(def.innerType as ZodTypeAny) };
+    case 'ZodRecord':
+      return {
+        type: 'record',
+        key: def.keyType ? extractSchemaDescription(def.keyType as ZodTypeAny) : undefined,
+        value: extractSchemaDescription(def.valueType as ZodTypeAny),
+      };
+    case 'ZodUnion':
+      return { type: 'union', options: (def.options as ZodTypeAny[]).map((entry) => extractSchemaDescription(entry)) };
+    case 'ZodUnknown':
+      return { type: 'unknown' };
+    case 'ZodAny':
+      return { type: 'any' };
+    case 'ZodNull':
+      return { type: 'null' };
+    case 'ZodNever':
+      return { type: 'never' };
+    case 'ZodEffects':
+      return { type: 'effects', inner: extractSchemaDescription(def.schema as ZodTypeAny) };
+    default:
+      return { type: typeof typeName === 'string' ? typeName : 'unknown' };
+  }
+}
+
+/**
+ * Compute a deterministic hash of a Zod schema's shape.
+ *
+ * The hash captures the schema's structural definition so that any
+ * change to the schema (added/removed fields, type changes, constraint changes)
+ * produces a different hash.
+ */
+export function computeSchemaHash(schema: ZodTypeAny): string {
+  const description = extractSchemaDescription(schema);
+  const serialized = stableJsonStringify(description);
+  return createHash('sha256').update(serialized).digest('hex').slice(0, 16);
+}
+


### PR DESCRIPTION
## Summary
- Added deterministic schema hashing for replay tool response schemas
- Injected optional `schema_hash` into replay tool outputs for drift detection
- Added schema changelog utilities and lint + pinned-hash tests

## Test plan
- [x] `cd mcp && npm test`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:fast`
- [x] `npm run typecheck`

Closes #980