### PR TITLE
feat(runtime): multi-provider embedding generation (#1079)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -894,6 +894,14 @@ export {
   // Redis backend
   RedisBackend,
   type RedisBackendConfig,
+  // Embeddings
+  type EmbeddingProvider,
+  OpenAIEmbeddingProvider,
+  OllamaEmbeddingProvider,
+  NoopEmbeddingProvider,
+  createEmbeddingProvider,
+  cosineSimilarity,
+  normalizeVector,
   // Memory graph
   MemoryGraph,
   type ProvenanceSourceType,

--- a/runtime/src/memory/embeddings.test.ts
+++ b/runtime/src/memory/embeddings.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  NoopEmbeddingProvider,
+  OpenAIEmbeddingProvider,
+  OllamaEmbeddingProvider,
+  createEmbeddingProvider,
+  cosineSimilarity,
+  normalizeVector,
+} from './embeddings.js';
+
+// ============================================================================
+// NoopEmbeddingProvider
+// ============================================================================
+
+describe('NoopEmbeddingProvider', () => {
+  it('embed returns zero vector of correct dimension', async () => {
+    const provider = new NoopEmbeddingProvider(64);
+    const vec = await provider.embed('hello');
+
+    expect(vec).toHaveLength(64);
+    expect(vec.every((v) => v === 0)).toBe(true);
+  });
+
+  it('embedBatch returns correct number of vectors', async () => {
+    const provider = new NoopEmbeddingProvider(32);
+    const vecs = await provider.embedBatch(['a', 'b', 'c']);
+
+    expect(vecs).toHaveLength(3);
+    for (const vec of vecs) {
+      expect(vec).toHaveLength(32);
+      expect(vec.every((v) => v === 0)).toBe(true);
+    }
+  });
+
+  it('isAvailable returns true', async () => {
+    const provider = new NoopEmbeddingProvider();
+    expect(await provider.isAvailable()).toBe(true);
+  });
+
+  it('uses default dimension of 128', () => {
+    const provider = new NoopEmbeddingProvider();
+    expect(provider.dimension).toBe(128);
+  });
+
+  it('embed returns vector of correct dimension', async () => {
+    const provider = new NoopEmbeddingProvider(256);
+    const vec = await provider.embed('test text');
+    expect(vec).toHaveLength(256);
+  });
+
+  it('embedBatch handles empty input', async () => {
+    const provider = new NoopEmbeddingProvider();
+    const vecs = await provider.embedBatch([]);
+    expect(vecs).toHaveLength(0);
+  });
+
+  it('handles empty text input gracefully', async () => {
+    const provider = new NoopEmbeddingProvider(16);
+    const vec = await provider.embed('');
+    expect(vec).toHaveLength(16);
+  });
+});
+
+// ============================================================================
+// cosineSimilarity
+// ============================================================================
+
+describe('cosineSimilarity', () => {
+  it('identical vectors return 1.0', () => {
+    const v = [1, 2, 3, 4, 5];
+    expect(cosineSimilarity(v, v)).toBeCloseTo(1.0);
+  });
+
+  it('orthogonal vectors return 0.0', () => {
+    const a = [1, 0, 0];
+    const b = [0, 1, 0];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0.0);
+  });
+
+  it('opposite vectors return -1.0', () => {
+    const a = [1, 2, 3];
+    const b = [-1, -2, -3];
+    expect(cosineSimilarity(a, b)).toBeCloseTo(-1.0);
+  });
+
+  it('throws on length mismatch', () => {
+    expect(() => cosineSimilarity([1, 2], [1, 2, 3])).toThrow('Vector length mismatch');
+  });
+
+  it('returns 0 for zero vectors', () => {
+    expect(cosineSimilarity([0, 0, 0], [0, 0, 0])).toBe(0);
+  });
+
+  it('returns 0 for empty vectors', () => {
+    expect(cosineSimilarity([], [])).toBe(0);
+  });
+});
+
+// ============================================================================
+// normalizeVector
+// ============================================================================
+
+describe('normalizeVector', () => {
+  it('produces unit-length vector', () => {
+    const v = [3, 4];
+    const normalized = normalizeVector(v);
+
+    const magnitude = Math.sqrt(normalized.reduce((sum, x) => sum + x * x, 0));
+    expect(magnitude).toBeCloseTo(1.0);
+  });
+
+  it('handles zero vector gracefully', () => {
+    const v = [0, 0, 0];
+    const normalized = normalizeVector(v);
+
+    expect(normalized).toHaveLength(3);
+    expect(normalized.every((x) => x === 0)).toBe(true);
+  });
+
+  it('preserves direction', () => {
+    const v = [3, 4];
+    const normalized = normalizeVector(v);
+    // ratio between components should be preserved
+    expect(normalized[0] / normalized[1]).toBeCloseTo(3 / 4);
+  });
+
+  it('handles single-element vector', () => {
+    const normalized = normalizeVector([5]);
+    expect(normalized).toEqual([1]);
+  });
+});
+
+// ============================================================================
+// OpenAIEmbeddingProvider
+// ============================================================================
+
+describe('OpenAIEmbeddingProvider', () => {
+  it('constructor stores config', () => {
+    const provider = new OpenAIEmbeddingProvider({ apiKey: 'test-key' });
+    expect(provider.name).toBe('openai');
+    expect(provider.dimension).toBe(1536);
+  });
+
+  it('embed calls embedBatch and returns first result', async () => {
+    const provider = new OpenAIEmbeddingProvider({ apiKey: 'test-key' });
+    const mockEmbedding = Array.from({ length: 1536 }, (_, i) => i * 0.001);
+
+    // Mock the internal client
+    (provider as any).client = {
+      embeddings: {
+        create: vi.fn().mockResolvedValue({
+          data: [{ embedding: mockEmbedding }],
+        }),
+      },
+    };
+
+    const result = await provider.embed('hello');
+    expect(result).toEqual(mockEmbedding);
+  });
+
+  it('embedBatch returns correct number of vectors', async () => {
+    const provider = new OpenAIEmbeddingProvider({ apiKey: 'test-key' });
+    const mockVec1 = Array.from({ length: 1536 }, () => 0.1);
+    const mockVec2 = Array.from({ length: 1536 }, () => 0.2);
+
+    (provider as any).client = {
+      embeddings: {
+        create: vi.fn().mockResolvedValue({
+          data: [{ embedding: mockVec1 }, { embedding: mockVec2 }],
+        }),
+      },
+    };
+
+    const results = await provider.embedBatch(['a', 'b']);
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual(mockVec1);
+    expect(results[1]).toEqual(mockVec2);
+  });
+
+  it('embedBatch returns empty array for empty input', async () => {
+    const provider = new OpenAIEmbeddingProvider({ apiKey: 'test-key' });
+    const results = await provider.embedBatch([]);
+    expect(results).toHaveLength(0);
+  });
+
+  it('wraps API errors as MemoryBackendError', async () => {
+    const provider = new OpenAIEmbeddingProvider({ apiKey: 'test-key' });
+
+    (provider as any).client = {
+      embeddings: {
+        create: vi.fn().mockRejectedValue(new Error('API rate limited')),
+      },
+    };
+
+    await expect(provider.embed('test')).rejects.toThrow('Embedding generation failed');
+  });
+});
+
+// ============================================================================
+// OllamaEmbeddingProvider
+// ============================================================================
+
+describe('OllamaEmbeddingProvider', () => {
+  it('constructor stores config', () => {
+    const provider = new OllamaEmbeddingProvider({ host: 'http://custom:11434' });
+    expect(provider.name).toBe('ollama');
+    expect(provider.dimension).toBe(768);
+  });
+
+  it('uses defaults with no config', () => {
+    const provider = new OllamaEmbeddingProvider();
+    expect(provider.name).toBe('ollama');
+    expect(provider.dimension).toBe(768);
+  });
+
+  it('embed returns vector from Ollama API', async () => {
+    const provider = new OllamaEmbeddingProvider();
+    const mockEmbedding = Array.from({ length: 768 }, (_, i) => i * 0.001);
+
+    (provider as any).client = {
+      embed: vi.fn().mockResolvedValue({
+        embeddings: [mockEmbedding],
+      }),
+    };
+
+    const result = await provider.embed('hello');
+    expect(result).toEqual(mockEmbedding);
+  });
+
+  it('embedBatch calls embed sequentially', async () => {
+    const provider = new OllamaEmbeddingProvider();
+    const mockVec1 = Array.from({ length: 768 }, () => 0.1);
+    const mockVec2 = Array.from({ length: 768 }, () => 0.2);
+    let callCount = 0;
+
+    (provider as any).client = {
+      embed: vi.fn().mockImplementation(() => {
+        callCount++;
+        return Promise.resolve({
+          embeddings: [callCount === 1 ? mockVec1 : mockVec2],
+        });
+      }),
+    };
+
+    const results = await provider.embedBatch(['a', 'b']);
+    expect(results).toHaveLength(2);
+    expect((provider as any).client.embed).toHaveBeenCalledTimes(2);
+  });
+
+  it('wraps API errors as MemoryBackendError', async () => {
+    const provider = new OllamaEmbeddingProvider();
+
+    (provider as any).client = {
+      embed: vi.fn().mockRejectedValue(new Error('Connection refused')),
+    };
+
+    await expect(provider.embed('test')).rejects.toThrow('Embedding generation failed');
+  });
+});
+
+// ============================================================================
+// createEmbeddingProvider
+// ============================================================================
+
+describe('createEmbeddingProvider', () => {
+  it('with noop returns NoopProvider', async () => {
+    const provider = await createEmbeddingProvider({ preferred: 'noop' });
+    expect(provider).toBeInstanceOf(NoopEmbeddingProvider);
+    expect(provider.name).toBe('noop');
+  });
+
+  it('with openai returns OpenAIProvider', async () => {
+    const provider = await createEmbeddingProvider({
+      preferred: 'openai',
+      apiKey: 'test-key',
+    });
+    expect(provider).toBeInstanceOf(OpenAIEmbeddingProvider);
+  });
+
+  it('with openai without apiKey throws', async () => {
+    await expect(
+      createEmbeddingProvider({ preferred: 'openai' }),
+    ).rejects.toThrow('API key is required');
+  });
+
+  it('with ollama returns OllamaProvider', async () => {
+    const provider = await createEmbeddingProvider({ preferred: 'ollama' });
+    expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+  });
+
+  it('auto-selection falls back to Noop when no providers available', async () => {
+    // Mock Ollama isAvailable to return false so fallback chain reaches Noop
+    const spy = vi.spyOn(OllamaEmbeddingProvider.prototype, 'isAvailable').mockResolvedValue(false);
+    try {
+      // No apiKey, Ollama "not running" → should fall back to Noop
+      const provider = await createEmbeddingProvider();
+      expect(provider).toBeInstanceOf(NoopEmbeddingProvider);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('auto-selection with no config returns a provider', async () => {
+    const provider = await createEmbeddingProvider();
+    expect(provider).toBeDefined();
+    expect(provider.name).toBeDefined();
+    expect(typeof provider.dimension).toBe('number');
+  });
+});

--- a/runtime/src/memory/embeddings.ts
+++ b/runtime/src/memory/embeddings.ts
@@ -1,0 +1,301 @@
+/**
+ * Multi-provider embedding generation for semantic memory.
+ *
+ * Supports OpenAI/Grok (via compatible API), Ollama (local), and a Noop
+ * provider for testing. Provider auto-selection tries local-first for
+ * privacy, then falls back to cloud providers.
+ *
+ * @module
+ */
+
+import { ensureLazyModule } from '../utils/lazy-import.js';
+import { MemoryBackendError, MemoryConnectionError } from './errors.js';
+
+// ============================================================================
+// Interface
+// ============================================================================
+
+/** Embedding provider interface. */
+export interface EmbeddingProvider {
+  /** Provider name for logging. */
+  readonly name: string;
+  /** Embedding dimension. */
+  readonly dimension: number;
+  /** Generate embedding for a single text. */
+  embed(text: string): Promise<number[]>;
+  /** Generate embeddings for a batch of texts. */
+  embedBatch(texts: string[]): Promise<number[][]>;
+  /** Check if provider is available. */
+  isAvailable(): Promise<boolean>;
+}
+
+// ============================================================================
+// OpenAI-compatible provider (works with Grok)
+// ============================================================================
+
+const OPENAI_DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+const OPENAI_DEFAULT_MODEL = 'text-embedding-3-small';
+const OPENAI_DEFAULT_DIMENSION = 1536;
+
+/** OpenAI-compatible embedding provider (works with Grok). */
+export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'openai';
+  readonly dimension = OPENAI_DEFAULT_DIMENSION;
+
+  private client: unknown | null = null;
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly model: string;
+
+  constructor(config: { apiKey: string; baseUrl?: string; model?: string }) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl ?? OPENAI_DEFAULT_BASE_URL;
+    this.model = config.model ?? OPENAI_DEFAULT_MODEL;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const results = await this.embedBatch([text]);
+    return results[0];
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    const client = await this.ensureClient();
+    try {
+      const response = await (client as any).embeddings.create({
+        model: this.model,
+        input: texts,
+      });
+      return response.data.map((item: any) => item.embedding as number[]);
+    } catch (err: unknown) {
+      throw new MemoryBackendError(
+        this.name,
+        `Embedding generation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const client = await this.ensureClient();
+      await (client as any).models.list();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async ensureClient(): Promise<unknown> {
+    if (this.client) return this.client;
+
+    this.client = await ensureLazyModule(
+      'openai',
+      (msg) => new MemoryConnectionError(this.name, msg),
+      (mod) => {
+        const OpenAI = (mod.default ?? mod.OpenAI ?? mod) as any;
+        return new OpenAI({
+          apiKey: this.apiKey,
+          baseURL: this.baseUrl,
+        });
+      },
+    );
+    return this.client;
+  }
+}
+
+// ============================================================================
+// Ollama local provider
+// ============================================================================
+
+const OLLAMA_DEFAULT_HOST = 'http://localhost:11434';
+const OLLAMA_DEFAULT_MODEL = 'nomic-embed-text';
+const OLLAMA_DEFAULT_DIMENSION = 768;
+
+/** Ollama local embedding provider. */
+export class OllamaEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'ollama';
+  readonly dimension = OLLAMA_DEFAULT_DIMENSION;
+
+  private client: unknown | null = null;
+  private readonly host: string;
+  private readonly model: string;
+
+  constructor(config?: { host?: string; model?: string }) {
+    this.host = config?.host ?? OLLAMA_DEFAULT_HOST;
+    this.model = config?.model ?? OLLAMA_DEFAULT_MODEL;
+  }
+
+  async embed(text: string): Promise<number[]> {
+    const client = await this.ensureClient();
+    try {
+      const response = await (client as any).embed({
+        model: this.model,
+        input: text,
+      });
+      return response.embeddings[0] as number[];
+    } catch (err: unknown) {
+      throw new MemoryBackendError(
+        this.name,
+        `Embedding generation failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    if (texts.length === 0) return [];
+
+    // Ollama: map to sequential calls
+    const results: number[][] = [];
+    for (const text of texts) {
+      results.push(await this.embed(text));
+    }
+    return results;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    try {
+      const client = await this.ensureClient();
+      await (client as any).list();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async ensureClient(): Promise<unknown> {
+    if (this.client) return this.client;
+
+    this.client = await ensureLazyModule(
+      'ollama',
+      (msg) => new MemoryConnectionError(this.name, msg),
+      (mod) => {
+        const OllamaClass = (mod.Ollama ?? mod.default) as any;
+        return new OllamaClass({ host: this.host });
+      },
+    );
+    return this.client;
+  }
+}
+
+// ============================================================================
+// Noop provider (testing)
+// ============================================================================
+
+/** Noop provider for testing (returns zero vectors). */
+export class NoopEmbeddingProvider implements EmbeddingProvider {
+  readonly name = 'noop';
+  readonly dimension: number;
+
+  constructor(dimension?: number) {
+    this.dimension = dimension ?? 128;
+  }
+
+  async embed(_text: string): Promise<number[]> {
+    return new Array(this.dimension).fill(0);
+  }
+
+  async embedBatch(texts: string[]): Promise<number[][]> {
+    return texts.map(() => new Array(this.dimension).fill(0));
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+}
+
+// ============================================================================
+// Factory with auto-selection
+// ============================================================================
+
+/** Create embedding provider with auto-selection fallback chain. */
+export async function createEmbeddingProvider(config?: {
+  preferred?: 'openai' | 'ollama' | 'noop';
+  apiKey?: string;
+  baseUrl?: string;
+  model?: string;
+}): Promise<EmbeddingProvider> {
+  if (config?.preferred === 'noop') {
+    return new NoopEmbeddingProvider();
+  }
+
+  if (config?.preferred === 'openai') {
+    if (!config.apiKey) {
+      throw new MemoryBackendError('openai', 'API key is required for OpenAI embedding provider');
+    }
+    return new OpenAIEmbeddingProvider({
+      apiKey: config.apiKey,
+      baseUrl: config.baseUrl,
+      model: config.model,
+    });
+  }
+
+  if (config?.preferred === 'ollama') {
+    return new OllamaEmbeddingProvider({
+      host: config.baseUrl,
+      model: config.model,
+    });
+  }
+
+  // Auto-selection: Ollama (local, private) → OpenAI/Grok → Noop fallback
+  const ollama = new OllamaEmbeddingProvider({
+    host: config?.baseUrl,
+    model: config?.model,
+  });
+  if (await ollama.isAvailable()) {
+    return ollama;
+  }
+
+  if (config?.apiKey) {
+    const openai = new OpenAIEmbeddingProvider({
+      apiKey: config.apiKey,
+      baseUrl: config.baseUrl,
+      model: config.model,
+    });
+    if (await openai.isAvailable()) {
+      return openai;
+    }
+  }
+
+  return new NoopEmbeddingProvider();
+}
+
+// ============================================================================
+// Vector utilities
+// ============================================================================
+
+/** Cosine similarity between two vectors. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error(`Vector length mismatch: ${a.length} vs ${b.length}`);
+  }
+  if (a.length === 0) return 0;
+
+  let dotProduct = 0;
+  let normA = 0;
+  let normB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+
+  const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+  if (denominator === 0) return 0;
+
+  return dotProduct / denominator;
+}
+
+/** Normalize a vector to unit length. */
+export function normalizeVector(v: number[]): number[] {
+  let squaredSum = 0;
+  for (let i = 0; i < v.length; i++) {
+    squaredSum += v[i] * v[i];
+  }
+
+  const norm = Math.sqrt(squaredSum);
+  if (norm === 0) return new Array(v.length).fill(0);
+
+  return v.map((x) => x / norm);
+}

--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -43,6 +43,17 @@ export { SqliteBackend, type SqliteBackendConfig } from './sqlite/index.js';
 // Redis backend (optional ioredis)
 export { RedisBackend, type RedisBackendConfig } from './redis/index.js';
 
+// Embeddings (Phase 5.1)
+export {
+  type EmbeddingProvider,
+  OpenAIEmbeddingProvider,
+  OllamaEmbeddingProvider,
+  NoopEmbeddingProvider,
+  createEmbeddingProvider,
+  cosineSimilarity,
+  normalizeVector,
+} from './embeddings.js';
+
 // Provenance-aware graph layer
 export {
   MemoryGraph,


### PR DESCRIPTION
## Summary
- Add `EmbeddingProvider` interface with `embed`, `embedBatch`, and `isAvailable` methods
- Implement `OpenAIEmbeddingProvider` (works with Grok via compatible API, lazy-loaded)
- Implement `OllamaEmbeddingProvider` (local inference, lazy-loaded, sequential batch)
- Implement `NoopEmbeddingProvider` for testing (zero vectors)
- Add `createEmbeddingProvider` factory with auto-selection fallback chain: Ollama (local, private) → OpenAI/Grok → Noop
- Add `cosineSimilarity` and `normalizeVector` vector utility functions

## Test plan
- 33 tests covering all 15 specified test cases plus edge cases
- Noop provider: zero vectors, correct dimensions, batch, empty input
- OpenAI provider: config storage, embed/embedBatch with mocked client, error wrapping
- Ollama provider: config storage, embed/embedBatch with mocked client, sequential batch verification, error wrapping
- Factory: preferred provider selection, auto-selection fallback, missing apiKey validation
- Vector utils: identical/orthogonal/opposite cosine similarity, unit normalization, zero vector handling

Closes #1079