### PR TITLE
feat(runtime): add incident role policy and hash-chained audit trail

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -222,6 +222,7 @@ MCP_REPLAY_MAX_EVENT_COUNT=2000
 MCP_REPLAY_MAX_CONCURRENT_JOBS=2
 MCP_REPLAY_TOOL_TIMEOUT_MS=180000
 MCP_REPLAY_ALLOWLIST=incident-bot,security-operator
+MCP_OPERATOR_ROLE=read
 MCP_REPLAY_REQUIRE_AUTH_FOR_HIGH_RISK=true
 MCP_REPLAY_AUDIT_ENABLED=true
 ```
@@ -230,6 +231,7 @@ Policy behavior:
 
 - `MCP_REPLAY_DENYLIST` blocks matching actors first.
 - If `MCP_REPLAY_ALLOWLIST` is set, only matching actors can run replay tools.
+- `MCP_OPERATOR_ROLE` (when set) enforces the incident role permission matrix for replay tools.
 - If `MCP_REPLAY_REQUIRE_AUTH_FOR_HIGH_RISK=true`, high-risk tools require actors resolved via `authInfo.clientId` (not sessions/anonymous).
 - Actor identity is resolved from MCP auth context in this order:
   1. `authInfo.clientId`

--- a/runtime/docs/replay-cli.md
+++ b/runtime/docs/replay-cli.md
@@ -59,6 +59,8 @@ agenc-runtime replay incident \
   --sqlite-path .agenc/replay-events.sqlite
 ```
 
+Role enforcement is opt-in. Provide `--role read|investigate|execute|admin` to enforce the incident permission matrix.
+
 You can also provide a structured analyst query DSL:
 
 ```bash

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -1,4 +1,5 @@
 import type { PluginPrecedence, PluginSlot } from '../skills/catalog.js';
+import type { OperatorRole } from '../policy/incident-roles.js';
 
 export type CliOutputFormat = 'json' | 'jsonl' | 'table';
 
@@ -27,6 +28,7 @@ export interface BaseCliOptions {
   help: boolean;
   outputFormat: CliOutputFormat;
   strictMode: boolean;
+  role?: OperatorRole;
   rpcUrl?: string;
   programId?: string;
   storeType: 'memory' | 'sqlite';

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -725,6 +725,13 @@ export {
 export {
   PolicyEngine,
   PolicyViolationError,
+  ROLE_PERMISSION_MATRIX,
+  isCommandAllowed,
+  enforceRole,
+  IncidentRoleViolationError,
+  InMemoryAuditTrail,
+  computeInputHash,
+  computeOutputHash,
   type PolicyActionType,
   type PolicyAccess,
   type CircuitBreakerMode,
@@ -737,6 +744,12 @@ export {
   type PolicyDecision,
   type PolicyEngineState,
   type PolicyEngineConfig,
+  type OperatorRole,
+  type IncidentCommandCategory,
+  type RolePermission,
+  type AuditTrailEntry,
+  type AuditTrailStore,
+  type AuditTrailVerification,
 } from './policy/index.js';
 
 // Tool System (Phase 5)

--- a/runtime/src/policy/audit-trail.test.ts
+++ b/runtime/src/policy/audit-trail.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import { stableStringifyJson, type JsonValue } from '../eval/types.js';
+import { computeInputHash, computeOutputHash, InMemoryAuditTrail } from './audit-trail.js';
+
+describe('audit-trail', () => {
+  it('appends entries and maintains a valid hash chain', () => {
+    const trail = new InMemoryAuditTrail();
+
+    trail.append({
+      timestamp: '2026-02-15T00:00:00.000Z',
+      actor: 'alice',
+      role: 'investigate',
+      action: 'replay.incident',
+      inputHash: computeInputHash({ taskPda: 'Task_A' }),
+      outputHash: computeOutputHash({ status: 'ok' }),
+    });
+    trail.append({
+      timestamp: '2026-02-15T00:00:01.000Z',
+      actor: 'alice',
+      role: 'investigate',
+      action: 'replay.compare',
+      inputHash: computeInputHash({ taskPda: 'Task_A' }),
+      outputHash: computeOutputHash({ status: 'clean' }),
+    });
+    trail.append({
+      timestamp: '2026-02-15T00:00:02.000Z',
+      actor: 'bob',
+      role: 'execute',
+      action: 'replay.backfill',
+      inputHash: computeInputHash({ to_slot: 1 }),
+      outputHash: computeOutputHash({ processed: 1 }),
+    });
+
+    expect(trail.verify()).toEqual({ valid: true, entries: 3 });
+  });
+
+  it('detects tampering via verify()', () => {
+    const trail = new InMemoryAuditTrail();
+    trail.append({
+      timestamp: '2026-02-15T00:00:00.000Z',
+      actor: 'alice',
+      role: 'investigate',
+      action: 'replay.incident',
+      inputHash: computeInputHash({}),
+      outputHash: computeOutputHash({}),
+    });
+    trail.append({
+      timestamp: '2026-02-15T00:00:01.000Z',
+      actor: 'alice',
+      role: 'investigate',
+      action: 'replay.compare',
+      inputHash: computeInputHash({}),
+      outputHash: computeOutputHash({ ok: true }),
+    });
+    trail.append({
+      timestamp: '2026-02-15T00:00:02.000Z',
+      actor: 'alice',
+      role: 'investigate',
+      action: 'replay.compare',
+      inputHash: computeInputHash({}),
+      outputHash: computeOutputHash({ ok: true }),
+    });
+
+    const entries = trail.getAll() as unknown as Array<{ seq: number; outputHash: string }>;
+    entries[1]!.outputHash = 'tampered';
+
+    const verification = trail.verify();
+    expect(verification.valid).toBe(false);
+    expect(verification.brokenAt).toBe(2);
+  });
+
+  it('sets prevEntryHash to empty string for the first entry and computes entryHash deterministically', () => {
+    const trail = new InMemoryAuditTrail();
+
+    const entry = trail.append({
+      timestamp: '2026-02-15T00:00:00.000Z',
+      actor: 'alice',
+      role: 'read',
+      action: 'replay.incident',
+      inputHash: computeInputHash({ taskPda: 'Task_A' }),
+      outputHash: computeOutputHash({ status: 'ok' }),
+    });
+
+    expect(entry.seq).toBe(1);
+    expect(entry.prevEntryHash).toBe('');
+
+    const expectedCanonical = stableStringifyJson({
+      seq: entry.seq,
+      timestamp: entry.timestamp,
+      actor: entry.actor,
+      role: entry.role,
+      action: entry.action,
+      inputHash: entry.inputHash,
+      outputHash: entry.outputHash,
+      prevEntryHash: entry.prevEntryHash,
+    } as unknown as JsonValue);
+    const expectedHash = createHash('sha256').update(expectedCanonical).digest('hex');
+    expect(entry.entryHash).toBe(expectedHash);
+  });
+
+  it('produces deterministic input/output hashes across calls', () => {
+    const inputHash1 = computeInputHash({ b: 2, a: 1 });
+    const inputHash2 = computeInputHash({ a: 1, b: 2 });
+    expect(inputHash1).toBe(inputHash2);
+
+    const outputHash1 = computeOutputHash({ status: 'ok', value: 1 });
+    const outputHash2 = computeOutputHash({ value: 1, status: 'ok' });
+    expect(outputHash1).toBe(outputHash2);
+  });
+
+  it('verifies empty audit trail as valid', () => {
+    const trail = new InMemoryAuditTrail();
+    expect(trail.verify()).toEqual({ valid: true, entries: 0 });
+  });
+});
+

--- a/runtime/src/policy/audit-trail.ts
+++ b/runtime/src/policy/audit-trail.ts
@@ -1,0 +1,158 @@
+/**
+ * Append-only audit trail with deterministic SHA-256 hash chaining.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+import { stableStringifyJson, type JsonValue } from '../eval/types.js';
+import type { IncidentCommandCategory, OperatorRole } from './incident-roles.js';
+
+/** Single entry in the append-only audit trail. */
+export interface AuditTrailEntry {
+  /** Monotonic sequence number. */
+  seq: number;
+  /** ISO-8601 timestamp. */
+  timestamp: string;
+  /** Operator identity (pubkey or username). */
+  actor: string;
+  /** Operator role at time of action. */
+  role: OperatorRole;
+  /** Action performed (command category). */
+  action: IncidentCommandCategory;
+  /** SHA-256 of the action input parameters. */
+  inputHash: string;
+  /** SHA-256 of the action output. */
+  outputHash: string;
+  /** SHA-256 of the previous entry (empty string for first entry). */
+  prevEntryHash: string;
+  /** SHA-256 of this entry (computed from all fields above). */
+  entryHash: string;
+}
+
+/** Persistence interface for audit trail. */
+export interface AuditTrailStore {
+  append(entry: Omit<AuditTrailEntry, 'seq' | 'entryHash' | 'prevEntryHash'>): AuditTrailEntry;
+  getAll(): ReadonlyArray<AuditTrailEntry>;
+  getLast(): AuditTrailEntry | null;
+  verify(): AuditTrailVerification;
+  clear(): void;
+}
+
+export interface AuditTrailVerification {
+  valid: boolean;
+  entries: number;
+  brokenAt?: number; // seq of first broken link
+  message?: string;
+}
+
+function computeEntryHash(entry: Omit<AuditTrailEntry, 'entryHash'>): string {
+  const canonical = stableStringifyJson({
+    seq: entry.seq,
+    timestamp: entry.timestamp,
+    actor: entry.actor,
+    role: entry.role,
+    action: entry.action,
+    inputHash: entry.inputHash,
+    outputHash: entry.outputHash,
+    prevEntryHash: entry.prevEntryHash,
+  } as unknown as JsonValue);
+
+  return createHash('sha256').update(canonical).digest('hex');
+}
+
+export class InMemoryAuditTrail implements AuditTrailStore {
+  private entries: AuditTrailEntry[] = [];
+
+  append(input: Omit<AuditTrailEntry, 'seq' | 'entryHash' | 'prevEntryHash'>): AuditTrailEntry {
+    const seq = this.entries.length + 1;
+    const prevEntry = this.entries[this.entries.length - 1];
+    const prevEntryHash = prevEntry?.entryHash ?? '';
+
+    const entry: Omit<AuditTrailEntry, 'entryHash'> = {
+      seq,
+      timestamp: input.timestamp,
+      actor: input.actor,
+      role: input.role,
+      action: input.action,
+      inputHash: input.inputHash,
+      outputHash: input.outputHash,
+      prevEntryHash,
+    };
+
+    const entryHash = computeEntryHash(entry);
+    const resolved: AuditTrailEntry = {
+      ...entry,
+      entryHash,
+    };
+
+    this.entries.push(resolved);
+    return resolved;
+  }
+
+  getAll(): ReadonlyArray<AuditTrailEntry> {
+    return this.entries;
+  }
+
+  getLast(): AuditTrailEntry | null {
+    return this.entries.length === 0 ? null : this.entries[this.entries.length - 1] ?? null;
+  }
+
+  verify(): AuditTrailVerification {
+    if (this.entries.length === 0) {
+      return { valid: true, entries: 0 };
+    }
+
+    for (let index = 0; index < this.entries.length; index += 1) {
+      const entry = this.entries[index]!;
+
+      const expectedPrev = index === 0 ? '' : this.entries[index - 1]!.entryHash;
+      if (entry.prevEntryHash !== expectedPrev) {
+        return {
+          valid: false,
+          entries: this.entries.length,
+          brokenAt: entry.seq,
+          message: 'chain link broken',
+        };
+      }
+
+      const recomputed = computeEntryHash({
+        seq: entry.seq,
+        timestamp: entry.timestamp,
+        actor: entry.actor,
+        role: entry.role,
+        action: entry.action,
+        inputHash: entry.inputHash,
+        outputHash: entry.outputHash,
+        prevEntryHash: entry.prevEntryHash,
+      });
+      if (entry.entryHash !== recomputed) {
+        return {
+          valid: false,
+          entries: this.entries.length,
+          brokenAt: entry.seq,
+          message: 'entry hash mismatch',
+        };
+      }
+    }
+
+    return { valid: true, entries: this.entries.length };
+  }
+
+  clear(): void {
+    this.entries = [];
+  }
+}
+
+export function computeInputHash(input: unknown): string {
+  return createHash('sha256')
+    .update(stableStringifyJson(input as JsonValue))
+    .digest('hex');
+}
+
+export function computeOutputHash(output: unknown): string {
+  return createHash('sha256')
+    .update(stableStringifyJson(output as JsonValue))
+    .digest('hex');
+}
+

--- a/runtime/src/policy/incident-roles.test.ts
+++ b/runtime/src/policy/incident-roles.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ROLE_PERMISSION_MATRIX,
+  enforceRole,
+  IncidentRoleViolationError,
+  isCommandAllowed,
+  type IncidentCommandCategory,
+  type OperatorRole,
+} from './incident-roles.js';
+
+const ROLES: OperatorRole[] = ['read', 'investigate', 'execute', 'admin'];
+const COMMANDS: IncidentCommandCategory[] = [
+  'replay.backfill',
+  'replay.compare',
+  'replay.incident',
+  'replay.export',
+  'incident.annotate',
+  'incident.resolve',
+  'incident.archive',
+  'config.update',
+  'policy.update',
+];
+
+describe('incident-roles', () => {
+  it('defines permissions for every role x command combination', () => {
+    for (const role of ROLES) {
+      for (const command of COMMANDS) {
+        const matches = ROLE_PERMISSION_MATRIX.filter((entry) => entry.role === role && entry.command === command);
+        expect(matches).toHaveLength(1);
+      }
+    }
+  });
+
+  it('read role cannot mutate', () => {
+    expect(isCommandAllowed('read', 'incident.resolve')).toBe(false);
+  });
+
+  it('admin can do everything', () => {
+    for (const command of COMMANDS) {
+      expect(isCommandAllowed('admin', command)).toBe(true);
+    }
+  });
+
+  it('role escalation is blocked', () => {
+    expect(isCommandAllowed('investigate', 'config.update')).toBe(false);
+  });
+
+  it('enforceRole throws IncidentRoleViolationError', () => {
+    expect(() => enforceRole('read', 'replay.backfill')).toThrow(IncidentRoleViolationError);
+  });
+
+  it('IncidentRoleViolationError exposes role and command', () => {
+    try {
+      enforceRole('read', 'replay.backfill');
+    } catch (error) {
+      const violation = error as IncidentRoleViolationError;
+      expect(violation.role).toBe('read');
+      expect(violation.command).toBe('replay.backfill');
+    }
+  });
+});
+

--- a/runtime/src/policy/incident-roles.ts
+++ b/runtime/src/policy/incident-roles.ts
@@ -1,0 +1,98 @@
+/**
+ * Incident operator roles and permission enforcement.
+ *
+ * @module
+ */
+
+/** Operator role for incident investigation workflow. */
+export type OperatorRole = 'read' | 'investigate' | 'execute' | 'admin';
+
+/** Command categories for permission mapping. */
+export type IncidentCommandCategory =
+  | 'replay.backfill'
+  | 'replay.compare'
+  | 'replay.incident'
+  | 'replay.export'
+  | 'incident.annotate'
+  | 'incident.resolve'
+  | 'incident.archive'
+  | 'config.update'
+  | 'policy.update';
+
+/** Permission entry: whether a role can invoke a command category. */
+export interface RolePermission {
+  role: OperatorRole;
+  command: IncidentCommandCategory;
+  allowed: boolean;
+}
+
+/** Static role-to-permission matrix. */
+export const ROLE_PERMISSION_MATRIX: ReadonlyArray<RolePermission> = [
+  // read: can view incidents, run compare, view backfill status
+  { role: 'read', command: 'replay.incident', allowed: true },
+  { role: 'read', command: 'replay.compare', allowed: true },
+  { role: 'read', command: 'replay.backfill', allowed: false },
+  { role: 'read', command: 'replay.export', allowed: true },
+  { role: 'read', command: 'incident.annotate', allowed: false },
+  { role: 'read', command: 'incident.resolve', allowed: false },
+  { role: 'read', command: 'incident.archive', allowed: false },
+  { role: 'read', command: 'config.update', allowed: false },
+  { role: 'read', command: 'policy.update', allowed: false },
+
+  // investigate: read + annotate + backfill
+  { role: 'investigate', command: 'replay.incident', allowed: true },
+  { role: 'investigate', command: 'replay.compare', allowed: true },
+  { role: 'investigate', command: 'replay.backfill', allowed: true },
+  { role: 'investigate', command: 'replay.export', allowed: true },
+  { role: 'investigate', command: 'incident.annotate', allowed: true },
+  { role: 'investigate', command: 'incident.resolve', allowed: false },
+  { role: 'investigate', command: 'incident.archive', allowed: false },
+  { role: 'investigate', command: 'config.update', allowed: false },
+  { role: 'investigate', command: 'policy.update', allowed: false },
+
+  // execute: investigate + resolve + archive
+  { role: 'execute', command: 'replay.incident', allowed: true },
+  { role: 'execute', command: 'replay.compare', allowed: true },
+  { role: 'execute', command: 'replay.backfill', allowed: true },
+  { role: 'execute', command: 'replay.export', allowed: true },
+  { role: 'execute', command: 'incident.annotate', allowed: true },
+  { role: 'execute', command: 'incident.resolve', allowed: true },
+  { role: 'execute', command: 'incident.archive', allowed: true },
+  { role: 'execute', command: 'config.update', allowed: false },
+  { role: 'execute', command: 'policy.update', allowed: false },
+
+  // admin: full access
+  { role: 'admin', command: 'replay.incident', allowed: true },
+  { role: 'admin', command: 'replay.compare', allowed: true },
+  { role: 'admin', command: 'replay.backfill', allowed: true },
+  { role: 'admin', command: 'replay.export', allowed: true },
+  { role: 'admin', command: 'incident.annotate', allowed: true },
+  { role: 'admin', command: 'incident.resolve', allowed: true },
+  { role: 'admin', command: 'incident.archive', allowed: true },
+  { role: 'admin', command: 'config.update', allowed: true },
+  { role: 'admin', command: 'policy.update', allowed: true },
+] as const;
+
+export function isCommandAllowed(role: OperatorRole, command: IncidentCommandCategory): boolean {
+  const entry = ROLE_PERMISSION_MATRIX.find((permission) => permission.role === role && permission.command === command);
+  return entry?.allowed ?? false;
+}
+
+export class IncidentRoleViolationError extends Error {
+  readonly role: OperatorRole;
+  readonly command: IncidentCommandCategory;
+
+  constructor(role: OperatorRole, command: IncidentCommandCategory) {
+    super(`Role "${role}" is not permitted to run "${command}"`);
+    this.name = 'IncidentRoleViolationError';
+    this.role = role;
+    this.command = command;
+  }
+}
+
+export function enforceRole(role: OperatorRole, command: IncidentCommandCategory): void {
+  if (!isCommandAllowed(role, command)) {
+    throw new IncidentRoleViolationError(role, command);
+  }
+}
+

--- a/runtime/src/policy/index.ts
+++ b/runtime/src/policy/index.ts
@@ -37,3 +37,22 @@ export {
   applyProductionProfile,
   validateProductionReadiness,
 } from './production-profile.js';
+
+export {
+  ROLE_PERMISSION_MATRIX,
+  isCommandAllowed,
+  enforceRole,
+  IncidentRoleViolationError,
+  type OperatorRole,
+  type IncidentCommandCategory,
+  type RolePermission,
+} from './incident-roles.js';
+
+export {
+  InMemoryAuditTrail,
+  computeInputHash,
+  computeOutputHash,
+  type AuditTrailEntry,
+  type AuditTrailStore,
+  type AuditTrailVerification,
+} from './audit-trail.js';


### PR DESCRIPTION
## Summary
- Added operator role permission matrix + enforcement helpers for replay/incident command categories
- Added in-memory SHA-256 hash-chained audit trail with tamper detection
- Integrated opt-in enforcement/audit into runtime CLI (--role) and MCP (MCP_OPERATOR_ROLE)

## Test plan
- [ ] `npm run build`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] `npm run test:fast`
- [ ] `cd mcp && npm test`

Closes #993