### PR TITLE
feat(runtime): structured memory model — daily logs, curated facts, entity extraction

### DIFF
--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -58,3 +58,13 @@ export {
   type MemoryGraphConfig,
   type CompactOptions,
 } from './graph.js';
+
+// Structured memory (daily logs, curated facts, entity extraction)
+export {
+  formatLogDate,
+  DailyLogManager,
+  CuratedMemoryManager,
+  NoopEntityExtractor,
+  type StructuredMemoryEntry,
+  type EntityExtractor,
+} from './structured.js';

--- a/runtime/src/memory/structured.test.ts
+++ b/runtime/src/memory/structured.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  formatLogDate,
+  DailyLogManager,
+  CuratedMemoryManager,
+  NoopEntityExtractor,
+  type StructuredMemoryEntry,
+} from './structured.js';
+
+// ---------------------------------------------------------------------------
+// formatLogDate
+// ---------------------------------------------------------------------------
+
+describe('formatLogDate', () => {
+  it('returns YYYY-MM-DD for a known date', () => {
+    const d = new Date('2025-03-15T10:30:00Z');
+    expect(formatLogDate(d)).toBe('2025-03-15');
+  });
+
+  it('defaults to current date when no argument given', () => {
+    const result = formatLogDate();
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('uses UTC to avoid timezone shifts', () => {
+    // Jan 1 00:30 UTC — in UTC-5 this would still be Dec 31
+    const d = new Date('2025-01-01T00:30:00Z');
+    expect(formatLogDate(d)).toBe('2025-01-01');
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    const d = new Date('2025-02-03T12:00:00Z');
+    expect(formatLogDate(d)).toBe('2025-02-03');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StructuredMemoryEntry
+// ---------------------------------------------------------------------------
+
+describe('StructuredMemoryEntry', () => {
+  it('has all required fields', () => {
+    const entry: StructuredMemoryEntry = {
+      id: 'e1',
+      content: 'Alice prefers dark mode',
+      entityName: 'Alice',
+      entityType: 'person',
+      confidence: 0.9,
+      source: 'conversation',
+      tags: ['preference'],
+      createdAt: Date.now(),
+    };
+    expect(entry.id).toBe('e1');
+    expect(entry.tags).toEqual(['preference']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DailyLogManager
+// ---------------------------------------------------------------------------
+
+describe('DailyLogManager', () => {
+  let tmpDir: string;
+  let logDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'daily-log-'));
+    logDir = join(tmpDir, 'logs');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('creates the log file on first append', async () => {
+    const mgr = new DailyLogManager(logDir);
+    await mgr.append('sess-1', 'user', 'Hello');
+    const content = await mgr.readLog(formatLogDate());
+    expect(content).toBeDefined();
+    expect(content).toContain('**User:** Hello');
+  });
+
+  it('appends to the same file on subsequent calls', async () => {
+    const mgr = new DailyLogManager(logDir);
+    await mgr.append('sess-1', 'user', 'Hello');
+    await mgr.append('sess-1', 'assistant', 'Hi there');
+    const content = await mgr.readLog(formatLogDate());
+    expect(content).toContain('**User:** Hello');
+    expect(content).toContain('**Agent:** Hi there');
+  });
+
+  it('includes timestamp and session id in entries', async () => {
+    const mgr = new DailyLogManager(logDir);
+    await mgr.append('sess-42', 'user', 'test');
+    const content = await mgr.readLog(formatLogDate());
+    expect(content).toMatch(/## \d{2}:\d{2} \[sess-42\]/);
+  });
+
+  it('writes multiple sessions to the same day file', async () => {
+    const mgr = new DailyLogManager(logDir);
+    await mgr.append('sess-1', 'user', 'from session 1');
+    await mgr.append('sess-2', 'user', 'from session 2');
+    const content = await mgr.readLog(formatLogDate());
+    expect(content).toContain('[sess-1]');
+    expect(content).toContain('[sess-2]');
+  });
+
+  it('readLog returns undefined for missing date', async () => {
+    const mgr = new DailyLogManager(logDir);
+    const result = await mgr.readLog('1999-01-01');
+    expect(result).toBeUndefined();
+  });
+
+  it('listDates returns sorted date strings', async () => {
+    const mgr = new DailyLogManager(logDir);
+    await mgr.append('s1', 'user', 'a');
+    const dates = await mgr.listDates();
+    expect(dates).toHaveLength(1);
+    expect(dates[0]).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('listDates returns empty array for missing dir', async () => {
+    const mgr = new DailyLogManager(join(tmpDir, 'nonexistent'));
+    const dates = await mgr.listDates();
+    expect(dates).toEqual([]);
+  });
+
+  it('todayPath uses current date', () => {
+    const mgr = new DailyLogManager('/some/dir');
+    expect(mgr.todayPath).toContain(formatLogDate());
+    expect(mgr.todayPath).toMatch(/\.md$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CuratedMemoryManager
+// ---------------------------------------------------------------------------
+
+describe('CuratedMemoryManager', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'curated-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('load reads file content', async () => {
+    const mgr = new CuratedMemoryManager(join(tmpDir, 'MEMORY.md'));
+    await mgr.addFact('sky is blue');
+    const content = await mgr.load();
+    expect(content).toContain('- sky is blue');
+  });
+
+  it('load returns empty string if file missing', async () => {
+    const mgr = new CuratedMemoryManager(join(tmpDir, 'nope.md'));
+    expect(await mgr.load()).toBe('');
+  });
+
+  it('addFact appends a bullet line', async () => {
+    const mgr = new CuratedMemoryManager(join(tmpDir, 'MEMORY.md'));
+    await mgr.addFact('first');
+    await mgr.addFact('second');
+    const content = await mgr.load();
+    expect(content).toBe('- first\n- second\n');
+  });
+
+  it('removeFact removes matching line', async () => {
+    const mgr = new CuratedMemoryManager(join(tmpDir, 'MEMORY.md'));
+    await mgr.addFact('keep');
+    await mgr.addFact('remove me');
+    await mgr.addFact('also keep');
+    const removed = await mgr.removeFact('remove me');
+    expect(removed).toBe(true);
+    const content = await mgr.load();
+    expect(content).toContain('- keep');
+    expect(content).toContain('- also keep');
+    expect(content).not.toContain('remove me');
+  });
+
+  it('removeFact returns false if not found', async () => {
+    const mgr = new CuratedMemoryManager(join(tmpDir, 'MEMORY.md'));
+    await mgr.addFact('existing');
+    expect(await mgr.removeFact('nonexistent')).toBe(false);
+  });
+
+  it('removeFact returns false if file missing', async () => {
+    const mgr = new CuratedMemoryManager(join(tmpDir, 'nope.md'));
+    expect(await mgr.removeFact('anything')).toBe(false);
+  });
+
+  it('proposeAddition formats with source', () => {
+    const mgr = new CuratedMemoryManager(join(tmpDir, 'MEMORY.md'));
+    expect(mgr.proposeAddition('sky is blue', 'observation')).toBe(
+      '- sky is blue (source: observation)',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NoopEntityExtractor
+// ---------------------------------------------------------------------------
+
+describe('NoopEntityExtractor', () => {
+  it('extract returns empty array', async () => {
+    const extractor = new NoopEntityExtractor();
+    const result = await extractor.extract('some text', 'sess-1');
+    expect(result).toEqual([]);
+  });
+});

--- a/runtime/src/memory/structured.ts
+++ b/runtime/src/memory/structured.ts
@@ -1,0 +1,154 @@
+/**
+ * Structured memory model: daily conversation logs, curated long-term memory,
+ * and entity extraction interface (noop placeholder for Phase 5.4).
+ *
+ * @module
+ */
+
+import { readFile, writeFile, mkdir, appendFile, readdir, rename } from 'node:fs/promises';
+import { join, basename, dirname } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function isEnoent(err: unknown): boolean {
+  return err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+/** Returns `YYYY-MM-DD` in UTC for the given date (defaults to now). */
+export function formatLogDate(date?: Date): string {
+  const d = date ?? new Date();
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface StructuredMemoryEntry {
+  readonly id: string;
+  readonly content: string;
+  readonly entityName: string;
+  readonly entityType: string;
+  readonly confidence: number;
+  readonly source: string;
+  readonly tags: readonly string[];
+  readonly createdAt: number;
+}
+
+export interface EntityExtractor {
+  extract(text: string, sessionId: string): Promise<StructuredMemoryEntry[]>;
+}
+
+// ---------------------------------------------------------------------------
+// NoopEntityExtractor
+// ---------------------------------------------------------------------------
+
+export class NoopEntityExtractor implements EntityExtractor {
+  async extract(_text: string, _sessionId: string): Promise<StructuredMemoryEntry[]> {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DailyLogManager
+// ---------------------------------------------------------------------------
+
+export class DailyLogManager {
+  private readonly logDir: string;
+
+  constructor(logDir: string) {
+    this.logDir = logDir;
+  }
+
+  get todayPath(): string {
+    return join(this.logDir, formatLogDate() + '.md');
+  }
+
+  async append(sessionId: string, role: 'user' | 'assistant', content: string): Promise<void> {
+    await mkdir(this.logDir, { recursive: true });
+    const now = new Date();
+    const hh = String(now.getUTCHours()).padStart(2, '0');
+    const mm = String(now.getUTCMinutes()).padStart(2, '0');
+    const label = role === 'user' ? 'User' : 'Agent';
+    const line = `## ${hh}:${mm} [${sessionId}]\n**${label}:** ${content}\n\n`;
+    await appendFile(this.todayPath, line);
+  }
+
+  async readLog(date: string): Promise<string | undefined> {
+    try {
+      return await readFile(join(this.logDir, date + '.md'), 'utf-8');
+    } catch (err) {
+      if (isEnoent(err)) return undefined;
+      throw err;
+    }
+  }
+
+  async listDates(): Promise<string[]> {
+    try {
+      const files = await readdir(this.logDir);
+      return files
+        .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
+        .map((f) => basename(f, '.md'))
+        .sort();
+    } catch (err) {
+      if (isEnoent(err)) return [];
+      throw err;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CuratedMemoryManager
+// ---------------------------------------------------------------------------
+
+export class CuratedMemoryManager {
+  private readonly memoryFilePath: string;
+
+  constructor(memoryFilePath: string) {
+    this.memoryFilePath = memoryFilePath;
+  }
+
+  async load(): Promise<string> {
+    try {
+      return await readFile(this.memoryFilePath, 'utf-8');
+    } catch (err) {
+      if (isEnoent(err)) return '';
+      throw err;
+    }
+  }
+
+  proposeAddition(fact: string, source: string): string {
+    return `- ${fact} (source: ${source})`;
+  }
+
+  async addFact(fact: string): Promise<void> {
+    await mkdir(dirname(this.memoryFilePath), { recursive: true });
+    await appendFile(this.memoryFilePath, `- ${fact}\n`);
+  }
+
+  async removeFact(fact: string): Promise<boolean> {
+    let content: string;
+    try {
+      content = await readFile(this.memoryFilePath, 'utf-8');
+    } catch (err) {
+      if (isEnoent(err)) return false;
+      throw err;
+    }
+
+    const lines = content.split('\n');
+    const target = '- ' + fact;
+    const idx = lines.findIndex((line) => line.trimEnd() === target);
+    if (idx === -1) return false;
+
+    lines.splice(idx, 1);
+    const tmpPath = this.memoryFilePath + '.tmp';
+    await writeFile(tmpPath, lines.join('\n'));
+    await rename(tmpPath, this.memoryFilePath);
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `DailyLogManager` for append-only conversation logs partitioned by UTC date
- Adds `CuratedMemoryManager` for user-editable long-term memory (MEMORY.md) with atomic write-via-rename
- Adds `NoopEntityExtractor` as a placeholder interface for Phase 5.4 entity extraction
- Barrel exports from `runtime/src/memory/index.ts`
- 21 unit tests covering all public API

Closes #1080

## Test plan
- [x] `npx vitest run src/memory/structured.test.ts` — 21/21 passing
- [x] No new TypeScript errors in changed files