### PR TITLE
chore: add [programs.mainnet] section to Anchor.toml

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -12,6 +12,9 @@ agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"
 [programs.devnet]
 agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"
 
+[programs.mainnet]
+agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"
+
 [registry]
 url = "https://api.apr.dev"
 


### PR DESCRIPTION
## Summary
- Add `[programs.mainnet]` section to `Anchor.toml` with the same program ID used by localnet and devnet
- Provider cluster remains `localnet` for development; mainnet cluster/wallet are configured at deploy time

## Before
```toml
[programs.localnet]
agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"

[programs.devnet]
agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"

# No [programs.mainnet] — anchor build has no mainnet target
```

## After
```toml
[programs.localnet]
agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"

[programs.devnet]
agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"

[programs.mainnet]
agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"
```

## Test plan
- [x] `anchor build` still works with localnet provider
- [x] `check-deployment-readiness.sh --network mainnet` can now resolve mainnet program ID

Closes #1047