### PR TITLE
feat(runtime): system.bash tool with allow/deny lists (#1067)

### DIFF
--- a/runtime/src/tools/index.ts
+++ b/runtime/src/tools/index.ts
@@ -50,3 +50,12 @@ export {
   type SerializedAgent,
   type SerializedProtocolConfig,
 } from './agenc/index.js';
+
+// System tools
+export {
+  createBashTool,
+  isCommandAllowed,
+  DEFAULT_DENY_LIST,
+  type BashToolConfig,
+  type BashExecutionResult,
+} from './system/index.js';

--- a/runtime/src/tools/system/bash.test.ts
+++ b/runtime/src/tools/system/bash.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'node:path';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import {
+  createBashTool,
+  isCommandAllowed,
+  DEFAULT_DENY_LIST,
+} from './bash.js';
+
+function parseResult(result: { content: string }) {
+  return JSON.parse(result.content);
+}
+
+describe('isCommandAllowed', () => {
+  it('allows all commands with empty lists', () => {
+    const result = isCommandAllowed('echo hello', [], []);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('denies command matching deny list', () => {
+    const result = isCommandAllowed('rm -rf / --no-preserve-root');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('rm -rf /');
+  });
+
+  it('allows command matching allow list prefix', () => {
+    const result = isCommandAllowed('echo hello world', ['echo', 'ls'], []);
+    expect(result.allowed).toBe(true);
+  });
+
+  it('denies command not matching any allow list prefix', () => {
+    const result = isCommandAllowed('cat /etc/passwd', ['echo', 'ls'], []);
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('allow list');
+  });
+
+  it('deny list takes precedence over allow list', () => {
+    const result = isCommandAllowed(
+      'rm -rf /',
+      ['rm'],
+      ['rm -rf /'],
+    );
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('deny');
+  });
+
+  it('default deny list includes dangerous commands', () => {
+    for (const dangerous of ['rm -rf /', 'mkfs', 'shutdown', 'reboot', 'dd if=']) {
+      const result = isCommandAllowed(dangerous);
+      expect(result.allowed).toBe(false);
+    }
+  });
+});
+
+describe('DEFAULT_DENY_LIST', () => {
+  it('contains expected dangerous patterns', () => {
+    expect(DEFAULT_DENY_LIST).toContain('rm -rf /');
+    expect(DEFAULT_DENY_LIST).toContain('rm -rf ~');
+    expect(DEFAULT_DENY_LIST).toContain('mkfs');
+    expect(DEFAULT_DENY_LIST).toContain('shutdown');
+    expect(DEFAULT_DENY_LIST).toContain('reboot');
+    expect(DEFAULT_DENY_LIST).toContain('dd if=');
+    expect(DEFAULT_DENY_LIST.length).toBeGreaterThanOrEqual(10);
+  });
+});
+
+describe('createBashTool', () => {
+  it('matches Tool interface shape', () => {
+    const tool = createBashTool();
+    expect(tool.name).toBe('system.bash');
+    expect(typeof tool.description).toBe('string');
+    expect(tool.inputSchema).toBeDefined();
+    expect(typeof tool.execute).toBe('function');
+    expect(tool.inputSchema.type).toBe('object');
+  });
+
+  it('executes simple command and returns stdout', async () => {
+    const tool = createBashTool({ denyList: [] });
+    const result = await tool.execute({ command: 'echo hello' });
+    const parsed = parseResult(result);
+
+    expect(parsed.stdout.trim()).toBe('hello');
+    expect(parsed.exitCode).toBe(0);
+    expect(result.isError).toBeFalsy();
+  });
+
+  it('captures stderr in result', async () => {
+    const tool = createBashTool({ useShell: true, denyList: [] });
+    const result = await tool.execute({ command: 'echo error-output >&2' });
+    const parsed = parseResult(result);
+
+    expect(parsed.stderr.trim()).toBe('error-output');
+  });
+
+  it('returns isError for non-zero exit code', async () => {
+    const tool = createBashTool({ useShell: true, denyList: [] });
+    const result = await tool.execute({ command: 'exit 42' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.exitCode).not.toBe(0);
+  });
+
+  it('rejects denied command before execution', async () => {
+    const tool = createBashTool();
+    const result = await tool.execute({ command: 'rm -rf / --no-preserve-root' });
+
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result);
+    expect(parsed.error).toContain('denied');
+  });
+
+  it('rejects empty command', async () => {
+    const tool = createBashTool();
+    const result = await tool.execute({ command: '' });
+
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result);
+    expect(parsed.error).toContain('non-empty');
+  });
+
+  it('rejects non-string command', async () => {
+    const tool = createBashTool();
+    const result = await tool.execute({ command: 123 as unknown as string });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('truncates output at maxOutputBytes', async () => {
+    const tool = createBashTool({
+      maxOutputBytes: 20,
+      useShell: true,
+      denyList: [],
+    });
+    // Generate output larger than 20 bytes
+    const result = await tool.execute({
+      command: 'echo "This is a long output string that exceeds the limit"',
+    });
+    const parsed = parseResult(result);
+
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.stdout).toContain('[truncated]');
+  });
+
+  it('enforces timeout on long-running commands', async () => {
+    const tool = createBashTool({
+      timeoutMs: 200,
+      useShell: true,
+      denyList: [],
+    });
+    const result = await tool.execute({ command: 'sleep 30' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(parsed.timedOut).toBe(true);
+    expect(parsed.durationMs).toBeLessThan(5000);
+  }, 10_000);
+
+  it('overrides cwd per-call', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'bash-tool-test-'));
+    try {
+      await writeFile(join(dir, 'marker.txt'), 'found', 'utf-8');
+      const tool = createBashTool({ denyList: [] });
+      const result = await tool.execute({ command: 'ls marker.txt', cwd: dir });
+      const parsed = parseResult(result);
+
+      expect(parsed.stdout.trim()).toBe('marker.txt');
+      expect(parsed.exitCode).toBe(0);
+    } finally {
+      await rm(dir, { recursive: true });
+    }
+  });
+
+  it('useShell: false prevents shell expansion', async () => {
+    const tool = createBashTool({ useShell: false, denyList: [] });
+    // Without shell, glob patterns are not expanded by the shell
+    const result = await tool.execute({ command: 'echo *' });
+    const parsed = parseResult(result);
+
+    // execFile passes '*' as a literal arg to echo, so output is '*'
+    expect(parsed.stdout.trim()).toBe('*');
+  });
+
+  it('useShell: true enables shell features', async () => {
+    const tool = createBashTool({ useShell: true, denyList: [] });
+    // Pipe works in shell mode
+    const result = await tool.execute({ command: 'echo hello | tr a-z A-Z' });
+    const parsed = parseResult(result);
+
+    expect(parsed.stdout.trim()).toBe('HELLO');
+    expect(parsed.exitCode).toBe(0);
+  });
+});

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -1,0 +1,302 @@
+/**
+ * system.bash tool — command execution with allow/deny lists.
+ *
+ * Uses `child_process.execFile` by default to prevent shell injection.
+ * Operators can opt into full shell mode via `useShell: true` in config,
+ * which passes `shell: true` to execFile.
+ *
+ * @module
+ */
+
+import { execFile } from 'node:child_process';
+import type { Tool, ToolResult } from '../types.js';
+import { safeStringify } from '../types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Bash tool configuration. */
+export interface BashToolConfig {
+  /** Working directory (default: process.cwd()). */
+  readonly cwd?: string;
+  /** Command timeout in ms (default: 30000). */
+  readonly timeoutMs?: number;
+  /** Allowed command prefixes (empty = allow all that aren't denied). */
+  readonly allowList?: readonly string[];
+  /** Blocked command prefixes. */
+  readonly denyList?: readonly string[];
+  /** Max output size in bytes (default: 100000). */
+  readonly maxOutputBytes?: number;
+  /** Whether to use shell mode (default: false — uses execFile). */
+  readonly useShell?: boolean;
+}
+
+/** Result of a bash command execution. */
+export interface BashExecutionResult {
+  /** stdout content. */
+  readonly stdout: string;
+  /** stderr content. */
+  readonly stderr: string;
+  /** Exit code (0 = success). */
+  readonly exitCode: number;
+  /** Whether output was truncated. */
+  readonly truncated: boolean;
+  /** Whether the command timed out. */
+  readonly timedOut: boolean;
+  /** Execution duration in ms. */
+  readonly durationMs: number;
+}
+
+// ============================================================================
+// Default deny list
+// ============================================================================
+
+/** Default deny list for dangerous commands. */
+export const DEFAULT_DENY_LIST: readonly string[] = [
+  'rm -rf /',
+  'rm -rf ~',
+  'dd if=',
+  'mkfs',
+  'shutdown',
+  'reboot',
+  ':(){ :|:& };:',
+  'curl | sh',
+  'wget | sh',
+  '> /dev/sda',
+];
+
+// ============================================================================
+// Command validation
+// ============================================================================
+
+/** Check if a command is allowed by allow/deny lists. */
+export function isCommandAllowed(
+  command: string,
+  allowList?: readonly string[],
+  denyList?: readonly string[],
+): { allowed: boolean; reason?: string } {
+  const effectiveDenyList = denyList ?? DEFAULT_DENY_LIST;
+
+  // Deny list checked first (takes precedence)
+  for (const pattern of effectiveDenyList) {
+    if (command.includes(pattern)) {
+      return { allowed: false, reason: `Command matches deny pattern: "${pattern}"` };
+    }
+  }
+
+  // Allow list: if set, command must match at least one prefix
+  if (allowList && allowList.length > 0) {
+    const matches = allowList.some((prefix) => command.startsWith(prefix));
+    if (!matches) {
+      return {
+        allowed: false,
+        reason: `Command does not match any allow list prefix: ${allowList.join(', ')}`,
+      };
+    }
+  }
+
+  return { allowed: true };
+}
+
+// ============================================================================
+// Defaults
+// ============================================================================
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_OUTPUT_BYTES = 100_000;
+
+// ============================================================================
+// Tool factory
+// ============================================================================
+
+/** Create the system.bash tool. */
+export function createBashTool(config?: BashToolConfig): Tool {
+  const cwd = config?.cwd ?? process.cwd();
+  const timeoutMs = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const allowList = config?.allowList;
+  const denyList = config?.denyList;
+  const maxOutputBytes = config?.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const useShell = config?.useShell ?? false;
+
+  return {
+    name: 'system.bash',
+    description:
+      'Execute a shell command on the host system. Commands are validated ' +
+      'against allow/deny lists before execution. Uses execFile by default ' +
+      '(no shell expansion) for safety.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        command: { type: 'string', description: 'The command to execute' },
+        cwd: { type: 'string', description: 'Working directory override' },
+        timeout: { type: 'number', description: 'Timeout override in ms' },
+      },
+      required: ['command'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const command = args.command;
+      if (typeof command !== 'string' || command.trim().length === 0) {
+        return {
+          content: safeStringify({ error: 'command must be a non-empty string' }),
+          isError: true,
+        };
+      }
+
+      // Check allow/deny lists
+      const check = isCommandAllowed(command, allowList, denyList);
+      if (!check.allowed) {
+        return {
+          content: safeStringify({ error: `Command denied: ${check.reason}` }),
+          isError: true,
+        };
+      }
+
+      const effectiveCwd = typeof args.cwd === 'string' ? args.cwd : cwd;
+      const effectiveTimeout = typeof args.timeout === 'number' ? args.timeout : timeoutMs;
+
+      const start = Date.now();
+
+      try {
+        const result = await executeCommand(
+          command,
+          effectiveCwd,
+          effectiveTimeout,
+          maxOutputBytes,
+          useShell,
+        );
+
+        return {
+          content: safeStringify(result),
+          isError: result.exitCode !== 0 || result.timedOut,
+          metadata: { durationMs: result.durationMs },
+        };
+      } catch (err) {
+        const durationMs = Date.now() - start;
+        return {
+          content: safeStringify({
+            error: err instanceof Error ? err.message : String(err),
+            durationMs,
+          }),
+          isError: true,
+        };
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Internal execution
+// ============================================================================
+
+function truncateOutput(output: string, maxBytes: number): { text: string; truncated: boolean } {
+  const bytes = Buffer.byteLength(output, 'utf-8');
+  if (bytes <= maxBytes) {
+    return { text: output, truncated: false };
+  }
+  const buf = Buffer.from(output, 'utf-8').subarray(0, maxBytes);
+  return { text: buf.toString('utf-8') + '\n[truncated]', truncated: true };
+}
+
+function executeCommand(
+  command: string,
+  cwd: string,
+  timeout: number,
+  maxOutputBytes: number,
+  useShell: boolean,
+): Promise<BashExecutionResult> {
+  return new Promise((resolve) => {
+    const start = Date.now();
+
+    const callback = (error: Error | null, stdout: string, stderr: string) => {
+      const durationMs = Date.now() - start;
+
+      let timedOut = false;
+      let exitCode = 0;
+
+      if (error) {
+        const err = error as NodeJS.ErrnoException & { killed?: boolean; code?: string | number };
+        timedOut = err.killed === true;
+
+        if (typeof err.code === 'number') {
+          exitCode = err.code;
+        } else if ('status' in err && typeof (err as Record<string, unknown>).status === 'number') {
+          exitCode = (err as Record<string, unknown>).status as number;
+        } else {
+          exitCode = timedOut ? 124 : 1;
+        }
+      }
+
+      const stdoutResult = truncateOutput(stdout ?? '', maxOutputBytes);
+      const stderrResult = truncateOutput(stderr ?? '', maxOutputBytes);
+
+      resolve({
+        stdout: stdoutResult.text,
+        stderr: stderrResult.text,
+        exitCode,
+        truncated: stdoutResult.truncated || stderrResult.truncated,
+        timedOut,
+        durationMs,
+      });
+    };
+
+    if (useShell) {
+      // Shell mode: pass command as-is via shell option on execFile.
+      // This enables pipes, redirects, and shell builtins.
+      // Operators must explicitly opt in via config.
+      execFile('/bin/sh', ['-c', command], { cwd, timeout, maxBuffer: maxOutputBytes * 2 }, callback);
+    } else {
+      // Safe mode: split command and use execFile (no shell expansion)
+      const parts = parseCommand(command);
+      execFile(parts[0], parts.slice(1), { cwd, timeout, maxBuffer: maxOutputBytes * 2 }, callback);
+    }
+  });
+}
+
+/** Split a command string into [executable, ...args] for execFile. */
+function parseCommand(command: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let escaped = false;
+
+  for (const ch of command) {
+    if (escaped) {
+      current += ch;
+      escaped = false;
+      continue;
+    }
+
+    if (ch === '\\' && !inSingleQuote) {
+      escaped = true;
+      continue;
+    }
+
+    if (ch === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (ch === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (ch === ' ' && !inSingleQuote && !inDoubleQuote) {
+      if (current.length > 0) {
+        parts.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (current.length > 0) {
+    parts.push(current);
+  }
+
+  return parts;
+}

--- a/runtime/src/tools/system/index.ts
+++ b/runtime/src/tools/system/index.ts
@@ -1,0 +1,10 @@
+export type {
+  BashToolConfig,
+  BashExecutionResult,
+} from './bash.js';
+
+export {
+  createBashTool,
+  isCommandAllowed,
+  DEFAULT_DENY_LIST,
+} from './bash.js';


### PR DESCRIPTION
## Summary
- Adds `system.bash` tool implementing the `Tool` interface with configurable allow/deny lists, timeouts, and output truncation
- Uses `child_process.execFile` by default (no shell injection); operators opt into shell mode via `useShell: true`
- Exports `createBashTool`, `isCommandAllowed`, `DEFAULT_DENY_LIST` from `tools/system/` barrel

## Test plan
- [x] 19 unit tests passing (`npx vitest run src/tools/system/bash.test.ts`)
- [x] Simple command execution (`echo hello`)
- [x] Non-zero exit returns `isError: true`
- [x] Denied commands rejected before execution
- [x] Allow/deny list precedence verified
- [x] Output truncation at `maxOutputBytes`
- [x] Timeout enforcement on long-running commands
- [x] `cwd` override per-call
- [x] Shell mode vs safe mode behavior

Closes #1067

🤖 Generated with [Claude Code](https://claude.com/claude-code)