### PR TITLE
feat(runtime): add plugin catalog and lifecycle CLI

### DIFF
--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -1,3 +1,5 @@
+import type { PluginPrecedence, PluginSlot } from '../skills/catalog.js';
+
 export type CliOutputFormat = 'json' | 'jsonl' | 'table';
 
 export interface CliReplayOutput<TPayload = unknown> {
@@ -49,6 +51,23 @@ export interface ReplayIncidentOptions extends BaseCliOptions {
   disputePda?: string;
   fromSlot?: number;
   toSlot?: number;
+}
+
+export interface PluginListOptions extends BaseCliOptions {}
+
+export interface PluginInstallOptions extends BaseCliOptions {
+  manifestPath: string;
+  precedence?: PluginPrecedence;
+  slot?: PluginSlot;
+}
+
+export interface PluginToggleOptions extends BaseCliOptions {
+  pluginId: string;
+}
+
+export interface PluginReloadOptions extends BaseCliOptions {
+  pluginId: string;
+  manifestPath?: string;
 }
 
 export interface CliUsage {

--- a/runtime/src/skills/catalog.test.ts
+++ b/runtime/src/skills/catalog.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PluginCatalog, type PluginManifest } from './catalog.js';
+
+function createManifest(overrides: Partial<PluginManifest> = {}): PluginManifest {
+  return {
+    id: 'agenc.memory.local',
+    version: '1.0.0',
+    schemaVersion: 1,
+    displayName: 'Local memory plugin',
+    labels: ['memory'],
+    permissions: [
+      {
+        type: 'tool_call',
+        scope: 'memory.get',
+        required: true,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('PluginCatalog', () => {
+  let statePath = '';
+  let stateDir = '';
+
+  afterEach(() => {
+    if (stateDir.length > 0) {
+      rmSync(stateDir, { recursive: true, force: true });
+      stateDir = '';
+      statePath = '';
+    }
+  });
+
+  function makeCatalog(overrides: { path?: string } = {}): PluginCatalog {
+    const base = mkdtempSync(join(tmpdir(), 'agenc-plugin-catalog-'));
+    stateDir = base;
+    statePath = join(base, '.agenc', 'plugins.json');
+    mkdirSync(join(base, '.agenc'), { recursive: true });
+    return new PluginCatalog(overrides.path ?? statePath);
+  }
+
+  it('installs and lists an enabled plugin', () => {
+    const catalog = makeCatalog();
+    const result = catalog.install(createManifest({ id: 'agenc.memory.plugin-a' }), 'workspace');
+
+    expect(result.success).toBe(true);
+    const entries = catalog.list();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual(
+      expect.objectContaining({
+        manifest: expect.objectContaining({ id: 'agenc.memory.plugin-a', version: '1.0.0' }),
+        enabled: true,
+        precedence: 'workspace',
+      }),
+    );
+  });
+
+  it('returns failure when installing a duplicate plugin', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.plugin-b' }), 'user');
+    const result = catalog.install(createManifest({ id: 'agenc.memory.plugin-b' }), 'user');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('already installed');
+    expect(catalog.list()).toHaveLength(1);
+  });
+
+  it('disables a plugin', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.plugin-c' }), 'user');
+    const result = catalog.disable('agenc.memory.plugin-c');
+
+    expect(result.success).toBe(true);
+    const plugin = catalog.list().find((entry) => entry.manifest.id === 'agenc.memory.plugin-c');
+    expect(plugin).toEqual(expect.objectContaining({ enabled: false }));
+  });
+
+  it('enables a plugin after disable', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.plugin-d' }), 'user');
+    catalog.disable('agenc.memory.plugin-d');
+    const result = catalog.enable('agenc.memory.plugin-d');
+
+    expect(result.success).toBe(true);
+    const plugin = catalog.list().find((entry) => entry.manifest.id === 'agenc.memory.plugin-d');
+    expect(plugin).toEqual(expect.objectContaining({ enabled: true }));
+  });
+
+  it('reloads manifest and updates plugin entry', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.plugin-e', version: '1.0.0' }), 'user');
+    const result = catalog.reload('agenc.memory.plugin-e', createManifest({ id: 'agenc.memory.plugin-e', version: '2.0.0' }));
+
+    expect(result.success).toBe(true);
+    expect(catalog.list().find((entry) => entry.manifest.id === 'agenc.memory.plugin-e')).toEqual(
+      expect.objectContaining({
+        manifest: expect.objectContaining({ version: '2.0.0' }),
+      }),
+    );
+  });
+
+  it('sorts list by precedence', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.alpha' }), 'builtin', { slot: 'memory' });
+    catalog.install(createManifest({ id: 'agenc.llm.beta' }), 'user', { slot: 'llm' });
+    catalog.install(createManifest({ id: 'agenc.proof.gamma' }), 'workspace', { slot: 'proof' });
+
+    const precedence = catalog.list().map((entry) => entry.precedence);
+    expect(precedence.slice(0, 3)).toEqual(['workspace', 'user', 'builtin']);
+  });
+
+  it('blocks slot collisions at the same precedence level', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.delta' }), 'user', { slot: 'memory' });
+    const result = catalog.install(createManifest({ id: 'agenc.memory.epsilon' }), 'user', { slot: 'memory' });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('occupied');
+  });
+
+  it('allows a higher-precedence plugin to take over a slot', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.zeta' }), 'builtin', { slot: 'memory' });
+    const result = catalog.install(createManifest({ id: 'agenc.memory.eta' }), 'workspace', { slot: 'memory' });
+
+    expect(result.success).toBe(true);
+    expect(catalog.list()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ manifest: expect.objectContaining({ id: 'agenc.memory.zeta' }), enabled: false }),
+        expect.objectContaining({ manifest: expect.objectContaining({ id: 'agenc.memory.eta' }), enabled: true }),
+      ]),
+    );
+  });
+
+  it('releases slot assignment after disable', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.theta' }), 'workspace', { slot: 'memory' });
+    catalog.disable('agenc.memory.theta');
+    const result = catalog.install(createManifest({ id: 'agenc.memory.iota' }), 'user', { slot: 'memory' });
+
+    expect(result.success).toBe(true);
+    expect(catalog.list().find((entry) => entry.manifest.id === 'agenc.memory.iota')).toEqual(
+      expect.objectContaining({ enabled: true }),
+    );
+    expect(catalog.list().find((entry) => entry.manifest.id === 'agenc.memory.theta')).toEqual(
+      expect.objectContaining({ enabled: false }),
+    );
+  });
+
+  it('prevents enable when slot becomes occupied', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.kappa' }), 'builtin', { slot: 'memory' });
+    catalog.disable('agenc.memory.kappa');
+    catalog.install(createManifest({ id: 'agenc.memory.lambda' }), 'user', { slot: 'memory' });
+
+    const result = catalog.enable('agenc.memory.kappa');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('occupied by');
+  });
+
+  it('persists catalog state to disk', () => {
+    const catalogPathCatalog = makeCatalog();
+    catalogPathCatalog.install(createManifest({ id: 'agenc.memory.mu' }), 'user');
+    const reopened = new PluginCatalog(statePath);
+    expect(reopened.list()).toHaveLength(1);
+    expect(reopened.list()[0]).toEqual(expect.objectContaining({ manifest: expect.objectContaining({ id: 'agenc.memory.mu' }) }));
+  });
+
+  it('returns empty list for a new catalog', () => {
+    const catalog = makeCatalog();
+    expect(catalog.list()).toEqual([]);
+  });
+
+  it('fails to disable an unknown plugin', () => {
+    const catalog = makeCatalog();
+    const result = catalog.disable('agenc.memory.missing');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('not found');
+  });
+
+  it('resolves precedence and collisions deterministically', () => {
+    const catalog = makeCatalog();
+    catalog.install(createManifest({ id: 'agenc.memory.builtin' }), 'builtin', { slot: 'memory' });
+    catalog.install(createManifest({ id: 'agenc.memory.user' }), 'user', { slot: 'memory' });
+    catalog.install(createManifest({ id: 'agenc.llm.workspace' }), 'workspace', { slot: 'llm' });
+    const takeover = catalog.install(createManifest({ id: 'agenc.memory.workspace' }), 'workspace', { slot: 'memory' });
+
+    expect(takeover.success).toBe(true);
+    expect(catalog.list().find((entry) => entry.manifest.id === 'agenc.memory.user')).toEqual(
+      expect.objectContaining({ enabled: false }),
+    );
+    expect(catalog.list().find((entry) => entry.manifest.id === 'agenc.memory.workspace')).toEqual(
+      expect.objectContaining({ enabled: true }),
+    );
+
+    const collision = catalog.install(createManifest({ id: 'agenc.memory.user2' }), 'user', { slot: 'memory' });
+    expect(collision.success).toBe(false);
+    expect(collision.message).toContain('occupied by');
+  });
+});

--- a/runtime/src/skills/catalog.ts
+++ b/runtime/src/skills/catalog.ts
@@ -1,0 +1,411 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
+import type { PluginManifest } from './manifest.js';
+
+export type PluginPrecedence = 'workspace' | 'user' | 'builtin';
+
+export type PluginSlot = 'memory' | 'llm' | 'proof' | 'telemetry' | 'custom';
+
+export interface CatalogEntry {
+  manifest: PluginManifest;
+  precedence: PluginPrecedence;
+  enabled: boolean;
+  slot?: PluginSlot;
+  sourcePath?: string;
+  installedAtMs: number;
+  lastModifiedMs: number;
+}
+
+export interface CatalogState {
+  schemaVersion: number;
+  entries: Record<string, CatalogEntry>;
+  slotAssignments: Record<string, string>;
+  lastModifiedMs: number;
+}
+
+export interface CatalogOperationResult {
+  success: boolean;
+  pluginId: string;
+  operation: 'install' | 'enable' | 'disable' | 'reload' | 'uninstall';
+  message: string;
+  previousState?: Partial<CatalogEntry>;
+  newState?: Partial<CatalogEntry>;
+}
+
+export interface SlotCollision {
+  slot: PluginSlot;
+  incumbent: string;
+  challenger: string;
+  incumbentPrecedence: PluginPrecedence;
+  challengerPrecedence: PluginPrecedence;
+}
+
+export class PluginCatalogError extends Error {
+  public readonly pluginId?: string;
+
+  constructor(message: string, pluginId?: string) {
+    super(message);
+    this.name = 'PluginCatalogError';
+    this.pluginId = pluginId;
+  }
+}
+
+const DEFAULT_CATALOG_PATH = '.agenc/plugins.json';
+const DEFAULT_SCHEMA_VERSION = 1;
+const PRECEDENCE_ORDER: Record<PluginPrecedence, number> = {
+  workspace: 0,
+  user: 1,
+  builtin: 2,
+};
+
+function toDateNow(): number {
+  return Date.now();
+}
+
+function normalizePluginPrecedence(precedence: PluginPrecedence): PluginPrecedence {
+  return precedence;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cloneEntry(entry: CatalogEntry): CatalogEntry {
+  return {
+    manifest: { ...entry.manifest },
+    precedence: entry.precedence,
+    enabled: entry.enabled,
+    slot: entry.slot,
+    sourcePath: entry.sourcePath,
+    installedAtMs: entry.installedAtMs,
+    lastModifiedMs: entry.lastModifiedMs,
+  };
+}
+
+function emptyState(): CatalogState {
+  return {
+    schemaVersion: DEFAULT_SCHEMA_VERSION,
+    entries: {},
+    slotAssignments: {},
+    lastModifiedMs: 0,
+  };
+}
+
+export class PluginCatalog {
+  private state: CatalogState;
+  private readonly statePath: string;
+
+  constructor(statePath = DEFAULT_CATALOG_PATH) {
+    this.statePath = statePath;
+    this.state = this.loadState();
+  }
+
+  list(): CatalogEntry[] {
+    return Object.values(this.state.entries)
+      .map(cloneEntry)
+      .sort((left, right) => {
+        const precedenceDelta = PRECEDENCE_ORDER[left.precedence] - PRECEDENCE_ORDER[right.precedence];
+        if (precedenceDelta !== 0) {
+          return precedenceDelta;
+        }
+        return left.manifest.id.localeCompare(right.manifest.id);
+      });
+  }
+
+  install(
+    manifest: PluginManifest,
+    precedence: PluginPrecedence,
+    options?: { slot?: PluginSlot; sourcePath?: string },
+  ): CatalogOperationResult {
+    const id = manifest.id;
+
+    if (this.state.entries[id]) {
+      return {
+        success: false,
+        pluginId: id,
+        operation: 'install',
+        message: `Plugin "${id}" is already installed`,
+      };
+    }
+
+    const slot = options?.slot;
+    if (slot) {
+      const collision = this.checkSlotCollision(id, slot, precedence);
+      if (collision) {
+        return {
+          success: false,
+          pluginId: id,
+          operation: 'install',
+          message: `Slot "${collision.slot}" is occupied by "${collision.incumbent}"`,
+        };
+      }
+    }
+
+    const normalizedPrecedence = normalizePluginPrecedence(precedence);
+    const now = toDateNow();
+    const entry: CatalogEntry = {
+      manifest,
+      precedence: normalizedPrecedence,
+      enabled: true,
+      slot,
+      sourcePath: options?.sourcePath,
+      installedAtMs: now,
+      lastModifiedMs: now,
+    };
+
+    this.state.entries[id] = cloneEntry(entry);
+    if (slot) {
+      this.claimSlot(id, slot, now);
+    }
+    this.state.lastModifiedMs = now;
+    this.saveState();
+
+    return {
+      success: true,
+      pluginId: id,
+      operation: 'install',
+      message: `Plugin "${id}" installed`,
+      newState: {
+        enabled: true,
+        precedence: normalizedPrecedence,
+        slot,
+      },
+    };
+  }
+
+  disable(pluginId: string): CatalogOperationResult {
+    const entry = this.state.entries[pluginId];
+    if (!entry) {
+      return {
+        success: false,
+        pluginId,
+        operation: 'disable',
+        message: `Plugin "${pluginId}" not found`,
+      };
+    }
+
+    if (!entry.enabled) {
+      return {
+        success: true,
+        pluginId,
+        operation: 'disable',
+        message: `Plugin "${pluginId}" is already disabled`,
+      };
+    }
+
+    const previous = {
+      enabled: entry.enabled,
+      lastModifiedMs: entry.lastModifiedMs,
+    };
+    entry.enabled = false;
+    entry.lastModifiedMs = toDateNow();
+    this.releaseSlot(pluginId);
+    this.state.lastModifiedMs = entry.lastModifiedMs;
+    this.saveState();
+
+    return {
+      success: true,
+      pluginId,
+      operation: 'disable',
+      message: `Plugin "${pluginId}" disabled`,
+      previousState: previous,
+      newState: {
+        enabled: false,
+        lastModifiedMs: entry.lastModifiedMs,
+      },
+    };
+  }
+
+  enable(pluginId: string): CatalogOperationResult {
+    const entry = this.state.entries[pluginId];
+    if (!entry) {
+      return {
+        success: false,
+        pluginId,
+        operation: 'enable',
+        message: `Plugin "${pluginId}" not found`,
+      };
+    }
+
+    if (entry.enabled) {
+      return {
+        success: true,
+        pluginId,
+        operation: 'enable',
+        message: `Plugin "${pluginId}" is already enabled`,
+        newState: {
+          enabled: true,
+        },
+      };
+    }
+
+    const previous = {
+      enabled: entry.enabled,
+      lastModifiedMs: entry.lastModifiedMs,
+    };
+
+    if (entry.slot) {
+      const currentOccupant = this.state.slotAssignments[entry.slot];
+      if (currentOccupant && currentOccupant !== pluginId) {
+        return {
+          success: false,
+          pluginId,
+          operation: 'enable',
+          message: `Slot "${entry.slot}" is occupied by "${currentOccupant}"`,
+          previousState: previous,
+        };
+      }
+    }
+
+    entry.enabled = true;
+    entry.lastModifiedMs = toDateNow();
+    if (entry.slot) {
+      this.claimSlot(pluginId, entry.slot, entry.lastModifiedMs);
+    }
+    this.state.lastModifiedMs = entry.lastModifiedMs;
+    this.saveState();
+
+    return {
+      success: true,
+      pluginId,
+      operation: 'enable',
+      message: `Plugin "${pluginId}" enabled`,
+      previousState: previous,
+      newState: {
+        enabled: true,
+        lastModifiedMs: entry.lastModifiedMs,
+      },
+    };
+  }
+
+  reload(pluginId: string, manifest?: PluginManifest): CatalogOperationResult {
+    const entry = this.state.entries[pluginId];
+    if (!entry) {
+      return {
+        success: false,
+        pluginId,
+        operation: 'reload',
+        message: `Plugin "${pluginId}" not found`,
+      };
+    }
+
+    const previous = {
+      manifest: { ...entry.manifest },
+      lastModifiedMs: entry.lastModifiedMs,
+    };
+    if (manifest) {
+      entry.manifest = manifest;
+    }
+    entry.lastModifiedMs = toDateNow();
+    this.state.lastModifiedMs = entry.lastModifiedMs;
+    this.saveState();
+
+    return {
+      success: true,
+      pluginId,
+      operation: 'reload',
+      message: `Plugin "${pluginId}" reloaded`,
+      previousState: previous,
+      newState: {
+        manifest: { ...entry.manifest },
+        lastModifiedMs: entry.lastModifiedMs,
+      },
+    };
+  }
+
+  private loadState(): CatalogState {
+    if (!existsSync(this.statePath)) {
+      return emptyState();
+    }
+
+    const raw = readFileSync(this.statePath, 'utf8');
+    const parsed = JSON.parse(raw) as Partial<CatalogState>;
+    const entries = isRecord(parsed.entries) ? parsed.entries : {};
+    const slotAssignments = isRecord(parsed.slotAssignments)
+      ? parsed.slotAssignments
+      : {};
+    const normalizedEntries = Object.entries(entries).reduce<Record<string, CatalogEntry>>(
+      (accumulator, [id, candidate]) => {
+        if (isRecord(candidate) && typeof candidate.manifest === 'object' && candidate.manifest !== null) {
+          accumulator[id] = {
+            ...(candidate as CatalogEntry),
+            manifest: candidate.manifest as PluginManifest,
+          };
+        }
+        return accumulator;
+      },
+      {},
+    );
+
+    return {
+      schemaVersion: typeof parsed.schemaVersion === 'number' ? parsed.schemaVersion : DEFAULT_SCHEMA_VERSION,
+      entries: normalizedEntries,
+      slotAssignments: Object.entries(slotAssignments).reduce<Record<string, string>>((accumulator, [slot, pluginId]) => {
+        if (typeof pluginId === 'string') {
+          accumulator[slot] = pluginId;
+        }
+        return accumulator;
+      }, {}),
+      lastModifiedMs: typeof parsed.lastModifiedMs === 'number' ? parsed.lastModifiedMs : toDateNow(),
+    };
+  }
+
+  private saveState(): void {
+    const directory = dirname(this.statePath);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(this.statePath, JSON.stringify(this.state, null, 2));
+  }
+
+  private checkSlotCollision(
+    pluginId: string,
+    slot: PluginSlot,
+    precedence: PluginPrecedence,
+  ): SlotCollision | null {
+    const incumbentId = this.state.slotAssignments[slot];
+    if (!incumbentId || incumbentId === pluginId) {
+      return null;
+    }
+
+    const incumbent = this.state.entries[incumbentId];
+    if (!incumbent) {
+      return null;
+    }
+
+    if (PRECEDENCE_ORDER[precedence] < PRECEDENCE_ORDER[incumbent.precedence]) {
+      return null;
+    }
+
+    return {
+      slot,
+      incumbent: incumbentId,
+      challenger: pluginId,
+      incumbentPrecedence: incumbent.precedence,
+      challengerPrecedence: precedence,
+    };
+  }
+
+  private claimSlot(pluginId: string, slot: PluginSlot, nowMs: number): void {
+    const incumbentId = this.state.slotAssignments[slot];
+    if (incumbentId && incumbentId !== pluginId) {
+      const incumbent = this.state.entries[incumbentId];
+      if (incumbent && incumbent.enabled) {
+        incumbent.enabled = false;
+        incumbent.lastModifiedMs = nowMs;
+      }
+    }
+
+    this.state.slotAssignments[slot] = pluginId;
+  }
+
+  private releaseSlot(pluginId: string): void {
+    const plugin = this.state.entries[pluginId];
+    if (!plugin?.slot) {
+      return;
+    }
+
+    if (this.state.slotAssignments[plugin.slot] === pluginId) {
+      delete this.state.slotAssignments[plugin.slot];
+    }
+  }
+}

--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -9,6 +9,7 @@
 
 // Core types
 export {
+  // Plugin catalog
   type Skill,
   type SkillMetadata,
   type SkillAction,
@@ -17,6 +18,17 @@ export {
   type SkillRegistryConfig,
   SkillState,
 } from './types.js';
+
+export {
+  PluginCatalog,
+  PluginCatalogError,
+  type CatalogEntry,
+  type CatalogOperationResult,
+  type CatalogState,
+  type PluginPrecedence,
+  type PluginSlot,
+  type SlotCollision,
+} from './catalog.js';
 
 // Error types
 export {


### PR DESCRIPTION
## Summary
- Added runtime plugin catalog with schema-backed persistence at `.agenc/plugins.json`.
- Implemented `PluginCatalog` lifecycle operations: list, install, disable, enable, reload.
- Added precedence-aware slot assignment/collision handling for plugin functional slots.
- Added CLI `plugin` command group with list/install/disable/enable/reload subcommands and typed option parsing.
- Added unit coverage for install, disable, enable, reload, precedence ordering, slot exclusivity, persistence, and collision behaviors.

## Test plan
- [x] `npm run build` passes
- [x] `npm run test` passes (SDK + runtime)
- [x] `npm run test:fast` passes
- [x] `npm run typecheck` succeeds
- [x] `cd runtime && npx vitest run src/skills/catalog.test.ts` passes

Closes #998
