### PR TITLE
feat(runtime): add production hardening profile preset

### DIFF
--- a/docs/DEPLOYMENT_CHECKLIST.md
+++ b/docs/DEPLOYMENT_CHECKLIST.md
@@ -129,3 +129,38 @@ All checks PASS
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | build differs across machines | toolchain mismatch | align Anchor/Solana versions and rebuild |
+
+## Release-Hardening Guide
+
+### 1. Local Operator Policy
+
+- Enable the policy engine with `policy.enabled: true`
+- Set `maxRiskScore` to `0.7` or lower
+- Configure action budgets for `tx_submission` and `tool_call`
+- Enable circuit breaker with threshold of `10` violations in `5` minutes
+
+### 2. Endpoint Exposure Limits
+
+- Limit public endpoints to `1` (`maxPublicEndpoints: 1`)
+- Require HTTPS for all public endpoints
+- Set CORS allowed origins explicitly (empty for no CORS)
+- Configure rate limits (`publicRateLimitPerMinute: 60`)
+
+### 3. Incident Triage Escalation
+
+- Configure operator roles (`read`, `investigate`, `execute`, `admin`)
+- Set up audit trail persistence
+- Define evidence retention policy (`90` days recommended)
+
+### 4. Retention and Deletion Defaults
+
+- Replay events: `30` days TTL, `1_000_000` max events
+- Audit trail: `1` year TTL
+- Evidence bundles: `90` days, `1000` max
+- Enable auto-delete for replay events
+
+### 5. Evidence Retention and Redaction
+
+- Enable sealed mode for all evidence exports (`requireSealedExport: true`)
+- Redact actor pubkeys (`redactActors: true`)
+- Strip sensitive payload fields (`secretKey`, `privateKey`, trace context)

--- a/runtime/src/policy/index.ts
+++ b/runtime/src/policy/index.ts
@@ -19,5 +19,21 @@ export {
   type PolicyDecision,
   type PolicyEngineState,
   type PolicyEngineConfig,
+  type EndpointExposureConfig,
+  type EvidenceRetentionPolicy,
+  type ProductionRedactionPolicy,
+  type DeletionDefaults,
+  type ProductionRuntimeExtensions,
 } from './types.js';
-
+export {
+  type ProductionReadinessCheck,
+  type ProductionProfileConfig,
+  PRODUCTION_POLICY,
+  PRODUCTION_ENDPOINT_EXPOSURE,
+  PRODUCTION_EVIDENCE_RETENTION,
+  PRODUCTION_REDACTION,
+  PRODUCTION_DELETION,
+  PRODUCTION_PROFILE,
+  applyProductionProfile,
+  validateProductionReadiness,
+} from './production-profile.js';

--- a/runtime/src/policy/production-profile.test.ts
+++ b/runtime/src/policy/production-profile.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyProductionProfile,
+  PRODUCTION_DELETION,
+  PRODUCTION_EVIDENCE_RETENTION,
+  PRODUCTION_ENDPOINT_EXPOSURE,
+  PRODUCTION_POLICY,
+  PRODUCTION_PROFILE,
+  PRODUCTION_REDACTION,
+  validateProductionReadiness,
+} from './production-profile.js';
+
+describe('production profile defaults', () => {
+  it('exposes all required production defaults', () => {
+    expect(PRODUCTION_PROFILE.policy.enabled).toBe(true);
+    expect(PRODUCTION_PROFILE.policy.actionBudgets).toMatchObject({
+      'tx_submission:*': { limit: 100, windowMs: 60_000 },
+      'task_claim:*': { limit: 50, windowMs: 60_000 },
+      'tool_call:*': { limit: 200, windowMs: 60_000 },
+    });
+    expect(PRODUCTION_PROFILE.policy.maxRiskScore).toBe(0.7);
+    expect(PRODUCTION_PROFILE.endpointExposure).toEqual(PRODUCTION_ENDPOINT_EXPOSURE);
+    expect(PRODUCTION_PROFILE.evidenceRetention).toEqual(PRODUCTION_EVIDENCE_RETENTION);
+    expect(PRODUCTION_PROFILE.deletion).toEqual(PRODUCTION_DELETION);
+  });
+});
+
+describe('applyProductionProfile', () => {
+  it('uses production defaults when base is empty', () => {
+    expect(applyProductionProfile({})).toEqual(PRODUCTION_PROFILE);
+  });
+
+  it('applies operator overrides', () => {
+    const applied = applyProductionProfile({
+      policy: {
+        maxRiskScore: 0.5,
+      },
+    });
+
+    expect(applied.policy.maxRiskScore).toBe(0.5);
+  });
+
+  it('prevents maxRiskScore from being weakened', () => {
+    const applied = applyProductionProfile({
+      policy: {
+        maxRiskScore: 0.9,
+      },
+    });
+
+    expect(applied.policy.maxRiskScore).toBe(0.7);
+  });
+
+  it('forces HTTPS when applying base config', () => {
+    const applied = applyProductionProfile({
+      endpointExposure: {
+        maxPublicEndpoints: 3,
+        requireHttps: false,
+        allowedOrigins: ['https://example.com'],
+        publicRateLimitPerMinute: 120,
+      },
+    });
+
+    expect(applied.endpointExposure).toMatchObject({
+      maxPublicEndpoints: 3,
+      requireHttps: true,
+      allowedOrigins: ['https://example.com'],
+      publicRateLimitPerMinute: 120,
+    });
+  });
+
+  it('merges redaction strip fields', () => {
+    const applied = applyProductionProfile({
+      redaction: {
+        redactActors: true,
+        alwaysStripFields: ['payload.apiKey', 'payload.secretKey'],
+        redactPatterns: ['abc'],
+      },
+    });
+
+    expect(applied.redaction.alwaysStripFields).toContain('payload.secretKey');
+    expect(applied.redaction.alwaysStripFields).toContain('payload.privateKey');
+    expect(applied.redaction.alwaysStripFields).toContain('payload.apiKey');
+  });
+});
+
+describe('validateProductionReadiness', () => {
+  it('passes for baseline production profile', () => {
+    const checks = validateProductionReadiness(PRODUCTION_PROFILE);
+    const failed = checks.find((check) => !check.passed);
+
+    expect(failed).toBeUndefined();
+    expect(checks).toHaveLength(6);
+  });
+
+  it('fails when policy is disabled', () => {
+    const custom = {
+      ...PRODUCTION_PROFILE,
+      policy: {
+        ...PRODUCTION_PROFILE.policy,
+        enabled: false,
+      },
+    };
+    const checks = validateProductionReadiness(custom);
+    const enabledCheck = checks.find((check) => check.id === 'policy.enabled');
+
+    expect(enabledCheck?.passed).toBe(false);
+    expect(enabledCheck?.severity).toBe('critical');
+  });
+
+  it('fails when circuit breaker is disabled', () => {
+    const custom = applyProductionProfile({
+      policy: {
+        circuitBreaker: {
+          enabled: false,
+          threshold: 10,
+          windowMs: 300_000,
+          mode: 'safe_mode',
+        },
+      },
+    });
+
+    const checks = validateProductionReadiness(custom);
+    const cbCheck = checks.find((check) => check.id === 'policy.circuit_breaker');
+
+    expect(cbCheck?.passed).toBe(false);
+    expect(cbCheck?.severity).toBe('high');
+  });
+
+  it('fails when max risk is too high', () => {
+    const custom = {
+      ...PRODUCTION_PROFILE,
+      policy: {
+        ...PRODUCTION_PROFILE.policy,
+        maxRiskScore: 0.95,
+      },
+    };
+
+    const checks = validateProductionReadiness(custom);
+    const riskCheck = checks.find((check) => check.id === 'policy.max_risk_score');
+
+    expect(riskCheck?.passed).toBe(false);
+    expect(riskCheck?.severity).toBe('high');
+  });
+});
+
+describe('production defaults and budget values', () => {
+  it('uses expected evidence retention defaults', () => {
+    expect(PRODUCTION_EVIDENCE_RETENTION).toEqual({
+      maxRetentionMs: 90 * 24 * 60 * 60 * 1_000,
+      maxBundles: 1000,
+      autoDelete: true,
+      requireSealedExport: true,
+    });
+  });
+
+  it('uses expected deletion defaults', () => {
+    expect(PRODUCTION_DELETION).toEqual({
+      replayEventTtlMs: 30 * 24 * 60 * 60 * 1_000,
+      auditTrailTtlMs: 365 * 24 * 60 * 60 * 1_000,
+      maxReplayEventsTotal: 1_000_000,
+      deleteOnStartup: false,
+    });
+  });
+
+  it('pins production action budgets', () => {
+    expect(PRODUCTION_POLICY.actionBudgets?.['tx_submission:*']).toEqual({
+      limit: 100,
+      windowMs: 60_000,
+    });
+    expect(PRODUCTION_POLICY.actionBudgets?.['task_claim:*']).toEqual({
+      limit: 50,
+      windowMs: 60_000,
+    });
+  });
+
+  it('requires redaction in production profile', () => {
+    expect(PRODUCTION_REDACTION.redactActors).toBe(true);
+    expect(PRODUCTION_REDACTION.redactPatterns).toContain('[1-9A-HJ-NP-Za-km-z]{44,}');
+  });
+});
+
+describe('smoke', () => {
+  it('accepts baseline produced config after applying profile', () => {
+    const profile = applyProductionProfile({});
+    const checks = validateProductionReadiness(profile);
+    expect(checks.every((check) => check.passed)).toBe(true);
+  });
+});

--- a/runtime/src/policy/production-profile.ts
+++ b/runtime/src/policy/production-profile.ts
@@ -1,0 +1,228 @@
+/**
+ * Production deployment policy presets and validation.
+ *
+ * @module
+ */
+
+import type {
+  CircuitBreakerConfig,
+  DeletionDefaults,
+  EndpointExposureConfig,
+  EvidenceRetentionPolicy,
+  PolicyBudgetRule,
+  ProductionRedactionPolicy,
+  RuntimePolicyConfig,
+  SpendBudgetRule,
+} from './types.js';
+
+export interface ProductionReadinessCheck {
+  /** Unique identifier for the readiness check. */
+  id: string;
+  /** Whether the check passed. */
+  passed: boolean;
+  /** Human-readable status message. */
+  message: string;
+  /** Check severity. */
+  severity: 'critical' | 'high' | 'medium';
+}
+
+export interface ProductionProfileConfig {
+  /** Runtime policy controls for production environments. */
+  policy: RuntimePolicyConfig;
+  /** Endpoint exposure hardening. */
+  endpointExposure: EndpointExposureConfig;
+  /** Evidence retention policy. */
+  evidenceRetention: EvidenceRetentionPolicy;
+  /** Evidence redaction policy. */
+  redaction: ProductionRedactionPolicy;
+  /** Background deletion defaults. */
+  deletion: DeletionDefaults;
+}
+
+const PRODUCTION_ACTION_BUDGETS: Record<string, PolicyBudgetRule> = {
+  'tx_submission:*': {
+    limit: 100,
+    windowMs: 60_000,
+  },
+  'task_claim:*': {
+    limit: 50,
+    windowMs: 60_000,
+  },
+  'tool_call:*': {
+    limit: 200,
+    windowMs: 60_000,
+  },
+};
+
+const PRODUCTION_SPEND_BUDGET: SpendBudgetRule = {
+  limitLamports: 10_000_000_000n,
+  windowMs: 3_600_000,
+};
+
+const PRODUCTION_CIRCUIT_BREAKER: CircuitBreakerConfig = {
+  enabled: true,
+  threshold: 10,
+  windowMs: 300_000,
+  mode: 'safe_mode',
+};
+
+/** Default production policy configuration. */
+export const PRODUCTION_POLICY: RuntimePolicyConfig = {
+  enabled: true,
+  actionBudgets: {
+    ...PRODUCTION_ACTION_BUDGETS,
+  },
+  spendBudget: PRODUCTION_SPEND_BUDGET,
+  maxRiskScore: 0.7,
+  circuitBreaker: {
+    ...PRODUCTION_CIRCUIT_BREAKER,
+  },
+};
+
+/** Default endpoint exposure hardening. */
+export const PRODUCTION_ENDPOINT_EXPOSURE: EndpointExposureConfig = {
+  maxPublicEndpoints: 1,
+  requireHttps: true,
+  allowedOrigins: [],
+  publicRateLimitPerMinute: 60,
+};
+
+/** Default evidence retention policy. */
+export const PRODUCTION_EVIDENCE_RETENTION: EvidenceRetentionPolicy = {
+  maxRetentionMs: 90 * 24 * 60 * 60 * 1_000,
+  maxBundles: 1000,
+  autoDelete: true,
+  requireSealedExport: true,
+};
+
+/** Default production redaction policy. */
+export const PRODUCTION_REDACTION: ProductionRedactionPolicy = {
+  redactActors: true,
+  alwaysStripFields: [
+    'payload.onchain.trace',
+    'payload.secretKey',
+    'payload.privateKey',
+  ],
+  redactPatterns: ['[1-9A-HJ-NP-Za-km-z]{44,}'],
+};
+
+/** Default deletion defaults for production. */
+export const PRODUCTION_DELETION: DeletionDefaults = {
+  replayEventTtlMs: 30 * 24 * 60 * 60 * 1_000,
+  auditTrailTtlMs: 365 * 24 * 60 * 60 * 1_000,
+  maxReplayEventsTotal: 1_000_000,
+  deleteOnStartup: false,
+};
+
+/** Complete production profile preset. */
+export const PRODUCTION_PROFILE: ProductionProfileConfig = {
+  policy: PRODUCTION_POLICY,
+  endpointExposure: PRODUCTION_ENDPOINT_EXPOSURE,
+  evidenceRetention: PRODUCTION_EVIDENCE_RETENTION,
+  redaction: PRODUCTION_REDACTION,
+  deletion: PRODUCTION_DELETION,
+};
+
+export function applyProductionProfile(
+  base: Partial<ProductionProfileConfig> = {},
+): ProductionProfileConfig {
+  return {
+    policy: {
+      ...PRODUCTION_POLICY,
+      ...(base.policy ?? {}),
+      enabled: true,
+      actionBudgets: {
+        ...PRODUCTION_POLICY.actionBudgets,
+        ...(base.policy?.actionBudgets ?? {}),
+      },
+      maxRiskScore: Math.min(
+        base.policy?.maxRiskScore ?? PRODUCTION_POLICY.maxRiskScore ?? 0,
+        PRODUCTION_POLICY.maxRiskScore ?? 0,
+      ),
+    },
+    endpointExposure: {
+      ...PRODUCTION_ENDPOINT_EXPOSURE,
+      ...(base.endpointExposure ?? {}),
+      requireHttps: true,
+    },
+    evidenceRetention: {
+      ...PRODUCTION_EVIDENCE_RETENTION,
+      ...(base.evidenceRetention ?? {}),
+    },
+    redaction: {
+      ...PRODUCTION_REDACTION,
+      ...(base.redaction ?? {}),
+      alwaysStripFields: Array.from(
+        new Set([
+          ...PRODUCTION_REDACTION.alwaysStripFields,
+          ...(base.redaction?.alwaysStripFields ?? []),
+        ]),
+      ),
+    },
+    deletion: {
+      ...PRODUCTION_DELETION,
+      ...(base.deletion ?? {}),
+    },
+  };
+}
+
+export function validateProductionReadiness(
+  config: ProductionProfileConfig,
+): ProductionReadinessCheck[] {
+  return [
+    {
+      id: 'policy.enabled',
+      passed: config.policy.enabled === true,
+      message:
+        config.policy.enabled === true
+          ? 'Policy engine is enabled'
+          : 'Policy engine must be enabled in production',
+      severity: 'critical',
+    },
+    {
+      id: 'policy.max_risk_score',
+      passed: typeof config.policy.maxRiskScore === 'number' && config.policy.maxRiskScore <= 0.8,
+      message:
+        config.policy.maxRiskScore === undefined
+          ? 'Max risk score is unset'
+          : `Max risk score: ${config.policy.maxRiskScore}`,
+      severity: 'high',
+    },
+    {
+      id: 'policy.circuit_breaker',
+      passed: config.policy.circuitBreaker?.enabled === true,
+      message:
+        config.policy.circuitBreaker?.enabled === true
+          ? 'Circuit breaker is enabled'
+          : 'Circuit breaker should be enabled',
+      severity: 'high',
+    },
+    {
+      id: 'endpoint.require_https',
+      passed: config.endpointExposure.requireHttps === true,
+      message:
+        config.endpointExposure.requireHttps === true
+          ? 'HTTPS required'
+          : 'HTTPS is not required',
+      severity: 'critical',
+    },
+    {
+      id: 'evidence.sealed_export',
+      passed: config.evidenceRetention.requireSealedExport === true,
+      message:
+        config.evidenceRetention.requireSealedExport === true
+          ? 'Sealed evidence export required'
+          : 'Sealed evidence export is not required',
+      severity: 'medium',
+    },
+    {
+      id: 'redaction.actors',
+      passed: config.redaction.redactActors === true,
+      message:
+        config.redaction.redactActors === true
+          ? 'Actor redaction enabled'
+          : 'Actor redaction disabled',
+      severity: 'medium',
+    },
+  ];
+}

--- a/runtime/src/policy/types.ts
+++ b/runtime/src/policy/types.ts
@@ -41,6 +41,48 @@ export interface PolicyBudgetRule {
   windowMs: number;
 }
 
+export interface EndpointExposureConfig {
+  /** Maximum number of RPC endpoints exposed publicly. */
+  maxPublicEndpoints: number;
+  /** Require HTTPS for all public endpoints. */
+  requireHttps: boolean;
+  /** Allowed origin patterns for CORS (empty means no CORS). */
+  allowedOrigins: string[];
+  /** Rate limit for public endpoint requests per minute. */
+  publicRateLimitPerMinute: number;
+}
+
+export interface EvidenceRetentionPolicy {
+  /** Maximum retention period for incident evidence bundles in milliseconds. */
+  maxRetentionMs: number;
+  /** Maximum number of evidence bundles to retain. */
+  maxBundles: number;
+  /** Auto-delete evidence older than retention period. */
+  autoDelete: boolean;
+  /** Require sealed (redacted) mode for evidence exports. */
+  requireSealedExport: boolean;
+}
+
+export interface ProductionRedactionPolicy {
+  /** Always redact actor pubkeys in evidence exports. */
+  redactActors: boolean;
+  /** Fields to always strip from evidence payloads. */
+  alwaysStripFields: string[];
+  /** Patterns to redact in all evidence output. */
+  redactPatterns: string[];
+}
+
+export interface DeletionDefaults {
+  /** Auto-delete replay events older than this TTL in milliseconds. */
+  replayEventTtlMs: number;
+  /** Auto-delete audit trail entries older than this TTL in milliseconds. */
+  auditTrailTtlMs: number;
+  /** Maximum total replay events before triggering compaction. */
+  maxReplayEventsTotal: number;
+  /** Run deletion on startup. */
+  deleteOnStartup: boolean;
+}
+
 export interface SpendBudgetRule {
   /** Max allowed spend in lamports for the rolling window. */
   limitLamports: bigint;
@@ -81,6 +123,13 @@ export interface RuntimePolicyConfig {
   maxRiskScore?: number;
   /** Auto-trip configuration on repeated policy violations. */
   circuitBreaker?: CircuitBreakerConfig;
+}
+
+export interface ProductionRuntimeExtensions {
+  endpointExposure?: EndpointExposureConfig;
+  evidenceRetention?: EvidenceRetentionPolicy;
+  redaction?: ProductionRedactionPolicy;
+  deletion?: DeletionDefaults;
 }
 
 export interface PolicyViolation {
@@ -129,4 +178,3 @@ export class PolicyViolationError extends Error {
     this.decision = decision;
   }
 }
-


### PR DESCRIPTION
## Summary
- Added production readiness module with secure default preset, operator merge logic, and validation checks
- Extended policy types with endpoint exposure, evidence retention, redaction, and deletion settings
- Added policy production-profile unit tests for defaults, merge overrides, and readiness failures
- Updated deployment checklist with release-hardening guidance

## Test plan
- [ ] 
 RUN  v2.1.9 /home/tetsuo/git/AgenC/runtime

 ✓ src/policy/production-profile.test.ts (15 tests) 4ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Start at  13:32:43
   Duration  228ms (transform 24ms, setup 0ms, collect 25ms, tests 4ms, environment 0ms, prepare 33ms)
- [x] 
> @agenc/runtime@0.1.0 typecheck
> tsc --noEmit

Closes #999