### PR TITLE
fix: replace grep -P with portable patterns in deployment scripts

### DIFF
--- a/circuits-circom/task_completion/scripts/ceremony.sh
+++ b/circuits-circom/task_completion/scripts/ceremony.sh
@@ -171,7 +171,7 @@ cmd_contribute() {
     local verify_output
     verify_output=$(snarkjs zkey verify "$CIRCUIT_R1CS" "$PTAU_FILE" "$output" 2>&1 || true)
     local contribution_hash
-    contribution_hash=$(echo "$verify_output" | grep -oP '[a-f0-9]{8}\s[a-f0-9]{8}\s[a-f0-9]{8}\s[a-f0-9]{8}' | tail -1 || echo "unknown")
+    contribution_hash=$(echo "$verify_output" | grep -Eo '[a-f0-9]{8}\s[a-f0-9]{8}\s[a-f0-9]{8}\s[a-f0-9]{8}' | tail -1 || echo "unknown")
 
     add_contribution_to_transcript "$contributor_name" "$contribution_hash" "$next_index"
 

--- a/scripts/check-deployment-readiness.sh
+++ b/scripts/check-deployment-readiness.sh
@@ -59,7 +59,7 @@ else
     fi
 
     # Check VK_VERSION (fix #962)
-    VK_VERSION=$(grep 'pub const VK_VERSION' "$VK_FILE" | grep -oP '= \K\d+' | head -1 || echo "")
+    VK_VERSION=$(sed -n 's/.*pub const VK_VERSION.*= \([0-9][0-9]*\).*/\1/p' "$VK_FILE" | head -1 || echo "")
     if [ -n "$VK_VERSION" ]; then
         if [ "$VK_VERSION" = "0" ]; then
             if [ "$NETWORK" = "mainnet" ]; then

--- a/scripts/validate-verifying-key.sh
+++ b/scripts/validate-verifying-key.sh
@@ -36,8 +36,8 @@ echo "=== Verifying Key Security Check (issues #356, #358, #962) ==="
 echo ""
 
 # Check 1: gamma != delta
-GAMMA_HEX=$(grep -A 8 "pub const VK_GAMMA_G2" "$VK_FILE" | grep -oP '0x[0-9a-f]{2}' | tr -d '\n' | sed 's/0x//g')
-DELTA_HEX=$(grep -A 8 "pub const VK_DELTA_G2" "$VK_FILE" | grep -oP '0x[0-9a-f]{2}' | tr -d '\n' | sed 's/0x//g')
+GAMMA_HEX=$(grep -A 8 "pub const VK_GAMMA_G2" "$VK_FILE" | grep -Eo '0x[0-9a-f]{2}' | tr -d '\n' | sed 's/0x//g')
+DELTA_HEX=$(grep -A 8 "pub const VK_DELTA_G2" "$VK_FILE" | grep -Eo '0x[0-9a-f]{2}' | tr -d '\n' | sed 's/0x//g')
 
 if [ "$GAMMA_HEX" = "$DELTA_HEX" ]; then
     echo "WARNING: VK_GAMMA_G2 == VK_DELTA_G2"
@@ -63,7 +63,7 @@ else
 fi
 
 # Check 2: VK_VERSION
-VK_VERSION=$(grep 'pub const VK_VERSION' "$VK_FILE" | grep -oP '= \K\d+' | head -1)
+VK_VERSION=$(sed -n 's/.*pub const VK_VERSION.*= \([0-9][0-9]*\).*/\1/p' "$VK_FILE" | head -1)
 echo "VK_VERSION: $VK_VERSION"
 if [ "$VK_VERSION" = "0" ]; then
     if [ "$MAINNET_MODE" = true ]; then


### PR DESCRIPTION
## Summary
- Replace `grep -oP` (GNU Perl regex) with POSIX-compatible `grep -Eo` and `sed` across 3 scripts
- Fixes 5 occurrences that silently break on macOS/BSD grep

## Changed files

| File | Line | Before | After |
|------|------|--------|-------|
| `scripts/check-deployment-readiness.sh` | 62 | `grep -oP '= \K\d+'` | `sed -n 's/.*VK_VERSION.*= \([0-9]...\).*/\1/p'` |
| `scripts/validate-verifying-key.sh` | 39 | `grep -oP '0x[0-9a-f]{2}'` | `grep -Eo '0x[0-9a-f]{2}'` |
| `scripts/validate-verifying-key.sh` | 40 | `grep -oP '0x[0-9a-f]{2}'` | `grep -Eo '0x[0-9a-f]{2}'` |
| `scripts/validate-verifying-key.sh` | 66 | `grep -oP '= \K\d+'` | `sed -n 's/.*VK_VERSION.*= \([0-9]...\).*/\1/p'` |
| `circuits-circom/.../ceremony.sh` | 174 | `grep -oP '[a-f0-9]{8}...'` | `grep -Eo '[a-f0-9]{8}...'` |

## Test plan
- [x] Verified no `grep -P` occurrences remain in `scripts/` or `circuits-circom/`
- [ ] Run `./scripts/validate-verifying-key.sh` on macOS to confirm output matches Linux

Closes #1045