### PR TITLE
feat(runtime): workspace files loader, prompt assembly, and scaffolding (#1066)

### DIFF
--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -56,7 +56,7 @@ export {
 } from './message.js';
 
 // Workspace files (Phase 3.5)
-export type { WorkspaceFiles, WorkspaceValidation, WorkspaceFileName } from './workspace-files.js';
+export type { WorkspaceFiles, WorkspaceValidation, WorkspaceFileName, AssembleSystemPromptOptions } from './workspace-files.js';
 export {
   WORKSPACE_FILES,
   WorkspaceLoader,

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1192,6 +1192,7 @@ export {
   type WorkspaceFiles,
   type WorkspaceValidation,
   type WorkspaceFileName,
+  type AssembleSystemPromptOptions,
 } from './gateway/index.js';
 
 // Agent Builder (Phase 10)


### PR DESCRIPTION
## Summary

- Add `WorkspaceLoader` class that reads 11 markdown config files (AGENT.md, SOUL.md, USER.md, TOOLS.md, HEARTBEAT.md, BOOT.md, IDENTITY.md, MEMORY.md, CAPABILITIES.md, POLICY.md, REPUTATION.md) from `~/.agenc/workspace/`
- Add `assembleSystemPrompt()` with deterministic ordering (AGENT → SOUL → IDENTITY → CAPABILITIES → POLICY → REPUTATION → USER → TOOLS → MEMORY) and `maxLength` truncation
- Add `scaffoldWorkspace()` for first-run template generation (skips existing files)
- Add workspace validation with warnings for missing AGENT.md
- Export all types and functions from gateway and top-level barrels

## Test plan

- [x] 15 vitest tests covering loader, validation, prompt assembly, templates, scaffolding
- [x] `npm run typecheck` clean
- [x] `npm run build` succeeds with exports in dist

Closes #1066