### PR TITLE
fix: support --network flag in check-deployment-readiness.sh

### DIFF
--- a/scripts/check-deployment-readiness.sh
+++ b/scripts/check-deployment-readiness.sh
@@ -5,11 +5,24 @@
 # It should be run as part of CI and before any mainnet deployment.
 #
 # Usage:
-#   ./scripts/check-deployment-readiness.sh [--network mainnet|devnet]
+#   ./scripts/check-deployment-readiness.sh --network mainnet|devnet
+#   ./scripts/check-deployment-readiness.sh mainnet|devnet   (positional, backward compat)
 
 set -euo pipefail
 
-NETWORK="${1:-devnet}"
+NETWORK="devnet"
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --network)
+            shift
+            NETWORK="${1:-devnet}"
+            ;;
+        mainnet|devnet|localnet)
+            NETWORK="$1"
+            ;;
+    esac
+    shift
+done
 EXIT_CODE=0
 
 RED='\033[0;31m'


### PR DESCRIPTION
## Summary
- Fix argument parsing in `scripts/check-deployment-readiness.sh` to accept `--network mainnet` as documented
- Previously only read positional `$1`, so the documented command set `NETWORK="--network"` and silently skipped mainnet-specific checks (ceremony transcript, VK version enforcement)

## Before/After

```bash
# Before: NETWORK becomes "--network", all mainnet checks silently skipped
./scripts/check-deployment-readiness.sh --network mainnet

# After: both forms work correctly
./scripts/check-deployment-readiness.sh --network mainnet  # flag form (matches docs)
./scripts/check-deployment-readiness.sh mainnet            # positional (backward compat)
```

## Test plan
- [x] `--network mainnet` correctly sets `NETWORK=mainnet`
- [x] Positional `mainnet` still works (backward compat)
- [x] No arguments defaults to `devnet`

Closes #1046