### PR TITLE
feat(runtime): SKILL.md parser — YAML frontmatter + markdown body

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -422,6 +422,16 @@ export {
   USDC_MINT,
   USDT_MINT,
   WELL_KNOWN_TOKENS,
+  // Markdown SKILL.md parser
+  type MarkdownSkill,
+  type MarkdownSkillMetadata,
+  type SkillRequirements,
+  type SkillInstallStep,
+  type SkillParseError,
+  isSkillMarkdown,
+  parseSkillContent,
+  parseSkillFile,
+  validateSkillMetadata,
 } from './skills/index.js';
 
 // LLM Adapters (Phase 4)

--- a/runtime/src/skills/catalog.ts
+++ b/runtime/src/skills/catalog.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
 import type { PluginManifest } from './manifest.js';
+import { isRecord } from '../utils/type-guards.js';
 
 export type PluginPrecedence = 'workspace' | 'user' | 'builtin';
 
@@ -65,10 +66,6 @@ function toDateNow(): number {
 
 function normalizePluginPrecedence(precedence: PluginPrecedence): PluginPrecedence {
   return precedence;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function cloneEntry(entry: CatalogEntry): CatalogEntry {

--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -78,3 +78,16 @@ export {
   USDT_MINT,
   WELL_KNOWN_TOKENS,
 } from './jupiter/index.js';
+
+// Markdown SKILL.md parser
+export {
+  type MarkdownSkill,
+  type MarkdownSkillMetadata,
+  type SkillRequirements,
+  type SkillInstallStep,
+  type SkillParseError,
+  isSkillMarkdown,
+  parseSkillContent,
+  parseSkillFile,
+  validateSkillMetadata,
+} from './markdown/index.js';

--- a/runtime/src/skills/manifest.ts
+++ b/runtime/src/skills/manifest.ts
@@ -4,6 +4,8 @@
  * @module
  */
 
+import { isRecord, isStringArray } from '../utils/type-guards.js';
+
 /** Permission a plugin requests. */
 export interface PluginPermission {
   /** Permission type. */
@@ -87,14 +89,6 @@ export class PluginManifestError extends Error {
 const VALID_PLUGIN_ID = /^[a-z][a-z0-9._-]*$/;
 
 const VALID_PERMISSION_TYPES = ['tool_call', 'network', 'filesystem', 'wallet_sign'];
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
-}
 
 /**
  * Validate a single plugin manifest and return structured errors.

--- a/runtime/src/skills/markdown/index.ts
+++ b/runtime/src/skills/markdown/index.ts
@@ -1,0 +1,20 @@
+/**
+ * SKILL.md parser — YAML frontmatter + markdown body.
+ *
+ * @module
+ */
+
+export type {
+  MarkdownSkill,
+  MarkdownSkillMetadata,
+  SkillRequirements,
+  SkillInstallStep,
+  SkillParseError,
+} from './types.js';
+
+export {
+  isSkillMarkdown,
+  parseSkillContent,
+  parseSkillFile,
+  validateSkillMetadata,
+} from './parser.js';

--- a/runtime/src/skills/markdown/parser.test.ts
+++ b/runtime/src/skills/markdown/parser.test.ts
@@ -1,0 +1,363 @@
+import { describe, expect, it } from 'vitest';
+import { writeFile, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  isSkillMarkdown,
+  parseSkillContent,
+  parseSkillFile,
+  validateSkillMetadata,
+} from './parser.js';
+
+const FULL_SKILL_MD = `---
+name: noir-prover
+description: Generate and verify Noir ZK proofs
+version: 1.0.0
+metadata:
+  agenc:
+    emoji: "\u{1F50F}"
+    primaryEnv: NARGO_HOME
+    requires:
+      binaries:
+        - nargo
+        - bb
+      env:
+        - NARGO_HOME
+      channels:
+        - solana
+      os:
+        - linux
+        - macos
+    install:
+      - type: brew
+        package: noir-lang/noir/nargo
+      - type: download
+        url: https://example.com/bb
+        path: /usr/local/bin/bb
+    tags:
+      - zk
+      - privacy
+      - noir
+    requiredCapabilities: "0x03"
+    onChainAuthor: 5FHwkrdxPp8A5yjft7QsiqU3Y95JyB1vKNpkaLBjj7Gk
+    contentHash: QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco
+---
+# Noir Prover
+
+This skill provides ZK proof generation.
+
+## Usage
+
+Call \`nargo prove\` with the circuit path.
+`;
+
+const MINIMAL_SKILL_MD = `---
+name: echo
+description: Simple echo skill
+version: 0.1.0
+---
+Echo back the input.
+`;
+
+const OPENCLAW_SKILL_MD = `---
+name: openclaw-tool
+description: An OpenClaw-compatible skill
+version: 2.0.0
+metadata:
+  openclaw:
+    emoji: "\u{1F4E6}"
+    tags:
+      - compat
+    requires:
+      binaries:
+        - node
+---
+Body text.
+`;
+
+const AGENC_PRECEDENCE_MD = `---
+name: dual-ns
+description: Both namespaces present
+version: 1.0.0
+metadata:
+  agenc:
+    emoji: "\u{1F680}"
+    tags:
+      - agenc-tag
+  openclaw:
+    emoji: "\u{1F4E6}"
+    tags:
+      - openclaw-tag
+---
+Body.
+`;
+
+describe('isSkillMarkdown', () => {
+  it('returns true for content with frontmatter', () => {
+    expect(isSkillMarkdown(FULL_SKILL_MD)).toBe(true);
+    expect(isSkillMarkdown(MINIMAL_SKILL_MD)).toBe(true);
+  });
+
+  it('returns false for plain markdown', () => {
+    expect(isSkillMarkdown('# Just a heading\n\nSome text.')).toBe(false);
+    expect(isSkillMarkdown('')).toBe(false);
+    expect(isSkillMarkdown('--- not on its own line')).toBe(false);
+  });
+});
+
+describe('parseSkillContent', () => {
+  it('parses valid SKILL.md with all fields', () => {
+    const skill = parseSkillContent(FULL_SKILL_MD, '/skills/noir-prover/SKILL.md');
+
+    expect(skill.name).toBe('noir-prover');
+    expect(skill.description).toBe('Generate and verify Noir ZK proofs');
+    expect(skill.version).toBe('1.0.0');
+    expect(skill.sourcePath).toBe('/skills/noir-prover/SKILL.md');
+
+    expect(skill.metadata.emoji).toBe('\u{1F50F}');
+    expect(skill.metadata.primaryEnv).toBe('NARGO_HOME');
+    expect(skill.metadata.requiredCapabilities).toBe('0x03');
+    expect(skill.metadata.onChainAuthor).toBe(
+      '5FHwkrdxPp8A5yjft7QsiqU3Y95JyB1vKNpkaLBjj7Gk',
+    );
+    expect(skill.metadata.contentHash).toBe(
+      'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
+    );
+
+    // Requirements
+    expect(skill.metadata.requires.binaries).toEqual(['nargo', 'bb']);
+    expect(skill.metadata.requires.env).toEqual(['NARGO_HOME']);
+    expect(skill.metadata.requires.channels).toEqual(['solana']);
+    expect(skill.metadata.requires.os).toEqual(['linux', 'macos']);
+
+    // Install
+    expect(skill.metadata.install).toHaveLength(2);
+    expect(skill.metadata.install[0]).toEqual({
+      type: 'brew',
+      package: 'noir-lang/noir/nargo',
+    });
+    expect(skill.metadata.install[1]).toEqual({
+      type: 'download',
+      url: 'https://example.com/bb',
+      path: '/usr/local/bin/bb',
+    });
+
+    // Tags
+    expect(skill.metadata.tags).toEqual(['zk', 'privacy', 'noir']);
+  });
+
+  it('parses minimal frontmatter (name, description, version only)', () => {
+    const skill = parseSkillContent(MINIMAL_SKILL_MD);
+
+    expect(skill.name).toBe('echo');
+    expect(skill.description).toBe('Simple echo skill');
+    expect(skill.version).toBe('0.1.0');
+    expect(skill.metadata.requires.binaries).toEqual([]);
+    expect(skill.metadata.requires.env).toEqual([]);
+    expect(skill.metadata.requires.channels).toEqual([]);
+    expect(skill.metadata.requires.os).toEqual([]);
+    expect(skill.metadata.install).toEqual([]);
+    expect(skill.metadata.tags).toEqual([]);
+    expect(skill.sourcePath).toBeUndefined();
+  });
+
+  it('parses metadata.openclaw namespace and normalizes', () => {
+    const skill = parseSkillContent(OPENCLAW_SKILL_MD);
+
+    expect(skill.name).toBe('openclaw-tool');
+    expect(skill.metadata.emoji).toBe('\u{1F4E6}');
+    expect(skill.metadata.tags).toEqual(['compat']);
+    expect(skill.metadata.requires.binaries).toEqual(['node']);
+  });
+
+  it('parses metadata.agenc namespace (takes precedence over openclaw)', () => {
+    const skill = parseSkillContent(AGENC_PRECEDENCE_MD);
+
+    // agenc should win
+    expect(skill.metadata.emoji).toBe('\u{1F680}');
+    expect(skill.metadata.tags).toEqual(['agenc-tag']);
+  });
+
+  it('body preserves markdown formatting', () => {
+    const skill = parseSkillContent(FULL_SKILL_MD);
+
+    expect(skill.body).toContain('# Noir Prover');
+    expect(skill.body).toContain('## Usage');
+    expect(skill.body).toContain('`nargo prove`');
+  });
+
+  it('parses install instructions', () => {
+    const md = `---
+name: installer-test
+description: Test install parsing
+version: 1.0.0
+metadata:
+  agenc:
+    install:
+      - type: npm
+        package: "@agenc/sdk"
+      - type: cargo
+        package: nargo
+      - type: apt
+        package: build-essential
+---
+`;
+    const skill = parseSkillContent(md);
+
+    expect(skill.metadata.install).toHaveLength(3);
+    expect(skill.metadata.install[0]).toEqual({ type: 'npm', package: '@agenc/sdk' });
+    expect(skill.metadata.install[1]).toEqual({ type: 'cargo', package: 'nargo' });
+    expect(skill.metadata.install[2]).toEqual({ type: 'apt', package: 'build-essential' });
+  });
+
+  it('parses requirements (binaries, env, os)', () => {
+    const md = `---
+name: req-test
+description: Requirements parsing
+version: 0.1.0
+metadata:
+  agenc:
+    requires:
+      binaries:
+        - python3
+        - pip
+      env:
+        - OPENAI_API_KEY
+        - HOME
+      os:
+        - linux
+---
+`;
+    const skill = parseSkillContent(md);
+
+    expect(skill.metadata.requires.binaries).toEqual(['python3', 'pip']);
+    expect(skill.metadata.requires.env).toEqual(['OPENAI_API_KEY', 'HOME']);
+    expect(skill.metadata.requires.os).toEqual(['linux']);
+    expect(skill.metadata.requires.channels).toEqual([]);
+  });
+
+  it('parses AgenC extensions (requiredCapabilities, onChainAuthor)', () => {
+    const md = `---
+name: ext-test
+description: Extensions test
+version: 1.0.0
+metadata:
+  agenc:
+    requiredCapabilities: "0xFF"
+    onChainAuthor: 11111111111111111111111111111111
+    contentHash: QmTest123
+---
+`;
+    const skill = parseSkillContent(md);
+
+    expect(skill.metadata.requiredCapabilities).toBe('0xFF');
+    expect(skill.metadata.onChainAuthor).toBe('11111111111111111111111111111111');
+    expect(skill.metadata.contentHash).toBe('QmTest123');
+  });
+
+  it('empty body returns empty string', () => {
+    const md = `---
+name: nobody
+description: No body
+version: 1.0.0
+---`;
+    const skill = parseSkillContent(md);
+
+    expect(skill.body).toBe('');
+  });
+
+  it('unknown fields do not error (lenient)', () => {
+    const md = `---
+name: lenient
+description: Lenient parsing test
+version: 1.0.0
+custom_field: ignored
+another:
+  nested: value
+metadata:
+  agenc:
+    unknown_ext: whatever
+---
+Body.
+`;
+    const skill = parseSkillContent(md);
+
+    expect(skill.name).toBe('lenient');
+    expect(skill.body).toBe('Body.\n');
+  });
+
+  it('URL-like array items are not misidentified as objects', () => {
+    const md = `---
+name: url-test
+description: URL array test
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - https://example.com:443/path
+      - simple-tag
+---
+`;
+    const skill = parseSkillContent(md);
+
+    expect(skill.metadata.tags).toEqual(['https://example.com:443/path', 'simple-tag']);
+  });
+});
+
+describe('parseSkillFile', () => {
+  it('reads and parses from filesystem', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'skill-test-'));
+    const filePath = join(dir, 'SKILL.md');
+
+    try {
+      await writeFile(filePath, MINIMAL_SKILL_MD, 'utf-8');
+      const skill = await parseSkillFile(filePath);
+
+      expect(skill.name).toBe('echo');
+      expect(skill.description).toBe('Simple echo skill');
+      expect(skill.version).toBe('0.1.0');
+      expect(skill.sourcePath).toBe(filePath);
+      expect(skill.body).toBe('Echo back the input.\n');
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+});
+
+describe('validateSkillMetadata', () => {
+  it('missing name produces error', () => {
+    const skill = parseSkillContent(`---
+description: desc
+version: 1.0.0
+---
+`);
+    const errors = validateSkillMetadata(skill);
+    expect(errors.some((e) => e.field === 'name')).toBe(true);
+  });
+
+  it('missing description produces error', () => {
+    const skill = parseSkillContent(`---
+name: test
+version: 1.0.0
+---
+`);
+    const errors = validateSkillMetadata(skill);
+    expect(errors.some((e) => e.field === 'description')).toBe(true);
+  });
+
+  it('missing version produces error', () => {
+    const skill = parseSkillContent(`---
+name: test
+description: desc
+---
+`);
+    const errors = validateSkillMetadata(skill);
+    expect(errors.some((e) => e.field === 'version')).toBe(true);
+  });
+
+  it('valid skill produces no errors', () => {
+    const skill = parseSkillContent(MINIMAL_SKILL_MD);
+    const errors = validateSkillMetadata(skill);
+    expect(errors).toEqual([]);
+  });
+});

--- a/runtime/src/skills/markdown/parser.ts
+++ b/runtime/src/skills/markdown/parser.ts
@@ -1,0 +1,414 @@
+/**
+ * SKILL.md parser — extracts YAML frontmatter metadata and markdown body.
+ *
+ * Parses markdown files with YAML frontmatter delimited by `---` fences.
+ * Supports the `metadata.agenc` and `metadata.openclaw` namespaces
+ * (agenc takes precedence when both are present).
+ *
+ * @module
+ */
+
+import { readFile } from 'node:fs/promises';
+import type {
+  MarkdownSkill,
+  MarkdownSkillMetadata,
+  SkillInstallStep,
+  SkillParseError,
+  SkillRequirements,
+} from './types.js';
+
+const FRONTMATTER_DELIMITER = '---';
+const VALID_INSTALL_TYPES = new Set(['brew', 'apt', 'npm', 'cargo', 'download']);
+
+/**
+ * Check whether content looks like a SKILL.md file (has YAML frontmatter).
+ */
+export function isSkillMarkdown(content: string): boolean {
+  return content.startsWith(`${FRONTMATTER_DELIMITER}\n`)
+    || content.startsWith(`${FRONTMATTER_DELIMITER}\r\n`);
+}
+
+/**
+ * Parse SKILL.md content (frontmatter + body) into a structured MarkdownSkill.
+ *
+ * This function is lenient — it extracts what it can and defaults missing
+ * fields to empty values. Use {@link validateSkillMetadata} for strict checks.
+ */
+export function parseSkillContent(content: string, sourcePath?: string): MarkdownSkill {
+  const { frontmatter, body } = splitFrontmatter(content);
+  const data = parseFrontmatter(frontmatter);
+
+  const name = getString(data, 'name') ?? '';
+  const description = getString(data, 'description') ?? '';
+  const version = getString(data, 'version') ?? '';
+
+  const metadata = extractMetadata(data);
+
+  return {
+    name,
+    description,
+    version,
+    metadata,
+    body,
+    ...(sourcePath !== undefined ? { sourcePath } : {}),
+  };
+}
+
+/**
+ * Read a SKILL.md file from the filesystem and parse it.
+ */
+export async function parseSkillFile(filePath: string): Promise<MarkdownSkill> {
+  const content = await readFile(filePath, 'utf-8');
+  return parseSkillContent(content, filePath);
+}
+
+/**
+ * Validate a parsed MarkdownSkill's metadata for required fields.
+ *
+ * Returns an array of errors. An empty array means the skill is valid.
+ */
+export function validateSkillMetadata(skill: MarkdownSkill): SkillParseError[] {
+  const errors: SkillParseError[] = [];
+
+  if (!skill.name) {
+    errors.push({ field: 'name', message: 'name is required' });
+  }
+
+  if (!skill.description) {
+    errors.push({ field: 'description', message: 'description is required' });
+  }
+
+  if (!skill.version) {
+    errors.push({ field: 'version', message: 'version is required' });
+  }
+
+  for (const [index, step] of skill.metadata.install.entries()) {
+    if (!VALID_INSTALL_TYPES.has(step.type)) {
+      errors.push({
+        field: `metadata.install[${index}].type`,
+        message: `Invalid install type "${step.type}". Must be one of: ${[...VALID_INSTALL_TYPES].join(', ')}`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface FrontmatterSplit {
+  frontmatter: string;
+  body: string;
+}
+
+/** Split content into frontmatter YAML and markdown body. */
+function splitFrontmatter(content: string): FrontmatterSplit {
+  if (!isSkillMarkdown(content)) {
+    return { frontmatter: '', body: content };
+  }
+
+  // Find closing delimiter (skip opening line)
+  const afterOpening = content.indexOf('\n') + 1;
+  const closingIndex = content.indexOf(`\n${FRONTMATTER_DELIMITER}`, afterOpening);
+
+  if (closingIndex === -1) {
+    // No closing delimiter — treat entire content after opening as frontmatter
+    return { frontmatter: content.slice(afterOpening), body: '' };
+  }
+
+  const frontmatter = content.slice(afterOpening, closingIndex);
+  // Body starts after closing `---\n`
+  const bodyStart = closingIndex + 1 + FRONTMATTER_DELIMITER.length;
+  const body = content.slice(bodyStart).replace(/^\r?\n/, '');
+
+  return { frontmatter, body };
+}
+
+/** Extract metadata from the agenc or openclaw namespace. */
+function extractMetadata(
+  data: Record<string, unknown>,
+): MarkdownSkillMetadata {
+  const metadataObj = getObject(data, 'metadata') ?? {};
+
+  // agenc namespace takes precedence over openclaw
+  const ns = getObject(metadataObj, 'agenc') ?? getObject(metadataObj, 'openclaw') ?? {};
+
+  const requiresObj = getObject(ns, 'requires') ?? {};
+  const requires: SkillRequirements = {
+    binaries: getStringArray(requiresObj, 'binaries'),
+    env: getStringArray(requiresObj, 'env'),
+    channels: getStringArray(requiresObj, 'channels'),
+    os: getStringArray(requiresObj, 'os'),
+  };
+
+  const rawInstall = getArray(ns, 'install');
+  const install: SkillInstallStep[] = [];
+  for (const item of rawInstall) {
+    if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+      const stepObj = item as Record<string, unknown>;
+      const type = getString(stepObj, 'type') ?? '';
+      install.push({
+        // Cast is intentionally lenient — validateSkillMetadata() checks valid types
+        type: type as SkillInstallStep['type'],
+        ...(stepObj.package !== undefined ? { package: String(stepObj.package) } : {}),
+        ...(stepObj.url !== undefined ? { url: String(stepObj.url) } : {}),
+        ...(stepObj.path !== undefined ? { path: String(stepObj.path) } : {}),
+      });
+    }
+  }
+
+  return {
+    ...(ns.emoji !== undefined ? { emoji: String(ns.emoji) } : {}),
+    requires,
+    ...(ns.primaryEnv !== undefined ? { primaryEnv: String(ns.primaryEnv) } : {}),
+    install,
+    tags: getStringArray(ns, 'tags'),
+    ...(ns.requiredCapabilities !== undefined
+      ? { requiredCapabilities: String(ns.requiredCapabilities) }
+      : {}),
+    ...(ns.onChainAuthor !== undefined ? { onChainAuthor: String(ns.onChainAuthor) } : {}),
+    ...(ns.contentHash !== undefined ? { contentHash: String(ns.contentHash) } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recursive-descent YAML frontmatter parser
+// ---------------------------------------------------------------------------
+
+/** Mutable parse state shared across recursive calls. */
+interface ParseState {
+  lines: string[];
+  pos: number;
+}
+
+/**
+ * Parse simple YAML into a nested Record.
+ *
+ * Uses recursive descent to correctly handle nested objects, arrays,
+ * and arrays of objects. Supports: `key: value`, `key:` (object/array start),
+ * `- item` (array), `- key: value` (array of objects), `[a, b]` (inline array),
+ * `#` comments, quoted strings, booleans, numbers.
+ */
+function parseFrontmatter(yaml: string): Record<string, unknown> {
+  if (!yaml.trim()) return {};
+
+  const lines = yaml.split(/\r?\n/)
+    .map((line) => stripComment(line));
+
+  const state: ParseState = { lines, pos: 0 };
+  return parseMapping(state, -1);
+}
+
+/** Parse a YAML mapping (object) at the given parent indent level. */
+function parseMapping(state: ParseState, parentIndent: number): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  while (state.pos < state.lines.length) {
+    const line = state.lines[state.pos];
+    if (!line.trim()) { state.pos++; continue; }
+
+    const indent = leadingSpaces(line);
+    const trimmed = line.trim();
+
+    // Dedented past our scope — done
+    if (indent <= parentIndent) break;
+
+    // Array items belong to a different scope
+    if (trimmed.startsWith('- ')) break;
+
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex === -1) { state.pos++; continue; }
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    const rawValue = trimmed.slice(colonIndex + 1).trim();
+
+    state.pos++;
+
+    if (rawValue === '') {
+      // Peek at the next non-blank line to decide array vs object
+      const nextInfo = peekNextLine(state);
+      if (nextInfo && nextInfo.indent > indent && nextInfo.trimmed.startsWith('- ')) {
+        result[key] = parseSequence(state, indent);
+      } else if (nextInfo && nextInfo.indent > indent) {
+        result[key] = parseMapping(state, indent);
+      } else {
+        result[key] = {};
+      }
+    } else {
+      result[key] = parseYamlValue(rawValue);
+    }
+  }
+
+  return result;
+}
+
+/** Parse a YAML sequence (array) at the given parent indent level. */
+function parseSequence(state: ParseState, parentIndent: number): unknown[] {
+  const result: unknown[] = [];
+
+  while (state.pos < state.lines.length) {
+    const line = state.lines[state.pos];
+    if (!line.trim()) { state.pos++; continue; }
+
+    const indent = leadingSpaces(line);
+    const trimmed = line.trim();
+
+    // Dedented past our scope — done
+    if (indent <= parentIndent) break;
+    if (!trimmed.startsWith('- ')) break;
+
+    const afterDash = trimmed.slice(2).trim();
+    const colonIndex = afterDash.indexOf(':');
+
+    // Check if this is `- key: value` (object array item).
+    // Guard against URL-like values (e.g. `- https://example.com:443`).
+    const keyCandidate = colonIndex > 0 ? afterDash.slice(0, colonIndex).trim() : '';
+    const isObjectItem = colonIndex > 0
+      && /^[a-zA-Z_]\w*$/.test(keyCandidate)
+      && !afterDash.startsWith('"')
+      && !afterDash.startsWith("'")
+      && !afterDash.includes('://');
+
+    if (isObjectItem) {
+      // Array of objects: `- key: value` followed by continuation keys
+      const itemKey = keyCandidate;
+      const itemRawValue = afterDash.slice(colonIndex + 1).trim();
+      const item: Record<string, unknown> = {};
+      item[itemKey] = parseYamlValue(itemRawValue);
+
+      state.pos++;
+
+      // Read continuation key-value pairs at deeper indent
+      while (state.pos < state.lines.length) {
+        const contLine = state.lines[state.pos];
+        if (!contLine.trim()) { state.pos++; continue; }
+
+        const contIndent = leadingSpaces(contLine);
+        const contTrimmed = contLine.trim();
+
+        // Back at same indent or dedented, or new array item
+        if (contIndent <= indent || contTrimmed.startsWith('- ')) break;
+
+        const contColonIndex = contTrimmed.indexOf(':');
+        if (contColonIndex === -1) { state.pos++; continue; }
+
+        const contKey = contTrimmed.slice(0, contColonIndex).trim();
+        const contRawValue = contTrimmed.slice(contColonIndex + 1).trim();
+        item[contKey] = parseYamlValue(contRawValue);
+        state.pos++;
+      }
+
+      result.push(item);
+    } else {
+      // Simple array item: `- value`
+      result.push(parseYamlValue(afterDash));
+      state.pos++;
+    }
+  }
+
+  return result;
+}
+
+/** Peek at the next non-blank line without advancing position. */
+function peekNextLine(state: ParseState): { indent: number; trimmed: string } | null {
+  let i = state.pos;
+  while (i < state.lines.length) {
+    const trimmed = state.lines[i].trim();
+    if (trimmed) {
+      return { indent: leadingSpaces(state.lines[i]), trimmed };
+    }
+    i++;
+  }
+  return null;
+}
+
+/** Parse a single YAML value (inline). */
+function parseYamlValue(raw: string): unknown {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  if (raw === 'null' || raw === '~') return null;
+
+  // Inline array: [a, b, c]
+  if (raw.startsWith('[') && raw.endsWith(']')) {
+    const inner = raw.slice(1, -1).trim();
+    if (!inner) return [];
+    return inner.split(',').map((item) => parseYamlValue(item.trim()));
+  }
+
+  // Quoted strings
+  if ((raw.startsWith('"') && raw.endsWith('"'))
+    || (raw.startsWith("'") && raw.endsWith("'"))) {
+    return raw.slice(1, -1);
+  }
+
+  // Numbers — only convert if roundtrip-safe (avoids precision loss on large integers)
+  if (/^-?\d+(\.\d+)?$/.test(raw)) {
+    const num = Number(raw);
+    if (String(num) === raw) {
+      return num;
+    }
+    return raw;
+  }
+
+  return raw;
+}
+
+/** Strip inline comments (outside of quotes). */
+function stripComment(line: string): string {
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (ch === "'" && !inDouble) inSingle = !inSingle;
+    else if (ch === '"' && !inSingle) inDouble = !inDouble;
+    else if (ch === '#' && !inSingle && !inDouble) {
+      if (i === 0 || line[i - 1] === ' ') {
+        return line.slice(0, i);
+      }
+    }
+  }
+  return line;
+}
+
+/** Count leading spaces. */
+function leadingSpaces(line: string): number {
+  let count = 0;
+  for (const ch of line) {
+    if (ch === ' ') count++;
+    else break;
+  }
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Type-safe accessors for parsed YAML data
+// ---------------------------------------------------------------------------
+
+function getString(obj: Record<string, unknown>, key: string): string | undefined {
+  const val = obj[key];
+  return val !== undefined && val !== null ? String(val) : undefined;
+}
+
+function getObject(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const val = obj[key];
+  if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+    return val as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function getArray(obj: Record<string, unknown>, key: string): unknown[] {
+  const val = obj[key];
+  return Array.isArray(val) ? val : [];
+}
+
+function getStringArray(obj: Record<string, unknown>, key: string): string[] {
+  return getArray(obj, key)
+    .filter((item) => item !== null && item !== undefined)
+    .map(String);
+}

--- a/runtime/src/skills/markdown/types.ts
+++ b/runtime/src/skills/markdown/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Types for SKILL.md parsing — YAML frontmatter + markdown body.
+ *
+ * These types represent the parsed structure of a SKILL.md file,
+ * which is used for LLM prompt injection of skill instructions.
+ *
+ * @module
+ */
+
+/** Parsed SKILL.md file. */
+export interface MarkdownSkill {
+  /** Skill name from frontmatter. */
+  readonly name: string;
+  /** Human-readable description from frontmatter. */
+  readonly description: string;
+  /** Semantic version string. */
+  readonly version: string;
+  /** Structured metadata block. */
+  readonly metadata: MarkdownSkillMetadata;
+  /** Raw markdown body (everything after closing `---`). */
+  readonly body: string;
+  /** Filesystem path the skill was loaded from, if available. */
+  readonly sourcePath?: string;
+}
+
+/** Metadata block extracted from SKILL.md frontmatter. */
+export interface MarkdownSkillMetadata {
+  /** Optional emoji identifier for the skill. */
+  readonly emoji?: string;
+  /** Runtime requirements (binaries, env vars, channels, OS). */
+  readonly requires: SkillRequirements;
+  /** Primary environment hint (e.g. 'node', 'python', 'rust'). */
+  readonly primaryEnv?: string;
+  /** Installation steps. */
+  readonly install: readonly SkillInstallStep[];
+  /** Tags for categorization and discovery. */
+  readonly tags: readonly string[];
+  /** Required capability bitmask as bigint string. */
+  readonly requiredCapabilities?: string;
+  /** On-chain author public key. */
+  readonly onChainAuthor?: string;
+  /** Content hash for integrity verification. */
+  readonly contentHash?: string;
+}
+
+/** Runtime requirements for a skill. */
+export interface SkillRequirements {
+  /** Required binary executables (e.g. 'nargo', 'node'). */
+  readonly binaries: readonly string[];
+  /** Required environment variables. */
+  readonly env: readonly string[];
+  /** Required communication channels. */
+  readonly channels: readonly string[];
+  /** Supported operating systems. */
+  readonly os: readonly string[];
+}
+
+/** A single installation step. */
+export interface SkillInstallStep {
+  /** Package manager or method. */
+  readonly type: 'brew' | 'apt' | 'npm' | 'cargo' | 'download';
+  /** Package name (for brew/apt/npm/cargo). */
+  readonly package?: string;
+  /** Download URL (for download type). */
+  readonly url?: string;
+  /** Installation path override. */
+  readonly path?: string;
+}
+
+/** Validation error from SKILL.md parsing. */
+export interface SkillParseError {
+  /** Field path that failed validation. */
+  readonly field: string;
+  /** Human-readable error message. */
+  readonly message: string;
+  /** Optional line number in source file. */
+  readonly line?: number;
+}

--- a/runtime/src/utils/index.ts
+++ b/runtime/src/utils/index.ts
@@ -29,6 +29,8 @@ export { fetchTreasury } from './treasury.js';
 
 export { ensureLazyModule } from './lazy-import.js';
 
+export { isRecord, isStringArray } from './type-guards.js';
+
 export {
   isTokenTask,
   buildCompleteTaskTokenAccounts,

--- a/runtime/src/utils/type-guards.ts
+++ b/runtime/src/utils/type-guards.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared type guard utilities for runtime modules.
+ *
+ * @module
+ */
+
+/** Check if a value is a non-null, non-array object. */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Check if a value is an array of strings. */
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}


### PR DESCRIPTION
## Summary

- Add SKILL.md parser for Phase 3 skills system (#1065) — P0 foundation unblocking 6 downstream issues
- Recursive-descent YAML frontmatter parser (no external deps) extracts structured metadata + raw markdown body for LLM prompt injection
- OpenClaw namespace normalization (`metadata.openclaw` → `metadata.agenc`)
- Extract shared `isRecord`/`isStringArray` type guards from `manifest.ts` + `catalog.ts` into `utils/type-guards.ts`

## Test plan

- [x] 17 unit tests covering all issue test plan items (`npx vitest run src/skills/markdown/parser.test.ts`)
- [x] `npm run typecheck` — clean across sdk, runtime, mcp
- [x] `npm run build` — succeeds
- [x] Existing manifest + catalog tests pass (46/46 in affected files)
- [x] No regressions in full runtime test suite

Closes #1065