### PR TITLE
test(runtime): add API contract tests for CLI SDK and MCP

### DIFF
--- a/mcp/src/tools/replay-contract.test.ts
+++ b/mcp/src/tools/replay-contract.test.ts
@@ -1,0 +1,607 @@
+import assert from 'node:assert/strict';
+import {
+  mkdirSync,
+  rmSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import test from 'node:test';
+import { z } from 'zod';
+import {
+  ReplayBackfillOutputSchema,
+  ReplayCompareOutputSchema,
+  ReplayIncidentOutputSchema,
+  ReplayStatusOutputSchema,
+  ReplayToolErrorSchema,
+  type ReplayBackfillInput,
+  type ReplayCompareInput,
+  type ReplayIncidentInput,
+  type ReplayStatusInput,
+} from './replay-types.js';
+import {
+  runReplayBackfillTool,
+  runReplayCompareTool,
+  runReplayIncidentTool,
+  runReplayStatusTool,
+  type ReplayToolRuntime,
+  type ReplayPolicy,
+} from './replay.js';
+
+interface ContractSnapshot<TInput extends Record<string, unknown>, TOutput extends Record<string, unknown>> {
+  id: string;
+  version: number;
+  command: string;
+  input: TInput;
+  output: {
+    schema: string;
+    shape: TOutput;
+  };
+  metadata: {
+    generatedAt: string;
+    generatedBy: string;
+  };
+}
+
+function stripUndefined<T>(value: T): T {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripUndefined(entry)) as T;
+  }
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, entryValue]) => entryValue !== undefined)
+    .map(([key, entryValue]) => [key, stripUndefined(entryValue)] as const);
+
+  return Object.fromEntries(entries) as T;
+}
+
+interface ReplayRecord {
+  seq: number;
+  type: string;
+  sourceEventName: string;
+  sourceEventType: string;
+  taskPda?: string;
+  disputePda?: string;
+  signature: string;
+  slot: number;
+  timestampMs: number;
+  payload: Record<string, unknown>;
+  projectionHash?: string;
+}
+
+interface FakeReplayStore {
+  save: (records: readonly ReplayRecord[]) => Promise<{ inserted: number; duplicates: number }>;
+  query: (filter?: Record<string, unknown>) => Promise<readonly ReplayRecord[]>;
+  getCursor: () => Promise<Record<string, unknown> | null>;
+  saveCursor: (cursor: Record<string, unknown> | null) => Promise<void>;
+}
+
+interface ContractRunnerCase<TInput extends Record<string, unknown>, TOutput extends Record<string, unknown>> {
+  id: string;
+  command: string;
+  fixturePath: URL;
+  input: TInput;
+  schema: z.ZodType<TOutput>;
+  schemaName: string;
+  requiredTopLevelKeys: ReadonlyArray<string>;
+  optionalTopLevelKeys?: ReadonlyArray<string>;
+  assertOutput?: (output: TOutput) => void;
+  execute: (input: TInput) => Promise<unknown>;
+}
+
+const UPDATE_GOLDENS = process.env.UPDATE_GOLDENS === '1';
+const SNAPSHOT_VERSION = 1;
+const FIXTURE_DIR = new URL('../../tests/fixtures/golden/', import.meta.url);
+
+const REPLAY_COMPARE_SCHEMA = 'replay.compare.output.v1';
+const REPLAY_BACKFILL_SCHEMA = 'replay.backfill.output.v1';
+const REPLAY_INCIDENT_SCHEMA = 'replay.incident.output.v1';
+const REPLAY_STATUS_SCHEMA = 'replay.status.output.v1';
+
+const COMPARE_TRACE_PATH = join(process.cwd(), 'tmp', 'mcp-replay-compare-success.trace.json');
+const COMPARE_TRACE_RELATIVE = 'tmp/mcp-replay-compare-success.trace.json';
+
+function normalizeKeys(payload: unknown): string[] {
+  return Object.keys(payload as Record<string, unknown>).sort();
+}
+
+function makeStore(records: ReplayRecord[] = []): FakeReplayStore {
+  const saved = [...records];
+  let cursor: Record<string, unknown> | null = null;
+
+  return {
+    async save(incoming) {
+      let inserted = 0;
+      let duplicates = 0;
+      for (const record of incoming) {
+        const key = `${record.slot}|${record.signature}|${record.sourceEventType}`;
+        if (saved.some((existing) => existing.signature === record.signature && existing.slot === record.slot)) {
+          duplicates += 1;
+          continue;
+        }
+        saved.push(record);
+        inserted += 1;
+      }
+      return { inserted, duplicates };
+    },
+    async query(filter = {}) {
+      return saved.filter((entry) => {
+        if (filter.taskPda !== undefined && entry.taskPda !== filter.taskPda) {
+          return false;
+        }
+        if (filter.disputePda !== undefined && entry.disputePda !== filter.disputePda) {
+          return false;
+        }
+        if (filter.fromSlot !== undefined && entry.slot < Number(filter.fromSlot)) {
+          return false;
+        }
+        if (filter.toSlot !== undefined && entry.slot > Number(filter.toSlot)) {
+          return false;
+        }
+        return true;
+      });
+    },
+    async getCursor() {
+      return cursor;
+    },
+    async saveCursor(nextCursor) {
+      cursor = nextCursor;
+    },
+  };
+}
+
+function makeReplayRuntime(overrides: {
+  store?: FakeReplayStore;
+  fetchEvents?: ReplayRecord[];
+  trace?: string;
+  currentSlot?: number;
+} = {}): ReplayToolRuntime {
+  const store = overrides.store ?? makeStore();
+
+  return {
+    createStore: () => store,
+    createBackfillFetcher: () => ({
+      async fetchPage() {
+        return {
+          events: overrides.fetchEvents ?? [],
+          nextCursor: null,
+          done: true,
+        };
+      },
+    }),
+    readLocalTrace(path) {
+      const tracePath = overrides.trace ?? path;
+      if (tracePath !== path && tracePath !== overrides.trace) {
+        throw new Error(`trace not found: ${path}`);
+      }
+      return JSON.parse(readFileSync(tracePath, 'utf8'));
+    },
+    async getCurrentSlot() {
+      return overrides.currentSlot ?? 1_000_000;
+    },
+  };
+}
+
+function buildPolicy(overrides: Partial<ReplayPolicy> = {}): ReplayPolicy {
+  return {
+    maxSlotWindow: 2_000_000,
+    maxEventCount: 100,
+    maxConcurrentJobs: 2,
+    maxToolRuntimeMs: 60_000,
+    allowlist: new Set<string>(),
+    denylist: new Set<string>(),
+    defaultRedactions: ['signature'],
+    auditEnabled: false,
+    ...overrides,
+  };
+}
+
+function buildReplayRecord(seed: string, index: number): ReplayRecord {
+  return {
+    seq: index,
+    type: 'discovered',
+    sourceEventName: 'task.discovered',
+    sourceEventType: 'discovered',
+    taskPda: `Task_${seed}`,
+    disputePda: index % 2 === 0 ? `Dispute_${seed}` : undefined,
+    signature: `${seed}-${index}`,
+    slot: 100 + index,
+    timestampMs: 1_000 + index,
+    payload: {
+      index,
+      task: `Task_${seed}`,
+      event: 'discover',
+    },
+    projectionHash: `hash-${seed}-${index}`,
+  };
+}
+
+function assertTopLevelKeys(payload: Record<string, unknown>, required: readonly string[], optional: readonly string[] = []): void {
+  const allowed = new Set([...required, ...optional]);
+  const keys = normalizeKeys(payload);
+
+  for (const requiredKey of required) {
+    assert.equal(keys.includes(requiredKey), true, `${requiredKey} missing from contract output`);
+  }
+
+  for (const key of keys) {
+    assert.equal(allowed.has(key), true, `unexpected top-level key: ${key}`);
+  }
+}
+
+function writeFixture(path: URL, payload: unknown): void {
+  writeFileSync(path, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function writeCompareTrace(seed: string, recordCount: number): void {
+  const traceDir = join(process.cwd(), 'tmp');
+  mkdirSync(traceDir, { recursive: true });
+
+  const trace = {
+    schemaVersion: 1,
+    traceId: `trace-${seed}`,
+    seed: 10,
+    createdAtMs: 1,
+    events: Array.from({ length: recordCount }, (_, index) => ({
+      seq: index + 1,
+      type: 'discovered',
+      taskPda: `Task_${seed}`,
+      timestampMs: 1_000 + index,
+      payload: {
+        task: `Task_${seed}`,
+        event: 'discover',
+        index,
+      },
+    })),
+  };
+
+  writeFileSync(COMPARE_TRACE_PATH, JSON.stringify(trace), 'utf8');
+}
+
+function cleanupCompareTrace(): void {
+  rmSync(join(process.cwd(), 'tmp'), { recursive: true, force: true });
+}
+
+async function runContractCase<TInput extends Record<string, unknown>, TOutput extends Record<string, unknown>>(
+  args: ContractRunnerCase<TInput, TOutput>,
+): Promise<void> {
+  const output = await args.execute(args.input);
+  const parsed = args.schema.safeParse(output);
+  assert.equal(parsed.success, true, parsed.success ? '' : parsed.error.message);
+
+  if (args.assertOutput) {
+    args.assertOutput(parsed.data as TOutput);
+  }
+
+  assertTopLevelKeys(output as Record<string, unknown>, args.requiredTopLevelKeys, args.optionalTopLevelKeys ?? []);
+
+  const shape = stripUndefined(parsed.data as TOutput);
+  const snapshot: ContractSnapshot<TInput, TOutput> = {
+    id: args.id,
+    version: SNAPSHOT_VERSION,
+    command: args.command,
+    input: args.input,
+    output: {
+      schema: args.schemaName,
+      shape,
+    },
+    metadata: {
+      generatedAt: new Date().toISOString(),
+      generatedBy: 'contract-validator',
+    },
+  };
+
+  if (UPDATE_GOLDENS) {
+    mkdirSync(dirname(args.fixturePath.pathname), { recursive: true });
+    writeFixture(args.fixturePath, snapshot);
+    return;
+  }
+
+  const expected = JSON.parse(readFileSync(args.fixturePath, 'utf8')) as ContractSnapshot<TInput, TOutput>;
+  assert.equal(expected.id, args.id);
+  assert.equal(expected.version, SNAPSHOT_VERSION);
+  assert.equal(expected.output.schema, args.schemaName);
+  assert.deepStrictEqual(expected.output.shape, shape);
+}
+
+const baseRecords = [
+  buildReplayRecord('A', 1),
+  buildReplayRecord('A', 2),
+  buildReplayRecord('A', 3),
+];
+
+const truncatedRecords = Array.from({ length: 80 }, (_, index) => buildReplayRecord('B', index + 1));
+
+await test('replay MCP backfill and error contract cases', async () => {
+  await runContractCase({
+    id: 'mcp.replay.backfill.success',
+    command: 'agenc_replay_backfill',
+    fixturePath: new URL('mcp-replay-backfill-success.json', FIXTURE_DIR),
+    input: {
+      rpc: 'http://localhost:8899',
+      to_slot: 10,
+      store_type: 'memory',
+    } as ReplayBackfillInput,
+    schema: ReplayBackfillOutputSchema,
+    schemaName: REPLAY_BACKFILL_SCHEMA,
+    requiredTopLevelKeys: [
+      'status',
+      'command',
+      'schema',
+      'mode',
+      'to_slot',
+      'store_type',
+      'result',
+      'command_params',
+      'sections',
+      'redactions',
+      'truncated',
+    ],
+    optionalTopLevelKeys: ['page_size', 'schema_hash', 'truncation_reason'],
+    async execute(input) {
+      const store = makeStore();
+      const runtime = makeReplayRuntime({
+        store,
+        fetchEvents: [
+          {
+            seq: 1,
+            type: 'discovered',
+            sourceEventName: 'task.discovered',
+            sourceEventType: 'discovered',
+            taskPda: 'Task_A',
+            signature: 'sig-A',
+            slot: 1,
+            timestampMs: 1,
+            payload: {},
+          },
+        ],
+        currentSlot: 100,
+      });
+      return (await runReplayBackfillTool(input, runtime, buildPolicy())).structuredContent;
+    },
+  });
+
+  await runContractCase({
+    id: 'mcp.replay.backfill.error.slot_window',
+    command: 'agenc_replay_backfill',
+    fixturePath: new URL('mcp-replay-backfill-error-slot-window.json', FIXTURE_DIR),
+    input: {
+      rpc: 'http://localhost:8899',
+      to_slot: 1,
+      store_type: 'memory',
+    } as ReplayBackfillInput,
+    schema: ReplayToolErrorSchema,
+    schemaName: REPLAY_BACKFILL_SCHEMA,
+    requiredTopLevelKeys: ['status', 'command', 'schema', 'code', 'message', 'retriable'],
+    optionalTopLevelKeys: ['schema_hash', 'details'],
+    async execute(input) {
+      const runtime = makeReplayRuntime({ currentSlot: 1000 });
+      return (await runReplayBackfillTool(input, runtime, buildPolicy({ maxSlotWindow: 10 }))).structuredContent;
+    },
+  });
+});
+
+await test('replay MCP compare contract cases', async () => {
+  writeCompareTrace('A', baseRecords.length);
+
+  try {
+    await runContractCase({
+      id: 'mcp.replay.compare.success',
+      command: 'agenc_replay_compare',
+      fixturePath: new URL('mcp-replay-compare-success.json', FIXTURE_DIR),
+      input: {
+        local_trace_path: COMPARE_TRACE_RELATIVE,
+        store_type: 'memory',
+        strict_mode: false,
+        task_pda: 'Task_A',
+      } as ReplayCompareInput,
+      schema: ReplayCompareOutputSchema,
+      schemaName: REPLAY_COMPARE_SCHEMA,
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'strictness',
+        'local_trace_path',
+        'result',
+        'command_params',
+        'sections',
+        'redactions',
+        'truncated',
+      ],
+      optionalTopLevelKeys: ['task_pda', 'dispute_pda', 'schema_hash', 'truncation_reason'],
+      async execute(input) {
+        const store = makeStore([...baseRecords]);
+        const runtime = makeReplayRuntime({
+          store,
+          trace: COMPARE_TRACE_PATH,
+        });
+        await store.save(baseRecords);
+        return (await runReplayCompareTool(input, runtime, buildPolicy())).structuredContent;
+      },
+    });
+
+    await runContractCase({
+      id: 'mcp.replay.compare.failure.invalid_trace',
+      command: 'agenc_replay_compare',
+      fixturePath: new URL('mcp-replay-compare-failure-invalid-trace.json', FIXTURE_DIR),
+      input: {
+        local_trace_path: '/tmp/does-not-exist.json',
+        store_type: 'memory',
+      } as ReplayCompareInput,
+      schema: ReplayToolErrorSchema,
+      schemaName: REPLAY_COMPARE_SCHEMA,
+      requiredTopLevelKeys: ['status', 'command', 'schema', 'code', 'message', 'retriable'],
+      optionalTopLevelKeys: ['schema_hash', 'details'],
+      async execute(input) {
+        const runtime = makeReplayRuntime({
+          store: makeStore(),
+          trace: '/tmp/trace-not-found.json',
+        });
+        return (await runReplayCompareTool(input, runtime, buildPolicy())).structuredContent;
+      },
+    });
+
+    await runContractCase({
+      id: 'mcp.replay.compare.empty_store',
+      command: 'agenc_replay_compare',
+      fixturePath: new URL('mcp-replay-compare-empty-store.json', FIXTURE_DIR),
+      input: {
+        local_trace_path: COMPARE_TRACE_RELATIVE,
+        store_type: 'memory',
+      } as ReplayCompareInput,
+      schema: ReplayCompareOutputSchema,
+      schemaName: REPLAY_COMPARE_SCHEMA,
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'strictness',
+        'local_trace_path',
+        'result',
+        'command_params',
+        'sections',
+        'redactions',
+        'truncated',
+      ],
+      optionalTopLevelKeys: ['task_pda', 'dispute_pda', 'schema_hash', 'truncation_reason'],
+      async execute(input) {
+        writeCompareTrace('EMPTY', 0);
+        const runtime = makeReplayRuntime({
+          store: makeStore(),
+          trace: COMPARE_TRACE_PATH,
+        });
+        return (await runReplayCompareTool(input, runtime, buildPolicy())).structuredContent;
+      },
+      assertOutput(output) {
+        const parsed = output as {
+          truncated: boolean;
+          truncation_reason?: string | null;
+        };
+
+        assert.equal(parsed.truncated, false);
+        assert.ok(parsed.truncation_reason === undefined || parsed.truncation_reason === null);
+      },
+    });
+  } finally {
+    cleanupCompareTrace();
+  }
+});
+
+await test('replay MCP incident and status contract cases', async () => {
+  const store = makeStore([...truncatedRecords]);
+  await store.save(truncatedRecords);
+
+  await runContractCase({
+    id: 'mcp.replay.incident.success',
+    command: 'agenc_replay_incident',
+    fixturePath: new URL('mcp-replay-incident-success.json', FIXTURE_DIR),
+    input: {
+      task_pda: 'Task_A',
+      store_type: 'memory',
+    } as ReplayIncidentInput,
+    schema: ReplayIncidentOutputSchema,
+    schemaName: REPLAY_INCIDENT_SCHEMA,
+    requiredTopLevelKeys: [
+      'status',
+      'command',
+      'schema',
+      'command_params',
+      'sections',
+      'redactions',
+      'summary',
+      'validation',
+      'narrative',
+      'truncated',
+    ],
+    optionalTopLevelKeys: ['schema_hash', 'truncation_reason'],
+    async execute(input) {
+      const runtime = makeReplayRuntime({
+        store,
+      });
+      return (await runReplayIncidentTool(input, runtime, buildPolicy())).structuredContent;
+    },
+  });
+
+  await runContractCase({
+    id: 'mcp.replay.incident.truncated',
+    command: 'agenc_replay_incident',
+    fixturePath: new URL('mcp-replay-incident-truncated.json', FIXTURE_DIR),
+    input: {
+      task_pda: 'Task_A',
+      store_type: 'memory',
+      max_payload_bytes: 200,
+    } as ReplayIncidentInput,
+    schema: ReplayIncidentOutputSchema,
+    schemaName: REPLAY_INCIDENT_SCHEMA,
+    requiredTopLevelKeys: [
+      'status',
+      'command',
+      'schema',
+      'command_params',
+      'sections',
+      'redactions',
+      'summary',
+      'validation',
+      'narrative',
+      'truncated',
+    ],
+    optionalTopLevelKeys: ['schema_hash', 'truncation_reason'],
+    async execute(input) {
+      const runtime = makeReplayRuntime({
+        store,
+      });
+      return (await runReplayIncidentTool(input, runtime, buildPolicy())).structuredContent;
+    },
+    assertOutput(output) {
+      const parsed = output as {
+        truncated: boolean;
+        truncation_reason?: string;
+      };
+
+      assert.equal(parsed.truncated, true);
+      assert.equal(typeof parsed.truncation_reason, 'string');
+      assert.ok((parsed.truncation_reason?.length ?? 0) > 0);
+    },
+  });
+
+  await runContractCase({
+    id: 'mcp.replay.status.success',
+    command: 'agenc_replay_status',
+    fixturePath: new URL('mcp-replay-status-success.json', FIXTURE_DIR),
+    input: {
+      store_type: 'memory',
+    } as ReplayStatusInput,
+    schema: ReplayStatusOutputSchema,
+    schemaName: REPLAY_STATUS_SCHEMA,
+    requiredTopLevelKeys: [
+      'status',
+      'command',
+      'schema',
+      'store_type',
+      'event_count',
+      'unique_task_count',
+      'unique_dispute_count',
+      'active_cursor',
+      'sections',
+      'redactions',
+    ],
+    optionalTopLevelKeys: ['schema_hash'],
+    async execute(input) {
+      const statusStore = makeStore([...baseRecords]);
+      await statusStore.save(baseRecords);
+      const runtime = makeReplayRuntime({
+        store: statusStore,
+      });
+      return (await runReplayStatusTool(input, runtime, buildPolicy())).structuredContent;
+    },
+  });
+});

--- a/mcp/tests/fixtures/golden/mcp-replay-backfill-error-slot-window.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-backfill-error-slot-window.json
@@ -1,0 +1,31 @@
+{
+  "id": "mcp.replay.backfill.error.slot_window",
+  "version": 1,
+  "command": "agenc_replay_backfill",
+  "input": {
+    "rpc": "http://localhost:8899",
+    "to_slot": 1,
+    "store_type": "memory"
+  },
+  "output": {
+    "schema": "replay.backfill.output.v1",
+    "shape": {
+      "status": "error",
+      "command": "agenc_replay_backfill",
+      "schema": "replay.backfill.output.v1",
+      "schema_hash": "73a7a33b91d3436f",
+      "code": "replay.slot_window_exceeded",
+      "message": "to_slot is more than 10 slots behind current slot",
+      "details": {
+        "currentSlot": 1000,
+        "toSlot": 1,
+        "maxSlotWindow": 10
+      },
+      "retriable": false
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:13:59.196Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/mcp/tests/fixtures/golden/mcp-replay-backfill-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-backfill-success.json
@@ -1,0 +1,46 @@
+{
+  "id": "mcp.replay.backfill.success",
+  "version": 1,
+  "command": "agenc_replay_backfill",
+  "input": {
+    "rpc": "http://localhost:8899",
+    "to_slot": 10,
+    "store_type": "memory"
+  },
+  "output": {
+    "schema": "replay.backfill.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "agenc_replay_backfill",
+      "schema": "replay.backfill.output.v1",
+      "schema_hash": "a98f92cd016e3338",
+      "mode": "backfill",
+      "to_slot": 10,
+      "store_type": "memory",
+      "page_size": 100,
+      "result": {
+        "processed": 0,
+        "duplicates": 0,
+        "cursor": null
+      },
+      "sections": [
+        "result"
+      ],
+      "redactions": [
+        "signature"
+      ],
+      "command_params": {
+        "rpc": "http://localhost:8899",
+        "strict_mode": false,
+        "page_size": 100,
+        "max_slot_window": 2000000
+      },
+      "truncated": false,
+      "truncation_reason": null
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:13:59.195Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/mcp/tests/fixtures/golden/mcp-replay-compare-empty-store.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-compare-empty-store.json
@@ -1,0 +1,72 @@
+{
+  "id": "mcp.replay.compare.empty_store",
+  "version": 1,
+  "command": "agenc_replay_compare",
+  "input": {
+    "local_trace_path": "tmp/mcp-replay-compare-success.trace.json",
+    "store_type": "memory"
+  },
+  "output": {
+    "schema": "replay.compare.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "agenc_replay_compare",
+      "schema": "replay.compare.output.v1",
+      "schema_hash": "6827a16d81fa9dbb",
+      "strictness": "lenient",
+      "local_trace_path": "tmp/mcp-replay-compare-success.trace.json",
+      "result": {
+        "status": "clean",
+        "strictness": "lenient",
+        "local_event_count": 0,
+        "projected_event_count": 0,
+        "mismatch_count": 0,
+        "match_rate": 1,
+        "anomaly_ids": [],
+        "top_anomalies": [],
+        "hashes": {
+          "local": "95af14550896665df3af5f6de4549409191fe585cc7f662858e8bdc32a6ef098",
+          "projected": "95af14550896665df3af5f6de4549409191fe585cc7f662858e8bdc32a6ef098"
+        },
+        "local_summary": {
+          "totalEvents": 0,
+          "taskCount": 0,
+          "completedTasks": 0,
+          "failedTasks": 0,
+          "escalatedTasks": 0,
+          "policyViolations": 0,
+          "verifierVerdicts": 0,
+          "speculationAborts": 0
+        },
+        "projected_summary": {
+          "totalEvents": 0,
+          "taskCount": 0,
+          "completedTasks": 0,
+          "failedTasks": 0,
+          "escalatedTasks": 0,
+          "policyViolations": 0,
+          "verifierVerdicts": 0,
+          "speculationAborts": 0
+        }
+      },
+      "task_pda": null,
+      "dispute_pda": null,
+      "sections": [
+        "result"
+      ],
+      "redactions": [
+        "signature"
+      ],
+      "command_params": {
+        "strict_mode": false,
+        "store_type": "memory"
+      },
+      "truncated": false,
+      "truncation_reason": null
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:20:55.076Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/mcp/tests/fixtures/golden/mcp-replay-compare-failure-invalid-trace.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-compare-failure-invalid-trace.json
@@ -1,0 +1,25 @@
+{
+  "id": "mcp.replay.compare.failure.invalid_trace",
+  "version": 1,
+  "command": "agenc_replay_compare",
+  "input": {
+    "local_trace_path": "/tmp/does-not-exist.json",
+    "store_type": "memory"
+  },
+  "output": {
+    "schema": "replay.compare.output.v1",
+    "shape": {
+      "status": "error",
+      "command": "agenc_replay_compare",
+      "schema": "replay.compare.output.v1",
+      "schema_hash": "73a7a33b91d3436f",
+      "code": "replay.compare_failed",
+      "message": "ENOENT: no such file or directory, open '/tmp/trace-not-found.json'",
+      "retriable": true
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:20:55.076Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/mcp/tests/fixtures/golden/mcp-replay-compare-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-compare-success.json
@@ -1,0 +1,144 @@
+{
+  "id": "mcp.replay.compare.success",
+  "version": 1,
+  "command": "agenc_replay_compare",
+  "input": {
+    "local_trace_path": "tmp/mcp-replay-compare-success.trace.json",
+    "store_type": "memory",
+    "strict_mode": false,
+    "task_pda": "Task_A"
+  },
+  "output": {
+    "schema": "replay.compare.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "agenc_replay_compare",
+      "schema": "replay.compare.output.v1",
+      "schema_hash": "6827a16d81fa9dbb",
+      "strictness": "lenient",
+      "local_trace_path": "tmp/mcp-replay-compare-success.trace.json",
+      "result": {
+        "status": "mismatched",
+        "strictness": "lenient",
+        "local_event_count": 3,
+        "projected_event_count": 3,
+        "mismatch_count": 7,
+        "match_rate": 0,
+        "anomaly_ids": [
+          "0432da73d04ecdd1",
+          "b6961ff1271e0c48",
+          "986e74b6a2765550",
+          "6c220700b73fad63",
+          "0f3700ab7e6a3bcc",
+          "81b465c6012f2ac2",
+          "2de5e4cbd3ca0d2e"
+        ],
+        "top_anomalies": [
+          {
+            "anomaly_id": "0432da73d04ecdd1",
+            "code": "hash_mismatch",
+            "severity": "error",
+            "message": "projected event hash mismatch",
+            "source_event_name": "task.discovered",
+            "signature": "[REDACTED]",
+            "seq": 1
+          },
+          {
+            "anomaly_id": "b6961ff1271e0c48",
+            "code": "task_id_mismatch",
+            "severity": "warning",
+            "message": "signature mismatch at seq=1",
+            "source_event_name": "task.discovered",
+            "signature": "[REDACTED]",
+            "seq": 1
+          },
+          {
+            "anomaly_id": "986e74b6a2765550",
+            "code": "hash_mismatch",
+            "severity": "error",
+            "message": "projected event hash mismatch",
+            "source_event_name": "task.discovered",
+            "signature": "[REDACTED]",
+            "seq": 2
+          },
+          {
+            "anomaly_id": "6c220700b73fad63",
+            "code": "task_id_mismatch",
+            "severity": "warning",
+            "message": "signature mismatch at seq=2",
+            "source_event_name": "task.discovered",
+            "signature": "[REDACTED]",
+            "seq": 2
+          },
+          {
+            "anomaly_id": "0f3700ab7e6a3bcc",
+            "code": "hash_mismatch",
+            "severity": "error",
+            "message": "projected event hash mismatch",
+            "source_event_name": "task.discovered",
+            "signature": "[REDACTED]",
+            "seq": 3
+          },
+          {
+            "anomaly_id": "81b465c6012f2ac2",
+            "code": "task_id_mismatch",
+            "severity": "warning",
+            "message": "signature mismatch at seq=3",
+            "source_event_name": "task.discovered",
+            "signature": "[REDACTED]",
+            "seq": 3
+          },
+          {
+            "anomaly_id": "30366d07cde6ba9d",
+            "code": "hash_mismatch",
+            "severity": "error",
+            "message": "deterministic replay hash mismatch"
+          }
+        ],
+        "hashes": {
+          "local": "004946de70b8df4061162cf9025f1507f65a2eeee121a92e235f6923482966f8",
+          "projected": "a89a43ea0a765fbb7239903a2c7fc6e6a7a670b7064d87a22e468a42b4092218"
+        },
+        "local_summary": {
+          "totalEvents": 3,
+          "taskCount": 1,
+          "completedTasks": 0,
+          "failedTasks": 0,
+          "escalatedTasks": 0,
+          "policyViolations": 0,
+          "verifierVerdicts": 0,
+          "speculationAborts": 0
+        },
+        "projected_summary": {
+          "totalEvents": 3,
+          "taskCount": 1,
+          "completedTasks": 0,
+          "failedTasks": 0,
+          "escalatedTasks": 0,
+          "policyViolations": 0,
+          "verifierVerdicts": 0,
+          "speculationAborts": 0
+        }
+      },
+      "task_pda": "Task_A",
+      "dispute_pda": null,
+      "sections": [
+        "result"
+      ],
+      "redactions": [
+        "signature"
+      ],
+      "command_params": {
+        "task_pda": "Task_A",
+        "strict_mode": false,
+        "store_type": "memory"
+      },
+      "truncated": false,
+      "truncation_reason": null
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:20:55.075Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/mcp/tests/fixtures/golden/mcp-replay-incident-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-incident-success.json
@@ -1,0 +1,67 @@
+{
+  "id": "mcp.replay.incident.success",
+  "version": 1,
+  "command": "agenc_replay_incident",
+  "input": {
+    "task_pda": "Task_A",
+    "store_type": "memory"
+  },
+  "output": {
+    "schema": "replay.incident.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "agenc_replay_incident",
+      "schema": "replay.incident.output.v1",
+      "schema_hash": "c237bc370cdd5241",
+      "command_params": {
+        "task_pda": "Task_A",
+        "strict_mode": false,
+        "store_type": "memory"
+      },
+      "sections": [
+        "summary",
+        "validation",
+        "narrative"
+      ],
+      "redactions": [
+        "signature"
+      ],
+      "summary": {
+        "total_events": 0,
+        "task_pda_filters": [
+          "Task_A"
+        ],
+        "dispute_pda_filters": [
+          null
+        ],
+        "unique_task_ids": [],
+        "unique_dispute_ids": [],
+        "source_event_type_counts": {},
+        "source_event_name_counts": {},
+        "trace_id_counts": {},
+        "events": []
+      },
+      "validation": {
+        "strict_mode": false,
+        "event_validation": {
+          "errors": [],
+          "warnings": [],
+          "replay_task_count": 0
+        },
+        "anomaly_ids": [],
+        "deterministic_hash": "86722aba9b480d17fe418dc9bcc6da2147ee58c0f4773ea21597f01fa312f171"
+      },
+      "narrative": {
+        "lines": [],
+        "anomaly_ids": [],
+        "deterministic_hash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+      },
+      "truncated": false,
+      "truncation_reason": null
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:13:59.203Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/mcp/tests/fixtures/golden/mcp-replay-incident-truncated.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-incident-truncated.json
@@ -1,0 +1,68 @@
+{
+  "id": "mcp.replay.incident.truncated",
+  "version": 1,
+  "command": "agenc_replay_incident",
+  "input": {
+    "task_pda": "Task_A",
+    "store_type": "memory",
+    "max_payload_bytes": 200
+  },
+  "output": {
+    "schema": "replay.incident.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "agenc_replay_incident",
+      "schema": "replay.incident.output.v1",
+      "schema_hash": "c237bc370cdd5241",
+      "command_params": {
+        "task_pda": "Task_A",
+        "strict_mode": false,
+        "store_type": "memory"
+      },
+      "sections": [
+        "summary",
+        "validation",
+        "narrative"
+      ],
+      "redactions": [
+        "signature"
+      ],
+      "summary": {
+        "total_events": 0,
+        "task_pda_filters": [
+          "Task_A"
+        ],
+        "dispute_pda_filters": [
+          null
+        ],
+        "unique_task_ids": [],
+        "unique_dispute_ids": [],
+        "source_event_type_counts": {},
+        "source_event_name_counts": {},
+        "trace_id_counts": {},
+        "events": []
+      },
+      "validation": {
+        "strict_mode": false,
+        "event_validation": {
+          "errors": [],
+          "warnings": [],
+          "replay_task_count": 0
+        },
+        "anomaly_ids": [],
+        "deterministic_hash": "86722aba9b480d17fe418dc9bcc6da2147ee58c0f4773ea21597f01fa312f171"
+      },
+      "narrative": {
+        "lines": [],
+        "anomaly_ids": [],
+        "deterministic_hash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+      },
+      "truncated": true,
+      "truncation_reason": "payload_limit_exceeded"
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:13:59.203Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/mcp/tests/fixtures/golden/mcp-replay-status-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-status-success.json
@@ -1,0 +1,32 @@
+{
+  "id": "mcp.replay.status.success",
+  "version": 1,
+  "command": "agenc_replay_status",
+  "input": {
+    "store_type": "memory"
+  },
+  "output": {
+    "schema": "replay.status.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "agenc_replay_status",
+      "schema": "replay.status.output.v1",
+      "schema_hash": "7fbe5363088b59e7",
+      "store_type": "memory",
+      "event_count": 3,
+      "unique_task_count": 1,
+      "unique_dispute_count": 1,
+      "active_cursor": null,
+      "sections": [
+        "status"
+      ],
+      "redactions": [
+        "signature"
+      ]
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:13:59.204Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/cli-contract.test.ts
+++ b/runtime/tests/cli-contract.test.ts
@@ -1,0 +1,565 @@
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { Writable } from 'node:stream';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runCli } from '../src/cli/index.js';
+import { projectOnChainEvents, type ProjectedTimelineEvent } from '../src/eval/projector.js';
+import { computeProjectionHash, type ReplayTimelineRecord } from '../src/replay/types.js';
+import * as cliReplay from '../src/cli/replay.js';
+import {
+  ContractCase,
+  runContractCase,
+  loadGoldenSnapshot,
+} from './helpers/contract-validator.js';
+
+interface OnChainFixtureEvent {
+  eventName: string;
+  slot: number;
+  signature: string;
+  timestampMs: number;
+  event: Record<string, unknown>;
+}
+
+interface CliCapture {
+  stream: Writable;
+  getText: () => string;
+}
+
+const FIXTURE_EVENTS = JSON.parse(
+  readFileSync(new URL('./fixtures/replay-cli/onchain-events.json', import.meta.url), 'utf8'),
+) as OnChainFixtureEvent[];
+
+const TASK_FIXTURE_EVENTS = FIXTURE_EVENTS.filter((entry) => entry.eventName.startsWith('task'));
+
+function createCapture(): CliCapture {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _encoding, callback) {
+      chunks.push(String(chunk));
+      callback();
+    },
+  });
+
+  return {
+    stream,
+    getText() {
+      return chunks.join('');
+    },
+  };
+}
+
+function createWorkspace(): string {
+  const workspace = join(tmpdir(), `agenc-cli-contract-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+  mkdirSync(workspace, { recursive: true });
+  return workspace;
+}
+
+function createReplayRecords(
+  events: OnChainFixtureEvent[],
+  traceId: string,
+  seed = 0,
+): ReplayTimelineRecord[] {
+  const projection = projectOnChainEvents(events, {
+    traceId,
+    seed,
+  });
+
+  return projection.events.map((entry: ProjectedTimelineEvent, index) => ({
+    seq: entry.seq,
+    type: entry.type,
+    taskPda: entry.taskPda,
+    timestampMs: entry.timestampMs,
+    payload: entry.payload,
+    slot: entry.slot,
+    signature: entry.signature,
+    sourceEventName: entry.sourceEventName,
+    sourceEventSequence: entry.sourceEventSequence,
+    sourceEventType: entry.type,
+    projectionHash: computeProjectionHash(entry),
+  }));
+}
+
+function writeTraceFixture(workspace: string, trace: {
+  schemaVersion: number;
+  traceId: string;
+  seed: number;
+  createdAtMs: number;
+  events: Array<{
+    seq: number;
+    type: string;
+    taskPda?: string;
+    timestampMs: number;
+    payload: Record<string, unknown>;
+  }>;
+}): string {
+  const tracePath = join(workspace, `${trace.traceId}-trace.json`);
+  const payload = {
+    schemaVersion: 1,
+    traceId: trace.traceId,
+    seed: trace.seed,
+    createdAtMs: trace.createdAtMs,
+    events: trace.events,
+  };
+  writeFileSync(tracePath, JSON.stringify(payload), 'utf8');
+  return tracePath;
+}
+
+function repeatRecords(records: ReplayTimelineRecord[], repeats: number): ReplayTimelineRecord[] {
+  const output: ReplayTimelineRecord[] = [];
+  for (let round = 0; round < repeats; round += 1) {
+    for (const entry of records) {
+      output.push({
+        ...entry,
+        seq: round * records.length + entry.seq,
+        slot: entry.slot + round * 10_000,
+        signature: `${entry.signature}-${round}`,
+        timestampMs: entry.timestampMs + round * 1_000,
+      });
+    }
+  }
+
+  return output;
+}
+
+async function runCliCapture(argv: string[]): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const stdout = createCapture();
+  const stderr = createCapture();
+
+  const code = await runCli({
+    argv,
+    stdout: stdout.stream,
+    stderr: stderr.stream,
+  });
+
+  return {
+    code,
+    stdout: stdout.getText(),
+    stderr: stderr.getText(),
+  };
+}
+
+function parseCliOutput(result: { stdout: string; stderr: string }): unknown {
+  const candidates = [result.stdout.trim(), result.stderr.trim()].filter((entry) => entry.length > 0);
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // ignored
+    }
+  }
+  throw new Error('cli output was not valid JSON');
+}
+
+describe('CLI output contract tests', () => {
+  let workspace = '';
+
+  beforeEach(() => {
+    workspace = createWorkspace();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  const fixtureDir = new URL('./fixtures/golden/', import.meta.url);
+  const backfillProjection = projectOnChainEvents(FIXTURE_EVENTS, {
+    traceId: 'fixture-backfill',
+    seed: 99,
+  });
+  const replayRecords = createReplayRecords(TASK_FIXTURE_EVENTS, 'fixture-compare', 33);
+
+  const baseCases: ContractCase<Record<string, unknown>, Record<string, unknown>>[] = [
+    {
+      id: 'cli.replay.backfill.success',
+      command: 'replay.backfill',
+      fixturePath: new URL('cli-replay-backfill-success.json', fixtureDir).pathname,
+      outputSchema: 'replay.backfill.output.v1',
+      expectedStatus: 'ok',
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'mode',
+        'toSlot',
+        'storeType',
+        'strictMode',
+        'idempotencyWindow',
+        'result',
+      ],
+      optionalTopLevelKeys: ['pageSize', 'traceId'],
+      input: {
+        argv: [
+          'replay',
+          'backfill',
+          '--to-slot',
+          '999',
+          '--store-type',
+          'memory',
+          '--rpc',
+          'https://example.com',
+          '--trace-id',
+          'fixture-backfill-trace',
+        ],
+      },
+      async execute({}) {
+        const mappedEvents = backfillProjection.events.map((entry) => ({
+          eventName: entry.sourceEventName,
+          event: entry.payload,
+          slot: entry.slot,
+          signature: entry.signature,
+          timestampMs: entry.timestampMs,
+          sourceEventSequence: entry.sourceEventSequence,
+        }));
+        const store = cliReplay.createReplayStore({ storeType: 'memory' });
+
+        vi.spyOn(cliReplay, 'createReplayStore').mockReturnValue(store);
+        vi.spyOn(cliReplay, 'createOnChainReplayBackfillFetcher').mockReturnValue({
+          async fetchPage() {
+            return {
+              events: mappedEvents,
+              nextCursor: mappedEvents.length > 0 ? {
+                slot: mappedEvents.at(-1)?.slot ?? 0,
+                signature: mappedEvents.at(-1)?.signature ?? 'sig-empty',
+                eventName: mappedEvents.at(-1)?.eventName,
+              } : null,
+              done: true,
+            };
+          },
+        });
+
+        const result = await runCliCapture([
+          'replay',
+          'backfill',
+          '--to-slot',
+          '999',
+          '--store-type',
+          'memory',
+          '--rpc',
+          'https://example.com',
+          '--trace-id',
+          'fixture-backfill-trace',
+        ]);
+        return parseCliOutput(result);
+      },
+      shape(output) {
+        const parsed = output as {
+          localTracePath?: string;
+        } & Record<string, unknown>;
+        return {
+          ...parsed,
+          localTracePath: parsed.localTracePath ? basename(parsed.localTracePath) : parsed.localTracePath,
+        };
+      },
+    },
+    {
+      id: 'cli.replay.backfill.failure.missing-rpc',
+      command: 'replay.backfill',
+      fixturePath: new URL('cli-replay-backfill-failure-missing-rpc.json', fixtureDir).pathname,
+      outputSchema: 'replay-error',
+      expectedStatus: 'error',
+      requiredTopLevelKeys: ['status', 'code', 'message'],
+      input: {
+        argv: ['replay', 'backfill', '--to-slot', '999', '--store-type', 'memory'],
+      },
+      async execute({}) {
+        const result = await runCliCapture([
+          'replay',
+          'backfill',
+          '--to-slot',
+          '999',
+          '--store-type',
+          'memory',
+        ]);
+        return parseCliOutput(result);
+      },
+      shape(output) {
+        const parsed = output as { status: string; code: string; message: string };
+        return {
+          status: parsed.status,
+          code: parsed.code,
+          message: parsed.message,
+        };
+      },
+    },
+    {
+      id: 'cli.replay.compare.success',
+      command: 'replay.compare',
+      fixturePath: new URL('cli-replay-compare-success.json', fixtureDir).pathname,
+      outputSchema: 'replay.compare.output.v1',
+      expectedStatus: 'ok',
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'result',
+        'localTracePath',
+        'strictness',
+        'strictMode',
+        'storeType',
+      ],
+      optionalTopLevelKeys: ['taskPda', 'disputePda'],
+      input: {
+        argv: [
+          'replay',
+          'compare',
+          '--local-trace-path',
+          '/tmp/compare-trace.json',
+          '--store-type',
+          'memory',
+          '--strict-mode',
+          'true',
+        ],
+      },
+      async execute({}) {
+        const records = createReplayRecords(TASK_FIXTURE_EVENTS, 'fixture-compare', 33);
+        const trace = {
+          schemaVersion: 1,
+          traceId: 'fixture-compare',
+          seed: 33,
+          createdAtMs: 1,
+          events: records.map((entry, index) => ({
+            seq: index + 1,
+            type: entry.type,
+            taskPda: entry.taskPda,
+            timestampMs: entry.timestampMs,
+            payload: entry.payload,
+          })),
+        };
+
+        const store = cliReplay.createReplayStore({ storeType: 'memory' });
+        await store.save(records);
+        vi.spyOn(cliReplay, 'createReplayStore').mockReturnValue(store);
+
+        const localTracePath = writeTraceFixture(workspace, trace);
+        const result = await runCliCapture([
+          'replay',
+          'compare',
+          '--local-trace-path',
+          localTracePath,
+          '--store-type',
+          'memory',
+          '--task-pda',
+          records[0]?.taskPda ?? 'task-missing',
+          '--strict-mode',
+          'true',
+        ]);
+        return parseCliOutput(result);
+      },
+      shape(output) {
+        const parsed = output as {
+          localTracePath?: string;
+        } & Record<string, unknown>;
+        return {
+          ...parsed,
+          localTracePath: parsed.localTracePath ? basename(parsed.localTracePath) : parsed.localTracePath,
+        };
+      },
+    },
+    {
+      id: 'cli.replay.compare.mismatch',
+      command: 'replay.compare',
+      fixturePath: new URL('cli-replay-compare-mismatch.json', fixtureDir).pathname,
+      outputSchema: 'replay.compare.output.v1',
+      expectedStatus: 'ok',
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'result',
+        'localTracePath',
+        'strictness',
+        'strictMode',
+        'storeType',
+      ],
+      optionalTopLevelKeys: ['taskPda', 'disputePda'],
+      input: {
+        argv: [
+          'replay',
+          'compare',
+          '--local-trace-path',
+          '/tmp/compare-trace-mismatch.json',
+          '--store-type',
+          'memory',
+        ],
+      },
+      async execute({}) {
+        const records = createReplayRecords(TASK_FIXTURE_EVENTS, 'fixture-compare-mismatch', 42);
+        const store = cliReplay.createReplayStore({ storeType: 'memory' });
+        await store.save(records);
+
+        const mismatchTrace = {
+          schemaVersion: 1,
+          traceId: 'fixture-compare-mismatch',
+          seed: 42,
+          createdAtMs: 1,
+          events: records.map((entry, index) => ({
+            seq: index + 1,
+            type: index === 0 ? `${entry.type}-mismatch` : entry.type,
+            taskPda: entry.taskPda,
+            timestampMs: entry.timestampMs,
+            payload: entry.payload,
+          })),
+        };
+
+        vi.spyOn(cliReplay, 'createReplayStore').mockReturnValue(store);
+        const localTracePath = writeTraceFixture(workspace, mismatchTrace);
+
+        const result = await runCliCapture([
+          'replay',
+          'compare',
+          '--local-trace-path',
+          localTracePath,
+          '--store-type',
+          'memory',
+        ]);
+        return parseCliOutput(result);
+      },
+      shape(output) {
+        const parsed = output as {
+          localTracePath?: string;
+        } & Record<string, unknown>;
+        return {
+          ...parsed,
+          localTracePath: parsed.localTracePath ? basename(parsed.localTracePath) : parsed.localTracePath,
+        };
+      },
+    },
+    {
+      id: 'cli.replay.incident.success',
+      command: 'replay.incident',
+      fixturePath: new URL('cli-replay-incident-success.json', fixtureDir).pathname,
+      outputSchema: 'replay.incident.output.v1',
+      expectedStatus: 'ok',
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'commandParams',
+        'summary',
+        'validation',
+        'narrative',
+      ],
+      input: {
+        argv: ['replay', 'incident', '--store-type', 'memory', '--task-pda', 'task-main'],
+      },
+      async execute({}) {
+        const store = cliReplay.createReplayStore({ storeType: 'memory' });
+        const records = createReplayRecords(FIXTURE_EVENTS, 'fixture-incident-success', 12);
+        await store.save(records);
+        vi.spyOn(cliReplay, 'createReplayStore').mockReturnValue(store);
+
+        const result = await runCliCapture([
+          'replay',
+          'incident',
+          '--store-type',
+          'memory',
+          '--task-pda',
+          records[0]?.taskPda ?? 'task-main',
+        ]);
+        return parseCliOutput(result);
+      },
+      shape(output) {
+        return output as Record<string, unknown>;
+      },
+    },
+    {
+      id: 'cli.replay.incident.truncated',
+      command: 'replay.incident',
+      fixturePath: new URL('cli-replay-incident-truncated.json', fixtureDir).pathname,
+      outputSchema: 'replay.incident.output.v1',
+      expectedStatus: 'ok',
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'commandParams',
+        'summary',
+        'validation',
+        'narrative',
+      ],
+      input: {
+        argv: ['replay', 'incident', '--store-type', 'memory', '--task-pda', 'task-main'],
+      },
+      async execute({}) {
+        const store = cliReplay.createReplayStore({ storeType: 'memory' });
+        const baseRecords = replayRecords;
+        const records = repeatRecords(baseRecords, 60);
+        const baseTaskPda = baseRecords[0]?.taskPda ?? 'task-main';
+        await store.save(records);
+        vi.spyOn(cliReplay, 'createReplayStore').mockReturnValue(store);
+
+        const result = await runCliCapture([
+          'replay',
+          'incident',
+          '--store-type',
+          'memory',
+          '--task-pda',
+          baseTaskPda,
+        ]);
+        return parseCliOutput(result);
+      },
+      shape(output) {
+        return output as Record<string, unknown>;
+      },
+    },
+    {
+      id: 'cli.replay.incident.empty',
+      command: 'replay.incident',
+      fixturePath: new URL('cli-replay-incident-empty.json', fixtureDir).pathname,
+      outputSchema: 'replay.incident.output.v1',
+      expectedStatus: 'ok',
+      requiredTopLevelKeys: [
+        'status',
+        'command',
+        'schema',
+        'commandParams',
+        'summary',
+        'validation',
+        'narrative',
+      ],
+      input: {
+        argv: ['replay', 'incident', '--store-type', 'memory', '--task-pda', 'task-missing'],
+      },
+      async execute({}) {
+        const store = cliReplay.createReplayStore({ storeType: 'memory' });
+        vi.spyOn(cliReplay, 'createReplayStore').mockReturnValue(store);
+
+        const result = await runCliCapture([
+          'replay',
+          'incident',
+          '--store-type',
+          'memory',
+          '--task-pda',
+          'task-missing',
+        ]);
+        return parseCliOutput(result);
+      },
+      shape(output) {
+        return output as Record<string, unknown>;
+      },
+    },
+  ];
+
+  for (const testCase of baseCases) {
+    it(`cli contract: ${testCase.id}`, async () => {
+      await runContractCase(testCase);
+    });
+  }
+
+  it('does not include extra top-level keys for mismatch case', () => {
+    const mismatchPath = new URL('cli-replay-compare-mismatch.json', fixtureDir).pathname;
+    const fixture = loadGoldenSnapshot<Record<string, unknown>, Record<string, unknown>>(mismatchPath);
+    expect(fixture.output.shape).toBeTypeOf('object');
+  });
+});

--- a/runtime/tests/fixtures/golden/cli-replay-backfill-failure-missing-rpc.json
+++ b/runtime/tests/fixtures/golden/cli-replay-backfill-failure-missing-rpc.json
@@ -1,0 +1,27 @@
+{
+  "id": "cli.replay.backfill.failure.missing-rpc",
+  "version": 1,
+  "command": "replay.backfill",
+  "input": {
+    "argv": [
+      "replay",
+      "backfill",
+      "--to-slot",
+      "999",
+      "--store-type",
+      "memory"
+    ]
+  },
+  "output": {
+    "schema": "replay-error",
+    "shape": {
+      "status": "error",
+      "code": "MISSING_REQUIRED_OPTION",
+      "message": "--rpc is required for replay backfill"
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:17:05.678Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/fixtures/golden/cli-replay-backfill-success.json
+++ b/runtime/tests/fixtures/golden/cli-replay-backfill-success.json
@@ -1,0 +1,48 @@
+{
+  "id": "cli.replay.backfill.success",
+  "version": 1,
+  "command": "replay.backfill",
+  "input": {
+    "argv": [
+      "replay",
+      "backfill",
+      "--to-slot",
+      "999",
+      "--store-type",
+      "memory",
+      "--rpc",
+      "https://example.com",
+      "--trace-id",
+      "fixture-backfill-trace"
+    ]
+  },
+  "output": {
+    "schema": "replay.backfill.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "replay.backfill",
+      "schema": "replay.backfill.output.v1",
+      "mode": "backfill",
+      "strictMode": false,
+      "toSlot": 999,
+      "storeType": "memory",
+      "traceId": "fixture-backfill-trace",
+      "idempotencyWindow": 900,
+      "result": {
+        "processed": 6,
+        "duplicates": 0,
+        "cursor": {
+          "slot": 15,
+          "signature": "SIGCLIDISPUTERESOLVE",
+          "eventName": "disputeResolved",
+          "traceId": "fixture-backfill-trace",
+          "traceSpanId": "6d4a8aae3c6f9856"
+        }
+      }
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:17:05.677Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/fixtures/golden/cli-replay-compare-mismatch.json
+++ b/runtime/tests/fixtures/golden/cli-replay-compare-mismatch.json
@@ -1,0 +1,103 @@
+{
+  "id": "cli.replay.compare.mismatch",
+  "version": 1,
+  "command": "replay.compare",
+  "input": {
+    "argv": [
+      "replay",
+      "compare",
+      "--local-trace-path",
+      "/tmp/compare-trace-mismatch.json",
+      "--store-type",
+      "memory"
+    ]
+  },
+  "output": {
+    "schema": "replay.compare.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "replay.compare",
+      "schema": "replay.compare.output.v1",
+      "localTracePath": "fixture-compare-mismatch-trace.json",
+      "strictness": "lenient",
+      "strictMode": false,
+      "storeType": "memory",
+      "result": {
+        "status": "mismatched",
+        "strictness": "lenient",
+        "localEventCount": 3,
+        "projectedEventCount": 3,
+        "mismatchCount": 3,
+        "matchRate": 0,
+        "anomalyIds": [
+          "83c35b501fe0dfc3",
+          "c82f37ac12e92e1b",
+          "b121653778054d0c"
+        ],
+        "topAnomalies": [
+          {
+            "anomalyId": "1c22ded427dbd1bd",
+            "code": "type_mismatch",
+            "severity": "error",
+            "message": "event type mismatch at seq=1",
+            "sourceEventName": "taskCreated",
+            "signature": "SIGCLITASKCREATED",
+            "seq": 1
+          },
+          {
+            "anomalyId": "aac7a2470ab1f9b6",
+            "code": "hash_mismatch",
+            "severity": "error",
+            "message": "deterministic replay hash mismatch"
+          },
+          {
+            "anomalyId": "e1f253ce2e5b77dd",
+            "code": "transition_invalid",
+            "severity": "warning",
+            "message": "[local] unknown event type \"discovered-mismatch\" at seq=1"
+          }
+        ],
+        "hashes": {
+          "local": "cd682a13e268f5f0897d6f9595a9bdabcb9d6104330098dd9bc16a50f4879e98",
+          "projected": "4a82760b0803300f6e93d6378eb22c711b73137da711c35f1e2fb0d7374ff3b3"
+        },
+        "localSummary": {
+          "deterministicHash": "cd682a13e268f5f0897d6f9595a9bdabcb9d6104330098dd9bc16a50f4879e98",
+          "errors": [],
+          "warnings": [
+            "unknown event type \"discovered-mismatch\" at seq=1"
+          ],
+          "summary": {
+            "totalEvents": 3,
+            "taskCount": 1,
+            "completedTasks": 1,
+            "failedTasks": 0,
+            "escalatedTasks": 0,
+            "policyViolations": 0,
+            "verifierVerdicts": 0,
+            "speculationAborts": 0
+          }
+        },
+        "projectedSummary": {
+          "deterministicHash": "4a82760b0803300f6e93d6378eb22c711b73137da711c35f1e2fb0d7374ff3b3",
+          "errors": [],
+          "warnings": [],
+          "summary": {
+            "totalEvents": 3,
+            "taskCount": 1,
+            "completedTasks": 1,
+            "failedTasks": 0,
+            "escalatedTasks": 0,
+            "policyViolations": 0,
+            "verifierVerdicts": 0,
+            "speculationAborts": 0
+          }
+        }
+      }
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:17:05.681Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/fixtures/golden/cli-replay-compare-success.json
+++ b/runtime/tests/fixtures/golden/cli-replay-compare-success.json
@@ -1,0 +1,78 @@
+{
+  "id": "cli.replay.compare.success",
+  "version": 1,
+  "command": "replay.compare",
+  "input": {
+    "argv": [
+      "replay",
+      "compare",
+      "--local-trace-path",
+      "/tmp/compare-trace.json",
+      "--store-type",
+      "memory",
+      "--strict-mode",
+      "true"
+    ]
+  },
+  "output": {
+    "schema": "replay.compare.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "replay.compare",
+      "schema": "replay.compare.output.v1",
+      "localTracePath": "fixture-compare-trace.json",
+      "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+      "strictness": "strict",
+      "strictMode": true,
+      "storeType": "memory",
+      "result": {
+        "status": "clean",
+        "strictness": "strict",
+        "localEventCount": 3,
+        "projectedEventCount": 3,
+        "mismatchCount": 0,
+        "matchRate": 1,
+        "anomalyIds": [],
+        "topAnomalies": [],
+        "hashes": {
+          "local": "9caa5f8c26c204eee2b37134df36fe444e86cd77d98461701babae789e843df3",
+          "projected": "9caa5f8c26c204eee2b37134df36fe444e86cd77d98461701babae789e843df3"
+        },
+        "localSummary": {
+          "deterministicHash": "9caa5f8c26c204eee2b37134df36fe444e86cd77d98461701babae789e843df3",
+          "errors": [],
+          "warnings": [],
+          "summary": {
+            "totalEvents": 3,
+            "taskCount": 1,
+            "completedTasks": 1,
+            "failedTasks": 0,
+            "escalatedTasks": 0,
+            "policyViolations": 0,
+            "verifierVerdicts": 0,
+            "speculationAborts": 0
+          }
+        },
+        "projectedSummary": {
+          "deterministicHash": "9caa5f8c26c204eee2b37134df36fe444e86cd77d98461701babae789e843df3",
+          "errors": [],
+          "warnings": [],
+          "summary": {
+            "totalEvents": 3,
+            "taskCount": 1,
+            "completedTasks": 1,
+            "failedTasks": 0,
+            "escalatedTasks": 0,
+            "policyViolations": 0,
+            "verifierVerdicts": 0,
+            "speculationAborts": 0
+          }
+        }
+      }
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:17:05.680Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/fixtures/golden/cli-replay-incident-empty.json
+++ b/runtime/tests/fixtures/golden/cli-replay-incident-empty.json
@@ -1,0 +1,62 @@
+{
+  "id": "cli.replay.incident.empty",
+  "version": 1,
+  "command": "replay.incident",
+  "input": {
+    "argv": [
+      "replay",
+      "incident",
+      "--store-type",
+      "memory",
+      "--task-pda",
+      "task-missing"
+    ]
+  },
+  "output": {
+    "schema": "replay.incident.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "replay.incident",
+      "schema": "replay.incident.output.v1",
+      "commandParams": {
+        "taskPda": "task-missing",
+        "strictMode": false,
+        "storeType": "memory"
+      },
+      "summary": {
+        "totalEvents": 0,
+        "taskPdaFilters": [
+          "task-missing"
+        ],
+        "disputePdaFilters": [
+          null
+        ],
+        "uniqueTaskIds": [],
+        "uniqueDisputeIds": [],
+        "sourceEventTypeCounts": {},
+        "sourceEventNameCounts": {},
+        "traceIdCounts": {},
+        "events": [],
+        "deterministicHash": "87c8b6e721bf2a4a994816015dae429682e2c8f5410ed2e6da645260ff24c11a",
+        "eventType": "replay-incidents"
+      },
+      "validation": {
+        "strictMode": false,
+        "eventValidation": {
+          "errors": [],
+          "warnings": [],
+          "replayTaskCount": 0
+        },
+        "anomalyIds": []
+      },
+      "narrative": {
+        "lines": [],
+        "anomalyIds": []
+      }
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:17:05.687Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/fixtures/golden/cli-replay-incident-success.json
+++ b/runtime/tests/fixtures/golden/cli-replay-incident-success.json
@@ -1,0 +1,120 @@
+{
+  "id": "cli.replay.incident.success",
+  "version": 1,
+  "command": "replay.incident",
+  "input": {
+    "argv": [
+      "replay",
+      "incident",
+      "--store-type",
+      "memory",
+      "--task-pda",
+      "task-main"
+    ]
+  },
+  "output": {
+    "schema": "replay.incident.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "replay.incident",
+      "schema": "replay.incident.output.v1",
+      "commandParams": {
+        "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+        "strictMode": false,
+        "storeType": "memory"
+      },
+      "summary": {
+        "totalEvents": 4,
+        "taskPdaFilters": [
+          "01010101010101010101010101010101010101010101010101010101010101010101"
+        ],
+        "disputePdaFilters": [
+          null
+        ],
+        "firstSlot": 10,
+        "lastSlot": 13,
+        "firstSeq": 1,
+        "lastSeq": 4,
+        "uniqueTaskIds": [
+          "01010101010101010101010101010101010101010101010101010101010101010101"
+        ],
+        "uniqueDisputeIds": [],
+        "sourceEventTypeCounts": {
+          "claimed": 1,
+          "completed": 1,
+          "discovered": 1,
+          "dispute:initiated": 1
+        },
+        "sourceEventNameCounts": {
+          "disputeInitiated": 1,
+          "taskClaimed": 1,
+          "taskCompleted": 1,
+          "taskCreated": 1
+        },
+        "traceIdCounts": {},
+        "events": [
+          {
+            "seq": 1,
+            "slot": 10,
+            "signature": "SIGCLITASKCREATED",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000000000
+          },
+          {
+            "seq": 2,
+            "slot": 11,
+            "signature": "SIGCLITASKCLAIMED",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000000001
+          },
+          {
+            "seq": 3,
+            "slot": 12,
+            "signature": "SIGCLITASKCOMPLETED",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000000002
+          },
+          {
+            "seq": 4,
+            "slot": 13,
+            "signature": "SIGCLIDISPUTEINIT",
+            "sourceEventType": "dispute:initiated",
+            "sourceEventName": "disputeInitiated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000000003
+          }
+        ],
+        "deterministicHash": "bf9bee0a752fd84f8a00efbc552001230c89d81c51ccd54455883e0beb335195",
+        "eventType": "replay-incidents"
+      },
+      "validation": {
+        "strictMode": false,
+        "eventValidation": {
+          "errors": [],
+          "warnings": [],
+          "replayTaskCount": 1
+        },
+        "anomalyIds": []
+      },
+      "narrative": {
+        "lines": [
+          "1/10/SIGCLITASKCREATED: taskCreated (discovered)",
+          "2/11/SIGCLITASKCLAIMED: taskClaimed (claimed)",
+          "3/12/SIGCLITASKCOMPLETED: taskCompleted (completed)",
+          "4/13/SIGCLIDISPUTEINIT: disputeInitiated (dispute:initiated)"
+        ],
+        "anomalyIds": []
+      }
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:17:05.683Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/fixtures/golden/cli-replay-incident-truncated.json
+++ b/runtime/tests/fixtures/golden/cli-replay-incident-truncated.json
@@ -1,0 +1,1738 @@
+{
+  "id": "cli.replay.incident.truncated",
+  "version": 1,
+  "command": "replay.incident",
+  "input": {
+    "argv": [
+      "replay",
+      "incident",
+      "--store-type",
+      "memory",
+      "--task-pda",
+      "task-main"
+    ]
+  },
+  "output": {
+    "schema": "replay.incident.output.v1",
+    "shape": {
+      "status": "ok",
+      "command": "replay.incident",
+      "schema": "replay.incident.output.v1",
+      "commandParams": {
+        "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+        "strictMode": false,
+        "storeType": "memory"
+      },
+      "summary": {
+        "totalEvents": 180,
+        "taskPdaFilters": [
+          "01010101010101010101010101010101010101010101010101010101010101010101"
+        ],
+        "disputePdaFilters": [
+          null
+        ],
+        "firstSlot": 10,
+        "lastSlot": 590012,
+        "firstSeq": 1,
+        "lastSeq": 180,
+        "uniqueTaskIds": [
+          "01010101010101010101010101010101010101010101010101010101010101010101"
+        ],
+        "uniqueDisputeIds": [],
+        "sourceEventTypeCounts": {
+          "claimed": 60,
+          "completed": 60,
+          "discovered": 60
+        },
+        "sourceEventNameCounts": {
+          "taskClaimed": 60,
+          "taskCompleted": 60,
+          "taskCreated": 60
+        },
+        "traceIdCounts": {},
+        "events": [
+          {
+            "seq": 1,
+            "slot": 10,
+            "signature": "SIGCLITASKCREATED-0",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000000000
+          },
+          {
+            "seq": 2,
+            "slot": 11,
+            "signature": "SIGCLITASKCLAIMED-0",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000000001
+          },
+          {
+            "seq": 3,
+            "slot": 12,
+            "signature": "SIGCLITASKCOMPLETED-0",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000000002
+          },
+          {
+            "seq": 4,
+            "slot": 10010,
+            "signature": "SIGCLITASKCREATED-1",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000001000
+          },
+          {
+            "seq": 5,
+            "slot": 10011,
+            "signature": "SIGCLITASKCLAIMED-1",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000001001
+          },
+          {
+            "seq": 6,
+            "slot": 10012,
+            "signature": "SIGCLITASKCOMPLETED-1",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000001002
+          },
+          {
+            "seq": 7,
+            "slot": 20010,
+            "signature": "SIGCLITASKCREATED-2",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000002000
+          },
+          {
+            "seq": 8,
+            "slot": 20011,
+            "signature": "SIGCLITASKCLAIMED-2",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000002001
+          },
+          {
+            "seq": 9,
+            "slot": 20012,
+            "signature": "SIGCLITASKCOMPLETED-2",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000002002
+          },
+          {
+            "seq": 10,
+            "slot": 30010,
+            "signature": "SIGCLITASKCREATED-3",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000003000
+          },
+          {
+            "seq": 11,
+            "slot": 30011,
+            "signature": "SIGCLITASKCLAIMED-3",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000003001
+          },
+          {
+            "seq": 12,
+            "slot": 30012,
+            "signature": "SIGCLITASKCOMPLETED-3",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000003002
+          },
+          {
+            "seq": 13,
+            "slot": 40010,
+            "signature": "SIGCLITASKCREATED-4",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000004000
+          },
+          {
+            "seq": 14,
+            "slot": 40011,
+            "signature": "SIGCLITASKCLAIMED-4",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000004001
+          },
+          {
+            "seq": 15,
+            "slot": 40012,
+            "signature": "SIGCLITASKCOMPLETED-4",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000004002
+          },
+          {
+            "seq": 16,
+            "slot": 50010,
+            "signature": "SIGCLITASKCREATED-5",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000005000
+          },
+          {
+            "seq": 17,
+            "slot": 50011,
+            "signature": "SIGCLITASKCLAIMED-5",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000005001
+          },
+          {
+            "seq": 18,
+            "slot": 50012,
+            "signature": "SIGCLITASKCOMPLETED-5",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000005002
+          },
+          {
+            "seq": 19,
+            "slot": 60010,
+            "signature": "SIGCLITASKCREATED-6",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000006000
+          },
+          {
+            "seq": 20,
+            "slot": 60011,
+            "signature": "SIGCLITASKCLAIMED-6",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000006001
+          },
+          {
+            "seq": 21,
+            "slot": 60012,
+            "signature": "SIGCLITASKCOMPLETED-6",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000006002
+          },
+          {
+            "seq": 22,
+            "slot": 70010,
+            "signature": "SIGCLITASKCREATED-7",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000007000
+          },
+          {
+            "seq": 23,
+            "slot": 70011,
+            "signature": "SIGCLITASKCLAIMED-7",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000007001
+          },
+          {
+            "seq": 24,
+            "slot": 70012,
+            "signature": "SIGCLITASKCOMPLETED-7",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000007002
+          },
+          {
+            "seq": 25,
+            "slot": 80010,
+            "signature": "SIGCLITASKCREATED-8",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000008000
+          },
+          {
+            "seq": 26,
+            "slot": 80011,
+            "signature": "SIGCLITASKCLAIMED-8",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000008001
+          },
+          {
+            "seq": 27,
+            "slot": 80012,
+            "signature": "SIGCLITASKCOMPLETED-8",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000008002
+          },
+          {
+            "seq": 28,
+            "slot": 90010,
+            "signature": "SIGCLITASKCREATED-9",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000009000
+          },
+          {
+            "seq": 29,
+            "slot": 90011,
+            "signature": "SIGCLITASKCLAIMED-9",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000009001
+          },
+          {
+            "seq": 30,
+            "slot": 90012,
+            "signature": "SIGCLITASKCOMPLETED-9",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000009002
+          },
+          {
+            "seq": 31,
+            "slot": 100010,
+            "signature": "SIGCLITASKCREATED-10",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000010000
+          },
+          {
+            "seq": 32,
+            "slot": 100011,
+            "signature": "SIGCLITASKCLAIMED-10",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000010001
+          },
+          {
+            "seq": 33,
+            "slot": 100012,
+            "signature": "SIGCLITASKCOMPLETED-10",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000010002
+          },
+          {
+            "seq": 34,
+            "slot": 110010,
+            "signature": "SIGCLITASKCREATED-11",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000011000
+          },
+          {
+            "seq": 35,
+            "slot": 110011,
+            "signature": "SIGCLITASKCLAIMED-11",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000011001
+          },
+          {
+            "seq": 36,
+            "slot": 110012,
+            "signature": "SIGCLITASKCOMPLETED-11",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000011002
+          },
+          {
+            "seq": 37,
+            "slot": 120010,
+            "signature": "SIGCLITASKCREATED-12",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000012000
+          },
+          {
+            "seq": 38,
+            "slot": 120011,
+            "signature": "SIGCLITASKCLAIMED-12",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000012001
+          },
+          {
+            "seq": 39,
+            "slot": 120012,
+            "signature": "SIGCLITASKCOMPLETED-12",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000012002
+          },
+          {
+            "seq": 40,
+            "slot": 130010,
+            "signature": "SIGCLITASKCREATED-13",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000013000
+          },
+          {
+            "seq": 41,
+            "slot": 130011,
+            "signature": "SIGCLITASKCLAIMED-13",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000013001
+          },
+          {
+            "seq": 42,
+            "slot": 130012,
+            "signature": "SIGCLITASKCOMPLETED-13",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000013002
+          },
+          {
+            "seq": 43,
+            "slot": 140010,
+            "signature": "SIGCLITASKCREATED-14",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000014000
+          },
+          {
+            "seq": 44,
+            "slot": 140011,
+            "signature": "SIGCLITASKCLAIMED-14",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000014001
+          },
+          {
+            "seq": 45,
+            "slot": 140012,
+            "signature": "SIGCLITASKCOMPLETED-14",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000014002
+          },
+          {
+            "seq": 46,
+            "slot": 150010,
+            "signature": "SIGCLITASKCREATED-15",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000015000
+          },
+          {
+            "seq": 47,
+            "slot": 150011,
+            "signature": "SIGCLITASKCLAIMED-15",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000015001
+          },
+          {
+            "seq": 48,
+            "slot": 150012,
+            "signature": "SIGCLITASKCOMPLETED-15",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000015002
+          },
+          {
+            "seq": 49,
+            "slot": 160010,
+            "signature": "SIGCLITASKCREATED-16",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000016000
+          },
+          {
+            "seq": 50,
+            "slot": 160011,
+            "signature": "SIGCLITASKCLAIMED-16",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000016001
+          },
+          {
+            "seq": 51,
+            "slot": 160012,
+            "signature": "SIGCLITASKCOMPLETED-16",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000016002
+          },
+          {
+            "seq": 52,
+            "slot": 170010,
+            "signature": "SIGCLITASKCREATED-17",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000017000
+          },
+          {
+            "seq": 53,
+            "slot": 170011,
+            "signature": "SIGCLITASKCLAIMED-17",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000017001
+          },
+          {
+            "seq": 54,
+            "slot": 170012,
+            "signature": "SIGCLITASKCOMPLETED-17",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000017002
+          },
+          {
+            "seq": 55,
+            "slot": 180010,
+            "signature": "SIGCLITASKCREATED-18",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000018000
+          },
+          {
+            "seq": 56,
+            "slot": 180011,
+            "signature": "SIGCLITASKCLAIMED-18",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000018001
+          },
+          {
+            "seq": 57,
+            "slot": 180012,
+            "signature": "SIGCLITASKCOMPLETED-18",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000018002
+          },
+          {
+            "seq": 58,
+            "slot": 190010,
+            "signature": "SIGCLITASKCREATED-19",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000019000
+          },
+          {
+            "seq": 59,
+            "slot": 190011,
+            "signature": "SIGCLITASKCLAIMED-19",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000019001
+          },
+          {
+            "seq": 60,
+            "slot": 190012,
+            "signature": "SIGCLITASKCOMPLETED-19",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000019002
+          },
+          {
+            "seq": 61,
+            "slot": 200010,
+            "signature": "SIGCLITASKCREATED-20",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000020000
+          },
+          {
+            "seq": 62,
+            "slot": 200011,
+            "signature": "SIGCLITASKCLAIMED-20",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000020001
+          },
+          {
+            "seq": 63,
+            "slot": 200012,
+            "signature": "SIGCLITASKCOMPLETED-20",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000020002
+          },
+          {
+            "seq": 64,
+            "slot": 210010,
+            "signature": "SIGCLITASKCREATED-21",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000021000
+          },
+          {
+            "seq": 65,
+            "slot": 210011,
+            "signature": "SIGCLITASKCLAIMED-21",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000021001
+          },
+          {
+            "seq": 66,
+            "slot": 210012,
+            "signature": "SIGCLITASKCOMPLETED-21",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000021002
+          },
+          {
+            "seq": 67,
+            "slot": 220010,
+            "signature": "SIGCLITASKCREATED-22",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000022000
+          },
+          {
+            "seq": 68,
+            "slot": 220011,
+            "signature": "SIGCLITASKCLAIMED-22",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000022001
+          },
+          {
+            "seq": 69,
+            "slot": 220012,
+            "signature": "SIGCLITASKCOMPLETED-22",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000022002
+          },
+          {
+            "seq": 70,
+            "slot": 230010,
+            "signature": "SIGCLITASKCREATED-23",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000023000
+          },
+          {
+            "seq": 71,
+            "slot": 230011,
+            "signature": "SIGCLITASKCLAIMED-23",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000023001
+          },
+          {
+            "seq": 72,
+            "slot": 230012,
+            "signature": "SIGCLITASKCOMPLETED-23",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000023002
+          },
+          {
+            "seq": 73,
+            "slot": 240010,
+            "signature": "SIGCLITASKCREATED-24",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000024000
+          },
+          {
+            "seq": 74,
+            "slot": 240011,
+            "signature": "SIGCLITASKCLAIMED-24",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000024001
+          },
+          {
+            "seq": 75,
+            "slot": 240012,
+            "signature": "SIGCLITASKCOMPLETED-24",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000024002
+          },
+          {
+            "seq": 76,
+            "slot": 250010,
+            "signature": "SIGCLITASKCREATED-25",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000025000
+          },
+          {
+            "seq": 77,
+            "slot": 250011,
+            "signature": "SIGCLITASKCLAIMED-25",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000025001
+          },
+          {
+            "seq": 78,
+            "slot": 250012,
+            "signature": "SIGCLITASKCOMPLETED-25",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000025002
+          },
+          {
+            "seq": 79,
+            "slot": 260010,
+            "signature": "SIGCLITASKCREATED-26",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000026000
+          },
+          {
+            "seq": 80,
+            "slot": 260011,
+            "signature": "SIGCLITASKCLAIMED-26",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000026001
+          },
+          {
+            "seq": 81,
+            "slot": 260012,
+            "signature": "SIGCLITASKCOMPLETED-26",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000026002
+          },
+          {
+            "seq": 82,
+            "slot": 270010,
+            "signature": "SIGCLITASKCREATED-27",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000027000
+          },
+          {
+            "seq": 83,
+            "slot": 270011,
+            "signature": "SIGCLITASKCLAIMED-27",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000027001
+          },
+          {
+            "seq": 84,
+            "slot": 270012,
+            "signature": "SIGCLITASKCOMPLETED-27",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000027002
+          },
+          {
+            "seq": 85,
+            "slot": 280010,
+            "signature": "SIGCLITASKCREATED-28",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000028000
+          },
+          {
+            "seq": 86,
+            "slot": 280011,
+            "signature": "SIGCLITASKCLAIMED-28",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000028001
+          },
+          {
+            "seq": 87,
+            "slot": 280012,
+            "signature": "SIGCLITASKCOMPLETED-28",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000028002
+          },
+          {
+            "seq": 88,
+            "slot": 290010,
+            "signature": "SIGCLITASKCREATED-29",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000029000
+          },
+          {
+            "seq": 89,
+            "slot": 290011,
+            "signature": "SIGCLITASKCLAIMED-29",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000029001
+          },
+          {
+            "seq": 90,
+            "slot": 290012,
+            "signature": "SIGCLITASKCOMPLETED-29",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000029002
+          },
+          {
+            "seq": 91,
+            "slot": 300010,
+            "signature": "SIGCLITASKCREATED-30",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000030000
+          },
+          {
+            "seq": 92,
+            "slot": 300011,
+            "signature": "SIGCLITASKCLAIMED-30",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000030001
+          },
+          {
+            "seq": 93,
+            "slot": 300012,
+            "signature": "SIGCLITASKCOMPLETED-30",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000030002
+          },
+          {
+            "seq": 94,
+            "slot": 310010,
+            "signature": "SIGCLITASKCREATED-31",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000031000
+          },
+          {
+            "seq": 95,
+            "slot": 310011,
+            "signature": "SIGCLITASKCLAIMED-31",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000031001
+          },
+          {
+            "seq": 96,
+            "slot": 310012,
+            "signature": "SIGCLITASKCOMPLETED-31",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000031002
+          },
+          {
+            "seq": 97,
+            "slot": 320010,
+            "signature": "SIGCLITASKCREATED-32",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000032000
+          },
+          {
+            "seq": 98,
+            "slot": 320011,
+            "signature": "SIGCLITASKCLAIMED-32",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000032001
+          },
+          {
+            "seq": 99,
+            "slot": 320012,
+            "signature": "SIGCLITASKCOMPLETED-32",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000032002
+          },
+          {
+            "seq": 100,
+            "slot": 330010,
+            "signature": "SIGCLITASKCREATED-33",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000033000
+          },
+          {
+            "seq": 101,
+            "slot": 330011,
+            "signature": "SIGCLITASKCLAIMED-33",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000033001
+          },
+          {
+            "seq": 102,
+            "slot": 330012,
+            "signature": "SIGCLITASKCOMPLETED-33",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000033002
+          },
+          {
+            "seq": 103,
+            "slot": 340010,
+            "signature": "SIGCLITASKCREATED-34",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000034000
+          },
+          {
+            "seq": 104,
+            "slot": 340011,
+            "signature": "SIGCLITASKCLAIMED-34",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000034001
+          },
+          {
+            "seq": 105,
+            "slot": 340012,
+            "signature": "SIGCLITASKCOMPLETED-34",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000034002
+          },
+          {
+            "seq": 106,
+            "slot": 350010,
+            "signature": "SIGCLITASKCREATED-35",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000035000
+          },
+          {
+            "seq": 107,
+            "slot": 350011,
+            "signature": "SIGCLITASKCLAIMED-35",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000035001
+          },
+          {
+            "seq": 108,
+            "slot": 350012,
+            "signature": "SIGCLITASKCOMPLETED-35",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000035002
+          },
+          {
+            "seq": 109,
+            "slot": 360010,
+            "signature": "SIGCLITASKCREATED-36",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000036000
+          },
+          {
+            "seq": 110,
+            "slot": 360011,
+            "signature": "SIGCLITASKCLAIMED-36",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000036001
+          },
+          {
+            "seq": 111,
+            "slot": 360012,
+            "signature": "SIGCLITASKCOMPLETED-36",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000036002
+          },
+          {
+            "seq": 112,
+            "slot": 370010,
+            "signature": "SIGCLITASKCREATED-37",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000037000
+          },
+          {
+            "seq": 113,
+            "slot": 370011,
+            "signature": "SIGCLITASKCLAIMED-37",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000037001
+          },
+          {
+            "seq": 114,
+            "slot": 370012,
+            "signature": "SIGCLITASKCOMPLETED-37",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000037002
+          },
+          {
+            "seq": 115,
+            "slot": 380010,
+            "signature": "SIGCLITASKCREATED-38",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000038000
+          },
+          {
+            "seq": 116,
+            "slot": 380011,
+            "signature": "SIGCLITASKCLAIMED-38",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000038001
+          },
+          {
+            "seq": 117,
+            "slot": 380012,
+            "signature": "SIGCLITASKCOMPLETED-38",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000038002
+          },
+          {
+            "seq": 118,
+            "slot": 390010,
+            "signature": "SIGCLITASKCREATED-39",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000039000
+          },
+          {
+            "seq": 119,
+            "slot": 390011,
+            "signature": "SIGCLITASKCLAIMED-39",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000039001
+          },
+          {
+            "seq": 120,
+            "slot": 390012,
+            "signature": "SIGCLITASKCOMPLETED-39",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000039002
+          },
+          {
+            "seq": 121,
+            "slot": 400010,
+            "signature": "SIGCLITASKCREATED-40",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000040000
+          },
+          {
+            "seq": 122,
+            "slot": 400011,
+            "signature": "SIGCLITASKCLAIMED-40",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000040001
+          },
+          {
+            "seq": 123,
+            "slot": 400012,
+            "signature": "SIGCLITASKCOMPLETED-40",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000040002
+          },
+          {
+            "seq": 124,
+            "slot": 410010,
+            "signature": "SIGCLITASKCREATED-41",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000041000
+          },
+          {
+            "seq": 125,
+            "slot": 410011,
+            "signature": "SIGCLITASKCLAIMED-41",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000041001
+          },
+          {
+            "seq": 126,
+            "slot": 410012,
+            "signature": "SIGCLITASKCOMPLETED-41",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000041002
+          },
+          {
+            "seq": 127,
+            "slot": 420010,
+            "signature": "SIGCLITASKCREATED-42",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000042000
+          },
+          {
+            "seq": 128,
+            "slot": 420011,
+            "signature": "SIGCLITASKCLAIMED-42",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000042001
+          },
+          {
+            "seq": 129,
+            "slot": 420012,
+            "signature": "SIGCLITASKCOMPLETED-42",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000042002
+          },
+          {
+            "seq": 130,
+            "slot": 430010,
+            "signature": "SIGCLITASKCREATED-43",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000043000
+          },
+          {
+            "seq": 131,
+            "slot": 430011,
+            "signature": "SIGCLITASKCLAIMED-43",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000043001
+          },
+          {
+            "seq": 132,
+            "slot": 430012,
+            "signature": "SIGCLITASKCOMPLETED-43",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000043002
+          },
+          {
+            "seq": 133,
+            "slot": 440010,
+            "signature": "SIGCLITASKCREATED-44",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000044000
+          },
+          {
+            "seq": 134,
+            "slot": 440011,
+            "signature": "SIGCLITASKCLAIMED-44",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000044001
+          },
+          {
+            "seq": 135,
+            "slot": 440012,
+            "signature": "SIGCLITASKCOMPLETED-44",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000044002
+          },
+          {
+            "seq": 136,
+            "slot": 450010,
+            "signature": "SIGCLITASKCREATED-45",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000045000
+          },
+          {
+            "seq": 137,
+            "slot": 450011,
+            "signature": "SIGCLITASKCLAIMED-45",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000045001
+          },
+          {
+            "seq": 138,
+            "slot": 450012,
+            "signature": "SIGCLITASKCOMPLETED-45",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000045002
+          },
+          {
+            "seq": 139,
+            "slot": 460010,
+            "signature": "SIGCLITASKCREATED-46",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000046000
+          },
+          {
+            "seq": 140,
+            "slot": 460011,
+            "signature": "SIGCLITASKCLAIMED-46",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000046001
+          },
+          {
+            "seq": 141,
+            "slot": 460012,
+            "signature": "SIGCLITASKCOMPLETED-46",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000046002
+          },
+          {
+            "seq": 142,
+            "slot": 470010,
+            "signature": "SIGCLITASKCREATED-47",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000047000
+          },
+          {
+            "seq": 143,
+            "slot": 470011,
+            "signature": "SIGCLITASKCLAIMED-47",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000047001
+          },
+          {
+            "seq": 144,
+            "slot": 470012,
+            "signature": "SIGCLITASKCOMPLETED-47",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000047002
+          },
+          {
+            "seq": 145,
+            "slot": 480010,
+            "signature": "SIGCLITASKCREATED-48",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000048000
+          },
+          {
+            "seq": 146,
+            "slot": 480011,
+            "signature": "SIGCLITASKCLAIMED-48",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000048001
+          },
+          {
+            "seq": 147,
+            "slot": 480012,
+            "signature": "SIGCLITASKCOMPLETED-48",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000048002
+          },
+          {
+            "seq": 148,
+            "slot": 490010,
+            "signature": "SIGCLITASKCREATED-49",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000049000
+          },
+          {
+            "seq": 149,
+            "slot": 490011,
+            "signature": "SIGCLITASKCLAIMED-49",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000049001
+          },
+          {
+            "seq": 150,
+            "slot": 490012,
+            "signature": "SIGCLITASKCOMPLETED-49",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000049002
+          },
+          {
+            "seq": 151,
+            "slot": 500010,
+            "signature": "SIGCLITASKCREATED-50",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000050000
+          },
+          {
+            "seq": 152,
+            "slot": 500011,
+            "signature": "SIGCLITASKCLAIMED-50",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000050001
+          },
+          {
+            "seq": 153,
+            "slot": 500012,
+            "signature": "SIGCLITASKCOMPLETED-50",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000050002
+          },
+          {
+            "seq": 154,
+            "slot": 510010,
+            "signature": "SIGCLITASKCREATED-51",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000051000
+          },
+          {
+            "seq": 155,
+            "slot": 510011,
+            "signature": "SIGCLITASKCLAIMED-51",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000051001
+          },
+          {
+            "seq": 156,
+            "slot": 510012,
+            "signature": "SIGCLITASKCOMPLETED-51",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000051002
+          },
+          {
+            "seq": 157,
+            "slot": 520010,
+            "signature": "SIGCLITASKCREATED-52",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000052000
+          },
+          {
+            "seq": 158,
+            "slot": 520011,
+            "signature": "SIGCLITASKCLAIMED-52",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000052001
+          },
+          {
+            "seq": 159,
+            "slot": 520012,
+            "signature": "SIGCLITASKCOMPLETED-52",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000052002
+          },
+          {
+            "seq": 160,
+            "slot": 530010,
+            "signature": "SIGCLITASKCREATED-53",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000053000
+          },
+          {
+            "seq": 161,
+            "slot": 530011,
+            "signature": "SIGCLITASKCLAIMED-53",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000053001
+          },
+          {
+            "seq": 162,
+            "slot": 530012,
+            "signature": "SIGCLITASKCOMPLETED-53",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000053002
+          },
+          {
+            "seq": 163,
+            "slot": 540010,
+            "signature": "SIGCLITASKCREATED-54",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000054000
+          },
+          {
+            "seq": 164,
+            "slot": 540011,
+            "signature": "SIGCLITASKCLAIMED-54",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000054001
+          },
+          {
+            "seq": 165,
+            "slot": 540012,
+            "signature": "SIGCLITASKCOMPLETED-54",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000054002
+          },
+          {
+            "seq": 166,
+            "slot": 550010,
+            "signature": "SIGCLITASKCREATED-55",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000055000
+          },
+          {
+            "seq": 167,
+            "slot": 550011,
+            "signature": "SIGCLITASKCLAIMED-55",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000055001
+          },
+          {
+            "seq": 168,
+            "slot": 550012,
+            "signature": "SIGCLITASKCOMPLETED-55",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000055002
+          },
+          {
+            "seq": 169,
+            "slot": 560010,
+            "signature": "SIGCLITASKCREATED-56",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000056000
+          },
+          {
+            "seq": 170,
+            "slot": 560011,
+            "signature": "SIGCLITASKCLAIMED-56",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000056001
+          },
+          {
+            "seq": 171,
+            "slot": 560012,
+            "signature": "SIGCLITASKCOMPLETED-56",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000056002
+          },
+          {
+            "seq": 172,
+            "slot": 570010,
+            "signature": "SIGCLITASKCREATED-57",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000057000
+          },
+          {
+            "seq": 173,
+            "slot": 570011,
+            "signature": "SIGCLITASKCLAIMED-57",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000057001
+          },
+          {
+            "seq": 174,
+            "slot": 570012,
+            "signature": "SIGCLITASKCOMPLETED-57",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000057002
+          },
+          {
+            "seq": 175,
+            "slot": 580010,
+            "signature": "SIGCLITASKCREATED-58",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000058000
+          },
+          {
+            "seq": 176,
+            "slot": 580011,
+            "signature": "SIGCLITASKCLAIMED-58",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000058001
+          },
+          {
+            "seq": 177,
+            "slot": 580012,
+            "signature": "SIGCLITASKCOMPLETED-58",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000058002
+          },
+          {
+            "seq": 178,
+            "slot": 590010,
+            "signature": "SIGCLITASKCREATED-59",
+            "sourceEventType": "discovered",
+            "sourceEventName": "taskCreated",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000059000
+          },
+          {
+            "seq": 179,
+            "slot": 590011,
+            "signature": "SIGCLITASKCLAIMED-59",
+            "sourceEventType": "claimed",
+            "sourceEventName": "taskClaimed",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000059001
+          },
+          {
+            "seq": 180,
+            "slot": 590012,
+            "signature": "SIGCLITASKCOMPLETED-59",
+            "sourceEventType": "completed",
+            "sourceEventName": "taskCompleted",
+            "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "timestampMs": 1000000059002
+          }
+        ],
+        "deterministicHash": "bca58fe16eb505dd17d37d754c2b4c831045ae023e0ff16c0cc6226723a18a6e",
+        "eventType": "replay-incidents"
+      },
+      "validation": {
+        "strictMode": false,
+        "eventValidation": {
+          "errors": [],
+          "warnings": [],
+          "replayTaskCount": 1
+        },
+        "anomalyIds": []
+      },
+      "narrative": {
+        "lines": [
+          "1/10/SIGCLITASKCREATED-0: taskCreated (discovered)",
+          "2/11/SIGCLITASKCLAIMED-0: taskClaimed (claimed)",
+          "3/12/SIGCLITASKCOMPLETED-0: taskCompleted (completed)",
+          "4/10010/SIGCLITASKCREATED-1: taskCreated (discovered)",
+          "5/10011/SIGCLITASKCLAIMED-1: taskClaimed (claimed)",
+          "6/10012/SIGCLITASKCOMPLETED-1: taskCompleted (completed)",
+          "7/20010/SIGCLITASKCREATED-2: taskCreated (discovered)",
+          "8/20011/SIGCLITASKCLAIMED-2: taskClaimed (claimed)",
+          "9/20012/SIGCLITASKCOMPLETED-2: taskCompleted (completed)",
+          "10/30010/SIGCLITASKCREATED-3: taskCreated (discovered)",
+          "11/30011/SIGCLITASKCLAIMED-3: taskClaimed (claimed)",
+          "12/30012/SIGCLITASKCOMPLETED-3: taskCompleted (completed)",
+          "13/40010/SIGCLITASKCREATED-4: taskCreated (discovered)",
+          "14/40011/SIGCLITASKCLAIMED-4: taskClaimed (claimed)",
+          "15/40012/SIGCLITASKCOMPLETED-4: taskCompleted (completed)",
+          "16/50010/SIGCLITASKCREATED-5: taskCreated (discovered)",
+          "17/50011/SIGCLITASKCLAIMED-5: taskClaimed (claimed)",
+          "18/50012/SIGCLITASKCOMPLETED-5: taskCompleted (completed)",
+          "19/60010/SIGCLITASKCREATED-6: taskCreated (discovered)",
+          "20/60011/SIGCLITASKCLAIMED-6: taskClaimed (claimed)",
+          "21/60012/SIGCLITASKCOMPLETED-6: taskCompleted (completed)",
+          "22/70010/SIGCLITASKCREATED-7: taskCreated (discovered)",
+          "23/70011/SIGCLITASKCLAIMED-7: taskClaimed (claimed)",
+          "24/70012/SIGCLITASKCOMPLETED-7: taskCompleted (completed)",
+          "25/80010/SIGCLITASKCREATED-8: taskCreated (discovered)",
+          "26/80011/SIGCLITASKCLAIMED-8: taskClaimed (claimed)",
+          "27/80012/SIGCLITASKCOMPLETED-8: taskCompleted (completed)",
+          "28/90010/SIGCLITASKCREATED-9: taskCreated (discovered)",
+          "29/90011/SIGCLITASKCLAIMED-9: taskClaimed (claimed)",
+          "30/90012/SIGCLITASKCOMPLETED-9: taskCompleted (completed)",
+          "31/100010/SIGCLITASKCREATED-10: taskCreated (discovered)",
+          "32/100011/SIGCLITASKCLAIMED-10: taskClaimed (claimed)",
+          "33/100012/SIGCLITASKCOMPLETED-10: taskCompleted (completed)",
+          "34/110010/SIGCLITASKCREATED-11: taskCreated (discovered)",
+          "35/110011/SIGCLITASKCLAIMED-11: taskClaimed (claimed)",
+          "36/110012/SIGCLITASKCOMPLETED-11: taskCompleted (completed)",
+          "37/120010/SIGCLITASKCREATED-12: taskCreated (discovered)",
+          "38/120011/SIGCLITASKCLAIMED-12: taskClaimed (claimed)",
+          "39/120012/SIGCLITASKCOMPLETED-12: taskCompleted (completed)",
+          "40/130010/SIGCLITASKCREATED-13: taskCreated (discovered)"
+        ],
+        "anomalyIds": []
+      }
+    }
+  },
+  "metadata": {
+    "generatedAt": "2026-02-14T20:17:05.686Z",
+    "generatedBy": "contract-validator"
+  }
+}

--- a/runtime/tests/helpers/contract-validator.ts
+++ b/runtime/tests/helpers/contract-validator.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { expect } from 'vitest';
+
+export interface GoldenContractSnapshot<TInput = Record<string, unknown>, TOutput = Record<string, unknown>> {
+  id: string;
+  version: number;
+  command: string;
+  input: TInput;
+  output: {
+    schema: string;
+    shape: TOutput;
+  };
+  metadata: {
+    generatedAt: string;
+    generatedBy: string;
+  };
+}
+
+export interface ContractCase<TInput, TOutput> {
+  id: string;
+  command: string;
+  fixturePath: string;
+  outputSchema: string;
+  expectedStatus: 'ok' | 'error';
+  requiredTopLevelKeys: ReadonlyArray<string>;
+  optionalTopLevelKeys?: ReadonlyArray<string>;
+  input: TInput;
+  execute: (input: TInput) => Promise<unknown>;
+  shape: (output: unknown) => TOutput;
+}
+
+const UPDATE_GOLDENS = process.env.UPDATE_GOLDENS === '1';
+const SNAPSHOT_VERSION = 1;
+
+export function loadGoldenSnapshot<TInput = Record<string, unknown>, TOutput = Record<string, unknown>>(
+  path: string,
+): GoldenContractSnapshot<TInput, TOutput> {
+  const raw = readFileSync(path, 'utf8');
+  return JSON.parse(raw) as GoldenContractSnapshot<TInput, TOutput>;
+}
+
+function writeGoldenSnapshot<TInput, TOutput>(
+  path: string,
+  snapshot: GoldenContractSnapshot<TInput, TOutput>,
+): void {
+  const normalized = JSON.stringify(snapshot, null, 2) + '\n';
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, normalized, 'utf8');
+}
+
+function assertTopLevelKeys(
+  value: unknown,
+  requiredKeys: readonly string[],
+  optionalKeys: readonly string[] = [],
+  command: string,
+): void {
+  expect(value).toBeTypeOf('object');
+  expect(value).toBeTruthy();
+
+  const payload = value as Record<string, unknown>;
+  const allowedKeys = new Set([...requiredKeys, ...optionalKeys, 'command']);
+  const actualKeys = Object.keys(payload).sort();
+
+  for (const key of requiredKeys) {
+    expect(actualKeys).toContain(key);
+  }
+
+  for (const key of actualKeys) {
+    if (key === 'command') {
+      expect(typeof payload.command, `${command}: command should be a string`).toBe('string');
+      continue;
+    }
+
+    expect(
+      allowedKeys.has(key),
+      `${command}: unexpected top-level key: ${key}`,
+    ).toBe(true);
+  }
+}
+
+export async function runContractCase<TInput, TOutput>(
+  testCase: ContractCase<TInput, TOutput>,
+): Promise<void> {
+  const rawOutput = await testCase.execute(testCase.input);
+  expect(rawOutput).toBeTypeOf('object');
+  expect(rawOutput).not.toBeNull();
+
+  const payload = rawOutput as Record<string, unknown>;
+
+  assertTopLevelKeys(
+    rawOutput,
+    testCase.requiredTopLevelKeys,
+    testCase.optionalTopLevelKeys,
+    testCase.command,
+  );
+  expect(payload.status).toBe(testCase.expectedStatus);
+
+  const shape = testCase.shape(rawOutput);
+  const snapshot = {
+    id: testCase.id,
+    version: SNAPSHOT_VERSION,
+    command: testCase.command,
+    input: testCase.input,
+    output: {
+      schema: testCase.outputSchema,
+      shape,
+    },
+    metadata: {
+      generatedAt: new Date().toISOString(),
+      generatedBy: 'contract-validator',
+    },
+  } as const;
+
+  if (UPDATE_GOLDENS) {
+    writeGoldenSnapshot(testCase.fixturePath, snapshot);
+    return;
+  }
+
+  const expected = loadGoldenSnapshot<TInput, TOutput>(testCase.fixturePath);
+  expect(expected.id).toBe(testCase.id);
+  expect(expected.version).toBe(SNAPSHOT_VERSION);
+  expect(expected.command).toBe(testCase.command);
+  expect(expected.output.schema).toBe(testCase.outputSchema);
+  expect(expected.output.shape).toEqual(shape);
+}

--- a/sdk/src/__tests__/contract.test.ts
+++ b/sdk/src/__tests__/contract.test.ts
@@ -1,0 +1,236 @@
+import * as fs from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import {
+  createTask,
+  claimTask,
+  completeTask,
+  getTask,
+  generateProof,
+  deriveTokenEscrowAddress,
+} from '../index.js';
+import { getAssociatedTokenAddressSync } from '@solana/spl-token';
+import { TaskState, PROGRAM_ID } from '../constants.js';
+import { getAccount } from '../anchor-utils.js';
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+const mockFullProve = vi.fn();
+
+vi.mock('snarkjs', () => ({
+  default: {
+    groth16: {
+      fullProve: mockFullProve,
+    },
+  },
+  groth16: {
+    fullProve: mockFullProve,
+  },
+}));
+
+vi.mock('../anchor-utils.js', () => ({
+  getAccount: vi.fn(),
+}));
+
+function makeKeypair(seed: number): Keypair {
+  const bytes = new Uint8Array(32);
+  bytes.fill(seed);
+  return Keypair.fromSeed(bytes);
+}
+
+function makeProgram(methodNames: string[], rpcValue: string): unknown {
+  const builder = {
+    accountsPartial: vi.fn().mockReturnThis(),
+    signers: vi.fn().mockReturnThis(),
+    rpc: vi.fn().mockResolvedValue(rpcValue),
+  };
+
+  const methods: Record<string, (..._args: unknown[]) => unknown> = {};
+  for (const methodName of methodNames) {
+    methods[methodName] = vi.fn().mockReturnValue(builder);
+  }
+
+  return {
+    methods,
+    programId: PROGRAM_ID,
+  };
+}
+
+function mockGetAccount(data: unknown): void {
+  vi.mocked(getAccount).mockReturnValueOnce({
+    fetch: vi.fn().mockResolvedValue(data),
+  } as never);
+}
+
+const createPublicKeySeeded = (seed: number): PublicKey => {
+  const bytes = new Uint8Array(32);
+  bytes.fill(seed);
+  return new PublicKey(bytes);
+};
+
+describe('SDK contract tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+  });
+
+  it('returns stable contract for createTask', async () => {
+    const connection = { confirmTransaction: vi.fn() } as unknown as Connection;
+    const program = makeProgram(['createTask'], 'tx-create-task') as never;
+    const creator = makeKeypair(1);
+    const creatorId = new Uint8Array(32);
+    creatorId.fill(1);
+
+    const result = await createTask(
+      connection,
+      program as never,
+      creator,
+      creatorId,
+      {
+        taskId: new Uint8Array(32),
+        requiredCapabilities: 1,
+        description: new Uint8Array(64),
+        rewardAmount: 1,
+        maxWorkers: 1,
+        deadline: 1,
+        taskType: 0,
+        constraintHash: undefined,
+        minReputation: 0,
+      },
+    );
+
+    expect(result).toHaveProperty('taskPda');
+    expect(result.taskPda).toBeInstanceOf(PublicKey);
+    expect(result).toHaveProperty('txSignature', 'tx-create-task');
+    expect(typeof result.txSignature).toBe('string');
+    expect(result.txSignature).toBe('tx-create-task');
+  });
+
+  it('returns stable contract for claimTask', async () => {
+    const connection = { confirmTransaction: vi.fn() } as unknown as Connection;
+    const program = makeProgram(['claimTask'], 'tx-claim-task') as never;
+    const worker = makeKeypair(2);
+    const taskPda = createPublicKeySeeded(3);
+    const workerId = new Uint8Array(32);
+    workerId.fill(2);
+
+    const result = await claimTask(
+      connection,
+      program as never,
+      worker,
+      workerId,
+      taskPda,
+    );
+
+    expect(result).toEqual({ txSignature: 'tx-claim-task' });
+    expect(result.txSignature).toMatch(/\S+/);
+  });
+
+  it('returns stable contract for completeTask', async () => {
+    const connection = { confirmTransaction: vi.fn() } as unknown as Connection;
+    const program = makeProgram(['completeTask'], 'tx-complete-task') as never;
+    const worker = makeKeypair(3);
+    const taskPda = createPublicKeySeeded(4);
+    const workerId = new Uint8Array(32);
+    workerId.fill(3);
+
+    mockGetAccount({
+      creator: createPublicKeySeeded(5),
+      rewardMint: null,
+    } as never);
+    mockGetAccount({
+      treasury: createPublicKeySeeded(6),
+    } as never);
+
+    const result = await completeTask(
+      connection,
+      program as never,
+      worker,
+      workerId,
+      taskPda,
+      new Uint8Array(32),
+    );
+
+    expect(result).toEqual({ txSignature: 'tx-complete-task' });
+    expect(result.txSignature).toMatch(/\S+/);
+  });
+
+  it('returns stable TaskStatus contract for getTask', async () => {
+    const taskPda = createPublicKeySeeded(7);
+    const creator = createPublicKeySeeded(8);
+    const constraintHash = new Uint8Array([9, 8, 7, 6]);
+
+    mockGetAccount({
+      taskId: new Uint8Array(32),
+      status: { open: {} },
+      creator,
+      rewardAmount: { toString: () => '42' },
+      deadline: { toNumber: () => 1_234_567 },
+      constraintHash,
+      currentWorkers: 1,
+      maxWorkers: 2,
+      completedAt: null,
+      rewardMint: null,
+    } as never);
+
+    const status = await getTask(
+      { rpc: () => Promise.resolve('ok') } as never,
+      taskPda,
+    );
+
+    expect(status).not.toBeNull();
+    expect(status).toMatchObject({
+      taskId: new Uint8Array(32),
+      state: TaskState.Open,
+      creator,
+      rewardAmount: 42n,
+      deadline: 1_234_567,
+      currentWorkers: 1,
+      maxWorkers: 2,
+      completedAt: null,
+      rewardMint: null,
+      constraintHash,
+    });
+  });
+
+  it('returns stable ProofResult contract for generateProof', async () => {
+    mockFullProve.mockResolvedValue({
+      proof: {
+        pi_a: ['1', '2'],
+        pi_b: [['3', '4'], ['5', '6']],
+        pi_c: ['7', '8'],
+      },
+    } as never);
+
+    const result = await generateProof({
+      taskPda: createPublicKeySeeded(9),
+      agentPubkey: createPublicKeySeeded(10),
+      output: [1n, 2n, 3n, 4n],
+      salt: 7n,
+      circuitPath: 'circuits-circom/task_completion',
+    });
+
+    expect(result).toMatchObject({
+      proof: expect.any(Buffer),
+      constraintHash: expect.any(Buffer),
+      outputCommitment: expect.any(Buffer),
+      expectedBinding: expect.any(Buffer),
+      proofSize: 256,
+      generationTime: expect.any(Number),
+    });
+    expect(result.generationTime).toBeGreaterThanOrEqual(0);
+  });
+
+  it('returns stable contract for deriveTokenEscrowAddress', () => {
+    const mint = createPublicKeySeeded(11);
+    const escrow = createPublicKeySeeded(12);
+    const expected = getAssociatedTokenAddressSync(mint, escrow, true);
+
+    const result = deriveTokenEscrowAddress(mint, escrow);
+
+    expect(result).toBeInstanceOf(PublicKey);
+    expect(result.toBase58()).toBe(expected.toBase58());
+  });
+});


### PR DESCRIPTION
## Summary
- Added generic contract snapshot validator for CLI and MCP tests
- Added CLI replay contract tests for backfill, compare, and incident with success/failure fixtures
- Added MCP replay tool contract tests for backfill, compare, incident, and status with truncation/empty-store coverage
- Added SDK contract tests for task lifecycle and proof APIs and created required golden fixtures

## Test plan
- [x] runtime 
- [x] 
- [x] 
 RUN  v2.1.9 /home/tetsuo/git/AgenC/sdk

 ✓ src/__tests__/contract.test.ts (6 tests) 28ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  13:24:42
   Duration  502ms (transform 108ms, setup 0ms, collect 274ms, tests 28ms, environment 0ms, prepare 32ms)

Closes #988