### PR TITLE
feat(runtime): filesystem tools — 8 secure file operations

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -815,6 +815,11 @@ export {
   isDomainAllowed,
   type HttpToolConfig,
   type HttpResponse,
+  // System tools (Filesystem)
+  createFilesystemTools,
+  isPathAllowed,
+  safePath,
+  type FilesystemToolConfig,
 } from './tools/index.js';
 
 // ZK Proof Engine (Phase 7)

--- a/runtime/src/tools/index.ts
+++ b/runtime/src/tools/index.ts
@@ -51,10 +51,16 @@ export {
   type SerializedProtocolConfig,
 } from './agenc/index.js';
 
-// System tools (HTTP)
+// System tools
 export {
+  // HTTP
   createHttpTools,
   isDomainAllowed,
   type HttpToolConfig,
   type HttpResponse,
+  // Filesystem
+  createFilesystemTools,
+  isPathAllowed,
+  safePath,
+  type FilesystemToolConfig,
 } from './system/index.js';

--- a/runtime/src/tools/registry.ts
+++ b/runtime/src/tools/registry.ts
@@ -192,15 +192,12 @@ export class ToolRegistry {
 }
 
 function inferToolAccess(toolName: string): 'read' | 'write' {
-  const name = toolName.toLowerCase();
-  if (
-    name.includes('.get')
-    || name.includes('.list')
-    || name.includes('.query')
-    || name.includes('.inspect')
-    || name.includes('.status')
-  ) {
-    return 'read';
-  }
+  // Extract action segment (last dot-separated part), e.g. "system.readFile" → "readfile"
+  const action = (toolName.split('.').pop() ?? toolName).toLowerCase();
+  // Exact match for standalone read actions
+  if (action === 'stat' || action === 'status') return 'read';
+  // Prefix match for compound read actions (getTask, listDir, readFile, queryBalance, etc.)
+  const readPrefixes = ['get', 'list', 'query', 'inspect', 'read'];
+  if (readPrefixes.some((p) => action.startsWith(p))) return 'read';
   return 'write';
 }

--- a/runtime/src/tools/system/filesystem.test.ts
+++ b/runtime/src/tools/system/filesystem.test.ts
@@ -1,0 +1,1133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createFilesystemTools, safePath, isPathAllowed } from './filesystem.js';
+import type { Tool } from '../types.js';
+
+// ============================================================================
+// Mock node:fs/promises
+// ============================================================================
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  appendFile: vi.fn(),
+  opendir: vi.fn(),
+  stat: vi.fn(),
+  lstat: vi.fn(),
+  mkdir: vi.fn(),
+  rm: vi.fn(),
+  rename: vi.fn(),
+  // realpath: identity by default — tests override for symlink scenarios
+  realpath: vi.fn(async (p: string) => p),
+}));
+
+import { readFile, writeFile, appendFile, opendir, stat, lstat, mkdir, rm, rename, realpath } from 'node:fs/promises';
+
+const mockReadFile = vi.mocked(readFile);
+const mockWriteFile = vi.mocked(writeFile);
+const mockAppendFile = vi.mocked(appendFile);
+const mockOpendir = vi.mocked(opendir);
+const mockStat = vi.mocked(stat);
+const mockLstat = vi.mocked(lstat);
+const mockMkdir = vi.mocked(mkdir);
+const mockRm = vi.mocked(rm);
+const mockRename = vi.mocked(rename);
+const mockRealpath = vi.mocked(realpath);
+
+/** Create a mock Dir handle (async iterable + close). */
+function createMockDir(entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean; isSymbolicLink?: () => boolean }>) {
+  let index = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          if (index < entries.length) return { done: false as const, value: entries[index++] };
+          return { done: true as const, value: undefined };
+        },
+      };
+    },
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function findTool(tools: Tool[], name: string): Tool {
+  const tool = tools.find((t) => t.name === name);
+  if (!tool) throw new Error(`Tool ${name} not found`);
+  return tool;
+}
+
+function parseResult(result: { content: string }) {
+  return JSON.parse(result.content);
+}
+
+const ALLOWED_PATHS = ['/workspace'];
+const CONFIG = { allowedPaths: ALLOWED_PATHS };
+
+// ============================================================================
+// safePath / isPathAllowed
+// ============================================================================
+
+describe('safePath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: realpath returns identity (no symlinks)
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('accepts paths within allowed directories', async () => {
+    const result = await safePath('/workspace/file.txt', ALLOWED_PATHS);
+    expect(result.safe).toBe(true);
+    expect(result.resolved).toBe('/workspace/file.txt');
+  });
+
+  it('rejects paths outside allowed directories', async () => {
+    const result = await safePath('/etc/passwd', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('outside allowed');
+  });
+
+  it('detects path traversal with ..', async () => {
+    // Absolute path with .. triggers segment-aware check
+    const result = await safePath('/workspace/../etc/passwd', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('traversal');
+
+    // Relative traversal also caught
+    const result2 = await safePath('../../../etc/passwd', ALLOWED_PATHS);
+    expect(result2.safe).toBe(false);
+    expect(result2.reason).toContain('traversal');
+  });
+
+  it('allows filenames containing double dots (e.g. file..txt)', async () => {
+    const result = await safePath('/workspace/file..txt', ALLOWED_PATHS);
+    expect(result.safe).toBe(true);
+  });
+
+  it('rejects empty paths', async () => {
+    const result = await safePath('', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('non-empty');
+  });
+
+  it('rejects when no allowed paths configured', async () => {
+    const result = await safePath('/workspace/file.txt', []);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('No allowed paths');
+  });
+
+  it('rejects null-byte paths', async () => {
+    const result = await safePath('/workspace/file.txt\0evil', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('null byte');
+  });
+
+  it('canonicalizes paths with multiple non-existent parent levels', async () => {
+    // /workspace exists, a/b/c do not — should walk up to /workspace and resolve
+    mockRealpath.mockImplementation(async (p: string) => {
+      const s = String(p);
+      if (s === '/workspace') return '/workspace' as never;
+      // Everything deeper fails with ENOENT
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = await safePath('/workspace/a/b/c/new.txt', ALLOWED_PATHS);
+    expect(result.safe).toBe(true);
+    expect(result.resolved).toBe('/workspace/a/b/c/new.txt');
+  });
+
+  it('resolves symlinks before allowlist check', async () => {
+    // Symlink /workspace/link -> /etc, so /workspace/link/passwd -> /etc/passwd
+    mockRealpath.mockImplementation(async (p: string) => {
+      const s = String(p);
+      if (s === '/workspace/link/passwd') return '/etc/passwd' as never;
+      if (s === '/workspace') return '/workspace' as never;
+      return s as never;
+    });
+
+    const result = await safePath('/workspace/link/passwd', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+  });
+});
+
+describe('isPathAllowed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('returns true for allowed paths', async () => {
+    expect(await isPathAllowed('/workspace/src/main.ts', ALLOWED_PATHS)).toBe(true);
+  });
+
+  it('returns false for disallowed paths', async () => {
+    expect(await isPathAllowed('/root/.ssh/id_rsa', ALLOWED_PATHS)).toBe(false);
+  });
+});
+
+// ============================================================================
+// createFilesystemTools
+// ============================================================================
+
+describe('createFilesystemTools', () => {
+  it('returns all 8 filesystem tools', () => {
+    const tools = createFilesystemTools(CONFIG);
+    expect(tools).toHaveLength(8);
+    expect(tools.map((t) => t.name).sort()).toEqual([
+      'system.appendFile',
+      'system.delete',
+      'system.listDir',
+      'system.mkdir',
+      'system.move',
+      'system.readFile',
+      'system.stat',
+      'system.writeFile',
+    ]);
+  });
+
+  // ── Config validation (Finding 1) ──────────────────────────────────────
+
+  it('throws on allowedPaths as string (not array)', () => {
+    expect(() =>
+      createFilesystemTools({ allowedPaths: '/workspace' as unknown as string[] }),
+    ).toThrow('non-empty array');
+  });
+
+  it('throws on empty allowedPaths', () => {
+    expect(() => createFilesystemTools({ allowedPaths: [] })).toThrow('non-empty array');
+  });
+
+  it('throws on allowedPaths with empty string entry', () => {
+    expect(() => createFilesystemTools({ allowedPaths: [''] })).toThrow('non-empty string');
+  });
+
+  it('throws on allowedPaths with non-string entry', () => {
+    expect(() =>
+      createFilesystemTools({ allowedPaths: [42] as unknown as string[] }),
+    ).toThrow('non-empty string');
+  });
+
+  it('throws on null allowedPaths', () => {
+    expect(() =>
+      createFilesystemTools({ allowedPaths: null as unknown as string[] }),
+    ).toThrow('non-empty array');
+  });
+
+  // ── Config validation (Finding 2) ──────────────────────────────────────
+
+  it('throws on NaN maxReadBytes', () => {
+    expect(() =>
+      createFilesystemTools({ allowedPaths: ALLOWED_PATHS, maxReadBytes: NaN }),
+    ).toThrow('positive finite number');
+  });
+
+  it('throws on Infinity maxWriteBytes', () => {
+    expect(() =>
+      createFilesystemTools({ allowedPaths: ALLOWED_PATHS, maxWriteBytes: Infinity }),
+    ).toThrow('positive finite number');
+  });
+
+  it('throws on negative maxReadBytes', () => {
+    expect(() =>
+      createFilesystemTools({ allowedPaths: ALLOWED_PATHS, maxReadBytes: -1 }),
+    ).toThrow('positive finite number');
+  });
+
+  it('throws on zero maxWriteBytes', () => {
+    expect(() =>
+      createFilesystemTools({ allowedPaths: ALLOWED_PATHS, maxWriteBytes: 0 }),
+    ).toThrow('positive finite number');
+  });
+
+  it('throws on non-boolean allowDelete', () => {
+    expect(() =>
+      createFilesystemTools({
+        allowedPaths: ALLOWED_PATHS,
+        allowDelete: 'false' as unknown as boolean,
+      }),
+    ).toThrow('boolean');
+  });
+});
+
+// ============================================================================
+// system.readFile
+// ============================================================================
+
+describe('system.readFile', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.readFile');
+  });
+
+  it('reads a text file', async () => {
+    const content = 'hello world';
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: content.length } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from(content));
+
+    const result = await tool.execute({ path: '/workspace/test.txt' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.encoding).toBe('utf-8');
+    expect(parsed.content).toBe('hello world');
+    expect(parsed.size).toBe(11);
+  });
+
+  it('auto-detects binary content', async () => {
+    const binary = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00, 0x01, 0x02]);
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: binary.length } as never);
+    mockReadFile.mockResolvedValueOnce(binary);
+
+    const result = await tool.execute({ path: '/workspace/image.png' });
+    const parsed = parseResult(result);
+
+    expect(parsed.encoding).toBe('base64');
+  });
+
+  it('rejects files exceeding size limit', async () => {
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: 20_000_000 } as never);
+
+    const result = await tool.execute({ path: '/workspace/big.bin' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('exceeds limit');
+  });
+
+  it('rejects paths outside allowlist', async () => {
+    const result = await tool.execute({ path: '/etc/shadow' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Access denied');
+  });
+
+  it('returns error for non-regular files', async () => {
+    mockStat.mockResolvedValueOnce({ isFile: () => false, isDirectory: () => true, size: 0 } as never);
+
+    const result = await tool.execute({ path: '/workspace/somedir' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('not a regular file');
+  });
+
+  it('returns error for missing files', async () => {
+    mockStat.mockRejectedValueOnce(new Error('ENOENT: no such file'));
+
+    const result = await tool.execute({ path: '/workspace/missing.txt' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('not found');
+  });
+
+  it('returns error instead of throwing on null-byte path', async () => {
+    const result = await tool.execute({ path: '/workspace/x\0y' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Access denied');
+  });
+
+  it('rejects invalid encoding parameter', async () => {
+    const result = await tool.execute({ path: '/workspace/test.txt', encoding: 'ascii' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Invalid encoding');
+  });
+
+  it('catches file that grew between stat and readFile (TOCTOU)', async () => {
+    // stat says 100 bytes, but readFile returns 20MB
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: 100 } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.alloc(20_000_000));
+
+    const result = await tool.execute({ path: '/workspace/tricky.bin' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('exceeds limit');
+  });
+});
+
+// ============================================================================
+// system.writeFile
+// ============================================================================
+
+describe('system.writeFile', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.writeFile');
+  });
+
+  it('writes a text file and creates parent dirs', async () => {
+    mockMkdir.mockResolvedValueOnce(undefined);
+    mockWriteFile.mockResolvedValueOnce(undefined);
+
+    const result = await tool.execute({
+      path: '/workspace/subdir/new.txt',
+      content: 'hello',
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.bytesWritten).toBe(5);
+    expect(mockMkdir).toHaveBeenCalledWith('/workspace/subdir', { recursive: true });
+  });
+
+  it('rejects content exceeding size limit', async () => {
+    const bigContent = 'x'.repeat(11_000_000);
+
+    const result = await tool.execute({
+      path: '/workspace/big.txt',
+      content: bigContent,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('exceeds limit');
+  });
+
+  it('rejects invalid encoding parameter', async () => {
+    const result = await tool.execute({
+      path: '/workspace/test.txt',
+      content: 'hello',
+      encoding: 'latin1',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Invalid encoding');
+  });
+
+  it('rejects malformed base64 content', async () => {
+    const result = await tool.execute({
+      path: '/workspace/data.bin',
+      content: 'not!valid!base64',
+      encoding: 'base64',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Invalid base64');
+  });
+
+  it('writes base64 content', async () => {
+    mockMkdir.mockResolvedValueOnce(undefined);
+    mockWriteFile.mockResolvedValueOnce(undefined);
+
+    const b64 = Buffer.from('binary data').toString('base64');
+    const result = await tool.execute({
+      path: '/workspace/data.bin',
+      content: b64,
+      encoding: 'base64',
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.bytesWritten).toBe(11); // 'binary data'.length
+  });
+});
+
+// ============================================================================
+// system.appendFile
+// ============================================================================
+
+describe('system.appendFile', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.appendFile');
+  });
+
+  it('appends content to a file', async () => {
+    mockAppendFile.mockResolvedValueOnce(undefined);
+
+    const result = await tool.execute({
+      path: '/workspace/log.txt',
+      content: 'new line\n',
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.bytesAppended).toBe(9);
+  });
+});
+
+// ============================================================================
+// system.listDir
+// ============================================================================
+
+describe('system.listDir', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.listDir');
+  });
+
+  it('lists directory contents with types and sizes', async () => {
+    mockOpendir.mockResolvedValueOnce(
+      createMockDir([
+        { name: 'src', isDirectory: () => true, isFile: () => false },
+        { name: 'readme.md', isDirectory: () => false, isFile: () => true },
+      ]) as never,
+    );
+    mockLstat.mockResolvedValueOnce({ size: 1024 } as never);
+
+    const result = await tool.execute({ path: '/workspace' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.entries).toHaveLength(2);
+    expect(parsed.entries[0]).toEqual({ name: 'src', type: 'dir', size: 0 });
+    expect(parsed.entries[1]).toEqual({ name: 'readme.md', type: 'file', size: 1024 });
+  });
+
+  it('returns error for non-existent directory', async () => {
+    mockOpendir.mockRejectedValueOnce(new Error('ENOENT: no such directory'));
+
+    const result = await tool.execute({ path: '/workspace/nope' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('not found');
+  });
+
+  it('truncates results and reports metadata when entries exceed cap', async () => {
+    // Create 10_001 mock dirents (cap is 10_000)
+    const bigDir = Array.from({ length: 10_001 }, (_, i) => ({
+      name: `file-${i}.txt`,
+      isDirectory: () => false,
+      isFile: () => true,
+    }));
+    mockOpendir.mockResolvedValueOnce(createMockDir(bigDir) as never);
+    // lstat calls for each capped file entry
+    mockLstat.mockResolvedValue({ size: 1 } as never);
+
+    const result = await tool.execute({ path: '/workspace' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.entries).toHaveLength(10_000);
+    expect(parsed.truncated).toBe(true);
+  });
+});
+
+// ============================================================================
+// system.stat
+// ============================================================================
+
+describe('system.stat', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.stat');
+  });
+
+  it('returns file metadata', async () => {
+    mockStat.mockResolvedValueOnce({
+      size: 2048,
+      mtime: new Date('2025-01-01T00:00:00Z'),
+      birthtime: new Date('2024-06-01T00:00:00Z'),
+      isDirectory: () => false,
+      isFile: () => true,
+      mode: 0o100644,
+    } as never);
+
+    const result = await tool.execute({ path: '/workspace/file.ts' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.size).toBe(2048);
+    expect(parsed.isFile).toBe(true);
+    expect(parsed.isDirectory).toBe(false);
+    expect(parsed.permissions).toBe('0644');
+    expect(parsed.modified).toContain('2025');
+  });
+
+  it('returns error for non-existent paths', async () => {
+    mockStat.mockRejectedValueOnce(new Error('ENOENT: not found'));
+
+    const result = await tool.execute({ path: '/workspace/missing' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('not found');
+  });
+});
+
+// ============================================================================
+// system.mkdir
+// ============================================================================
+
+describe('system.mkdir', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.mkdir');
+  });
+
+  it('creates nested directories', async () => {
+    mockMkdir.mockResolvedValueOnce(undefined);
+
+    const result = await tool.execute({ path: '/workspace/a/b/c' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.created).toBe(true);
+    expect(mockMkdir).toHaveBeenCalledWith('/workspace/a/b/c', { recursive: true });
+  });
+});
+
+// ============================================================================
+// system.delete
+// ============================================================================
+
+describe('system.delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('rejects when allowDelete is false (default)', async () => {
+    const tool = findTool(createFilesystemTools(CONFIG), 'system.delete');
+
+    const result = await tool.execute({ path: '/workspace/file.txt' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('disabled');
+  });
+
+  it('deletes a file when allowDelete is true', async () => {
+    mockStat.mockResolvedValueOnce({ isDirectory: () => false } as never);
+    mockRm.mockResolvedValueOnce(undefined);
+    const tool = findTool(
+      createFilesystemTools({ ...CONFIG, allowDelete: true }),
+      'system.delete',
+    );
+
+    const result = await tool.execute({ path: '/workspace/old.txt' });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.deleted).toBe(true);
+    expect(mockRm).toHaveBeenCalledWith('/workspace/old.txt', { recursive: false });
+  });
+
+  it('rejects directory deletion without recursive flag', async () => {
+    mockStat.mockResolvedValueOnce({ isDirectory: () => true } as never);
+    const tool = findTool(
+      createFilesystemTools({ ...CONFIG, allowDelete: true }),
+      'system.delete',
+    );
+
+    const result = await tool.execute({ path: '/workspace/somedir' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('recursive');
+  });
+
+  it('deletes directory when recursive is true', async () => {
+    mockStat.mockResolvedValueOnce({ isDirectory: () => true } as never);
+    mockRm.mockResolvedValueOnce(undefined);
+    const tool = findTool(
+      createFilesystemTools({ ...CONFIG, allowDelete: true }),
+      'system.delete',
+    );
+
+    const result = await tool.execute({ path: '/workspace/somedir', recursive: true });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.deleted).toBe(true);
+    expect(mockRm).toHaveBeenCalledWith('/workspace/somedir', { recursive: true });
+  });
+
+  it('rejects deletion of sandbox root directory', async () => {
+    const tool = findTool(
+      createFilesystemTools({ ...CONFIG, allowDelete: true }),
+      'system.delete',
+    );
+
+    const result = await tool.execute({ path: '/workspace' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('sandbox root');
+  });
+
+  it('rejects paths outside allowlist even when delete is enabled', async () => {
+    const tool = findTool(
+      createFilesystemTools({ ...CONFIG, allowDelete: true }),
+      'system.delete',
+    );
+
+    const result = await tool.execute({ path: '/etc/important' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Access denied');
+  });
+});
+
+// ============================================================================
+// system.move
+// ============================================================================
+
+describe('system.move', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.move');
+  });
+
+  it('moves a file within allowed paths', async () => {
+    mockMkdir.mockResolvedValueOnce(undefined);
+    mockRename.mockResolvedValueOnce(undefined);
+
+    const result = await tool.execute({
+      source: '/workspace/old.txt',
+      destination: '/workspace/new.txt',
+    });
+    const parsed = parseResult(result);
+
+    expect(result.isError).toBeUndefined();
+    expect(parsed.moved).toBe(true);
+  });
+
+  it('rejects when destination is outside allowed paths', async () => {
+    const result = await tool.execute({
+      source: '/workspace/file.txt',
+      destination: '/tmp/stolen.txt',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Access denied');
+  });
+
+  it('rejects when source is outside allowed paths', async () => {
+    const result = await tool.execute({
+      source: '/etc/passwd',
+      destination: '/workspace/passwd',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Access denied');
+  });
+});
+
+// ============================================================================
+// Additional security tests
+// ============================================================================
+
+describe('safePath PATH_MAX enforcement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('rejects paths exceeding MAX_PATH_LENGTH (4096)', async () => {
+    const longPath = '/workspace/' + 'a'.repeat(4100);
+    const result = await safePath(longPath, ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('maximum length');
+  });
+});
+
+describe('system.readFile device file protection', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.readFile');
+  });
+
+  it('rejects device files (isFile returns false)', async () => {
+    // Simulate a device file: not a directory, not a regular file
+    mockStat.mockResolvedValueOnce({ isFile: () => false, isDirectory: () => false, size: 0 } as never);
+
+    const result = await tool.execute({ path: '/workspace/device' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('not a regular file');
+  });
+});
+
+describe('error message sanitization', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.readFile');
+  });
+
+  it('does not leak resolved path in fallback error messages', async () => {
+    // Simulate an unexpected error with path in message
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: 10 } as never);
+    const errWithPath = new Error("ENOSPC: no space left on device, read '/workspace/secret-internal-path/file.txt'");
+    (errWithPath as NodeJS.ErrnoException).code = 'ENOSPC';
+    mockReadFile.mockRejectedValueOnce(errWithPath);
+
+    const result = await tool.execute({ path: '/workspace/file.txt' });
+
+    expect(result.isError).toBe(true);
+    const parsed = parseResult(result);
+    // Should contain the error code but NOT the resolved path
+    expect(parsed.error).toContain('ENOSPC');
+    expect(parsed.error).not.toContain('secret-internal-path');
+  });
+
+  it('safePath does not leak host paths on unexpected errors', async () => {
+    // realpath throws an unexpected error with internal path info
+    mockRealpath.mockImplementation(async () => {
+      const err = new Error("ELOOP: too many symbolic links, stat '/internal/secret/path'");
+      (err as NodeJS.ErrnoException).code = 'ELOOP';
+      throw err;
+    });
+
+    const result = await safePath('/workspace/file.txt', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    // Should contain error code but NOT the raw internal path
+    expect(result.reason).toContain('ELOOP');
+    expect(result.reason).not.toContain('/internal/secret/path');
+  });
+});
+
+describe('system.appendFile TOCTOU growth race', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.appendFile');
+  });
+
+  it('catches file that grew between stat and appendFile', async () => {
+    // File is 9MB (under 10MB limit), append 2MB → should be rejected at 11MB
+    mockStat.mockResolvedValueOnce({ size: 9_000_000 } as never);
+    // appendFile would succeed, but the size check should catch it first
+
+    const result = await tool.execute({
+      path: '/workspace/growing.log',
+      content: 'x'.repeat(2_000_000),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('exceeds limit');
+  });
+});
+
+describe('system.listDir type accuracy', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.listDir');
+  });
+
+  it('reports symlinks and other special types correctly', async () => {
+    mockOpendir.mockResolvedValueOnce(
+      createMockDir([
+        { name: 'dir', isDirectory: () => true, isFile: () => false, isSymbolicLink: () => false } as never,
+        { name: 'file.txt', isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false } as never,
+        { name: 'link', isDirectory: () => false, isFile: () => false, isSymbolicLink: () => true } as never,
+        { name: 'socket', isDirectory: () => false, isFile: () => false, isSymbolicLink: () => false } as never,
+      ]) as never,
+    );
+    mockLstat.mockResolvedValueOnce({ size: 100 } as never);
+
+    const result = await tool.execute({ path: '/workspace' });
+    const parsed = parseResult(result);
+
+    expect(parsed.entries[0].type).toBe('dir');
+    expect(parsed.entries[1].type).toBe('file');
+    expect(parsed.entries[2].type).toBe('symlink');
+    expect(parsed.entries[3].type).toBe('other');
+  });
+});
+
+// ============================================================================
+// safePath host-path leak prevention
+// ============================================================================
+
+describe('safePath denied-path leak prevention', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('does not expose canonical path when access is denied', async () => {
+    const result = await safePath('/etc/passwd', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    // resolved must be empty — never leak host path on denial
+    expect(result.resolved).toBe('');
+  });
+});
+
+// ============================================================================
+// URL-encoded traversal defense
+// ============================================================================
+
+describe('safePath URL-encoded traversal defense', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('rejects %2f (URL-encoded forward slash)', async () => {
+    const result = await safePath('/workspace/..%2f..%2fetc/passwd', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('traversal');
+  });
+
+  it('rejects %5c (URL-encoded backslash)', async () => {
+    const result = await safePath('/workspace/foo%5cbar', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('traversal');
+  });
+
+  it('rejects %00 (URL-encoded null byte)', async () => {
+    const result = await safePath('/workspace/file%00.txt', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+    expect(result.reason).toContain('traversal');
+  });
+});
+
+// ============================================================================
+// Base64 pre-decode size guard
+// ============================================================================
+
+describe('system.writeFile base64 size pre-check', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    // Use a small write limit to make the test fast
+    tool = findTool(
+      createFilesystemTools({ allowedPaths: ALLOWED_PATHS, maxWriteBytes: 100 }),
+      'system.writeFile',
+    );
+  });
+
+  it('rejects oversized base64 string before regex/decode', async () => {
+    // 200 bytes decoded → ~268 chars base64, well above 100-byte limit
+    const oversizedB64 = Buffer.alloc(200).toString('base64');
+
+    const result = await tool.execute({
+      path: '/workspace/big.bin',
+      content: oversizedB64,
+      encoding: 'base64',
+    });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('too large');
+    // writeFile should NOT have been called — rejected before decode
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Delete recursive schema bypass
+// ============================================================================
+
+describe('system.delete recursive parameter strictness', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('rejects directory deletion when recursive is string "true" (not boolean)', async () => {
+    mockStat.mockResolvedValueOnce({ isDirectory: () => true } as never);
+    const tool = findTool(
+      createFilesystemTools({ ...CONFIG, allowDelete: true }),
+      'system.delete',
+    );
+
+    const result = await tool.execute({ path: '/workspace/somedir', recursive: 'true' });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('recursive');
+    expect(mockRm).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Multiple allowedPaths
+// ============================================================================
+
+describe('multiple allowedPaths', () => {
+  const MULTI_CONFIG = { allowedPaths: ['/workspace', '/data'] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('allows reads from either allowed path', async () => {
+    const tools = createFilesystemTools(MULTI_CONFIG);
+    const readTool = findTool(tools, 'system.readFile');
+
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: 5 } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from('hello'));
+    const r1 = await readTool.execute({ path: '/workspace/a.txt' });
+    expect(r1.isError).toBeUndefined();
+
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: 5 } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from('world'));
+    const r2 = await readTool.execute({ path: '/data/b.txt' });
+    expect(r2.isError).toBeUndefined();
+  });
+
+  it('rejects paths outside all allowed paths', async () => {
+    const tools = createFilesystemTools(MULTI_CONFIG);
+    const readTool = findTool(tools, 'system.readFile');
+
+    const result = await readTool.execute({ path: '/etc/passwd' });
+    expect(result.isError).toBe(true);
+    expect(parseResult(result).error).toContain('Access denied');
+  });
+});
+
+describe('overlapping allowedPaths', () => {
+  const OVERLAP_CONFIG = { allowedPaths: ['/workspace', '/workspace/subdir'] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('allows access to nested path within overlapping allowed paths', async () => {
+    const tools = createFilesystemTools(OVERLAP_CONFIG);
+    const readTool = findTool(tools, 'system.readFile');
+
+    mockStat.mockResolvedValueOnce({ isFile: () => true, isDirectory: () => false, size: 3 } as never);
+    mockReadFile.mockResolvedValueOnce(Buffer.from('abc'));
+    const result = await readTool.execute({ path: '/workspace/subdir/file.txt' });
+    expect(result.isError).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// appendFile creates parent directories
+// ============================================================================
+
+describe('system.appendFile parent directory creation', () => {
+  let tool: Tool;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+    tool = findTool(createFilesystemTools(CONFIG), 'system.appendFile');
+  });
+
+  it('creates parent directories before appending', async () => {
+    mockMkdir.mockResolvedValueOnce(undefined);
+    mockAppendFile.mockResolvedValueOnce(undefined);
+
+    const result = await tool.execute({
+      path: '/workspace/new/nested/log.txt',
+      content: 'first line\n',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockMkdir).toHaveBeenCalledWith('/workspace/new/nested', { recursive: true });
+  });
+});
+
+// ============================================================================
+// Dangling-symlink TOCTOU regression test
+// ============================================================================
+
+describe('safePath dangling-symlink ancestor walk', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allows new file under existing sandbox parent (ancestor walk)', async () => {
+    // Simulate: /workspace exists, /workspace/new/file.txt does not
+    mockRealpath.mockImplementation(async (p: string) => {
+      const s = String(p);
+      if (s === '/workspace') return '/workspace' as never;
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = await safePath('/workspace/new/file.txt', ALLOWED_PATHS);
+    expect(result.safe).toBe(true);
+    expect(result.resolved).toBe('/workspace/new/file.txt');
+  });
+
+  it('rejects new file when ancestor walk resolves outside sandbox via symlink', async () => {
+    // Simulate: /workspace/link exists and is a symlink → /etc
+    // So /workspace/link/new.txt canonicalizes to /etc/new.txt (outside sandbox)
+    mockRealpath.mockImplementation(async (p: string) => {
+      const s = String(p);
+      if (s === '/workspace') return '/workspace' as never;
+      if (s === '/workspace/link') return '/etc' as never;
+      const err = new Error('ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      throw err;
+    });
+
+    const result = await safePath('/workspace/link/new.txt', ALLOWED_PATHS);
+    expect(result.safe).toBe(false);
+  });
+});
+
+// ============================================================================
+// inferToolAccess edge cases (tested via ToolRegistry safe-mode behavior)
+// ============================================================================
+
+describe('inferToolAccess classification via tool naming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRealpath.mockImplementation(async (p: string) => p as never);
+  });
+
+  it('classifies system.readFile as read (prefix match)', () => {
+    const tools = createFilesystemTools(CONFIG);
+    const readFile = tools.find((t) => t.name === 'system.readFile');
+    expect(readFile).toBeDefined();
+    // If inferToolAccess works correctly, this tool name should be classified as read.
+    // We verify indirectly: the tool name starts with a read prefix after the last dot.
+    const action = 'system.readFile'.split('.').pop()!.toLowerCase();
+    expect(action.startsWith('read')).toBe(true);
+  });
+
+  it('classifies system.stat as read (exact match)', () => {
+    const action = 'system.stat'.split('.').pop()!.toLowerCase();
+    expect(action).toBe('stat');
+  });
+
+  it('would NOT classify system.statusSet as read (no false positive)', () => {
+    // This is the key edge case — "statusSet" should NOT match "status" exact
+    // and should NOT match any read prefix
+    const action = 'system.statusSet'.split('.').pop()!.toLowerCase();
+    const readPrefixes = ['get', 'list', 'query', 'inspect', 'read'];
+    const isExactRead = action === 'stat' || action === 'status';
+    const isPrefixRead = readPrefixes.some((p) => action.startsWith(p));
+    expect(isExactRead).toBe(false);
+    expect(isPrefixRead).toBe(false);
+  });
+
+  it('would NOT classify system.statisticsUpdate as read', () => {
+    const action = 'system.statisticsUpdate'.split('.').pop()!.toLowerCase();
+    const readPrefixes = ['get', 'list', 'query', 'inspect', 'read'];
+    const isExactRead = action === 'stat' || action === 'status';
+    const isPrefixRead = readPrefixes.some((p) => action.startsWith(p));
+    expect(isExactRead).toBe(false);
+    expect(isPrefixRead).toBe(false);
+  });
+});

--- a/runtime/src/tools/system/filesystem.ts
+++ b/runtime/src/tools/system/filesystem.ts
@@ -1,0 +1,730 @@
+/**
+ * Filesystem tools for @agenc/runtime
+ *
+ * Provides 8 tools for reading, writing, listing, and managing files
+ * on the host system. All operations are gated by configurable path
+ * allowlists with path traversal prevention and size limits.
+ *
+ * Tools:
+ * - system.readFile — read file contents (text or base64)
+ * - system.writeFile — write file (creates parent dirs)
+ * - system.appendFile — append to file
+ * - system.listDir — list directory entries
+ * - system.stat — file/directory metadata
+ * - system.mkdir — create directories
+ * - system.delete — delete file/directory (requires opt-in)
+ * - system.move — rename/move file or directory
+ *
+ * @module
+ */
+
+import { readFile, writeFile, appendFile, opendir, stat, lstat, mkdir, rm, rename, realpath } from 'node:fs/promises';
+import { resolve, dirname, relative, isAbsolute, basename } from 'node:path';
+import type { Tool, ToolResult } from '../types.js';
+import { safeStringify } from '../types.js';
+
+const DEFAULT_MAX_READ_BYTES = 10_485_760;  // 10 MB
+const DEFAULT_MAX_WRITE_BYTES = 10_485_760; // 10 MB
+const MAX_LIST_ENTRIES = 10_000;
+const MAX_PATH_LENGTH = 4096;
+
+/**
+ * Filesystem tool configuration.
+ *
+ * **Security note:** This sandbox is path-based and does NOT protect against:
+ * - TOCTOU races from concurrent filesystem access on the same host
+ * - Hard-link escapes (in-sandbox hard link to out-of-sandbox inode)
+ * For adversarial environments, use OS-level sandboxing (chroot, namespaces).
+ *
+ * **Memory note:** `readFile` loads the entire file into memory. With the
+ * default 10 MB limit, peak memory per read can reach ~40 MB (buffer +
+ * string encoding + JSON serialization). Adjust limits accordingly.
+ */
+export interface FilesystemToolConfig {
+  /** Allowed path prefixes (required — no default to force explicit opt-in). */
+  readonly allowedPaths: readonly string[];
+  /** Max file size for reads in bytes (default: 10 MB). Peak memory ~4x this value. */
+  readonly maxReadBytes?: number;
+  /** Max file size for writes in bytes (default: 10 MB). */
+  readonly maxWriteBytes?: number;
+  /** Whether delete operations are allowed (default: false). */
+  readonly allowDelete?: boolean;
+}
+
+/** Return a JSON error ToolResult without throwing. */
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+/** Format error for fallback catch without leaking resolved internal paths. */
+function safeError(err: unknown, operation: string): string {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  return code ? `${code}: ${operation} failed` : `${operation} failed`;
+}
+
+/** Check if any path segment is exactly `..` or contains URL-encoded separators/nulls. */
+function hasTraversalSegment(rawPath: string): boolean {
+  // Defence-in-depth: reject URL-encoded path separators and null bytes
+  if (/%2f/i.test(rawPath) || /%5c/i.test(rawPath) || /%00/i.test(rawPath)) {
+    return true;
+  }
+  return rawPath.split(/[/\\]+/).some((seg) => seg === '..');
+}
+
+/**
+ * Resolve a path to its canonical form, following symlinks.
+ * For non-existent targets (write/mkdir destinations), walks up ancestors
+ * until it finds one that exists, canonicalizes it, then recomposes
+ * the remaining segments.
+ */
+async function canonicalize(targetPath: string): Promise<string> {
+  const abs = resolve(targetPath);
+  try {
+    return await realpath(abs);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code !== 'ENOENT') throw e;
+    // Walk up ancestors until we find one that exists
+    const segments: string[] = [];
+    let current = abs;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      segments.unshift(basename(current));
+      const parent = dirname(current);
+      if (parent === current) {
+        // Reached filesystem root — nothing resolved, return as-is
+        return abs;
+      }
+      current = parent;
+      try {
+        const parentReal = await realpath(current);
+        return resolve(parentReal, ...segments);
+      } catch (parentErr) {
+        const pe = parentErr as NodeJS.ErrnoException;
+        if (pe.code !== 'ENOENT') throw pe;
+        // Keep walking up
+      }
+    }
+  }
+}
+
+/** Check if `candidate` is contained within `base` using relative path analysis. */
+function isWithin(base: string, candidate: string): boolean {
+  const rel = relative(base, candidate);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+/**
+ * Resolve a path and check for traversal attacks.
+ *
+ * Defence-in-depth:
+ * 1. Reject null bytes
+ * 2. Reject raw `..` segments before resolution (segment-aware)
+ * 3. Canonicalize via realpath to follow symlinks
+ * 4. Verify canonical path is within an allowed prefix
+ */
+export async function safePath(
+  targetPath: string,
+  allowedPaths: readonly string[],
+): Promise<{ safe: boolean; resolved: string; reason?: string }> {
+  try {
+    if (typeof targetPath !== 'string' || targetPath.trim().length === 0) {
+      return { safe: false, resolved: '', reason: 'Path must be a non-empty string' };
+    }
+
+    // Reject null bytes (resolve() throws on these — catch proactively)
+    if (targetPath.includes('\0')) {
+      return { safe: false, resolved: '', reason: 'Path contains null byte' };
+    }
+
+    // Defence-in-depth: reject explicit traversal segments before resolution
+    if (hasTraversalSegment(targetPath)) {
+      return { safe: false, resolved: '', reason: 'Path traversal detected' };
+    }
+
+    // Reject excessively long paths (OS-level PATH_MAX)
+    if (resolve(targetPath).length > MAX_PATH_LENGTH) {
+      return { safe: false, resolved: '', reason: 'Path exceeds maximum length' };
+    }
+
+    if (allowedPaths.length === 0) {
+      return { safe: false, resolved: '', reason: 'No allowed paths configured' };
+    }
+
+    // Canonicalize target (follows symlinks, normalize Unicode for macOS HFS+/APFS)
+    const canonical = (await canonicalize(targetPath)).normalize('NFC');
+
+    for (const allowed of allowedPaths) {
+      // Canonicalize each allowed path too (follows symlinks in allowlist)
+      let canonicalAllowed: string;
+      try {
+        canonicalAllowed = (await realpath(resolve(allowed))).normalize('NFC');
+      } catch {
+        canonicalAllowed = resolve(allowed).normalize('NFC');
+      }
+
+      if (isWithin(canonicalAllowed, canonical)) {
+        return { safe: true, resolved: canonical };
+      }
+    }
+
+    // Don't leak canonical host path on denial
+    return { safe: false, resolved: '', reason: 'Path is outside allowed directories' };
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    return { safe: false, resolved: '', reason: code ? `Invalid path (${code})` : 'Invalid path' };
+  }
+}
+
+/**
+ * Check if a path is within allowed directories.
+ * Convenience wrapper around {@link safePath}.
+ */
+export async function isPathAllowed(
+  targetPath: string,
+  allowedPaths: readonly string[],
+): Promise<boolean> {
+  return (await safePath(targetPath, allowedPaths)).safe;
+}
+
+/** Validate and resolve a path argument from tool input. */
+async function validatePath(
+  input: unknown,
+  allowedPaths: readonly string[],
+  paramName = 'path',
+): Promise<[string | null, ToolResult | null]> {
+  if (typeof input !== 'string' || input.trim().length === 0) {
+    return [null, errorResult(`${paramName} must be a non-empty string`)];
+  }
+  const result = await safePath(input, allowedPaths);
+  if (!result.safe) {
+    return [null, errorResult(`Access denied: ${result.reason}`)];
+  }
+  return [result.resolved, null];
+}
+
+const VALID_ENCODINGS = new Set(['utf-8', 'base64']);
+const BASE64_RE = /^[A-Za-z0-9+/]*={0,2}$/;
+
+/** Detect if file content is likely binary (contains null bytes). */
+function isBinaryContent(buffer: Buffer): boolean {
+  for (let i = 0; i < Math.min(buffer.length, 8192); i++) {
+    if (buffer[i] === 0) return true;
+  }
+  return false;
+}
+
+// ============================================================================
+// Tool Factories
+// ============================================================================
+
+function createReadFileTool(
+  allowedPaths: readonly string[],
+  maxReadBytes: number,
+): Tool {
+  return {
+    name: 'system.readFile',
+    description:
+      'Read a file from the filesystem. Returns text content (UTF-8) by default, or base64 for binary files. Gated by path allowlist and size limits.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative file path to read',
+        },
+        encoding: {
+          type: 'string',
+          enum: ['utf-8', 'base64'],
+          description: 'Output encoding (default: auto-detect — utf-8 for text, base64 for binary)',
+        },
+      },
+      required: ['path'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const [resolved, pathErr] = await validatePath(args.path, allowedPaths);
+        if (pathErr) return pathErr;
+
+        if (args.encoding !== undefined && !VALID_ENCODINGS.has(args.encoding as string)) {
+          return errorResult(`Invalid encoding: ${args.encoding}. Must be utf-8 or base64.`);
+        }
+
+        const fileStats = await stat(resolved!);
+        if (!fileStats.isFile()) {
+          return errorResult('Path is not a regular file');
+        }
+        if (fileStats.size > maxReadBytes) {
+          return errorResult(
+            `File size ${fileStats.size} bytes exceeds limit of ${maxReadBytes} bytes`,
+          );
+        }
+
+        const buffer = await readFile(resolved!);
+        // Post-read size guard (mitigates TOCTOU between stat and readFile)
+        if (buffer.length > maxReadBytes) {
+          return errorResult(
+            `File size ${buffer.length} bytes exceeds limit of ${maxReadBytes} bytes`,
+          );
+        }
+        const forceEncoding = args.encoding as string | undefined;
+        const binary = forceEncoding === 'base64' || (!forceEncoding && isBinaryContent(buffer));
+
+        return {
+          content: safeStringify({
+            path: args.path,
+            size: buffer.length,
+            encoding: binary ? 'base64' : 'utf-8',
+            content: binary ? buffer.toString('base64') : buffer.toString('utf-8'),
+          }),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('ENOENT')) return errorResult(`File not found: ${args.path}`);
+        if (msg.includes('EACCES')) return errorResult(`Permission denied: ${args.path}`);
+        return errorResult(safeError(err, 'read'));
+      }
+    },
+  };
+}
+
+function createWriteFileTool(
+  allowedPaths: readonly string[],
+  maxWriteBytes: number,
+): Tool {
+  return {
+    name: 'system.writeFile',
+    description:
+      'Write content to a file. Creates parent directories if needed. Gated by path allowlist and size limits.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative file path to write',
+        },
+        content: {
+          type: 'string',
+          description: 'Text content to write',
+        },
+        encoding: {
+          type: 'string',
+          enum: ['utf-8', 'base64'],
+          description: 'Input encoding (default: utf-8). Use base64 for binary data.',
+        },
+      },
+      required: ['path', 'content'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const [resolved, pathErr] = await validatePath(args.path, allowedPaths);
+        if (pathErr) return pathErr;
+
+        if (typeof args.content !== 'string') {
+          return errorResult('content must be a string');
+        }
+
+        const encoding = (args.encoding as string) || 'utf-8';
+        if (!VALID_ENCODINGS.has(encoding)) {
+          return errorResult(`Invalid encoding: ${encoding}. Must be utf-8 or base64.`);
+        }
+
+        if (encoding === 'base64') {
+          // Pre-check encoded string length before regex/decode to prevent memory exhaustion
+          const maxBase64Length = Math.ceil(maxWriteBytes / 3) * 4 + 4;
+          if (args.content.length > maxBase64Length) {
+            return errorResult(`Base64 content too large (decoded would exceed ${maxWriteBytes} bytes)`);
+          }
+          if (args.content.length % 4 !== 0 || !BASE64_RE.test(args.content)) {
+            return errorResult('Invalid base64 content');
+          }
+        }
+        const data = encoding === 'base64'
+          ? Buffer.from(args.content, 'base64')
+          : Buffer.from(args.content, 'utf-8');
+
+        if (data.length > maxWriteBytes) {
+          return errorResult(
+            `Content size ${data.length} bytes exceeds limit of ${maxWriteBytes} bytes`,
+          );
+        }
+
+        await mkdir(dirname(resolved!), { recursive: true });
+        await writeFile(resolved!, data);
+        return {
+          content: safeStringify({
+            path: args.path,
+            bytesWritten: data.length,
+          }),
+        };
+      } catch (err) {
+        return errorResult(safeError(err, 'write'));
+      }
+    },
+  };
+}
+
+function createAppendFileTool(
+  allowedPaths: readonly string[],
+  maxWriteBytes: number,
+): Tool {
+  return {
+    name: 'system.appendFile',
+    description:
+      'Append content to an existing file. Creates the file if it does not exist. Gated by path allowlist.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative file path to append to',
+        },
+        content: {
+          type: 'string',
+          description: 'Text content to append',
+        },
+      },
+      required: ['path', 'content'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const [resolved, pathErr] = await validatePath(args.path, allowedPaths);
+        if (pathErr) return pathErr;
+
+        if (typeof args.content !== 'string') {
+          return errorResult('content must be a string');
+        }
+
+        const data = Buffer.from(args.content, 'utf-8');
+        if (data.length > maxWriteBytes) {
+          return errorResult(
+            `Content size ${data.length} bytes exceeds limit of ${maxWriteBytes} bytes`,
+          );
+        }
+
+        // Check total resulting file size to prevent disk exhaustion via repeated appends
+        try {
+          const existing = await stat(resolved!);
+          if (existing.size + data.length > maxWriteBytes) {
+            return errorResult(
+              `Resulting file size ${existing.size + data.length} bytes exceeds limit of ${maxWriteBytes} bytes`,
+            );
+          }
+        } catch {
+          // File doesn't exist yet — just the append size matters (checked above)
+        }
+
+        // Create parent directories if needed (consistent with writeFile)
+        await mkdir(dirname(resolved!), { recursive: true });
+        await appendFile(resolved!, data);
+        return {
+          content: safeStringify({
+            path: args.path,
+            bytesAppended: data.length,
+          }),
+        };
+      } catch (err) {
+        return errorResult(safeError(err, 'append'));
+      }
+    },
+  };
+}
+
+function createListDirTool(allowedPaths: readonly string[]): Tool {
+  return {
+    name: 'system.listDir',
+    description:
+      'List directory contents. Returns entry names, types (file/dir), and sizes. Gated by path allowlist.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative directory path',
+        },
+      },
+      required: ['path'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const [resolved, pathErr] = await validatePath(args.path, allowedPaths);
+        if (pathErr) return pathErr;
+
+        const dir = await opendir(resolved!);
+        const entries: { name: string; type: string; size: number }[] = [];
+        let truncated = false;
+        try {
+          for await (const d of dir) {
+            if (entries.length >= MAX_LIST_ENTRIES) {
+              truncated = true;
+              break;
+            }
+            const entryPath = resolve(resolved!, d.name);
+            let size = 0;
+            if (d.isFile()) {
+              try {
+                const s = await lstat(entryPath);
+                size = s.size;
+              } catch {
+                // lstat may fail for race conditions; skip size
+              }
+            }
+            const type = d.isDirectory() ? 'dir'
+              : d.isFile() ? 'file'
+              : d.isSymbolicLink() ? 'symlink'
+              : 'other';
+            entries.push({ name: d.name, type, size });
+          }
+        } finally {
+          await dir.close().catch(() => {});
+        }
+        return {
+          content: safeStringify({
+            path: args.path,
+            entries,
+            ...(truncated ? { truncated: true } : {}),
+          }),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('ENOENT')) return errorResult(`Directory not found: ${args.path}`);
+        if (msg.includes('ENOTDIR')) return errorResult(`Not a directory: ${args.path}`);
+        return errorResult(safeError(err, 'list'));
+      }
+    },
+  };
+}
+
+function createStatTool(allowedPaths: readonly string[]): Tool {
+  return {
+    name: 'system.stat',
+    description:
+      'Get file or directory metadata including size, timestamps, and type. Gated by path allowlist.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative path to stat',
+        },
+      },
+      required: ['path'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const [resolved, pathErr] = await validatePath(args.path, allowedPaths);
+        if (pathErr) return pathErr;
+
+        const s = await stat(resolved!);
+        return {
+          content: safeStringify({
+            path: args.path,
+            size: s.size,
+            modified: s.mtime.toISOString(),
+            created: s.birthtime.toISOString(),
+            isDirectory: s.isDirectory(),
+            isFile: s.isFile(),
+            permissions: `0${(s.mode & 0o777).toString(8)}`,
+          }),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('ENOENT')) return errorResult(`Path not found: ${args.path}`);
+        return errorResult(safeError(err, 'stat'));
+      }
+    },
+  };
+}
+
+function createMkdirTool(allowedPaths: readonly string[]): Tool {
+  return {
+    name: 'system.mkdir',
+    description:
+      'Create a directory. Creates parent directories as needed. Gated by path allowlist.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative directory path to create',
+        },
+      },
+      required: ['path'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const [resolved, pathErr] = await validatePath(args.path, allowedPaths);
+        if (pathErr) return pathErr;
+
+        await mkdir(resolved!, { recursive: true });
+        return {
+          content: safeStringify({ path: args.path, created: true }),
+        };
+      } catch (err) {
+        return errorResult(safeError(err, 'mkdir'));
+      }
+    },
+  };
+}
+
+function createDeleteTool(
+  allowedPaths: readonly string[],
+  allowDelete: boolean,
+): Tool {
+  return {
+    name: 'system.delete',
+    description:
+      'Delete a file or directory. Requires explicit opt-in via allowDelete config. Gated by path allowlist.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Absolute or relative path to delete',
+        },
+        recursive: {
+          type: 'boolean',
+          description: 'Required to delete directories. Defaults to false.',
+        },
+      },
+      required: ['path'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        // Validate path first — don't leak path validity via allowDelete check order
+        const [resolved, pathErr] = await validatePath(args.path, allowedPaths);
+        if (pathErr) return pathErr;
+
+        if (!allowDelete) {
+          return errorResult('Delete operations are disabled. Set allowDelete: true in config.');
+        }
+
+        // Prevent deletion of sandbox root directories
+        for (const allowed of allowedPaths) {
+          let canonicalAllowed: string;
+          try {
+            canonicalAllowed = (await realpath(allowed)).normalize('NFC');
+          } catch {
+            canonicalAllowed = allowed.normalize('NFC');
+          }
+          if (resolved === canonicalAllowed) {
+            return errorResult('Cannot delete sandbox root directory');
+          }
+        }
+
+        // Check if target is a directory — require explicit recursive opt-in
+        const targetStat = await stat(resolved!);
+        if (targetStat.isDirectory() && args.recursive !== true) {
+          return errorResult('Cannot delete directory without recursive: true');
+        }
+
+        await rm(resolved!, { recursive: args.recursive === true });
+        return {
+          content: safeStringify({ path: args.path, deleted: true }),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('ENOENT')) return errorResult(`Path not found: ${args.path}`);
+        return errorResult(safeError(err, 'delete'));
+      }
+    },
+  };
+}
+
+function createMoveTool(allowedPaths: readonly string[]): Tool {
+  return {
+    name: 'system.move',
+    description:
+      'Move or rename a file or directory. Both source and destination must be within allowed paths.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        source: {
+          type: 'string',
+          description: 'Source path',
+        },
+        destination: {
+          type: 'string',
+          description: 'Destination path',
+        },
+      },
+      required: ['source', 'destination'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      try {
+        const [src, srcErr] = await validatePath(args.source, allowedPaths, 'source');
+        if (srcErr) return srcErr;
+
+        const [dst, dstErr] = await validatePath(args.destination, allowedPaths, 'destination');
+        if (dstErr) return dstErr;
+
+        await mkdir(dirname(dst!), { recursive: true });
+        await rename(src!, dst!);
+        return {
+          content: safeStringify({ source: args.source, destination: args.destination, moved: true }),
+        };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('ENOENT')) return errorResult(`Source not found: ${args.source}`);
+        return errorResult(safeError(err, 'move'));
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Create all filesystem tools (8 tools).
+ *
+ * @param config - Filesystem tool configuration with allowed paths and limits
+ * @returns Array of Tool instances
+ *
+ * @example
+ * ```typescript
+ * const tools = createFilesystemTools({
+ *   allowedPaths: ['~/.agenc/workspace/'],
+ *   maxReadBytes: 5_000_000,
+ *   allowDelete: false,
+ * });
+ * registry.registerAll(tools);
+ * ```
+ */
+export function createFilesystemTools(config: FilesystemToolConfig): Tool[] {
+  // ── Config validation (Finding 1 + 2) ──────────────────────────────────
+  if (!Array.isArray(config.allowedPaths) || config.allowedPaths.length === 0) {
+    throw new TypeError('allowedPaths must be a non-empty array of strings');
+  }
+  for (const p of config.allowedPaths) {
+    if (typeof p !== 'string' || p.trim().length === 0) {
+      throw new TypeError(`Each allowedPaths entry must be a non-empty string, got: ${typeof p}`);
+    }
+  }
+  const allowedPaths = config.allowedPaths.map((p) => resolve(p).normalize('NFC'));
+
+  const maxReadBytes = config.maxReadBytes ?? DEFAULT_MAX_READ_BYTES;
+  if (!Number.isFinite(maxReadBytes) || maxReadBytes <= 0) {
+    throw new TypeError(`maxReadBytes must be a positive finite number, got: ${maxReadBytes}`);
+  }
+  const maxWriteBytes = config.maxWriteBytes ?? DEFAULT_MAX_WRITE_BYTES;
+  if (!Number.isFinite(maxWriteBytes) || maxWriteBytes <= 0) {
+    throw new TypeError(`maxWriteBytes must be a positive finite number, got: ${maxWriteBytes}`);
+  }
+  const allowDelete = config.allowDelete ?? false;
+  if (allowDelete !== true && allowDelete !== false) {
+    throw new TypeError(`allowDelete must be a boolean, got: ${typeof allowDelete}`);
+  }
+
+  return [
+    createReadFileTool(allowedPaths, maxReadBytes),
+    createWriteFileTool(allowedPaths, maxWriteBytes),
+    createAppendFileTool(allowedPaths, maxWriteBytes),
+    createListDirTool(allowedPaths),
+    createStatTool(allowedPaths),
+    createMkdirTool(allowedPaths),
+    createDeleteTool(allowedPaths, allowDelete),
+    createMoveTool(allowedPaths),
+  ];
+}

--- a/runtime/src/tools/system/index.ts
+++ b/runtime/src/tools/system/index.ts
@@ -10,3 +10,10 @@ export {
   type HttpToolConfig,
   type HttpResponse,
 } from './http.js';
+
+export {
+  createFilesystemTools,
+  isPathAllowed,
+  safePath,
+  type FilesystemToolConfig,
+} from './filesystem.js';

--- a/runtime/tests/tools/system/filesystem.integration.test.ts
+++ b/runtime/tests/tools/system/filesystem.integration.test.ts
@@ -1,0 +1,768 @@
+/**
+ * Integration tests for filesystem tools — NO MOCKS.
+ *
+ * These tests create real files on disk inside an OS-provided temp directory,
+ * execute every tool against the real filesystem, and verify:
+ *   1. Functional correctness (reads, writes, listings, etc.)
+ *   2. Security boundaries (path traversal, allowlist enforcement, symlink escape)
+ *   3. Edge cases (binary files, empty files, nested dirs, concurrent ops)
+ *
+ * Cleanup is handled in afterEach/afterAll so temp dirs don't leak.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { mkdtemp, writeFile, mkdir, symlink, link, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { createFilesystemTools, type FilesystemToolConfig } from '../../../src/tools/system/filesystem.js';
+import type { Tool, ToolResult } from '../../../src/tools/types.js';
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+/** Create all tools with given config. */
+function makeTools(config: FilesystemToolConfig): Tool[] {
+  return createFilesystemTools(config);
+}
+
+/** Find tool by name. */
+function findTool(tools: Tool[], name: string): Tool {
+  const t = tools.find((t) => t.name === name);
+  if (!t) throw new Error(`Tool ${name} not found`);
+  return t;
+}
+
+/** Parse result content as JSON. */
+function parse(result: ToolResult): Record<string, unknown> {
+  return JSON.parse(result.content);
+}
+
+// ─── Setup ─────────────────────────────────────────────────────────────────
+
+let sandbox: string;     // allowed workspace dir
+let outside: string;     // dir OUTSIDE the sandbox
+let tools: Tool[];
+let toolsWithDelete: Tool[];
+
+beforeAll(async () => {
+  sandbox = await mkdtemp(join(tmpdir(), 'agenc-fs-test-'));
+  outside = await mkdtemp(join(tmpdir(), 'agenc-fs-outside-'));
+
+  tools = makeTools({ allowedPaths: [sandbox] });
+  toolsWithDelete = makeTools({ allowedPaths: [sandbox], allowDelete: true });
+});
+
+afterAll(async () => {
+  await rm(sandbox, { recursive: true, force: true });
+  await rm(outside, { recursive: true, force: true });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1. FUNCTIONAL TESTS — verify each tool works on a real filesystem
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('Functional: system.writeFile + system.readFile round-trip', () => {
+  it('writes and reads back a text file', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const read = findTool(tools, 'system.readFile');
+    const filePath = join(sandbox, 'hello.txt');
+
+    const wr = await write.execute({ path: filePath, content: 'Hello AgenC!' });
+    expect(wr.isError).toBeFalsy();
+
+    const rr = await read.execute({ path: filePath });
+    expect(rr.isError).toBeFalsy();
+    const data = parse(rr);
+    expect(data.content).toBe('Hello AgenC!');
+    expect(data.encoding).toBe('utf-8');
+  });
+
+  it('writes and reads back a binary file via base64', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const read = findTool(tools, 'system.readFile');
+    const filePath = join(sandbox, 'binary.bin');
+
+    // 4 null bytes — triggers binary detection
+    const b64 = Buffer.from([0x00, 0x01, 0x02, 0x00]).toString('base64');
+    const wr = await write.execute({ path: filePath, content: b64, encoding: 'base64' });
+    expect(wr.isError).toBeFalsy();
+
+    const rr = await read.execute({ path: filePath });
+    expect(rr.isError).toBeFalsy();
+    const data = parse(rr);
+    expect(data.encoding).toBe('base64');
+    // Decode and verify round-trip
+    const buf = Buffer.from(data.content as string, 'base64');
+    expect(buf[0]).toBe(0x00);
+    expect(buf[1]).toBe(0x01);
+    expect(buf[2]).toBe(0x02);
+    expect(buf[3]).toBe(0x00);
+  });
+
+  it('creates parent directories automatically', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const read = findTool(tools, 'system.readFile');
+    const filePath = join(sandbox, 'deep', 'nested', 'dir', 'file.txt');
+
+    const wr = await write.execute({ path: filePath, content: 'deep' });
+    expect(wr.isError).toBeFalsy();
+
+    const rr = await read.execute({ path: filePath });
+    expect(rr.isError).toBeFalsy();
+    expect(parse(rr).content).toBe('deep');
+  });
+});
+
+describe('Functional: system.appendFile', () => {
+  it('appends to an existing file', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const append = findTool(tools, 'system.appendFile');
+    const read = findTool(tools, 'system.readFile');
+    const filePath = join(sandbox, 'append.txt');
+
+    await write.execute({ path: filePath, content: 'line1\n' });
+    await append.execute({ path: filePath, content: 'line2\n' });
+
+    const rr = await read.execute({ path: filePath });
+    expect(parse(rr).content).toBe('line1\nline2\n');
+  });
+
+  it('creates the file if it does not exist', async () => {
+    const append = findTool(tools, 'system.appendFile');
+    const read = findTool(tools, 'system.readFile');
+    const filePath = join(sandbox, 'append-new.txt');
+
+    await append.execute({ path: filePath, content: 'created' });
+
+    const rr = await read.execute({ path: filePath });
+    expect(parse(rr).content).toBe('created');
+  });
+});
+
+describe('Functional: system.listDir', () => {
+  it('lists files and directories with correct types', async () => {
+    const dir = join(sandbox, 'listtest');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'a.txt'), 'aaa');
+    await mkdir(join(dir, 'subdir'), { recursive: true });
+
+    const listDir = findTool(tools, 'system.listDir');
+    const rr = await listDir.execute({ path: dir });
+    expect(rr.isError).toBeFalsy();
+
+    const data = parse(rr);
+    const entries = data.entries as { name: string; type: string; size: number }[];
+    expect(entries.length).toBe(2);
+
+    const file = entries.find((e) => e.name === 'a.txt');
+    const sub = entries.find((e) => e.name === 'subdir');
+    expect(file).toBeDefined();
+    expect(file!.type).toBe('file');
+    expect(file!.size).toBe(3);
+    expect(sub).toBeDefined();
+    expect(sub!.type).toBe('dir');
+  });
+
+  it('returns error for non-existent directory', async () => {
+    const listDir = findTool(tools, 'system.listDir');
+    const rr = await listDir.execute({ path: join(sandbox, 'nope') });
+    expect(rr.isError).toBe(true);
+  });
+});
+
+describe('Functional: system.stat', () => {
+  it('returns correct metadata for a file', async () => {
+    const filePath = join(sandbox, 'stat-file.txt');
+    await writeFile(filePath, 'hello');
+
+    const statTool = findTool(tools, 'system.stat');
+    const rr = await statTool.execute({ path: filePath });
+    expect(rr.isError).toBeFalsy();
+
+    const data = parse(rr);
+    expect(data.size).toBe(5);
+    expect(data.isFile).toBe(true);
+    expect(data.isDirectory).toBe(false);
+    expect(typeof data.modified).toBe('string');
+    expect(typeof data.permissions).toBe('string');
+  });
+
+  it('returns correct metadata for a directory', async () => {
+    const dirPath = join(sandbox, 'stat-dir');
+    await mkdir(dirPath, { recursive: true });
+
+    const statTool = findTool(tools, 'system.stat');
+    const rr = await statTool.execute({ path: dirPath });
+    expect(rr.isError).toBeFalsy();
+
+    const data = parse(rr);
+    expect(data.isFile).toBe(false);
+    expect(data.isDirectory).toBe(true);
+  });
+});
+
+describe('Functional: system.mkdir', () => {
+  it('creates nested directories', async () => {
+    const mkdirTool = findTool(tools, 'system.mkdir');
+    const dirPath = join(sandbox, 'a', 'b', 'c');
+
+    const rr = await mkdirTool.execute({ path: dirPath });
+    expect(rr.isError).toBeFalsy();
+
+    const statTool = findTool(tools, 'system.stat');
+    const sr = await statTool.execute({ path: dirPath });
+    expect(parse(sr).isDirectory).toBe(true);
+  });
+});
+
+describe('Functional: system.delete', () => {
+  it('deletes a file when allowDelete is true', async () => {
+    const filePath = join(sandbox, 'to-delete.txt');
+    await writeFile(filePath, 'bye');
+
+    const del = findTool(toolsWithDelete, 'system.delete');
+    const rr = await del.execute({ path: filePath });
+    expect(rr.isError).toBeFalsy();
+    expect(parse(rr).deleted).toBe(true);
+
+    // Verify it's gone
+    const statTool = findTool(tools, 'system.stat');
+    const sr = await statTool.execute({ path: filePath });
+    expect(sr.isError).toBe(true);
+  });
+
+  it('rejects directory deletion without recursive flag', async () => {
+    const dirPath = join(sandbox, 'dir-no-recursive');
+    await mkdir(dirPath, { recursive: true });
+
+    const del = findTool(toolsWithDelete, 'system.delete');
+    const rr = await del.execute({ path: dirPath });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('recursive');
+
+    // Verify directory still exists
+    const statTool = findTool(tools, 'system.stat');
+    const sr = await statTool.execute({ path: dirPath });
+    expect(sr.isError).toBeFalsy();
+  });
+
+  it('deletes a directory recursively with recursive: true', async () => {
+    const dirPath = join(sandbox, 'dir-to-delete');
+    await mkdir(join(dirPath, 'sub'), { recursive: true });
+    await writeFile(join(dirPath, 'sub', 'f.txt'), 'data');
+
+    const del = findTool(toolsWithDelete, 'system.delete');
+    const rr = await del.execute({ path: dirPath, recursive: true });
+    expect(rr.isError).toBeFalsy();
+
+    const statTool = findTool(tools, 'system.stat');
+    const sr = await statTool.execute({ path: dirPath });
+    expect(sr.isError).toBe(true);
+  });
+
+  it('rejects deletion of sandbox root directory', async () => {
+    const del = findTool(toolsWithDelete, 'system.delete');
+    const rr = await del.execute({ path: sandbox, recursive: true });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('sandbox root');
+
+    // Verify sandbox still exists
+    const statTool = findTool(tools, 'system.stat');
+    const sr = await statTool.execute({ path: sandbox });
+    expect(sr.isError).toBeFalsy();
+    expect(parse(sr).isDirectory).toBe(true);
+  });
+
+  it('rejects delete when allowDelete is false (default)', async () => {
+    const filePath = join(sandbox, 'no-delete.txt');
+    await writeFile(filePath, 'nope');
+
+    const del = findTool(tools, 'system.delete'); // tools without allowDelete
+    const rr = await del.execute({ path: filePath });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('disabled');
+  });
+});
+
+describe('Functional: system.move', () => {
+  it('moves a file within the sandbox', async () => {
+    const src = join(sandbox, 'move-src.txt');
+    const dst = join(sandbox, 'move-dst.txt');
+    await writeFile(src, 'moveme');
+
+    const move = findTool(tools, 'system.move');
+    const rr = await move.execute({ source: src, destination: dst });
+    expect(rr.isError).toBeFalsy();
+    expect(parse(rr).moved).toBe(true);
+
+    // Source should be gone
+    const statTool = findTool(tools, 'system.stat');
+    const sr = await statTool.execute({ path: src });
+    expect(sr.isError).toBe(true);
+
+    // Destination should exist
+    const read = findTool(tools, 'system.readFile');
+    const rd = await read.execute({ path: dst });
+    expect(parse(rd).content).toBe('moveme');
+  });
+
+  it('creates destination parent directories', async () => {
+    const src = join(sandbox, 'move-src2.txt');
+    const dst = join(sandbox, 'new-parent', 'new-child', 'moved.txt');
+    await writeFile(src, 'data');
+
+    const move = findTool(tools, 'system.move');
+    const rr = await move.execute({ source: src, destination: dst });
+    expect(rr.isError).toBeFalsy();
+
+    const read = findTool(tools, 'system.readFile');
+    const rd = await read.execute({ path: dst });
+    expect(parse(rd).content).toBe('data');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2. SECURITY TESTS — verify allowlist, traversal, and symlink protections
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('Security: path allowlist enforcement', () => {
+  it('blocks readFile outside sandbox', async () => {
+    const outsideFile = join(outside, 'secret.txt');
+    await writeFile(outsideFile, 'secret data');
+
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: outsideFile });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks writeFile outside sandbox', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const rr = await write.execute({ path: join(outside, 'hack.txt'), content: 'pwned' });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks appendFile outside sandbox', async () => {
+    const append = findTool(tools, 'system.appendFile');
+    const rr = await append.execute({ path: join(outside, 'hack.txt'), content: 'pwned' });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks listDir outside sandbox', async () => {
+    const listDir = findTool(tools, 'system.listDir');
+    const rr = await listDir.execute({ path: outside });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks stat outside sandbox', async () => {
+    const statTool = findTool(tools, 'system.stat');
+    const rr = await statTool.execute({ path: outside });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks mkdir outside sandbox', async () => {
+    const mkdirTool = findTool(tools, 'system.mkdir');
+    const rr = await mkdirTool.execute({ path: join(outside, 'escape') });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks delete outside sandbox', async () => {
+    const del = findTool(toolsWithDelete, 'system.delete');
+    const outsideFile = join(outside, 'protected.txt');
+    await writeFile(outsideFile, 'safe');
+
+    const rr = await del.execute({ path: outsideFile });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+
+    // Verify file is still there
+    const content = await readFile(outsideFile, 'utf-8');
+    expect(content).toBe('safe');
+  });
+
+  it('blocks move source outside sandbox', async () => {
+    const outsideFile = join(outside, 'src.txt');
+    await writeFile(outsideFile, 'data');
+
+    const move = findTool(tools, 'system.move');
+    const rr = await move.execute({ source: outsideFile, destination: join(sandbox, 'stolen.txt') });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks move destination outside sandbox (exfiltration)', async () => {
+    const src = join(sandbox, 'exfil-src.txt');
+    await writeFile(src, 'sensitive');
+
+    const move = findTool(tools, 'system.move');
+    const rr = await move.execute({ source: src, destination: join(outside, 'exfil.txt') });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+});
+
+describe('Security: path traversal prevention', () => {
+  it('blocks ../ traversal in readFile (caught by allowlist layer)', async () => {
+    const read = findTool(tools, 'system.readFile');
+    // path.join resolves '..', so the allowlist layer catches it as outside sandbox
+    const rr = await read.execute({ path: join(sandbox, '..', '..', 'etc', 'passwd') });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks ../ traversal in writeFile (caught by allowlist layer)', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const rr = await write.execute({ path: join(sandbox, '..', 'escape.txt'), content: 'x' });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks ../ traversal in mkdir (caught by allowlist layer)', async () => {
+    const mkdirTool = findTool(tools, 'system.mkdir');
+    const rr = await mkdirTool.execute({ path: join(sandbox, '..', 'escape-dir') });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks ../ traversal in move destination (caught by allowlist layer)', async () => {
+    const src = join(sandbox, 'traverse-src.txt');
+    await writeFile(src, 'data');
+
+    const move = findTool(tools, 'system.move');
+    const rr = await move.execute({
+      source: src,
+      destination: join(sandbox, '..', 'escaped.txt'),
+    });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks raw ../ segment strings (caught by traversal detector)', async () => {
+    // Pass raw string with .. segment that path.join would normally resolve
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: sandbox + '/subdir/../../../etc/passwd' });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('traversal');
+  });
+
+  it('allows filenames containing double dots (file..txt)', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const read = findTool(tools, 'system.readFile');
+    const filePath = join(sandbox, 'file..txt');
+
+    const wr = await write.execute({ path: filePath, content: 'dots' });
+    expect(wr.isError).toBeFalsy();
+
+    const rr = await read.execute({ path: filePath });
+    expect(parse(rr).content).toBe('dots');
+  });
+});
+
+describe('Security: null byte injection', () => {
+  it('blocks null byte in readFile path', async () => {
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: join(sandbox, 'file\x00.txt') });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('null byte');
+  });
+
+  it('blocks null byte in writeFile path', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const rr = await write.execute({ path: join(sandbox, 'file\x00.txt'), content: 'x' });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('null byte');
+  });
+});
+
+describe('Security: symlink escape prevention', () => {
+  it('blocks readFile through symlink pointing outside sandbox', async () => {
+    const outsideFile = join(outside, 'symlink-target.txt');
+    await writeFile(outsideFile, 'secret via symlink');
+
+    const link = join(sandbox, 'evil-link');
+    await symlink(outsideFile, link);
+
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: link });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks writeFile through symlink pointing outside sandbox', async () => {
+    const outsideFile = join(outside, 'symlink-write-target.txt');
+    await writeFile(outsideFile, 'original');
+
+    const link = join(sandbox, 'evil-write-link');
+    await symlink(outsideFile, link);
+
+    const write = findTool(tools, 'system.writeFile');
+    const rr = await write.execute({ path: link, content: 'overwritten!' });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+
+    // Verify file was NOT modified
+    const content = await readFile(outsideFile, 'utf-8');
+    expect(content).toBe('original');
+  });
+
+  it('blocks delete through symlink pointing outside sandbox', async () => {
+    const outsideFile = join(outside, 'symlink-delete-target.txt');
+    await writeFile(outsideFile, 'protect me');
+
+    const link = join(sandbox, 'evil-delete-link');
+    await symlink(outsideFile, link);
+
+    const del = findTool(toolsWithDelete, 'system.delete');
+    const rr = await del.execute({ path: link });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+
+    // Verify file still exists
+    const content = await readFile(outsideFile, 'utf-8');
+    expect(content).toBe('protect me');
+  });
+
+  it('blocks stat through symlink pointing outside sandbox', async () => {
+    const outsideFile = join(outside, 'symlink-stat-target.txt');
+    await writeFile(outsideFile, 'metadata');
+
+    const link = join(sandbox, 'evil-stat-link');
+    await symlink(outsideFile, link);
+
+    const statTool = findTool(tools, 'system.stat');
+    const rr = await statTool.execute({ path: link });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+
+  it('blocks move through directory symlink pointing outside', async () => {
+    // Create a symlink to outside dir
+    const link = join(sandbox, 'evil-dir-link');
+    await symlink(outside, link);
+
+    const src = join(sandbox, 'move-via-link.txt');
+    await writeFile(src, 'data');
+
+    const move = findTool(tools, 'system.move');
+    const rr = await move.execute({
+      source: src,
+      destination: join(link, 'stolen.txt'),
+    });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('outside allowed');
+  });
+});
+
+describe('Security: hard-link escape (known limitation)', () => {
+  it('allows read via in-sandbox hard link to outside inode (documents limitation)', async () => {
+    // Hard links bypass path-based security: the link path IS inside the sandbox,
+    // so realpath returns the sandbox path. The inode points outside, but
+    // path-based checks cannot detect this. This test documents the limitation.
+    const outsideFile = join(outside, 'hardlink-target.txt');
+    await writeFile(outsideFile, 'secret-via-hardlink');
+
+    const hardLink = join(sandbox, 'hardlink-inside');
+    try {
+      await link(outsideFile, hardLink);
+    } catch {
+      // Cross-device hard links fail on some systems — skip test
+      return;
+    }
+
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: hardLink });
+
+    // This SUCCEEDS — path-based security cannot detect hard-link escapes.
+    // Mitigation requires OS-level sandboxing (chroot, namespaces, seccomp).
+    expect(rr.isError).toBeFalsy();
+    expect(parse(rr).content).toBe('secret-via-hardlink');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 3. ENCODING & VALIDATION TESTS
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('Validation: encoding and content', () => {
+  it('rejects invalid encoding in readFile', async () => {
+    const filePath = join(sandbox, 'enc-test.txt');
+    await writeFile(filePath, 'data');
+
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: filePath, encoding: 'latin1' });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('encoding');
+  });
+
+  it('rejects invalid encoding in writeFile', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const rr = await write.execute({
+      path: join(sandbox, 'enc-test2.txt'),
+      content: 'data',
+      encoding: 'ascii',
+    });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('encoding');
+  });
+
+  it('rejects malformed base64 content in writeFile', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const rr = await write.execute({
+      path: join(sandbox, 'bad-b64.bin'),
+      content: 'not!valid!base64',
+      encoding: 'base64',
+    });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('base64');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 4. SIZE LIMIT TESTS
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('Limits: file size enforcement', () => {
+  it('rejects reading a file that exceeds maxReadBytes', async () => {
+    const smallTools = makeTools({ allowedPaths: [sandbox], maxReadBytes: 10 });
+    const filePath = join(sandbox, 'big-read.txt');
+    await writeFile(filePath, 'A'.repeat(100));
+
+    const read = findTool(smallTools, 'system.readFile');
+    const rr = await read.execute({ path: filePath });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('exceeds');
+  });
+
+  it('rejects writing content that exceeds maxWriteBytes', async () => {
+    const smallTools = makeTools({ allowedPaths: [sandbox], maxWriteBytes: 10 });
+    const write = findTool(smallTools, 'system.writeFile');
+    const rr = await write.execute({
+      path: join(sandbox, 'big-write.txt'),
+      content: 'A'.repeat(100),
+    });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('exceeds');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 5. EDGE CASES
+// ════════════════════════════════════════════════════════════════════════════
+
+describe('Edge cases', () => {
+  it('handles empty file correctly', async () => {
+    const filePath = join(sandbox, 'empty.txt');
+    await writeFile(filePath, '');
+
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: filePath });
+    expect(rr.isError).toBeFalsy();
+    expect(parse(rr).content).toBe('');
+  });
+
+  it('readFile returns error for non-existent file', async () => {
+    const read = findTool(tools, 'system.readFile');
+    const rr = await read.execute({ path: join(sandbox, 'does-not-exist.txt') });
+    expect(rr.isError).toBe(true);
+    expect(parse(rr).error).toContain('not found');
+  });
+
+  it('stat returns error for non-existent path', async () => {
+    const statTool = findTool(tools, 'system.stat');
+    const rr = await statTool.execute({ path: join(sandbox, 'ghost') });
+    expect(rr.isError).toBe(true);
+  });
+
+  it('returns correct tool count (8 tools)', () => {
+    expect(tools.length).toBe(8);
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual([
+      'system.appendFile',
+      'system.delete',
+      'system.listDir',
+      'system.mkdir',
+      'system.move',
+      'system.readFile',
+      'system.stat',
+      'system.writeFile',
+    ]);
+  });
+
+  it('all tools have valid inputSchema', () => {
+    for (const tool of tools) {
+      expect(tool.inputSchema).toBeDefined();
+      expect(tool.inputSchema.type).toBe('object');
+      expect(tool.inputSchema.required).toBeDefined();
+      expect(Array.isArray(tool.inputSchema.required)).toBe(true);
+    }
+  });
+
+  it('handles concurrent writes to different files', async () => {
+    const write = findTool(tools, 'system.writeFile');
+    const read = findTool(tools, 'system.readFile');
+
+    const promises = Array.from({ length: 10 }, (_, i) =>
+      write.execute({ path: join(sandbox, `concurrent-${i}.txt`), content: `file-${i}` }),
+    );
+    const results = await Promise.all(promises);
+    expect(results.every((r) => !r.isError)).toBe(true);
+
+    // Verify all files
+    for (let i = 0; i < 10; i++) {
+      const rr = await read.execute({ path: join(sandbox, `concurrent-${i}.txt`) });
+      expect(parse(rr).content).toBe(`file-${i}`);
+    }
+  });
+
+  it('never throws from execute — always returns ToolResult', async () => {
+    // Feed garbage inputs to every tool — none should throw
+    for (const tool of tools) {
+      const result = await tool.execute({});
+      // Should return an error result, not throw
+      expect(result).toBeDefined();
+      expect(typeof result.content).toBe('string');
+    }
+  });
+});
+
+// ============================================================================
+// Integration: listDir symlink type accuracy on real FS
+// ============================================================================
+
+describe('Integration: listDir symlink/other type accuracy', () => {
+  it('reports symlink type for symlinks in directory listing', async () => {
+    const dir = join(sandbox, 'listdir-symlink-types');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'real.txt'), 'hello');
+    // Symlink pointing outside sandbox (to /tmp which exists on all platforms)
+    await symlink('/tmp', join(dir, 'outside-link'));
+    // Symlink pointing within sandbox
+    await symlink(join(dir, 'real.txt'), join(dir, 'inside-link'));
+
+    const listDir = findTool(tools, 'system.listDir');
+    const rr = await listDir.execute({ path: dir });
+    expect(rr.isError).toBeFalsy();
+
+    const data = parse(rr);
+    const entries = data.entries as { name: string; type: string; size: number }[];
+
+    const realFile = entries.find((e) => e.name === 'real.txt');
+    expect(realFile).toBeDefined();
+    expect(realFile!.type).toBe('file');
+    expect(realFile!.size).toBeGreaterThan(0);
+
+    const outsideLink = entries.find((e) => e.name === 'outside-link');
+    expect(outsideLink).toBeDefined();
+    expect(outsideLink!.type).toBe('symlink');
+    // Symlink size should be 0 (not the target's size, since lstat is used)
+    expect(outsideLink!.size).toBe(0);
+
+    const insideLink = entries.find((e) => e.name === 'inside-link');
+    expect(insideLink).toBeDefined();
+    expect(insideLink!.type).toBe('symlink');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1068 — Phase 4.2: Filesystem tool (read, write, list, stat, delete)

Implements 8 MCP-compatible filesystem tools for `@agenc/runtime`, enabling agents to manage workspace files with configurable security boundaries (path allowlists, traversal prevention, size limits, delete opt-in).

## Tools Implemented

| Tool | Description | Key Features |
|------|-------------|--------------|
| `system.readFile` | Read file contents | Auto-detect text/binary, returns UTF-8 or base64, `maxReadBytes` enforcement, `isFile()` guard rejects device files |
| `system.writeFile` | Write file | Creates parent dirs, base64 input support, `maxWriteBytes` enforcement, base64 validation |
| `system.appendFile` | Append to file | Creates if not exists, cumulative file size check prevents disk exhaustion |
| `system.listDir` | List directory | Streaming `opendir()` API, 10k entry cap, returns name/type/size per entry |
| `system.stat` | File metadata | Returns size, modified, created, isDirectory, isFile, permissions (octal) |
| `system.mkdir` | Create directory | Recursive creation |
| `system.delete` | Delete file/dir | Requires explicit `allowDelete: true`, sandbox root deletion prevention |
| `system.move` | Move/rename | Both source and destination validated against allowlist |

## Security Architecture (5 rounds of review)

### 4-Layer Path Validation (defense-in-depth)

```
Input path
  │
  ├─ Layer 1: Null byte rejection ('