### PR TITLE
feat(runtime): SKILL.md parser (YAML frontmatter + markdown body)

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -15,7 +15,11 @@
       "require": "./dist/index.js"
     }
   },
-  "files": ["dist", "idl", "README.md"],
+  "files": [
+    "dist",
+    "idl",
+    "README.md"
+  ],
   "scripts": {
     "prebuild": "npm run build --prefix ../sdk && node scripts/copy-idl.js",
     "build": "tsup src/index.ts src/bin/agenc-runtime.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token --external ws",
@@ -31,7 +35,14 @@
     "mutation:gates": "npx tsx scripts/check-mutation-gates.ts --artifact benchmarks/artifacts/mutation.ci.json",
     "prepublishOnly": "npm run build"
   },
-  "keywords": ["solana", "agents", "runtime", "coordination", "privacy", "zk"],
+  "keywords": [
+    "solana",
+    "agents",
+    "runtime",
+    "coordination",
+    "privacy",
+    "zk"
+  ],
   "author": "Tetsuo AI",
   "license": "MIT",
   "repository": {
@@ -40,15 +51,16 @@
     "directory": "runtime"
   },
   "optionalDependencies": {
-    "openai": "^4.0.0",
     "@anthropic-ai/sdk": "^0.30.0",
-    "ollama": "^0.5.0",
     "better-sqlite3": "^12.0.0",
     "ioredis": "^5.0.0",
+    "ollama": "^0.5.0",
+    "openai": "^4.0.0",
     "ws": "^8.0.0"
   },
   "dependencies": {
-    "@agenc/sdk": "file:../sdk"
+    "@agenc/sdk": "file:../sdk",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@coral-xyz/anchor": "^0.32.1",
@@ -60,8 +72,8 @@
     "anchor-litesvm": "^0.2.1",
     "bs58": "^6.0.0",
     "litesvm": "^0.5.0",
-    "tsx": "^4.21.0",
     "tsup": "^8.0.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.0.0",
     "vitest": "^2.0.0"
   },

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -422,6 +422,16 @@ export {
   USDC_MINT,
   USDT_MINT,
   WELL_KNOWN_TOKENS,
+  // Markdown skill parser (SKILL.md)
+  parseSkillFile,
+  parseSkillContent,
+  validateSkillMetadata,
+  isSkillMarkdown,
+  type MarkdownSkill,
+  type SkillMetadataBlock,
+  type SkillRequirements,
+  type SkillInstallStep,
+  type SkillParseError,
 } from './skills/index.js';
 
 // LLM Adapters (Phase 4)

--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -78,3 +78,16 @@ export {
   USDT_MINT,
   WELL_KNOWN_TOKENS,
 } from './jupiter/index.js';
+
+// Markdown skill parser (SKILL.md)
+export {
+  parseSkillFile,
+  parseSkillContent,
+  validateSkillMetadata,
+  isSkillMarkdown,
+  type MarkdownSkill,
+  type SkillMetadataBlock,
+  type SkillRequirements,
+  type SkillInstallStep,
+  type SkillParseError,
+} from './markdown/index.js';

--- a/runtime/src/skills/markdown/index.ts
+++ b/runtime/src/skills/markdown/index.ts
@@ -1,0 +1,14 @@
+export type {
+  MarkdownSkill,
+  SkillMetadataBlock,
+  SkillRequirements,
+  SkillInstallStep,
+  SkillParseError,
+} from './types.js';
+
+export {
+  parseSkillFile,
+  parseSkillContent,
+  validateSkillMetadata,
+  isSkillMarkdown,
+} from './parser.js';

--- a/runtime/src/skills/markdown/parser.test.ts
+++ b/runtime/src/skills/markdown/parser.test.ts
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import {
+  parseSkillContent,
+  parseSkillFile,
+  validateSkillMetadata,
+  isSkillMarkdown,
+} from './parser.js';
+
+const FULL_SKILL_MD = `---
+name: solana-tools
+description: Solana blockchain tools for agent operations
+version: 1.0.0
+metadata:
+  agenc:
+    emoji: "🔧"
+    primaryEnv: SOLANA_RPC_URL
+    requires:
+      binaries:
+        - solana
+        - anchor
+      env:
+        - SOLANA_RPC_URL
+        - ANCHOR_WALLET
+      channels:
+        - telegram
+      os:
+        - linux
+        - darwin
+    install:
+      - type: npm
+        package: "@solana/web3.js"
+      - type: cargo
+        package: anchor-cli
+    tags:
+      - solana
+      - defi
+      - blockchain
+    requiredCapabilities: "0x0f"
+    onChainAuthor: "9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin"
+    contentHash: "QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco"
+---
+
+# Solana Tools
+
+Use these tools to interact with the Solana blockchain.
+
+## Available Commands
+
+- \`solana balance\` — Check wallet balance
+- \`anchor deploy\` — Deploy a program
+`;
+
+const MINIMAL_SKILL_MD = `---
+name: minimal-skill
+description: A minimal skill
+version: 0.1.0
+---
+
+Minimal body.
+`;
+
+const OPENCLAW_SKILL_MD = `---
+name: openclaw-skill
+description: An OpenClaw compatible skill
+version: 2.0.0
+metadata:
+  openclaw:
+    emoji: "🐾"
+    tags:
+      - compat
+      - openclaw
+    requires:
+      binaries:
+        - git
+---
+
+OpenClaw compatible skill body.
+`;
+
+describe('parseSkillContent', () => {
+  it('parses valid SKILL.md with all frontmatter fields', () => {
+    const skill = parseSkillContent(FULL_SKILL_MD, '/skills/solana/SKILL.md');
+
+    expect(skill.name).toBe('solana-tools');
+    expect(skill.description).toBe('Solana blockchain tools for agent operations');
+    expect(skill.version).toBe('1.0.0');
+    expect(skill.sourcePath).toBe('/skills/solana/SKILL.md');
+
+    // Metadata
+    expect(skill.metadata.emoji).toBe('🔧');
+    expect(skill.metadata.primaryEnv).toBe('SOLANA_RPC_URL');
+    expect(skill.metadata.requiredCapabilities).toBe('0x0f');
+    expect(skill.metadata.onChainAuthor).toBe(
+      '9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin',
+    );
+    expect(skill.metadata.contentHash).toBe(
+      'QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco',
+    );
+
+    // Requirements
+    expect(skill.metadata.requires.binaries).toEqual(['solana', 'anchor']);
+    expect(skill.metadata.requires.env).toEqual([
+      'SOLANA_RPC_URL',
+      'ANCHOR_WALLET',
+    ]);
+    expect(skill.metadata.requires.channels).toEqual(['telegram']);
+    expect(skill.metadata.requires.os).toEqual(['linux', 'darwin']);
+
+    // Install steps
+    expect(skill.metadata.install).toHaveLength(2);
+    expect(skill.metadata.install[0]).toEqual({
+      type: 'npm',
+      package: '@solana/web3.js',
+    });
+    expect(skill.metadata.install[1]).toEqual({
+      type: 'cargo',
+      package: 'anchor-cli',
+    });
+
+    // Tags
+    expect(skill.metadata.tags).toEqual(['solana', 'defi', 'blockchain']);
+  });
+
+  it('parses SKILL.md with minimal frontmatter', () => {
+    const skill = parseSkillContent(MINIMAL_SKILL_MD);
+
+    expect(skill.name).toBe('minimal-skill');
+    expect(skill.description).toBe('A minimal skill');
+    expect(skill.version).toBe('0.1.0');
+    expect(skill.metadata.requires.binaries).toEqual([]);
+    expect(skill.metadata.requires.env).toEqual([]);
+    expect(skill.metadata.install).toEqual([]);
+    expect(skill.metadata.tags).toEqual([]);
+    expect(skill.body).toBe('Minimal body.\n');
+  });
+
+  it('parses SKILL.md with metadata.openclaw namespace (OpenClaw compat)', () => {
+    const skill = parseSkillContent(OPENCLAW_SKILL_MD);
+
+    expect(skill.name).toBe('openclaw-skill');
+    expect(skill.version).toBe('2.0.0');
+    expect(skill.metadata.emoji).toBe('🐾');
+    expect(skill.metadata.tags).toEqual(['compat', 'openclaw']);
+    expect(skill.metadata.requires.binaries).toEqual(['git']);
+  });
+
+  it('prefers metadata.agenc over metadata.openclaw', () => {
+    const content = `---
+name: dual-ns
+description: Both namespaces
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - agenc-tag
+  openclaw:
+    tags:
+      - openclaw-tag
+---
+
+Body.
+`;
+    const skill = parseSkillContent(content);
+    expect(skill.metadata.tags).toEqual(['agenc-tag']);
+  });
+
+  it('preserves markdown body formatting', () => {
+    const skill = parseSkillContent(FULL_SKILL_MD);
+    expect(skill.body).toContain('# Solana Tools');
+    expect(skill.body).toContain('## Available Commands');
+    expect(skill.body).toContain('`solana balance`');
+  });
+
+  it('returns empty string body for frontmatter-only content', () => {
+    const content = `---
+name: no-body
+description: No body content
+version: 1.0.0
+---
+`;
+    const skill = parseSkillContent(content);
+    expect(skill.body).toBe('');
+  });
+
+  it('ignores unknown frontmatter fields (lenient parsing)', () => {
+    const content = `---
+name: lenient
+description: Lenient parsing test
+version: 1.0.0
+customField: should be ignored
+anotherOne:
+  nested: true
+---
+
+Body.
+`;
+    const skill = parseSkillContent(content);
+    expect(skill.name).toBe('lenient');
+    expect(skill.body).toBe('Body.\n');
+  });
+
+  it('handles content without frontmatter', () => {
+    const content = '# Just Markdown\n\nNo frontmatter here.';
+    const skill = parseSkillContent(content);
+    expect(skill.name).toBe('');
+    expect(skill.body).toBe(content);
+  });
+
+  it('handles numeric version in frontmatter', () => {
+    const content = `---
+name: numeric-ver
+description: Numeric version
+version: 2.0
+---
+`;
+    const skill = parseSkillContent(content);
+    // YAML parses 2.0 as float 2, which stringifies to "2"
+    expect(skill.version).toBe('2');
+  });
+
+  it('parses SKILL.md with install instructions', () => {
+    const content = `---
+name: install-test
+description: Install test
+version: 1.0.0
+metadata:
+  agenc:
+    install:
+      - type: brew
+        package: solana
+      - type: download
+        url: https://example.com/tool
+        path: /usr/local/bin/tool
+---
+`;
+    const skill = parseSkillContent(content);
+    expect(skill.metadata.install).toHaveLength(2);
+    expect(skill.metadata.install[0]).toEqual({ type: 'brew', package: 'solana' });
+    expect(skill.metadata.install[1]).toEqual({
+      type: 'download',
+      url: 'https://example.com/tool',
+      path: '/usr/local/bin/tool',
+    });
+  });
+});
+
+describe('parseSkillFile', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'skill-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  it('reads and parses a SKILL.md file from disk', async () => {
+    const filePath = join(tmpDir, 'SKILL.md');
+    await writeFile(filePath, MINIMAL_SKILL_MD, 'utf-8');
+
+    const skill = await parseSkillFile(filePath);
+    expect(skill.name).toBe('minimal-skill');
+    expect(skill.sourcePath).toBe(filePath);
+  });
+});
+
+describe('validateSkillMetadata', () => {
+  it('returns no errors for valid skill', () => {
+    const skill = parseSkillContent(FULL_SKILL_MD);
+    const errors = validateSkillMetadata(skill);
+    expect(errors).toEqual([]);
+  });
+
+  it('returns error for missing name', () => {
+    const content = `---
+description: No name
+version: 1.0.0
+---
+`;
+    const skill = parseSkillContent(content);
+    const errors = validateSkillMetadata(skill);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe('name');
+  });
+
+  it('returns error for missing description', () => {
+    const content = `---
+name: no-desc
+version: 1.0.0
+---
+`;
+    const skill = parseSkillContent(content);
+    const errors = validateSkillMetadata(skill);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe('description');
+  });
+
+  it('returns error for missing version', () => {
+    const content = `---
+name: no-ver
+description: No version
+---
+`;
+    const skill = parseSkillContent(content);
+    const errors = validateSkillMetadata(skill);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe('version');
+  });
+
+  it('returns multiple errors when all required fields missing', () => {
+    const content = `---
+customField: true
+---
+`;
+    const skill = parseSkillContent(content);
+    const errors = validateSkillMetadata(skill);
+    expect(errors).toHaveLength(3);
+    const fields = errors.map((e) => e.field);
+    expect(fields).toContain('name');
+    expect(fields).toContain('description');
+    expect(fields).toContain('version');
+  });
+});
+
+describe('isSkillMarkdown', () => {
+  it('returns true for content with frontmatter', () => {
+    expect(isSkillMarkdown(FULL_SKILL_MD)).toBe(true);
+    expect(isSkillMarkdown(MINIMAL_SKILL_MD)).toBe(true);
+  });
+
+  it('returns false for plain markdown without frontmatter', () => {
+    expect(isSkillMarkdown('# Just a header\n\nSome text.')).toBe(false);
+    expect(isSkillMarkdown('')).toBe(false);
+  });
+
+  it('returns true even with leading whitespace', () => {
+    expect(isSkillMarkdown('  ---\nname: test\n---\n')).toBe(true);
+  });
+});

--- a/runtime/src/skills/markdown/parser.ts
+++ b/runtime/src/skills/markdown/parser.ts
@@ -1,0 +1,238 @@
+/**
+ * SKILL.md parser — extracts YAML frontmatter and markdown body.
+ *
+ * Skills are passive documentation injected into the LLM system prompt.
+ * The format is compatible with OpenClaw's SKILL.md for ecosystem
+ * portability, with AgenC-specific extensions in the `metadata.agenc`
+ * namespace.
+ *
+ * @module
+ */
+
+import { readFile } from 'node:fs/promises';
+import { parse as parseYaml } from 'yaml';
+import type {
+  MarkdownSkill,
+  SkillMetadataBlock,
+  SkillRequirements,
+  SkillInstallStep,
+  SkillParseError,
+} from './types.js';
+
+// ============================================================================
+// Frontmatter Extraction
+// ============================================================================
+
+const FRONTMATTER_OPEN = '---';
+
+interface FrontmatterResult {
+  frontmatter: string;
+  body: string;
+}
+
+function extractFrontmatter(content: string): FrontmatterResult | null {
+  const lines = content.split('\n');
+  if (lines.length === 0 || lines[0].trim() !== FRONTMATTER_OPEN) {
+    return null;
+  }
+
+  let closeIndex = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === FRONTMATTER_OPEN) {
+      closeIndex = i;
+      break;
+    }
+  }
+
+  if (closeIndex === -1) {
+    return null;
+  }
+
+  const frontmatter = lines.slice(1, closeIndex).join('\n');
+  const body = lines.slice(closeIndex + 1).join('\n');
+
+  return { frontmatter, body };
+}
+
+// ============================================================================
+// Metadata Normalization
+// ============================================================================
+
+function toStringArray(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+function normalizeRequirements(raw: unknown): SkillRequirements {
+  if (typeof raw !== 'object' || raw === null) {
+    return { binaries: [], env: [], channels: [], os: [] };
+  }
+  const obj = raw as Record<string, unknown>;
+  return {
+    binaries: toStringArray(obj.binaries),
+    env: toStringArray(obj.env),
+    channels: toStringArray(obj.channels),
+    os: toStringArray(obj.os),
+  };
+}
+
+const VALID_INSTALL_TYPES = new Set(['brew', 'apt', 'npm', 'cargo', 'download']);
+
+function normalizeInstallSteps(raw: unknown): readonly SkillInstallStep[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(
+      (item): item is Record<string, unknown> =>
+        typeof item === 'object' && item !== null,
+    )
+    .filter((item) => typeof item.type === 'string' && VALID_INSTALL_TYPES.has(item.type))
+    .map((item): SkillInstallStep => ({
+      type: item.type as SkillInstallStep['type'],
+      ...(typeof item.package === 'string' ? { package: item.package } : {}),
+      ...(typeof item.url === 'string' ? { url: item.url } : {}),
+      ...(typeof item.path === 'string' ? { path: item.path } : {}),
+    }));
+}
+
+function normalizeMetadata(raw: unknown): SkillMetadataBlock {
+  if (typeof raw !== 'object' || raw === null) {
+    return {
+      requires: { binaries: [], env: [], channels: [], os: [] },
+      install: [],
+      tags: [],
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+  return {
+    emoji: typeof obj.emoji === 'string' ? obj.emoji : undefined,
+    requires: normalizeRequirements(obj.requires),
+    primaryEnv: typeof obj.primaryEnv === 'string' ? obj.primaryEnv : undefined,
+    install: normalizeInstallSteps(obj.install),
+    tags: toStringArray(obj.tags),
+    requiredCapabilities:
+      typeof obj.requiredCapabilities === 'string'
+        ? obj.requiredCapabilities
+        : undefined,
+    onChainAuthor:
+      typeof obj.onChainAuthor === 'string' ? obj.onChainAuthor : undefined,
+    contentHash:
+      typeof obj.contentHash === 'string' ? obj.contentHash : undefined,
+  };
+}
+
+/**
+ * Resolve the metadata block from parsed YAML, accepting both
+ * `metadata.agenc` and `metadata.openclaw` namespaces. The `agenc`
+ * namespace takes precedence; `openclaw` is normalized to `agenc`.
+ */
+function resolveMetadataNamespace(
+  parsed: Record<string, unknown>,
+): SkillMetadataBlock {
+  const meta = parsed.metadata as Record<string, unknown> | undefined;
+  if (typeof meta !== 'object' || meta === null) {
+    return normalizeMetadata(undefined);
+  }
+
+  // agenc namespace takes precedence
+  if (meta.agenc !== undefined) {
+    return normalizeMetadata(meta.agenc);
+  }
+  // OpenClaw compatibility
+  if (meta.openclaw !== undefined) {
+    return normalizeMetadata(meta.openclaw);
+  }
+
+  return normalizeMetadata(undefined);
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/** Check if content looks like a SKILL.md file (has YAML frontmatter). */
+export function isSkillMarkdown(content: string): boolean {
+  return content.trimStart().startsWith(FRONTMATTER_OPEN + '\n') ||
+    content.trimStart().startsWith(FRONTMATTER_OPEN + '\r\n');
+}
+
+/** Parse SKILL.md content from a string. */
+export function parseSkillContent(
+  content: string,
+  sourcePath = '<string>',
+): MarkdownSkill {
+  const result = extractFrontmatter(content);
+  if (!result) {
+    return {
+      name: '',
+      description: '',
+      version: '',
+      metadata: normalizeMetadata(undefined),
+      body: content,
+      sourcePath,
+    };
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseYaml(result.frontmatter) as Record<string, unknown>;
+  } catch {
+    parsed = {};
+  }
+
+  if (typeof parsed !== 'object' || parsed === null) {
+    parsed = {};
+  }
+
+  const name = typeof parsed.name === 'string' ? parsed.name : '';
+  const description =
+    typeof parsed.description === 'string' ? parsed.description : '';
+  const version = typeof parsed.version === 'string'
+    ? parsed.version
+    : typeof parsed.version === 'number'
+      ? String(parsed.version)
+      : '';
+
+  const metadata = resolveMetadataNamespace(parsed);
+
+  // Trim leading newline from body but preserve the rest
+  const body = result.body.startsWith('\n')
+    ? result.body.slice(1)
+    : result.body;
+
+  return {
+    name,
+    description,
+    version,
+    metadata,
+    body,
+    sourcePath,
+  };
+}
+
+/** Parse a SKILL.md file from a file path. */
+export async function parseSkillFile(filePath: string): Promise<MarkdownSkill> {
+  const content = await readFile(filePath, 'utf-8');
+  return parseSkillContent(content, filePath);
+}
+
+/** Validate parsed skill metadata. Returns an array of errors (empty = valid). */
+export function validateSkillMetadata(skill: MarkdownSkill): SkillParseError[] {
+  const errors: SkillParseError[] = [];
+
+  if (!skill.name || skill.name.trim().length === 0) {
+    errors.push({ field: 'name', message: 'Skill name is required' });
+  }
+
+  if (!skill.description || skill.description.trim().length === 0) {
+    errors.push({
+      field: 'description',
+      message: 'Skill description is required',
+    });
+  }
+
+  if (!skill.version || skill.version.trim().length === 0) {
+    errors.push({ field: 'version', message: 'Skill version is required' });
+  }
+
+  return errors;
+}

--- a/runtime/src/skills/markdown/types.ts
+++ b/runtime/src/skills/markdown/types.ts
@@ -1,0 +1,88 @@
+/**
+ * Types for SKILL.md markdown-based skill definitions.
+ *
+ * Skills are passive documentation injected into the LLM system prompt.
+ * The SKILL.md format uses YAML frontmatter for structured metadata
+ * and a markdown body for the skill documentation.
+ *
+ * @module
+ */
+
+// ============================================================================
+// Parsed Skill
+// ============================================================================
+
+/** Parsed SKILL.md file. */
+export interface MarkdownSkill {
+  /** Skill name (from frontmatter). */
+  readonly name: string;
+  /** Description (from frontmatter). */
+  readonly description: string;
+  /** Semantic version. */
+  readonly version: string;
+  /** AgenC metadata extensions. */
+  readonly metadata: SkillMetadataBlock;
+  /** Raw markdown body (after frontmatter). */
+  readonly body: string;
+  /** Source file path. */
+  readonly sourcePath: string;
+}
+
+// ============================================================================
+// Metadata
+// ============================================================================
+
+/** Skill metadata from YAML frontmatter. */
+export interface SkillMetadataBlock {
+  /** Display emoji. */
+  readonly emoji?: string;
+  /** Requirement checks. */
+  readonly requires: SkillRequirements;
+  /** Primary environment variable for auth. */
+  readonly primaryEnv?: string;
+  /** Install instructions per platform. */
+  readonly install: readonly SkillInstallStep[];
+  /** Categorization tags. */
+  readonly tags: readonly string[];
+  /** Required on-chain capabilities bitmask (hex string). */
+  readonly requiredCapabilities?: string;
+  /** On-chain author pubkey. */
+  readonly onChainAuthor?: string;
+  /** Content hash (IPFS CID). */
+  readonly contentHash?: string;
+}
+
+/** Skill requirements. */
+export interface SkillRequirements {
+  /** Required binaries on PATH. */
+  readonly binaries: readonly string[];
+  /** Required environment variables. */
+  readonly env: readonly string[];
+  /** Required channel plugins. */
+  readonly channels: readonly string[];
+  /** Supported operating systems. */
+  readonly os: readonly string[];
+}
+
+/** Install instruction for a platform. */
+export interface SkillInstallStep {
+  /** Package manager type. */
+  readonly type: 'brew' | 'apt' | 'npm' | 'cargo' | 'download';
+  /** Package name. */
+  readonly package?: string;
+  /** Download URL. */
+  readonly url?: string;
+  /** Install path. */
+  readonly path?: string;
+}
+
+// ============================================================================
+// Parse Errors
+// ============================================================================
+
+/** Parse error for a specific field. */
+export interface SkillParseError {
+  readonly field: string;
+  readonly message: string;
+  readonly line?: number;
+}

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -37,6 +37,25 @@
   resolved "https://registry.npmjs.org/@coral-xyz/anchor-errors/-/anchor-errors-0.31.1.tgz"
   integrity sha512-NhNEku4F3zzUSBtrYz84FzYWm48+9OvmT1Hhnwr6GnPQry2dsEqH/ti/7ASjjpoFTWRnPXrjAIT1qM6Isop+LQ==
 
+"@coral-xyz/anchor@^0.31.1":
+  version "0.31.1"
+  resolved "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.31.1.tgz"
+  integrity sha512-QUqpoEK+gi2S6nlYc2atgT2r41TT3caWr/cPUEL8n8Md9437trZ68STknq897b82p5mW0XrTBNOzRbmIRJtfsA==
+  dependencies:
+    "@coral-xyz/anchor-errors" "^0.31.1"
+    "@coral-xyz/borsh" "^0.31.1"
+    "@noble/hashes" "^1.3.1"
+    "@solana/web3.js" "^1.69.0"
+    bn.js "^5.1.2"
+    bs58 "^4.0.1"
+    buffer-layout "^1.2.2"
+    camelcase "^6.3.0"
+    cross-fetch "^3.1.5"
+    eventemitter3 "^4.0.7"
+    pako "^2.0.3"
+    superstruct "^0.15.4"
+    toml "^3.0.0"
+
 "@coral-xyz/anchor@^0.32.1":
   version "0.32.1"
   resolved "https://registry.npmjs.org/@coral-xyz/anchor/-/anchor-0.32.1.tgz"
@@ -73,6 +92,11 @@
   version "0.27.2"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz"
   integrity sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==
+
+"@iarna/toml@^2.2.5":
+  version "2.2.5"
+  resolved "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz"
+  integrity sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==
 
 "@ioredis/commands@1.5.0":
   version "1.5.0"
@@ -255,7 +279,7 @@
     "@solana/spl-token-metadata" "^0.1.6"
     buffer "^6.0.3"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.95.0", "@solana/web3.js@^1.95.3", "@solana/web3.js@^1.95.5":
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.95.0", "@solana/web3.js@^1.95.3", "@solana/web3.js@^1.95.5", "@solana/web3.js@^1.98.4":
   version "1.98.4"
   resolved "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz"
   integrity sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==
@@ -341,7 +365,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^8.2.2":
+"@types/ws@^8.0.0", "@types/ws@^8.2.2":
   version "8.18.1"
   resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
   integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
@@ -426,6 +450,16 @@ agentkeepalive@^4.2.1, agentkeepalive@^4.5.0:
   dependencies:
     humanize-ms "^1.2.1"
 
+anchor-litesvm@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/anchor-litesvm/-/anchor-litesvm-0.2.1.tgz"
+  integrity sha512-WBFxuW982eXTZqxmoE0lewuPFpSipAd/MoyuRpPmYJ4bshU5eNM14XAsViQ2ARkIxeDP/W2BMoi9rRZlG/lzXw==
+  dependencies:
+    "@coral-xyz/anchor" "^0.31.1"
+    "@iarna/toml" "^2.2.5"
+    "@solana/web3.js" "^1.98.4"
+    litesvm "^0.3.3"
+
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
@@ -447,6 +481,11 @@ base-x@^3.0.2:
   integrity sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==
   dependencies:
     safe-buffer "^5.0.1"
+
+base-x@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
 
 base64-js@^1.3.1:
   version "1.5.1"
@@ -503,12 +542,26 @@ borsh@^0.7.0:
     bs58 "^4.0.0"
     text-encoding-utf-8 "^1.0.2"
 
-bs58@^4.0.0, bs58@^4.0.1:
+bs58@^4.0.0:
   version "4.0.1"
   resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz"
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
   dependencies:
     base-x "^3.0.2"
+
+bs58@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz"
+  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
+  dependencies:
+    base-x "^3.0.2"
+
+bs58@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz"
+  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
+  dependencies:
+    base-x "^5.0.0"
 
 buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   version "1.2.2"
@@ -778,7 +831,7 @@ esbuild@^0.21.3:
     "@esbuild/win32-ia32" "0.21.5"
     "@esbuild/win32-x64" "0.21.5"
 
-esbuild@^0.27.0, esbuild@>=0.18:
+esbuild@^0.27.0, esbuild@>=0.18, esbuild@~0.27.0:
   version "0.27.2"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz"
   integrity sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==
@@ -934,6 +987,13 @@ get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
+get-tsconfig@^4.7.5:
+  version "4.13.6"
+  resolved "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz"
+  integrity sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
 github-from-package@0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz"
@@ -986,9 +1046,9 @@ ini@~1.3.0:
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 ioredis@^5.0.0:
-  version "5.9.2"
-  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.9.2.tgz"
-  integrity sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==
+  version "5.9.3"
+  resolved "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz"
+  integrity sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==
   dependencies:
     "@ioredis/commands" "1.5.0"
     cluster-key-slot "^1.1.0"
@@ -1042,6 +1102,56 @@ lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
+
+litesvm-linux-x64-gnu@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.npmjs.org/litesvm-linux-x64-gnu/-/litesvm-linux-x64-gnu-0.3.3.tgz"
+  integrity sha512-Qai2/E8Eq03w8VKnJDREyiWxwavjykW/H6onE179ayMnBjVVmkj5fN7XF50VV4z73kasx5bpDzBNK8fcaxMdzA==
+
+litesvm-linux-x64-gnu@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/litesvm-linux-x64-gnu/-/litesvm-linux-x64-gnu-0.5.0.tgz"
+  integrity sha512-W8IIBVlLSBN5RkM88292TImBmYmDMgiYGecin6Qan+dRsBxUffFjRSFHgZRzJQ6X7pfhjlXI6kzuqwsZYchUHA==
+
+litesvm-linux-x64-musl@0.3.3:
+  version "0.3.3"
+  resolved "https://registry.npmjs.org/litesvm-linux-x64-musl/-/litesvm-linux-x64-musl-0.3.3.tgz"
+  integrity sha512-bpWZ2f506hbfu1y6bkmuZf+qqtnLDxggpOMTQbibjd+q6faEO3sETWwKGlIgHB99P8wyU+aXKwLSGQX2sJEw6Q==
+
+litesvm-linux-x64-musl@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/litesvm-linux-x64-musl/-/litesvm-linux-x64-musl-0.5.0.tgz"
+  integrity sha512-MECozYJjeEiuAEv04FucrFCA0ivdIxisuiK7Fxzx5uSda0W6AieuDx6rnkMXXTgEsR3PKQUA18KmHR93CN1cdw==
+
+litesvm@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.npmjs.org/litesvm/-/litesvm-0.3.3.tgz"
+  integrity sha512-QHXjAIXzvG0uAMOza6aJcYl19yTKz3guwq/z0Zml4KnQxyQvPhjaBpUFc5sf2ey/NxMVdqFhoXmL02CXOOomjw==
+  dependencies:
+    "@solana/web3.js" "^1.98.4"
+    bs58 "^6.0.0"
+    fastestsmallesttextencoderdecoder "^1.0.22"
+  optionalDependencies:
+    litesvm-darwin-arm64 "0.3.3"
+    litesvm-darwin-x64 "0.3.3"
+    litesvm-linux-arm64-musl "0.3.3"
+    litesvm-linux-x64-gnu "0.3.3"
+    litesvm-linux-x64-musl "0.3.3"
+
+litesvm@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/litesvm/-/litesvm-0.5.0.tgz"
+  integrity sha512-lo/W4FcTdUGksuStmdGvRpB6lLRKB5qlvJdMwkGBnOzpIcApHxrvNosHmde4tk9lpWn4ICqW55OYDrSs258bXA==
+  dependencies:
+    "@solana/web3.js" "^1.98.4"
+    fastestsmallesttextencoderdecoder "^1.0.22"
+  optionalDependencies:
+    litesvm-darwin-arm64 "0.5.0"
+    litesvm-darwin-x64 "0.5.0"
+    litesvm-linux-arm64-gnu "0.5.0"
+    litesvm-linux-arm64-musl "0.5.0"
+    litesvm-linux-x64-gnu "0.5.0"
+    litesvm-linux-x64-musl "0.5.0"
 
 load-tsconfig@^0.2.3:
   version "0.2.5"
@@ -1319,6 +1429,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 rollup@^4.20.0, rollup@^4.34.8:
   version "4.55.2"
   resolved "https://registry.npmjs.org/rollup/-/rollup-4.55.2.tgz"
@@ -1591,6 +1706,16 @@ tsup@^8.0.0:
     tinyglobby "^0.2.11"
     tree-kill "^1.2.2"
 
+tsx@^4.21.0, tsx@^4.8.1:
+  version "4.21.0"
+  resolved "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz"
+  integrity sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==
+  dependencies:
+    esbuild "~0.27.0"
+    get-tsconfig "^4.7.5"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 tunnel-agent@^0.6.0:
   version "0.6.0"
   resolved "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
@@ -1719,7 +1844,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^8.18.0, ws@^8.5.0:
+ws@*, ws@^8.0.0, ws@^8.18.0, ws@^8.5.0:
   version "8.19.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz"
   integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
@@ -1728,3 +1853,8 @@ ws@^7.5.10:
   version "7.5.10"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz"
   integrity sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==
+
+yaml@^2.4.2, yaml@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz"
+  integrity sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==


### PR DESCRIPTION
## Summary
- Adds `parseSkillContent` / `parseSkillFile` to extract YAML frontmatter and markdown body from SKILL.md files
- Supports both `metadata.agenc` and `metadata.openclaw` namespaces for OpenClaw ecosystem compatibility
- Includes `validateSkillMetadata` for required field validation and `isSkillMarkdown` for frontmatter detection
- Extracts structured metadata: requirements (binaries, env, channels, os), install steps, tags, and AgenC-specific extensions (capabilities, on-chain author, content hash)
- Adds `yaml` package dependency for robust YAML parsing

## Test plan
- [x] 19 unit tests covering all acceptance criteria from #1065
- [x] Full frontmatter extraction with all fields
- [x] Minimal frontmatter (name, description, version only)
- [x] OpenClaw `metadata.openclaw` namespace normalized to agenc
- [x] Validation errors for missing required fields
- [x] Body preservation with markdown formatting
- [x] Lenient parsing ignores unknown fields
- [x] File system read via `parseSkillFile`
- [x] Types exported from barrel `index.ts`
- [x] No regressions in existing tests

Closes #1065

🤖 Generated with [Claude Code](https://claude.com/claude-code)