### PR TITLE
docs: refresh README stats and add sprint issue map

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ AgenC is a decentralized protocol for coordinating AI agents on Solana. Agents r
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`programs/agenc-coordination`](programs/agenc-coordination/) | — | Solana smart contract (Rust/Anchor) — 24 instructions, 25 event types |
+| [`programs/agenc-coordination`](programs/agenc-coordination/) | — | Solana smart contract (Rust/Anchor) — 25 instructions, 30 event types |
 | [`@agenc/sdk`](sdk/) | 1.3.0 | TypeScript SDK — task operations, ZK proofs, SPL token support |
 | [`@agenc/runtime`](runtime/) | 0.1.0 | Agent runtime (~90k lines) — LLM adapters, memory, workflows, marketplace |
 | [`@agenc/mcp`](mcp/) | 0.1.0 | MCP server — protocol operations as AI-consumable tools |
@@ -97,7 +97,7 @@ anchor build
 ### Run Tests
 
 ```bash
-# Fast integration tests via LiteSVM (~5s, 163 tests)
+# Fast integration tests via LiteSVM (~5s, 185 tests)
 npm run test:fast
 
 # SDK + Runtime unit tests (~1800+ tests)
@@ -226,13 +226,13 @@ npm run test:fixtures
 AgenC/
 ├── programs/agenc-coordination/     # Solana program (Rust/Anchor)
 │   ├── src/
-│   │   ├── lib.rs                   # Program entrypoint (24 instructions)
+│   │   ├── lib.rs                   # Program entrypoint (25 instructions)
 │   │   ├── state.rs                 # Account structures
-│   │   ├── errors.rs                # 139+ error codes
-│   │   ├── events.rs                # 25 event types
+│   │   ├── errors.rs                # 147 error codes (6000-6146)
+│   │   ├── events.rs                # 30 event types
 │   │   ├── verifying_key.rs         # Groth16 verifying key
-│   │   └── instructions/            # 24 instruction + 9 helper modules
-│   └── fuzz/                        # Fuzz testing (5 targets)
+│   │   └── instructions/            # Instruction handlers + helper modules
+│   └── fuzz/                        # Fuzz testing targets + infrastructure
 ├── sdk/                             # TypeScript SDK (v1.3.0)
 │   └── src/                         # Client, proofs, tasks, tokens, bids, validation
 ├── runtime/                         # Agent Runtime (v0.1.0, ~90k lines)
@@ -243,7 +243,7 @@ AgenC/
 ├── circuits/task_completion/        # Noir ZK circuits
 ├── circuits-circom/task_completion/ # Circom circuits + MPC ceremony tooling
 ├── examples/                        # 10 example projects
-├── tests/                           # LiteSVM integration tests (163 tests)
+├── tests/                           # LiteSVM integration tests (185 tests)
 ├── docs/                            # Security audits, deployment, observability
 └── migrations/                      # Protocol version migration tools
 ```
@@ -291,7 +291,8 @@ AgenC/
 | `initialize_protocol` | Set up protocol config, treasury, fees |
 | `update_protocol_fee` | Adjust protocol fees (multisig required) |
 | `update_rate_limits` | Configure rate limits (multisig required) |
-| `migrate` | Protocol version migration (multisig required) |
+| `migrate_protocol` | Protocol version migration (multisig required) |
+| `update_min_version` | Update minimum supported version (multisig required) |
 | `update_state` | Sync shared state with version tracking |
 
 ## Zero-Knowledge Privacy
@@ -396,7 +397,7 @@ const agent = new AgentBuilder()
 | `skills/` | Pluggable skill registry + Jupiter DEX integration |
 | `telemetry/` | Unified metrics collection with pluggable sinks |
 | `eval/` | Deterministic benchmarks, mutation testing, trajectory recording + replay |
-| `events/` | Event subscriptions + parsing for 17+ on-chain event types |
+| `events/` | Event subscriptions + parsing for 30 on-chain event types |
 
 ### LLM Providers
 
@@ -543,6 +544,7 @@ The project runs a comprehensive CI pipeline via GitHub Actions:
 | [Static Analysis](docs/STATIC_ANALYSIS.md) | Static analysis results |
 | [Privacy Guide](docs/PRIVACY_README.md) | Privacy features deep-dive |
 | [Noir Reference](docs/NOIR_REFERENCE.md) | Noir circuit language reference |
+| [Sprint Issue Map (959-999)](docs/ISSUES_959_999.md) | Issue-to-PR mapping snapshot for the 959-999 backlog |
 | [Whitepaper](WHITEPAPER.md) | Protocol vision and design |
 
 ## Ecosystem

--- a/docs/ISSUES_959_999.md
+++ b/docs/ISSUES_959_999.md
@@ -1,0 +1,52 @@
+# Closed Issues #959-#999
+
+This file is a snapshot of the sprint backlog issues #959 through #999 and the PR(s) that closed them.
+
+| Issue | PR | Closed | Title |
+|---|---|---|---|
+| [#959](https://github.com/tetsuo-ai/AgenC/issues/959) | [#1000](https://github.com/tetsuo-ai/AgenC/pull/1000) | 2026-02-14 | P0-001: Close all high-risk task lifecycle gaps |
+| [#960](https://github.com/tetsuo-ai/AgenC/issues/960) | [#1001](https://github.com/tetsuo-ai/AgenC/pull/1001) | 2026-02-14 | P0-002: Make dispute paths deterministic and replay-aligned |
+| [#961](https://github.com/tetsuo-ai/AgenC/issues/961) | [#1002](https://github.com/tetsuo-ai/AgenC/pull/1002) | 2026-02-14 | P0-003: Enforce reserved on-chain state fields and migration safety |
+| [#962](https://github.com/tetsuo-ai/AgenC/issues/962) | [#1003](https://github.com/tetsuo-ai/AgenC/pull/1003) | 2026-02-14 | P0-004: Replace dev/test proving key assumptions with deployment hardening |
+| [#963](https://github.com/tetsuo-ai/AgenC/issues/963) | [#1004](https://github.com/tetsuo-ai/AgenC/pull/1004) | 2026-02-14 | P0-005: Remove protocol-critical edge leaks |
+| [#964](https://github.com/tetsuo-ai/AgenC/issues/964) | [#1005](https://github.com/tetsuo-ai/AgenC/pull/1005) | 2026-02-14 | P0-006: Canonical event normalization and stable IDs |
+| [#965](https://github.com/tetsuo-ai/AgenC/issues/965) | [#1006](https://github.com/tetsuo-ai/AgenC/pull/1006) | 2026-02-14 | P0-007: Backfill reliability and cursor correctness |
+| [#966](https://github.com/tetsuo-ai/AgenC/issues/966) | [#1007](https://github.com/tetsuo-ai/AgenC/pull/1007) | 2026-02-14 | P0-008: Transition validation parity between on-chain and local replay |
+| [#967](https://github.com/tetsuo-ai/AgenC/issues/967) | [#1010](https://github.com/tetsuo-ai/AgenC/pull/1010) | 2026-02-14 | P0-009: Replay anomaly and alert schema stability |
+| [#968](https://github.com/tetsuo-ai/AgenC/issues/968) | [#1011](https://github.com/tetsuo-ai/AgenC/pull/1011) | 2026-02-14 | P0-010: Deterministic incident reconstruction UX |
+| [#969](https://github.com/tetsuo-ai/AgenC/issues/969) | [#1012](https://github.com/tetsuo-ai/AgenC/pull/1012) | 2026-02-14 | P1-011: Memory and store portability hardening |
+| [#970](https://github.com/tetsuo-ai/AgenC/issues/970) | [#1013](https://github.com/tetsuo-ai/AgenC/pull/1013) | 2026-02-14 | P1-012: Adaptive execution budget policy stability |
+| [#971](https://github.com/tetsuo-ai/AgenC/issues/971) | [#1014](https://github.com/tetsuo-ai/AgenC/pull/1014) | 2026-02-14 | P1-013: Speculative execution safety net |
+| [#972](https://github.com/tetsuo-ai/AgenC/issues/972) | [#1015](https://github.com/tetsuo-ai/AgenC/pull/1015) | 2026-02-14 | P1-014: Workflow compiler and mutation gates reproducibility |
+| [#973](https://github.com/tetsuo-ai/AgenC/issues/973) | [#1016](https://github.com/tetsuo-ai/AgenC/pull/1016) | 2026-02-14 | P1-015: LLM adapters resilience and error normalization |
+| [#974](https://github.com/tetsuo-ai/AgenC/issues/974) | [#1017](https://github.com/tetsuo-ai/AgenC/pull/1017) | 2026-02-14 | P1-101: Full API surface alignment with program IDsL |
+| [#975](https://github.com/tetsuo-ai/AgenC/issues/975) | [#1018](https://github.com/tetsuo-ai/AgenC/pull/1018) | 2026-02-14 | P1-102: High-value developer convenience APIs |
+| [#976](https://github.com/tetsuo-ai/AgenC/issues/976) | [#1019](https://github.com/tetsuo-ai/AgenC/pull/1019) | 2026-02-14 | P1-103: Proof lifecycle hardening (private completion path) |
+| [#977](https://github.com/tetsuo-ai/AgenC/issues/977) | [#1020](https://github.com/tetsuo-ai/AgenC/pull/1020) | 2026-02-14 | P1-104: Versioning and migration metadata in SDK |
+| [#978](https://github.com/tetsuo-ai/AgenC/issues/978) | [#1021](https://github.com/tetsuo-ai/AgenC/pull/1021) | 2026-02-14 | P1-201: Replay tools parity and bounded outputs |
+| [#979](https://github.com/tetsuo-ai/AgenC/issues/979) | [#1022](https://github.com/tetsuo-ai/AgenC/pull/1022) | 2026-02-14 | P1-202: MCP policy/risk controls |
+| [#980](https://github.com/tetsuo-ai/AgenC/issues/980) | [#1023](https://github.com/tetsuo-ai/AgenC/pull/1023) | 2026-02-14 | P1-203: MCP schema stability and changelog |
+| [#981](https://github.com/tetsuo-ai/AgenC/issues/981) | [#1024](https://github.com/tetsuo-ai/AgenC/pull/1024) | 2026-02-14 | P1-204: Operator prompt tooling |
+| [#982](https://github.com/tetsuo-ai/AgenC/issues/982) | [#1025](https://github.com/tetsuo-ai/AgenC/pull/1025) | 2026-02-14 | P2-301: Complete deployment and operations runbooks |
+| [#983](https://github.com/tetsuo-ai/AgenC/issues/983) | [#1026](https://github.com/tetsuo-ai/AgenC/pull/1026) | 2026-02-14 | P2-302: Versioned API and changelog quality |
+| [#984](https://github.com/tetsuo-ai/AgenC/issues/984) | [#1027](https://github.com/tetsuo-ai/AgenC/pull/1027) | 2026-02-14 | P2-303: Local developer onboarding and reproducibility |
+| [#985](https://github.com/tetsuo-ai/AgenC/issues/985) | [#1028](https://github.com/tetsuo-ai/AgenC/pull/1028) | 2026-02-14 | P2-304: Demo and examples hardening |
+| [#986](https://github.com/tetsuo-ai/AgenC/issues/986) | [#1030](https://github.com/tetsuo-ai/AgenC/pull/1030) | 2026-02-14 | P2-401: Mutation and chaos matrix |
+| [#987](https://github.com/tetsuo-ai/AgenC/issues/987) | [#1031](https://github.com/tetsuo-ai/AgenC/pull/1031) | 2026-02-14 | P2-402: Property-based and fuzz tests for protocol edge states |
+| [#988](https://github.com/tetsuo-ai/AgenC/issues/988) | [#1032](https://github.com/tetsuo-ai/AgenC/pull/1032) | 2026-02-14 | P2-403: API contract tests for CLI/SDK/MCP |
+| [#989](https://github.com/tetsuo-ai/AgenC/issues/989) | [#1036](https://github.com/tetsuo-ai/AgenC/pull/1036) | 2026-02-15 | P2-404: Cross-layer observability parity tests |
+| [#990](https://github.com/tetsuo-ai/AgenC/issues/990) | [#1038](https://github.com/tetsuo-ai/AgenC/pull/1038) | 2026-02-15 | P2-501: Case object model and timeline evidence |
+| [#991](https://github.com/tetsuo-ai/AgenC/issues/991) | [#1039](https://github.com/tetsuo-ai/AgenC/pull/1039) | 2026-02-15 | P2-502: Reproducible evidence-pack export |
+| [#992](https://github.com/tetsuo-ai/AgenC/issues/992) | [#1040](https://github.com/tetsuo-ai/AgenC/pull/1040) | 2026-02-15 | P2-503: Analyst query DSL and deterministic slicing |
+| [#993](https://github.com/tetsuo-ai/AgenC/issues/993) | [#1041](https://github.com/tetsuo-ai/AgenC/pull/1041) | 2026-02-15 | P2-504: Role-aware incident workflow + immutable audit trail |
+| [#994](https://github.com/tetsuo-ai/AgenC/issues/994) | [#1042](https://github.com/tetsuo-ai/AgenC/pull/1042) | 2026-02-15 | P2-505: Operator onboarding and environment health bootstrap |
+| [#995](https://github.com/tetsuo-ai/AgenC/issues/995) | [#1008](https://github.com/tetsuo-ai/AgenC/pull/1008) | 2026-02-14 | P2-506: Configuration migration and schema compatibility |
+| [#996](https://github.com/tetsuo-ai/AgenC/issues/996) | [#1009](https://github.com/tetsuo-ai/AgenC/pull/1009) | 2026-02-14 | P2-507: Security posture command (`doctor security`) |
+| [#997](https://github.com/tetsuo-ai/AgenC/issues/997) | [#1033](https://github.com/tetsuo-ai/AgenC/pull/1033) | 2026-02-14 | P2-508: Plugin/skill manifest governance |
+| [#998](https://github.com/tetsuo-ai/AgenC/issues/998) | [#1035](https://github.com/tetsuo-ai/AgenC/pull/1035) | 2026-02-14 | P2-509: Plugin/skill lifecycle and catalog management |
+| [#999](https://github.com/tetsuo-ai/AgenC/issues/999) | [#1034](https://github.com/tetsuo-ai/AgenC/pull/1034) | 2026-02-14 | P2-510: Open-source readiness hardening around operations |
+
+## Notes
+
+- Some issues may be closed by a PR that also closes other issues. This table records the first closing PR returned by GitHub for each issue.
+- For implementation details, use the PR links and the corresponding squash-merge commit on `main`.


### PR DESCRIPTION
## Summary
- Updated README program/test counts and governance instruction names
- Added docs/ISSUES_959_999.md snapshot mapping issues to closing PRs

## Test plan
- [ ] ./scripts/check-docs-links.sh