### PR TITLE
feat(runtime): unified message format + shared validation (#1051)

### DIFF
--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -30,6 +30,7 @@ export {
   getDefaultConfigPath,
   loadGatewayConfig,
   validateGatewayConfig,
+  isValidGatewayConfig,
   diffGatewayConfig,
   ConfigWatcher,
   type ConfigReloadCallback,
@@ -37,3 +38,19 @@ export {
 } from './config-watcher.js';
 
 export { Gateway, type GatewayOptions } from './gateway.js';
+
+export type {
+  GatewayMessage,
+  OutboundMessage,
+  MessageAttachment,
+  MessageScope,
+  CreateGatewayMessageParams,
+} from './message.js';
+
+export {
+  createGatewayMessage,
+  createOutboundMessage,
+  validateGatewayMessage,
+  validateOutboundMessage,
+  validateAttachment,
+} from './message.js';

--- a/runtime/src/gateway/message.test.ts
+++ b/runtime/src/gateway/message.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createGatewayMessage,
+  createOutboundMessage,
+  validateGatewayMessage,
+  validateOutboundMessage,
+  validateAttachment,
+  type CreateGatewayMessageParams,
+  type GatewayMessage,
+  type MessageAttachment,
+} from './message.js';
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeParams(overrides?: Partial<CreateGatewayMessageParams>): CreateGatewayMessageParams {
+  return {
+    channel: 'telegram',
+    senderId: 'user-123',
+    senderName: 'Alice',
+    sessionId: 'session-abc',
+    content: 'Hello world',
+    scope: 'dm',
+    ...overrides,
+  };
+}
+
+function makeMessage(overrides?: Partial<GatewayMessage>): GatewayMessage {
+  return {
+    id: 'test-id',
+    channel: 'telegram',
+    senderId: 'user-123',
+    senderName: 'Alice',
+    sessionId: 'session-abc',
+    content: 'Hello world',
+    timestamp: Date.now(),
+    scope: 'dm',
+    ...overrides,
+  };
+}
+
+function makeAttachment(overrides?: Partial<MessageAttachment>): MessageAttachment {
+  return {
+    type: 'image',
+    mimeType: 'image/png',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// createGatewayMessage
+// ============================================================================
+
+describe('createGatewayMessage', () => {
+  it('generates unique UUID per call', () => {
+    const a = createGatewayMessage(makeParams());
+    const b = createGatewayMessage(makeParams());
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it('sets timestamp to current time', () => {
+    const before = Date.now();
+    const msg = createGatewayMessage(makeParams());
+    const after = Date.now();
+    expect(msg.timestamp).toBeGreaterThanOrEqual(before);
+    expect(msg.timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it('preserves all provided fields', () => {
+    const params = makeParams({
+      identityId: 'id-xyz',
+      attachments: [makeAttachment()],
+      metadata: { key: 'value' },
+      scope: 'group',
+    });
+    const msg = createGatewayMessage(params);
+    expect(msg.channel).toBe('telegram');
+    expect(msg.senderId).toBe('user-123');
+    expect(msg.senderName).toBe('Alice');
+    expect(msg.sessionId).toBe('session-abc');
+    expect(msg.content).toBe('Hello world');
+    expect(msg.identityId).toBe('id-xyz');
+    expect(msg.attachments).toHaveLength(1);
+    expect(msg.metadata).toEqual({ key: 'value' });
+    expect(msg.scope).toBe('group');
+  });
+});
+
+// ============================================================================
+// validateGatewayMessage
+// ============================================================================
+
+describe('validateGatewayMessage', () => {
+  it('returns valid for a well-formed message', () => {
+    const result = validateGatewayMessage(makeMessage());
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns false for missing channel', () => {
+    const msg = makeMessage();
+    const { channel: _, ...rest } = msg;
+    const result = validateGatewayMessage(rest);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('channel must be a non-empty string');
+  });
+
+  it('returns false for missing senderId', () => {
+    const msg = makeMessage();
+    const { senderId: _, ...rest } = msg;
+    const result = validateGatewayMessage(rest);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('senderId must be a non-empty string');
+  });
+
+  it('returns false for missing content', () => {
+    const msg = makeMessage();
+    const { content: _, ...rest } = msg;
+    const result = validateGatewayMessage(rest);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('content must be a string');
+  });
+
+  it('returns false for invalid scope', () => {
+    const result = validateGatewayMessage(makeMessage({ scope: 'invalid' as never }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('scope must be one of'))).toBe(true);
+  });
+
+  it('accepts empty string content (voice-only messages)', () => {
+    const result = validateGatewayMessage(makeMessage({ content: '' }));
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts empty attachments array', () => {
+    const result = validateGatewayMessage(makeMessage({ attachments: [] }));
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// validateAttachment
+// ============================================================================
+
+describe('validateAttachment', () => {
+  it('rejects exceeding maxSizeBytes', () => {
+    const att = makeAttachment({ sizeBytes: 2_000_000 });
+    const result = validateAttachment(att, 1_000_000);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('exceeds maximum'))).toBe(true);
+  });
+
+  it('accepts within size limit', () => {
+    const att = makeAttachment({ sizeBytes: 500_000 });
+    const result = validateAttachment(att, 1_000_000);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects empty MIME type', () => {
+    const result = validateAttachment({ type: 'image', mimeType: '' });
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes('mimeType'))).toBe(true);
+  });
+
+  it('accepts attachment with both url and data', () => {
+    const att = makeAttachment({
+      url: 'https://example.com/img.png',
+      data: new Uint8Array([1, 2, 3]),
+    });
+    const result = validateAttachment(att);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ============================================================================
+// createOutboundMessage
+// ============================================================================
+
+describe('createOutboundMessage', () => {
+  it('creates valid outbound message', () => {
+    const msg = createOutboundMessage({
+      sessionId: 'session-abc',
+      content: 'Response text',
+      isPartial: false,
+      tts: true,
+    });
+    expect(msg.sessionId).toBe('session-abc');
+    expect(msg.content).toBe('Response text');
+    expect(msg.isPartial).toBe(false);
+    expect(msg.tts).toBe(true);
+  });
+
+  it('throws on missing sessionId', () => {
+    expect(() => createOutboundMessage({ sessionId: '', content: 'hi' })).toThrow(TypeError);
+  });
+
+  it('throws on missing content', () => {
+    expect(() =>
+      createOutboundMessage({ sessionId: 'ses', content: undefined } as never),
+    ).toThrow(TypeError);
+  });
+});
+
+// ============================================================================
+// validateOutboundMessage
+// ============================================================================
+
+describe('validateOutboundMessage', () => {
+  it('returns valid for well-formed outbound message', () => {
+    const result = validateOutboundMessage({ sessionId: 'ses', content: 'hi' });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects non-object input', () => {
+    const result = validateOutboundMessage(null);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects empty sessionId', () => {
+    const result = validateOutboundMessage({ sessionId: '', content: 'hi' });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain('sessionId must be a non-empty string');
+  });
+});
+
+// ============================================================================
+// Type-level readonly doc test
+// ============================================================================
+
+describe('GatewayMessage readonly properties', () => {
+  it('readonly fields are enforced at type level', () => {
+    const msg = makeMessage();
+    // Runtime shallow copy works — readonly is compile-time only
+    const copy = { ...msg, content: 'modified' };
+    expect(copy.content).toBe('modified');
+    expect(msg.content).toBe('Hello world');
+  });
+});

--- a/runtime/src/gateway/message.ts
+++ b/runtime/src/gateway/message.ts
@@ -1,0 +1,225 @@
+/**
+ * Unified message format for the AgenC Gateway.
+ *
+ * Defines canonical inbound (`GatewayMessage`) and outbound (`OutboundMessage`)
+ * types that all channel plugins normalize to/from. This is the foundational
+ * type layer for Phase 1.2 — no dependencies on other gateway modules.
+ *
+ * @module
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  type ValidationResult,
+  validationResult,
+  requireNonEmptyString,
+  requireFiniteNumber,
+  requireOneOf,
+} from '../utils/validation.js';
+import { isRecord } from '../utils/type-guards.js';
+
+// ============================================================================
+// Scope
+// ============================================================================
+
+/** Conversation scope for a gateway message. */
+export type MessageScope = 'dm' | 'group' | 'thread';
+
+const VALID_SCOPES: ReadonlySet<string> = new Set<string>(['dm', 'group', 'thread']);
+
+// ============================================================================
+// Attachments
+// ============================================================================
+
+/** A media attachment on a gateway message. */
+export interface MessageAttachment {
+  /** Attachment kind (e.g. 'image', 'audio', 'video', 'file'). */
+  readonly type: string;
+  /** Remote URL if the attachment is hosted externally. */
+  readonly url?: string;
+  /** Raw binary data for inline attachments. */
+  readonly data?: Uint8Array;
+  /** MIME type (e.g. 'image/png', 'audio/ogg'). */
+  readonly mimeType: string;
+  /** Original filename, if available. */
+  readonly filename?: string;
+  /** File size in bytes. */
+  readonly sizeBytes?: number;
+  /** Duration in seconds for audio/video attachments. */
+  readonly durationSeconds?: number;
+}
+
+// ============================================================================
+// GatewayMessage (inbound)
+// ============================================================================
+
+/** Canonical inbound message from any channel plugin. */
+export interface GatewayMessage {
+  /** Unique message identifier (UUID v4). */
+  readonly id: string;
+  /** Channel name that produced this message (e.g. 'telegram', 'discord'). */
+  readonly channel: string;
+  /** Platform-specific sender identifier. */
+  readonly senderId: string;
+  /** Human-readable sender display name. */
+  readonly senderName: string;
+  /** Resolved cross-channel identity, if available. */
+  readonly identityId?: string;
+  /** Session identifier for conversation continuity. */
+  readonly sessionId: string;
+  /** Message text content. Empty string is valid (e.g. voice-only messages). */
+  readonly content: string;
+  /** Media attachments. */
+  readonly attachments?: readonly MessageAttachment[];
+  /** Unix epoch milliseconds when the message was received. */
+  readonly timestamp: number;
+  /** Arbitrary channel-specific metadata. */
+  readonly metadata?: Readonly<Record<string, unknown>>;
+  /** Conversation scope. */
+  readonly scope: MessageScope;
+}
+
+// ============================================================================
+// OutboundMessage
+// ============================================================================
+
+/** Response message to send back through a channel plugin. */
+export interface OutboundMessage {
+  /** Target session identifier. */
+  readonly sessionId: string;
+  /** Response text content. */
+  readonly content: string;
+  /** Media attachments to include in the response. */
+  readonly attachments?: readonly MessageAttachment[];
+  /** Whether this is a partial/streaming chunk. */
+  readonly isPartial?: boolean;
+  /** Whether the message should be spoken via text-to-speech. */
+  readonly tts?: boolean;
+}
+
+// ============================================================================
+// Factory params
+// ============================================================================
+
+/** Parameters for creating a GatewayMessage (id and timestamp are generated). */
+export type CreateGatewayMessageParams = Omit<GatewayMessage, 'id' | 'timestamp'>;
+
+// ============================================================================
+// Factory functions
+// ============================================================================
+
+/**
+ * Create a new GatewayMessage with an auto-generated UUID and timestamp.
+ */
+export function createGatewayMessage(params: CreateGatewayMessageParams): GatewayMessage {
+  return {
+    ...params,
+    id: randomUUID(),
+    timestamp: Date.now(),
+  };
+}
+
+/**
+ * Create a new OutboundMessage, validating required fields.
+ */
+export function createOutboundMessage(params: OutboundMessage): OutboundMessage {
+  const result = validateOutboundMessage(params);
+  if (!result.valid) {
+    throw new TypeError(`Invalid OutboundMessage: ${result.errors.join('; ')}`);
+  }
+  return { ...params };
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/**
+ * Validate a GatewayMessage-shaped object, accumulating all errors.
+ */
+export function validateGatewayMessage(msg: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(msg)) {
+    return { valid: false, errors: ['Message must be a non-null object'] };
+  }
+
+  requireNonEmptyString(msg.id, 'id', errors);
+  requireNonEmptyString(msg.channel, 'channel', errors);
+  requireNonEmptyString(msg.senderId, 'senderId', errors);
+  requireNonEmptyString(msg.senderName, 'senderName', errors);
+  requireNonEmptyString(msg.sessionId, 'sessionId', errors);
+
+  if (typeof msg.content !== 'string') {
+    errors.push('content must be a string');
+  }
+
+  requireFiniteNumber(msg.timestamp, 'timestamp', errors);
+  requireOneOf(msg.scope, 'scope', VALID_SCOPES, errors);
+
+  if (msg.attachments !== undefined) {
+    if (!Array.isArray(msg.attachments)) {
+      errors.push('attachments must be an array');
+    } else {
+      for (let i = 0; i < msg.attachments.length; i++) {
+        const result = validateAttachment(msg.attachments[i] as unknown);
+        if (!result.valid) {
+          for (const err of result.errors) {
+            errors.push(`attachments[${i}]: ${err}`);
+          }
+        }
+      }
+    }
+  }
+
+  return validationResult(errors);
+}
+
+/**
+ * Validate an OutboundMessage-shaped object, accumulating all errors.
+ */
+export function validateOutboundMessage(msg: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(msg)) {
+    return { valid: false, errors: ['OutboundMessage must be a non-null object'] };
+  }
+
+  requireNonEmptyString(msg.sessionId, 'sessionId', errors);
+
+  if (typeof msg.content !== 'string') {
+    errors.push('content must be a string');
+  }
+
+  return validationResult(errors);
+}
+
+/**
+ * Validate a single attachment object.
+ *
+ * Exported separately for reuse by media pipeline (#1059).
+ * Returns accumulated errors (consistent with other gateway validators).
+ */
+export function validateAttachment(
+  att: unknown,
+  maxSizeBytes?: number,
+): ValidationResult {
+  const errors: string[] = [];
+
+  if (!isRecord(att)) {
+    return { valid: false, errors: ['Attachment must be a non-null object'] };
+  }
+
+  requireNonEmptyString(att.type, 'type', errors);
+  requireNonEmptyString(att.mimeType, 'mimeType', errors);
+
+  if (att.sizeBytes !== undefined) {
+    if (typeof att.sizeBytes !== 'number' || att.sizeBytes < 0) {
+      errors.push('sizeBytes must be a non-negative number');
+    } else if (maxSizeBytes !== undefined && att.sizeBytes > maxSizeBytes) {
+      errors.push(`sizeBytes (${att.sizeBytes}) exceeds maximum (${maxSizeBytes})`);
+    }
+  }
+
+  return validationResult(errors);
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -263,6 +263,16 @@ export {
   toAnchorBytes,
 } from './utils/index.js';
 
+// Validation utilities
+export {
+  type ValidationResult,
+  validationResult,
+  requireNonEmptyString,
+  requireFiniteNumber,
+  requireOneOf,
+  requireIntRange,
+} from './utils/index.js';
+
 // SPL Token utilities
 export {
   isTokenTask,
@@ -1134,6 +1144,7 @@ export {
   getDefaultConfigPath,
   loadGatewayConfig,
   validateGatewayConfig,
+  isValidGatewayConfig,
   diffGatewayConfig,
   GatewayValidationError,
   GatewayConnectionError,
@@ -1160,6 +1171,17 @@ export {
   type ConfigDiff,
   type ConfigReloadCallback,
   type ConfigErrorCallback,
+  // Message types (Phase 1.2)
+  createGatewayMessage,
+  createOutboundMessage,
+  validateGatewayMessage,
+  validateOutboundMessage,
+  validateAttachment,
+  type GatewayMessage,
+  type OutboundMessage,
+  type MessageAttachment,
+  type MessageScope,
+  type CreateGatewayMessageParams,
 } from './gateway/index.js';
 
 // Agent Builder (Phase 10)

--- a/runtime/src/utils/index.ts
+++ b/runtime/src/utils/index.ts
@@ -31,6 +31,16 @@ export { ensureLazyModule } from './lazy-import.js';
 
 export { isRecord, isStringArray } from './type-guards.js';
 
+export type { ValidationResult } from './validation.js';
+
+export {
+  validationResult,
+  requireNonEmptyString,
+  requireFiniteNumber,
+  requireOneOf,
+  requireIntRange,
+} from './validation.js';
+
 export {
   isTokenTask,
   buildCompleteTaskTokenAccounts,

--- a/runtime/src/utils/validation.test.ts
+++ b/runtime/src/utils/validation.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validationResult,
+  requireNonEmptyString,
+  requireFiniteNumber,
+  requireOneOf,
+  requireIntRange,
+} from './validation.js';
+
+describe('validationResult', () => {
+  it('returns valid when no errors', () => {
+    const result = validationResult([]);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('returns invalid when errors present', () => {
+    const result = validationResult(['bad field']);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(['bad field']);
+  });
+});
+
+describe('requireNonEmptyString', () => {
+  it('accepts a non-empty string', () => {
+    const errors: string[] = [];
+    requireNonEmptyString('hello', 'name', errors);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects empty string', () => {
+    const errors: string[] = [];
+    requireNonEmptyString('', 'name', errors);
+    expect(errors).toContain('name must be a non-empty string');
+  });
+
+  it('rejects non-string', () => {
+    const errors: string[] = [];
+    requireNonEmptyString(42, 'name', errors);
+    expect(errors).toContain('name must be a non-empty string');
+  });
+
+  it('rejects undefined', () => {
+    const errors: string[] = [];
+    requireNonEmptyString(undefined, 'name', errors);
+    expect(errors).toContain('name must be a non-empty string');
+  });
+});
+
+describe('requireFiniteNumber', () => {
+  it('accepts a finite number', () => {
+    const errors: string[] = [];
+    requireFiniteNumber(42, 'age', errors);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects NaN', () => {
+    const errors: string[] = [];
+    requireFiniteNumber(NaN, 'age', errors);
+    expect(errors).toContain('age must be a finite number');
+  });
+
+  it('rejects Infinity', () => {
+    const errors: string[] = [];
+    requireFiniteNumber(Infinity, 'age', errors);
+    expect(errors).toContain('age must be a finite number');
+  });
+
+  it('rejects non-number', () => {
+    const errors: string[] = [];
+    requireFiniteNumber('42', 'age', errors);
+    expect(errors).toContain('age must be a finite number');
+  });
+});
+
+describe('requireOneOf', () => {
+  const allowed = new Set(['a', 'b', 'c']);
+
+  it('accepts allowed value', () => {
+    const errors: string[] = [];
+    requireOneOf('b', 'field', allowed, errors);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects disallowed value', () => {
+    const errors: string[] = [];
+    requireOneOf('x', 'field', allowed, errors);
+    expect(errors[0]).toContain('field must be one of');
+  });
+
+  it('rejects non-string', () => {
+    const errors: string[] = [];
+    requireOneOf(1, 'field', allowed, errors);
+    expect(errors).toHaveLength(1);
+  });
+});
+
+describe('requireIntRange', () => {
+  it('accepts integer in range', () => {
+    const errors: string[] = [];
+    requireIntRange(8080, 'port', 1, 65535, errors);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects below min', () => {
+    const errors: string[] = [];
+    requireIntRange(0, 'port', 1, 65535, errors);
+    expect(errors[0]).toContain('port must be an integer between 1 and 65535');
+  });
+
+  it('rejects above max', () => {
+    const errors: string[] = [];
+    requireIntRange(70000, 'port', 1, 65535, errors);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects float', () => {
+    const errors: string[] = [];
+    requireIntRange(3.14, 'port', 1, 65535, errors);
+    expect(errors).toHaveLength(1);
+  });
+
+  it('rejects non-number', () => {
+    const errors: string[] = [];
+    requireIntRange('8080', 'port', 1, 65535, errors);
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/runtime/src/utils/validation.ts
+++ b/runtime/src/utils/validation.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared validation helpers for accumulate-errors validators.
+ *
+ * Used by gateway config and message validators. Each check function pushes
+ * errors onto a shared array so callers can report all problems at once.
+ *
+ * @module
+ */
+
+// ============================================================================
+// Result type
+// ============================================================================
+
+/** Outcome of an accumulate-errors validation pass. */
+export interface ValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+/** Build a {@link ValidationResult} from an error list. */
+export function validationResult(errors: string[]): ValidationResult {
+  return { valid: errors.length === 0, errors };
+}
+
+// ============================================================================
+// Field checks
+// ============================================================================
+
+/** Push an error if `value` is not a non-empty string. */
+export function requireNonEmptyString(
+  value: unknown,
+  field: string,
+  errors: string[],
+): void {
+  if (typeof value !== 'string' || value.length === 0) {
+    errors.push(`${field} must be a non-empty string`);
+  }
+}
+
+/** Push an error if `value` is not a finite number. */
+export function requireFiniteNumber(
+  value: unknown,
+  field: string,
+  errors: string[],
+): void {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    errors.push(`${field} must be a finite number`);
+  }
+}
+
+/** Push an error if `value` is not one of the allowed strings. */
+export function requireOneOf(
+  value: unknown,
+  field: string,
+  allowed: ReadonlySet<string>,
+  errors: string[],
+): void {
+  if (typeof value !== 'string' || !allowed.has(value)) {
+    errors.push(`${field} must be one of: ${[...allowed].join(', ')}`);
+  }
+}
+
+/** Push an error if `value` is not an integer in [min, max]. */
+export function requireIntRange(
+  value: unknown,
+  field: string,
+  min: number,
+  max: number,
+  errors: string[],
+): void {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < min || value > max) {
+    errors.push(`${field} must be an integer between ${min} and ${max}`);
+  }
+}


### PR DESCRIPTION
## Summary

- Add `GatewayMessage` / `OutboundMessage` types and factory functions for canonical inbound/outbound message normalization across channel plugins (Phase 1.2)
- Extract shared validation helpers (`requireNonEmptyString`, `requireOneOf`, `requireIntRange`, `requireFiniteNumber`, `validationResult`) into `utils/validation.ts`
- Refactor `config-watcher.ts` to use shared helpers, eliminating duplicated accumulate-errors boilerplate
- Add `isValidGatewayConfig` type predicate to replace unsafe `as GatewayConfig` cast
- Align `validateAttachment` to return consistent `ValidationResult` shape (was `{ reason?: string }`)
- Add `validateOutboundMessage` + validation in `createOutboundMessage` factory

## Test plan

- [x] 18 new tests for `utils/validation.ts` (all shared helpers)
- [x] 21 tests for `gateway/message.ts` (factories, validators, attachments, outbound)
- [x] 20 existing `gateway.test.ts` tests still pass (config validation refactor)
- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds

Closes #1051