### PR TITLE
feat(runtime): bash tool with allow/deny lists and execFile security (#1067)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -851,10 +851,12 @@ export {
   type FilesystemToolConfig,
   // Bash
   createBashTool,
+  isCommandAllowed as isBashCommandAllowed,
   type BashToolConfig,
   type BashToolInput,
   type BashExecutionResult,
   DEFAULT_DENY_LIST,
+  DEFAULT_DENY_PREFIXES,
   DEFAULT_TIMEOUT_MS,
   DEFAULT_MAX_OUTPUT_BYTES,
 } from './tools/index.js';

--- a/runtime/src/tools/index.ts
+++ b/runtime/src/tools/index.ts
@@ -74,6 +74,7 @@ export {
   type BashToolInput,
   type BashExecutionResult,
   DEFAULT_DENY_LIST,
+  DEFAULT_DENY_PREFIXES,
   DEFAULT_TIMEOUT_MS,
   DEFAULT_MAX_OUTPUT_BYTES,
 } from './system/index.js';

--- a/runtime/src/tools/system/index.ts
+++ b/runtime/src/tools/system/index.ts
@@ -31,6 +31,7 @@ export {
   type BashToolInput,
   type BashExecutionResult,
   DEFAULT_DENY_LIST,
+  DEFAULT_DENY_PREFIXES,
   DEFAULT_TIMEOUT_MS,
   DEFAULT_MAX_OUTPUT_BYTES,
 } from './types.js';


### PR DESCRIPTION
## Summary
  - Add `system.bash` tool implementing the `Tool` interface with `execFile()` (no shell injection)
  - Allow/deny list validation before command execution, with a default deny list for dangerous commands
  - Configurable timeouts, output truncation, and per-call cwd overrides
  - 19 tests covering execution, security controls, input validation, and edge cases

  ## Test plan
  - [x] `npx vitest run src/tools/system/bash.test.ts` — 19/19 pass
  - [x] All 62 system tool tests pass (bash + HTTP)
  - [x] Typecheck clean (no new errors)

Closes #1067
