### PR TITLE
feat(runtime): add incident case object model

### DIFF
--- a/runtime/src/eval/incident-case.test.ts
+++ b/runtime/src/eval/incident-case.test.ts
@@ -1,0 +1,519 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createHash } from 'node:crypto';
+import { PublicKey } from '@solana/web3.js';
+import { projectOnChainEvents, type OnChainProjectionInput } from './projector.js';
+import { stableStringifyJson } from './types.js';
+import {
+  INCIDENT_CASE_SCHEMA_VERSION,
+  buildIncidentCase,
+  computeEvidenceHash,
+} from './incident-case.js';
+import type { ReplayAnomaly } from './replay-comparison.js';
+
+function pubkey(seed: number): PublicKey {
+  const bytes = new Uint8Array(32);
+  bytes.fill(seed);
+  return new PublicKey(bytes);
+}
+
+function bytes(seed = 0, length = 32): Uint8Array {
+  const output = new Uint8Array(length);
+  output.fill(seed);
+  return output;
+}
+
+describe('incident case model', () => {
+  it('builds a deterministic case from fixture events', () => {
+    const taskId = bytes(1);
+    const creator = pubkey(8);
+    const worker = pubkey(9);
+
+    const inputs: OnChainProjectionInput[] = [
+      {
+        eventName: 'taskCreated',
+        slot: 10,
+        signature: 'AAA',
+        timestampMs: 1_000,
+        event: {
+          taskId,
+          creator,
+          requiredCapabilities: 100n,
+          rewardAmount: 50_000n,
+          taskType: 0,
+          deadline: 5_000,
+          minReputation: 1,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+      {
+        eventName: 'taskClaimed',
+        slot: 10,
+        signature: 'AAA',
+        timestampMs: 1_100,
+        event: {
+          taskId,
+          worker,
+          currentWorkers: 1,
+          maxWorkers: 5,
+          timestamp: 1_100,
+        },
+      },
+      {
+        eventName: 'taskCompleted',
+        slot: 100,
+        signature: 'ZZZ',
+        timestampMs: 2_000,
+        event: {
+          taskId,
+          worker,
+          proofHash: bytes(1, 32),
+          resultData: bytes(2, 64),
+          rewardPaid: 123n,
+          timestamp: 2_000,
+        },
+      },
+    ];
+
+    const projected = projectOnChainEvents(inputs, { traceId: 'trace-1' }).events;
+    const incident = buildIncidentCase({ events: projected });
+
+    expect(incident.schemaVersion).toBe(INCIDENT_CASE_SCHEMA_VERSION);
+    expect(incident.traceWindow).toEqual({
+      fromSlot: 10,
+      toSlot: 100,
+      fromTimestampMs: 1_000,
+      toTimestampMs: 2_000,
+    });
+
+    expect(incident.transitions.map((entry) => entry.toState)).toEqual([
+      'discovered',
+      'claimed',
+      'completed',
+    ]);
+
+    expect(incident.actorMap).toEqual([
+      { pubkey: creator.toBase58(), role: 'creator', firstSeenSeq: 1 },
+      { pubkey: worker.toBase58(), role: 'worker', firstSeenSeq: 2 },
+    ]);
+
+    expect(incident.taskIds).toEqual([new PublicKey(taskId).toBase58()]);
+    expect(incident.disputeIds).toEqual([]);
+    expect(incident.anomalies).toEqual([]);
+    expect(incident.anomalyIds).toEqual([]);
+    expect(incident.evidenceHashes).toEqual([]);
+    expect(incident.caseStatus).toBe('open');
+  });
+
+  it('handles empty event lists', () => {
+    const incident = buildIncidentCase({ events: [] });
+
+    expect(incident.traceWindow).toEqual({
+      fromSlot: 0,
+      toSlot: 0,
+      fromTimestampMs: 0,
+      toTimestampMs: 0,
+    });
+    expect(incident.transitions).toEqual([]);
+    expect(incident.taskIds).toEqual([]);
+    expect(incident.disputeIds).toEqual([]);
+    expect(incident.actorMap).toEqual([]);
+    expect(incident.anomalies).toEqual([]);
+    expect(incident.anomalyIds).toEqual([]);
+  });
+
+  it('supports trace window override', () => {
+    const taskId = bytes(3);
+    const worker = pubkey(4);
+
+    const inputs: OnChainProjectionInput[] = [
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'A',
+        timestampMs: 1_000,
+        event: {
+          taskId,
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+      {
+        eventName: 'taskClaimed',
+        slot: 10,
+        signature: 'B',
+        timestampMs: 1_100,
+        event: {
+          taskId,
+          worker,
+          currentWorkers: 1,
+          maxWorkers: 1,
+          timestamp: 1_100,
+        },
+      },
+      {
+        eventName: 'taskCompleted',
+        slot: 20,
+        signature: 'C',
+        timestampMs: 1_200,
+        event: {
+          taskId,
+          worker,
+          proofHash: bytes(1, 32),
+          resultData: bytes(2, 64),
+          rewardPaid: 0n,
+          timestamp: 1_200,
+        },
+      },
+    ];
+
+    const projected = projectOnChainEvents(inputs).events;
+    const incident = buildIncidentCase({ events: projected, window: { fromSlot: 5, toSlot: 15 } });
+
+    expect(incident.traceWindow.fromSlot).toBe(5);
+    expect(incident.traceWindow.toSlot).toBe(15);
+    expect(incident.transitions).toHaveLength(1);
+    expect(incident.transitions[0]?.slot).toBe(10);
+    expect(incident.transitions[0]?.toState).toBe('claimed');
+  });
+
+  it('deduplicates actors and keeps earliest firstSeenSeq', () => {
+    const taskId = bytes(5);
+    const worker = pubkey(7);
+
+    const inputs: OnChainProjectionInput[] = [
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'A',
+        timestampMs: 1_000,
+        event: {
+          taskId,
+          creator: pubkey(2),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+      {
+        eventName: 'taskClaimed',
+        slot: 2,
+        signature: 'B',
+        timestampMs: 1_100,
+        event: {
+          taskId,
+          worker,
+          currentWorkers: 1,
+          maxWorkers: 1,
+          timestamp: 1_100,
+        },
+      },
+      {
+        eventName: 'taskCompleted',
+        slot: 3,
+        signature: 'C',
+        timestampMs: 1_200,
+        event: {
+          taskId,
+          worker,
+          proofHash: bytes(1, 32),
+          resultData: bytes(2, 64),
+          rewardPaid: 0n,
+          timestamp: 1_200,
+        },
+      },
+    ];
+
+    const projected = projectOnChainEvents(inputs).events;
+    const incident = buildIncidentCase({ events: projected });
+    const workerEntry = incident.actorMap.find((entry) => entry.pubkey === worker.toBase58());
+
+    expect(incident.actorMap.filter((entry) => entry.pubkey === worker.toBase58())).toHaveLength(1);
+    expect(workerEntry?.firstSeenSeq).toBe(2);
+    expect(workerEntry?.role).toBe('worker');
+  });
+
+  it('tracks dispute lifecycle transitions', () => {
+    const disputeId = bytes(6);
+    const taskId = bytes(7);
+    const initiator = pubkey(1);
+    const defendant = pubkey(2);
+    const voter = pubkey(3);
+
+    const inputs: OnChainProjectionInput[] = [
+      {
+        eventName: 'disputeInitiated',
+        slot: 30,
+        signature: 'S1',
+        timestampMs: 3_000,
+        event: {
+          disputeId,
+          taskId,
+          initiator,
+          defendant,
+          resolutionType: 0,
+          votingDeadline: 10_000,
+          timestamp: 3_000,
+        },
+      },
+      {
+        eventName: 'disputeVoteCast',
+        slot: 40,
+        signature: 'S2',
+        timestampMs: 3_500,
+        event: {
+          disputeId,
+          voter,
+          approved: true,
+          votesFor: 1n,
+          votesAgainst: 0n,
+          timestamp: 3_500,
+        },
+      },
+      {
+        eventName: 'disputeResolved',
+        slot: 50,
+        signature: 'S3',
+        timestampMs: 4_000,
+        event: {
+          disputeId,
+          resolutionType: 0,
+          outcome: 1,
+          votesFor: 1n,
+          votesAgainst: 0n,
+          timestamp: 4_000,
+        },
+      },
+    ];
+
+    const projected = projectOnChainEvents(inputs).events;
+    const incident = buildIncidentCase({ events: projected });
+    const disputePda = new PublicKey(disputeId).toBase58();
+
+    expect(incident.disputeIds).toEqual([disputePda]);
+
+    const disputeTransitions = incident.transitions.filter((entry) => entry.disputePda === disputePda);
+    expect(disputeTransitions.map((entry) => entry.toState)).toEqual([
+      'dispute:initiated',
+      'dispute:vote_cast',
+      'dispute:resolved',
+    ]);
+
+    expect(incident.actorMap).toEqual([
+      { pubkey: initiator.toBase58(), role: 'creator', firstSeenSeq: 1 },
+      { pubkey: defendant.toBase58(), role: 'worker', firstSeenSeq: 1 },
+      { pubkey: voter.toBase58(), role: 'arbiter', firstSeenSeq: 2 },
+    ]);
+  });
+
+  it('maps replay anomalies deterministically', () => {
+    const taskId = bytes(9);
+
+    const projected = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'A',
+        timestampMs: 1_000,
+        event: {
+          taskId,
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+    ]).events;
+
+    const anomalies: ReplayAnomaly[] = [
+      {
+        code: 'hash_mismatch',
+        severity: 'error',
+        message: 'hash differs',
+        context: {
+          seq: 1,
+          taskPda: new PublicKey(taskId).toBase58(),
+          signature: 'A',
+          sourceEventName: 'taskCreated',
+          sourceEventSequence: 0,
+        },
+      },
+      {
+        code: 'missing_event',
+        severity: 'warning',
+        message: 'missing event',
+        context: {
+          seq: 2,
+          signature: 'B',
+        },
+      },
+    ];
+
+    const first = buildIncidentCase({ events: projected, anomalies });
+    const second = buildIncidentCase({ events: projected, anomalies });
+
+    expect(first.anomalyIds).toEqual(first.anomalies.map((entry) => entry.anomalyId));
+    expect(first.anomalies.map((entry) => entry.code)).toEqual(['hash_mismatch', 'missing_event']);
+    expect(first.anomalyIds).toEqual(second.anomalyIds);
+  });
+
+  it('computes evidence hashes using stable JSON canonicalization', () => {
+    const content = { b: 2, a: 1 };
+    const evidence = computeEvidenceHash('example', content);
+
+    const expected = createHash('sha256')
+      .update(stableStringifyJson(content))
+      .digest('hex');
+
+    expect(evidence).toEqual({ label: 'example', sha256: expected });
+  });
+
+  it('produces deterministic case IDs for identical inputs', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+
+    const taskId = bytes(11);
+    const worker = pubkey(12);
+
+    const projected = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'A',
+        timestampMs: 1_000,
+        event: {
+          taskId,
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+      {
+        eventName: 'taskClaimed',
+        slot: 2,
+        signature: 'B',
+        timestampMs: 1_100,
+        event: {
+          taskId,
+          worker,
+          currentWorkers: 1,
+          maxWorkers: 1,
+          timestamp: 1_100,
+        },
+      },
+    ]).events;
+
+    const first = buildIncidentCase({ events: projected });
+    const second = buildIncidentCase({ events: projected });
+    expect(first.caseId).toBe(second.caseId);
+
+    const narrowed = buildIncidentCase({ events: projected, window: { fromSlot: 1, toSlot: 1 } });
+    expect(narrowed.caseId).not.toBe(first.caseId);
+
+    const otherTaskId = bytes(12);
+    const differentTasks = buildIncidentCase({
+      events: projectOnChainEvents([
+        {
+          eventName: 'taskCreated',
+          slot: 1,
+          signature: 'A',
+          timestampMs: 1_000,
+          event: {
+            taskId,
+            creator: pubkey(1),
+            requiredCapabilities: 0n,
+            rewardAmount: 0n,
+            taskType: 0,
+            deadline: 0,
+            minReputation: 0,
+            rewardMint: null,
+            timestamp: 1_000,
+          },
+        },
+        {
+          eventName: 'taskClaimed',
+          slot: 2,
+          signature: 'B',
+          timestampMs: 1_100,
+          event: {
+            taskId,
+            worker,
+            currentWorkers: 1,
+            maxWorkers: 1,
+            timestamp: 1_100,
+          },
+        },
+        {
+          eventName: 'taskCreated',
+          slot: 3,
+          signature: 'C',
+          timestampMs: 1_200,
+          event: {
+            taskId: otherTaskId,
+            creator: pubkey(2),
+            requiredCapabilities: 0n,
+            rewardAmount: 0n,
+            taskType: 0,
+            deadline: 0,
+            minReputation: 0,
+            rewardMint: null,
+            timestamp: 1_200,
+          },
+        },
+      ]).events,
+    });
+    expect(differentTasks.caseId).not.toBe(first.caseId);
+
+    vi.useRealTimers();
+  });
+
+  it('round-trips through JSON serialization without loss', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2020-01-01T00:00:00.000Z'));
+
+    const projected = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'A',
+        timestampMs: 1_000,
+        event: {
+          taskId: bytes(13),
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+    ]).events;
+
+    const incident = buildIncidentCase({ events: projected });
+    const roundTrip = JSON.parse(JSON.stringify(incident));
+    expect(roundTrip).toEqual(incident);
+
+    vi.useRealTimers();
+  });
+});

--- a/runtime/src/eval/incident-case.ts
+++ b/runtime/src/eval/incident-case.ts
@@ -1,0 +1,440 @@
+/**
+ * Incident case model for deterministic timeline reconstruction and evidence export.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+import { PublicKey } from '@solana/web3.js';
+import { bytesToHex, hexToBytes } from '../utils/encoding.js';
+import { stableStringifyJson, type JsonValue } from './types.js';
+import type { ProjectedTimelineEvent } from './projector.js';
+import type { ReplayAnomaly, ReplayAnomalyCode } from './replay-comparison.js';
+
+/** Schema version for case export format — bump on breaking layout changes. */
+export const INCIDENT_CASE_SCHEMA_VERSION = 1 as const;
+
+/** Deterministic slot+timestamp window bounding the incident. */
+export interface IncidentTraceWindow {
+  fromSlot: number;
+  toSlot: number;
+  fromTimestampMs: number;
+  toTimestampMs: number;
+}
+
+/** Actor role in the incident context. */
+export type IncidentActorRole = 'creator' | 'worker' | 'arbiter' | 'authority' | 'unknown';
+
+/** Resolved actor entry. */
+export interface IncidentActor {
+  pubkey: string;
+  role: IncidentActorRole;
+  firstSeenSeq: number;
+}
+
+/** Lifecycle transition recorded in the case timeline. */
+export interface IncidentTransition {
+  seq: number;
+  fromState: string | null;
+  toState: string;
+  slot: number;
+  signature: string;
+  sourceEventName: string;
+  timestampMs: number;
+  taskPda?: string;
+  disputePda?: string;
+}
+
+/** Reference to an anomaly detected during comparison/replay. */
+export interface IncidentAnomalyRef {
+  anomalyId: string;
+  code: ReplayAnomalyCode;
+  severity: 'error' | 'warning';
+  message: string;
+  seq?: number;
+}
+
+/** SHA-256 hash of an attached evidence artifact. */
+export interface IncidentEvidenceHash {
+  label: string;
+  sha256: string;
+}
+
+export type IncidentCaseStatus = 'open' | 'investigating' | 'resolved' | 'archived';
+
+/** Top-level incident case payload. */
+export interface IncidentCase {
+  schemaVersion: typeof INCIDENT_CASE_SCHEMA_VERSION;
+  caseId: string;
+  createdAtMs: number;
+  traceWindow: IncidentTraceWindow;
+  transitions: IncidentTransition[];
+  anomalyIds: string[];
+  anomalies: IncidentAnomalyRef[];
+  actorMap: IncidentActor[];
+  evidenceHashes: IncidentEvidenceHash[];
+  caseStatus: IncidentCaseStatus;
+  taskIds: string[];
+  disputeIds: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface BuildIncidentCaseInput {
+  events: readonly ProjectedTimelineEvent[];
+  anomalies?: readonly ReplayAnomaly[];
+  window?: { fromSlot?: number; toSlot?: number };
+  metadata?: Record<string, unknown>;
+}
+
+const TASK_TRANSITIONS: Readonly<Record<string, ReadonlySet<string>>> = {
+  discovered: new Set(['claimed', 'failed']),
+  claimed: new Set(['completed', 'failed', 'disputed']),
+  disputed: new Set(['completed', 'failed']),
+  completed: new Set(),
+  failed: new Set(),
+};
+
+const TASK_EVENT_TYPES = new Set<string>([
+  'discovered',
+  'claimed',
+  'completed',
+  'failed',
+  'disputed',
+]);
+
+const DISPUTE_EVENT_TYPES = new Set<string>([
+  'dispute:initiated',
+  'dispute:vote_cast',
+  'dispute:resolved',
+  'dispute:cancelled',
+  'dispute:expired',
+]);
+
+const SPECULATION_EVENT_TYPES = new Set<string>([
+  'speculation_started',
+  'speculation_confirmed',
+  'speculation_aborted',
+]);
+
+export function buildIncidentCase(input: BuildIncidentCaseInput): IncidentCase {
+  const sorted = [...input.events].sort((left, right) => {
+    if (left.seq !== right.seq) return left.seq - right.seq;
+    if (left.slot !== right.slot) return left.slot - right.slot;
+    if (left.timestampMs !== right.timestampMs) return left.timestampMs - right.timestampMs;
+    if (left.signature !== right.signature) return left.signature.localeCompare(right.signature);
+    if (left.sourceEventName !== right.sourceEventName) return left.sourceEventName.localeCompare(right.sourceEventName);
+    if (left.type !== right.type) return left.type.localeCompare(right.type);
+    return (left.taskPda ?? '').localeCompare(right.taskPda ?? '');
+  });
+
+  const traceWindow = computeTraceWindow(sorted, input.window);
+
+  const windowedEvents = sorted.filter((event) => (
+    event.slot >= traceWindow.fromSlot && event.slot <= traceWindow.toSlot
+  ));
+
+  const transitions = buildTransitions(windowedEvents);
+  const actorMap = resolveActors(windowedEvents);
+
+  const anomalyRefs = (input.anomalies ?? []).map((anomaly, index) => ({
+    anomalyId: computeAnomalyId(anomaly, index),
+    code: anomaly.code,
+    severity: anomaly.severity,
+    message: anomaly.message,
+    ...(typeof anomaly.context.seq === 'number' ? { seq: anomaly.context.seq } : {}),
+  }));
+
+  const taskIds = [...new Set(
+    windowedEvents
+      .map((event) => event.taskPda)
+      .filter((entry): entry is string => typeof entry === 'string' && entry.length > 0),
+  )].sort();
+
+  const disputeIds = collectDisputeIds(windowedEvents);
+  const caseId = computeCaseId(traceWindow, taskIds, disputeIds);
+
+  return {
+    schemaVersion: INCIDENT_CASE_SCHEMA_VERSION,
+    caseId,
+    createdAtMs: Date.now(),
+    traceWindow,
+    transitions,
+    anomalyIds: anomalyRefs.map((entry) => entry.anomalyId),
+    anomalies: anomalyRefs,
+    actorMap,
+    evidenceHashes: [],
+    caseStatus: 'open',
+    taskIds,
+    disputeIds,
+    metadata: input.metadata,
+  };
+}
+
+export function computeEvidenceHash(label: string, content: JsonValue): IncidentEvidenceHash {
+  const sha256 = createHash('sha256')
+    .update(stableStringifyJson(content))
+    .digest('hex');
+  return { label, sha256 };
+}
+
+function computeTraceWindow(
+  events: readonly ProjectedTimelineEvent[],
+  override?: { fromSlot?: number; toSlot?: number },
+): IncidentTraceWindow {
+  if (events.length === 0) {
+    return { fromSlot: 0, toSlot: 0, fromTimestampMs: 0, toTimestampMs: 0 };
+  }
+
+  const overrideFrom = override?.fromSlot;
+  const overrideTo = override?.toSlot;
+
+  const resolvedFromSlot = Number.isInteger(overrideFrom) && (overrideFrom as number) >= 0
+    ? (overrideFrom as number)
+    : events[0].slot;
+  const resolvedToSlot = Number.isInteger(overrideTo) && (overrideTo as number) >= 0
+    ? (overrideTo as number)
+    : events[events.length - 1].slot;
+
+  const fromSlot = Math.min(resolvedFromSlot, resolvedToSlot);
+  const toSlot = Math.max(resolvedFromSlot, resolvedToSlot);
+
+  const fromTimestampMs = events.find((event) => event.slot >= fromSlot)?.timestampMs ?? 0;
+  const toTimestampMs = [...events].reverse().find((event) => event.slot <= toSlot)?.timestampMs ?? 0;
+
+  return { fromSlot, toSlot, fromTimestampMs, toTimestampMs };
+}
+
+function resolveActors(events: readonly ProjectedTimelineEvent[]): IncidentActor[] {
+  const actors = new Map<string, IncidentActor>();
+
+  for (const event of events) {
+    const payload = event.payload as unknown as Record<string, unknown>;
+    const candidates: Array<{ pubkey: string; role: IncidentActorRole }> = [];
+
+    const creator = payload.creator;
+    if (typeof creator === 'string' && creator.length > 0) candidates.push({ pubkey: creator, role: 'creator' });
+
+    const worker = payload.worker;
+    if (typeof worker === 'string' && worker.length > 0) candidates.push({ pubkey: worker, role: 'worker' });
+
+    const authority = payload.authority;
+    if (typeof authority === 'string' && authority.length > 0) candidates.push({ pubkey: authority, role: 'authority' });
+
+    const voter = payload.voter;
+    if (typeof voter === 'string' && voter.length > 0) candidates.push({ pubkey: voter, role: 'arbiter' });
+
+    const initiator = payload.initiator;
+    if (typeof initiator === 'string' && initiator.length > 0) candidates.push({ pubkey: initiator, role: 'creator' });
+
+    const defendant = payload.defendant;
+    if (typeof defendant === 'string' && defendant.length > 0) candidates.push({ pubkey: defendant, role: 'worker' });
+
+    const recipient = payload.recipient;
+    if (typeof recipient === 'string' && recipient.length > 0) candidates.push({ pubkey: recipient, role: 'worker' });
+
+    const updater = payload.updater;
+    if (typeof updater === 'string' && updater.length > 0) candidates.push({ pubkey: updater, role: 'authority' });
+
+    const updatedBy = payload.updatedBy;
+    if (typeof updatedBy === 'string' && updatedBy.length > 0) candidates.push({ pubkey: updatedBy, role: 'authority' });
+
+    const agent = payload.agent;
+    if (typeof agent === 'string' && agent.length > 0 && !candidates.some((entry) => entry.pubkey === agent)) {
+      candidates.push({ pubkey: agent, role: 'unknown' });
+    }
+
+    for (const { pubkey, role } of candidates) {
+      const existing = actors.get(pubkey);
+      if (!existing) {
+        actors.set(pubkey, { pubkey, role, firstSeenSeq: event.seq });
+        continue;
+      }
+
+      if (existing.role === 'unknown' && role !== 'unknown') {
+        existing.role = role;
+      }
+    }
+  }
+
+  return [...actors.values()].sort((left, right) => {
+    if (left.firstSeenSeq !== right.firstSeenSeq) return left.firstSeenSeq - right.firstSeenSeq;
+    return left.pubkey.localeCompare(right.pubkey);
+  });
+}
+
+function buildTransitions(events: readonly ProjectedTimelineEvent[]): IncidentTransition[] {
+  const transitions: IncidentTransition[] = [];
+
+  const taskStates = new Map<string, string>();
+  const disputeStates = new Map<string, string>();
+  const speculationStates = new Map<string, string>();
+
+  for (const event of events) {
+    const { seq, type, slot, signature, sourceEventName, timestampMs, taskPda } = event;
+
+    if (TASK_EVENT_TYPES.has(type) && taskPda) {
+      const previous = taskStates.get(taskPda) ?? null;
+      transitions.push({
+        seq,
+        fromState: previous,
+        toState: type,
+        slot,
+        signature,
+        sourceEventName,
+        timestampMs,
+        taskPda,
+      });
+      taskStates.set(taskPda, type);
+    }
+
+    if (sourceEventName === 'disputeInitiated' && taskPda) {
+      const previous = taskStates.get(taskPda);
+      if (previous !== undefined && TASK_TRANSITIONS[previous]?.has('disputed')) {
+        transitions.push({
+          seq,
+          fromState: previous,
+          toState: 'disputed',
+          slot,
+          signature,
+          sourceEventName,
+          timestampMs,
+          taskPda,
+        });
+        taskStates.set(taskPda, 'disputed');
+      }
+    }
+
+    if (DISPUTE_EVENT_TYPES.has(type)) {
+      const disputePda = extractDisputePda(event);
+      if (disputePda) {
+        const previous = disputeStates.get(disputePda) ?? null;
+        transitions.push({
+          seq,
+          fromState: previous,
+          toState: type,
+          slot,
+          signature,
+          sourceEventName,
+          timestampMs,
+          taskPda,
+          disputePda,
+        });
+        disputeStates.set(disputePda, type);
+      }
+    }
+
+    if (SPECULATION_EVENT_TYPES.has(type) && taskPda) {
+      const previous = speculationStates.get(taskPda) ?? null;
+      transitions.push({
+        seq,
+        fromState: previous,
+        toState: type,
+        slot,
+        signature,
+        sourceEventName,
+        timestampMs,
+        taskPda,
+      });
+      speculationStates.set(taskPda, type);
+    }
+  }
+
+  return transitions;
+}
+
+function collectDisputeIds(events: readonly ProjectedTimelineEvent[]): string[] {
+  const disputeIds = new Set<string>();
+  for (const event of events) {
+    const disputePda = extractDisputePda(event);
+    if (disputePda) disputeIds.add(disputePda);
+  }
+  return [...disputeIds].sort();
+}
+
+function extractDisputePda(event: ProjectedTimelineEvent): string | undefined {
+  const payload = event.payload as unknown as Record<string, unknown>;
+  const onchain = payload.onchain;
+
+  if (typeof onchain === 'object' && onchain !== null) {
+    const raw = (onchain as Record<string, unknown>).disputeId;
+    const normalized = normalizePdaValue(raw);
+    if (normalized) return normalized;
+  }
+
+  const direct = payload.disputeId;
+  const normalized = normalizePdaValue(direct);
+  if (normalized) return normalized;
+
+  return undefined;
+}
+
+function normalizePdaValue(value: unknown): string | undefined {
+  if (value instanceof PublicKey) return value.toBase58();
+
+  if (value instanceof Uint8Array) {
+    return bytesToPdaString(value);
+  }
+
+  if (Array.isArray(value) && value.every((entry) => Number.isInteger(entry) && entry >= 0 && entry <= 255)) {
+    return bytesToPdaString(new Uint8Array(value));
+  }
+
+  if (typeof value === 'string' && value.length > 0) {
+    const clean = value.startsWith('0x') ? value.slice(2) : value;
+    if (clean.length === 64 && /^[0-9a-fA-F]+$/.test(clean)) {
+      try {
+        return bytesToPdaString(hexToBytes(clean));
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+
+  return undefined;
+}
+
+function bytesToPdaString(bytes: Uint8Array): string {
+  if (bytes.length !== 32) return bytesToHex(bytes);
+  try {
+    return new PublicKey(bytes).toBase58();
+  } catch {
+    return bytesToHex(bytes);
+  }
+}
+
+function computeCaseId(
+  window: IncidentTraceWindow,
+  taskIds: string[],
+  disputeIds: string[],
+): string {
+  const seed = stableStringifyJson({
+    fromSlot: window.fromSlot,
+    toSlot: window.toSlot,
+    taskIds,
+    disputeIds,
+  } as unknown as JsonValue);
+
+  return createHash('sha256').update(seed).digest('hex').slice(0, 32);
+}
+
+function computeAnomalyId(anomaly: ReplayAnomaly, fallbackIndex: number): string {
+  const context = anomaly.context;
+  const seed = stableStringifyJson({
+    code: anomaly.code,
+    severity: anomaly.severity,
+    taskPda: context.taskPda,
+    disputePda: context.disputePda,
+    sourceEventName: context.sourceEventName,
+    sourceEventSequence: context.sourceEventSequence,
+    signature: context.signature,
+    eventType: context.eventType,
+    seq: context.seq ?? fallbackIndex,
+    traceId: context.traceId,
+    traceSpanId: context.traceSpanId,
+    traceParentSpanId: context.traceParentSpanId,
+    traceSampled: context.traceSampled,
+  } as unknown as JsonValue);
+
+  return createHash('sha1').update(seed).digest('hex').slice(0, 16);
+}

--- a/runtime/src/eval/index.ts
+++ b/runtime/src/eval/index.ts
@@ -84,6 +84,21 @@ export {
 } from './replay-comparison.js';
 
 export {
+  INCIDENT_CASE_SCHEMA_VERSION,
+  buildIncidentCase,
+  computeEvidenceHash,
+  type BuildIncidentCaseInput,
+  type IncidentActor,
+  type IncidentActorRole,
+  type IncidentAnomalyRef,
+  type IncidentCase,
+  type IncidentCaseStatus,
+  type IncidentEvidenceHash,
+  type IncidentTraceWindow,
+  type IncidentTransition,
+} from './incident-case.js';
+
+export {
   BENCHMARK_MANIFEST_SCHEMA_VERSION,
   parseBenchmarkManifest,
   loadBenchmarkManifest,

--- a/runtime/tests/fixtures/golden/cli-replay-incident-success.json
+++ b/runtime/tests/fixtures/golden/cli-replay-incident-success.json
@@ -38,7 +38,9 @@
         "uniqueTaskIds": [
           "01010101010101010101010101010101010101010101010101010101010101010101"
         ],
-        "uniqueDisputeIds": [],
+        "uniqueDisputeIds": [
+          "07070707070707070707070707070707070707070707070707070707070707070707"
+        ],
         "sourceEventTypeCounts": {
           "claimed": 1,
           "completed": 1,
@@ -87,10 +89,11 @@
             "sourceEventType": "dispute:initiated",
             "sourceEventName": "disputeInitiated",
             "taskPda": "01010101010101010101010101010101010101010101010101010101010101010101",
+            "disputePda": "07070707070707070707070707070707070707070707070707070707070707070707",
             "timestampMs": 1000000000003
           }
         ],
-        "deterministicHash": "bf9bee0a752fd84f8a00efbc552001230c89d81c51ccd54455883e0beb335195",
+        "deterministicHash": "175172ac641c0f1141c492467944537f9a298bc142f578a256efb653e1f6c0d4",
         "eventType": "replay-incidents"
       },
       "validation": {
@@ -114,7 +117,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:17:05.683Z",
+    "generatedAt": "2026-02-15T01:15:37.066Z",
     "generatedBy": "contract-validator"
   }
 }


### PR DESCRIPTION
## Summary
- Added IncidentCase model + buildIncidentCase builder for deterministic incident reconstruction
- Added computeEvidenceHash helper and exported all incident-case types via runtime eval barrel
- Added vitest coverage for windows, transitions, actor resolution, anomaly mapping, determinism, and JSON round-trip
- Updated CLI replay incident golden snapshot to reflect dispute PDA extraction in summaries

## Test plan
- [x] 
> agenc-coordination@0.1.0 build
> npm run build:sdk && npm run build:runtime && npm run build:mcp


> agenc-coordination@0.1.0 build:sdk
> npm run build --prefix sdk


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM dist/index.mjs 125.47 KB
ESM ⚡️ Build success in 24ms
CJS dist/index.js 134.41 KB
CJS ⚡️ Build success in 24ms
DTS Build start
DTS ⚡️ Build success in 646ms
DTS dist/index.d.ts  55.75 KB
DTS dist/index.d.mts 55.75 KB

> agenc-coordination@0.1.0 build:runtime
> npm run build --prefix runtime


> @agenc/runtime@0.1.0 prebuild
> npm run build --prefix ../sdk && node scripts/copy-idl.js


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/index.js 134.41 KB
CJS ⚡️ Build success in 23ms
ESM dist/index.mjs 125.47 KB
ESM ⚡️ Build success in 23ms
DTS Build start
DTS ⚡️ Build success in 660ms
DTS dist/index.d.ts  55.75 KB
DTS dist/index.d.mts 55.75 KB
Copying IDL and types from Anchor build output...
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Copied: /home/tetsuo/git/AgenC/target/idl/agenc_coordination.json -> /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts
  Copied: /home/tetsuo/git/AgenC/target/types/agenc_coordination.ts -> /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts (with DO NOT EDIT header)
Done.

> @agenc/runtime@0.1.0 build
> tsup src/index.ts src/bin/agenc-runtime.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token

CLI Building entry: src/index.ts, src/bin/agenc-runtime.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM dist/bin/agenc-runtime.mjs 56.71 KB
ESM dist/chunk-VGJN5IXP.mjs    369.75 KB
ESM dist/index.mjs             699.30 KB
ESM ⚡️ Build success in 63ms
CJS dist/bin/agenc-runtime.js 329.94 KB
CJS dist/index.js             1.05 MB
CJS ⚡️ Build success in 63ms
DTS Build start
DTS ⚡️ Build success in 2565ms
DTS dist/bin/agenc-runtime.d.ts  20.00 B
DTS dist/index.d.ts              670.62 KB
DTS dist/bin/agenc-runtime.d.mts 20.00 B
DTS dist/index.d.mts             670.62 KB

> agenc-coordination@0.1.0 build:mcp
> npm run build --prefix mcp


> @agenc/mcp@0.1.0 prebuild
> npm run build --prefix ../sdk && npm run build --prefix ../runtime


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM dist/index.mjs 125.47 KB
ESM ⚡️ Build success in 24ms
CJS dist/index.js 134.41 KB
CJS ⚡️ Build success in 24ms
DTS Build start
DTS ⚡️ Build success in 643ms
DTS dist/index.d.ts  55.75 KB
DTS dist/index.d.mts 55.75 KB

> @agenc/runtime@0.1.0 prebuild
> npm run build --prefix ../sdk && node scripts/copy-idl.js


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/index.js 134.41 KB
CJS ⚡️ Build success in 25ms
ESM dist/index.mjs 125.47 KB
ESM ⚡️ Build success in 25ms
DTS Build start
DTS ⚡️ Build success in 628ms
DTS dist/index.d.ts  55.75 KB
DTS dist/index.d.mts 55.75 KB
Copying IDL and types from Anchor build output...
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Copied: /home/tetsuo/git/AgenC/target/idl/agenc_coordination.json -> /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts
  Copied: /home/tetsuo/git/AgenC/target/types/agenc_coordination.ts -> /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts (with DO NOT EDIT header)
Done.

> @agenc/runtime@0.1.0 build
> tsup src/index.ts src/bin/agenc-runtime.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token

CLI Building entry: src/index.ts, src/bin/agenc-runtime.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/bin/agenc-runtime.js 329.94 KB
CJS dist/index.js             1.05 MB
CJS ⚡️ Build success in 57ms
ESM dist/bin/agenc-runtime.mjs 56.71 KB
ESM dist/chunk-VGJN5IXP.mjs    369.75 KB
ESM dist/index.mjs             699.30 KB
ESM ⚡️ Build success in 59ms
DTS Build start
DTS ⚡️ Build success in 2594ms
DTS dist/bin/agenc-runtime.d.ts  20.00 B
DTS dist/index.d.ts              670.62 KB
DTS dist/bin/agenc-runtime.d.mts 20.00 B
DTS dist/index.d.mts             670.62 KB

> @agenc/mcp@0.1.0 build
> tsup

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /home/tetsuo/git/AgenC/mcp/tsup.config.ts
CLI Target: node18
CLI Cleaning output folder
CJS Build start
DTS Build start
CJS dist/index.cjs 10.90 MB
CJS ⚡️ Build success in 206ms
DTS ⚡️ Build success in 1086ms
DTS dist/index.d.cts 20.00 B
- [x] 
> agenc-coordination@0.1.0 test
> npm run build:sdk && npm run build:runtime && npm run test --prefix sdk && npm run test --prefix runtime


> agenc-coordination@0.1.0 build:sdk
> npm run build --prefix sdk


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/index.js 134.41 KB
CJS ⚡️ Build success in 23ms
ESM dist/index.mjs 125.47 KB
ESM ⚡️ Build success in 23ms
DTS Build start
DTS ⚡️ Build success in 682ms
DTS dist/index.d.ts  55.75 KB
DTS dist/index.d.mts 55.75 KB

> agenc-coordination@0.1.0 build:runtime
> npm run build --prefix runtime


> @agenc/runtime@0.1.0 prebuild
> npm run build --prefix ../sdk && node scripts/copy-idl.js


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/index.js 134.41 KB
CJS ⚡️ Build success in 24ms
ESM dist/index.mjs 125.47 KB
ESM ⚡️ Build success in 23ms
DTS Build start
DTS ⚡️ Build success in 710ms
DTS dist/index.d.ts  55.75 KB
DTS dist/index.d.mts 55.75 KB
Copying IDL and types from Anchor build output...
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Copied: /home/tetsuo/git/AgenC/target/idl/agenc_coordination.json -> /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts
  Copied: /home/tetsuo/git/AgenC/target/types/agenc_coordination.ts -> /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts (with DO NOT EDIT header)
Done.

> @agenc/runtime@0.1.0 build
> tsup src/index.ts src/bin/agenc-runtime.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token

CLI Building entry: src/index.ts, src/bin/agenc-runtime.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM dist/bin/agenc-runtime.mjs 56.71 KB
ESM dist/chunk-VGJN5IXP.mjs    369.75 KB
ESM dist/index.mjs             699.30 KB
ESM ⚡️ Build success in 62ms
CJS dist/bin/agenc-runtime.js 329.94 KB
CJS dist/index.js             1.05 MB
CJS ⚡️ Build success in 62ms
DTS Build start
DTS ⚡️ Build success in 2649ms
DTS dist/bin/agenc-runtime.d.ts  20.00 B
DTS dist/index.d.ts              670.62 KB
DTS dist/bin/agenc-runtime.d.mts 20.00 B
DTS dist/index.d.mts             670.62 KB

> @agenc/sdk@1.3.0 test
> vitest run


 RUN  v2.1.9 /home/tetsuo/git/AgenC/sdk

 ✓ src/__tests__/bids.test.ts (4 tests) 2ms
 ✓ src/__tests__/validation.test.ts (8 tests) 4ms
 ✓ src/__tests__/errors.test.ts (5 tests) 2ms
 ✓ src/__tests__/tokens.test.ts (19 tests) 7ms
 ✓ src/__tests__/agents.test.ts (2 tests) 28ms
 ✓ src/__tests__/protocol.test.ts (2 tests) 28ms
 ✓ src/__tests__/queries.test.ts (25 tests) 7ms
 ✓ src/__tests__/idl-alignment.test.ts (3 tests) 4ms
 ✓ src/__tests__/client.test.ts (6 tests) 3ms
 ✓ src/__tests__/disputes.test.ts (2 tests) 25ms
 ✓ src/__tests__/proofs.test.ts (35 tests) 44ms
 ✓ src/__tests__/tasks.test.ts (29 tests) 34ms
 ✓ src/__tests__/convenience-apis.test.ts (13 tests) 37ms
 ✓ src/__tests__/proof-validation.test.ts (23 tests) 57ms
 ✓ src/__tests__/version.test.ts (13 tests) 5ms
 ✓ src/__tests__/contract.test.ts (6 tests) 27ms

 Test Files  16 passed (16)
      Tests  195 passed (195)
   Start at  18:17:27
   Duration  502ms (transform 901ms, setup 0ms, collect 2.79s, tests 314ms, environment 2ms, prepare 603ms)


> @agenc/runtime@0.1.0 pretest
> npm run build --prefix ../sdk


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/index.js 134.41 KB
CJS ⚡️ Build success in 25ms
ESM dist/index.mjs 125.47 KB
ESM ⚡️ Build success in 25ms
DTS Build start
DTS ⚡️ Build success in 664ms
DTS dist/index.d.ts  55.75 KB
DTS dist/index.d.mts 55.75 KB

> @agenc/runtime@0.1.0 test
> vitest run


 RUN  v2.1.9 /home/tetsuo/git/AgenC/runtime

 ✓ src/events/parse.test.ts (26 tests) 8ms
 ✓ src/utils/encoding.test.ts (69 tests) 10ms
 ✓ src/types/protocol.test.ts (32 tests) 8ms
 ✓ src/types/errors.test.ts (75 tests) 18ms
 ✓ src/replay/alerting.test.ts (21 tests) 6ms
 ✓ src/events/dispute.test.ts (23 tests) 8ms
 ✓ src/events/task.test.ts (21 tests) 7ms
 ✓ src/cli/security.test.ts (22 tests) 6ms
 ✓ src/types/wallet.test.ts (24 tests) 45ms
 ✓ src/agent/events.test.ts (22 tests) 15ms
 ✓ src/events/protocol.test.ts (38 tests) 16ms
 ✓ src/agent/types.test.ts (88 tests) 15ms
 ✓ src/task/rollback-controller.test.ts (35 tests) 97ms
 ✓ src/autonomous/verification-budget.test.ts (20 tests) 49ms
 ✓ src/llm/executor.test.ts (22 tests) 54ms
 ✓ src/task/commitment-ledger.test.ts (55 tests) 209ms
 ✓ src/task/priority-queue.test.ts (25 tests) 7ms
 ✓ src/proof/engine.test.ts (37 tests) 73ms
 ✓ src/utils/token.test.ts (19 tests) 23ms
 ✓ src/skills/catalog.test.ts (14 tests) 15ms
 ✓ src/utils/logger.test.ts (33 tests) 13ms
 ✓ src/eval/mutation-gates.test.ts (8 tests) 4ms
 ✓ src/team/engine.test.ts (8 tests) 14ms
 ✓ src/memory/in-memory/backend.test.ts (38 tests) 11ms
 ✓ src/task/speculation-chaos.test.ts (18 tests) 356ms
 ✓ src/llm/anthropic/adapter.test.ts (16 tests) 90ms
 ✓ src/events/monitor.test.ts (39 tests) 16ms
 ✓ src/skills/manifest.test.ts (15 tests) 6ms
 ✓ src/memory/conformance.test.ts (31 tests) 18ms
 ✓ src/task/speculation-metrics.test.ts (17 tests) 6ms
 ✓ src/autonomous/scanner.test.ts (29 tests) 10ms
 ✓ src/task/pda.test.ts (26 tests) 48ms
 ✓ src/llm/grok/adapter.test.ts (15 tests) 116ms
 ✓ src/task/speculation-safety.test.ts (12 tests) 45ms
 ✓ src/llm/ollama/adapter.test.ts (17 tests) 121ms
 ✓ src/task/discovery.test.ts (35 tests) 60ms
 ✓ src/autonomous/speculation-adapter.test.ts (15 tests) 8ms
 ✓ src/eval/transition-validator.test.ts (50 tests) 15ms
 ✓ src/types/config-migration.test.ts (26 tests) 10ms
 ✓ src/task/filters.test.ts (43 tests) 46ms
 ✓ src/agent/capabilities.test.ts (29 tests) 7ms
 ✓ src/task/types.test.ts (44 tests) 55ms
 ✓ src/team/payout.test.ts (5 tests) 10ms
 ✓ src/marketplace/engine.test.ts (10 tests) 13ms
 ✓ src/autonomous/verifier.test.ts (10 tests) 54ms
 ✓ src/eval/incident-case.test.ts (9 tests) 15ms
 ✓ src/task/speculative-scheduler.test.ts (46 tests) 76ms
 ✓ src/replay/backfill.test.ts (8 tests) 13ms
 ✓ tests/eval-scorecard.integration.test.ts (2 tests) 6ms
 ✓ src/idl.test.ts (32 tests) 88ms
 ✓ src/task/dependency-graph.test.ts (52 tests) 183ms
 ✓ src/eval/projector.test.ts (20 tests) 27ms
 ✓ src/connection/manager.test.ts (66 tests) 53ms
 ✓ src/workflow/optimizer-types.test.ts (6 tests) 4ms
 ✓ src/task/__tests__/speculation-integration.test.ts (16 tests) 196ms
 ✓ src/policy/production-profile.test.ts (15 tests) 6ms
 ✓ src/memory/sqlite/backend.test.ts (29 tests) 235ms
 ✓ src/task/proof-pipeline.test.ts (31 tests) 356ms
 ✓ src/task/operations.test.ts (35 tests) 67ms
 ✓ src/builder.test.ts (42 tests) 30ms
 ✓ src/eval/benchmark-runner.test.ts (2 tests) 12ms
 ✓ src/memory/redis/backend.test.ts (38 tests) 261ms
 ✓ src/events/idl-drift-check.test.ts (7 tests) 5ms
 ✓ src/eval/mutation-engine.test.ts (4 tests) 10ms
 ✓ src/tools/agenc/agenc-tools.test.ts (23 tests) 18ms
 ✓ src/agent/manager.test.ts (52 tests) 237ms
 ✓ src/skills/registry.test.ts (23 tests) 41ms
 ✓ src/tools/skill-adapter.test.ts (8 tests) 6ms
 ✓ src/replay/replay-storage.test.ts (7 tests) 22ms
 ✓ src/workflow/compiler.test.ts (10 tests) 14ms
 ✓ src/telemetry/collector.test.ts (24 tests) 12ms
 ✓ src/dispute/operations.test.ts (63 tests) 163ms
 ✓ src/eval/replay-comparison.test.ts (9 tests) 37ms
 ✓ src/llm/fallback.test.ts (5 tests) 4ms
 ✓ src/eval/mutation-runner.test.ts (2 tests) 23ms
 ✓ tests/cli-replay-commands.test.ts (7 tests) 33ms
 ✓ src/eval/replay.test.ts (4 tests) 4ms
 ✓ src/workflow/orchestrator.test.ts (50 tests) 90ms
 ✓ src/types/config.test.ts (7 tests) 34ms
 ✓ src/agent/pda.test.ts (21 tests) 10ms
 ✓ tests/cli-contract.test.ts (8 tests) 20ms
 ✓ tests/cli-foundation.test.ts (11 tests) 9ms
 ✓ src/tools/registry.test.ts (17 tests) 7ms
 ✓ src/idl-validation.test.ts (14 tests) 5ms
 ✓ src/autonomous/arbitration.test.ts (2 tests) 3ms
 ✓ src/autonomous/candidate-generator.test.ts (3 tests) 41ms
 ✓ src/replay/sqlite-store.test.ts (7 tests) 148ms
 ✓ src/workflow/mutations.test.ts (3 tests) 13ms
 ✓ src/eval/types.test.ts (5 tests) 4ms
 ✓ src/eval/benchmark-manifest.test.ts (3 tests) 10ms
 ✓ src/skills/jupiter/jupiter-skill.test.ts (16 tests) 44ms
 ✓ src/skills/jupiter/jupiter-client.test.ts (10 tests) 18ms
 ✓ src/autonomous/escalation-graph.test.ts (3 tests) 2ms
 ✓ src/autonomous/verifier-scheduler.test.ts (3 tests) 2ms
 ✓ src/telemetry/sinks.test.ts (5 tests) 4ms
 ✓ src/autonomous/types.test.ts (6 tests) 3ms
 ✓ src/llm/response-converter.test.ts (7 tests) 4ms
 ✓ src/policy/engine.test.ts (7 tests) 3ms
 ✓ src/autonomous/risk-scoring.test.ts (3 tests) 39ms
 ✓ src/llm/types.test.ts (4 tests) 2ms
 ✓ src/eval/recorder.test.ts (5 tests) 37ms
 ✓ src/events/types.test.ts (4 tests) 2ms
 ✓ src/eval/calibration.test.ts (4 tests) 4ms
 ✓ src/memory/graph.test.ts (6 tests) 14ms
 ✓ src/eval/metrics.test.ts (5 tests) 4ms
 ✓ tests/replay-chaos.test.ts (5 tests) 15ms
 ✓ tests/verifier-adaptive-escalation.integration.test.ts (2 tests) 54ms
 ✓ tests/replay-chaos-comparator.test.ts (4 tests) 4ms
 ✓ tests/replay-chaos-transition.test.ts (3 tests) 9ms
 ✓ src/workflow/optimizer.test.ts (3 tests) 10ms
 ✓ src/runtime.test.ts (30 tests) 135ms
 ✓ src/cli/replay.test.ts (9 tests) 3ms
 ✓ tests/adaptive-verification-budget.integration.test.ts (1 test) 32ms
 ✓ tests/replay-chaos-store.test.ts (3 tests) 10ms
 ✓ tests/mutation-regression.integration.test.ts (2 tests) 279ms
 ✓ src/workflow/feature-extractor.test.ts (3 tests) 8ms
 ✓ tests/benchmark-runner.integration.test.ts (2 tests) 80ms
 ✓ src/team/workflow-adapter.test.ts (7 tests) 11ms
 ✓ src/workflow/rollout.test.ts (3 tests) 4ms
 ✓ tests/workflow-optimizer.integration.test.ts (2 tests) 9ms
 ✓ tests/workflow-feature-store.integration.test.ts (2 tests) 34ms
 ✓ src/workflow/validation.test.ts (5 tests) 9ms
 ✓ src/marketplace/strategy.test.ts (3 tests) 4ms
 ✓ tests/replay-chaos-partial-write.test.ts (2 tests) 9ms
 ✓ tests/integration.test.ts (8 tests) 150ms
 ✓ src/autonomous/inconsistency-detector.test.ts (2 tests) 23ms
 ✓ src/autonomous/agent.adaptive-risk.test.ts (2 tests) 40ms
 ✓ src/autonomous/agent.verifier.test.ts (4 tests) 51ms
 ✓ src/autonomous/agent.multi-candidate.test.ts (2 tests) 44ms
 ✓ src/autonomous/agent.verifier-adaptive.test.ts (2 tests) 42ms
 ✓ src/autonomous/agent.policy.test.ts (3 tests) 40ms
 ✓ src/workflow/orchestrator-goal.test.ts (2 tests) 30ms
 ✓ tests/eval-replay.integration.test.ts (2 tests) 82ms
 ✓ tests/multi-candidate-consistency.integration.test.ts (1 test) 27ms
 ✓ src/task/metrics.test.ts (30 tests) 1030ms
 ✓ src/task/speculative-executor.test.ts (24 tests) 1417ms
 ✓ src/task/checkpoint.test.ts (16 tests) 1330ms
 ✓ src/task/dlq.test.ts (31 tests) 1554ms
   ✓ DeadLetterQueue > maxSize eviction (FIFO) > defaults to maxSize 1000 406ms
 ✓ src/task/proof-deferral.test.ts (24 tests) 2193ms
   ✓ ProofDeferralManager > Ancestor Confirmation Unblocking > should handle multiple children waiting on same ancestor 354ms
   ✓ ProofDeferralManager > Ancestor Confirmation Unblocking > should handle chain of ancestors confirming in order 305ms
 ✓ src/task/executor.test.ts (67 tests) 6340ms
   ✓ TaskExecutor > claim deadline monitoring > aborts mid-execution when claim deadline timer fires 402ms

 Test Files  140 passed (140)
      Tests  2524 passed (2524)
   Start at  18:17:29
   Duration  7.57s (transform 18.49s, setup 0ms, collect 79.09s, tests 19.78s, environment 19ms, prepare 7.14s)
- [x] 
> agenc-coordination@0.1.0 test:fast
> ts-mocha -p ./tsconfig.json -t 60000 tests/test_1.ts tests/dispute-slash-logic.ts tests/spl-token-tasks.ts tests/lifecycle-guards.ts



  test_1
    create_task Happy Paths
      ✔ Exclusive task creation with Open state
      ✔ Collaborative task with required_completions validation
      ✔ Competitive task with multiple slots
      ✔ Reward transfer to escrow validation
      ✔ Zero-reward task handling - rejects zero reward
    create_task Rejection Cases
      ✔ Non-creator authority rejection
      ✔ max_workers == 0 rejection
      ✔ Past deadline rejection
      ✔ Invalid task type rejection
    claim_task Happy Paths
      ✔ Single claim on Open task
      ✔ Multiple claims on collaborative task
      ✔ Additional claims on InProgress task
    claim_task Rejection Cases
      ✔ Non-worker authority rejection
      ✔ Inactive agent rejection
      ✔ Insufficient capabilities rejection
      ✔ Claim on Completed task rejection
      ✔ Claim on Cancelled task rejection
      ✔ Claim after deadline rejection
      ✔ Claim when fully claimed rejection
      ✔ Claim with 10 active tasks rejection
    Lifecycle & Adversarial
      ✔ Completed task cannot be claimed
      ✔ Cancelled task cannot be claimed
      ✔ Open to InProgress state transition
      ✔ InProgress persistence on additional claims
      ✔ Worker cannot claim same task twice
    Design-Bounded Invariants
      ✔ Worker count max limit (design-bounded: max 100)
      ✔ Active task count overflow prevention (design-bounded: u8 max 10)
      ✔ Complete task and verify payout (Happy Path)
      ✔ PDA-based double claim prevention (design-bounded: unique seeds)
    Issue #19: Task Lifecycle State Machine Tests
      Valid State Transitions
        ✔ Open → InProgress (via first claim)
        ✔ InProgress → Completed (via complete)
        ✔ Open → Cancelled (via cancel by creator)
        ✔ InProgress → Cancelled (expired deadline + no completions)
      Invalid State Transitions
        ✔ Completed → anything: cannot claim completed task
        ✔ Completed → anything: cannot cancel completed task
        ✔ Cancelled → anything: cannot claim cancelled task
        ✔ Cancelled → anything: cannot complete on cancelled task
        ✔ Cancelled → anything: cannot cancel already cancelled task
        ✔ InProgress → Open: cannot revert to Open state (no such instruction)
        ✔ Completed task: cannot double-complete same claim
      Terminal State Immutability
        ✔ Completed is terminal - no state changes possible
        ✔ Cancelled is terminal - no state changes possible
    Issue #20: Authority and PDA Validation Tests
      register_agent
        ✔ Rejects registration with wrong authority (signer mismatch)
      update_agent
        ✔ Rejects update by non-owner
        ✔ Rejects update with mismatched authority account
      deregister_agent
        ✔ Rejects deregistration by non-owner
      create_task
        ✔ Rejects task creation with wrong protocol_config PDA
      claim_task
        ✔ Rejects claim with wrong worker authority
        ✔ Rejects claim with wrong agent PDA
      complete_task
        ✔ Rejects completion with wrong worker authority
        ✔ Rejects completion with wrong treasury
        ✔ Rejects completion with wrong claim PDA
      cancel_task
        ✔ Rejects cancellation by non-creator
        ✔ Does not reopen cancelled task when claim expires (zombie task fix #138)
      update_state
        ✔ Rejects state update with wrong agent authority
        ✔ Allows state update with correct authority
      initiate_dispute
        ✔ Rejects dispute initiation with wrong agent authority
      vote_dispute
        ✔ Rejects vote with wrong arbiter authority
        ✔ Rejects vote by non-arbiter (lacks ARBITER capability)
      resolve_dispute
        ✔ Rejects resolution before voting ends
        ✔ Rejects resolution with insufficient votes (no votes cast)
      initialize_protocol
        ✔ Rejects re-initialization of already initialized protocol
        ✔ Confirms protocol singleton pattern via PDA
    Audit Gap Filling (Issues 3 & 4)
      ✔ Unauthorized Cancel Rejection (Issue 4)
      ✔ Unauthorized Complete Rejection (Issue 4)
      ✔ Cannot Cancel a Completed Task (Rug Pull Prevention) (Issue 3)
      ✔ Cannot Complete a Cancelled Task (Theft Prevention) (Issue 3)
    Issue #21: Escrow Fund Safety and Lamport Accounting Tests
      create_task lamport accounting
        ✔ Creator balance decreases by exactly reward_amount + rent, escrow has reward_amount
        ✔ Zero-reward task: rejected with InvalidReward error
      complete_task lamport accounting
        ✔ Escrow decreases by reward, worker increases by (reward - fee), treasury increases by fee
        ✔ Collaborative task: reward splits exactly among workers, no dust left
      cancel_task lamport accounting
        ✔ Creator receives exact refund (escrow.amount - escrow.distributed)
        ✔ Cannot cancel task with completions > 0 (funds already distributed) (3018ms)
      Double withdrawal prevention
        ✔ Completing same claim twice fails
        ✔ Cancelling completed task fails
      Escrow close behavior
        ✔ After task completion, escrow.is_closed = true, lamports drained correctly
        ✔ After cancel, escrow.is_closed = true
      Lamport conservation (no leaks)
        ✔ Sum of all balance deltas equals zero (accounting for tx fees)
    Issue #22: Dispute Initiation Correctness Tests
      Valid dispute initiation
        ✔ Can dispute InProgress task
        ✔ Dispute creates with correct voting_deadline (24 hours from creation)
        ✔ Task status changes to Disputed after initiation
        ✔ All resolution types (0, 1, 2) are accepted
      Invalid task states for dispute
        ✔ Cannot dispute Open task
        ✔ Cannot dispute Completed task
        ✔ Cannot dispute Cancelled task
        ✔ Cannot dispute already Disputed task (duplicate dispute)
      Agent validation for dispute initiation
        ✔ Inactive agent cannot initiate dispute
        ✔ Wrong agent authority rejected
      Invalid resolution type
        ✔ resolution_type > 2 is rejected
      Dispute initialization details
        ✔ Dispute fields are correctly initialized
    Issue #23: Dispute Voting and Resolution Safety Tests
      Voting tests
        ✔ Only agents with ARBITER capability (1 << 7 = 128) can vote
        ✔ Arbiter must have sufficient stake (>= protocol_config.min_arbiter_stake)
        ✔ Cannot vote after voting_deadline
        ✔ Cannot vote twice on same dispute (PDA prevents duplicate vote accounts)
        ✔ Vote counts (votes_for, votes_against) increment correctly
        ✔ Active agent status required to vote
      Resolution tests
        ✔ Cannot resolve before voting_deadline
        ✔ Cannot resolve with zero votes (InsufficientVotes)
        ✔ Dispute status changes to Resolved after resolution (verified in existing #22 tests)
    Issue #24: Reputation and Stake Safety Tests
      Reputation tests
        ✔ Initial reputation is 5000 (50%)
        ✔ Reputation increases by 100 on task completion
        ✔ Reputation caps at 10000 (saturating_add)
        ✔ Reputation cannot go negative (saturating behavior)
      Stake tests
        ✔ Arbiter must have stake >= min_arbiter_stake to vote on disputes
        ✔ Stake is tracked in agent.stake field
      Worker stats
        ✔ tasks_completed increments on completion
        ✔ total_earned tracks cumulative rewards
        ✔ active_tasks increments on claim, decrements on completion
    Issue #25: Concurrency and Race Condition Simulation Tests
      Multiple claims
        ✔ Multiple workers can claim collaborative task up to max_workers
        ✔ max_workers+1 claim attempt fails (TaskFullyClaimed)
        ✔ Concurrent claims don't exceed limit (PDA uniqueness enforces this)
      Completion races
        ✔ First completion on exclusive task wins full reward
        ✔ Collaborative task: all required completions must happen
      State consistency
        ✔ current_workers count stays accurate across multiple claims
        ✔ completions count stays accurate across multiple completions
        ✔ Worker active_tasks count stays consistent
    Issue #26: Instruction Fuzzing and Invariant Validation
      Boundary inputs
        ✔ max_workers = 100 (max allowed) is valid
        ✔ max_workers = 0 should fail (InvalidMaxWorkers)
        ✔ reward_amount = 0 is rejected (InvalidReward)
        ✔ reward_amount = very large value should fail (insufficient funds)
        ✔ deadline = 0 should fail with InvalidDeadline (#492)
        ✔ deadline in past should fail on creation
        ✔ task_type > 2 should fail (InvalidTaskType)
        ✔ capabilities = 0 is rejected (InvalidCapabilities)
        ✔ capabilities = u64::MAX is valid
        ✔ Empty strings for endpoint are rejected (InvalidInput)
        ✔ Max length strings (128 chars) for endpoint - must be valid URL
        ✔ Over max length strings (129 chars) should fail
      Invariant checks
        ✔ task.current_workers <= task.max_workers always
        ✔ task.completions <= task.required_completions always
        ✔ escrow.distributed <= escrow.amount always (verified before completion)
        ✔ worker.active_tasks <= 10 always (70ms)
        ✔ Protocol stats only increase (total_tasks, total_agents, completed_tasks)
      PDA uniqueness
        ✔ Same task_id + different creator = different task PDA
        ✔ Same agent_id = same agent PDA (cannot register twice)
    Reputation System
      Reputation gate on claim_task
        ✔ rejects claim when worker reputation is below task min_reputation
        ✔ allows claim when worker reputation meets task min_reputation
        ✔ allows claim when min_reputation is 0 (no gate)
      Task creation validation
        ✔ rejects min_reputation > 10000 (InvalidMinReputation)
        ✔ stores min_reputation on task account

  dispute-slash-logic (issue #136)
    applyDisputeSlash preconditions
      ✔ should fail if dispute is not resolved (DisputeNotResolved error)
      ✔ should verify dispute can be voted on by arbiters
    Issue #136 fix verification (code review)
      ✔ documents the fix for issue #136
      ✔ documents expected behavior for each scenario
    defendant binding (issue #827)
      ✔ should set defendant field and reject slash on wrong worker
    Vote window boundary math (#960)
      ✔ accepts vote 1 second before voting_deadline
      ✔ rejects vote exactly at voting_deadline (VotingEnded)
      ✔ accepts resolve exactly at voting_deadline
      ✔ rejects resolve 1 second before voting_deadline (VotingNotEnded)
    Slash idempotency and window (#960)
      ✔ applies worker slash exactly once (SlashAlreadyApplied on retry)
      ✔ applies initiator slash exactly once (SlashAlreadyApplied on retry)
      ✔ rejects slash after 7-day window (SlashWindowExpired)
      ✔ accepts slash at exactly SLASH_WINDOW boundary
    Deterministic outcome calculation (#960)
      ✔ 3 FOR / 0 AGAINST → APPROVED (worker slash succeeds)
      ✔ 0 FOR / 3 AGAINST → REJECTED (initiator slash succeeds)
      ✔ 2 FOR / 1 AGAINST → APPROVED (66% ≥ 51%)
      ✔ 1 FOR / 2 AGAINST → REJECTED (33% < 51%)
    Split payout correctness (#960)
      ✔ split resolution gives creator the odd-lamport remainder
    Related functionality verification
      ✔ should verify worker stake is tracked correctly
      ✔ should verify arbiters have required stake and capability

  spl-token-tasks (issue #860)
    happy path
      ✔ should create a token-denominated task with escrow funded
      ✔ should claim a token task (no token accounts needed)
      ✔ should complete a token task with correct fee distribution
      ✔ should cancel an unclaimed token task with full refund
      ✔ should create a dependent token task
    edge cases
      ✔ should create SOL task with reward_mint: null (regression)
      ✔ should fail with MissingTokenAccounts when token accounts omitted
      ✔ should fail when creator has insufficient token balance
      ✔ should handle competitive token task (first completer gets tokens)
      ✔ should handle collaborative token task (multiple workers get tokens)
      ✔ should handle minimum reward amount (1 unit, fee rounds to 0)
      ✔ should work with 0-decimal mint
    fee verification
      ✔ should collect protocol fees in tokens, not SOL
    dispute preconditions (token tasks)
      ✔ should initiate a dispute on a token task
      ✔ should vote on a dispute for a token task
      ✔ should reject resolve before voting period ends (VotingNotEnded)
    token dispute resolution + slash
      ✔ should reserve token slash at resolve and settle it in applyDisputeSlash

  Task lifecycle guards (#959)
    ✔ rejects double completion on competitive task (CompetitiveTaskAlreadyWon)
    ✔ rejects dispute initiation on completed task (TaskNotInProgress)
    ✔ rejects claim after task deadline (TaskExpired)
    ✔ rejects cancel on completed task (InvalidStatusTransition)
    ✔ rejects deregister with active tasks (AgentHasActiveTasks)
    ✔ rejects deregister with disputes_as_defendant > 0 (ActiveDisputesExist)
    ✔ rejects completion of cancelled task (TaskCannotBeCancelled or TaskNotInProgress)
    ✔ rejects claim on cancelled task (TaskNotOpen)


  185 passing (5s)
- [x] 
> agenc-coordination@0.1.0 typecheck
> npm run typecheck --prefix sdk && npm run typecheck --prefix runtime && npm run typecheck --prefix mcp


> @agenc/sdk@1.3.0 typecheck
> tsc --noEmit


> @agenc/runtime@0.1.0 typecheck
> tsc --noEmit


> @agenc/mcp@0.1.0 pretypecheck
> npm install --no-save --no-package-lock --no-audit --no-fund


changed 13 packages in 1s

> @agenc/mcp@0.1.0 typecheck
> tsc --noEmit

Closes #990