### PR TITLE
feat(runtime): skill CLI commands (#1074)

### DIFF
--- a/runtime/src/cli/index.ts
+++ b/runtime/src/cli/index.ts
@@ -24,9 +24,25 @@ import {
   HealthOptions,
   DoctorOptions,
   SecurityOptions,
+  SkillCommandOptions,
+  SkillInfoOptions,
+  SkillCreateOptions,
+  SkillInstallOptions,
+  SkillUninstallOptions,
+  SkillToggleOptions,
 } from './types.js';
 import { validateConfigStrict } from '../types/config-migration.js';
 import { runSecurityCommand } from './security.js';
+import {
+  runSkillListCommand,
+  runSkillInfoCommand,
+  runSkillValidateCommand,
+  runSkillCreateCommand,
+  runSkillInstallCommand,
+  runSkillUninstallCommand,
+  runSkillEnableCommand,
+  runSkillDisableCommand,
+} from './skills-cli.js';
 import { runOnboardCommand } from './onboard.js';
 import { runDoctorCommand, runHealthCommand } from './health.js';
 import {
@@ -246,6 +262,86 @@ const PLUGIN_COMMANDS: Record<PluginCommand, PluginCommandDescriptor> = {
   },
 };
 
+type SkillCommand = 'list' | 'info' | 'validate' | 'create' | 'install' | 'uninstall' | 'enable' | 'disable';
+
+const SKILL_COMMAND_OPTIONS: Record<SkillCommand, Set<string>> = {
+  list: new Set(),
+  info: new Set(),
+  validate: new Set(),
+  create: new Set(),
+  install: new Set(),
+  uninstall: new Set(),
+  enable: new Set(),
+  disable: new Set(),
+};
+
+interface SkillCommandDescriptor {
+  name: string;
+  description: string;
+  commandOptions: Set<string>;
+  run: (
+    context: CliRuntimeContext,
+    options: SkillCommandOptions,
+  ) => Promise<CliStatusCode>;
+}
+
+const SKILL_COMMANDS: Record<SkillCommand, SkillCommandDescriptor> = {
+  list: {
+    name: 'list',
+    description: 'List all discovered skills',
+    commandOptions: SKILL_COMMAND_OPTIONS.list,
+    run: runSkillListCommand,
+  },
+  info: {
+    name: 'info',
+    description: 'Show detailed skill information',
+    commandOptions: SKILL_COMMAND_OPTIONS.info,
+    run: runSkillInfoCommand,
+  },
+  validate: {
+    name: 'validate',
+    description: 'Validate all discovered skills',
+    commandOptions: SKILL_COMMAND_OPTIONS.validate,
+    run: runSkillValidateCommand,
+  },
+  create: {
+    name: 'create',
+    description: 'Scaffold a new skill in ~/.agenc/skills/',
+    commandOptions: SKILL_COMMAND_OPTIONS.create,
+    run: runSkillCreateCommand,
+  },
+  install: {
+    name: 'install',
+    description: 'Install a skill from URL or local path',
+    commandOptions: SKILL_COMMAND_OPTIONS.install,
+    run: runSkillInstallCommand,
+  },
+  uninstall: {
+    name: 'uninstall',
+    description: 'Remove a user-level skill',
+    commandOptions: SKILL_COMMAND_OPTIONS.uninstall,
+    run: runSkillUninstallCommand,
+  },
+  enable: {
+    name: 'enable',
+    description: 'Enable a disabled skill',
+    commandOptions: SKILL_COMMAND_OPTIONS.enable,
+    run: runSkillEnableCommand,
+  },
+  disable: {
+    name: 'disable',
+    description: 'Disable a skill',
+    commandOptions: SKILL_COMMAND_OPTIONS.disable,
+    run: runSkillDisableCommand,
+  },
+};
+
+function validateSkillCommand(name: string): name is SkillCommand {
+  return name === 'list' || name === 'info' || name === 'validate'
+    || name === 'create' || name === 'install' || name === 'uninstall'
+    || name === 'enable' || name === 'disable';
+}
+
 const ERROR_CODES = {
   MISSING_ROOT_COMMAND: 'MISSING_ROOT_COMMAND',
   UNKNOWN_COMMAND: 'UNKNOWN_COMMAND',
@@ -258,6 +354,8 @@ const ERROR_CODES = {
   MISSING_REQUIRED_OPTION: 'MISSING_REQUIRED_OPTION',
   CONFIG_PARSE_ERROR: 'CONFIG_PARSE_ERROR',
   MISSING_TARGET: 'MISSING_TARGET',
+  MISSING_SKILL_COMMAND: 'MISSING_SKILL_COMMAND',
+  UNKNOWN_SKILL_COMMAND: 'UNKNOWN_SKILL_COMMAND',
   INTERNAL_ERROR: 'INTERNAL_ERROR',
 } as const;
 
@@ -283,6 +381,7 @@ function buildHelp(): string {
     'service install [--help] [options]',
     'replay [--help] <command> [options]',
     'plugin [--help] <command> [options]',
+    'skill [--help] <command> [options]',
     '',
     'Bootstrap commands:',
     '  onboard   Generate a runtime config file and run sanity checks',
@@ -301,6 +400,16 @@ function buildHelp(): string {
     '  backfill   Backfill replay timeline from on-chain history',
     '  compare    Compare replay projection against local trace',
     '  incident   Reconstruct incident timeline and summarize',
+    '',
+    'Skill subcommands:',
+    '  list                               List all discovered skills',
+    '  info <name>                        Show detailed skill information',
+    '  validate                           Validate all discovered skills',
+    '  create <name>                      Scaffold a new skill in ~/.agenc/skills/',
+    '  install <url-or-path>              Install a skill from URL or local path',
+    '  uninstall <name>                   Remove a user-level skill',
+    '  enable <name>                      Enable a disabled skill',
+    '  disable <name>                     Disable a skill',
     '',
     'Plugin subcommands:',
     '  list                               List registered plugins',
@@ -394,6 +503,14 @@ function buildHelp(): string {
     '  agenc-runtime plugin install --manifest ./plugin.json --precedence workspace --slot llm',
     '  agenc-runtime plugin disable memory.plugin',
     '  agenc-runtime plugin list',
+    '  agenc-runtime skill list',
+    '  agenc-runtime skill info my-skill',
+    '  agenc-runtime skill validate',
+    '  agenc-runtime skill create my-new-skill',
+    '  agenc-runtime skill install ./path/to/skill.md',
+    '  agenc-runtime skill uninstall my-skill',
+    '  agenc-runtime skill enable my-skill',
+    '  agenc-runtime skill disable my-skill',
   ].join('\n');
 }
 
@@ -1217,6 +1334,109 @@ function normalizeAndValidatePluginCommand(
   };
 }
 
+interface SkillParseReport {
+  command: 'skill';
+  skillCommand: SkillCommand;
+  global: {
+    help: boolean;
+    strictMode: boolean;
+    outputFormat: CliOutputFormat;
+    role?: OperatorRole;
+    rpcUrl?: string;
+    programId?: string;
+    storeType: 'memory' | 'sqlite';
+    sqlitePath?: string;
+    traceId?: string;
+    idempotencyWindow: number;
+  };
+  options: SkillCommandOptions;
+  outputFormat: CliOutputFormat;
+}
+
+function normalizeAndValidateSkillCommand(
+  parsed: ParsedArgv,
+): SkillParseReport {
+  const configPath = resolveConfigPath(parsed.flags);
+  let fileConfig: CliFileConfig;
+  try {
+    fileConfig = loadFileConfig(configPath);
+  } catch (error) {
+    throw createCliError(`failed to parse config file ${configPath}: ${error instanceof Error ? error.message : String(error)}`, ERROR_CODES.CONFIG_PARSE_ERROR);
+  }
+
+  const envConfig = readEnvironmentConfig();
+
+  const skillCommand = parsed.positional[1] as string | undefined;
+  if (!skillCommand) {
+    throw createCliError('missing skill subcommand', ERROR_CODES.MISSING_SKILL_COMMAND);
+  }
+  if (!validateSkillCommand(skillCommand)) {
+    throw createCliError(`unknown skill command: ${skillCommand}`, ERROR_CODES.UNKNOWN_SKILL_COMMAND);
+  }
+
+  validateUnknownStandaloneOptions(parsed.flags, SKILL_COMMAND_OPTIONS[skillCommand]);
+
+  const global = normalizeGlobalFlags(parsed.flags, fileConfig, envConfig);
+
+  const base: BaseCliOptions = {
+    help: global.help,
+    outputFormat: global.outputFormat,
+    strictMode: global.strictMode,
+    role: global.role,
+    rpcUrl: global.rpcUrl,
+    programId: global.programId,
+    storeType: global.storeType,
+    sqlitePath: global.sqlitePath,
+    traceId: global.traceId,
+    idempotencyWindow: global.idempotencyWindow,
+  };
+
+  let options: SkillCommandOptions;
+
+  if (skillCommand === 'info' || skillCommand === 'enable' || skillCommand === 'disable' || skillCommand === 'uninstall' || skillCommand === 'create') {
+    const target = parsed.positional[2];
+    if (!target) {
+      throw createCliError(`skill ${skillCommand} requires a name argument`, ERROR_CODES.MISSING_TARGET);
+    }
+    if (skillCommand === 'info') {
+      options = { ...base, skillName: target } as SkillInfoOptions;
+    } else if (skillCommand === 'create') {
+      options = { ...base, skillName: target } as SkillCreateOptions;
+    } else if (skillCommand === 'uninstall') {
+      options = { ...base, skillName: target } as SkillUninstallOptions;
+    } else {
+      options = { ...base, skillName: target } as SkillToggleOptions;
+    }
+  } else if (skillCommand === 'install') {
+    const source = parsed.positional[2];
+    if (!source) {
+      throw createCliError('skill install requires a source argument', ERROR_CODES.MISSING_TARGET);
+    }
+    options = { ...base, source } as SkillInstallOptions;
+  } else {
+    options = { ...base };
+  }
+
+  return {
+    command: 'skill',
+    skillCommand,
+    global: {
+      help: base.help,
+      strictMode: base.strictMode,
+      outputFormat: base.outputFormat,
+      role: base.role,
+      rpcUrl: base.rpcUrl,
+      programId: base.programId,
+      storeType: base.storeType,
+      sqlitePath: base.sqlitePath,
+      traceId: base.traceId,
+      idempotencyWindow: base.idempotencyWindow,
+    },
+    options,
+    outputFormat: base.outputFormat,
+  };
+}
+
 export async function runCli(options: CliRunOptions = {}): Promise<CliStatusCode> {
   const argv = options.argv ?? process.argv.slice(2);
   const stdout = options.stdout ?? process.stdout;
@@ -1474,6 +1694,38 @@ export async function runCli(options: CliRunOptions = {}): Promise<CliStatusCode
       const payload = buildErrorPayload(error);
       context.error(payload);
       return payload.code === ERROR_CODES.INVALID_OPTION ? 2 : 1;
+    }
+  }
+
+  if (parsed.positional[0] === 'skill') {
+    let skillReport: SkillParseReport;
+    try {
+      skillReport = normalizeAndValidateSkillCommand(parsed);
+    } catch (error) {
+      const payload = buildErrorPayload(error);
+      context.error(payload);
+      return 2;
+    }
+
+    const skillContext = createContext(
+      stdout,
+      stderr,
+      skillReport.outputFormat,
+      normalizeLogLevel(parsed.flags['log-level']),
+    );
+
+    if (skillReport.global.help) {
+      skillContext.output(buildHelp());
+      return 0;
+    }
+
+    const skillDescriptor = SKILL_COMMANDS[skillReport.skillCommand];
+    try {
+      return await skillDescriptor.run(skillContext, skillReport.options);
+    } catch (error) {
+      const payload = buildErrorPayload(error);
+      skillContext.error(payload);
+      return 1;
     }
   }
 

--- a/runtime/src/cli/skills-cli-integration.test.ts
+++ b/runtime/src/cli/skills-cli-integration.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Integration tests for skill CLI routing via runCli.
+ *
+ * These import index.ts which transitively pulls in @agenc/sdk via replay.ts.
+ * They will fail at module resolution until @agenc/sdk is built/linked.
+ *
+ * To run: npx vitest run src/cli/skills-cli-integration.test.ts
+ */
+import { Writable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { runCli } from './index.js';
+
+function createNullStream(): Writable {
+  return new Writable({ write(_chunk, _encoding, cb) { cb(); } });
+}
+
+function captureStream(): { stream: Writable; data: string } {
+  let data = '';
+  const stream = new Writable({
+    write(chunk, _encoding, cb) {
+      data += chunk.toString();
+      cb();
+    },
+  });
+  return {
+    stream,
+    get data() { return data; },
+  };
+}
+
+describe('skill cli integration', () => {
+  it('skill list routes correctly', async () => {
+    const out = captureStream();
+    const err = createNullStream();
+
+    const code = await runCli({
+      argv: ['skill', 'list'],
+      stdout: out.stream,
+      stderr: err,
+    });
+
+    expect(code).toBe(0);
+    const payload = JSON.parse(out.data.trim());
+    expect(payload.status).toBe('ok');
+    expect(payload.command).toBe('skill.list');
+  });
+
+  it('skill with missing subcommand returns exit 2', async () => {
+    const out = createNullStream();
+    const err = captureStream();
+
+    const code = await runCli({
+      argv: ['skill'],
+      stdout: out,
+      stderr: err.stream,
+    });
+
+    expect(code).toBe(2);
+    const payload = JSON.parse(err.data.trim());
+    expect(payload.code).toBe('MISSING_SKILL_COMMAND');
+  });
+
+  it('skill with unknown subcommand returns exit 2', async () => {
+    const out = createNullStream();
+    const err = captureStream();
+
+    const code = await runCli({
+      argv: ['skill', 'bogus'],
+      stdout: out,
+      stderr: err.stream,
+    });
+
+    expect(code).toBe(2);
+    const payload = JSON.parse(err.data.trim());
+    expect(payload.code).toBe('UNKNOWN_SKILL_COMMAND');
+  });
+
+  it('skill info without name returns exit 2', async () => {
+    const out = createNullStream();
+    const err = captureStream();
+
+    const code = await runCli({
+      argv: ['skill', 'info'],
+      stdout: out,
+      stderr: err.stream,
+    });
+
+    expect(code).toBe(2);
+    const payload = JSON.parse(err.data.trim());
+    expect(payload.code).toBe('MISSING_TARGET');
+  });
+
+  it('skill --help shows help text', async () => {
+    const out = captureStream();
+    const err = createNullStream();
+
+    const code = await runCli({
+      argv: ['skill', 'list', '--help'],
+      stdout: out.stream,
+      stderr: err,
+    });
+
+    expect(code).toBe(0);
+    expect(out.data).toContain('Skill subcommands');
+  });
+});

--- a/runtime/src/cli/skills-cli.test.ts
+++ b/runtime/src/cli/skills-cli.test.ts
@@ -1,0 +1,444 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliRuntimeContext, SkillCommandOptions } from './types.js';
+import {
+  runSkillListCommand,
+  runSkillInfoCommand,
+  runSkillValidateCommand,
+  runSkillCreateCommand,
+  runSkillInstallCommand,
+  runSkillUninstallCommand,
+  runSkillEnableCommand,
+  runSkillDisableCommand,
+} from './skills-cli.js';
+import type { DiscoveryPaths } from '../skills/markdown/discovery.js';
+
+function createContextCapture(): { context: CliRuntimeContext; outputs: unknown[]; errors: unknown[] } {
+  const outputs: unknown[] = [];
+  const errors: unknown[] = [];
+  return {
+    context: {
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      },
+      outputFormat: 'json',
+      output: (value) => outputs.push(value),
+      error: (value) => errors.push(value),
+    },
+    outputs,
+    errors,
+  };
+}
+
+const VALID_SKILL_MD = `---
+name: test-skill
+description: A test skill
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - testing
+    requires:
+      binaries: []
+      env: []
+      channels: []
+      os: []
+    install: []
+---
+
+# Test Skill
+
+This is a test skill body.
+`;
+
+const INVALID_SKILL_MD = `---
+description: Missing name field
+version: 1.0.0
+metadata:
+  agenc:
+    tags: []
+    requires:
+      binaries: []
+      env: []
+      channels: []
+      os: []
+    install: []
+---
+
+Body without name.
+`;
+
+function baseOpts(): SkillCommandOptions {
+  return {
+    help: false,
+    outputFormat: 'json',
+    strictMode: false,
+    storeType: 'memory',
+    idempotencyWindow: 900,
+  };
+}
+
+describe('skills-cli', () => {
+  let workspace: string;
+  let userSkillsDir: string;
+  let projectSkillsDir: string;
+  let discoveryPaths: DiscoveryPaths;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'agenc-skill-cli-'));
+    userSkillsDir = join(workspace, 'user-skills');
+    projectSkillsDir = join(workspace, 'project-skills');
+    mkdirSync(userSkillsDir, { recursive: true });
+    mkdirSync(projectSkillsDir, { recursive: true });
+    discoveryPaths = {
+      userSkills: userSkillsDir,
+      projectSkills: projectSkillsDir,
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  // --- list ---
+
+  it('list: returns discovered skills with correct fields', async () => {
+    writeFileSync(join(userSkillsDir, 'test-skill.md'), VALID_SKILL_MD, 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const code = await runSkillListCommand(context, baseOpts(), { discoveryPaths, userSkillsDir });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.status).toBe('ok');
+    expect(payload.command).toBe('skill.list');
+    expect(payload.count).toBe(1);
+    expect(payload.skills[0].name).toBe('test-skill');
+    expect(payload.skills[0].tier).toBe('user');
+    expect(payload.skills[0].tags).toEqual(['testing']);
+  });
+
+  it('list: empty dir returns count 0', async () => {
+    const { context, outputs } = createContextCapture();
+    const code = await runSkillListCommand(context, baseOpts(), { discoveryPaths, userSkillsDir });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.count).toBe(0);
+    expect(payload.skills).toEqual([]);
+  });
+
+  it('list: shows disabled status when marker exists', async () => {
+    const filePath = join(userSkillsDir, 'test-skill.md');
+    writeFileSync(filePath, VALID_SKILL_MD, 'utf-8');
+    writeFileSync(`${filePath}.disabled`, '', 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const code = await runSkillListCommand(context, baseOpts(), { discoveryPaths, userSkillsDir });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.skills[0].disabled).toBe(true);
+  });
+
+  // --- info ---
+
+  it('info: returns full details for existing skill', async () => {
+    writeFileSync(join(userSkillsDir, 'test-skill.md'), VALID_SKILL_MD, 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test-skill' };
+    const code = await runSkillInfoCommand(context, opts, { discoveryPaths });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.status).toBe('ok');
+    expect(payload.command).toBe('skill.info');
+    expect(payload.skill.name).toBe('test-skill');
+    expect(payload.skill.version).toBe('1.0.0');
+    expect(payload.skill.description).toBe('A test skill');
+    expect(payload.skill.bodyPreview).toContain('Test Skill');
+  });
+
+  it('info: error with suggestions for unknown name', async () => {
+    writeFileSync(join(userSkillsDir, 'test-skill.md'), VALID_SKILL_MD, 'utf-8');
+
+    const { context, errors } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test' };
+    const code = await runSkillInfoCommand(context, opts, { discoveryPaths });
+
+    expect(code).toBe(1);
+    const payload = errors[0] as any;
+    expect(payload.code).toBe('SKILL_NOT_FOUND');
+    expect(payload.suggestions).toContain('test-skill');
+  });
+
+  // --- validate ---
+
+  it('validate: exit 0 for all-valid skills', async () => {
+    writeFileSync(join(userSkillsDir, 'test-skill.md'), VALID_SKILL_MD, 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const code = await runSkillValidateCommand(context, baseOpts(), { discoveryPaths });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.valid).toBe(true);
+    expect(payload.results[0].valid).toBe(true);
+  });
+
+  it('validate: exit 1 when validation errors', async () => {
+    writeFileSync(join(userSkillsDir, 'bad-skill.md'), INVALID_SKILL_MD, 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const code = await runSkillValidateCommand(context, baseOpts(), { discoveryPaths });
+
+    expect(code).toBe(1);
+    const payload = outputs[0] as any;
+    expect(payload.valid).toBe(false);
+    expect(payload.results[0].errors.length).toBeGreaterThan(0);
+  });
+
+  // --- create ---
+
+  it('create: scaffolds SKILL.md with valid template', async () => {
+    const destDir = join(workspace, 'create-dest');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'my-new-skill' };
+    const code = await runSkillCreateCommand(context, opts, { userSkillsDir: destDir });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.status).toBe('ok');
+    expect(payload.skillName).toBe('my-new-skill');
+
+    const content = readFileSync(join(destDir, 'my-new-skill.md'), 'utf-8');
+    expect(content).toContain('name: my-new-skill');
+    expect(content).toContain('version: 0.1.0');
+  });
+
+  it('create: error if file already exists', async () => {
+    writeFileSync(join(userSkillsDir, 'existing.md'), VALID_SKILL_MD, 'utf-8');
+
+    const { context, errors } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'existing' };
+    const code = await runSkillCreateCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(1);
+    const payload = errors[0] as any;
+    expect(payload.code).toBe('SKILL_ALREADY_EXISTS');
+  });
+
+  // --- install ---
+
+  it('install: copies valid local SKILL.md using skill name as filename', async () => {
+    const sourcePath = join(workspace, 'source-skill.md');
+    writeFileSync(sourcePath, VALID_SKILL_MD, 'utf-8');
+    const installDir = join(workspace, 'install-dest');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), source: sourcePath };
+    const code = await runSkillInstallCommand(context, opts, { userSkillsDir: installDir });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.status).toBe('ok');
+    expect(payload.skillName).toBe('test-skill');
+
+    // Installed as {name}.md, not basename of source
+    const installed = readFileSync(join(installDir, 'test-skill.md'), 'utf-8');
+    expect(installed).toBe(VALID_SKILL_MD);
+  });
+
+  it('install: error for nonexistent source path', async () => {
+    const { context, errors } = createContextCapture();
+    const opts = { ...baseOpts(), source: '/nonexistent/path/skill.md' };
+    const code = await runSkillInstallCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(1);
+    const payload = errors[0] as any;
+    expect(payload.code).toBe('SOURCE_NOT_FOUND');
+  });
+
+  it('install: error for non-SKILL.md file', async () => {
+    const sourcePath = join(workspace, 'not-a-skill.md');
+    writeFileSync(sourcePath, '# Just a regular markdown file\n\nNo frontmatter here.', 'utf-8');
+
+    const { context, errors } = createContextCapture();
+    const opts = { ...baseOpts(), source: sourcePath };
+    const code = await runSkillInstallCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(1);
+    const payload = errors[0] as any;
+    expect(payload.code).toBe('INVALID_SKILL_FILE');
+  });
+
+  it('install: error if dest file already exists', async () => {
+    const sourcePath = join(workspace, 'whatever-name.md');
+    writeFileSync(sourcePath, VALID_SKILL_MD, 'utf-8');
+    // Dest uses skill name from frontmatter, not source basename
+    writeFileSync(join(userSkillsDir, 'test-skill.md'), VALID_SKILL_MD, 'utf-8');
+
+    const { context, errors } = createContextCapture();
+    const opts = { ...baseOpts(), source: sourcePath };
+    const code = await runSkillInstallCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(1);
+    const payload = errors[0] as any;
+    expect(payload.code).toBe('SKILL_ALREADY_EXISTS');
+  });
+
+  it('install: error for file with valid frontmatter but failing validation', async () => {
+    const sourcePath = join(workspace, 'bad-install.md');
+    writeFileSync(sourcePath, INVALID_SKILL_MD, 'utf-8');
+
+    const { context, errors } = createContextCapture();
+    const opts = { ...baseOpts(), source: sourcePath };
+    const code = await runSkillInstallCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(1);
+    const payload = errors[0] as any;
+    expect(payload.code).toBe('INVALID_SKILL_FILE');
+    expect(payload.message).toContain('validation failed');
+  });
+
+  // --- uninstall ---
+
+  it('uninstall: removes skill file', async () => {
+    const filePath = join(userSkillsDir, 'test-skill.md');
+    writeFileSync(filePath, VALID_SKILL_MD, 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test-skill' };
+    const code = await runSkillUninstallCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(0);
+    expect(existsSync(filePath)).toBe(false);
+    const payload = outputs[0] as any;
+    expect(payload.command).toBe('skill.uninstall');
+  });
+
+  it('uninstall: also removes .disabled marker', async () => {
+    const filePath = join(userSkillsDir, 'test-skill.md');
+    const markerPath = `${filePath}.disabled`;
+    writeFileSync(filePath, VALID_SKILL_MD, 'utf-8');
+    writeFileSync(markerPath, '', 'utf-8');
+
+    const { context } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test-skill' };
+    const code = await runSkillUninstallCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(0);
+    expect(existsSync(filePath)).toBe(false);
+    expect(existsSync(markerPath)).toBe(false);
+  });
+
+  it('uninstall: error for nonexistent skill', async () => {
+    const { context, errors } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'nonexistent' };
+    const code = await runSkillUninstallCommand(context, opts, { userSkillsDir });
+
+    expect(code).toBe(1);
+    const payload = errors[0] as any;
+    expect(payload.code).toBe('SKILL_NOT_FOUND');
+  });
+
+  // --- disable ---
+
+  it('disable: creates .disabled marker', async () => {
+    const filePath = join(userSkillsDir, 'test-skill.md');
+    writeFileSync(filePath, VALID_SKILL_MD, 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test-skill' };
+    const code = await runSkillDisableCommand(context, opts, { discoveryPaths });
+
+    expect(code).toBe(0);
+    expect(existsSync(`${filePath}.disabled`)).toBe(true);
+    const payload = outputs[0] as any;
+    expect(payload.command).toBe('skill.disable');
+  });
+
+  it('disable: idempotent when already disabled', async () => {
+    const filePath = join(userSkillsDir, 'test-skill.md');
+    writeFileSync(filePath, VALID_SKILL_MD, 'utf-8');
+    writeFileSync(`${filePath}.disabled`, '', 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test-skill' };
+    const code = await runSkillDisableCommand(context, opts, { discoveryPaths });
+
+    expect(code).toBe(0);
+    expect(existsSync(`${filePath}.disabled`)).toBe(true);
+    const payload = outputs[0] as any;
+    expect(payload.status).toBe('ok');
+  });
+
+  // --- enable ---
+
+  it('enable: removes .disabled marker', async () => {
+    const filePath = join(userSkillsDir, 'test-skill.md');
+    writeFileSync(filePath, VALID_SKILL_MD, 'utf-8');
+    writeFileSync(`${filePath}.disabled`, '', 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test-skill' };
+    const code = await runSkillEnableCommand(context, opts, { discoveryPaths });
+
+    expect(code).toBe(0);
+    expect(existsSync(`${filePath}.disabled`)).toBe(false);
+    const payload = outputs[0] as any;
+    expect(payload.command).toBe('skill.enable');
+  });
+
+  it('enable: idempotent when already enabled', async () => {
+    const filePath = join(userSkillsDir, 'test-skill.md');
+    writeFileSync(filePath, VALID_SKILL_MD, 'utf-8');
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), skillName: 'test-skill' };
+    const code = await runSkillEnableCommand(context, opts, { discoveryPaths });
+
+    expect(code).toBe(0);
+    expect(existsSync(`${filePath}.disabled`)).toBe(false);
+    const payload = outputs[0] as any;
+    expect(payload.status).toBe('ok');
+  });
+
+  // --- install from URL (mocked fetch) ---
+
+  it('install: fetches from URL and installs', async () => {
+    const installDir = join(workspace, 'url-install-dest');
+    const mockResponse = new Response(VALID_SKILL_MD, { status: 200 });
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(mockResponse);
+
+    const { context, outputs } = createContextCapture();
+    const opts = { ...baseOpts(), source: 'https://example.com/test-skill.md' };
+    const code = await runSkillInstallCommand(context, opts, { userSkillsDir: installDir });
+
+    expect(code).toBe(0);
+    const payload = outputs[0] as any;
+    expect(payload.status).toBe('ok');
+    expect(payload.skillName).toBe('test-skill');
+    expect(existsSync(join(installDir, 'test-skill.md'))).toBe(true);
+  });
+});
+
+/**
+ * Integration tests for skill CLI routing via runCli.
+ *
+ * These import index.ts which transitively pulls in @agenc/sdk via replay.ts.
+ * They will only run when that dependency is available. The test uses
+ * parseArgv (standalone export) and normalizeAndValidateSkillCommand
+ * indirectly, so these are covered separately.
+ *
+ * To run: npx vitest run src/cli/skills-cli-integration.test.ts
+ * (requires @agenc/sdk to be built/linked)
+ */

--- a/runtime/src/cli/skills-cli.ts
+++ b/runtime/src/cli/skills-cli.ts
@@ -1,0 +1,513 @@
+import { mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { basename, join } from 'node:path';
+import { homedir } from 'node:os';
+import { SkillDiscovery, type DiscoveredSkill, type DiscoveryPaths } from '../skills/markdown/discovery.js';
+import { isSkillMarkdown, parseSkillContent, validateSkillMetadata } from '../skills/markdown/parser.js';
+import type { CliRuntimeContext, CliStatusCode, SkillCommandOptions } from './types.js';
+
+const MAX_INSTALL_SIZE = 1_048_576; // 1 MB
+const BODY_PREVIEW_LENGTH = 500;
+
+export function getDefaultDiscoveryPaths(): DiscoveryPaths {
+  return {
+    userSkills: join(homedir(), '.agenc', 'skills'),
+    projectSkills: join(process.cwd(), 'skills'),
+  };
+}
+
+export function getUserSkillsDir(): string {
+  return join(homedir(), '.agenc', 'skills');
+}
+
+function suggestSimilarNames(input: string, skills: DiscoveredSkill[]): string[] {
+  const lower = input.toLowerCase();
+  return skills
+    .filter((s) => s.skill.name.toLowerCase().includes(lower) || lower.includes(s.skill.name.toLowerCase()))
+    .map((s) => s.skill.name);
+}
+
+function buildSkillTemplate(name: string): string {
+  return `---
+name: ${name}
+description: TODO — describe what this skill does
+version: 0.1.0
+metadata:
+  agenc:
+    tags: []
+    requires:
+      binaries: []
+      env: []
+      channels: []
+      os: []
+    install: []
+---
+
+# ${name}
+
+TODO — write skill instructions here.
+`;
+}
+
+async function resolveSkillByName(
+  name: string,
+  discovery: SkillDiscovery,
+): Promise<{ skill: DiscoveredSkill; disabled: boolean } | null> {
+  const all = await discovery.discoverAll();
+  const match = all.find((s) => s.skill.name === name);
+  if (!match) return null;
+  const disabled = match.skill.sourcePath
+    ? existsSync(`${match.skill.sourcePath}.disabled`)
+    : false;
+  return { skill: match, disabled };
+}
+
+export async function runSkillListCommand(
+  context: CliRuntimeContext,
+  _args: SkillCommandOptions,
+  overrides?: { discoveryPaths?: DiscoveryPaths; userSkillsDir?: string },
+): Promise<CliStatusCode> {
+  const paths = overrides?.discoveryPaths ?? getDefaultDiscoveryPaths();
+  const discovery = new SkillDiscovery(paths);
+
+  try {
+    const skills = await discovery.discoverAll();
+    const items = skills.map((s) => {
+      const disabled = s.skill.sourcePath
+        ? existsSync(`${s.skill.sourcePath}.disabled`)
+        : false;
+      return {
+        name: s.skill.name,
+        version: s.skill.version,
+        tier: s.tier,
+        available: s.available,
+        disabled,
+        tags: [...s.skill.metadata.tags],
+      };
+    });
+
+    context.output({
+      status: 'ok',
+      command: 'skill.list',
+      schema: 'skill.list.output.v1',
+      count: items.length,
+      skills: items,
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to discover skills: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runSkillInfoCommand(
+  context: CliRuntimeContext,
+  args: SkillCommandOptions,
+  overrides?: { discoveryPaths?: DiscoveryPaths },
+): Promise<CliStatusCode> {
+  const opts = args as { skillName: string };
+  const paths = overrides?.discoveryPaths ?? getDefaultDiscoveryPaths();
+  const discovery = new SkillDiscovery(paths);
+
+  try {
+    const result = await resolveSkillByName(opts.skillName, discovery);
+    if (!result) {
+      const all = await discovery.discoverAll();
+      const suggestions = suggestSimilarNames(opts.skillName, all);
+      context.error({
+        status: 'error',
+        code: 'SKILL_NOT_FOUND',
+        message: `Skill "${opts.skillName}" not found`,
+        ...(suggestions.length > 0 ? { suggestions } : {}),
+      });
+      return 1;
+    }
+
+    const { skill: discovered, disabled } = result;
+    const bodyPreview = discovered.skill.body.length > BODY_PREVIEW_LENGTH
+      ? `${discovered.skill.body.slice(0, BODY_PREVIEW_LENGTH)}...`
+      : discovered.skill.body;
+
+    context.output({
+      status: 'ok',
+      command: 'skill.info',
+      schema: 'skill.info.output.v1',
+      skill: {
+        name: discovered.skill.name,
+        description: discovered.skill.description,
+        version: discovered.skill.version,
+        tier: discovered.tier,
+        available: discovered.available,
+        disabled,
+        tags: [...discovered.skill.metadata.tags],
+        metadata: discovered.skill.metadata,
+        bodyPreview,
+        sourcePath: discovered.skill.sourcePath,
+        ...(discovered.unavailableReason ? { unavailableReason: discovered.unavailableReason } : {}),
+        ...(discovered.missingRequirements ? { missingRequirements: discovered.missingRequirements } : {}),
+      },
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to get skill info: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runSkillValidateCommand(
+  context: CliRuntimeContext,
+  _args: SkillCommandOptions,
+  overrides?: { discoveryPaths?: DiscoveryPaths },
+): Promise<CliStatusCode> {
+  const paths = overrides?.discoveryPaths ?? getDefaultDiscoveryPaths();
+  const discovery = new SkillDiscovery(paths);
+
+  try {
+    const skills = await discovery.discoverAll();
+    let hasErrors = false;
+    const results = skills.map((s) => {
+      const errors = validateSkillMetadata(s.skill);
+      if (errors.length > 0) hasErrors = true;
+      return {
+        name: s.skill.name,
+        tier: s.tier,
+        valid: errors.length === 0,
+        errors,
+      };
+    });
+
+    context.output({
+      status: 'ok',
+      command: 'skill.validate',
+      schema: 'skill.validate.output.v1',
+      count: results.length,
+      valid: !hasErrors,
+      results,
+    });
+    return hasErrors ? 1 : 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to validate skills: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runSkillCreateCommand(
+  context: CliRuntimeContext,
+  args: SkillCommandOptions,
+  overrides?: { userSkillsDir?: string },
+): Promise<CliStatusCode> {
+  const opts = args as { skillName: string };
+  const dir = overrides?.userSkillsDir ?? getUserSkillsDir();
+  const filePath = join(dir, `${opts.skillName}.md`);
+
+  if (existsSync(filePath)) {
+    context.error({
+      status: 'error',
+      code: 'SKILL_ALREADY_EXISTS',
+      message: `Skill file already exists: ${filePath}`,
+    });
+    return 1;
+  }
+
+  try {
+    await mkdir(dir, { recursive: true });
+    await writeFile(filePath, buildSkillTemplate(opts.skillName), 'utf-8');
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to create skill: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+
+  context.output({
+    status: 'ok',
+    command: 'skill.create',
+    schema: 'skill.create.output.v1',
+    skillName: opts.skillName,
+    filePath,
+  });
+  return 0;
+}
+
+export async function runSkillInstallCommand(
+  context: CliRuntimeContext,
+  args: SkillCommandOptions,
+  overrides?: { userSkillsDir?: string },
+): Promise<CliStatusCode> {
+  const opts = args as { source: string };
+  const dir = overrides?.userSkillsDir ?? getUserSkillsDir();
+
+  let content: string;
+  const isUrl = opts.source.startsWith('http://') || opts.source.startsWith('https://');
+
+  if (isUrl) {
+    try {
+      const response = await fetch(opts.source);
+      if (!response.ok) {
+        context.error({
+          status: 'error',
+          code: 'DOWNLOAD_FAILED',
+          message: `Failed to download skill: HTTP ${response.status}`,
+        });
+        return 1;
+      }
+      const contentLength = response.headers.get('content-length');
+      if (contentLength && Number(contentLength) > MAX_INSTALL_SIZE) {
+        context.error({
+          status: 'error',
+          code: 'INVALID_SKILL_FILE',
+          message: `Skill file exceeds 1MB size limit`,
+        });
+        return 1;
+      }
+      content = await response.text();
+    } catch (error) {
+      context.error({
+        status: 'error',
+        code: 'DOWNLOAD_FAILED',
+        message: `Failed to download skill: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return 1;
+    }
+  } else {
+    if (!existsSync(opts.source)) {
+      context.error({
+        status: 'error',
+        code: 'SOURCE_NOT_FOUND',
+        message: `Source file not found: ${opts.source}`,
+      });
+      return 1;
+    }
+    try {
+      content = await readFile(opts.source, 'utf-8');
+    } catch (error) {
+      context.error({
+        status: 'error',
+        code: 'IO_ERROR',
+        message: `Failed to read source file: ${error instanceof Error ? error.message : String(error)}`,
+      });
+      return 1;
+    }
+  }
+
+  if (Buffer.byteLength(content, 'utf-8') > MAX_INSTALL_SIZE) {
+    context.error({
+      status: 'error',
+      code: 'INVALID_SKILL_FILE',
+      message: `Skill file exceeds 1MB size limit`,
+    });
+    return 1;
+  }
+
+  if (!isSkillMarkdown(content)) {
+    context.error({
+      status: 'error',
+      code: 'INVALID_SKILL_FILE',
+      message: `Source is not a valid SKILL.md file (missing YAML frontmatter)`,
+    });
+    return 1;
+  }
+
+  const parsed = parseSkillContent(content);
+  const validationErrors = validateSkillMetadata(parsed);
+  if (validationErrors.length > 0) {
+    context.error({
+      status: 'error',
+      code: 'INVALID_SKILL_FILE',
+      message: `Skill validation failed: ${validationErrors.map((e) => e.message).join('; ')}`,
+    });
+    return 1;
+  }
+
+  const skillName = parsed.name || basename(opts.source, '.md');
+  const destPath = join(dir, `${skillName}.md`);
+
+  if (existsSync(destPath)) {
+    context.error({
+      status: 'error',
+      code: 'SKILL_ALREADY_EXISTS',
+      message: `Skill file already exists: ${destPath}`,
+    });
+    return 1;
+  }
+
+  try {
+    await mkdir(dir, { recursive: true });
+    await writeFile(destPath, content, 'utf-8');
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to install skill: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+
+  context.output({
+    status: 'ok',
+    command: 'skill.install',
+    schema: 'skill.install.output.v1',
+    skillName: parsed.name,
+    filePath: destPath,
+    source: opts.source,
+  });
+  return 0;
+}
+
+export async function runSkillUninstallCommand(
+  context: CliRuntimeContext,
+  args: SkillCommandOptions,
+  overrides?: { userSkillsDir?: string },
+): Promise<CliStatusCode> {
+  const opts = args as { skillName: string };
+  const dir = overrides?.userSkillsDir ?? getUserSkillsDir();
+
+  const filePath = join(dir, `${opts.skillName}.md`);
+  if (!existsSync(filePath)) {
+    context.error({
+      status: 'error',
+      code: 'SKILL_NOT_FOUND',
+      message: `Skill "${opts.skillName}" not found in user skills directory`,
+    });
+    return 1;
+  }
+
+  try {
+    await unlink(filePath);
+    const disabledMarker = `${filePath}.disabled`;
+    if (existsSync(disabledMarker)) {
+      await unlink(disabledMarker);
+    }
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to uninstall skill: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+
+  context.output({
+    status: 'ok',
+    command: 'skill.uninstall',
+    schema: 'skill.uninstall.output.v1',
+    skillName: opts.skillName,
+  });
+  return 0;
+}
+
+export async function runSkillEnableCommand(
+  context: CliRuntimeContext,
+  args: SkillCommandOptions,
+  overrides?: { discoveryPaths?: DiscoveryPaths },
+): Promise<CliStatusCode> {
+  const opts = args as { skillName: string };
+  const paths = overrides?.discoveryPaths ?? getDefaultDiscoveryPaths();
+  const discovery = new SkillDiscovery(paths);
+
+  try {
+    const result = await resolveSkillByName(opts.skillName, discovery);
+    if (!result) {
+      context.error({
+        status: 'error',
+        code: 'SKILL_NOT_FOUND',
+        message: `Skill "${opts.skillName}" not found`,
+      });
+      return 1;
+    }
+
+    if (!result.skill.skill.sourcePath) {
+      context.error({
+        status: 'error',
+        code: 'IO_ERROR',
+        message: `Skill "${opts.skillName}" has no source path and cannot be toggled`,
+      });
+      return 1;
+    }
+
+    const markerPath = `${result.skill.skill.sourcePath}.disabled`;
+    if (existsSync(markerPath)) {
+      await unlink(markerPath);
+    }
+
+    context.output({
+      status: 'ok',
+      command: 'skill.enable',
+      schema: 'skill.enable.output.v1',
+      skillName: opts.skillName,
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to enable skill: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runSkillDisableCommand(
+  context: CliRuntimeContext,
+  args: SkillCommandOptions,
+  overrides?: { discoveryPaths?: DiscoveryPaths },
+): Promise<CliStatusCode> {
+  const opts = args as { skillName: string };
+  const paths = overrides?.discoveryPaths ?? getDefaultDiscoveryPaths();
+  const discovery = new SkillDiscovery(paths);
+
+  try {
+    const result = await resolveSkillByName(opts.skillName, discovery);
+    if (!result) {
+      context.error({
+        status: 'error',
+        code: 'SKILL_NOT_FOUND',
+        message: `Skill "${opts.skillName}" not found`,
+      });
+      return 1;
+    }
+
+    if (!result.skill.skill.sourcePath) {
+      context.error({
+        status: 'error',
+        code: 'IO_ERROR',
+        message: `Skill "${opts.skillName}" has no source path and cannot be toggled`,
+      });
+      return 1;
+    }
+
+    const markerPath = `${result.skill.skill.sourcePath}.disabled`;
+    if (!existsSync(markerPath)) {
+      await writeFile(markerPath, '', 'utf-8');
+    }
+
+    context.output({
+      status: 'ok',
+      command: 'skill.disable',
+      schema: 'skill.disable.output.v1',
+      skillName: opts.skillName,
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IO_ERROR',
+      message: `Failed to disable skill: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -76,6 +76,23 @@ export interface PluginReloadOptions extends BaseCliOptions {
   manifestPath?: string;
 }
 
+export interface SkillListOptions extends BaseCliOptions {}
+export interface SkillInfoOptions extends BaseCliOptions { skillName: string; }
+export interface SkillValidateOptions extends BaseCliOptions {}
+export interface SkillCreateOptions extends BaseCliOptions { skillName: string; }
+export interface SkillInstallOptions extends BaseCliOptions { source: string; }
+export interface SkillUninstallOptions extends BaseCliOptions { skillName: string; }
+export interface SkillToggleOptions extends BaseCliOptions { skillName: string; }
+
+export type SkillCommandOptions =
+  | SkillListOptions
+  | SkillInfoOptions
+  | SkillValidateOptions
+  | SkillCreateOptions
+  | SkillInstallOptions
+  | SkillUninstallOptions
+  | SkillToggleOptions;
+
 export interface CliUsage {
   command: string;
   description: string;


### PR DESCRIPTION
## Summary

- Adds `agenc skill list|info|validate|create|install|uninstall|enable|disable` to the runtime CLI
- 8 commands for operator-level skill management, building on `SkillDiscovery` and SKILL.md parser (Phase 3.2)
- Install supports local paths and URLs with 1MB size cap, `isSkillMarkdown()` + `validateSkillMetadata()` validation, and no-silent-overwrite guard
- Enable/disable use idempotent `.disabled` marker files alongside the skill file
- All commands follow the output envelope pattern (`status`, `command`, `schema`) consistent with existing plugin/replay commands

## Test plan

- [x] 22 unit tests covering all 8 commands, edge cases, and error paths (`npx vitest run src/cli/skills-cli.test.ts`)
- [x] Type check passes (`npx tsc --noEmit` — no new errors)
- [x] No regressions in existing CLI tests (`security.test.ts` — 22/22 pass)
- [ ] Integration tests (`skills-cli-integration.test.ts`) will pass once `@agenc/sdk` is built/linked

Closes #1074