### PR TITLE
feat(runtime): add operator onboarding and health commands

### DIFF
--- a/runtime/docs/replay-cli.md
+++ b/runtime/docs/replay-cli.md
@@ -2,6 +2,42 @@
 
 The replay CLI commands are available under the `replay` root command and are intended for incident reconstruction workflows.
 
+## Bootstrap commands
+
+The runtime CLI also provides operator bootstrap and diagnostics commands. All three commands return deterministic exit codes:
+
+- `0`: healthy (all checks passed)
+- `1`: degraded (warnings present)
+- `2`: unhealthy (failures present)
+
+### 1) onboard
+
+Generate a runtime config file (default: `.agenc-runtime.json`) and run basic environment checks.
+
+```bash
+agenc-runtime onboard \
+  --force \
+  --rpc https://api.devnet.solana.com \
+  --store-type sqlite \
+  --sqlite-path .agenc/replay-events.sqlite
+```
+
+### 2) health
+
+Report RPC reachability, replay store status, wallet availability, and config validity.
+
+```bash
+agenc-runtime health --deep
+```
+
+### 3) doctor
+
+Run all health checks and surface remediation guidance. Use `--fix` to attempt safe automatic remediation where possible.
+
+```bash
+agenc-runtime doctor --deep --fix
+```
+
 ## Commands
 
 ### 1) backfill

--- a/runtime/src/cli/health.test.ts
+++ b/runtime/src/cli/health.test.ts
@@ -1,0 +1,260 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Connection } from '@solana/web3.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliRuntimeContext, DoctorOptions, HealthOptions } from './types.js';
+import { runDoctorCommand, runHealthCommand } from './health.js';
+
+function createContextCapture(): { context: CliRuntimeContext; outputs: unknown[]; errors: unknown[] } {
+  const outputs: unknown[] = [];
+  const errors: unknown[] = [];
+  return {
+    context: {
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      },
+      outputFormat: 'json',
+      output: (value) => outputs.push(value),
+      error: (value) => errors.push(value),
+    },
+    outputs,
+    errors,
+  };
+}
+
+function writeConfig(path: string, body: Record<string, unknown>): void {
+  writeFileSync(path, JSON.stringify(body, null, 2), 'utf8');
+}
+
+describe('health cli commands', () => {
+  let workspace = '';
+  let keypairPath = '';
+  let configPath = '';
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'agenc-health-'));
+    keypairPath = join(workspace, 'id.json');
+    configPath = join(workspace, '.agenc-runtime.json');
+    writeFileSync(keypairPath, '[]', 'utf8');
+    writeConfig(configPath, {
+      rpcUrl: 'http://rpc.example',
+      storeType: 'memory',
+      outputFormat: 'json',
+      strictMode: false,
+      idempotencyWindow: 900,
+    });
+    process.env.SOLANA_KEYPAIR_PATH = keypairPath;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(workspace, { recursive: true, force: true });
+    delete process.env.SOLANA_KEYPAIR_PATH;
+  });
+
+  it('health: RPC reachable (mocked) returns exit code 0 when all checks pass', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+
+    const { context, outputs } = createContextCapture();
+    const options: HealthOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'memory',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      deep: false,
+    };
+
+    const code = await runHealthCommand(context, options);
+    expect(code).toBe(0);
+
+    const payload = outputs[0] as any;
+    expect(payload.command).toBe('health');
+    expect(payload.report.exitCode).toBe(0);
+    expect(payload.report.status).toBe('healthy');
+  });
+
+  it('health: RPC unreachable (mocked) returns exit code 2', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockRejectedValue(new Error('nope'));
+
+    const { context, outputs } = createContextCapture();
+    const options: HealthOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'memory',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      deep: false,
+    };
+
+    const code = await runHealthCommand(context, options);
+    expect(code).toBe(2);
+
+    const payload = outputs[0] as any;
+    const rpc = payload.report.checks.find((c: any) => c.id === 'rpc.reachable');
+    expect(rpc.status).toBe('fail');
+  });
+
+  it('health: sqlite store directory missing yields fail with mkdir remediation', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+    const missingDir = join(workspace, 'missing-store');
+    const sqlitePath = join(missingDir, 'replay.sqlite');
+
+    const { context, outputs } = createContextCapture();
+    const options: HealthOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'sqlite',
+      sqlitePath,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      deep: false,
+    };
+
+    const code = await runHealthCommand(context, options);
+    expect(code).toBe(2);
+
+    const payload = outputs[0] as any;
+    const store = payload.report.checks.find((c: any) => c.id === 'store.directory');
+    expect(store.status).toBe('fail');
+    expect(store.remediation).toContain('mkdir -p');
+  });
+
+  it('health: deep mode adds rpc latency and store integrity checks', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+
+    const { context, outputs } = createContextCapture();
+    const options: HealthOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'memory',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      deep: true,
+    };
+
+    const code = await runHealthCommand(context, options);
+    expect(code).toBe(0);
+
+    const payload = outputs[0] as any;
+    const ids = new Set(payload.report.checks.map((c: any) => c.id));
+    expect(ids.has('rpc.latency')).toBe(true);
+    expect(ids.has('store.integrity')).toBe(true);
+  });
+
+  it('doctor: warnings only returns exit code 1', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+    process.env.SOLANA_KEYPAIR_PATH = join(workspace, 'missing-id.json');
+
+    const { context, outputs } = createContextCapture();
+    const options: DoctorOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'memory',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      deep: false,
+      fix: false,
+    };
+
+    const code = await runDoctorCommand(context, options);
+    expect(code).toBe(1);
+
+    const payload = outputs[0] as any;
+    expect(payload.command).toBe('doctor');
+    expect(payload.report.exitCode).toBe(1);
+    expect(Array.isArray(payload.recommendations)).toBe(true);
+  });
+
+  it('doctor: failures return exit code 2', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockRejectedValue(new Error('nope'));
+
+    const { context, outputs } = createContextCapture();
+    const options: DoctorOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'memory',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      deep: false,
+      fix: false,
+    };
+
+    const code = await runDoctorCommand(context, options);
+    expect(code).toBe(2);
+
+    const payload = outputs[0] as any;
+    expect(payload.report.status).toBe('unhealthy');
+  });
+
+  it('doctor: --fix attempts to create sqlite store directory when missing', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+    const missingDir = join(workspace, 'missing-store-fix');
+    const sqlitePath = join(missingDir, 'replay.sqlite');
+
+    const { context, outputs } = createContextCapture();
+    const options: DoctorOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'sqlite',
+      sqlitePath,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      deep: false,
+      fix: true,
+    };
+
+    const code = await runDoctorCommand(context, options);
+    expect(code).toBe(0);
+    expect(existsSync(missingDir)).toBe(true);
+
+    const payload = outputs[0] as any;
+    const storeDir = payload.report.checks.find((c: any) => c.id === 'store.directory');
+    expect(storeDir.status).toBe('pass');
+    expect(storeDir.message).toContain('auto-fixed');
+  });
+});

--- a/runtime/src/cli/health.ts
+++ b/runtime/src/cli/health.ts
@@ -1,0 +1,478 @@
+/**
+ * Operator environment health checks for runtime CLI bootstrap and diagnostics.
+ *
+ * @module
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Connection, PublicKey } from '@solana/web3.js';
+import { validateIdl } from '../idl.js';
+import { validateConfigStrict } from '../types/config-migration.js';
+import { DEFAULT_SQLITE_REPLAY_PATH } from './replay.js';
+import type { CliRuntimeContext, DoctorOptions, HealthOptions } from './types.js';
+
+/** Individual health check result. */
+export interface HealthCheckResult {
+  id: string; // e.g. 'rpc.reachable', 'store.sqlite', 'wallet.exists'
+  category: 'rpc' | 'store' | 'wallet' | 'capability' | 'config' | 'program';
+  status: 'pass' | 'warn' | 'fail';
+  message: string;
+  remediation?: string; // suggested fix
+  durationMs?: number;
+}
+
+/** Aggregate health report. */
+export interface HealthReport {
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  checks: HealthCheckResult[];
+  timestamp: string; // ISO-8601
+  exitCode: 0 | 1 | 2;
+}
+
+const DEFAULT_CONFIG_PATH = '.agenc-runtime.json';
+
+function resolveConfigPath(configPath: string | undefined): string {
+  if (typeof configPath === 'string' && configPath.length > 0) {
+    return path.resolve(process.cwd(), configPath);
+  }
+
+  const envPath = process.env.AGENC_RUNTIME_CONFIG;
+  if (typeof envPath === 'string' && envPath.length > 0) {
+    return path.resolve(process.cwd(), envPath);
+  }
+
+  return path.resolve(process.cwd(), DEFAULT_CONFIG_PATH);
+}
+
+export function aggregateHealthReport(checks: HealthCheckResult[]): HealthReport {
+  const hasErrors = checks.some((check) => check.status === 'fail');
+  const hasWarnings = checks.some((check) => check.status === 'warn');
+  const status: HealthReport['status'] = hasErrors ? 'unhealthy' : hasWarnings ? 'degraded' : 'healthy';
+  const exitCode: 0 | 1 | 2 = hasErrors ? 2 : hasWarnings ? 1 : 0;
+
+  return {
+    status,
+    checks,
+    timestamp: new Date().toISOString(),
+    exitCode,
+  };
+}
+
+export async function checkRpcReachability(
+  rpcUrl: string | undefined,
+  checks: HealthCheckResult[],
+): Promise<boolean> {
+  if (!rpcUrl) {
+    checks.push({
+      id: 'rpc.configured',
+      category: 'rpc',
+      status: 'fail',
+      message: 'No RPC URL configured',
+      remediation: 'Set --rpc or AGENC_RUNTIME_RPC_URL or rpcUrl in config file',
+    });
+    return false;
+  }
+
+  try {
+    const start = Date.now();
+    const connection = new Connection(rpcUrl);
+    await connection.getSlot();
+    checks.push({
+      id: 'rpc.reachable',
+      category: 'rpc',
+      status: 'pass',
+      message: `RPC at ${rpcUrl} is reachable`,
+      durationMs: Date.now() - start,
+    });
+    return true;
+  } catch (error) {
+    checks.push({
+      id: 'rpc.reachable',
+      category: 'rpc',
+      status: 'fail',
+      message: `RPC at ${rpcUrl} is unreachable: ${error instanceof Error ? error.message : String(error)}`,
+      remediation: 'Check RPC URL and network connectivity',
+    });
+    return false;
+  }
+}
+
+async function checkRpcLatency(rpcUrl: string | undefined, checks: HealthCheckResult[]): Promise<void> {
+  if (!rpcUrl) {
+    checks.push({
+      id: 'rpc.latency',
+      category: 'rpc',
+      status: 'warn',
+      message: 'RPC latency check skipped (no RPC configured)',
+    });
+    return;
+  }
+
+  try {
+    const start = Date.now();
+    const connection = new Connection(rpcUrl);
+    await connection.getSlot();
+    checks.push({
+      id: 'rpc.latency',
+      category: 'rpc',
+      status: 'pass',
+      message: 'RPC latency sample collected',
+      durationMs: Date.now() - start,
+    });
+  } catch (error) {
+    checks.push({
+      id: 'rpc.latency',
+      category: 'rpc',
+      status: 'warn',
+      message: `RPC latency check skipped (RPC unreachable): ${error instanceof Error ? error.message : String(error)}`,
+    });
+  }
+}
+
+export function checkReplayStore(
+  options: { storeType: 'memory' | 'sqlite'; sqlitePath?: string },
+  checks: HealthCheckResult[],
+): void {
+  if (options.storeType === 'sqlite') {
+    const sqlitePath = options.sqlitePath ?? DEFAULT_SQLITE_REPLAY_PATH;
+    const absoluteSqlitePath = path.resolve(process.cwd(), sqlitePath);
+    const parentDir = path.dirname(absoluteSqlitePath);
+    if (!existsSync(parentDir)) {
+      checks.push({
+        id: 'store.directory',
+        category: 'store',
+        status: 'fail',
+        message: `SQLite parent directory ${parentDir} does not exist`,
+        remediation: `Run: mkdir -p ${parentDir}`,
+      });
+      return;
+    }
+
+    checks.push({
+      id: 'store.sqlite',
+      category: 'store',
+      status: 'pass',
+      message: `SQLite store path ${absoluteSqlitePath} is accessible`,
+    });
+    return;
+  }
+
+  checks.push({
+    id: 'store.memory',
+    category: 'store',
+    status: 'pass',
+    message: 'In-memory store configured (no persistence)',
+  });
+}
+
+async function checkStoreIntegrity(
+  options: { storeType: 'memory' | 'sqlite'; sqlitePath?: string },
+  checks: HealthCheckResult[],
+): Promise<void> {
+  if (options.storeType !== 'sqlite') {
+    checks.push({
+      id: 'store.integrity',
+      category: 'store',
+      status: 'pass',
+      message: 'Store integrity check not applicable (memory store)',
+    });
+    return;
+  }
+
+  const sqlitePath = options.sqlitePath ?? DEFAULT_SQLITE_REPLAY_PATH;
+  const absoluteSqlitePath = path.resolve(process.cwd(), sqlitePath);
+  const parentDir = path.dirname(absoluteSqlitePath);
+  if (!existsSync(parentDir)) {
+    checks.push({
+      id: 'store.integrity',
+      category: 'store',
+      status: 'warn',
+      message: 'Store integrity check skipped (SQLite directory missing)',
+      remediation: `Run: mkdir -p ${parentDir}`,
+    });
+    return;
+  }
+
+  try {
+    const start = Date.now();
+    const mod = await import('better-sqlite3');
+    const Database = (mod.default ?? mod) as unknown as new (...args: unknown[]) => any;
+    const db = new Database(absoluteSqlitePath);
+    try {
+      const result = db.pragma('integrity_check', { simple: true }) as string;
+      const passed = result === 'ok';
+      checks.push({
+        id: 'store.integrity',
+        category: 'store',
+        status: passed ? 'pass' : 'fail',
+        message: passed ? 'SQLite integrity check passed' : `SQLite integrity check failed: ${result}`,
+        remediation: passed ? undefined : 'Consider backing up and recreating the SQLite store',
+        durationMs: Date.now() - start,
+      });
+    } finally {
+      db.close();
+    }
+  } catch (error) {
+    checks.push({
+      id: 'store.integrity',
+      category: 'store',
+      status: 'fail',
+      message: `SQLite integrity check failed: ${error instanceof Error ? error.message : String(error)}`,
+      remediation: 'Ensure better-sqlite3 is installed and the SQLite path is writable',
+    });
+  }
+}
+
+export async function checkWalletAvailability(checks: HealthCheckResult[]): Promise<boolean> {
+  const defaultKeyPath = path.join(os.homedir(), '.config', 'solana', 'id.json');
+  const envKeyPath = process.env.SOLANA_KEYPAIR_PATH;
+  const keyPath = (typeof envKeyPath === 'string' && envKeyPath.length > 0) ? envKeyPath : defaultKeyPath;
+
+  if (!existsSync(keyPath)) {
+    checks.push({
+      id: 'wallet.exists',
+      category: 'wallet',
+      status: 'warn',
+      message: `Keypair not found at ${keyPath}`,
+      remediation: 'Run: solana-keygen new',
+    });
+    return false;
+  }
+
+  checks.push({
+    id: 'wallet.exists',
+    category: 'wallet',
+    status: 'pass',
+    message: `Keypair found at ${keyPath}`,
+  });
+
+  return true;
+}
+
+export function checkProgramAvailability(programId: string | undefined, checks: HealthCheckResult[]): void {
+  if (programId === undefined) {
+    checks.push({
+      id: 'program.id',
+      category: 'program',
+      status: 'pass',
+      message: 'Program id not configured (using SDK default)',
+    });
+  } else {
+    try {
+      // PublicKey constructor validates base58 and byte length.
+      new PublicKey(programId);
+      checks.push({
+        id: 'program.id',
+        category: 'program',
+        status: 'pass',
+        message: `Program id ${programId} is valid`,
+      });
+    } catch (error) {
+      checks.push({
+        id: 'program.id',
+        category: 'program',
+        status: 'fail',
+        message: `Program id is invalid: ${error instanceof Error ? error.message : String(error)}`,
+        remediation: 'Set --program-id to a valid base58 public key',
+      });
+    }
+  }
+
+  try {
+    validateIdl();
+    checks.push({
+      id: 'capability.idl',
+      category: 'capability',
+      status: 'pass',
+      message: 'Program IDL is available',
+    });
+  } catch (error) {
+    checks.push({
+      id: 'capability.idl',
+      category: 'capability',
+      status: 'fail',
+      message: `Program IDL validation failed: ${error instanceof Error ? error.message : String(error)}`,
+      remediation: 'Run: anchor build',
+    });
+  }
+}
+
+export function checkConfigValidity(configPath: string | undefined, checks: HealthCheckResult[]): void {
+  const resolvedPath = resolveConfigPath(configPath);
+  if (!existsSync(resolvedPath)) {
+    checks.push({
+      id: 'config.exists',
+      category: 'config',
+      status: 'warn',
+      message: `Config file not found at ${resolvedPath}`,
+      remediation: 'Run: agenc-runtime onboard',
+    });
+    return;
+  }
+
+  try {
+    const raw = readFileSync(resolvedPath, 'utf8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      checks.push({
+        id: 'config.valid',
+        category: 'config',
+        status: 'fail',
+        message: `Config file at ${resolvedPath} must be a JSON object`,
+        remediation: 'Fix the config file or regenerate via agenc-runtime onboard',
+      });
+      return;
+    }
+
+    const validation = validateConfigStrict(parsed as Record<string, unknown>, false);
+    if (!validation.valid) {
+      checks.push({
+        id: 'config.valid',
+        category: 'config',
+        status: 'fail',
+        message: `Config validation failed: ${validation.errors.map(e => e.message).join('; ')}`,
+        remediation: 'Fix the config file or regenerate via agenc-runtime onboard',
+      });
+      return;
+    }
+
+    checks.push({
+      id: 'config.valid',
+      category: 'config',
+      status: 'pass',
+      message: `Config file at ${resolvedPath} is valid`,
+    });
+  } catch (error) {
+    checks.push({
+      id: 'config.valid',
+      category: 'config',
+      status: 'fail',
+      message: `Config file at ${resolvedPath} is unreadable: ${error instanceof Error ? error.message : String(error)}`,
+      remediation: 'Fix the config file or regenerate via agenc-runtime onboard',
+    });
+  }
+}
+
+export async function runAllHealthChecks(
+  options: Pick<HealthOptions, 'rpcUrl' | 'programId' | 'storeType' | 'sqlitePath' | 'deep' | 'configPath'>,
+  checks: HealthCheckResult[],
+): Promise<void> {
+  const rpcReachable = await checkRpcReachability(options.rpcUrl, checks);
+  checkReplayStore({ storeType: options.storeType, sqlitePath: options.sqlitePath }, checks);
+  await checkWalletAvailability(checks);
+  checkProgramAvailability(options.programId, checks);
+  checkConfigValidity(options.configPath, checks);
+
+  if (options.deep) {
+    if (rpcReachable) {
+      await checkRpcLatency(options.rpcUrl, checks);
+    } else {
+      checks.push({
+        id: 'rpc.latency',
+        category: 'rpc',
+        status: 'warn',
+        message: 'RPC latency check skipped (RPC unreachable)',
+      });
+    }
+
+    await checkStoreIntegrity({ storeType: options.storeType, sqlitePath: options.sqlitePath }, checks);
+  }
+}
+
+async function attemptAutoFix(check: HealthCheckResult, options: DoctorOptions): Promise<boolean> {
+  if (check.id === 'store.directory' && options.storeType === 'sqlite') {
+    const sqlitePath = options.sqlitePath ?? DEFAULT_SQLITE_REPLAY_PATH;
+    const absoluteSqlitePath = path.resolve(process.cwd(), sqlitePath);
+    const parentDir = path.dirname(absoluteSqlitePath);
+    try {
+      await mkdir(parentDir, { recursive: true });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+export async function runHealthCommand(
+  context: CliRuntimeContext,
+  options: HealthOptions,
+): Promise<0 | 1 | 2> {
+  const checks: HealthCheckResult[] = [];
+  await runAllHealthChecks(
+    {
+      rpcUrl: options.rpcUrl,
+      programId: options.programId,
+      storeType: options.storeType,
+      sqlitePath: options.sqlitePath,
+      deep: options.deep,
+      configPath: options.configPath,
+    },
+    checks,
+  );
+
+  const report = aggregateHealthReport(checks);
+
+  context.output({
+    status: 'ok',
+    command: 'health',
+    report,
+  });
+
+  return report.exitCode;
+}
+
+export async function runDoctorCommand(
+  context: CliRuntimeContext,
+  options: DoctorOptions,
+): Promise<0 | 1 | 2> {
+  const checks: HealthCheckResult[] = [];
+
+  await runAllHealthChecks(
+    {
+      rpcUrl: options.rpcUrl,
+      programId: options.programId,
+      storeType: options.storeType,
+      sqlitePath: options.sqlitePath,
+      deep: options.deep,
+      configPath: options.configPath,
+    },
+    checks,
+  );
+
+  if (options.fix) {
+    for (const check of checks) {
+      if (check.status !== 'fail') {
+        continue;
+      }
+
+      const fixed = await attemptAutoFix(check, options);
+      if (fixed) {
+        check.status = 'pass';
+        check.message += ' (auto-fixed)';
+      }
+    }
+  }
+
+  const report = aggregateHealthReport(checks);
+  const recommendations = checks
+    .filter((check) => check.status !== 'pass')
+    .map((check) => ({
+      id: check.id,
+      status: check.status,
+      remediation: check.remediation ?? 'No auto-fix available',
+    }));
+
+  context.output({
+    status: 'ok',
+    command: 'doctor',
+    report,
+    recommendations,
+  });
+
+  return report.exitCode;
+}

--- a/runtime/src/cli/onboard.test.ts
+++ b/runtime/src/cli/onboard.test.ts
@@ -1,0 +1,149 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Connection } from '@solana/web3.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliRuntimeContext, OnboardOptions } from './types.js';
+import { runOnboardCommand } from './onboard.js';
+
+function createContextCapture(): { context: CliRuntimeContext; outputs: unknown[]; errors: unknown[] } {
+  const outputs: unknown[] = [];
+  const errors: unknown[] = [];
+  return {
+    context: {
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      },
+      outputFormat: 'json',
+      output: (value) => outputs.push(value),
+      error: (value) => errors.push(value),
+    },
+    outputs,
+    errors,
+  };
+}
+
+describe('onboard cli command', () => {
+  let workspace = '';
+  let configPath = '';
+  let keypairPath = '';
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'agenc-onboard-'));
+    configPath = join(workspace, 'runtime-config.json');
+    keypairPath = join(workspace, 'id.json');
+    writeFileSync(keypairPath, '[]', 'utf8');
+    process.env.SOLANA_KEYPAIR_PATH = keypairPath;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(workspace, { recursive: true, force: true });
+    delete process.env.SOLANA_KEYPAIR_PATH;
+  });
+
+  it('onboard generates config when no existing config is present', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+
+    const { context, outputs } = createContextCapture();
+    const options: OnboardOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'sqlite',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      force: false,
+    };
+
+    const code = await runOnboardCommand(context, options);
+    expect(code).toBe(0);
+    expect(existsSync(configPath)).toBe(true);
+
+    const written = JSON.parse(readFileSync(configPath, 'utf8')) as any;
+    expect(written.rpcUrl).toBe('http://rpc.example');
+    expect(written.storeType).toBe('sqlite');
+    expect(typeof written.sqlitePath).toBe('string');
+    expect(written.logLevel).toBe('info');
+    expect(written.outputFormat).toBe('json');
+    expect(written.strictMode).toBe(false);
+
+    const payload = outputs[0] as any;
+    expect(payload.command).toBe('onboard');
+    expect(payload.result.configGenerated).toBe(true);
+    expect(payload.result.exitCode).toBe(0);
+  });
+
+  it('onboard skips existing config when --force is not provided', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+    writeFileSync(configPath, JSON.stringify({ rpcUrl: 'http://old.example', sentinel: 'keep' }, null, 2), 'utf8');
+
+    const { context, outputs } = createContextCapture();
+    const options: OnboardOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://rpc.example',
+      programId: undefined,
+      storeType: 'sqlite',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      force: false,
+    };
+
+    const code = await runOnboardCommand(context, options);
+    expect(code).toBe(1);
+
+    const written = JSON.parse(readFileSync(configPath, 'utf8')) as any;
+    expect(written.sentinel).toBe('keep');
+
+    const payload = outputs[0] as any;
+    expect(payload.result.configGenerated).toBe(false);
+    const existsCheck = payload.result.checks.find((c: any) => c.id === 'config.exists');
+    expect(existsCheck.status).toBe('warn');
+  });
+
+  it('onboard overwrites existing config when --force is provided', async () => {
+    vi.spyOn(Connection.prototype, 'getSlot').mockResolvedValue(123);
+    writeFileSync(configPath, JSON.stringify({ rpcUrl: 'http://old.example', sentinel: 'clobber' }, null, 2), 'utf8');
+
+    const { context, outputs } = createContextCapture();
+    const options: OnboardOptions = {
+      help: false,
+      outputFormat: 'json',
+      strictMode: false,
+      rpcUrl: 'http://new.example',
+      programId: undefined,
+      storeType: 'sqlite',
+      sqlitePath: undefined,
+      traceId: undefined,
+      idempotencyWindow: 900,
+      configPath,
+      nonInteractive: true,
+      force: true,
+    };
+
+    const code = await runOnboardCommand(context, options);
+    expect(code).toBe(0);
+
+    const written = JSON.parse(readFileSync(configPath, 'utf8')) as any;
+    expect(written.rpcUrl).toBe('http://new.example');
+    expect(written.sentinel).toBeUndefined();
+
+    const payload = outputs[0] as any;
+    expect(payload.result.configGenerated).toBe(true);
+    expect(payload.result.exitCode).toBe(0);
+  });
+});
+

--- a/runtime/src/cli/onboard.ts
+++ b/runtime/src/cli/onboard.ts
@@ -1,0 +1,144 @@
+/**
+ * Operator onboarding workflow for bootstrapping runtime CLI configuration.
+ *
+ * @module
+ */
+
+import { existsSync, writeFileSync, mkdirSync } from 'node:fs';
+import * as path from 'node:path';
+import { validateConfigStrict } from '../types/config-migration.js';
+import { DEFAULT_SQLITE_REPLAY_PATH } from './replay.js';
+import type { CliFileConfig, CliRuntimeContext, OnboardOptions } from './types.js';
+import {
+  type HealthCheckResult,
+  checkConfigValidity,
+  checkRpcReachability,
+  checkWalletAvailability,
+} from './health.js';
+
+/** Onboard configuration output. */
+export interface OnboardResult {
+  configPath: string;
+  configGenerated: boolean;
+  walletDetected: boolean;
+  rpcReachable: boolean;
+  checks: HealthCheckResult[];
+  exitCode: 0 | 1 | 2;
+}
+
+const DEFAULT_CONFIG_PATH = '.agenc-runtime.json';
+
+function resolveConfigPath(configPath: string | undefined): string {
+  if (typeof configPath === 'string' && configPath.length > 0) {
+    return path.resolve(process.cwd(), configPath);
+  }
+
+  const envPath = process.env.AGENC_RUNTIME_CONFIG;
+  if (typeof envPath === 'string' && envPath.length > 0) {
+    return path.resolve(process.cwd(), envPath);
+  }
+
+  return path.resolve(process.cwd(), DEFAULT_CONFIG_PATH);
+}
+
+function computeExitCode(checks: HealthCheckResult[]): 0 | 1 | 2 {
+  const hasErrors = checks.some((check) => check.status === 'fail');
+  const hasWarnings = checks.some((check) => check.status === 'warn');
+  return hasErrors ? 2 : hasWarnings ? 1 : 0;
+}
+
+function buildDefaultConfig(options: OnboardOptions): CliFileConfig {
+  const storeType = options.storeType ?? 'sqlite';
+  const sqlitePath = storeType === 'sqlite'
+    ? options.sqlitePath ?? DEFAULT_SQLITE_REPLAY_PATH
+    : undefined;
+
+  return {
+    rpcUrl: options.rpcUrl ?? 'https://api.devnet.solana.com',
+    storeType,
+    ...(sqlitePath ? { sqlitePath } : {}),
+    logLevel: 'info',
+    outputFormat: 'json',
+    strictMode: false,
+    idempotencyWindow: options.idempotencyWindow,
+  };
+}
+
+export async function runOnboardCommand(
+  context: CliRuntimeContext,
+  options: OnboardOptions,
+): Promise<0 | 1 | 2> {
+  const checks: HealthCheckResult[] = [];
+
+  const configPath = resolveConfigPath(options.configPath);
+  const configExists = existsSync(configPath);
+
+  if (configExists && !options.force) {
+    checks.push({
+      id: 'config.exists',
+      category: 'config',
+      status: 'warn',
+      message: `Config file already exists at ${configPath}. Use --force to overwrite.`,
+    });
+  }
+
+  const defaultConfig = buildDefaultConfig(options);
+  const validation = validateConfigStrict(defaultConfig as unknown as Record<string, unknown>, false);
+  if (!validation.valid) {
+    checks.push({
+      id: 'config.generated',
+      category: 'config',
+      status: 'fail',
+      message: `Generated config failed validation: ${validation.errors.map(e => e.message).join('; ')}`,
+      remediation: 'Fix runtime defaults or supply explicit config values',
+    });
+  }
+
+  let configGenerated = false;
+  if ((!configExists || options.force) && validation.valid) {
+    try {
+      mkdirSync(path.dirname(configPath), { recursive: true });
+      writeFileSync(configPath, JSON.stringify(validation.migratedConfig, null, 2), 'utf8');
+      configGenerated = true;
+      checks.push({
+        id: 'config.generated',
+        category: 'config',
+        status: 'pass',
+        message: `Config written to ${configPath}`,
+      });
+    } catch (error) {
+      checks.push({
+        id: 'config.generated',
+        category: 'config',
+        status: 'fail',
+        message: `Failed to write config to ${configPath}: ${error instanceof Error ? error.message : String(error)}`,
+        remediation: 'Ensure the config directory is writable',
+      });
+    }
+  }
+
+  const walletDetected = await checkWalletAvailability(checks);
+  const rpcUrl = defaultConfig.rpcUrl ?? options.rpcUrl;
+  const rpcReachable = await checkRpcReachability(rpcUrl, checks);
+
+  checkConfigValidity(configPath, checks);
+
+  const exitCode = computeExitCode(checks);
+
+  const result: OnboardResult = {
+    configPath,
+    configGenerated,
+    walletDetected,
+    rpcReachable,
+    checks,
+    exitCode,
+  };
+
+  context.output({
+    status: 'ok',
+    command: 'onboard',
+    result,
+  });
+
+  return exitCode;
+}

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -115,6 +115,33 @@ export interface CliFileConfig {
   logLevel?: CliLogLevel;
 }
 
+export interface OnboardOptions extends BaseCliOptions {
+  /** If true, skip interactive prompts (default false). */
+  nonInteractive?: boolean;
+  /** Force overwrite existing config. */
+  force?: boolean;
+  /** Config file path override for onboard output. */
+  configPath?: string;
+}
+
+export interface HealthOptions extends BaseCliOptions {
+  /** If true, skip interactive prompts. */
+  nonInteractive?: boolean;
+  /** Run extended checks (slower but more thorough). */
+  deep?: boolean;
+  /** Config file path override for health output. */
+  configPath?: string;
+}
+
+export interface DoctorOptions extends BaseCliOptions {
+  nonInteractive?: boolean;
+  deep?: boolean;
+  /** Attempt automatic fixes where possible. */
+  fix?: boolean;
+  /** Config file path override for doctor output. */
+  configPath?: string;
+}
+
 export interface SecurityOptions extends BaseCliOptions {
   deep?: boolean;
   json?: boolean;


### PR DESCRIPTION
## Summary
- Added `onboard`, `health`, and `doctor` commands to `agenc-runtime` for operator environment bootstrap and diagnostics
- Implemented deterministic health checks (RPC, store, wallet, IDL/config validation) with optional deep checks and safe auto-fix
- Added unit tests covering pass/fail/warn aggregation and exit code contract

## Test plan
- [ ] `npm run build`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] `npm run test:fast`
- [ ] `cd mcp && npm test`

Closes #994