### PR TITLE
docs(ops): sync deployment and incident runbooks

### DIFF
--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -22,3 +22,110 @@ Run: `cargo test --package agenc-coordination verify_key_validity`
 ### References
 - circuits-circom/task_completion/CEREMONY.md
 - https://docs.circom.io/getting-started/proving-circuits/
+
+---
+
+## Pre-Deploy Gates (mandatory)
+
+### Readiness check
+
+**Prerequisites**
+- [ ] `./scripts/check-deployment-readiness.sh` exists and is executable
+
+**Steps**
+1. Run:
+   ```bash
+   ./scripts/check-deployment-readiness.sh --network mainnet
+   ```
+
+**Expected Output**
+```
+All checks PASS
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| script exits non-zero | missing env/toolchain/config | follow the script output and rerun |
+
+### Test + mutation gates
+
+**Prerequisites**
+- [ ] Node toolchain installed
+- [ ] Dependencies installed
+
+**Steps**
+1. LiteSVM fast integration suite:
+   ```bash
+   npm run test:fast
+   ```
+2. Runtime unit tests:
+   ```bash
+   cd runtime && npm run test
+   ```
+3. Runtime mutation gates:
+   ```bash
+   cd runtime && npm run mutation:ci && npm run mutation:gates
+   ```
+
+**Expected Output**
+```
+# all commands exit 0
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `npm run test:fast` fails | protocol regression | fix before deploy |
+| mutation gate fails | behavior drift or insufficient coverage | inspect mutation artifact and remediate |
+
+---
+
+## Verifying key validation (mandatory)
+
+**Prerequisites**
+- [ ] `./scripts/validate-verifying-key.sh` exists and is executable
+
+**Steps**
+1. Run:
+   ```bash
+   ./scripts/validate-verifying-key.sh
+   ```
+
+**Expected Output**
+```
+# script exits 0 and prints PASS for production-safety checks
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| gamma/delta equality check fails | dev VK in repo | complete MPC ceremony and regenerate verifying_key.rs |
+
+---
+
+## Build artifact verification (verifiable build)
+
+**Prerequisites**
+- [ ] Anchor toolchain installed (Anchor 0.32.1, Solana 3.0.13)
+- [ ] solana-verify installed
+
+**Steps**
+1. Build verifiable program:
+   ```bash
+   anchor build --verifiable
+   ```
+2. Record executable hash:
+   ```bash
+   solana-verify get-executable-hash target/deploy/agenc_coordination.so
+   ```
+
+**Expected Output**
+```
+# solana-verify prints a hash (record it in the deployment log)
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| build differs across machines | toolchain mismatch | align Anchor/Solana versions and rebuild |

--- a/docs/EMERGENCY_RESPONSE_MATRIX.md
+++ b/docs/EMERGENCY_RESPONSE_MATRIX.md
@@ -1,0 +1,51 @@
+# Emergency Response Matrix
+
+This matrix maps replay and protocol anomaly signals to immediate operator actions.
+It is intended for on-call response during deployments, upgrades, and incident triage.
+
+Coverage requirements:
+- All `ReplayAnomalyCode` values emitted as `replay.compare.<code>` alerts
+- All `ReplayAlertKind` values emitted by `runtime/src/replay/alerting.ts`
+
+Sources of truth:
+- `runtime/src/eval/replay-comparison.ts` (alert `code` + `kind` mapping)
+- `runtime/src/replay/bridge.ts` (ingestion lag alert)
+
+---
+
+## Matrix
+
+| Code | Kind | Severity | Symptom | Action | Escalation | Automated check | SLA |
+|---|---|---|---|---|---|---|---|
+| `replay.compare.hash_mismatch` | `replay_hash_mismatch` | critical | Replay deterministic hash mismatch between local and projected | Halt new task assignments for affected scope. Re-run compare on narrowed window. Preserve evidence payloads. | Security lead + on-call engineer | `agenc-runtime replay compare ...` on narrowed window | 15 minutes |
+| `replay.compare.transition_invalid` | `transition_validation` | high | Invalid state transition detected in replay | Isolate affected task/dispute PDA. Re-backfill slot range and re-run incident reconstruction. | On-call engineer | `agenc-runtime replay incident ...` for the window | 30 minutes |
+| `replay.compare.missing_event` | `replay_anomaly_repeat` | high | Expected event is missing in projected timeline | Re-backfill with smaller page size. Check RPC health and projector logs. | On-call engineer | `agenc-runtime replay backfill ...` and verify processed > 0 | 30 minutes |
+| `replay.compare.unexpected_event` | `replay_anomaly_repeat` | high | Extra event present that should not exist | Verify slot/signature for duplicate ingestion. Inspect event parser inputs for replay. | On-call engineer | `agenc-runtime replay incident ...` and inspect anomalies | 30 minutes |
+| `replay.compare.type_mismatch` | `replay_anomaly_repeat` | high | Event type differs between local and projected trace | Check concurrent transactions in same slot; validate ordering assumptions. | On-call engineer | `agenc-runtime replay compare ...` strictness=lenient then strict | 30 minutes |
+| `replay.compare.task_id_mismatch` | `replay_anomaly_repeat` | high | Task/dispute association mismatched for an event | Freeze affected agent if suspicious. Verify on-chain state for referenced PDAs. | Security lead | `agenc_get_task` / `agenc_get_dispute` for referenced PDAs | 30 minutes |
+| `replay.compare.duplicate_sequence` | `replay_anomaly_repeat` | medium | Duplicate sequence numbers detected | Inspect store for duplicate keys. Re-run backfill from cursor. | On-call engineer | Re-run backfill with cursor reset in a fresh store | 1 hour |
+| `replay.ingestion.lag` | `replay_ingestion_lag` | medium | Event slot regression detected for a source event stream | Check RPC health and source clock. Switch to alternate RPC endpoint. | On-call engineer | Readiness: switch RPC + re-run backfill | 1 hour |
+| `vk.gamma_eq_delta` | n/a | critical | Verifying key gamma equals delta (dev key in production) | Halt all private task completions. Trigger MPC ceremony process. | All multisig signers | `./scripts/validate-verifying-key.sh` | Immediate |
+| `nullifier.already_spent` | n/a | critical | Proof replay detected | Freeze affected agent. Investigate double-spend and affected tasks. | Security lead | Query nullifier store / audit logs | Immediate |
+| `escrow.balance.sudden_drop` | n/a | critical | Escrow balance dropped > 90% in a single block | Pause protocol if possible. Audit recent completions and distributions. | All multisig signers | `agenc_get_escrow` diffs for affected tasks | 15 minutes |
+| `rate_limit.exceeded` | n/a | low | Agent hit rate limit | No action required; informational unless repeated. | None | None | N/A |
+
+---
+
+## Coverage checklist
+
+Replay compare anomaly codes (emitted as `replay.compare.<code>`):
+- [x] `hash_mismatch`
+- [x] `missing_event`
+- [x] `unexpected_event`
+- [x] `type_mismatch`
+- [x] `task_id_mismatch`
+- [x] `duplicate_sequence`
+- [x] `transition_invalid`
+
+Replay alert kinds:
+- [x] `transition_validation`
+- [x] `replay_hash_mismatch`
+- [x] `replay_anomaly_repeat`
+- [x] `replay_ingestion_lag`
+

--- a/docs/INCIDENT_REPLAY_RUNBOOK.md
+++ b/docs/INCIDENT_REPLAY_RUNBOOK.md
@@ -1,0 +1,187 @@
+# Incident Replay Runbook (CLI + MCP)
+
+This runbook provides a deterministic, command-by-command workflow for replay-based incident reconstruction.
+It covers both the CLI (`agenc-runtime replay ...`) and MCP tool paths (`agenc_replay_*`).
+
+---
+
+## CLI path
+
+### Backfill replay events for the incident window
+
+**Prerequisites**
+- [ ] `agenc-runtime` is installed and on `$PATH`
+- [ ] RPC URL for the target cluster
+- [ ] Write access to the replay store path (recommended: `.agenc/replay-events.sqlite`)
+
+**Steps**
+1. Backfill events into a local sqlite store:
+   ```bash
+   agenc-runtime replay backfill \
+     --to-slot <TO_SLOT> \
+     --page-size 100 \
+     --rpc <RPC_URL> \
+     --store-type sqlite \
+     --sqlite-path .agenc/replay-events.sqlite
+   ```
+
+**Expected Output**
+```
+status: ok
+schema: replay.backfill.output.v1
+result.processed: <number>
+result.duplicates: <number>
+result.cursor: <object|null>
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| output is `status: error` with `code: replay.timeout` | RPC slow or window too large | retry with smaller slot window or faster RPC |
+| cursor stalls (same cursor on repeated runs) | RPC instability or nondeterministic fetch ordering | rerun with the same inputs; if still stalled, switch RPC and retry |
+| store write fails | filesystem permissions | fix permissions and rerun |
+
+### Compare replay projection vs local trajectory trace
+
+**Prerequisites**
+- [ ] Local trace JSON available (e.g. `./trace.json`)
+- [ ] Backfill store exists at `.agenc/replay-events.sqlite`
+
+**Steps**
+1. Compare:
+   ```bash
+   agenc-runtime replay compare \
+     --local-trace-path ./trace.json \
+     --task-pda <TASK_PDA> \
+     --store-type sqlite \
+     --sqlite-path .agenc/replay-events.sqlite
+   ```
+
+**Expected Output**
+```
+status: ok
+schema: replay.compare.output.v1
+result.status: clean|mismatched
+result.anomalyIds: <string[]>
+result.topAnomalies: <object[]>
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `replay.slot_window_exceeded` | window violates policy caps | reduce `from_slot`/`to_slot` window |
+| `result.status: mismatched` | drift or missing/extra events | proceed to incident reconstruction and inspect anomaly IDs |
+
+### Build incident timeline reconstruction
+
+**Prerequisites**
+- [ ] Backfill store exists at `.agenc/replay-events.sqlite`
+
+**Steps**
+1. Reconstruct:
+   ```bash
+   agenc-runtime replay incident \
+     --task-pda <TASK_PDA> \
+     --from-slot <FROM_SLOT> \
+     --to-slot <TO_SLOT> \
+     --store-type sqlite \
+     --sqlite-path .agenc/replay-events.sqlite
+   ```
+
+**Expected Output**
+```
+status: ok
+schema: replay.incident.output.v1
+summary: <object|null>
+validation: <object|null>
+narrative.lines: <string[]>
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| summary/validation are null | filters too narrow or no events in window | widen slot window and rerun |
+| narrative is empty | no meaningful reconstruction possible | inspect raw events via store query / compare anomalies |
+
+---
+
+## MCP path
+
+### Backfill (MCP tool)
+
+**Prerequisites**
+- [ ] MCP server configured and running
+- [ ] Actor is permitted by replay policy (allowlist/denylist/high-risk auth as configured)
+
+**Steps**
+1. Invoke MCP tool `agenc_replay_backfill`:
+   ```json
+   {
+     "rpc": "<RPC_URL>",
+     "to_slot": "<TO_SLOT>",
+     "page_size": 100,
+     "store_type": "sqlite",
+     "sqlite_path": ".agenc/replay-events.sqlite"
+   }
+   ```
+
+**Expected Output**
+```
+structuredContent.status: ok
+structuredContent.schema: replay.backfill.output.v1
+```
+
+**Troubleshooting**
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `replay.access_denied` | actor policy denied | check allowlist/denylist; require auth for high-risk if enabled |
+| `replay.concurrency_limit` | too many concurrent jobs | retry after previous job completes |
+
+### Compare (MCP tool)
+
+**Steps**
+1. Invoke MCP tool `agenc_replay_compare`:
+   ```json
+   {
+     "local_trace_path": "./trace.json",
+     "task_pda": "<TASK_PDA>",
+     "store_type": "sqlite",
+     "sqlite_path": ".agenc/replay-events.sqlite"
+   }
+   ```
+
+**Expected Output**
+```
+structuredContent.status: ok
+structuredContent.schema: replay.compare.output.v1
+```
+
+### Incident (MCP tool)
+
+**Steps**
+1. Invoke MCP tool `agenc_replay_incident`:
+   ```json
+   {
+     "task_pda": "<TASK_PDA>",
+     "from_slot": "<FROM_SLOT>",
+     "to_slot": "<TO_SLOT>",
+     "store_type": "sqlite",
+     "sqlite_path": ".agenc/replay-events.sqlite"
+   }
+   ```
+
+**Expected Output**
+```
+structuredContent.status: ok
+structuredContent.schema: replay.incident.output.v1
+```
+
+---
+
+## Notes
+
+- Replay tool outputs are schema-validated. See:
+  - `mcp/src/tools/replay-types.ts` for MCP response schemas
+  - `runtime/docs/replay-cli.md` for CLI usage
+- Replay outputs may include optional `schema_hash` to detect schema drift.
+

--- a/runtime/docs/observability-incident-runbook.md
+++ b/runtime/docs/observability-incident-runbook.md
@@ -3,6 +3,12 @@
 This playbook is for reconstructing and triaging replay anomalies in production.
 It maps common incidents to deterministic steps and expected payload shapes.
 
+## Quick links
+
+- `docs/INCIDENT_REPLAY_RUNBOOK.md` (CLI + MCP step-by-step)
+- `runtime/docs/replay-cli.md` (CLI reference)
+- `mcp/README.md` (MCP replay tools and policy controls)
+
 ## Prerequisites
 
 - Replay enabled with deterministic tracing policy.
@@ -58,6 +64,14 @@ Failure handling:
 
 - if cursor stalls, rerun with same inputs; stalled window should be reproducible.
 - if `runBackfill()` fails, retry after fixing source fetcher only; do not mutate the store policy.
+
+Troubleshooting quick table:
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| cursor does not advance | RPC instability or nondeterministic window | rerun with same inputs; if persistent, switch RPC and retry |
+| empty backfill results | slot window wrong or filters too narrow | widen window and rerun |
+| repeated timeouts | window too large | narrow slot range; increase runtime/tool timeout where appropriate |
 
 ## 2) Comparison workflow
 


### PR DESCRIPTION
## Summary
- Synced mainnet deployment docs with current Anchor/Solana toolchain and added mandatory pre-deploy gates
- Added incident replay runbook covering both CLI and MCP paths with expected schemas
- Added emergency response matrix covering replay alert codes and kinds

## Test plan
- [x] Verified Anchor/Solana versions match `Anchor.toml`
- [x] Verified referenced scripts exist and are executable: `scripts/check-deployment-readiness.sh`, `scripts/validate-verifying-key.sh`

Closes #982