### PR TITLE
fix(runtime): redact replay cli outputs

### DIFF
--- a/runtime/src/cli/replay.ts
+++ b/runtime/src/cli/replay.ts
@@ -12,6 +12,7 @@ import {
 import { PROGRAM_ID } from '@agenc/sdk';
 import { parseTrajectoryTrace, stableStringifyJson, type JsonValue, type TrajectoryTrace } from '../eval/types.js';
 import { createReadOnlyProgram } from '../idl.js';
+import { extractDisputePdaFromPayload } from '../replay/pda-utils.js';
 import {
   type ReplayEventCursor,
   type BackfillFetcher,
@@ -316,6 +317,8 @@ export function summarizeReplayIncidentRecords(
   });
 
   const events = sorted.map((record) => {
+    const disputePda = record.disputePda ?? extractDisputePdaFromPayload(record.payload);
+
     sourceEventTypeCounts[record.sourceEventType] = (sourceEventTypeCounts[record.sourceEventType] ?? 0) + 1;
     sourceEventNameCounts[record.sourceEventName] = (sourceEventNameCounts[record.sourceEventName] ?? 0) + 1;
     if (record.traceId) {
@@ -325,8 +328,8 @@ export function summarizeReplayIncidentRecords(
     if (record.taskPda) {
       taskIds.add(record.taskPda);
     }
-    if (record.disputePda) {
-      disputeIds.add(record.disputePda);
+    if (disputePda) {
+      disputeIds.add(disputePda);
     }
 
     return {
@@ -336,7 +339,7 @@ export function summarizeReplayIncidentRecords(
       sourceEventType: record.sourceEventType,
       sourceEventName: record.sourceEventName,
       taskPda: record.taskPda,
-      disputePda: record.disputePda,
+      disputePda,
       timestampMs: record.timestampMs,
       traceId: record.traceId,
       traceSpanId: record.traceSpanId,

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -44,6 +44,7 @@ export interface ReplayCompareOptions extends BaseCliOptions {
   localTracePath?: string;
   taskPda?: string;
   disputePda?: string;
+  redactFields?: string[];
 }
 
 export interface ReplayIncidentOptions extends BaseCliOptions {
@@ -51,6 +52,7 @@ export interface ReplayIncidentOptions extends BaseCliOptions {
   disputePda?: string;
   fromSlot?: number;
   toSlot?: number;
+  redactFields?: string[];
 }
 
 export interface PluginListOptions extends BaseCliOptions {}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -708,6 +708,9 @@ export {
   computeAnomalySetHash,
   computeAnomalySetHashFromContexts,
   REPLAY_OPERATIONAL_LIMITS,
+  normalizePdaValue,
+  normalizePdaString,
+  extractDisputePdaFromPayload,
 } from './replay/index.js';
 
 // Policy and Safety Engine

--- a/runtime/src/replay/backfill.ts
+++ b/runtime/src/replay/backfill.ts
@@ -24,6 +24,7 @@ import {
   startReplaySpan,
 } from './trace.js';
 import type { ReplayAlertDispatcher } from './alerting.js';
+import { extractDisputePdaFromPayload } from './pda-utils.js';
 
 const DEFAULT_BACKFILL_PAGE_SIZE = 100;
 
@@ -344,6 +345,7 @@ function toReplayStoreRecord(event: ProjectedTimelineEvent): ReplayTimelineRecor
     seq: event.seq,
     type: event.type,
     taskPda: event.taskPda,
+    disputePda: extractDisputePdaFromPayload(event.payload),
     timestampMs: event.timestampMs,
     payload: event.payload,
     slot: event.slot,

--- a/runtime/src/replay/bridge.ts
+++ b/runtime/src/replay/bridge.ts
@@ -23,6 +23,7 @@ import {
   type ReplayAlertingPolicyOptions,
 } from './alerting.js';
 import { computeProjectionHash } from './types.js';
+import { extractDisputePdaFromPayload } from './pda-utils.js';
 import {
   buildReplayTraceContext,
   DEFAULT_TRACE_SAMPLE_RATE,
@@ -159,6 +160,7 @@ function toReplayStoreRecord(event: ProjectedTimelineEvent): ReplayTimelineRecor
     seq: event.seq,
     type: event.type,
     taskPda: event.taskPda,
+    disputePda: extractDisputePdaFromPayload(event.payload),
     timestampMs: event.timestampMs,
     payload: event.payload,
     slot: event.slot,

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -81,3 +81,9 @@ export {
   computeAnomalySetHash,
   computeAnomalySetHashFromContexts,
 } from './alerting.js';
+
+export {
+  normalizePdaValue,
+  normalizePdaString,
+  extractDisputePdaFromPayload,
+} from './pda-utils.js';

--- a/runtime/src/replay/pda-utils.ts
+++ b/runtime/src/replay/pda-utils.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared PDA normalization helpers for replay record construction.
+ *
+ * Used by backfill, bridge, and CLI replay summary to consistently
+ * extract and normalize dispute PDAs from event payloads.
+ *
+ * @module
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import { bytesToHex, hexToBytes } from '../utils/encoding.js';
+
+/**
+ * Try to convert a byte array to a base58 public key string.
+ * Returns base58 for valid 32-byte keys, hex for other lengths.
+ */
+function bytesToPdaString(bytes: Uint8Array): string | undefined {
+  if (bytes.length === 0) {
+    return undefined;
+  }
+  if (bytes.length === 32) {
+    try {
+      return new PublicKey(bytes).toBase58();
+    } catch {
+      return bytesToHex(bytes);
+    }
+  }
+  return bytesToHex(bytes);
+}
+
+/**
+ * Normalize a raw PDA value to a string identifier.
+ *
+ * Accepts:
+ * - base58 strings (passed through)
+ * - 32-byte hex strings with or without `0x` prefix (converted to base58)
+ * - number arrays or Uint8Arrays (32-byte → base58, other lengths → hex)
+ */
+export function normalizePdaValue(value: unknown): string | undefined {
+  if (value instanceof Uint8Array) {
+    return bytesToPdaString(value);
+  }
+
+  if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === 'number' && v >= 0 && v <= 255)) {
+    return bytesToPdaString(new Uint8Array(value));
+  }
+
+  if (typeof value !== 'string' || value.length === 0) {
+    return undefined;
+  }
+
+  // Match 64 hex chars (32 bytes) with optional 0x prefix.
+  // "0x" + 64 hex = 66 char input → hexToBytes strips prefix → 32 bytes.
+  // Bare 64 hex = 64 char input → hexToBytes parses directly → 32 bytes.
+  if (/^(0x)?[0-9a-fA-F]{64}$/.test(value)) {
+    try {
+      const bytes = hexToBytes(value);
+      if (bytes.length === 32) {
+        return new PublicKey(bytes).toBase58();
+      }
+    } catch {
+      // ignore hex parse errors and fall through to returning the raw string
+    }
+  }
+
+  return value;
+}
+
+/**
+ * @deprecated Use {@link normalizePdaValue} which also handles byte arrays.
+ */
+export const normalizePdaString = normalizePdaValue;
+
+/**
+ * Extract a dispute PDA from an event payload.
+ *
+ * Checks `payload.disputeId` first, then falls back to
+ * `payload.onchain.disputeId` for nested event data.
+ */
+export function extractDisputePdaFromPayload(payload: Readonly<Record<string, unknown>>): string | undefined {
+  const direct = normalizePdaValue(payload.disputeId);
+  if (direct) {
+    return direct;
+  }
+
+  const onchain = payload.onchain;
+  if (typeof onchain === 'object' && onchain !== null) {
+    const nested = normalizePdaValue((onchain as Record<string, unknown>).disputeId);
+    if (nested) {
+      return nested;
+    }
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Add --redact-fields for replay compare/incident (including narrative redaction)
- Fix replay compare emitting duplicate JSON output
- Populate disputePda on replay timeline records and incident summaries

Fixes #989

## Test plan
- [x] vitest: runtime tests/cli-replay-commands.test.ts
