### PR TITLE
feat(mcp): add operator investigation prompts

### DIFF
--- a/mcp/src/prompts/dispute-drift.ts
+++ b/mcp/src/prompts/dispute-drift.ts
@@ -1,0 +1,63 @@
+export interface DisputeDriftPromptInput {
+  dispute_pda: string;
+  trace_id?: string;
+}
+
+export interface DisputeDriftPromptOutput {
+  [key: string]: unknown;
+  messages: Array<{
+    role: 'user' | 'assistant';
+    content: { type: 'text'; text: string };
+  }>;
+}
+
+export function buildDisputeDriftPrompt(input: DisputeDriftPromptInput): DisputeDriftPromptOutput {
+  const traceRef = input.trace_id ? `\nTrace ID for correlation: ${input.trace_id}` : '';
+
+  return {
+    messages: [{
+      role: 'user',
+      content: {
+        type: 'text',
+        text: `Triage dispute drift for dispute at PDA ${input.dispute_pda}.${traceRef}
+
+## Investigation Steps
+
+### Step 1: Fetch Dispute State
+Use \`agenc_get_dispute\` with dispute_pda="${input.dispute_pda}" to get the current dispute state.
+- Record: status (Active/Resolved/Expired), votes_for, votes_against, voting_deadline, resolution_type
+
+### Step 2: Check Voting Deadline
+- If status is Active and current time > voting_deadline, this is a drift condition.
+  -> The dispute should have been expired or resolved.
+  -> Suggest: Use \`agenc_replay_incident\` with dispute_pda="${input.dispute_pda}" to check for missed events.
+
+### Step 3: Verify Vote Counts
+- Use \`agenc_list_disputes\` to cross-reference total vote count vs expected arbiter count.
+- If votes_for + votes_against < expected quorum, arbiter participation is low.
+  -> Check each arbiter's agent status with \`agenc_get_agent\`.
+
+### Step 4: Check Resolution Consistency
+- If status is Resolved, verify:
+  - outcome matches vote majority
+  - slash has been applied (if applicable): check agent stake changes
+  - task status matches resolution type (Refund -> Cancelled, Complete -> Completed)
+
+### Step 5: Replay Correlation
+- Use \`agenc_replay_incident\` with dispute_pda="${input.dispute_pda}" to get the full event timeline.
+- Look for:
+  - Missing DisputeVoteCast events
+  - DisputeResolved without sufficient votes
+  - Duplicate vote events (DuplicateArbiter error)
+
+### Step 6: Summarize Findings
+Provide:
+1. Current dispute state vs expected state
+2. Specific drift conditions found
+3. Root cause hypothesis
+4. Recommended remediation (expire_dispute, resolve_dispute, or escalate)
+${input.trace_id ? `\nInclude trace_id "${input.trace_id}" in any follow-up tool calls for correlation.` : ''}`,
+      },
+    }],
+  };
+}

--- a/mcp/src/prompts/payout-mismatch.ts
+++ b/mcp/src/prompts/payout-mismatch.ts
@@ -1,0 +1,68 @@
+import type { DisputeDriftPromptOutput } from './dispute-drift.js';
+
+export interface PayoutMismatchPromptInput {
+  task_pda: string;
+  expected_payout_lamports?: string;
+  trace_id?: string;
+}
+
+export function buildPayoutMismatchPrompt(input: PayoutMismatchPromptInput): DisputeDriftPromptOutput {
+  const expectedRef = input.expected_payout_lamports
+    ? `\nExpected payout: ${input.expected_payout_lamports} lamports`
+    : '';
+  const traceRef = input.trace_id ? `\nTrace ID for correlation: ${input.trace_id}` : '';
+
+  return {
+    messages: [{
+      role: 'user',
+      content: {
+        type: 'text',
+        text: `Investigate payout mismatch for task at PDA ${input.task_pda}.${expectedRef}${traceRef}
+
+## Investigation Steps
+
+### Step 1: Fetch Task State
+Use \`agenc_get_task\` with task_pda="${input.task_pda}" to get:
+- reward_amount, reward_mint (SOL vs SPL token), status, completions, protocol_fee_bps
+- creator, current_workers, task_type
+
+### Step 2: Check Escrow Balance
+Use \`agenc_get_escrow\` with task_pda="${input.task_pda}" to get the actual escrow balance.
+- For SOL tasks: compare escrow lamport balance vs reward_amount
+- For SPL token tasks: compare token account balance vs reward_amount
+
+### Step 3: Verify Protocol Fee
+Use \`agenc_get_protocol_config\` to get:
+- protocol_fee_bps (current)
+- Compare with task's locked protocol_fee_bps (locked at creation time)
+- Calculate expected fee: reward_amount * protocol_fee_bps / 10000
+- Check fee tier discount based on creator's completed task count
+
+### Step 4: Calculate Expected Payout
+- worker_payout = reward_amount - protocol_fee
+- For collaborative tasks: worker_payout / max_workers per worker
+- For competitive tasks: full worker_payout to first completer
+
+### Step 5: Check Actual Distribution
+Use \`agenc_replay_incident\` with task_pda="${input.task_pda}" to find:
+- RewardDistributed events: verify recipient, amount, protocol_fee fields
+- TaskCompleted events: verify reward_paid field
+- Look for multiple RewardDistributed for same task (double-pay bug)
+
+### Step 6: Token-Specific Checks (if SPL token task)
+- Verify token escrow ATA was closed after final completion
+- Verify worker token account received the correct amount
+- Verify treasury token account received the fee
+
+### Step 7: Summarize Findings
+Provide:
+1. Expected vs actual payout breakdown (reward, fee, net worker amount)
+2. Whether discrepancy is in fee calculation, distribution, or escrow balance
+3. Root cause hypothesis
+4. If overpaid/underpaid: exact lamport/token difference
+${input.trace_id ? `\nInclude trace_id "${input.trace_id}" in any follow-up tool calls.` : ''}`,
+      },
+    }],
+  };
+}
+

--- a/mcp/src/prompts/prompts.test.ts
+++ b/mcp/src/prompts/prompts.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildDisputeDriftPrompt } from './dispute-drift.js';
+import { buildPayoutMismatchPrompt } from './payout-mismatch.js';
+import { buildReplayAnomalyPrompt } from './replay-anomaly.js';
+import { registerPrompts } from './register.js';
+
+test('dispute-drift-triage: produces valid prompt with dispute_pda only', () => {
+  const result = buildDisputeDriftPrompt({
+    dispute_pda: '7VHUFJHWu2CuExkJcJrzhQPJ2oygupbLbCPTtfzTYMdW',
+  });
+  assert.equal(result.messages.length, 1);
+  assert.equal(result.messages[0].role, 'user');
+  assert.ok(result.messages[0].content.text.includes('7VHUFJHWu2CuExkJcJrzhQPJ2oygupbLbCPTtfzTYMdW'));
+  assert.ok(result.messages[0].content.text.includes('agenc_get_dispute'));
+  assert.ok(result.messages[0].content.text.includes('agenc_replay_incident'));
+});
+
+test('dispute-drift-triage: includes trace_id when provided', () => {
+  const result = buildDisputeDriftPrompt({
+    dispute_pda: '7VHUFJHWu2CuExkJcJrzhQPJ2oygupbLbCPTtfzTYMdW',
+    trace_id: 'trace-abc-123',
+  });
+  assert.ok(result.messages[0].content.text.includes('trace-abc-123'));
+});
+
+test('dispute-drift-triage: references all expected tool names', () => {
+  const result = buildDisputeDriftPrompt({
+    dispute_pda: '7VHUFJHWu2CuExkJcJrzhQPJ2oygupbLbCPTtfzTYMdW',
+  });
+  const text = result.messages[0].content.text;
+  assert.ok(text.includes('agenc_get_dispute'));
+  assert.ok(text.includes('agenc_list_disputes'));
+  assert.ok(text.includes('agenc_get_agent'));
+  assert.ok(text.includes('agenc_replay_incident'));
+});
+
+test('payout-mismatch: produces valid prompt with task_pda only', () => {
+  const result = buildPayoutMismatchPrompt({
+    task_pda: '4xKnMZrFqGZPMACbhfcUhbQk3TL8RE2TcDN8QLKM7u3N',
+  });
+  assert.equal(result.messages.length, 1);
+  assert.ok(result.messages[0].content.text.includes('4xKnMZrFqGZPMACbhfcUhbQk3TL8RE2TcDN8QLKM7u3N'));
+  assert.ok(result.messages[0].content.text.includes('agenc_get_task'));
+  assert.ok(result.messages[0].content.text.includes('agenc_get_escrow'));
+  assert.ok(result.messages[0].content.text.includes('agenc_get_protocol_config'));
+});
+
+test('payout-mismatch: includes expected payout when provided', () => {
+  const result = buildPayoutMismatchPrompt({
+    task_pda: '4xKnMZrFqGZPMACbhfcUhbQk3TL8RE2TcDN8QLKM7u3N',
+    expected_payout_lamports: '1000000000',
+  });
+  assert.ok(result.messages[0].content.text.includes('1000000000'));
+});
+
+test('payout-mismatch: references token-specific checks', () => {
+  const result = buildPayoutMismatchPrompt({
+    task_pda: '4xKnMZrFqGZPMACbhfcUhbQk3TL8RE2TcDN8QLKM7u3N',
+  });
+  const text = result.messages[0].content.text;
+  assert.ok(text.includes('SPL token'));
+  assert.ok(text.includes('token escrow ATA'));
+});
+
+test('replay-anomaly-root-cause: produces valid prompt with anomaly_id only', () => {
+  const result = buildReplayAnomalyPrompt({
+    anomaly_id: 'a1b2c3d4e5f6g7h8',
+  });
+  assert.equal(result.messages.length, 1);
+  assert.ok(result.messages[0].content.text.includes('a1b2c3d4e5f6g7h8'));
+});
+
+test('replay-anomaly-root-cause: includes all optional context when provided', () => {
+  const result = buildReplayAnomalyPrompt({
+    anomaly_id: 'a1b2c3d4e5f6g7h8',
+    task_pda: '4xKnMZrFqGZPMACbhfcUhbQk3TL8RE2TcDN8QLKM7u3N',
+    dispute_pda: '7VHUFJHWu2CuExkJcJrzhQPJ2oygupbLbCPTtfzTYMdW',
+    anomaly_code: 'replay.missing_event',
+    anomaly_message: 'Expected TaskCompleted event not found',
+    trace_id: 'trace-xyz-789',
+  });
+  const text = result.messages[0].content.text;
+  assert.ok(text.includes('4xKnMZrFqGZPMACbhfcUhbQk3TL8RE2TcDN8QLKM7u3N'));
+  assert.ok(text.includes('7VHUFJHWu2CuExkJcJrzhQPJ2oygupbLbCPTtfzTYMdW'));
+  assert.ok(text.includes('replay.missing_event'));
+  assert.ok(text.includes('Expected TaskCompleted event not found'));
+  assert.ok(text.includes('trace-xyz-789'));
+});
+
+test('replay-anomaly-root-cause: classifies five anomaly categories', () => {
+  const result = buildReplayAnomalyPrompt({ anomaly_id: 'test' });
+  const text = result.messages[0].content.text;
+  assert.ok(text.includes('Missing event'));
+  assert.ok(text.includes('Field mismatch'));
+  assert.ok(text.includes('Ordering violation'));
+  assert.ok(text.includes('Duplicate event'));
+  assert.ok(text.includes('Phantom event'));
+});
+
+test('replay-anomaly-root-cause: suggests replay tools for investigation', () => {
+  const result = buildReplayAnomalyPrompt({
+    anomaly_id: 'test',
+    task_pda: '4xKnMZrFqGZPMACbhfcUhbQk3TL8RE2TcDN8QLKM7u3N',
+  });
+  const text = result.messages[0].content.text;
+  assert.ok(text.includes('agenc_replay_incident'));
+  assert.ok(text.includes('agenc_get_task'));
+});
+
+test('server registration: all prompts', () => {
+  const prompts: string[] = [];
+  const server = {
+    prompt(name: string) {
+      prompts.push(name);
+    },
+  } as any;
+
+  registerPrompts(server);
+  assert.equal(prompts.length, 6);
+  assert.ok(prompts.includes('debug-task'));
+  assert.ok(prompts.includes('inspect-agent'));
+  assert.ok(prompts.includes('escrow-audit'));
+  assert.ok(prompts.includes('dispute-drift-triage'));
+  assert.ok(prompts.includes('payout-mismatch'));
+  assert.ok(prompts.includes('replay-anomaly-root-cause'));
+});
+

--- a/mcp/src/prompts/register.ts
+++ b/mcp/src/prompts/register.ts
@@ -1,0 +1,107 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { buildDisputeDriftPrompt } from './dispute-drift.js';
+import { buildPayoutMismatchPrompt } from './payout-mismatch.js';
+import { buildReplayAnomalyPrompt } from './replay-anomaly.js';
+
+export function registerPrompts(server: McpServer): void {
+  server.prompt(
+    'debug-task',
+    'Guided task debugging workflow',
+    { task_pda: z.string().describe('Task PDA to debug') },
+    ({ task_pda }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: 'Debug the AgenC task at PDA ' + task_pda + '. Steps:\n'
+            + '1. Use agenc_get_task to fetch the task state\n'
+            + '2. Check the task status and identify any issues\n'
+            + '3. Use agenc_get_escrow to verify escrow balance\n'
+            + '4. If disputed, use agenc_get_dispute to check dispute state\n'
+            + '5. Summarize findings and suggest next steps',
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'inspect-agent',
+    'Agent state inspection with decoded fields',
+    { agent_id: z.string().describe('Agent ID (hex) or PDA (base58)') },
+    ({ agent_id }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: 'Inspect the AgenC agent with ID/PDA ' + agent_id + '. Steps:\n'
+            + '1. Use agenc_get_agent to fetch full agent state\n'
+            + '2. Use agenc_decode_capabilities to explain the capability bitmask\n'
+            + '3. Check rate limit state and active tasks\n'
+            + '4. Summarize the agent health and any concerns',
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'escrow-audit',
+    'Escrow balance verification checklist',
+    { task_pda: z.string().describe('Task PDA to audit') },
+    ({ task_pda }) => ({
+      messages: [{
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: 'Audit the escrow for AgenC task at PDA ' + task_pda + '. Steps:\n'
+            + '1. Use agenc_get_task to fetch the task reward amount and status\n'
+            + '2. Use agenc_get_escrow to check actual escrow balance\n'
+            + '3. Compare expected vs actual balance\n'
+            + '4. Check if completions match distributed amounts\n'
+            + '5. Use agenc_get_protocol_config to verify fee calculations\n'
+            + '6. Report any discrepancies',
+        },
+      }],
+    }),
+  );
+
+  server.prompt(
+    'dispute-drift-triage',
+    'Guided dispute drift investigation workflow',
+    {
+      dispute_pda: z.string().describe('Dispute PDA to investigate'),
+      trace_id: z.string().optional().describe('Trace ID for correlation'),
+    },
+    ({ dispute_pda, trace_id }) => buildDisputeDriftPrompt({ dispute_pda, trace_id }),
+  );
+
+  server.prompt(
+    'payout-mismatch',
+    'Guided payout discrepancy investigation',
+    {
+      task_pda: z.string().describe('Task PDA with payout issue'),
+      expected_payout_lamports: z.string().optional().describe('Expected payout in lamports'),
+      trace_id: z.string().optional().describe('Trace ID for correlation'),
+    },
+    ({ task_pda, expected_payout_lamports, trace_id }) => buildPayoutMismatchPrompt({
+      task_pda,
+      expected_payout_lamports,
+      trace_id,
+    }),
+  );
+
+  server.prompt(
+    'replay-anomaly-root-cause',
+    'Guided replay anomaly investigation',
+    {
+      anomaly_id: z.string().describe('Anomaly ID from replay tool output'),
+      task_pda: z.string().optional().describe('Related task PDA'),
+      dispute_pda: z.string().optional().describe('Related dispute PDA'),
+      anomaly_code: z.string().optional().describe('Anomaly code (e.g., replay.missing_event)'),
+      anomaly_message: z.string().optional().describe('Original anomaly message'),
+      trace_id: z.string().optional().describe('Trace ID for correlation'),
+    },
+    (params) => buildReplayAnomalyPrompt(params),
+  );
+}
+

--- a/mcp/src/prompts/replay-anomaly.ts
+++ b/mcp/src/prompts/replay-anomaly.ts
@@ -1,0 +1,82 @@
+import type { DisputeDriftPromptOutput } from './dispute-drift.js';
+
+export interface ReplayAnomalyPromptInput {
+  anomaly_id: string;
+  task_pda?: string;
+  dispute_pda?: string;
+  anomaly_code?: string;
+  anomaly_message?: string;
+  trace_id?: string;
+}
+
+export function buildReplayAnomalyPrompt(input: ReplayAnomalyPromptInput): DisputeDriftPromptOutput {
+  const contextLines: string[] = [];
+  if (input.task_pda) contextLines.push(`Task PDA: ${input.task_pda}`);
+  if (input.dispute_pda) contextLines.push(`Dispute PDA: ${input.dispute_pda}`);
+  if (input.anomaly_code) contextLines.push(`Anomaly code: ${input.anomaly_code}`);
+  if (input.anomaly_message) contextLines.push(`Anomaly message: ${input.anomaly_message}`);
+  if (input.trace_id) contextLines.push(`Trace ID: ${input.trace_id}`);
+  const context = contextLines.length > 0 ? `\n${contextLines.join('\n')}` : '';
+
+  return {
+    messages: [{
+      role: 'user',
+      content: {
+        type: 'text',
+        text: `Investigate replay anomaly ${input.anomaly_id}.${context}
+
+## Investigation Steps
+
+### Step 1: Identify Anomaly Context
+The anomaly ID "${input.anomaly_id}" was reported by the replay comparison or incident tool.
+${input.anomaly_code ? `Anomaly type: ${input.anomaly_code}` : 'Determine the anomaly type from the original tool output.'}
+
+### Step 2: Fetch Related State
+${input.task_pda
+    ? `- Use \`agenc_get_task\` with task_pda="${input.task_pda}" to get current task state.`
+    : '- If a task PDA is available, fetch it with `agenc_get_task`.'}
+${input.dispute_pda
+    ? `- Use \`agenc_get_dispute\` with dispute_pda="${input.dispute_pda}" to get dispute state.`
+    : '- If a dispute PDA is available, fetch it with `agenc_get_dispute`.'}
+
+### Step 3: Replay Timeline Reconstruction
+${input.task_pda ? `Use \`agenc_replay_incident\` with task_pda="${input.task_pda}" to get the full event timeline.` : ''}
+${input.dispute_pda ? `Use \`agenc_replay_incident\` with dispute_pda="${input.dispute_pda}" to get the dispute timeline.` : ''}
+${!input.task_pda && !input.dispute_pda ? 'Use `agenc_replay_status` to check store health, then query with relevant filters.' : ''}
+
+Look for:
+- Events before and after the anomaly sequence number
+- Missing events that should be present based on state transitions
+- Events with unexpected field values compared to on-chain state
+
+### Step 4: Cross-Reference On-Chain State
+For each event in the anomaly window:
+- Verify the on-chain account state matches what the event claims
+- Check if a transaction was reverted or replaced
+- Look for race conditions (multiple transactions in same slot)
+
+### Step 5: Classify Root Cause
+Determine which category the anomaly falls into:
+1. **Missing event**: An expected state transition event is absent
+   -> Check if the transaction was dropped or if the event parser missed it
+2. **Field mismatch**: Event data doesn't match on-chain state
+   -> Check if there was a concurrent modification
+3. **Ordering violation**: Events appear out of expected sequence
+   -> Check for slot-level reordering or clock drift
+4. **Duplicate event**: Same event appears multiple times
+   -> Check for transaction replay or parser bug
+5. **Phantom event**: Event exists in replay but not on-chain
+   -> Check if account was closed/reallocated
+
+### Step 6: Summarize Findings
+Provide:
+1. Anomaly classification (from Step 5)
+2. Specific evidence from on-chain state and replay timeline
+3. Whether this is a replay infrastructure issue or a protocol issue
+4. Recommended action (re-backfill, manual correction, bug report)
+${input.trace_id ? `\nInclude trace_id "${input.trace_id}" in any follow-up tool calls for correlation.` : ''}`,
+      },
+    }],
+  };
+}
+

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,5 +1,4 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
 import { registerAgentTools } from './tools/agents.js';
 import { registerTaskTools } from './tools/tasks.js';
 import { registerProtocolTools } from './tools/protocol.js';
@@ -9,6 +8,7 @@ import { registerTestingTools } from './tools/testing.js';
 import { registerCircuitTools } from './tools/circuits.js';
 import { registerInspectorTools } from './tools/inspector.js';
 import { registerReplayTools } from './tools/replay.js';
+import { registerPrompts } from './prompts/register.js';
 
 export function createServer(): McpServer {
   const server = new McpServer({
@@ -81,68 +81,6 @@ function registerResources(server: McpServer): void {
       contents: [{
         uri: uri.href,
         text: TASK_STATES_REFERENCE,
-      }],
-    }),
-  );
-}
-
-function registerPrompts(server: McpServer): void {
-  server.prompt(
-    'debug-task',
-    'Guided task debugging workflow',
-    { task_pda: z.string().describe('Task PDA to debug') },
-    ({ task_pda }) => ({
-      messages: [{
-        role: 'user' as const,
-        content: {
-          type: 'text' as const,
-          text: 'Debug the AgenC task at PDA ' + task_pda + '. Steps:\n'
-            + '1. Use agenc_get_task to fetch the task state\n'
-            + '2. Check the task status and identify any issues\n'
-            + '3. Use agenc_get_escrow to verify escrow balance\n'
-            + '4. If disputed, use agenc_get_dispute to check dispute state\n'
-            + '5. Summarize findings and suggest next steps',
-        },
-      }],
-    }),
-  );
-
-  server.prompt(
-    'inspect-agent',
-    'Agent state inspection with decoded fields',
-    { agent_id: z.string().describe('Agent ID (hex) or PDA (base58)') },
-    ({ agent_id }) => ({
-      messages: [{
-        role: 'user' as const,
-        content: {
-          type: 'text' as const,
-          text: 'Inspect the AgenC agent with ID/PDA ' + agent_id + '. Steps:\n'
-            + '1. Use agenc_get_agent to fetch full agent state\n'
-            + '2. Use agenc_decode_capabilities to explain the capability bitmask\n'
-            + '3. Check rate limit state and active tasks\n'
-            + '4. Summarize the agent health and any concerns',
-        },
-      }],
-    }),
-  );
-
-  server.prompt(
-    'escrow-audit',
-    'Escrow balance verification checklist',
-    { task_pda: z.string().describe('Task PDA to audit') },
-    ({ task_pda }) => ({
-      messages: [{
-        role: 'user' as const,
-        content: {
-          type: 'text' as const,
-          text: 'Audit the escrow for AgenC task at PDA ' + task_pda + '. Steps:\n'
-            + '1. Use agenc_get_task to fetch the task reward amount and status\n'
-            + '2. Use agenc_get_escrow to check actual escrow balance\n'
-            + '3. Compare expected vs actual balance\n'
-            + '4. Check if completions match distributed amounts\n'
-            + '5. Use agenc_get_protocol_config to verify fee calculations\n'
-            + '6. Report any discrepancies',
-        },
       }],
     }),
   );


### PR DESCRIPTION
## Summary
- Added dispute drift triage, payout mismatch, and replay anomaly root-cause operator prompts
- Registered all prompts via a dedicated prompts module and kept existing prompts intact
- Added smoke tests validating prompt content, tool references, and trace_id propagation

## Test plan
- [x] `cd mcp && npm test`
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:fast`
- [x] `npm run typecheck`

Closes #981