### PR TITLE
feat(runtime): skill discovery and validation

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -442,6 +442,12 @@ export {
   parseSkillContent,
   parseSkillFile,
   validateSkillMetadata,
+  // Skill discovery (Phase 3.2)
+  type DiscoveryPaths,
+  type DiscoveryTier,
+  type DiscoveredSkill,
+  type MissingRequirement,
+  SkillDiscovery,
 } from './skills/index.js';
 
 // LLM Adapters (Phase 4)

--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -90,4 +90,10 @@ export {
   parseSkillContent,
   parseSkillFile,
   validateSkillMetadata,
+  // Skill discovery (Phase 3.2)
+  type DiscoveryPaths,
+  type DiscoveryTier,
+  type DiscoveredSkill,
+  type MissingRequirement,
+  SkillDiscovery,
 } from './markdown/index.js';

--- a/runtime/src/skills/markdown/discovery.test.ts
+++ b/runtime/src/skills/markdown/discovery.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it } from 'vitest';
+import { writeFile, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SkillDiscovery } from './discovery.js';
+import type { DiscoveryPaths } from './discovery.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildSkillMd(
+  name: string,
+  overrides?: {
+    binaries?: string[];
+    env?: string[];
+    os?: string[];
+    channels?: string[];
+  },
+): string {
+  const binaries = overrides?.binaries ?? [];
+  const env = overrides?.env ?? [];
+  const os = overrides?.os ?? [];
+  const channels = overrides?.channels ?? [];
+
+  const requiresBlock = [
+    '    requires:',
+    binaries.length > 0
+      ? `      binaries:\n${binaries.map((b) => `        - ${b}`).join('\n')}`
+      : null,
+    env.length > 0
+      ? `      env:\n${env.map((e) => `        - ${e}`).join('\n')}`
+      : null,
+    os.length > 0
+      ? `      os:\n${os.map((o) => `        - ${o}`).join('\n')}`
+      : null,
+    channels.length > 0
+      ? `      channels:\n${channels.map((c) => `        - ${c}`).join('\n')}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return `---
+name: ${name}
+description: Test skill ${name}
+version: 1.0.0
+metadata:
+  agenc:
+${requiresBlock}
+---
+Body for ${name}.
+`;
+}
+
+async function writeSkillMd(
+  dir: string,
+  name: string,
+  overrides?: Parameters<typeof buildSkillMd>[1],
+): Promise<string> {
+  const filePath = join(dir, `${name}.md`);
+  await writeFile(filePath, buildSkillMd(name, overrides), 'utf-8');
+  return filePath;
+}
+
+async function makeTmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'agenc-disc-'));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SkillDiscovery', () => {
+  // ------ discoverAll ------
+
+  describe('discoverAll', () => {
+    it('finds skills across all tiers', async () => {
+      const agentDir = await makeTmpDir();
+      const userDir = await makeTmpDir();
+      const projectDir = await makeTmpDir();
+      const builtinDir = await makeTmpDir();
+
+      try {
+        await writeSkillMd(agentDir, 'agent-skill');
+        await writeSkillMd(userDir, 'user-skill');
+        await writeSkillMd(projectDir, 'project-skill');
+        await writeSkillMd(builtinDir, 'builtin-skill');
+
+        const discovery = new SkillDiscovery({
+          agentSkills: agentDir,
+          userSkills: userDir,
+          projectSkills: projectDir,
+          builtinSkills: builtinDir,
+        });
+
+        const results = await discovery.discoverAll();
+        const names = results.map((r) => r.skill.name);
+
+        expect(names).toContain('agent-skill');
+        expect(names).toContain('user-skill');
+        expect(names).toContain('project-skill');
+        expect(names).toContain('builtin-skill');
+        expect(results).toHaveLength(4);
+      } finally {
+        await Promise.all([
+          rm(agentDir, { recursive: true }),
+          rm(userDir, { recursive: true }),
+          rm(projectDir, { recursive: true }),
+          rm(builtinDir, { recursive: true }),
+        ]);
+      }
+    });
+
+    it('higher-tier skill shadows lower-tier with same name', async () => {
+      const agentDir = await makeTmpDir();
+      const builtinDir = await makeTmpDir();
+
+      try {
+        await writeSkillMd(agentDir, 'shared-name');
+        await writeSkillMd(builtinDir, 'shared-name');
+
+        const discovery = new SkillDiscovery({
+          agentSkills: agentDir,
+          builtinSkills: builtinDir,
+        });
+
+        const results = await discovery.discoverAll();
+        const matching = results.filter((r) => r.skill.name === 'shared-name');
+
+        expect(matching).toHaveLength(1);
+        expect(matching[0].tier).toBe('agent');
+      } finally {
+        await Promise.all([
+          rm(agentDir, { recursive: true }),
+          rm(builtinDir, { recursive: true }),
+        ]);
+      }
+    });
+  });
+
+  // ------ validateRequirements ------
+
+  describe('validateRequirements', () => {
+    it('passes when all requirements met', async () => {
+      const dir = await makeTmpDir();
+
+      try {
+        await writeSkillMd(dir, 'all-met', {
+          binaries: ['node'],
+          env: ['PATH'],
+        });
+
+        const discovery = new SkillDiscovery({ projectSkills: dir });
+        const results = await discovery.discoverInDirectory(dir, 'project');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].available).toBe(true);
+        expect(results[0].missingRequirements).toBeUndefined();
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+
+    it('reports missing binary', async () => {
+      const dir = await makeTmpDir();
+
+      try {
+        await writeSkillMd(dir, 'missing-bin', {
+          binaries: ['nonexistent_binary_xyz_12345'],
+        });
+
+        const discovery = new SkillDiscovery({ projectSkills: dir });
+        const results = await discovery.discoverInDirectory(dir, 'project');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].available).toBe(false);
+        expect(results[0].missingRequirements).toBeDefined();
+        expect(results[0].missingRequirements!.some(
+          (m) => m.type === 'binary' && m.name === 'nonexistent_binary_xyz_12345',
+        )).toBe(true);
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+
+    it('reports missing env var', async () => {
+      const dir = await makeTmpDir();
+      const envVar = 'AGENC_TEST_MISSING_VAR_XYZ_98765';
+
+      try {
+        await writeSkillMd(dir, 'missing-env', { env: [envVar] });
+
+        const discovery = new SkillDiscovery({ projectSkills: dir });
+        const results = await discovery.discoverInDirectory(dir, 'project');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].available).toBe(false);
+        expect(results[0].missingRequirements!.some(
+          (m) => m.type === 'env' && m.name === envVar,
+        )).toBe(true);
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+
+    it('reports OS mismatch', async () => {
+      const dir = await makeTmpDir();
+      const fakeOs = process.platform === 'linux' ? 'windows' : 'linux';
+
+      try {
+        await writeSkillMd(dir, 'os-mismatch', { os: [fakeOs] });
+
+        const discovery = new SkillDiscovery({ projectSkills: dir });
+        const results = await discovery.discoverInDirectory(dir, 'project');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].available).toBe(false);
+        expect(results[0].missingRequirements!.some(
+          (m) => m.type === 'os',
+        )).toBe(true);
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+
+    it('skill with no requirements is always available', async () => {
+      const dir = await makeTmpDir();
+
+      try {
+        await writeSkillMd(dir, 'no-reqs');
+
+        const discovery = new SkillDiscovery({ projectSkills: dir });
+        const results = await discovery.discoverInDirectory(dir, 'project');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].available).toBe(true);
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+  });
+
+  // ------ checkBinary ------
+
+  describe('checkBinary', () => {
+    it('returns true for existing binary (node)', async () => {
+      const discovery = new SkillDiscovery({});
+      expect(await discovery.checkBinary('node')).toBe(true);
+    });
+
+    it('returns false for non-existent binary', async () => {
+      const discovery = new SkillDiscovery({});
+      expect(await discovery.checkBinary('nonexistent_binary_xyz_12345')).toBe(false);
+    });
+  });
+
+  // ------ checkEnv ------
+
+  describe('checkEnv', () => {
+    it('returns true for set variable', () => {
+      const discovery = new SkillDiscovery({});
+      expect(discovery.checkEnv('PATH')).toBe(true);
+    });
+
+    it('returns false for unset variable', () => {
+      const discovery = new SkillDiscovery({});
+      expect(discovery.checkEnv('AGENC_TEST_MISSING_VAR_XYZ_98765')).toBe(false);
+    });
+  });
+
+  // ------ checkOs ------
+
+  describe('checkOs', () => {
+    it('matches current platform', () => {
+      const discovery = new SkillDiscovery({});
+      expect(discovery.checkOs([process.platform])).toBe(true);
+    });
+
+    it('maps macos to darwin', () => {
+      const discovery = new SkillDiscovery({});
+      if (process.platform === 'darwin') {
+        expect(discovery.checkOs(['macos'])).toBe(true);
+      } else {
+        expect(discovery.checkOs(['macos'])).toBe(false);
+      }
+    });
+
+    it('empty list allows any OS', () => {
+      const discovery = new SkillDiscovery({});
+      expect(discovery.checkOs([])).toBe(true);
+    });
+  });
+
+  // ------ getAvailable ------
+
+  describe('getAvailable', () => {
+    it('filters out unavailable skills', async () => {
+      const dir = await makeTmpDir();
+
+      try {
+        await writeSkillMd(dir, 'available-skill');
+        await writeSkillMd(dir, 'unavailable-skill', {
+          binaries: ['nonexistent_binary_xyz_12345'],
+        });
+
+        const discovery = new SkillDiscovery({ projectSkills: dir });
+        const available = await discovery.getAvailable();
+
+        expect(available).toHaveLength(1);
+        expect(available[0].skill.name).toBe('available-skill');
+        expect(available[0].available).toBe(true);
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+  });
+
+  // ------ discoverInDirectory ------
+
+  describe('discoverInDirectory', () => {
+    it('empty directory returns empty array', async () => {
+      const dir = await makeTmpDir();
+
+      try {
+        const discovery = new SkillDiscovery({});
+        const results = await discovery.discoverInDirectory(dir, 'project');
+        expect(results).toEqual([]);
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+
+    it('missing directory returns empty array', async () => {
+      const discovery = new SkillDiscovery({});
+      const results = await discovery.discoverInDirectory(
+        '/tmp/nonexistent-dir-agenc-test-xyz-98765',
+        'project',
+      );
+      expect(results).toEqual([]);
+    });
+
+    it('non-SKILL.md files are skipped', async () => {
+      const dir = await makeTmpDir();
+
+      try {
+        // Write a .md file that is NOT a SKILL.md (no frontmatter)
+        await writeFile(join(dir, 'README.md'), '# Hello\n\nNot a skill.\n', 'utf-8');
+        // Write a valid skill for comparison
+        await writeSkillMd(dir, 'real-skill');
+
+        const discovery = new SkillDiscovery({});
+        const results = await discovery.discoverInDirectory(dir, 'project');
+
+        expect(results).toHaveLength(1);
+        expect(results[0].skill.name).toBe('real-skill');
+      } finally {
+        await rm(dir, { recursive: true });
+      }
+    });
+  });
+});

--- a/runtime/src/skills/markdown/discovery.ts
+++ b/runtime/src/skills/markdown/discovery.ts
@@ -1,0 +1,249 @@
+/**
+ * Skill discovery and requirement validation.
+ *
+ * Scans 4 directory tiers (agent, user, project, builtin) for SKILL.md files,
+ * validates their runtime requirements (binaries, env, OS, channels), and
+ * returns availability status. Higher-tier skills shadow lower-tier by name.
+ *
+ * @module
+ */
+
+import { readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { isSkillMarkdown, parseSkillContent } from './parser.js';
+import type { MarkdownSkill } from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+/** Paths for the 4 discovery tiers. All are optional — missing dirs are skipped. */
+export interface DiscoveryPaths {
+  /** Agent-specific skills directory (e.g. `~/.agenc/agents/<id>/skills/`). */
+  readonly agentSkills?: string;
+  /** User-level skills directory (e.g. `~/.agenc/skills/`). */
+  readonly userSkills?: string;
+  /** Project-level skills directory (e.g. `./skills/`). */
+  readonly projectSkills?: string;
+  /** Built-in skills bundled with runtime. */
+  readonly builtinSkills?: string;
+}
+
+/** Discovery tier determines shadowing precedence (agent > user > project > builtin). */
+export type DiscoveryTier = 'agent' | 'user' | 'project' | 'builtin';
+
+/** A skill found during discovery, annotated with availability status. */
+export interface DiscoveredSkill {
+  readonly skill: MarkdownSkill;
+  readonly available: boolean;
+  readonly unavailableReason?: string;
+  readonly tier: DiscoveryTier;
+  readonly missingRequirements?: MissingRequirement[];
+}
+
+/** A single unmet runtime requirement. */
+export interface MissingRequirement {
+  readonly type: 'binary' | 'env' | 'os' | 'channel';
+  readonly name: string;
+  readonly message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tier ordering (highest precedence first)
+// ---------------------------------------------------------------------------
+
+const TIER_ORDER: readonly DiscoveryTier[] = ['agent', 'user', 'project', 'builtin'];
+
+const TIER_PATH_KEY: Record<DiscoveryTier, keyof DiscoveryPaths> = {
+  agent: 'agentSkills',
+  user: 'userSkills',
+  project: 'projectSkills',
+  builtin: 'builtinSkills',
+};
+
+// ---------------------------------------------------------------------------
+// SkillDiscovery
+// ---------------------------------------------------------------------------
+
+export class SkillDiscovery {
+  private readonly paths: DiscoveryPaths;
+
+  constructor(paths: DiscoveryPaths) {
+    this.paths = paths;
+  }
+
+  /**
+   * Scan all tiers in precedence order. Higher-tier skills shadow lower-tier
+   * skills with the same name.
+   */
+  async discoverAll(): Promise<DiscoveredSkill[]> {
+    const seen = new Set<string>();
+    const results: DiscoveredSkill[] = [];
+
+    for (const tier of TIER_ORDER) {
+      const dirPath = this.paths[TIER_PATH_KEY[tier]];
+      if (!dirPath) continue;
+
+      const discovered = await this.discoverInDirectory(dirPath, tier);
+      for (const entry of discovered) {
+        if (seen.has(entry.skill.name)) continue;
+        seen.add(entry.skill.name);
+        results.push(entry);
+      }
+    }
+
+    return results;
+  }
+
+  /**
+   * Scan a single directory for SKILL.md files.
+   *
+   * Gracefully handles missing or unreadable directories (returns `[]`).
+   */
+  async discoverInDirectory(
+    dirPath: string,
+    tier: DiscoveryTier,
+  ): Promise<DiscoveredSkill[]> {
+    const entries = await readSafe(dirPath);
+    if (entries.length === 0) return [];
+
+    const mdFiles = entries.filter((name) => name.endsWith('.md'));
+    const results: DiscoveredSkill[] = [];
+
+    for (const fileName of mdFiles) {
+      const filePath = join(dirPath, fileName);
+      const content = await readFileSafe(filePath);
+      if (content === null) continue;
+      if (!isSkillMarkdown(content)) continue;
+
+      const skill = parseSkillContent(content, filePath);
+      const missing = await this.validateRequirements(skill);
+      const available = missing.length === 0;
+
+      results.push({
+        skill,
+        available,
+        tier,
+        ...(available
+          ? {}
+          : {
+              unavailableReason: missing
+                .map((m) => m.message)
+                .join('; '),
+              missingRequirements: missing,
+            }),
+      });
+    }
+
+    return results;
+  }
+
+  /**
+   * Validate a skill's runtime requirements.
+   * Returns an empty array when all requirements are met.
+   */
+  async validateRequirements(skill: MarkdownSkill): Promise<MissingRequirement[]> {
+    const missing: MissingRequirement[] = [];
+    const { requires } = skill.metadata;
+
+    // Binary checks (async)
+    for (const bin of requires.binaries) {
+      const found = await this.checkBinary(bin);
+      if (!found) {
+        missing.push({
+          type: 'binary',
+          name: bin,
+          message: `Required binary "${bin}" not found in PATH`,
+        });
+      }
+    }
+
+    // Environment variable checks
+    for (const envVar of requires.env) {
+      if (!this.checkEnv(envVar)) {
+        missing.push({
+          type: 'env',
+          name: envVar,
+          message: `Required environment variable "${envVar}" is not set`,
+        });
+      }
+    }
+
+    // OS checks
+    if (requires.os.length > 0 && !this.checkOs(requires.os)) {
+      missing.push({
+        type: 'os',
+        name: process.platform,
+        message: `Current OS "${process.platform}" not in allowed list: ${requires.os.join(', ')}`,
+      });
+    }
+
+    // Channel requirements — informational (deferred to future implementation)
+    for (const channel of requires.channels) {
+      missing.push({
+        type: 'channel',
+        name: channel,
+        message: `Channel "${channel}" availability cannot be verified yet`,
+      });
+    }
+
+    return missing;
+  }
+
+  /** Check if a binary is available via `which`. */
+  async checkBinary(name: string): Promise<boolean> {
+    try {
+      await execFileAsync('which', [name]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Check if an environment variable is set. */
+  checkEnv(name: string): boolean {
+    return process.env[name] !== undefined;
+  }
+
+  /** Check if the current OS is in the allowed list. Empty list means any OS. */
+  checkOs(allowed: readonly string[]): boolean {
+    if (allowed.length === 0) return true;
+    const platform = process.platform;
+    return allowed.some((os) => {
+      const normalized = os === 'macos' ? 'darwin' : os;
+      return normalized === platform;
+    });
+  }
+
+  /** Return only available (all requirements met) skills across all tiers. */
+  async getAvailable(): Promise<DiscoveredSkill[]> {
+    const all = await this.discoverAll();
+    return all.filter((s) => s.available);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Read directory entries, returning `[]` on any error. */
+async function readSafe(dirPath: string): Promise<string[]> {
+  try {
+    return await readdir(dirPath);
+  } catch {
+    return [];
+  }
+}
+
+/** Read file content, returning `null` on any error. */
+async function readFileSafe(filePath: string): Promise<string | null> {
+  try {
+    return await readFile(filePath, 'utf-8');
+  } catch {
+    return null;
+  }
+}

--- a/runtime/src/skills/markdown/index.ts
+++ b/runtime/src/skills/markdown/index.ts
@@ -18,3 +18,12 @@ export {
   parseSkillFile,
   validateSkillMetadata,
 } from './parser.js';
+
+export type {
+  DiscoveryPaths,
+  DiscoveryTier,
+  DiscoveredSkill,
+  MissingRequirement,
+} from './discovery.js';
+
+export { SkillDiscovery } from './discovery.js';


### PR DESCRIPTION
## Summary
- Add SkillDiscovery class with 4-tier directory scanning
- Validate runtime requirements: binaries (via which), env vars, OS, channels
- Higher-tier skills shadow lower-tier by name (agent > user > project > builtin)
- 18 tests covering discovery, validation, shadowing, and edge cases

Closes #1070

## Implementation Details

### SkillDiscovery Class
- `discoverAll()` — scan all tiers with shadowing
- `discoverInDirectory()` — scan single directory
- `validateRequirements()` — check binaries, env, OS, channels
- `getAvailable()` — filter to available skills only
- `checkBinary()` / `checkEnv()` / `checkOs()` — requirement checks

### Discovery Tiers
1. **Agent** (`agentSkills`) — highest precedence
2. **User** (`userSkills`)
3. **Project** (`projectSkills`)
4. **Builtin** (`builtinSkills`) — lowest precedence

### Requirement Validation
- **Binaries:** Uses `which` command to check PATH
- **Environment variables:** Checks `process.env`
- **OS:** Matches `process.platform` (with macos → darwin mapping)
- **Channels:** Informational (deferred to future implementation)

### Test Coverage (18 tests)
- Multi-tier discovery
- Name-based shadowing
- All requirement types (binary, env, OS)
- Missing requirements reporting
- Empty/missing directory handling
- Non-SKILL.md file filtering

## Files Changed
- New: `runtime/src/skills/markdown/discovery.ts` (249 lines)
- New: `runtime/src/skills/markdown/discovery.test.ts` (362 lines)
- Update: `runtime/src/skills/markdown/index.ts` (9 exports)
- Update: `runtime/src/skills/index.ts` (6 re-exports)
- Update: `runtime/src/index.ts` (6 public API exports)

## Dependencies
- **Unblocks:** #1071 (SkillRegistry), #1072 (SkillLoader)
- **Phase:** 3.2 (Skills Foundation)