### PR TITLE
feat(runtime): skill CLI commands — list, info, validate, create, install

### DIFF
--- a/runtime/src/cli/skills-cli.test.ts
+++ b/runtime/src/cli/skills-cli.test.ts
@@ -1,0 +1,337 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliRuntimeContext } from './types.js';
+import type { DiscoveryPaths } from '../skills/markdown/discovery.js';
+import { buildSkillTemplate, runSkillCommand, SKILL_ERROR_CODES, type SkillCommandOverrides } from './skills-cli.js';
+
+function createContextCapture(): { context: CliRuntimeContext; outputs: unknown[]; errors: unknown[] } {
+  const outputs: unknown[] = [];
+  const errors: unknown[] = [];
+  return {
+    context: {
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      },
+      outputFormat: 'json',
+      output: (value) => outputs.push(value),
+      error: (value) => errors.push(value),
+    },
+    outputs,
+    errors,
+  };
+}
+
+const MOCK_SKILL_CONTENT = `---
+name: test-skill
+description: A test skill for testing
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - test
+      - mock
+---
+
+# Test Skill
+
+This is a test skill.
+`;
+
+const MOCK_SKILL_NO_BINARIES = `---
+name: simple-skill
+description: A simple skill with no requirements
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - simple
+---
+
+# Simple Skill
+
+No requirements here.
+`;
+
+const MOCK_SKILL_MISSING_NAME = `---
+description: A skill without a name
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - broken
+---
+
+# Broken
+
+Missing name field.
+`;
+
+describe('skills-cli', () => {
+  let workspace: string;
+  let skillsDir: string;
+  let userSkillsDir: string;
+  let discoveryPaths: DiscoveryPaths;
+  let overrides: SkillCommandOverrides;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'agenc-skill-cli-'));
+    skillsDir = join(workspace, 'builtin-skills');
+    userSkillsDir = join(workspace, 'user-skills');
+
+    // Create mock skill files (flat .md files in the directory)
+    mkdirSync(skillsDir, { recursive: true });
+    writeFileSync(join(skillsDir, 'test-skill.md'), MOCK_SKILL_CONTENT, 'utf-8');
+    writeFileSync(join(skillsDir, 'simple-skill.md'), MOCK_SKILL_NO_BINARIES, 'utf-8');
+
+    mkdirSync(userSkillsDir, { recursive: true });
+
+    discoveryPaths = {
+      builtinSkills: skillsDir,
+      userSkills: userSkillsDir,
+      projectSkills: join(workspace, 'project-skills'),
+    };
+
+    overrides = { discoveryPaths, userSkillsDir };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  describe('list', () => {
+    it('returns all discovered skills', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'list', [], {}, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { status: string; command: string; skills: unknown[]; count: number };
+      expect(result.status).toBe('ok');
+      expect(result.command).toBe('skill.list');
+      expect(result.count).toBe(2);
+      expect(result.skills).toHaveLength(2);
+    });
+
+    it('filters by tier', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'list', [], { tier: 'builtin' }, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { skills: Array<{ tier: string }> };
+      for (const skill of result.skills) {
+        expect(skill.tier).toBe('builtin');
+      }
+    });
+
+    it('returns empty when filtering by nonexistent tier', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'list', [], { tier: 'agent' }, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { skills: unknown[]; count: number };
+      expect(result.count).toBe(0);
+    });
+
+    it('filters available only', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'list', [], { available: true }, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { skills: Array<{ available: boolean }> };
+      for (const skill of result.skills) {
+        expect(skill.available).toBe(true);
+      }
+    });
+  });
+
+  describe('info', () => {
+    it('returns skill details', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'info', ['test-skill'], {}, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { status: string; command: string; skill: { name: string; tags: string[]; bodyLength: number } };
+      expect(result.status).toBe('ok');
+      expect(result.command).toBe('skill.info');
+      expect(result.skill.name).toBe('test-skill');
+      expect(result.skill.tags).toContain('test');
+      expect(result.skill.bodyLength).toBeGreaterThan(0);
+    });
+
+    it('throws SKILL_NOT_FOUND for missing skill', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'info', ['nonexistent'], {}, overrides),
+      ).rejects.toThrow('not found');
+    });
+
+    it('throws MISSING_SKILL_NAME when no name provided', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'info', [], {}, overrides),
+      ).rejects.toThrow('requires a skill name');
+    });
+  });
+
+  describe('validate', () => {
+    it('validates all skills and returns 0 when all pass', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'validate', [], {}, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { results: Array<{ name: string; valid: boolean }>; allValid: boolean };
+      expect(result.results).toHaveLength(2);
+      expect(result.allValid).toBe(true);
+    });
+
+    it('validates a single skill by name', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'validate', ['simple-skill'], {}, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { results: Array<{ name: string; valid: boolean }> };
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].name).toBe('simple-skill');
+      expect(result.results[0].valid).toBe(true);
+    });
+
+    it('returns 1 when a skill has parse errors', async () => {
+      writeFileSync(join(skillsDir, 'broken.md'), MOCK_SKILL_MISSING_NAME, 'utf-8');
+
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'validate', [], {}, overrides);
+
+      expect(code).toBe(1);
+      const result = outputs[0] as { results: Array<{ name: string; valid: boolean; parseErrors: unknown[] }>; allValid: boolean };
+      expect(result.allValid).toBe(false);
+      const broken = result.results.find((r) => r.name === '');
+      expect(broken).toBeDefined();
+      expect(broken!.valid).toBe(false);
+      expect(broken!.parseErrors.length).toBeGreaterThan(0);
+    });
+
+    it('throws SKILL_NOT_FOUND for missing skill name', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'validate', ['nonexistent'], {}, overrides),
+      ).rejects.toThrow('not found');
+    });
+  });
+
+  describe('create', () => {
+    it('scaffolds SKILL.md in user directory', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'create', ['my-skill'], {}, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { status: string; name: string; path: string; created: boolean };
+      expect(result.status).toBe('ok');
+      expect(result.command).toBe('skill.create');
+      expect(result.name).toBe('my-skill');
+      expect(result.created).toBe(true);
+      expect(existsSync(result.path)).toBe(true);
+
+      const content = readFileSync(result.path, 'utf-8');
+      expect(content).toContain('name: my-skill');
+      expect(content).toContain('version: 1.0.0');
+    });
+
+    it('uses custom description', async () => {
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'create', ['my-skill'], { description: 'Custom desc' }, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { path: string };
+      const content = readFileSync(result.path, 'utf-8');
+      expect(content).toContain('description: Custom desc');
+    });
+
+    it('throws MISSING_SKILL_NAME when no name provided', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'create', [], {}, overrides),
+      ).rejects.toThrow('requires a skill name');
+    });
+  });
+
+  describe('install', () => {
+    it('copies SKILL.md to user directory', async () => {
+      const sourcePath = join(workspace, 'external-skill.md');
+      writeFileSync(sourcePath, MOCK_SKILL_CONTENT, 'utf-8');
+
+      const { context, outputs } = createContextCapture();
+      const code = await runSkillCommand(context, 'install', [sourcePath], {}, overrides);
+
+      expect(code).toBe(0);
+      const result = outputs[0] as { status: string; name: string; installedPath: string };
+      expect(result.status).toBe('ok');
+      expect(result.command).toBe('skill.install');
+      expect(result.name).toBe('test-skill');
+      expect(existsSync(result.installedPath)).toBe(true);
+
+      const installed = readFileSync(result.installedPath, 'utf-8');
+      expect(installed).toContain('name: test-skill');
+    });
+
+    it('throws SOURCE_NOT_FOUND for missing source path', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'install', ['/nonexistent/path.md'], {}, overrides),
+      ).rejects.toThrow('not found');
+    });
+
+    it('throws SKILL_PARSE_ERROR when SKILL.md has no name', async () => {
+      const sourcePath = join(workspace, 'no-name.md');
+      writeFileSync(sourcePath, MOCK_SKILL_MISSING_NAME, 'utf-8');
+
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'install', [sourcePath], {}, overrides),
+      ).rejects.toThrow('has no name field');
+    });
+
+    it('throws MISSING_SOURCE_PATH when no path provided', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'install', [], {}, overrides),
+      ).rejects.toThrow('requires a source path');
+    });
+  });
+
+  describe('routing errors', () => {
+    it('throws MISSING_SKILL_COMMAND when no subcommand', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, undefined, [], {}, overrides),
+      ).rejects.toThrow('missing skill subcommand');
+    });
+
+    it('throws UNKNOWN_SKILL_COMMAND for invalid subcommand', async () => {
+      const { context } = createContextCapture();
+      await expect(
+        runSkillCommand(context, 'bogus', [], {}, overrides),
+      ).rejects.toThrow('unknown skill command');
+    });
+  });
+
+  describe('buildSkillTemplate', () => {
+    it('generates valid SKILL.md content', () => {
+      const content = buildSkillTemplate('my-skill', 'My custom skill');
+      expect(content).toContain('name: my-skill');
+      expect(content).toContain('description: My custom skill');
+      expect(content).toContain('version: 1.0.0');
+      expect(content).toContain('- my-skill');
+      expect(content).toContain('# My-skill');
+    });
+
+    it('uses default description when omitted', () => {
+      const content = buildSkillTemplate('test');
+      expect(content).toContain('description: A custom skill');
+    });
+  });
+});

--- a/runtime/src/cli/skills-cli.ts
+++ b/runtime/src/cli/skills-cli.ts
@@ -1,0 +1,334 @@
+/**
+ * Skill CLI subcommands — list, info, validate, create, install.
+ *
+ * @module
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { mkdir, writeFile, copyFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { SkillDiscovery, type DiscoveryPaths, type DiscoveryTier } from '../skills/markdown/discovery.js';
+import { parseSkillContent, validateSkillMetadata } from '../skills/markdown/parser.js';
+import type { CliRuntimeContext, CliStatusCode, CliValidationError } from './types.js';
+
+const SKILL_ERROR_CODES = {
+  MISSING_SKILL_COMMAND: 'MISSING_SKILL_COMMAND',
+  UNKNOWN_SKILL_COMMAND: 'UNKNOWN_SKILL_COMMAND',
+  SKILL_NOT_FOUND: 'SKILL_NOT_FOUND',
+  MISSING_SKILL_NAME: 'MISSING_SKILL_NAME',
+  MISSING_SOURCE_PATH: 'MISSING_SOURCE_PATH',
+  SOURCE_NOT_FOUND: 'SOURCE_NOT_FOUND',
+  SKILL_PARSE_ERROR: 'SKILL_PARSE_ERROR',
+} as const;
+
+function createSkillError(message: string, code: string): CliValidationError {
+  const error = new Error(message) as unknown as CliValidationError;
+  error.code = code;
+  return error;
+}
+
+export function getDefaultDiscoveryPaths(): DiscoveryPaths {
+  const home = homedir();
+  return {
+    userSkills: join(home, '.agenc', 'skills'),
+    projectSkills: join(process.cwd(), 'skills'),
+    // __dirname is available at runtime (CJS output)
+    builtinSkills: join(__dirname, '..', 'skills', 'bundled'),
+  };
+}
+
+export function getDefaultUserSkillsDir(): string {
+  return join(homedir(), '.agenc', 'skills');
+}
+
+const VALID_SKILL_SUBCOMMANDS = new Set(['list', 'info', 'validate', 'create', 'install']);
+
+export interface SkillCommandOverrides {
+  discoveryPaths?: DiscoveryPaths;
+  userSkillsDir?: string;
+}
+
+export async function runSkillCommand(
+  context: CliRuntimeContext,
+  subcommand: string | undefined,
+  positional: string[],
+  flags: Record<string, string | number | boolean>,
+  overrides?: SkillCommandOverrides,
+): Promise<CliStatusCode> {
+  if (!subcommand) {
+    throw createSkillError('missing skill subcommand', SKILL_ERROR_CODES.MISSING_SKILL_COMMAND);
+  }
+
+  if (!VALID_SKILL_SUBCOMMANDS.has(subcommand)) {
+    throw createSkillError(`unknown skill command: ${subcommand}`, SKILL_ERROR_CODES.UNKNOWN_SKILL_COMMAND);
+  }
+
+  const discoveryPaths = overrides?.discoveryPaths ?? getDefaultDiscoveryPaths();
+  const userSkillsDir = overrides?.userSkillsDir ?? getDefaultUserSkillsDir();
+
+  if (subcommand === 'list') {
+    const tier = typeof flags.tier === 'string' ? flags.tier : undefined;
+    const available = flags.available === true ? true : undefined;
+    return runSkillListCommand(context, discoveryPaths, { tier, available });
+  }
+
+  if (subcommand === 'info') {
+    const name = positional[0];
+    if (!name) {
+      throw createSkillError('skill info requires a skill name', SKILL_ERROR_CODES.MISSING_SKILL_NAME);
+    }
+    return runSkillInfoCommand(context, discoveryPaths, name);
+  }
+
+  if (subcommand === 'validate') {
+    const name = positional[0];
+    return runSkillValidateCommand(context, discoveryPaths, name);
+  }
+
+  if (subcommand === 'create') {
+    const name = positional[0];
+    if (!name) {
+      throw createSkillError('skill create requires a skill name', SKILL_ERROR_CODES.MISSING_SKILL_NAME);
+    }
+    const description = typeof flags.description === 'string' ? flags.description : undefined;
+    return runSkillCreateCommand(context, userSkillsDir, name, description);
+  }
+
+  // install
+  const sourcePath = positional[0];
+  if (!sourcePath) {
+    throw createSkillError('skill install requires a source path', SKILL_ERROR_CODES.MISSING_SOURCE_PATH);
+  }
+  return runSkillInstallCommand(context, userSkillsDir, sourcePath);
+}
+
+async function runSkillListCommand(
+  context: CliRuntimeContext,
+  discoveryPaths: DiscoveryPaths,
+  options: { tier?: string; available?: boolean },
+): Promise<CliStatusCode> {
+  const discovery = new SkillDiscovery(discoveryPaths);
+  let skills = await discovery.discoverAll();
+
+  if (options.tier) {
+    const tier = options.tier as DiscoveryTier;
+    skills = skills.filter((s) => s.tier === tier);
+  }
+
+  if (options.available === true) {
+    skills = skills.filter((s) => s.available);
+  }
+
+  context.output({
+    status: 'ok',
+    command: 'skill.list',
+    skills: skills.map((s) => ({
+      name: s.skill.name,
+      description: s.skill.description,
+      version: s.skill.version,
+      tier: s.tier,
+      available: s.available,
+      tags: s.skill.metadata.tags,
+    })),
+    count: skills.length,
+  });
+
+  return 0;
+}
+
+async function runSkillInfoCommand(
+  context: CliRuntimeContext,
+  discoveryPaths: DiscoveryPaths,
+  name: string,
+): Promise<CliStatusCode> {
+  const discovery = new SkillDiscovery(discoveryPaths);
+  const skills = await discovery.discoverAll();
+  const found = skills.find((s) => s.skill.name === name);
+
+  if (!found) {
+    throw createSkillError(
+      `skill "${name}" not found`,
+      SKILL_ERROR_CODES.SKILL_NOT_FOUND,
+    );
+  }
+
+  context.output({
+    status: 'ok',
+    command: 'skill.info',
+    skill: {
+      name: found.skill.name,
+      description: found.skill.description,
+      version: found.skill.version,
+      tier: found.tier,
+      available: found.available,
+      tags: found.skill.metadata.tags,
+      requires: found.skill.metadata.requires,
+      install: found.skill.metadata.install,
+      bodyLength: found.skill.body.length,
+      sourcePath: found.skill.sourcePath,
+      ...(found.missingRequirements
+        ? { missingRequirements: found.missingRequirements }
+        : {}),
+    },
+  });
+
+  return 0;
+}
+
+async function runSkillValidateCommand(
+  context: CliRuntimeContext,
+  discoveryPaths: DiscoveryPaths,
+  name?: string,
+): Promise<CliStatusCode> {
+  const discovery = new SkillDiscovery(discoveryPaths);
+  const skills = await discovery.discoverAll();
+
+  let targets = skills;
+  if (name) {
+    targets = skills.filter((s) => s.skill.name === name);
+    if (targets.length === 0) {
+      throw createSkillError(
+        `skill "${name}" not found`,
+        SKILL_ERROR_CODES.SKILL_NOT_FOUND,
+      );
+    }
+  }
+
+  const results = [];
+  let hasErrors = false;
+
+  for (const entry of targets) {
+    const parseErrors = validateSkillMetadata(entry.skill);
+    const missing = entry.missingRequirements ?? [];
+    const valid = parseErrors.length === 0 && missing.length === 0;
+    if (!valid) hasErrors = true;
+
+    results.push({
+      name: entry.skill.name,
+      valid,
+      parseErrors: parseErrors.map((e) => ({ field: e.field, message: e.message })),
+      missingRequirements: missing.map((m) => ({ type: m.type, name: m.name, message: m.message })),
+    });
+  }
+
+  context.output({
+    status: 'ok',
+    command: 'skill.validate',
+    results,
+    allValid: !hasErrors,
+  });
+
+  return hasErrors ? 1 : 0;
+}
+
+export function buildSkillTemplate(name: string, description?: string): string {
+  const desc = description ?? 'A custom skill';
+  const title = name.charAt(0).toUpperCase() + name.slice(1);
+
+  return `---
+name: ${name}
+description: ${desc}
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - ${name}
+---
+
+# ${title}
+
+## Overview
+
+Describe what this skill does.
+
+## Usage
+
+Add usage instructions and code examples here.
+`;
+}
+
+async function runSkillCreateCommand(
+  context: CliRuntimeContext,
+  userSkillsDir: string,
+  name: string,
+  description?: string,
+): Promise<CliStatusCode> {
+  const skillDir = join(userSkillsDir, name);
+  const skillPath = join(skillDir, 'SKILL.md');
+
+  await mkdir(skillDir, { recursive: true });
+
+  const content = buildSkillTemplate(name, description);
+  await writeFile(skillPath, content, 'utf-8');
+
+  context.output({
+    status: 'ok',
+    command: 'skill.create',
+    name,
+    path: skillPath,
+    created: true,
+  });
+
+  return 0;
+}
+
+async function runSkillInstallCommand(
+  context: CliRuntimeContext,
+  userSkillsDir: string,
+  sourcePath: string,
+): Promise<CliStatusCode> {
+  const source = resolve(sourcePath);
+
+  if (!existsSync(source)) {
+    throw createSkillError(
+      `source path "${source}" not found`,
+      SKILL_ERROR_CODES.SOURCE_NOT_FOUND,
+    );
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(source, 'utf-8');
+  } catch (error) {
+    throw createSkillError(
+      `failed to read "${source}": ${error instanceof Error ? error.message : String(error)}`,
+      SKILL_ERROR_CODES.SOURCE_NOT_FOUND,
+    );
+  }
+
+  let skill;
+  try {
+    skill = parseSkillContent(content, source);
+  } catch (error) {
+    throw createSkillError(
+      `failed to parse "${source}": ${error instanceof Error ? error.message : String(error)}`,
+      SKILL_ERROR_CODES.SKILL_PARSE_ERROR,
+    );
+  }
+
+  if (!skill.name) {
+    throw createSkillError(
+      `SKILL.md at "${source}" has no name field`,
+      SKILL_ERROR_CODES.SKILL_PARSE_ERROR,
+    );
+  }
+
+  const skillDir = join(userSkillsDir, skill.name);
+  const destPath = join(skillDir, 'SKILL.md');
+
+  await mkdir(skillDir, { recursive: true });
+  await copyFile(source, destPath);
+
+  context.output({
+    status: 'ok',
+    command: 'skill.install',
+    name: skill.name,
+    installedPath: destPath,
+    source,
+  });
+
+  return 0;
+}
+
+export { SKILL_ERROR_CODES };

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -175,3 +175,30 @@ export interface ServiceInstallOptions {
 export interface CliValidationError extends Error {
   code: string;
 }
+
+export interface SkillListOptions {
+  outputFormat: CliOutputFormat;
+  tier?: string;
+  available?: boolean;
+}
+
+export interface SkillInfoOptions {
+  outputFormat: CliOutputFormat;
+  name: string;
+}
+
+export interface SkillValidateOptions {
+  outputFormat: CliOutputFormat;
+  name?: string;
+}
+
+export interface SkillCreateOptions {
+  outputFormat: CliOutputFormat;
+  name: string;
+  description?: string;
+}
+
+export interface SkillInstallCopyOptions {
+  outputFormat: CliOutputFormat;
+  sourcePath: string;
+}


### PR DESCRIPTION
## Summary
  - Add `skill` CLI subcommand group with 5 commands: `list`, `info`, `validate`, `create`, `install`
  - Integrate with existing `SkillDiscovery` for 4-tier skill scanning and `validateSkillMetadata` for validation
  - `create` scaffolds a SKILL.md template in `~/.agenc/skills/`, `install` copies external SKILL.md files there
  - 22 tests covering all subcommands, error cases, and template generation

  ## Test plan
  - [ ] `npx vitest run src/cli/skills-cli.test.ts` — 22 tests pass
  - [ ] `npx vitest run src/cli/` — all 63 CLI tests pass (no regressions)
  - [ ] `npx tsc --noEmit` — no new type errors

  Closes #1074