### PR TITLE
feat(runtime): expand chaos matrix coverage

### DIFF
--- a/runtime/scripts/check-mutation-gates.ts
+++ b/runtime/scripts/check-mutation-gates.ts
@@ -64,6 +64,10 @@ function parseCliArgs(argv: string[]): CliOptions {
       options.thresholds.maxOperatorPassRateDrop = parseThreshold(argv[++i]!, arg);
       continue;
     }
+    if (arg === '--max-chaos-scenario-fail-rate' && argv[i + 1]) {
+      options.thresholds.maxChaosScenarioFailRate = parseThreshold(argv[++i]!, arg);
+      continue;
+    }
     if (arg === '--help') {
       console.log([
         'Usage: check-mutation-gates --artifact <path> [threshold overrides]',
@@ -74,6 +78,7 @@ function parseCliArgs(argv: string[]): CliOptions {
         '  --max-aggregate-cost-utility-drop <float>',
         '  --max-scenario-pass-rate-drop <float>',
         '  --max-operator-pass-rate-drop <float>',
+        '  --max-chaos-scenario-fail-rate <float>',
         '',
         'Options:',
         '  --dry-run   Always exit 0, but print failures',
@@ -103,4 +108,3 @@ main().catch((error) => {
   console.error(`Mutation gate evaluation failed: ${message}`);
   process.exit(1);
 });
-

--- a/runtime/src/eval/chaos-matrix.ts
+++ b/runtime/src/eval/chaos-matrix.ts
@@ -90,9 +90,9 @@ export const CHAOS_SCENARIOS: readonly ChaosScenario[] = [
     category: 'store',
     trigger: 'Store rejects write mid-batch (simulated I/O error)',
     expectedAnomaly: {
-      code: 'missing_event',
+      alertCode: 'replay.backfill.store_write_failed',
       severity: 'error',
-      kind: 'replay_anomaly_repeat',
+      kind: 'replay_ingestion_lag',
     },
     classification: 'deterministic',
     fixture: 'runtime/tests/fixtures/replay-chaos-store-fixture.ts',
@@ -114,7 +114,7 @@ export const CHAOS_SCENARIOS: readonly ChaosScenario[] = [
     category: 'store',
     trigger: 'Store returns zero records for valid query',
     expectedAnomaly: {
-      code: 'missing_event',
+      code: 'unexpected_event',
       severity: 'warning',
       kind: 'replay_anomaly_repeat',
     },
@@ -182,4 +182,3 @@ export const CHAOS_SCENARIOS: readonly ChaosScenario[] = [
     fixture: 'runtime/tests/fixtures/replay-chaos-partial-write-fixture.ts',
   },
 ] as const;
-

--- a/runtime/src/eval/replay-comparison.ts
+++ b/runtime/src/eval/replay-comparison.ts
@@ -549,7 +549,7 @@ export class ReplayComparisonService {
         for (const duplicate of bucket.slice(1)) {
           mergeAnomaly(anomalies, {
             code: 'duplicate_sequence',
-            severity: 'warning',
+            severity: 'error',
             message: `duplicate projected event sequence ${duplicate.seq}`,
             context: replayReplayContextFromProjected(duplicate),
           });
@@ -562,7 +562,7 @@ export class ReplayComparisonService {
         for (const duplicate of bucket.slice(1)) {
           mergeAnomaly(anomalies, {
             code: 'duplicate_sequence',
-            severity: 'warning',
+            severity: 'error',
             message: `duplicate local event sequence ${duplicate.seq}`,
             context: replayContextFromLocal(duplicate),
           });

--- a/runtime/src/eval/replay.ts
+++ b/runtime/src/eval/replay.ts
@@ -188,12 +188,27 @@ export class TrajectoryReplayEngine {
 
     const previousStatus = task.status;
 
+    if (event.type === 'dispute:initiated' && previousStatus === 'failed') {
+      const message = `invalid dispute transition ${previousStatus} -> dispute:initiated at seq=${event.seq}`;
+      if (this.strictMode) {
+        errors.push(message);
+      } else {
+        warnings.push(message);
+      }
+    }
+
     switch (event.type) {
       case 'discovered':
         task.status = 'discovered';
         break;
       case 'claimed':
         task.status = 'claimed';
+        break;
+      case 'dispute:initiated':
+      case 'dispute:vote_cast':
+      case 'dispute:resolved':
+      case 'dispute:cancelled':
+      case 'dispute:expired':
         break;
       case 'executed':
       case 'executed_speculative':

--- a/runtime/tests/fixtures/replay-chaos-comparator-fixture.ts
+++ b/runtime/tests/fixtures/replay-chaos-comparator-fixture.ts
@@ -1,0 +1,134 @@
+import { computeProjectionHash, type ReplayTimelineRecord } from '../../src/replay/types.js';
+import { makeReplayTraceFromRecords } from '../../src/eval/replay-comparison.js';
+
+function makeRecord(
+  seq: number,
+  type: string,
+  slot: number,
+  signature: string,
+): ReplayTimelineRecord {
+  const event = {
+    seq,
+    type,
+    taskPda: 'task-1',
+    timestampMs: slot * 10,
+    payload: {
+      value: seq,
+      onchain: {
+        signature,
+        slot,
+        eventType: type,
+      },
+    },
+    slot,
+    signature,
+    sourceEventName: type === 'discovered' ? 'taskCreated' : 'taskClaimed',
+    sourceEventSequence: seq - 1,
+    sourceEventType: type,
+    disputePda: undefined,
+  } as Omit<ReplayTimelineRecord, 'projectionHash'>;
+
+  return {
+    ...event,
+    projectionHash: computeProjectionHash({
+      seq: event.seq,
+      type: event.type,
+      taskPda: event.taskPda,
+      timestampMs: event.timestampMs,
+      payload: event.payload,
+      slot: event.slot,
+      signature: event.signature,
+      sourceEventName: event.sourceEventName,
+      sourceEventSequence: event.sourceEventSequence,
+    }),
+  };
+}
+
+const BASE_PROJECTED: ReplayTimelineRecord[] = [
+  makeRecord(1, 'discovered', 1, 'SIG_1'),
+  makeRecord(2, 'claimed', 2, 'SIG_2'),
+];
+
+const BASE_LOCAL = makeReplayTraceFromRecords(BASE_PROJECTED, 1337, 'chaos-comparator-local');
+
+const HASH_MISMATCH_PROJECTED = BASE_PROJECTED.map((record, index) => {
+  if (index !== 0) {
+    return record;
+  }
+  const tampered = {
+    ...record,
+    payload: {
+      ...record.payload,
+      tampered: true,
+    },
+  } as ReplayTimelineRecord;
+  return {
+    ...tampered,
+    projectionHash: computeProjectionHash({
+      seq: tampered.seq,
+      type: tampered.type,
+      taskPda: tampered.taskPda,
+      timestampMs: tampered.timestampMs,
+      payload: tampered.payload,
+      slot: tampered.slot,
+      signature: tampered.signature,
+      sourceEventName: tampered.sourceEventName,
+      sourceEventSequence: tampered.sourceEventSequence,
+    }),
+  };
+});
+
+export const REPLAY_CHAOS_COMPARATOR_FIXTURE = {
+  traceId: 'replay-chaos-comparator-v1',
+  seed: 1337,
+  base: {
+    projected: BASE_PROJECTED,
+    localTrace: BASE_LOCAL,
+  },
+  scenarios: {
+    hashMismatch: {
+      projected: HASH_MISMATCH_PROJECTED,
+      localTrace: BASE_LOCAL,
+    },
+    missingEvent: {
+      projected: BASE_PROJECTED,
+      localTrace: {
+        ...BASE_LOCAL,
+        events: BASE_LOCAL.events.filter((event) => event.seq !== 2),
+      },
+    },
+    unexpectedEvent: {
+      projected: BASE_PROJECTED,
+      localTrace: {
+        ...BASE_LOCAL,
+        events: [
+          ...BASE_LOCAL.events,
+          {
+            seq: 3,
+            type: 'completed',
+            taskPda: 'task-1',
+            timestampMs: 30,
+            payload: {
+              value: 3,
+              onchain: {
+                signature: 'SIG_3',
+                slot: 3,
+                eventType: 'completed',
+              },
+            },
+          },
+        ],
+      },
+    },
+    typeMismatch: {
+      projected: BASE_PROJECTED,
+      localTrace: {
+        ...BASE_LOCAL,
+        events: BASE_LOCAL.events.map((event) => event.seq === 2
+          ? { ...event, type: 'failed' }
+          : event),
+      },
+    },
+  },
+} as const;
+

--- a/runtime/tests/fixtures/replay-chaos-partial-write-fixture.ts
+++ b/runtime/tests/fixtures/replay-chaos-partial-write-fixture.ts
@@ -1,0 +1,57 @@
+import { PublicKey } from '@solana/web3.js';
+import type { BackfillFetcherPage, ProjectedTimelineInput, ReplayEventCursor } from '../../src/replay/types.js';
+
+function pubkey(seed: number): PublicKey {
+  const buf = new Uint8Array(32);
+  buf.fill(seed);
+  return new PublicKey(buf);
+}
+
+function bytes(seed = 0, length = 32): Uint8Array {
+  const buf = new Uint8Array(length);
+  buf.fill(seed);
+  return buf;
+}
+
+function event(slot: number, signature: string, eventName: string): ProjectedTimelineInput {
+  return {
+    slot,
+    signature,
+    eventName,
+    event: {
+      taskId: bytes(slot),
+      creator: pubkey(slot),
+      requiredCapabilities: 1n,
+      rewardAmount: 1n,
+      taskType: 0,
+      deadline: 0,
+      minReputation: 0,
+      rewardMint: null,
+      timestamp: slot * 100,
+    },
+    timestampMs: slot * 100,
+  };
+}
+
+export const REPLAY_CHAOS_PARTIAL_WRITE_FIXTURE = {
+  resumeAfterCrash: {
+    firstPage: {
+      events: [event(1, 'SIG_1', 'taskCreated'), event(2, 'SIG_2', 'taskClaimed')],
+      nextCursor: { slot: 2, signature: 'SIG_2', eventName: 'taskClaimed' } satisfies ReplayEventCursor,
+      done: false,
+    },
+    finalPage: {
+      events: [event(3, 'SIG_3', 'taskCompleted')],
+      nextCursor: null,
+      done: true,
+    },
+  } satisfies Record<string, BackfillFetcherPage>,
+  cursorStall: {
+    stalledPage: {
+      events: [],
+      nextCursor: { slot: 9, signature: 'STALL', eventName: 'taskCreated' },
+      done: false,
+    },
+  } satisfies Record<string, BackfillFetcherPage>,
+} as const;
+

--- a/runtime/tests/fixtures/replay-chaos-store-fixture.ts
+++ b/runtime/tests/fixtures/replay-chaos-store-fixture.ts
@@ -1,0 +1,96 @@
+import { PublicKey } from '@solana/web3.js';
+import { computeProjectionHash, type ReplayTimelineRecord } from '../../src/replay/types.js';
+import type { BackfillFetcherPage, ProjectedTimelineInput } from '../../src/replay/types.js';
+
+function pubkey(seed: number): PublicKey {
+  const buf = new Uint8Array(32);
+  buf.fill(seed);
+  return new PublicKey(buf);
+}
+
+function bytes(seed = 0, length = 32): Uint8Array {
+  const buf = new Uint8Array(length);
+  buf.fill(seed);
+  return buf;
+}
+
+function event(slot: number, signature: string, eventName: string): ProjectedTimelineInput {
+  return {
+    slot,
+    signature,
+    eventName,
+    event: {
+      taskId: bytes(slot),
+      creator: pubkey(slot),
+      requiredCapabilities: 1n,
+      rewardAmount: 1n,
+      taskType: 0,
+      deadline: 0,
+      minReputation: 0,
+      rewardMint: null,
+      timestamp: slot * 100,
+    },
+    timestampMs: slot * 100,
+  };
+}
+
+function makeRecord(
+  seq: number,
+  type: string,
+  slot: number,
+  signature: string,
+): ReplayTimelineRecord {
+  const record = {
+    seq,
+    type,
+    taskPda: 'task-1',
+    timestampMs: slot * 10,
+    payload: { value: seq, onchain: { signature, slot, eventType: type } },
+    slot,
+    signature,
+    sourceEventName: type === 'discovered' ? 'taskCreated' : 'taskClaimed',
+    sourceEventSequence: seq - 1,
+    sourceEventType: type,
+    disputePda: undefined,
+  } as Omit<ReplayTimelineRecord, 'projectionHash'>;
+
+  return {
+    ...record,
+    projectionHash: computeProjectionHash({
+      seq: record.seq,
+      type: record.type,
+      taskPda: record.taskPda,
+      timestampMs: record.timestampMs,
+      payload: record.payload,
+      slot: record.slot,
+      signature: record.signature,
+      sourceEventName: record.sourceEventName,
+      sourceEventSequence: record.sourceEventSequence,
+    }),
+  };
+}
+
+export const REPLAY_CHAOS_STORE_FIXTURE = {
+  records: [
+    makeRecord(1, 'discovered', 1, 'SIG_1'),
+    makeRecord(2, 'claimed', 2, 'SIG_2'),
+  ],
+  writeFailurePages: [
+    {
+      events: [event(1, 'SIG_1', 'taskCreated')],
+      nextCursor: { slot: 1, signature: 'SIG_1', eventName: 'taskCreated' },
+      done: false,
+    },
+    {
+      events: [event(2, 'SIG_2', 'taskCreated')],
+      nextCursor: { slot: 2, signature: 'SIG_2', eventName: 'taskCreated' },
+      done: false,
+    },
+    {
+      events: [event(3, 'SIG_3', 'taskCreated')],
+      nextCursor: null,
+      done: true,
+    },
+  ] satisfies BackfillFetcherPage[],
+} as const;
+

--- a/runtime/tests/fixtures/replay-chaos-transition-fixture.ts
+++ b/runtime/tests/fixtures/replay-chaos-transition-fixture.ts
@@ -1,0 +1,85 @@
+import { computeProjectionHash, type ReplayTimelineRecord } from '../../src/replay/types.js';
+import { makeReplayTraceFromRecords } from '../../src/eval/replay-comparison.js';
+
+function makeRecord(
+  seq: number,
+  type: string,
+  slot: number,
+  signature: string,
+): ReplayTimelineRecord {
+  const record = {
+    seq,
+    type,
+    taskPda: 'task-1',
+    timestampMs: slot * 10,
+    payload: { value: seq, onchain: { signature, slot, eventType: type } },
+    slot,
+    signature,
+    sourceEventName: type === 'discovered'
+      ? 'taskCreated'
+      : type === 'claimed'
+        ? 'taskClaimed'
+        : type === 'completed'
+          ? 'taskCompleted'
+          : type === 'failed'
+            ? 'taskCancelled'
+            : 'disputeInitiated',
+    sourceEventSequence: seq - 1,
+    sourceEventType: type,
+    disputePda: undefined,
+  } as Omit<ReplayTimelineRecord, 'projectionHash'>;
+
+  return {
+    ...record,
+    projectionHash: computeProjectionHash({
+      seq: record.seq,
+      type: record.type,
+      taskPda: record.taskPda,
+      timestampMs: record.timestampMs,
+      payload: record.payload,
+      slot: record.slot,
+      signature: record.signature,
+      sourceEventName: record.sourceEventName,
+      sourceEventSequence: record.sourceEventSequence,
+    }),
+  };
+}
+
+const INVALID_OPEN_TO_COMPLETED = [
+  makeRecord(1, 'discovered', 1, 'SIG_1'),
+  makeRecord(2, 'completed', 2, 'SIG_2'),
+];
+
+const DISPUTE_ON_CANCELLED = [
+  makeRecord(1, 'discovered', 1, 'SIG_1'),
+  makeRecord(2, 'failed', 2, 'SIG_2'),
+  makeRecord(3, 'dispute:initiated', 3, 'SIG_3'),
+];
+
+const DOUBLE_COMPLETION_BASE = [
+  makeRecord(1, 'discovered', 1, 'SIG_1'),
+  makeRecord(2, 'completed', 2, 'SIG_2'),
+];
+
+export const REPLAY_CHAOS_TRANSITION_FIXTURE = {
+  seed: 4242,
+  scenarios: {
+    invalidOpenToCompleted: {
+      projected: INVALID_OPEN_TO_COMPLETED,
+      localTrace: makeReplayTraceFromRecords(INVALID_OPEN_TO_COMPLETED, 4242, 'chaos-transition-open'),
+    },
+    disputeOnCancelled: {
+      projected: DISPUTE_ON_CANCELLED,
+      localTrace: makeReplayTraceFromRecords(DISPUTE_ON_CANCELLED, 4242, 'chaos-transition-dispute'),
+    },
+    doubleCompletion: {
+      projected: [
+        DOUBLE_COMPLETION_BASE[0]!,
+        DOUBLE_COMPLETION_BASE[1]!,
+        { ...DOUBLE_COMPLETION_BASE[1]!, signature: 'SIG_2_DUP' },
+      ],
+      localTrace: makeReplayTraceFromRecords(DOUBLE_COMPLETION_BASE, 4242, 'chaos-transition-dup'),
+    },
+  },
+} as const;
+

--- a/runtime/tests/helpers/failing-store.ts
+++ b/runtime/tests/helpers/failing-store.ts
@@ -1,0 +1,53 @@
+import type {
+  ReplayEventCursor,
+  ReplayStorageWriteResult,
+  ReplayTimelineQuery,
+  ReplayTimelineRecord,
+  ReplayTimelineStore,
+} from '../../src/replay/types.js';
+
+export interface FailingReplayTimelineStoreConfig {
+  failAfterSaves?: number;
+  emptyQuery?: boolean;
+  corruptQueryResults?: (
+    records: ReadonlyArray<ReplayTimelineRecord>
+  ) => ReadonlyArray<ReplayTimelineRecord>;
+}
+
+export class FailingReplayTimelineStore implements ReplayTimelineStore {
+  private saveCount = 0;
+
+  constructor(
+    private readonly inner: ReplayTimelineStore,
+    private readonly config: FailingReplayTimelineStoreConfig = {},
+  ) {}
+
+  async save(records: readonly ReplayTimelineRecord[]): Promise<ReplayStorageWriteResult> {
+    this.saveCount += 1;
+    if (this.config.failAfterSaves !== undefined && this.saveCount > this.config.failAfterSaves) {
+      throw new Error('Simulated store write failure');
+    }
+    return await this.inner.save(records);
+  }
+
+  async query(filter: ReplayTimelineQuery = {}): Promise<ReadonlyArray<ReplayTimelineRecord>> {
+    if (this.config.emptyQuery) {
+      return [];
+    }
+    const records = await this.inner.query(filter);
+    return this.config.corruptQueryResults ? this.config.corruptQueryResults(records) : records;
+  }
+
+  async getCursor(): Promise<ReplayEventCursor | null> {
+    return await this.inner.getCursor();
+  }
+
+  async saveCursor(cursor: ReplayEventCursor | null): Promise<void> {
+    await this.inner.saveCursor(cursor);
+  }
+
+  async clear(): Promise<void> {
+    await this.inner.clear();
+  }
+}
+

--- a/runtime/tests/replay-chaos-comparator.test.ts
+++ b/runtime/tests/replay-chaos-comparator.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { ReplayComparisonService } from '../src/eval/replay-comparison.js';
+import { REPLAY_CHAOS_COMPARATOR_FIXTURE } from './fixtures/replay-chaos-comparator-fixture.ts';
+
+describe('replay comparator chaos scenarios', () => {
+  it('detects hash mismatch when projected payload differs', async () => {
+    const fixture = REPLAY_CHAOS_COMPARATOR_FIXTURE.scenarios.hashMismatch;
+    const result = await new ReplayComparisonService().compare({
+      projected: fixture.projected,
+      localTrace: fixture.localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    const anomaly = result.anomalies.find((entry) => entry.code === 'hash_mismatch');
+    expect(anomaly?.severity).toBe('error');
+  });
+
+  it('detects missing event when local trace drops a projected event', async () => {
+    const fixture = REPLAY_CHAOS_COMPARATOR_FIXTURE.scenarios.missingEvent;
+    const result = await new ReplayComparisonService().compare({
+      projected: fixture.projected,
+      localTrace: fixture.localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    expect(result.anomalies.some((entry) => entry.code === 'missing_event')).toBe(true);
+  });
+
+  it('detects unexpected event when local trace includes an extra event', async () => {
+    const fixture = REPLAY_CHAOS_COMPARATOR_FIXTURE.scenarios.unexpectedEvent;
+    const result = await new ReplayComparisonService().compare({
+      projected: fixture.projected,
+      localTrace: fixture.localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    expect(result.anomalies.some((entry) => entry.code === 'unexpected_event')).toBe(true);
+  });
+
+  it('detects type mismatch when local event type changes', async () => {
+    const fixture = REPLAY_CHAOS_COMPARATOR_FIXTURE.scenarios.typeMismatch;
+    const result = await new ReplayComparisonService().compare({
+      projected: fixture.projected,
+      localTrace: fixture.localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    const anomaly = result.anomalies.find((entry) => entry.code === 'type_mismatch');
+    expect(anomaly?.severity).toBe('error');
+  });
+});
+

--- a/runtime/tests/replay-chaos-partial-write.test.ts
+++ b/runtime/tests/replay-chaos-partial-write.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { ReplayBackfillService } from '../src/replay/backfill.js';
+import { InMemoryReplayTimelineStore } from '../src/replay/in-memory-store.js';
+import type { BackfillFetcher, BackfillFetcherPage, ReplayEventCursor } from '../src/replay/types.js';
+import type { ReplayAlertContext, ReplayAlertDispatcher } from '../src/replay/alerting.js';
+import { REPLAY_CHAOS_PARTIAL_WRITE_FIXTURE } from './fixtures/replay-chaos-partial-write-fixture.ts';
+
+describe('partial write and resume chaos scenarios', () => {
+  it('resumes from persisted cursor after simulated crash', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    let callCount = 0;
+
+    const fetcher: BackfillFetcher = {
+      async fetchPage(
+        _cursor: ReplayEventCursor | null,
+        _toSlot: number,
+        _pageSize: number,
+      ): Promise<BackfillFetcherPage> {
+        callCount += 1;
+        if (callCount === 1) {
+          return REPLAY_CHAOS_PARTIAL_WRITE_FIXTURE.resumeAfterCrash.firstPage;
+        }
+        if (callCount === 2) {
+          throw new Error('simulated crash');
+        }
+        return REPLAY_CHAOS_PARTIAL_WRITE_FIXTURE.resumeAfterCrash.finalPage;
+      },
+    };
+
+    const first = new ReplayBackfillService(store, { toSlot: 100, fetcher });
+    await expect(first.runBackfill()).rejects.toThrow('simulated crash');
+
+    const afterCrash = await store.query();
+    expect(afterCrash.length).toBeGreaterThan(0);
+
+    const alerts: ReplayAlertContext[] = [];
+    const alertDispatcher: ReplayAlertDispatcher = {
+      async emit(context: ReplayAlertContext) {
+        alerts.push(context);
+        return null;
+      },
+    };
+
+    const resumed = new ReplayBackfillService(store, { toSlot: 100, fetcher, alertDispatcher });
+    const result = await resumed.runBackfill();
+    expect(result.processed).toBe(1);
+
+    const finalRecords = await store.query();
+    expect(finalRecords).toHaveLength(3);
+    expect(alerts.some((alert) => alert.code === 'replay.backfill.resume_after_crash')).toBe(true);
+  });
+
+  it('emits a stall alert when cursor does not advance', async () => {
+    const store = new InMemoryReplayTimelineStore();
+    const alerts: ReplayAlertContext[] = [];
+    const alertDispatcher: ReplayAlertDispatcher = {
+      async emit(context: ReplayAlertContext) {
+        alerts.push(context);
+        return null;
+      },
+    };
+
+    const fetcher: BackfillFetcher = {
+      async fetchPage() {
+        return REPLAY_CHAOS_PARTIAL_WRITE_FIXTURE.cursorStall.stalledPage;
+      },
+    };
+
+    const service = new ReplayBackfillService(store, {
+      toSlot: 9,
+      fetcher,
+      alertDispatcher,
+    });
+
+    await expect(service.runBackfill()).rejects.toThrow('replay backfill stalled: cursor did not advance');
+    expect(alerts.some((alert) => alert.code === 'replay.backfill.stalled')).toBe(true);
+  });
+});
+

--- a/runtime/tests/replay-chaos-store.test.ts
+++ b/runtime/tests/replay-chaos-store.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { ReplayBackfillService } from '../src/replay/backfill.js';
+import { InMemoryReplayTimelineStore } from '../src/replay/in-memory-store.js';
+import type { BackfillFetcher, BackfillFetcherPage, ReplayEventCursor } from '../src/replay/types.js';
+import type { ReplayAlertContext, ReplayAlertDispatcher } from '../src/replay/alerting.js';
+import { ReplayComparisonService, makeReplayTraceFromRecords } from '../src/eval/replay-comparison.js';
+import { FailingReplayTimelineStore } from './helpers/failing-store.ts';
+import { REPLAY_CHAOS_STORE_FIXTURE } from './fixtures/replay-chaos-store-fixture.ts';
+
+function createMockFetcher(pages: ReadonlyArray<BackfillFetcherPage>): BackfillFetcher {
+  let pageIndex = 0;
+  return {
+    async fetchPage(
+      _cursor: ReplayEventCursor | null,
+      _toSlot: number,
+      _pageSize: number,
+    ): Promise<BackfillFetcherPage> {
+      const page = pages[pageIndex];
+      if (!page) {
+        return { events: [], nextCursor: null, done: true };
+      }
+      pageIndex++;
+      return page;
+    },
+  };
+}
+
+describe('replay store chaos scenarios', () => {
+  it('backfill handles store write failure gracefully', async () => {
+    const inner = new InMemoryReplayTimelineStore();
+    const failing = new FailingReplayTimelineStore(inner, { failAfterSaves: 2 });
+    const alerts: ReplayAlertContext[] = [];
+    const alertDispatcher: ReplayAlertDispatcher = {
+      async emit(context: ReplayAlertContext) {
+        alerts.push(context);
+        return null;
+      },
+    };
+
+    const service = new ReplayBackfillService(failing, {
+      toSlot: 100,
+      pageSize: 1,
+      fetcher: createMockFetcher(REPLAY_CHAOS_STORE_FIXTURE.writeFailurePages),
+      alertDispatcher,
+    });
+
+    const result = await service.runBackfill();
+    expect(result.processed).toBe(2);
+    expect(result.cursor).not.toBeNull();
+    expect(alerts.some((alert) => alert.code === 'replay.backfill.store_write_failed')).toBe(true);
+
+    const timeline = await inner.query();
+    expect(timeline).toHaveLength(2);
+  });
+
+  it('reports type mismatch when store corrupts projected event type', async () => {
+    const inner = new InMemoryReplayTimelineStore();
+    const records = REPLAY_CHAOS_STORE_FIXTURE.records;
+    await inner.save(records);
+
+    const corrupting = new FailingReplayTimelineStore(inner, {
+      corruptQueryResults: (rows) =>
+        rows.map((row, index) => index === 0 ? { ...row, type: 'failed' } : row),
+    });
+
+    const localTrace = makeReplayTraceFromRecords(records, 7, 'chaos-store-corruption');
+    const result = await new ReplayComparisonService().compare({
+      projected: corrupting,
+      localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    expect(result.anomalies.some((entry) => entry.code === 'type_mismatch')).toBe(true);
+  });
+
+  it('reports unexpected events when store returns empty projected timeline', async () => {
+    const inner = new InMemoryReplayTimelineStore();
+    const records = REPLAY_CHAOS_STORE_FIXTURE.records;
+    await inner.save(records);
+
+    const empty = new FailingReplayTimelineStore(inner, { emptyQuery: true });
+    const localTrace = makeReplayTraceFromRecords(records, 7, 'chaos-store-empty');
+
+    const result = await new ReplayComparisonService().compare({
+      projected: empty,
+      localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    expect(result.anomalies.some((entry) => entry.code === 'unexpected_event')).toBe(true);
+  });
+});
+

--- a/runtime/tests/replay-chaos-transition.test.ts
+++ b/runtime/tests/replay-chaos-transition.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { ReplayComparisonService } from '../src/eval/replay-comparison.js';
+import { REPLAY_CHAOS_TRANSITION_FIXTURE } from './fixtures/replay-chaos-transition-fixture.ts';
+
+describe('transition chaos scenarios', () => {
+  it('flags invalid open -> completed transition as transition_invalid', async () => {
+    const fixture = REPLAY_CHAOS_TRANSITION_FIXTURE.scenarios.invalidOpenToCompleted;
+    const result = await new ReplayComparisonService().compare({
+      projected: fixture.projected,
+      localTrace: fixture.localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    expect(result.anomalies.some((entry) => entry.code === 'transition_invalid')).toBe(true);
+  });
+
+  it('flags duplicate completion sequences as duplicate_sequence', async () => {
+    const fixture = REPLAY_CHAOS_TRANSITION_FIXTURE.scenarios.doubleCompletion;
+    const result = await new ReplayComparisonService().compare({
+      projected: fixture.projected,
+      localTrace: fixture.localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    const anomaly = result.anomalies.find((entry) => entry.code === 'duplicate_sequence');
+    expect(anomaly?.severity).toBe('error');
+  });
+
+  it('flags dispute initiated on cancelled task as transition_invalid', async () => {
+    const fixture = REPLAY_CHAOS_TRANSITION_FIXTURE.scenarios.disputeOnCancelled;
+    const result = await new ReplayComparisonService().compare({
+      projected: fixture.projected,
+      localTrace: fixture.localTrace,
+      options: { strictness: 'lenient' },
+    });
+
+    expect(result.status).toBe('mismatched');
+    expect(result.anomalies.some((entry) => entry.code === 'transition_invalid')).toBe(true);
+  });
+});
+

--- a/runtime/tests/replay-chaos.test.ts
+++ b/runtime/tests/replay-chaos.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { TrajectoryReplayEngine } from '../src/eval/replay.js';
 import { projectOnChainEvents } from '../src/eval/projector.js';
+import { CHAOS_SCENARIOS } from '../src/eval/chaos-matrix.js';
 import { REPLAY_CHAOS_FIXTURE } from './fixtures/replay-chaos-fixture.ts';
 
 function eventSignature(result: ReturnType<typeof projectOnChainEvents>): string {
@@ -10,6 +11,13 @@ function eventSignature(result: ReturnType<typeof projectOnChainEvents>): string
 }
 
 describe('chaotic replay projection pipeline', () => {
+  it('exposes a stable chaos scenario matrix', () => {
+    expect(CHAOS_SCENARIOS.length).toBeGreaterThanOrEqual(12);
+    const ids = CHAOS_SCENARIOS.map((scenario) => scenario.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(CHAOS_SCENARIOS.some((scenario) => scenario.category === 'partial_write')).toBe(true);
+  });
+
   it('remains deterministic for out-of-order and duplicated chaos streams in lenient mode', () => {
     const shuffled = [...REPLAY_CHAOS_FIXTURE.onChainEvents].sort((left, right) => {
       if (left.slot !== right.slot) {


### PR DESCRIPTION
## Summary
- Added deterministic chaos fixtures and tests covering replay comparator, store failures, transition anomalies, and backfill resume/stall behavior
- Hardened replay backfill against store write/cursor persistence failures
- Extended mutation gate evaluation with a chaos scenario fail-rate threshold

## Test plan
- [x] `cd runtime && npm run typecheck`
- [x] `cd runtime && npm run test -- --exclude tests/integration.test.ts --exclude tests/eval-replay.integration.test.ts --exclude tests/benchmark-runner.integration.test.ts`

Closes #986