### PR TITLE
feat(runtime): add evidence-pack export for incidents

### DIFF
--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -52,6 +52,7 @@ export interface ReplayIncidentOptions extends BaseCliOptions {
   disputePda?: string;
   fromSlot?: number;
   toSlot?: number;
+  sealed?: boolean;
   redactFields?: string[];
 }
 

--- a/runtime/src/eval/evidence-pack.test.ts
+++ b/runtime/src/eval/evidence-pack.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { PublicKey } from '@solana/web3.js';
+import { projectOnChainEvents, type OnChainProjectionInput } from './projector.js';
+import { buildIncidentCase } from './incident-case.js';
+import {
+  EVIDENCE_PACK_SCHEMA_VERSION,
+  buildEvidencePack,
+  serializeEvidencePack,
+} from './evidence-pack.js';
+
+function pubkey(seed: number): PublicKey {
+  const bytes = new Uint8Array(32);
+  bytes.fill(seed);
+  return new PublicKey(bytes);
+}
+
+function bytes(seed = 0, length = 32): Uint8Array {
+  const output = new Uint8Array(length);
+  output.fill(seed);
+  return output;
+}
+
+describe('evidence-pack', () => {
+  it('builds a basic evidence pack manifest with deterministic hashes', () => {
+    const taskId = bytes(1);
+    const creator = pubkey(2);
+    const worker = pubkey(3);
+
+    const inputs: OnChainProjectionInput[] = [
+      {
+        eventName: 'taskCreated',
+        slot: 10,
+        signature: 'AAA',
+        timestampMs: 1_000,
+        event: {
+          taskId,
+          creator,
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+      {
+        eventName: 'taskClaimed',
+        slot: 11,
+        signature: 'BBB',
+        timestampMs: 1_100,
+        event: {
+          taskId,
+          worker,
+          currentWorkers: 1,
+          maxWorkers: 1,
+          timestamp: 1_100,
+        },
+      },
+    ];
+
+    const events = projectOnChainEvents(inputs).events;
+    const incidentCase = buildIncidentCase({ events });
+    const queryHash = createHash('sha256').update('query').digest('hex');
+
+    const pack = buildEvidencePack({
+      incidentCase,
+      events,
+      seed: 99,
+      queryHash,
+      runtimeVersion: '0.1.0-test',
+    });
+
+    expect(pack.manifest.schemaVersion).toBe(EVIDENCE_PACK_SCHEMA_VERSION);
+    expect(pack.manifest.seed).toBe(99);
+    expect(pack.manifest.queryHash).toBe(queryHash);
+    expect(pack.manifest.runtimeVersion).toBe('0.1.0-test');
+    expect(pack.manifest.sealed).toBe(false);
+    expect(pack.manifest.cursorRange.fromSlot).toBe(pack.incidentCase.traceWindow.fromSlot);
+    expect(pack.manifest.cursorRange.toSlot).toBe(pack.incidentCase.traceWindow.toSlot);
+    expect(pack.manifest.cursorRange.fromSignature).toBe(events[0]?.signature);
+    expect(pack.manifest.cursorRange.toSignature).toBe(events[events.length - 1]?.signature);
+
+    expect(pack.manifest.schemaHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(pack.manifest.toolFingerprint).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(pack.manifest.evidenceHashes).toHaveLength(2);
+    expect(pack.manifest.evidenceHashes.map((entry) => entry.label)).toEqual(['incident-case', 'events']);
+    expect(pack.manifest.evidenceHashes.every((entry) => /^[0-9a-f]{64}$/.test(entry.sha256))).toBe(true);
+    expect(pack.incidentCase.evidenceHashes.some((entry) => entry.label === 'events')).toBe(true);
+  });
+
+  it('serializes to manifest + case jsonl + events jsonl', () => {
+    const events = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'SIG',
+        timestampMs: 1_000,
+        event: {
+          taskId: bytes(1),
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+    ]).events;
+
+    const pack = buildEvidencePack({
+      incidentCase: buildIncidentCase({ events }),
+      events,
+      seed: 0,
+      queryHash: createHash('sha256').update('q').digest('hex'),
+      runtimeVersion: '0.1.0-test',
+    });
+
+    const files = serializeEvidencePack(pack);
+    const manifest = JSON.parse(files['manifest.json']) as Record<string, unknown>;
+    expect(manifest.schemaVersion).toBe(EVIDENCE_PACK_SCHEMA_VERSION);
+
+    const parsedCase = JSON.parse(files['incident-case.jsonl']) as Record<string, unknown>;
+    expect(parsedCase.caseId).toBe(pack.incidentCase.caseId);
+
+    const parsedEvents = files['events.jsonl']
+      .split('\n')
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(parsedEvents).toHaveLength(events.length);
+    expect(parsedEvents[0]?.signature).toBe(events[0]?.signature);
+  });
+
+  it('supports sealed mode with dot-path redaction', () => {
+    const taskId = bytes(1);
+    const traceContext = {
+      traceId: 'trace-1',
+      spanId: 'span-1',
+      parentSpanId: 'parent-1',
+      sampled: true,
+    };
+
+    const events = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'SIG',
+        timestampMs: 1_000,
+        traceContext,
+        event: {
+          taskId,
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+    ]).events;
+
+    const pack = buildEvidencePack({
+      incidentCase: buildIncidentCase({ events }),
+      events,
+      seed: 0,
+      queryHash: createHash('sha256').update('q').digest('hex'),
+      runtimeVersion: '0.1.0-test',
+      sealed: true,
+      redactionPolicy: {
+        stripFields: ['payload.onchain.trace'],
+      },
+    });
+
+    const onchain = (pack.events[0]?.payload as Record<string, unknown>).onchain as Record<string, unknown>;
+    expect(onchain.trace).toBeUndefined();
+  });
+
+  it('supports actor redaction in sealed mode', () => {
+    const taskId = bytes(1);
+    const creator = pubkey(2);
+
+    const events = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'SIG',
+        timestampMs: 1_000,
+        event: {
+          taskId,
+          creator,
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+    ]).events;
+
+    const caseUnsealed = buildIncidentCase({ events });
+    const pack = buildEvidencePack({
+      incidentCase: caseUnsealed,
+      events,
+      seed: 0,
+      queryHash: createHash('sha256').update('q').digest('hex'),
+      runtimeVersion: '0.1.0-test',
+      sealed: true,
+      redactionPolicy: {
+        redactActors: true,
+      },
+    });
+
+    expect(caseUnsealed.actorMap[0]?.pubkey).toBe(creator.toBase58());
+    expect(pack.incidentCase.actorMap[0]?.pubkey).not.toBe(creator.toBase58());
+    expect(pack.incidentCase.actorMap[0]?.pubkey).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('produces identical evidence hashes for identical inputs', () => {
+    const events = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'SIG',
+        timestampMs: 1_000,
+        event: {
+          taskId: bytes(1),
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+    ]).events;
+
+    const incidentCase = buildIncidentCase({ events });
+    const queryHash = createHash('sha256').update('q').digest('hex');
+
+    const pack1 = buildEvidencePack({ incidentCase, events, seed: 0, queryHash, runtimeVersion: '0.1.0-test' });
+    const pack2 = buildEvidencePack({ incidentCase, events, seed: 0, queryHash, runtimeVersion: '0.1.0-test' });
+
+    expect(pack1.manifest.queryHash).toBe(pack2.manifest.queryHash);
+    expect(pack1.manifest.evidenceHashes).toEqual(pack2.manifest.evidenceHashes);
+  });
+
+  it('handles empty events', () => {
+    const pack = buildEvidencePack({
+      incidentCase: buildIncidentCase({ events: [] }),
+      events: [],
+      seed: 0,
+      queryHash: createHash('sha256').update('q').digest('hex'),
+      runtimeVersion: '0.1.0-test',
+    });
+
+    expect(pack.manifest.cursorRange.fromSlot).toBe(0);
+    expect(pack.manifest.cursorRange.toSlot).toBe(0);
+    expect(pack.events).toHaveLength(0);
+    expect(serializeEvidencePack(pack)['events.jsonl']).toBe('');
+  });
+
+  it('does not change evidence hashes when runtimeVersion changes', () => {
+    const events = projectOnChainEvents([
+      {
+        eventName: 'taskCreated',
+        slot: 1,
+        signature: 'SIG',
+        timestampMs: 1_000,
+        event: {
+          taskId: bytes(1),
+          creator: pubkey(1),
+          requiredCapabilities: 0n,
+          rewardAmount: 0n,
+          taskType: 0,
+          deadline: 0,
+          minReputation: 0,
+          rewardMint: null,
+          timestamp: 1_000,
+        },
+      },
+    ]).events;
+
+    const incidentCase = buildIncidentCase({ events });
+    const queryHash = createHash('sha256').update('q').digest('hex');
+
+    const pack1 = buildEvidencePack({ incidentCase, events, seed: 0, queryHash, runtimeVersion: '0.1.0-test' });
+    const pack2 = buildEvidencePack({ incidentCase, events, seed: 0, queryHash, runtimeVersion: '0.2.0-test' });
+
+    expect(pack1.manifest.runtimeVersion).not.toBe(pack2.manifest.runtimeVersion);
+    expect(pack1.manifest.evidenceHashes).toEqual(pack2.manifest.evidenceHashes);
+  });
+});
+

--- a/runtime/src/eval/evidence-pack.ts
+++ b/runtime/src/eval/evidence-pack.ts
@@ -1,0 +1,321 @@
+/**
+ * Evidence-pack builder for reproducible incident exports.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+import runtimePackage from '../../package.json';
+import { stableStringifyJson, type JsonValue, EVAL_TRACE_SCHEMA_VERSION } from './types.js';
+import { computeEvidenceHash, INCIDENT_CASE_SCHEMA_VERSION, type IncidentCase, type IncidentEvidenceHash } from './incident-case.js';
+import type { ProjectedTimelineEvent } from './projector.js';
+
+/** Schema version for evidence-pack manifest format. */
+export const EVIDENCE_PACK_SCHEMA_VERSION = 1 as const;
+
+/** Manifest included in every evidence bundle. */
+export interface EvidencePackManifest {
+  schemaVersion: typeof EVIDENCE_PACK_SCHEMA_VERSION;
+  seed: number;
+  queryHash: string;
+  cursorRange: {
+    fromSlot: number;
+    toSlot: number;
+    fromSignature?: string;
+    toSignature?: string;
+  };
+  runtimeVersion: string;
+  schemaHash: string;
+  toolFingerprint: string;
+  sealed: boolean;
+  createdAtMs: number;
+  evidenceHashes: IncidentEvidenceHash[];
+}
+
+/** Redaction policy for sealed mode exports. */
+export interface RedactionPolicy {
+  stripFields?: string[];
+  redactPatterns?: RegExp[];
+  redactActors?: boolean;
+}
+
+/** The complete evidence bundle (in-memory representation). */
+export interface EvidencePack {
+  manifest: EvidencePackManifest;
+  incidentCase: IncidentCase;
+  events: ProjectedTimelineEvent[];
+}
+
+export interface BuildEvidencePackInput {
+  incidentCase: IncidentCase;
+  events: readonly ProjectedTimelineEvent[];
+  seed: number;
+  queryHash: string;
+  sealed?: boolean;
+  redactionPolicy?: RedactionPolicy;
+  runtimeVersion?: string;
+}
+
+const DEFAULT_RUNTIME_VERSION = typeof (runtimePackage as { version?: unknown }).version === 'string'
+  ? (runtimePackage as { version: string }).version
+  : 'unknown';
+
+const REDACTED_MARKER = '[REDACTED]';
+
+export function buildEvidencePack(input: BuildEvidencePackInput): EvidencePack {
+  const sealed = input.sealed === true;
+  const runtimeVersion = typeof input.runtimeVersion === 'string' && input.runtimeVersion.length > 0
+    ? input.runtimeVersion
+    : DEFAULT_RUNTIME_VERSION;
+
+  let events = [...input.events];
+  let incidentCase: IncidentCase = {
+    ...input.incidentCase,
+    // Bundle content should be stable for identical event inputs.
+    createdAtMs: input.incidentCase.traceWindow.toTimestampMs,
+  };
+
+  if (sealed && input.redactionPolicy) {
+    events = events.map((event) => applyRedaction(event, input.redactionPolicy!));
+
+    if (input.redactionPolicy.redactActors) {
+      incidentCase = {
+        ...incidentCase,
+        actorMap: incidentCase.actorMap.map((actor) => ({
+          ...actor,
+          pubkey: truncateHash(actor.pubkey),
+        })),
+      };
+    }
+  }
+
+  const eventsHash = computeEvidenceHash('events', events as unknown as JsonValue);
+  const incidentCaseWithRefs: IncidentCase = {
+    ...incidentCase,
+    evidenceHashes: [...incidentCase.evidenceHashes, eventsHash],
+  };
+  const caseHash = computeEvidenceHash('incident-case', incidentCaseWithRefs as unknown as JsonValue);
+
+  const cursorRange = {
+    fromSlot: incidentCaseWithRefs.traceWindow.fromSlot,
+    toSlot: incidentCaseWithRefs.traceWindow.toSlot,
+    fromSignature: events[0]?.signature,
+    toSignature: events[events.length - 1]?.signature,
+  };
+
+  const toolFingerprint = computeToolFingerprint();
+  const schemaHash = computeSchemaHash();
+
+  const manifest: EvidencePackManifest = {
+    schemaVersion: EVIDENCE_PACK_SCHEMA_VERSION,
+    seed: input.seed,
+    queryHash: input.queryHash,
+    cursorRange,
+    runtimeVersion,
+    schemaHash,
+    toolFingerprint,
+    sealed,
+    createdAtMs: Date.now(),
+    evidenceHashes: [caseHash, eventsHash],
+  };
+
+  return {
+    manifest,
+    incidentCase: incidentCaseWithRefs,
+    events,
+  };
+}
+
+/** Serialize bundle to the three-file format. */
+export function serializeEvidencePack(pack: EvidencePack): {
+  'manifest.json': string;
+  'incident-case.jsonl': string;
+  'events.jsonl': string;
+} {
+  return {
+    'manifest.json': JSON.stringify(pack.manifest, null, 2),
+    'incident-case.jsonl': stableStringifyJson(pack.incidentCase as unknown as JsonValue),
+    'events.jsonl': pack.events
+      .map((event) => stableStringifyJson(event as unknown as JsonValue))
+      .join('\n'),
+  };
+}
+
+function applyRedaction(
+  event: ProjectedTimelineEvent,
+  policy: RedactionPolicy,
+): ProjectedTimelineEvent {
+  let payload: unknown = event.payload;
+
+  for (const rawPath of policy.stripFields ?? []) {
+    payload = deepDeleteField(payload, rawPath);
+  }
+
+  if (policy.redactPatterns && policy.redactPatterns.length > 0) {
+    payload = deepRedactPattern(payload, policy.redactPatterns);
+  }
+
+  return {
+    ...event,
+    payload: payload as ProjectedTimelineEvent['payload'],
+  };
+}
+
+function deepDeleteField(value: unknown, path: string): unknown {
+  const normalized = path.startsWith('payload.') ? path.slice('payload.'.length) : path;
+  const segments = normalized.split('.').filter((segment) => segment.length > 0);
+  if (segments.length === 0) {
+    return value;
+  }
+  return deepDeleteSegment(value, segments, 0);
+}
+
+function deepDeleteSegment(value: unknown, segments: readonly string[], index: number): unknown {
+  if (value === null || value === undefined || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    // Dot-path deletion is defined primarily for object payloads; leave arrays intact.
+    return value.map((entry) => deepDeleteSegment(entry, segments, index));
+  }
+
+  const key = segments[index];
+  if (!key) {
+    return value;
+  }
+
+  const record = value as Record<string, unknown>;
+  if (!(key in record)) {
+    return value;
+  }
+
+  if (index === segments.length - 1) {
+    const output: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(record)) {
+      if (k !== key) {
+        output[k] = v;
+      }
+    }
+    return output;
+  }
+
+  const child = record[key];
+  const updatedChild = deepDeleteSegment(child, segments, index + 1);
+  if (updatedChild === child) {
+    return value;
+  }
+
+  return {
+    ...record,
+    [key]: updatedChild,
+  };
+}
+
+function deepRedactPattern(value: unknown, patterns: readonly RegExp[]): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'string') {
+    for (const pattern of patterns) {
+      // Avoid stateful regexp surprises.
+      pattern.lastIndex = 0;
+      if (pattern.test(value)) {
+        return REDACTED_MARKER;
+      }
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => deepRedactPattern(entry, patterns));
+  }
+
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(record)) {
+      output[key] = deepRedactPattern(entry, patterns);
+    }
+    return output;
+  }
+
+  return value;
+}
+
+function truncateHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16);
+}
+
+function computeSchemaHash(): string {
+  const schemaLayout = {
+    IncidentCase: [
+      'schemaVersion',
+      'caseId',
+      'createdAtMs',
+      'traceWindow',
+      'transitions',
+      'anomalyIds',
+      'anomalies',
+      'actorMap',
+      'evidenceHashes',
+      'caseStatus',
+      'taskIds',
+      'disputeIds',
+      'metadata',
+    ],
+    IncidentTraceWindow: [
+      'fromSlot',
+      'toSlot',
+      'fromTimestampMs',
+      'toTimestampMs',
+    ],
+    IncidentTransition: [
+      'seq',
+      'fromState',
+      'toState',
+      'slot',
+      'signature',
+      'sourceEventName',
+      'timestampMs',
+      'taskPda',
+      'disputePda',
+    ],
+    IncidentActor: [
+      'pubkey',
+      'role',
+      'firstSeenSeq',
+    ],
+    IncidentAnomalyRef: [
+      'anomalyId',
+      'code',
+      'severity',
+      'message',
+      'seq',
+    ],
+    IncidentEvidenceHash: [
+      'label',
+      'sha256',
+    ],
+    versions: {
+      evalTrace: EVAL_TRACE_SCHEMA_VERSION,
+      incidentCase: INCIDENT_CASE_SCHEMA_VERSION,
+      evidencePack: EVIDENCE_PACK_SCHEMA_VERSION,
+    },
+  };
+
+  return createHash('sha256')
+    .update(stableStringifyJson(schemaLayout as unknown as JsonValue))
+    .digest('hex');
+}
+
+function computeToolFingerprint(): string {
+  const seed = stableStringifyJson({
+    evalTraceSchemaVersion: EVAL_TRACE_SCHEMA_VERSION,
+    incidentCaseSchemaVersion: INCIDENT_CASE_SCHEMA_VERSION,
+    evidencePackSchemaVersion: EVIDENCE_PACK_SCHEMA_VERSION,
+  } as unknown as JsonValue);
+  return createHash('sha256').update(seed).digest('hex');
+}
+

--- a/runtime/src/eval/index.ts
+++ b/runtime/src/eval/index.ts
@@ -99,6 +99,16 @@ export {
 } from './incident-case.js';
 
 export {
+  EVIDENCE_PACK_SCHEMA_VERSION,
+  buildEvidencePack,
+  serializeEvidencePack,
+  type BuildEvidencePackInput,
+  type EvidencePack,
+  type EvidencePackManifest,
+  type RedactionPolicy,
+} from './evidence-pack.js';
+
+export {
   BENCHMARK_MANIFEST_SCHEMA_VERSION,
   parseBenchmarkManifest,
   loadBenchmarkManifest,


### PR DESCRIPTION
## Summary
- Added eval evidence-pack builder/serializer with deterministic manifest + hashes
- Integrated `--sealed` into `replay incident` to emit a redacted evidence bundle
- Added tests for evidence pack generation/serialization/redaction and CLI sealed flag behavior

## Test plan
- [x] `npm run build`
- [x] `npm run test`
- [x] `npm run test:fast`
- [x] `npm run typecheck`

Closes #991
