### PR TITLE
fix(runtime): add plugin manifest validation module

### DIFF
--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -27,6 +27,19 @@ export {
   SkillAlreadyRegisteredError,
 } from './errors.js';
 
+// Plugin manifests and governance
+export {
+  type PluginManifest,
+  type PluginPermission,
+  type PluginAllowDeny,
+  type PluginsConfig,
+  type ManifestValidationError,
+  PluginManifestError,
+  validatePluginManifest,
+  validatePluginsConfig,
+  getPluginConfigHints,
+} from './manifest.js';
+
 // Registry
 export { SkillRegistry } from './registry.js';
 

--- a/runtime/src/skills/manifest.test.ts
+++ b/runtime/src/skills/manifest.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PluginManifestError,
+  type PluginManifest,
+  type PluginsConfig,
+  getPluginConfigHints,
+  validatePluginManifest,
+  validatePluginsConfig,
+} from './manifest.js';
+
+function createManifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: 'agenc.memory.redis',
+    version: '1.0.0',
+    schemaVersion: 1,
+    displayName: 'Redis memory plugin',
+    description: 'Persistent memory plugin integration',
+    labels: ['memory', 'storage'],
+    requiredCapabilities: '0x1',
+    permissions: [
+      {
+        type: 'tool_call',
+        scope: 'memory.get',
+        required: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('validatePluginManifest', () => {
+  it('passes for a valid manifest', () => {
+    expect(validatePluginManifest(createManifest())).toEqual([]);
+  });
+
+  it('reports missing id', () => {
+    const manifest = createManifest({ id: '' as string });
+    expect(validatePluginManifest(manifest)).toEqual([
+      {
+        pluginId: '',
+        field: 'id',
+        message: 'Plugin id is required and must be a non-empty string',
+        value: '',
+      },
+    ]);
+  });
+
+  it('reports invalid id pattern', () => {
+    const manifest = createManifest({ id: '123-bad' });
+    expect(validatePluginManifest(manifest)).toEqual([
+      {
+        pluginId: '123-bad',
+        field: 'id',
+        message: 'Plugin id must match pattern: ^[a-z][a-z0-9._-]*$',
+        value: '123-bad',
+      },
+    ]);
+  });
+
+  it('reports missing version', () => {
+    const manifest = createManifest({ version: '' as string });
+    expect(validatePluginManifest(manifest)).toEqual([
+      {
+        pluginId: 'agenc.memory.redis',
+        field: 'version',
+        message: 'Version is required',
+        value: '',
+      },
+    ]);
+  });
+
+  it('reports invalid schemaVersion', () => {
+    const manifest = createManifest({ schemaVersion: 0 });
+    expect(validatePluginManifest(manifest)).toEqual([
+      {
+        pluginId: 'agenc.memory.redis',
+        field: 'schemaVersion',
+        message: 'schemaVersion must be a positive integer',
+        value: 0,
+      },
+    ]);
+  });
+
+  it('reports non-array labels', () => {
+    const manifest = createManifest({ labels: 'not-array' as unknown as string[] });
+    expect(validatePluginManifest(manifest)).toEqual([
+      {
+        pluginId: 'agenc.memory.redis',
+        field: 'labels',
+        message: 'labels must be an array of strings',
+        value: 'not-array',
+      },
+    ]);
+  });
+
+  it('reports invalid permission type', () => {
+    const manifest = createManifest({
+      permissions: [
+        {
+          type: 'admin' as 'tool_call',
+          scope: 'tool',
+          required: true,
+        },
+      ],
+    });
+
+    expect(validatePluginManifest(manifest)).toEqual([
+      {
+        pluginId: 'agenc.memory.redis',
+        field: 'permissions[0].type',
+        message: 'Permission type must be one of: tool_call, network, filesystem, wallet_sign',
+        value: 'admin',
+      },
+    ]);
+  });
+
+  it('reports missing permission scope', () => {
+    const manifest = createManifest({
+      permissions: [
+        {
+          type: 'tool_call',
+          scope: undefined as unknown as string,
+          required: true,
+        },
+      ],
+    });
+
+    expect(validatePluginManifest(manifest)).toEqual([
+      {
+        pluginId: 'agenc.memory.redis',
+        field: 'permissions[0].scope',
+        message: 'Permission scope must be a string',
+        value: undefined,
+      },
+    ]);
+  });
+});
+
+describe('validatePluginsConfig', () => {
+  it('passes empty config', () => {
+    expect(validatePluginsConfig({ entries: {} })).toEqual([]);
+  });
+
+  it('reports undeclared allow-list plugin id', () => {
+    const config = { entries: {}, allow: ['nonexistent'] } as unknown as PluginsConfig;
+    expect(validatePluginsConfig(config)).toEqual([
+      {
+        pluginId: 'nonexistent',
+        field: 'allow',
+        message: 'Plugin "nonexistent" in allow list is not declared in entries',
+      },
+    ]);
+  });
+
+  it('reports undeclared deny-list plugin id', () => {
+    const config = { entries: {}, deny: ['nonexistent'] } as unknown as PluginsConfig;
+    expect(validatePluginsConfig(config)).toEqual([
+      {
+        pluginId: 'nonexistent',
+        field: 'deny',
+        message: 'Plugin "nonexistent" in deny list is not declared in entries',
+      },
+    ]);
+  });
+
+  it('reports manifest key mismatch', () => {
+    const config = {
+      entries: {
+        foo: createManifest({ id: 'bar' }),
+      },
+    } as unknown as PluginsConfig;
+
+    expect(validatePluginsConfig(config)).toContainEqual({
+      pluginId: 'foo',
+      field: 'id',
+      message: 'Manifest id "bar" does not match config key "foo"',
+    });
+  });
+});
+
+describe('manifest helper behavior', () => {
+  it('exposes structured errors via PluginManifestError', () => {
+    const errors = [
+      {
+        pluginId: 'foo',
+        field: 'id',
+        message: 'Plugin id is required',
+      },
+    ];
+    const err = new PluginManifestError(errors);
+
+    expect(err.name).toBe('PluginManifestError');
+    expect(err.errors).toEqual(errors);
+  });
+
+  it('builds plugin config hints', () => {
+    const config = {
+      entries: {
+        alpha: createManifest({
+          id: 'alpha',
+          displayName: 'Alpha',
+          labels: ['alpha'],
+          permissions: [],
+          allowDeny: { allow: ['memory:*'] },
+        }),
+        beta: createManifest({
+          id: 'beta',
+          displayName: 'Beta',
+          labels: ['beta'],
+          permissions: [{ type: 'network', scope: 'https://example.com', required: false }],
+          allowDeny: { deny: ['network.*'] },
+        }),
+      },
+      allow: ['alpha'],
+      deny: ['beta'],
+    } as PluginsConfig;
+
+    const hints = getPluginConfigHints(config);
+    const alpha = hints.find((hint) => hint.pluginId === 'alpha');
+    const beta = hints.find((hint) => hint.pluginId === 'beta');
+
+    expect(alpha).toEqual({
+      pluginId: 'alpha',
+      displayName: 'Alpha',
+      labels: ['alpha'],
+      hasPermissions: false,
+      isAllowed: true,
+      isDenied: false,
+    });
+    expect(beta).toEqual({
+      pluginId: 'beta',
+      displayName: 'Beta',
+      labels: ['beta'],
+      hasPermissions: true,
+      isAllowed: false,
+      isDenied: true,
+    });
+  });
+
+  it('captures malformed manifest regression fixture without false positives', () => {
+    const result = validatePluginManifest({
+      id: '123-bad',
+      version: '',
+      schemaVersion: 0,
+      displayName: '',
+      labels: ['good'],
+      permissions: [
+        { type: 'admin', scope: 123, required: 'true' },
+      ],
+    } as unknown);
+
+    expect(result).toHaveLength(7);
+    expect(result).toEqual([
+      {
+        pluginId: '123-bad',
+        field: 'id',
+        message: 'Plugin id must match pattern: ^[a-z][a-z0-9._-]*$',
+        value: '123-bad',
+      },
+      {
+        pluginId: '123-bad',
+        field: 'version',
+        message: 'Version is required',
+        value: '',
+      },
+      {
+        pluginId: '123-bad',
+        field: 'schemaVersion',
+        message: 'schemaVersion must be a positive integer',
+        value: 0,
+      },
+      {
+        pluginId: '123-bad',
+        field: 'displayName',
+        message: 'displayName is required',
+        value: '',
+      },
+      {
+        pluginId: '123-bad',
+        field: 'permissions[0].scope',
+        message: 'Permission scope must be a string',
+        value: 123,
+      },
+      {
+        pluginId: '123-bad',
+        field: 'permissions[0].required',
+        message: 'Permission required flag must be a boolean',
+        value: 'true',
+      },
+      {
+        pluginId: '123-bad',
+        field: 'permissions[0].type',
+        message: 'Permission type must be one of: tool_call, network, filesystem, wallet_sign',
+        value: 'admin',
+      },
+    ]);
+  });
+});

--- a/runtime/src/skills/manifest.ts
+++ b/runtime/src/skills/manifest.ts
@@ -1,0 +1,383 @@
+/**
+ * Plugin manifest types and validation helpers for the runtime skill ecosystem.
+ *
+ * @module
+ */
+
+/** Permission a plugin requests. */
+export interface PluginPermission {
+  /** Permission type. */
+  type: 'tool_call' | 'network' | 'filesystem' | 'wallet_sign';
+
+  /** Scope this permission applies to. */
+  scope: string;
+
+  /** Whether the permission is required to run this plugin. */
+  required: boolean;
+}
+
+/** Allow/deny rules for plugin actions. */
+export interface PluginAllowDeny {
+  /** Allowed action names. Empty means allow all. */
+  allow?: string[];
+  /** Denied action names. Deny list takes precedence over allow. */
+  deny?: string[];
+}
+
+/** Plugin manifest schema for governance. */
+export interface PluginManifest {
+  /** Unique plugin identifier (namespaced, e.g. 'agenc.memory.redis'). */
+  id: string;
+  /** Semantic version. */
+  version: string;
+  /** Schema compatibility version. */
+  schemaVersion: number;
+  /** Human-readable display name. */
+  displayName: string;
+  /** Description text for operators. */
+  description?: string;
+  /** Labels used for discovery and policy UI. */
+  labels: string[];
+  /** Optional capability requirements as bigint string. */
+  requiredCapabilities?: string;
+  /** Permissions the plugin requires. */
+  permissions: PluginPermission[];
+  /** Optional allow/deny metadata for plugin action gating. */
+  allowDeny?: PluginAllowDeny;
+}
+
+/** Config section for plugin governance. */
+export interface PluginsConfig {
+  /** Plugin manifests keyed by plugin ID. */
+  entries: Record<string, PluginManifest>;
+  /** Optional allow-list of plugin IDs. */
+  allow?: string[];
+  /** Optional deny-list of plugin IDs. */
+  deny?: string[];
+}
+
+/** Validation issue for a manifest or config value. */
+export interface ManifestValidationError {
+  /** Plugin identifier associated with the error. */
+  pluginId: string;
+  /** Field path where validation failed. */
+  field: string;
+  /** Human-readable validation message. */
+  message: string;
+  /** Optional raw value for debugging. */
+  value?: unknown;
+}
+
+/** Error raised when plugin manifests/config fail validation. */
+export class PluginManifestError extends Error {
+  /** Structured validation errors collected during checks. */
+  public readonly errors: readonly ManifestValidationError[];
+
+  constructor(errors: readonly ManifestValidationError[]) {
+    super(
+      `Plugin manifest validation failed: ${errors
+        .map((entry) => `[${entry.pluginId}] ${entry.message}`)
+        .join('; ')}`,
+    );
+    this.name = 'PluginManifestError';
+    this.errors = errors;
+  }
+}
+
+const VALID_PLUGIN_ID = /^[a-z][a-z0-9._-]*$/;
+
+const VALID_PERMISSION_TYPES = ['tool_call', 'network', 'filesystem', 'wallet_sign'];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+/**
+ * Validate a single plugin manifest and return structured errors.
+ */
+export function validatePluginManifest(manifest: unknown): ManifestValidationError[] {
+  const errors: ManifestValidationError[] = [];
+
+  if (!isRecord(manifest)) {
+    errors.push({
+      pluginId: 'unknown',
+      field: 'root',
+      message: 'Manifest must be an object',
+      value: manifest,
+    });
+    return errors;
+  }
+
+  const pluginId = typeof manifest.id === 'string' ? manifest.id : 'unknown';
+
+  if (typeof manifest.id !== 'string' || manifest.id.length === 0) {
+    errors.push({
+      pluginId,
+      field: 'id',
+      message: 'Plugin id is required and must be a non-empty string',
+      value: manifest.id,
+    });
+  } else if (!VALID_PLUGIN_ID.test(manifest.id)) {
+    errors.push({
+      pluginId,
+      field: 'id',
+      message: 'Plugin id must match pattern: ^[a-z][a-z0-9._-]*$',
+      value: manifest.id,
+    });
+  }
+
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    errors.push({
+      pluginId,
+      field: 'version',
+      message: 'Version is required',
+      value: manifest.version,
+    });
+  }
+
+  if (
+    typeof manifest.schemaVersion !== 'number'
+    || !Number.isInteger(manifest.schemaVersion)
+    || manifest.schemaVersion < 1
+  ) {
+    errors.push({
+      pluginId,
+      field: 'schemaVersion',
+      message: 'schemaVersion must be a positive integer',
+      value: manifest.schemaVersion,
+    });
+  }
+
+  if (typeof manifest.displayName !== 'string' || manifest.displayName.length === 0) {
+    errors.push({
+      pluginId,
+      field: 'displayName',
+      message: 'displayName is required',
+      value: manifest.displayName,
+    });
+  }
+
+  if (!isStringArray(manifest.labels)) {
+    errors.push({
+      pluginId,
+      field: 'labels',
+      message: 'labels must be an array of strings',
+      value: manifest.labels,
+    });
+  }
+
+  if (!Array.isArray(manifest.permissions)) {
+    errors.push({
+      pluginId,
+      field: 'permissions',
+      message: 'permissions must be an array',
+      value: manifest.permissions,
+    });
+    return errors;
+  }
+
+  for (const [index, permission] of manifest.permissions.entries()) {
+    if (!isRecord(permission)) {
+      errors.push({
+        pluginId,
+        field: `permissions[${index}]`,
+        message: 'Permission must be an object',
+        value: permission,
+      });
+      continue;
+    }
+
+    if (typeof permission.scope !== 'string') {
+      errors.push({
+        pluginId,
+        field: `permissions[${index}].scope`,
+        message: 'Permission scope must be a string',
+        value: permission.scope,
+      });
+    }
+
+    if (typeof permission.required !== 'boolean') {
+      errors.push({
+        pluginId,
+        field: `permissions[${index}].required`,
+        message: 'Permission required flag must be a boolean',
+        value: permission.required,
+      });
+  }
+
+    if (!VALID_PERMISSION_TYPES.includes(permission.type as string)) {
+      errors.push({
+        pluginId,
+        field: `permissions[${index}].type`,
+        message: `Permission type must be one of: ${VALID_PERMISSION_TYPES.join(', ')}`,
+        value: permission.type,
+      });
+    }
+  }
+
+  if (!manifest.allowDeny) {
+    return errors;
+  }
+
+  if (!isRecord(manifest.allowDeny)) {
+    errors.push({
+      pluginId,
+      field: 'allowDeny',
+      message: 'allowDeny must be an object',
+      value: manifest.allowDeny,
+    });
+    return errors;
+  }
+
+  if (!('allow' in manifest.allowDeny) && !('deny' in manifest.allowDeny)) {
+    return errors;
+  }
+
+  if (!isStringArray((manifest.allowDeny as PluginAllowDeny).allow)) {
+    errors.push({
+      pluginId,
+      field: 'allowDeny.allow',
+      message: 'allow must be an array of strings',
+      value: manifest.allowDeny.allow,
+    });
+  }
+
+  if (!isStringArray((manifest.allowDeny as PluginAllowDeny).deny)) {
+    errors.push({
+      pluginId,
+      field: 'allowDeny.deny',
+      message: 'deny must be an array of strings',
+      value: manifest.allowDeny.deny,
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Validate a plugins config object and return all discovered errors.
+ */
+export function validatePluginsConfig(config: unknown): ManifestValidationError[] {
+  if (!isRecord(config)) {
+    return [{
+      pluginId: 'unknown',
+      field: 'root',
+      message: 'Plugins config must be an object',
+      value: config,
+    }];
+  }
+
+  const errors: ManifestValidationError[] = [];
+  const typedConfig = config as {
+    entries?: unknown;
+    allow?: unknown;
+    deny?: unknown;
+  };
+
+  if (!isRecord(typedConfig.entries)) {
+    errors.push({
+      pluginId: 'config',
+      field: 'entries',
+      message: 'entries must be an object',
+      value: typedConfig.entries,
+    });
+  } else {
+    const entries = typedConfig.entries as Record<string, unknown>;
+    const knownIds = new Set(Object.keys(entries));
+
+    for (const [pluginId, manifest] of Object.entries(entries)) {
+      if (!isRecord(manifest) || !('id' in manifest)) {
+        errors.push({
+          pluginId,
+          field: 'manifest',
+          message: 'Manifest must be an object',
+          value: manifest,
+        });
+        continue;
+      }
+
+      const declaredId = typeof manifest.id === 'string' ? manifest.id : pluginId;
+
+      if (declaredId !== pluginId) {
+        errors.push({
+          pluginId,
+          field: 'id',
+          message: `Manifest id "${declaredId}" does not match config key "${pluginId}"`,
+        });
+      }
+
+      errors.push(...validatePluginManifest(manifest).map((error) => ({
+        ...error,
+        pluginId,
+      })));
+    }
+
+    for (const allowedId of isStringArray(typedConfig.allow) ? typedConfig.allow : []) {
+      if (!knownIds.has(allowedId)) {
+        errors.push({
+          pluginId: allowedId,
+          field: 'allow',
+          message: `Plugin "${allowedId}" in allow list is not declared in entries`,
+        });
+      }
+    }
+
+    for (const deniedId of isStringArray(typedConfig.deny) ? typedConfig.deny : []) {
+      if (!knownIds.has(deniedId)) {
+        errors.push({
+          pluginId: deniedId,
+          field: 'deny',
+          message: `Plugin "${deniedId}" in deny list is not declared in entries`,
+        });
+      }
+    }
+  }
+
+  if (typedConfig.allow !== undefined && !isStringArray(typedConfig.allow)) {
+    errors.push({
+      pluginId: 'config',
+      field: 'allow',
+      message: 'allow must be an array of strings',
+      value: typedConfig.allow,
+    });
+  }
+
+  if (typedConfig.deny !== undefined && !isStringArray(typedConfig.deny)) {
+    errors.push({
+      pluginId: 'config',
+      field: 'deny',
+      message: 'deny must be an array of strings',
+      value: typedConfig.deny,
+    });
+  }
+
+  return errors;
+}
+
+/**
+ * Produce operator-friendly manifest snapshots from plugin config.
+ */
+export function getPluginConfigHints(config: PluginsConfig): {
+  pluginId: string;
+  displayName: string;
+  labels: string[];
+  hasPermissions: boolean;
+  isAllowed: boolean;
+  isDenied: boolean;
+}[] {
+  const denySet = new Set(config.deny ?? []);
+  const allowSet = config.allow ? new Set(config.allow) : null;
+
+  return Object.values(config.entries).map((manifest) => ({
+    pluginId: manifest.id,
+    displayName: manifest.displayName,
+    labels: manifest.labels,
+    hasPermissions: manifest.permissions.length > 0,
+    isAllowed: allowSet === null || allowSet.has(manifest.id),
+    isDenied: denySet.has(manifest.id),
+  }));
+}


### PR DESCRIPTION
## Summary
- Add plugin manifest schema types for governance and permissions
- Implement manifest and config validation with explicit structured errors
- Add manifest config hint generation for allowed/denied/permissions metadata
- Export manifest APIs from runtime skill entrypoint

## Test plan
- [x]  passes
- [x] 
> agenc-coordination@0.1.0 typecheck
> npm run typecheck --prefix sdk && npm run typecheck --prefix runtime && npm run typecheck --prefix mcp


> @agenc/sdk@1.3.0 typecheck
> tsc --noEmit


> @agenc/runtime@0.1.0 typecheck
> tsc --noEmit


> @agenc/mcp@0.1.0 pretypecheck
> npm install --no-save --no-package-lock --no-audit --no-fund


changed 13 packages in 4s

> @agenc/mcp@0.1.0 typecheck
> tsc --noEmit passes

Closes #997