### PR TITLE
feat(runtime): channel plugin interface and PluginCatalog (#1054)

### DIFF
--- a/runtime/src/gateway/channel.ts
+++ b/runtime/src/gateway/channel.ts
@@ -248,6 +248,9 @@ export class PluginCatalog {
    * Register a channel plugin. Throws if a plugin with the same name exists.
    */
   register(plugin: ChannelPlugin): void {
+    if (!plugin.name || !plugin.name.trim()) {
+      throw new ChannelNameInvalidError(plugin.name);
+    }
     if (this.plugins.has(plugin.name)) {
       throw new ChannelAlreadyRegisteredError(plugin.name);
     }
@@ -408,6 +411,19 @@ export class PluginCatalog {
 // ============================================================================
 // Errors
 // ============================================================================
+
+export class ChannelNameInvalidError extends RuntimeError {
+  public readonly channelName: string;
+
+  constructor(channelName: string) {
+    super(
+      `Channel name must be a non-empty string, got "${channelName}"`,
+      RuntimeErrorCodes.GATEWAY_VALIDATION_ERROR,
+    );
+    this.name = 'ChannelNameInvalidError';
+    this.channelName = channelName;
+  }
+}
 
 export class ChannelAlreadyRegisteredError extends RuntimeError {
   public readonly channelName: string;

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -163,6 +163,7 @@ export {
   PluginCatalog,
   WebhookRouter,
   BaseChannelPlugin,
+  ChannelNameInvalidError,
   ChannelAlreadyRegisteredError,
   ChannelNotFoundError,
   type ChannelPlugin,

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1303,6 +1303,7 @@ export {
   PluginCatalog,
   WebhookRouter,
   BaseChannelPlugin,
+  ChannelNameInvalidError,
   ChannelAlreadyRegisteredError,
   ChannelNotFoundError,
   type ChannelPlugin,


### PR DESCRIPTION
## Summary
- Add `ChannelPlugin` interface — the contract for messaging platform adapters (Telegram, Discord, Slack, etc.) with lifecycle methods (`initialize`, `start`, `stop`), outbound messaging (`send`), optional webhook registration, and health checks
- Add `ChannelContext` — context object passed to plugins during initialization with `onMessage` callback, scoped logger, and channel config
- Add `WebhookRouter` — simple route registration for channel-specific HTTP endpoints (auto-prefixed with `/webhooks/{channelName}`)
- Add `PluginCatalog` — registry for managing channel plugins following the `ToolRegistry` pattern, with `activate`/`deactivate` lifecycle, webhook aggregation, and health status reporting
- Add `ChannelAlreadyRegisteredError` and `ChannelNotFoundError`
- Add `ReactionEvent` type for emoji reaction handling

### Files changed
- `runtime/src/gateway/channel.ts` — All types, interfaces, WebhookRouter, PluginCatalog (new)
- `runtime/src/gateway/channel.test.ts` — 23 tests (new)
- `runtime/src/gateway/index.ts` — Barrel exports

Closes #1054

## Test plan
- [x] WebhookRouter path prefixing and multi-route support
- [x] WebhookRouter handler invocation
- [x] PluginCatalog registration and duplicate detection
- [x] PluginCatalog get/getOrThrow lookup
- [x] PluginCatalog listNames/listAll
- [x] Activate: initialize → registerWebhooks → start lifecycle
- [x] Activate: context.onMessage forwarding
- [x] Activate: error on unregistered plugin
- [x] Deactivate: stop and cleanup
- [x] Deactivate: graceful error handling on stop() failure
- [x] Unregister: deactivate + remove
- [x] Webhook route aggregation (per-channel and all)
- [x] Health status reporting
- [x] StopAll batch deactivation
- [x] All 64 gateway tests passing (23 new + 41 existing), 0 regressions