### PR TITLE
feat(runtime): on-chain skill registry client

### DIFF
--- a/runtime/src/autonomous/agent.ts
+++ b/runtime/src/autonomous/agent.ts
@@ -1281,7 +1281,7 @@ export class AutonomousAgent extends AgentRuntime {
     this.autonomousLogger.info('Generating ZK proof...');
     const proofStartTime = Date.now();
 
-    let proofResult: { proof: Uint8Array; constraintHash: Uint8Array; outputCommitment: Uint8Array; expectedBinding: Uint8Array; proofSize: number };
+    let proofResult: { proof: Uint8Array; constraintHash: Uint8Array; outputCommitment: Uint8Array; expectedBinding: Uint8Array; nullifier: Uint8Array; proofSize: number };
     if (this.proofEngine) {
       const salt = this.proofEngine.generateSalt();
       proofResult = await this.proofEngine.generate({
@@ -1322,10 +1322,11 @@ export class AutonomousAgent extends AgentRuntime {
 
     const tx = await this.program.methods
       .completeTaskPrivate(new anchor.BN(0), {
-        proofData: toAnchorBytes(proofResult.proof),
+        proofData: Buffer.from(proofResult.proof),
         constraintHash: toAnchorBytes(proofResult.constraintHash),
         outputCommitment: toAnchorBytes(proofResult.outputCommitment),
         expectedBinding: toAnchorBytes(proofResult.expectedBinding),
+        nullifier: toAnchorBytes(proofResult.nullifier),
       })
       .accountsPartial({
         task: task.pda,

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -448,6 +448,18 @@ export {
   type DiscoveredSkill,
   type MissingRequirement,
   SkillDiscovery,
+  // Remote skill registry client (Phase 6.1)
+  type SkillListing,
+  type SkillListingEntry,
+  type SkillRegistryClient,
+  type SkillRegistryClientConfig,
+  type SearchOptions,
+  OnChainSkillRegistryClient,
+  SkillRegistryNotFoundError,
+  SkillDownloadError,
+  SkillVerificationError,
+  SkillPublishError,
+  SKILL_REGISTRY_PROGRAM_ID,
 } from './skills/index.js';
 
 // LLM Adapters (Phase 4)

--- a/runtime/src/proof/engine.test.ts
+++ b/runtime/src/proof/engine.test.ts
@@ -12,6 +12,7 @@ vi.mock('@agenc/sdk', () => {
       constraintHash: mockHash,
       outputCommitment: Buffer.alloc(32, 0xef),
       expectedBinding: Buffer.alloc(32, 0x12),
+      nullifier: Buffer.alloc(32, 0x34),
       proofSize: 256,
       generationTime: 42,
     }),
@@ -20,6 +21,7 @@ vi.mock('@agenc/sdk', () => {
       constraintHash: 123n,
       outputCommitment: 456n,
       expectedBinding: 789n,
+      nullifier: 101112n,
     }),
     generateSalt: vi.fn().mockReturnValue(999n),
     checkToolsAvailable: vi.fn().mockReturnValue({
@@ -132,6 +134,8 @@ describe('ProofEngine', () => {
       expect(result.constraintHash.length).toBe(32);
       expect(result.outputCommitment).toBeInstanceOf(Uint8Array);
       expect(result.expectedBinding).toBeInstanceOf(Uint8Array);
+      expect(result.nullifier).toBeInstanceOf(Uint8Array);
+      expect(result.nullifier.length).toBe(32);
       expect(result.proofSize).toBe(256);
       expect(result.fromCache).toBe(false);
       expect(result.verified).toBe(false);
@@ -349,6 +353,7 @@ describe('ProofEngine', () => {
       expect(result.constraintHash).toBe(123n);
       expect(result.outputCommitment).toBe(456n);
       expect(result.expectedBinding).toBe(789n);
+      expect(result.nullifier).toBe(101112n);
     });
   });
 
@@ -451,6 +456,7 @@ describe('ProofEngine', () => {
           constraintHash: new Uint8Array(32),
           outputCommitment: new Uint8Array(32),
           expectedBinding: new Uint8Array(32),
+          nullifier: new Uint8Array(32),
         },
       );
       expect(result).toBe(proof);
@@ -469,6 +475,7 @@ describe('ProofCache', () => {
       constraintHash: new Uint8Array(32).fill(0x02),
       outputCommitment: new Uint8Array(32).fill(0x03),
       expectedBinding: new Uint8Array(32).fill(0x04),
+      nullifier: new Uint8Array(32).fill(0x05),
       proofSize: 256,
       generationTimeMs: 100,
       fromCache: false,

--- a/runtime/src/proof/engine.ts
+++ b/runtime/src/proof/engine.ts
@@ -123,6 +123,7 @@ export class ProofEngine implements ProofGenerator {
       constraintHash: new Uint8Array(sdkResult.constraintHash),
       outputCommitment: new Uint8Array(sdkResult.outputCommitment),
       expectedBinding: new Uint8Array(sdkResult.expectedBinding),
+      nullifier: new Uint8Array(sdkResult.nullifier),
       proofSize: sdkResult.proofSize,
       generationTimeMs,
       fromCache: false,

--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -64,6 +64,8 @@ export interface EngineProofResult {
   outputCommitment: Uint8Array;
   /** Expected binding (32 bytes) */
   expectedBinding: Uint8Array;
+  /** Nullifier to prevent proof/knowledge reuse (32 bytes) */
+  nullifier: Uint8Array;
   /** Size of the proof in bytes */
   proofSize: number;
   /** Time taken for proof generation in milliseconds */

--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -103,3 +103,18 @@ export {
   estimateTokens,
   scoreRelevance,
 } from './markdown/index.js';
+
+// Remote skill registry client (Phase 6.1)
+export {
+  type SkillListing,
+  type SkillListingEntry,
+  type SkillRegistryClient,
+  type SkillRegistryClientConfig,
+  type SearchOptions,
+  OnChainSkillRegistryClient,
+  SkillRegistryNotFoundError,
+  SkillDownloadError,
+  SkillVerificationError,
+  SkillPublishError,
+  SKILL_REGISTRY_PROGRAM_ID,
+} from './registry/index.js';

--- a/runtime/src/skills/registry/client.test.ts
+++ b/runtime/src/skills/registry/client.test.ts
@@ -1,0 +1,655 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createHash } from 'node:crypto';
+import { Connection, Keypair, PublicKey } from '@solana/web3.js';
+import { ValidationError } from '../../types/errors.js';
+import { OnChainSkillRegistryClient, SKILL_REGISTRY_PROGRAM_ID } from './client.js';
+import {
+  SkillRegistryNotFoundError,
+  SkillDownloadError,
+  SkillVerificationError,
+  SkillPublishError,
+} from './errors.js';
+import type { SkillRegistryClientConfig } from './types.js';
+
+vi.mock('node:fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+}));
+
+vi.mock('@agenc/sdk', () => ({
+  silentLogger: { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} },
+  createLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {} }),
+  PROGRAM_ID: new PublicKey('11111111111111111111111111111111'),
+}));
+
+// Import mocked fs after vi.mock
+const { readFile, writeFile, mkdir } = await import('node:fs/promises');
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const noop = () => {};
+const silentLogger = {
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+};
+
+const SKILL_SEED = Buffer.from('skill');
+
+/** Derive a PDA — duplicated here to avoid importing utils/pda which pulls in @agenc/sdk. */
+function derivePda(seeds: Array<Buffer | Uint8Array>, programId: PublicKey) {
+  const [address, bump] = PublicKey.findProgramAddressSync(seeds, programId);
+  return { address, bump };
+}
+
+/** Build a mock skill account buffer matching the deserialization layout. */
+function buildSkillAccountBuffer(fields: {
+  author?: PublicKey;
+  rating?: number;
+  ratingCount?: number;
+  downloads?: number;
+  priceLamports?: bigint;
+  registeredAt?: number;
+  updatedAt?: number;
+  id?: string;
+  name?: string;
+  description?: string;
+  version?: string;
+  contentHash?: string;
+  tags?: string[];
+}): Buffer {
+  const author = fields.author ?? Keypair.generate().publicKey;
+  const rating = fields.rating ?? 4.5;
+  const ratingCount = fields.ratingCount ?? 10;
+  const downloads = fields.downloads ?? 100;
+  const priceLamports = fields.priceLamports ?? 0n;
+  const registeredAt = fields.registeredAt ?? Math.floor(Date.now() / 1000);
+  const updatedAt = fields.updatedAt ?? registeredAt;
+  const id = fields.id ?? 'test-skill-id';
+  const name = fields.name ?? 'Test Skill';
+  const description = fields.description ?? 'A test skill';
+  const version = fields.version ?? '1.0.0';
+  const contentHash = fields.contentHash ?? 'abc123hash';
+  const tags = fields.tags ?? ['test'];
+
+  const parts: Buffer[] = [];
+
+  // Discriminator (8 bytes)
+  parts.push(Buffer.alloc(8));
+
+  // Author pubkey (32 bytes)
+  parts.push(author.toBuffer());
+
+  // rating f64 (8 bytes)
+  const ratingBuf = Buffer.alloc(8);
+  ratingBuf.writeDoubleLE(rating);
+  parts.push(ratingBuf);
+
+  // ratingCount u32 (4 bytes)
+  const ratingCountBuf = Buffer.alloc(4);
+  ratingCountBuf.writeUInt32LE(ratingCount);
+  parts.push(ratingCountBuf);
+
+  // downloads u32 (4 bytes)
+  const downloadsBuf = Buffer.alloc(4);
+  downloadsBuf.writeUInt32LE(downloads);
+  parts.push(downloadsBuf);
+
+  // priceLamports u64 (8 bytes)
+  const priceBuf = Buffer.alloc(8);
+  priceBuf.writeBigUInt64LE(priceLamports);
+  parts.push(priceBuf);
+
+  // registeredAt i64 (8 bytes)
+  const regBuf = Buffer.alloc(8);
+  regBuf.writeBigInt64LE(BigInt(registeredAt));
+  parts.push(regBuf);
+
+  // updatedAt i64 (8 bytes)
+  const updBuf = Buffer.alloc(8);
+  updBuf.writeBigInt64LE(BigInt(updatedAt));
+  parts.push(updBuf);
+
+  // Variable-length string helper
+  function writeStr(s: string): void {
+    const strBuf = Buffer.from(s, 'utf-8');
+    const lenBuf = Buffer.alloc(4);
+    lenBuf.writeUInt32LE(strBuf.length);
+    parts.push(lenBuf, strBuf);
+  }
+
+  writeStr(id);
+  writeStr(name);
+  writeStr(description);
+  writeStr(version);
+  writeStr(contentHash);
+
+  // Tags: u32 count + strings
+  const tagCountBuf = Buffer.alloc(4);
+  tagCountBuf.writeUInt32LE(tags.length);
+  parts.push(tagCountBuf);
+  for (const tag of tags) {
+    writeStr(tag);
+  }
+
+  return Buffer.concat(parts);
+}
+
+function createMockConnection(): Connection {
+  return {
+    getProgramAccounts: vi.fn(async () => []),
+    getAccountInfo: vi.fn(async () => null),
+  } as unknown as Connection;
+}
+
+function createMockFetch(
+  response?: Partial<Response>,
+  throwError?: Error,
+): typeof fetch {
+  if (throwError) {
+    return vi.fn(async () => { throw throwError; }) as unknown as typeof fetch;
+  }
+  const body = response?.arrayBuffer
+    ?? (async () => new ArrayBuffer(0));
+  return vi.fn(async () => ({
+    ok: response?.ok ?? true,
+    status: response?.status ?? 200,
+    statusText: response?.statusText ?? 'OK',
+    arrayBuffer: body,
+  })) as unknown as typeof fetch;
+}
+
+function createClient(overrides?: Partial<SkillRegistryClientConfig>): OnChainSkillRegistryClient {
+  return new OnChainSkillRegistryClient({
+    connection: createMockConnection(),
+    logger: silentLogger,
+    fetchFn: createMockFetch(),
+    ...overrides,
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('OnChainSkillRegistryClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // --------------------------------------------------------------------------
+  // Constructor
+  // --------------------------------------------------------------------------
+
+  describe('constructor', () => {
+    it('accepts config and stores connection', () => {
+      const conn = createMockConnection();
+      const client = new OnChainSkillRegistryClient({ connection: conn });
+      expect(client).toBeInstanceOf(OnChainSkillRegistryClient);
+    });
+
+    it('sets defaults for contentGateway and logger', () => {
+      const conn = createMockConnection();
+      const client = new OnChainSkillRegistryClient({ connection: conn });
+      expect(client).toBeDefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // search
+  // --------------------------------------------------------------------------
+
+  describe('search', () => {
+    it('returns matching skills by query', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ name: 'Swap Helper', description: 'Helps with swaps' });
+      vi.mocked(conn.getProgramAccounts).mockResolvedValue([
+        { pubkey: Keypair.generate().publicKey, account: { data, executable: false, lamports: 0, owner: SKILL_REGISTRY_PROGRAM_ID } },
+      ]);
+
+      const client = createClient({ connection: conn });
+      const results = await client.search('swap');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].name).toBe('Swap Helper');
+    });
+
+    it('filters by tags', async () => {
+      const conn = createMockConnection();
+      const skill1 = buildSkillAccountBuffer({ id: 's1', name: 'DeFi Swap', tags: ['defi', 'swap'] });
+      const skill2 = buildSkillAccountBuffer({ id: 's2', name: 'DeFi Stake', tags: ['defi', 'staking'] });
+      vi.mocked(conn.getProgramAccounts).mockResolvedValue([
+        { pubkey: Keypair.generate().publicKey, account: { data: skill1, executable: false, lamports: 0, owner: SKILL_REGISTRY_PROGRAM_ID } },
+        { pubkey: Keypair.generate().publicKey, account: { data: skill2, executable: false, lamports: 0, owner: SKILL_REGISTRY_PROGRAM_ID } },
+      ]);
+
+      const client = createClient({ connection: conn });
+      const results = await client.search('defi', { tags: ['swap'] });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('s1');
+    });
+
+    it('respects default limit of 10', async () => {
+      const conn = createMockConnection();
+      const accounts = Array.from({ length: 15 }, (_, i) =>
+        ({
+          pubkey: Keypair.generate().publicKey,
+          account: {
+            data: buildSkillAccountBuffer({ id: `s${i}`, name: `Skill ${i}` }),
+            executable: false,
+            lamports: 0,
+            owner: SKILL_REGISTRY_PROGRAM_ID,
+          },
+        }),
+      );
+      vi.mocked(conn.getProgramAccounts).mockResolvedValue(accounts);
+
+      const client = createClient({ connection: conn });
+      const results = await client.search('skill');
+
+      expect(results).toHaveLength(10);
+    });
+
+    it('clamps limit to MAX_SEARCH_LIMIT (100)', async () => {
+      const conn = createMockConnection();
+      vi.mocked(conn.getProgramAccounts).mockResolvedValue([]);
+
+      const client = createClient({ connection: conn });
+      const results = await client.search('anything', { limit: 200 });
+      expect(results).toHaveLength(0);
+    });
+
+    it('returns empty array for no matches', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ name: 'Unrelated Skill' });
+      vi.mocked(conn.getProgramAccounts).mockResolvedValue([
+        { pubkey: Keypair.generate().publicKey, account: { data, executable: false, lamports: 0, owner: SKILL_REGISTRY_PROGRAM_ID } },
+      ]);
+
+      const client = createClient({ connection: conn });
+      const results = await client.search('nonexistent-query');
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // get
+  // --------------------------------------------------------------------------
+
+  describe('get', () => {
+    it('returns full SkillListing for existing skill', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({
+        id: 'my-skill',
+        name: 'My Skill',
+        description: 'A great skill',
+        version: '2.0.0',
+        contentHash: 'deadbeef',
+        tags: ['utility', 'tool'],
+        rating: 4.8,
+        ratingCount: 50,
+        downloads: 500,
+      });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const client = createClient({ connection: conn });
+      const listing = await client.get('my-skill');
+
+      expect(listing.id).toBe('my-skill');
+      expect(listing.name).toBe('My Skill');
+      expect(listing.version).toBe('2.0.0');
+      expect(listing.contentHash).toBe('deadbeef');
+      expect(listing.tags).toEqual(['utility', 'tool']);
+      expect(listing.rating).toBe(4.8);
+      expect(listing.downloads).toBe(500);
+    });
+
+    it('throws SkillRegistryNotFoundError for non-existent skill', async () => {
+      const conn = createMockConnection();
+      vi.mocked(conn.getAccountInfo).mockResolvedValue(null);
+
+      const client = createClient({ connection: conn });
+
+      await expect(client.get('missing-skill')).rejects.toThrow(SkillRegistryNotFoundError);
+    });
+
+    it('derives PDA using skill seed and skillId', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ id: 'pda-test' });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const client = createClient({ connection: conn });
+      await client.get('pda-test');
+
+      const expectedPda = derivePda(
+        [SKILL_SEED, Buffer.from('pda-test')],
+        SKILL_REGISTRY_PROGRAM_ID,
+      );
+      expect(conn.getAccountInfo).toHaveBeenCalledWith(expectedPda.address);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // install
+  // --------------------------------------------------------------------------
+
+  describe('install', () => {
+    it('downloads from gateway and saves to targetPath', async () => {
+      const conn = createMockConnection();
+      const contentBytes = Buffer.from('---\nname: test\n---\nbody');
+      const hash = createHash('sha256').update(contentBytes).digest('hex');
+
+      const data = buildSkillAccountBuffer({ id: 'install-test', contentHash: hash });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const mockFetch = createMockFetch({
+        ok: true,
+        arrayBuffer: async () => contentBytes.buffer.slice(
+          contentBytes.byteOffset,
+          contentBytes.byteOffset + contentBytes.byteLength,
+        ),
+      });
+
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(writeFile).mockResolvedValue(undefined);
+
+      const client = createClient({ connection: conn, fetchFn: mockFetch });
+      const listing = await client.install('install-test', '/tmp/skills/SKILL.md');
+
+      expect(listing.id).toBe('install-test');
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/ipfs/${hash}`),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+      expect(writeFile).toHaveBeenCalledWith('/tmp/skills/SKILL.md', expect.any(Buffer));
+    });
+
+    it('creates parent directories', async () => {
+      const conn = createMockConnection();
+      const contentBytes = Buffer.from('content');
+      const hash = createHash('sha256').update(contentBytes).digest('hex');
+
+      const data = buildSkillAccountBuffer({ id: 'dir-test', contentHash: hash });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const mockFetch = createMockFetch({
+        ok: true,
+        arrayBuffer: async () => contentBytes.buffer.slice(
+          contentBytes.byteOffset,
+          contentBytes.byteOffset + contentBytes.byteLength,
+        ),
+      });
+
+      vi.mocked(mkdir).mockResolvedValue(undefined);
+      vi.mocked(writeFile).mockResolvedValue(undefined);
+
+      const client = createClient({ connection: conn, fetchFn: mockFetch });
+      await client.install('dir-test', '/deep/nested/dir/SKILL.md');
+
+      expect(mkdir).toHaveBeenCalledWith('/deep/nested/dir', { recursive: true });
+    });
+
+    it('throws SkillDownloadError on fetch failure', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ id: 'fetch-fail' });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const mockFetch = createMockFetch(undefined, new Error('Network error'));
+
+      const client = createClient({ connection: conn, fetchFn: mockFetch });
+
+      await expect(client.install('fetch-fail', '/tmp/SKILL.md')).rejects.toThrow(SkillDownloadError);
+    });
+
+    it('throws SkillDownloadError on HTTP non-OK response', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ id: 'http-fail' });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const mockFetch = createMockFetch({ ok: false, status: 404, statusText: 'Not Found' });
+
+      const client = createClient({ connection: conn, fetchFn: mockFetch });
+
+      await expect(client.install('http-fail', '/tmp/SKILL.md')).rejects.toThrow(SkillDownloadError);
+    });
+
+    it('throws SkillVerificationError on hash mismatch', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ id: 'hash-mismatch', contentHash: 'expected-hash' });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const wrongContent = Buffer.from('wrong content');
+      const mockFetch = createMockFetch({
+        ok: true,
+        arrayBuffer: async () => wrongContent.buffer.slice(
+          wrongContent.byteOffset,
+          wrongContent.byteOffset + wrongContent.byteLength,
+        ),
+      });
+
+      const client = createClient({ connection: conn, fetchFn: mockFetch });
+
+      await expect(client.install('hash-mismatch', '/tmp/SKILL.md')).rejects.toThrow(SkillVerificationError);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // publish
+  // --------------------------------------------------------------------------
+
+  describe('publish', () => {
+    const validSkillMd = '---\nname: Test Skill\ndescription: A test\nversion: 1.0.0\n---\n# Test';
+
+    it('reads SKILL.md and computes hash', async () => {
+      vi.mocked(readFile).mockResolvedValue(Buffer.from(validSkillMd));
+
+      const client = createClient();
+      const skillId = await client.publish('/path/SKILL.md', {
+        name: 'Test Skill',
+        description: 'A test',
+      });
+
+      const expectedHash = createHash('sha256').update(Buffer.from(validSkillMd)).digest('hex');
+      expect(skillId).toBe(expectedHash);
+    });
+
+    it('returns hash as skillId', async () => {
+      vi.mocked(readFile).mockResolvedValue(Buffer.from(validSkillMd));
+
+      const client = createClient();
+      const skillId = await client.publish('/path/SKILL.md', {
+        name: 'Test',
+        description: 'Test',
+      });
+
+      expect(typeof skillId).toBe('string');
+      expect(skillId).toHaveLength(64); // SHA-256 hex
+    });
+
+    it('validates SKILL.md format', async () => {
+      const invalid = '---\ndescription: test\nversion: 1.0.0\n---\nbody';
+      vi.mocked(readFile).mockResolvedValue(Buffer.from(invalid));
+
+      const client = createClient();
+
+      await expect(
+        client.publish('/path/SKILL.md', { name: 'Test', description: 'Test' }),
+      ).rejects.toThrow(SkillPublishError);
+    });
+
+    it('throws SkillPublishError when file cannot be read', async () => {
+      vi.mocked(readFile).mockRejectedValue(new Error('ENOENT'));
+
+      const client = createClient();
+
+      await expect(
+        client.publish('/nonexistent/SKILL.md', { name: 'Test', description: 'Test' }),
+      ).rejects.toThrow(SkillPublishError);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // rate
+  // --------------------------------------------------------------------------
+
+  describe('rate', () => {
+    it('validates rating is between 1 and 5', async () => {
+      const wallet = {
+        publicKey: Keypair.generate().publicKey,
+        signTransaction: vi.fn(async (tx: unknown) => tx),
+        signAllTransactions: vi.fn(async (txs: unknown) => txs),
+      };
+      const client = createClient({ wallet });
+
+      await expect(client.rate('skill-1', 0)).rejects.toThrow(ValidationError);
+      await expect(client.rate('skill-1', 6)).rejects.toThrow(ValidationError);
+      await expect(client.rate('skill-1', 3.5)).rejects.toThrow(ValidationError);
+    });
+
+    it('throws ValidationError without wallet', async () => {
+      const client = createClient();
+
+      await expect(client.rate('skill-1', 4)).rejects.toThrow(ValidationError);
+    });
+
+    it('accepts valid rating with wallet', async () => {
+      const wallet = {
+        publicKey: Keypair.generate().publicKey,
+        signTransaction: vi.fn(async (tx: unknown) => tx),
+        signAllTransactions: vi.fn(async (txs: unknown) => txs),
+      };
+      const client = createClient({ wallet });
+
+      await expect(client.rate('skill-1', 5, 'Great skill!')).resolves.toBeUndefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // listByAuthor
+  // --------------------------------------------------------------------------
+
+  describe('listByAuthor', () => {
+    it('returns skills by author', async () => {
+      const conn = createMockConnection();
+      const authorKp = Keypair.generate();
+      const data = buildSkillAccountBuffer({
+        id: 'author-skill',
+        name: 'Author Skill',
+        author: authorKp.publicKey,
+      });
+      vi.mocked(conn.getProgramAccounts).mockResolvedValue([
+        { pubkey: Keypair.generate().publicKey, account: { data, executable: false, lamports: 0, owner: SKILL_REGISTRY_PROGRAM_ID } },
+      ]);
+
+      const client = createClient({ connection: conn });
+      const results = await client.listByAuthor(authorKp.publicKey.toBase58());
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('author-skill');
+    });
+
+    it('returns empty for unknown author', async () => {
+      const conn = createMockConnection();
+      vi.mocked(conn.getProgramAccounts).mockResolvedValue([]);
+
+      const client = createClient({ connection: conn });
+      const results = await client.listByAuthor(Keypair.generate().publicKey.toBase58());
+
+      expect(results).toHaveLength(0);
+    });
+
+    it('validates pubkey format', async () => {
+      const client = createClient();
+
+      await expect(client.listByAuthor('not-a-pubkey!!')).rejects.toThrow(ValidationError);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // verify
+  // --------------------------------------------------------------------------
+
+  describe('verify', () => {
+    it('returns true for matching hash', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ id: 'verify-skill', contentHash: 'abc123' });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const client = createClient({ connection: conn });
+      const result = await client.verify('verify-skill', 'abc123');
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false for mismatched hash', async () => {
+      const conn = createMockConnection();
+      const data = buildSkillAccountBuffer({ id: 'verify-skill', contentHash: 'abc123' });
+      vi.mocked(conn.getAccountInfo).mockResolvedValue({
+        data,
+        executable: false,
+        lamports: 0,
+        owner: SKILL_REGISTRY_PROGRAM_ID,
+      });
+
+      const client = createClient({ connection: conn });
+      const result = await client.verify('verify-skill', 'wrong-hash');
+
+      expect(result).toBe(false);
+    });
+
+    it('throws for non-existent skillId', async () => {
+      const conn = createMockConnection();
+      vi.mocked(conn.getAccountInfo).mockResolvedValue(null);
+
+      const client = createClient({ connection: conn });
+
+      await expect(client.verify('missing', 'somehash')).rejects.toThrow(SkillRegistryNotFoundError);
+    });
+  });
+});

--- a/runtime/src/skills/registry/client.ts
+++ b/runtime/src/skills/registry/client.ts
@@ -1,0 +1,425 @@
+/**
+ * On-chain skill registry client implementation.
+ *
+ * Bridges the on-chain skill registry (Phase 6.2) with the local skill system.
+ * Since the Solana program does not exist yet, on-chain operations use
+ * `Connection.getProgramAccounts()` directly. Some operations (publish, rate)
+ * are stub implementations that will be completed in Phase 6.2.
+ *
+ * @module
+ */
+
+import { createHash } from 'node:crypto';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { Connection, PublicKey } from '@solana/web3.js';
+import type { Logger } from '../../utils/logger.js';
+import { silentLogger } from '../../utils/logger.js';
+import { derivePda } from '../../utils/pda.js';
+import { ValidationError } from '../../types/errors.js';
+import type { Wallet } from '../../types/wallet.js';
+import { parseSkillContent, validateSkillMetadata } from '../markdown/parser.js';
+import type {
+  SkillListing,
+  SkillListingEntry,
+  SkillRegistryClient,
+  SkillRegistryClientConfig,
+  SearchOptions,
+} from './types.js';
+import {
+  SkillRegistryNotFoundError,
+  SkillDownloadError,
+  SkillVerificationError,
+  SkillPublishError,
+} from './errors.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Placeholder program ID for the skill registry Solana program.
+ * Will be replaced with the real program ID in Phase 6.2.
+ */
+export const SKILL_REGISTRY_PROGRAM_ID = new PublicKey(
+  '6cdqQ8wxWLnHAEJrdw89wJe6ZRdSnTuHfRgDp3r5tZ8K',
+);
+
+/** PDA seed prefix for skill accounts. */
+const SKILL_SEED = Buffer.from('skill');
+
+/** Default IPFS content gateway URL. */
+const DEFAULT_CONTENT_GATEWAY = 'https://gateway.ipfs.io';
+
+/** Default search result limit. */
+const DEFAULT_SEARCH_LIMIT = 10;
+
+/** Maximum allowed search result limit. */
+const MAX_SEARCH_LIMIT = 100;
+
+/** Download timeout in milliseconds. */
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+
+// ============================================================================
+// Account Deserialization (preliminary — updated in Phase 6.2)
+// ============================================================================
+
+/**
+ * Deserialize a skill account's raw data into a SkillListing.
+ *
+ * This layout is preliminary and will be updated when the Solana program
+ * is implemented in Phase 6.2. Fields are read sequentially from the buffer.
+ *
+ * Layout (byte offsets):
+ * - 0..8:     discriminator (8 bytes)
+ * - 8..40:    author pubkey (32 bytes)
+ * - 40..48:   rating (f64, 8 bytes)
+ * - 48..52:   ratingCount (u32, 4 bytes)
+ * - 52..56:   downloads (u32, 4 bytes)
+ * - 56..64:   priceLamports (u64, 8 bytes)
+ * - 64..72:   registeredAt (i64 unix timestamp, 8 bytes)
+ * - 72..80:   updatedAt (i64 unix timestamp, 8 bytes)
+ * - 80..:     variable-length strings (each prefixed with u32 length)
+ *             id, name, description, version, contentHash, tags (u32 count + strings)
+ */
+function deserializeSkillAccount(data: Buffer): SkillListing {
+  let offset = 8; // skip discriminator
+
+  const author = new PublicKey(data.subarray(offset, offset + 32)).toBase58();
+  offset += 32;
+
+  const rating = data.readDoubleLE(offset);
+  offset += 8;
+
+  const ratingCount = data.readUInt32LE(offset);
+  offset += 4;
+
+  const downloads = data.readUInt32LE(offset);
+  offset += 4;
+
+  const priceLamports = data.readBigUInt64LE(offset);
+  offset += 8;
+
+  const registeredAtUnix = Number(data.readBigInt64LE(offset));
+  offset += 8;
+
+  const updatedAtUnix = Number(data.readBigInt64LE(offset));
+  offset += 8;
+
+  // Variable-length string reader
+  function readString(): string {
+    const len = data.readUInt32LE(offset);
+    offset += 4;
+    const str = data.subarray(offset, offset + len).toString('utf-8');
+    offset += len;
+    return str;
+  }
+
+  const id = readString();
+  const name = readString();
+  const description = readString();
+  const version = readString();
+  const contentHash = readString();
+
+  // Tags: u32 count followed by that many strings
+  const tagCount = data.readUInt32LE(offset);
+  offset += 4;
+  const tags: string[] = [];
+  for (let i = 0; i < tagCount; i++) {
+    tags.push(readString());
+  }
+
+  return {
+    id,
+    name,
+    description,
+    version,
+    author,
+    downloads,
+    rating,
+    ratingCount,
+    tags,
+    contentHash,
+    priceLamports,
+    registeredAt: new Date(registeredAtUnix * 1000),
+    updatedAt: new Date(updatedAtUnix * 1000),
+  };
+}
+
+/**
+ * Extract an abbreviated listing entry from a full listing.
+ */
+function toListingEntry(listing: SkillListing): SkillListingEntry {
+  return {
+    id: listing.id,
+    name: listing.name,
+    author: listing.author,
+    rating: listing.rating,
+    tags: listing.tags,
+    priceLamports: listing.priceLamports,
+  };
+}
+
+// ============================================================================
+// Client Implementation
+// ============================================================================
+
+/**
+ * On-chain skill registry client.
+ *
+ * Provides read/write access to the on-chain skill registry.
+ * Write operations (publish, rate) are stub implementations pending Phase 6.2.
+ *
+ * @example
+ * ```typescript
+ * import { Connection } from '@solana/web3.js';
+ * import { OnChainSkillRegistryClient } from '@agenc/runtime';
+ *
+ * const client = new OnChainSkillRegistryClient({
+ *   connection: new Connection('https://api.mainnet-beta.solana.com'),
+ * });
+ *
+ * const results = await client.search('swap', { tags: ['defi'], limit: 5 });
+ * const skill = await client.get(results[0].id);
+ * await client.install(skill.id, './skills/swap/SKILL.md');
+ * ```
+ */
+export class OnChainSkillRegistryClient implements SkillRegistryClient {
+  private readonly connection: Connection;
+  private readonly wallet: Wallet | undefined;
+  private readonly contentGateway: string;
+  private readonly logger: Logger;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(config: SkillRegistryClientConfig) {
+    this.connection = config.connection;
+    this.wallet = config.wallet;
+    this.contentGateway = config.contentGateway ?? DEFAULT_CONTENT_GATEWAY;
+    this.logger = config.logger ?? silentLogger;
+    this.fetchFn = config.fetchFn ?? globalThis.fetch;
+  }
+
+  /**
+   * Search for skills by query string and optional filters.
+   */
+  async search(query: string, options?: SearchOptions): Promise<readonly SkillListingEntry[]> {
+    const limit = Math.max(1, Math.min(options?.limit ?? DEFAULT_SEARCH_LIMIT, MAX_SEARCH_LIMIT));
+    const offset = options?.offset ?? 0;
+    const filterTags = options?.tags;
+
+    this.logger.debug(`Searching registry for "${query}" (limit=${limit}, offset=${offset})`);
+
+    const accounts = await this.connection.getProgramAccounts(SKILL_REGISTRY_PROGRAM_ID);
+
+    const queryLower = query.toLowerCase();
+    const matches: SkillListing[] = [];
+
+    for (const { account } of accounts) {
+      try {
+        const listing = deserializeSkillAccount(account.data as Buffer);
+
+        // Substring match on name or description
+        if (
+          !listing.name.toLowerCase().includes(queryLower)
+          && !listing.description.toLowerCase().includes(queryLower)
+        ) {
+          continue;
+        }
+
+        // Tag filter: listing must contain all requested tags
+        if (filterTags && filterTags.length > 0) {
+          const listingTagsLower = listing.tags.map((t) => t.toLowerCase());
+          const allTagsMatch = filterTags.every((t) => listingTagsLower.includes(t.toLowerCase()));
+          if (!allTagsMatch) continue;
+        }
+
+        matches.push(listing);
+      } catch {
+        // Skip malformed accounts
+        this.logger.debug('Skipping malformed skill account during search');
+      }
+    }
+
+    // Sort: rating desc, then downloads desc
+    matches.sort((a, b) => b.rating - a.rating || b.downloads - a.downloads);
+
+    return matches.slice(offset, offset + limit).map(toListingEntry);
+  }
+
+  /**
+   * Get the full listing for a specific skill.
+   */
+  async get(skillId: string): Promise<SkillListing> {
+    this.logger.debug(`Getting skill listing: ${skillId}`);
+
+    const { address } = derivePda(
+      [SKILL_SEED, Buffer.from(skillId)],
+      SKILL_REGISTRY_PROGRAM_ID,
+    );
+
+    const accountInfo = await this.connection.getAccountInfo(address);
+
+    if (!accountInfo) {
+      throw new SkillRegistryNotFoundError(skillId);
+    }
+
+    return deserializeSkillAccount(accountInfo.data as Buffer);
+  }
+
+  /**
+   * Download and install a skill to the local filesystem.
+   */
+  async install(skillId: string, targetPath: string): Promise<SkillListing> {
+    this.logger.info(`Installing skill "${skillId}" to ${targetPath}`);
+
+    const listing = await this.get(skillId);
+    const url = `${this.contentGateway}/ipfs/${listing.contentHash}`;
+
+    let response: Response;
+    try {
+      response = await this.fetchFn(url, {
+        signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw new SkillDownloadError(
+        skillId,
+        err instanceof Error ? err.message : 'Fetch failed',
+      );
+    }
+
+    if (!response.ok) {
+      throw new SkillDownloadError(
+        skillId,
+        `HTTP ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const content = Buffer.from(await response.arrayBuffer());
+
+    // Verify content hash
+    const actualHash = createHash('sha256').update(content).digest('hex');
+    if (actualHash !== listing.contentHash) {
+      throw new SkillVerificationError(skillId, listing.contentHash, actualHash);
+    }
+
+    // Write to filesystem
+    await mkdir(dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, content);
+
+    this.logger.info(`Skill "${skillId}" installed to ${targetPath}`);
+    return listing;
+  }
+
+  /**
+   * Publish a local SKILL.md to the registry.
+   *
+   * Note: IPFS upload and on-chain instruction are deferred to Phase 6.2.
+   * Currently reads the file, validates it, computes the content hash, and
+   * returns the hash as the skillId.
+   */
+  async publish(
+    skillPath: string,
+    metadata: { name: string; description: string; tags?: readonly string[]; priceLamports?: bigint },
+  ): Promise<string> {
+    this.logger.info(`Publishing skill from ${skillPath}`);
+
+    let content: Buffer;
+    try {
+      content = await readFile(skillPath);
+    } catch (err) {
+      throw new SkillPublishError(
+        skillPath,
+        err instanceof Error ? err.message : 'Failed to read file',
+      );
+    }
+
+    // Validate SKILL.md format
+    const parsed = parseSkillContent(content.toString('utf-8'), skillPath);
+    const errors = validateSkillMetadata(parsed);
+    if (errors.length > 0) {
+      throw new SkillPublishError(
+        skillPath,
+        `Invalid SKILL.md: ${errors.map((e) => e.message).join('; ')}`,
+      );
+    }
+
+    const hash = createHash('sha256').update(content).digest('hex');
+
+    this.logger.info(`Skill content hash: ${hash}`);
+    this.logger.debug(
+      'IPFS upload deferred to Phase 6.2. '
+      + `Metadata: name="${metadata.name}", tags=[${(metadata.tags ?? []).join(', ')}]`,
+    );
+
+    return hash;
+  }
+
+  /**
+   * Rate a skill in the registry.
+   *
+   * Note: On-chain instruction is deferred to Phase 6.2.
+   */
+  async rate(skillId: string, rating: number, review?: string): Promise<void> {
+    if (rating < 1 || rating > 5 || !Number.isInteger(rating)) {
+      throw new ValidationError('Rating must be an integer between 1 and 5');
+    }
+
+    if (!this.wallet) {
+      throw new ValidationError('Wallet required to rate skills');
+    }
+
+    this.logger.info(`Rating skill "${skillId}": ${rating}/5${review ? ` — "${review}"` : ''}`);
+    this.logger.debug('On-chain rating instruction deferred to Phase 6.2');
+  }
+
+  /**
+   * List skills published by a specific author.
+   */
+  async listByAuthor(authorPubkey: string): Promise<readonly SkillListingEntry[]> {
+    // Validate base58 pubkey
+    let authorKey: PublicKey;
+    try {
+      authorKey = new PublicKey(authorPubkey);
+    } catch {
+      throw new ValidationError(`Invalid public key: "${authorPubkey}"`);
+    }
+
+    this.logger.debug(`Listing skills by author: ${authorKey.toBase58()}`);
+
+    // memcmp filter: author pubkey starts at offset 8 (after discriminator)
+    const accounts = await this.connection.getProgramAccounts(SKILL_REGISTRY_PROGRAM_ID, {
+      filters: [
+        {
+          memcmp: {
+            offset: 8,
+            bytes: authorKey.toBase58(),
+          },
+        },
+      ],
+    });
+
+    const listings: SkillListing[] = [];
+    for (const { account } of accounts) {
+      try {
+        listings.push(deserializeSkillAccount(account.data as Buffer));
+      } catch {
+        this.logger.debug('Skipping malformed skill account in listByAuthor');
+      }
+    }
+
+    // Sort by updatedAt desc
+    listings.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+
+    return listings.map(toListingEntry);
+  }
+
+  /**
+   * Verify a skill's content hash against the on-chain record.
+   */
+  async verify(skillId: string, contentHash: string): Promise<boolean> {
+    this.logger.debug(`Verifying skill "${skillId}" hash: ${contentHash}`);
+
+    const listing = await this.get(skillId);
+    return listing.contentHash === contentHash;
+  }
+}

--- a/runtime/src/skills/registry/errors.ts
+++ b/runtime/src/skills/registry/errors.ts
@@ -1,0 +1,87 @@
+/**
+ * Error types for the on-chain skill registry client.
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../../types/errors.js';
+
+/**
+ * Error thrown when a skill cannot be found in the on-chain registry.
+ */
+export class SkillRegistryNotFoundError extends RuntimeError {
+  /** The ID of the skill that was not found */
+  public readonly skillId: string;
+
+  constructor(skillId: string) {
+    super(
+      `Skill not found in registry: "${skillId}"`,
+      RuntimeErrorCodes.SKILL_REGISTRY_NOT_FOUND,
+    );
+    this.name = 'SkillRegistryNotFoundError';
+    this.skillId = skillId;
+  }
+}
+
+/**
+ * Error thrown when downloading a skill from the content gateway fails.
+ */
+export class SkillDownloadError extends RuntimeError {
+  /** The ID of the skill that failed to download */
+  public readonly skillId: string;
+  /** The reason the download failed */
+  public readonly reason: string;
+
+  constructor(skillId: string, reason: string) {
+    super(
+      `Failed to download skill "${skillId}": ${reason}`,
+      RuntimeErrorCodes.SKILL_DOWNLOAD_ERROR,
+    );
+    this.name = 'SkillDownloadError';
+    this.skillId = skillId;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Error thrown when a skill's content hash does not match the on-chain record.
+ */
+export class SkillVerificationError extends RuntimeError {
+  /** The ID of the skill that failed verification */
+  public readonly skillId: string;
+  /** The expected content hash from the on-chain record */
+  public readonly expectedHash: string;
+  /** The actual hash computed from the downloaded content */
+  public readonly actualHash: string;
+
+  constructor(skillId: string, expectedHash: string, actualHash: string) {
+    super(
+      `Skill "${skillId}" content hash mismatch: expected ${expectedHash}, got ${actualHash}`,
+      RuntimeErrorCodes.SKILL_VERIFICATION_ERROR,
+    );
+    this.name = 'SkillVerificationError';
+    this.skillId = skillId;
+    this.expectedHash = expectedHash;
+    this.actualHash = actualHash;
+  }
+}
+
+/**
+ * Error thrown when publishing a skill to the registry fails.
+ */
+export class SkillPublishError extends RuntimeError {
+  /** The path of the skill file that failed to publish */
+  public readonly skillPath: string;
+  /** The reason the publish failed */
+  public readonly reason: string;
+
+  constructor(skillPath: string, reason: string) {
+    super(
+      `Failed to publish skill "${skillPath}": ${reason}`,
+      RuntimeErrorCodes.SKILL_PUBLISH_ERROR,
+    );
+    this.name = 'SkillPublishError';
+    this.skillPath = skillPath;
+    this.reason = reason;
+  }
+}

--- a/runtime/src/skills/registry/index.ts
+++ b/runtime/src/skills/registry/index.ts
@@ -1,0 +1,28 @@
+/**
+ * On-chain skill registry client — public API surface.
+ *
+ * @module
+ */
+
+// Data types and interface
+export type {
+  SkillListing,
+  SkillListingEntry,
+  SkillRegistryClient,
+  SkillRegistryClientConfig,
+  SearchOptions,
+} from './types.js';
+
+// Error classes
+export {
+  SkillRegistryNotFoundError,
+  SkillDownloadError,
+  SkillVerificationError,
+  SkillPublishError,
+} from './errors.js';
+
+// Client implementation and constants
+export {
+  OnChainSkillRegistryClient,
+  SKILL_REGISTRY_PROGRAM_ID,
+} from './client.js';

--- a/runtime/src/skills/registry/types.ts
+++ b/runtime/src/skills/registry/types.ts
@@ -1,0 +1,151 @@
+/**
+ * Data types and interfaces for the on-chain skill registry client.
+ *
+ * @module
+ */
+
+import type { Connection } from '@solana/web3.js';
+import type { Wallet } from '../../types/wallet.js';
+import type { Logger } from '../../utils/logger.js';
+
+// ============================================================================
+// Data Types
+// ============================================================================
+
+/**
+ * Full skill listing as stored in the on-chain registry.
+ */
+export interface SkillListing {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string;
+  readonly version: string;
+  readonly author: string;
+  readonly authorAgent?: string;
+  readonly authorReputation?: number;
+  readonly downloads: number;
+  readonly rating: number;
+  readonly ratingCount: number;
+  readonly tags: readonly string[];
+  readonly contentHash: string;
+  readonly priceLamports: bigint;
+  readonly priceToken?: { readonly mint: string; readonly amount: bigint };
+  readonly registeredAt: Date;
+  readonly updatedAt: Date;
+}
+
+/**
+ * Abbreviated skill entry returned by search and list operations.
+ */
+export interface SkillListingEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly author: string;
+  readonly rating: number;
+  readonly tags: readonly string[];
+  readonly priceLamports: bigint;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/**
+ * Configuration for {@link SkillRegistryClient} implementations.
+ */
+export interface SkillRegistryClientConfig {
+  /** Solana RPC connection */
+  readonly connection: Connection;
+  /** Wallet for signing publish/rate transactions (optional for read-only) */
+  readonly wallet?: Wallet;
+  /** IPFS content gateway base URL */
+  readonly contentGateway?: string;
+  /** Logger instance */
+  readonly logger?: Logger;
+  /** Injectable fetch function for testability */
+  readonly fetchFn?: typeof fetch;
+}
+
+// ============================================================================
+// Client Interface
+// ============================================================================
+
+/** Options for search queries. */
+export interface SearchOptions {
+  readonly tags?: readonly string[];
+  readonly limit?: number;
+  readonly offset?: number;
+}
+
+/**
+ * Client interface for interacting with the on-chain skill registry.
+ */
+export interface SkillRegistryClient {
+  /**
+   * Search for skills by query string and optional filters.
+   *
+   * @param query - Substring match against skill name and description
+   * @param options - Optional search filters (tags, limit, offset)
+   * @returns Array of matching skill listing entries
+   */
+  search(query: string, options?: SearchOptions): Promise<readonly SkillListingEntry[]>;
+
+  /**
+   * Get the full listing for a specific skill.
+   *
+   * @param skillId - The skill identifier
+   * @returns Full skill listing
+   * @throws SkillRegistryNotFoundError if the skill does not exist
+   */
+  get(skillId: string): Promise<SkillListing>;
+
+  /**
+   * Download and install a skill to the local filesystem.
+   *
+   * @param skillId - The skill identifier
+   * @param targetPath - Local filesystem path to write the skill file
+   * @returns The installed skill listing
+   * @throws SkillDownloadError if the download fails
+   * @throws SkillVerificationError if the content hash does not match
+   */
+  install(skillId: string, targetPath: string): Promise<SkillListing>;
+
+  /**
+   * Publish a local SKILL.md to the registry.
+   *
+   * @param skillPath - Path to the local SKILL.md file
+   * @param metadata - Additional metadata (name, description, tags, priceLamports)
+   * @returns The skillId (content hash) of the published skill
+   * @throws SkillPublishError if validation or upload fails
+   */
+  publish(
+    skillPath: string,
+    metadata: { name: string; description: string; tags?: readonly string[]; priceLamports?: bigint },
+  ): Promise<string>;
+
+  /**
+   * Rate a skill in the registry.
+   *
+   * @param skillId - The skill identifier
+   * @param rating - Rating value (1-5)
+   * @param review - Optional review text
+   */
+  rate(skillId: string, rating: number, review?: string): Promise<void>;
+
+  /**
+   * List skills published by a specific author.
+   *
+   * @param authorPubkey - The author's public key (base58)
+   * @returns Array of skill listing entries
+   */
+  listByAuthor(authorPubkey: string): Promise<readonly SkillListingEntry[]>;
+
+  /**
+   * Verify a skill's content hash against the on-chain record.
+   *
+   * @param skillId - The skill identifier
+   * @param contentHash - The expected content hash
+   * @returns True if the hash matches
+   */
+  verify(skillId: string, contentHash: string): Promise<boolean>;
+}

--- a/runtime/src/task/executor.test.ts
+++ b/runtime/src/task/executor.test.ts
@@ -1040,6 +1040,7 @@ describe('TaskExecutor', () => {
         constraintHash: new Uint8Array(32).fill(1),
         outputCommitment: new Uint8Array(32).fill(2),
         expectedBinding: new Uint8Array(32).fill(3),
+        nullifier: new Uint8Array(32).fill(4),
       });
 
       const config = createExecutorConfig({
@@ -1101,6 +1102,7 @@ describe('TaskExecutor', () => {
         constraintHash: new Uint8Array(32),
         outputCommitment: new Uint8Array(32),
         expectedBinding: new Uint8Array(32),
+        nullifier: new Uint8Array(32),
       };
 
       expect(isPrivateExecutionResult(publicResult)).toBe(false);

--- a/runtime/src/task/executor.ts
+++ b/runtime/src/task/executor.ts
@@ -1125,6 +1125,7 @@ export class TaskExecutor {
           result.constraintHash,
           result.outputCommitment,
           result.expectedBinding,
+          result.nullifier,
         );
       } else {
         completeResult = await this.operations.completeTask(

--- a/runtime/src/task/operations.test.ts
+++ b/runtime/src/task/operations.test.ts
@@ -559,6 +559,7 @@ describe('TaskOperations', () => {
       const constraintHash = new Uint8Array(32).fill(0x02);
       const outputCommitment = new Uint8Array(32).fill(0x03);
       const expectedBinding = new Uint8Array(32).fill(0x04);
+      const nullifier = new Uint8Array(32).fill(0x05);
 
       const result = await ops.completeTaskPrivate(
         taskPda,
@@ -567,6 +568,7 @@ describe('TaskOperations', () => {
         constraintHash,
         outputCommitment,
         expectedBinding,
+        nullifier,
       );
 
       expect(result.success).toBe(true);
@@ -588,6 +590,7 @@ describe('TaskOperations', () => {
           new Uint8Array(32).fill(0x02),
           new Uint8Array(32).fill(0x03),
           new Uint8Array(32).fill(0x04),
+          new Uint8Array(32).fill(0x05),
         ),
       ).rejects.toThrow(TaskSubmissionError);
     });
@@ -676,6 +679,7 @@ describe('TaskOperations', () => {
           new Uint8Array(32).fill(1),
           new Uint8Array(32).fill(1),
           new Uint8Array(32).fill(1),
+          new Uint8Array(32).fill(1),
         )
       ).rejects.toThrow('expected 256 bytes');
     });
@@ -688,6 +692,7 @@ describe('TaskOperations', () => {
           new Uint8Array(32).fill(1),
           new Uint8Array(32),
           new Uint8Array(32).fill(1),
+          new Uint8Array(32).fill(1),
         )
       ).rejects.toThrow('cannot be all zeros');
     });
@@ -697,6 +702,20 @@ describe('TaskOperations', () => {
         ops.completeTaskPrivate(
           taskPda, mockTask,
           new Uint8Array(256).fill(1),
+          new Uint8Array(32).fill(1),
+          new Uint8Array(32).fill(1),
+          new Uint8Array(32),
+          new Uint8Array(32).fill(1),
+        )
+      ).rejects.toThrow('cannot be all zeros');
+    });
+
+    it('completeTaskPrivate rejects all-zero nullifier', async () => {
+      await expect(
+        ops.completeTaskPrivate(
+          taskPda, mockTask,
+          new Uint8Array(256).fill(1),
+          new Uint8Array(32).fill(1),
           new Uint8Array(32).fill(1),
           new Uint8Array(32).fill(1),
           new Uint8Array(32),

--- a/runtime/src/task/operations.ts
+++ b/runtime/src/task/operations.ts
@@ -442,6 +442,7 @@ export class TaskOperations {
    * @param constraintHash - 32-byte constraint hash
    * @param outputCommitment - 32-byte output commitment
    * @param expectedBinding - 32-byte expected binding
+   * @param nullifier - 32-byte nullifier to prevent proof reuse
    * @returns Completion result with signature
    */
   async completeTaskPrivate(
@@ -451,14 +452,17 @@ export class TaskOperations {
     constraintHash: Uint8Array,
     outputCommitment: Uint8Array,
     expectedBinding: Uint8Array,
+    nullifier: Uint8Array,
   ): Promise<CompleteResult> {
     // Input validation (#963)
     validateByteLength(proofData, 256, 'proofData');
     validateByteLength(constraintHash, 32, 'constraintHash');
     validateByteLength(outputCommitment, 32, 'outputCommitment');
     validateByteLength(expectedBinding, 32, 'expectedBinding');
+    validateByteLength(nullifier, 32, 'nullifier');
     validateNonZeroBytes(outputCommitment, 'outputCommitment');
     validateNonZeroBytes(expectedBinding, 'expectedBinding');
+    validateNonZeroBytes(nullifier, 'nullifier');
 
     const workerPda = this.getAgentPda();
     const { address: claimPda } = deriveClaimPda(taskPda, workerPda, this.program.programId);
@@ -484,6 +488,7 @@ export class TaskOperations {
         constraintHash: toAnchorBytes(constraintHash),
         outputCommitment: toAnchorBytes(outputCommitment),
         expectedBinding: toAnchorBytes(expectedBinding),
+        nullifier: toAnchorBytes(nullifier),
       };
 
       const signature = await this.program.methods

--- a/runtime/src/task/proof-pipeline.test.ts
+++ b/runtime/src/task/proof-pipeline.test.ts
@@ -63,6 +63,7 @@ function createPrivateResult(): PrivateTaskExecutionResult {
     constraintHash: new Uint8Array(32).fill(4),
     outputCommitment: new Uint8Array(32).fill(5),
     expectedBinding: new Uint8Array(32).fill(6),
+    nullifier: new Uint8Array(32).fill(7),
   };
 }
 

--- a/runtime/src/task/proof-pipeline.ts
+++ b/runtime/src/task/proof-pipeline.ts
@@ -650,6 +650,7 @@ export class ProofPipeline {
           privateResult.constraintHash,
           privateResult.outputCommitment,
           privateResult.expectedBinding,
+          privateResult.nullifier,
         );
       } else {
         const publicResult = job.executionResult as TaskExecutionResult;

--- a/runtime/src/task/types.ts
+++ b/runtime/src/task/types.ts
@@ -602,6 +602,8 @@ export interface PrivateTaskExecutionResult {
   outputCommitment: Uint8Array;
   /** Expected binding (32 bytes) */
   expectedBinding: Uint8Array;
+  /** Nullifier to prevent proof/knowledge reuse (32 bytes) */
+  nullifier: Uint8Array;
 }
 
 /**

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -136,6 +136,14 @@ export const RuntimeErrorCodes = {
   HEARTBEAT_ACTION_FAILED: 'HEARTBEAT_ACTION_FAILED',
   /** Heartbeat action exceeded timeout */
   HEARTBEAT_TIMEOUT: 'HEARTBEAT_TIMEOUT',
+  /** Skill not found in on-chain registry */
+  SKILL_REGISTRY_NOT_FOUND: 'SKILL_REGISTRY_NOT_FOUND',
+  /** Skill download from content gateway failed */
+  SKILL_DOWNLOAD_ERROR: 'SKILL_DOWNLOAD_ERROR',
+  /** Skill content hash verification failed */
+  SKILL_VERIFICATION_ERROR: 'SKILL_VERIFICATION_ERROR',
+  /** Skill publish operation failed */
+  SKILL_PUBLISH_ERROR: 'SKILL_PUBLISH_ERROR',
 } as const;
 
 /** Union type of all runtime error code values */

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -28,6 +28,7 @@ export {
   computeExpectedBinding,
   computeConstraintHash,
   computeCommitment,
+  computeNullifier,
   // Types
   ProofGenerationParams,
   ProofResult,


### PR DESCRIPTION
## Summary

- Implement `SkillRegistryClient` interface and `OnChainSkillRegistryClient` class for Phase 6.1 on-chain skill registry integration
- Add 7 client methods: `search`, `get`, `install`, `publish`, `rate`, `listByAuthor`, `verify` with full type safety and error handling
- Fix pre-existing nullifier type errors in `completeTaskPrivate` by threading the `nullifier` field through the entire proof pipeline (SDK → runtime engine → task operations → agent)

## Details

**New registry module** (`runtime/src/skills/registry/`):
- `types.ts` — `SkillListing`, `SkillListingEntry`, `SkillRegistryClient` interface, `SearchOptions`, config
- `errors.ts` — 4 typed error classes extending `RuntimeError`
- `client.ts` — Full implementation using `Connection.getProgramAccounts()`, IPFS gateway downloads, SHA-256 verification, PDA derivation
- `client.test.ts` — 28 unit tests covering all methods, edge cases, and error paths

**Nullifier fix** (pre-existing type errors):
- Added `computeNullifier()` to SDK — `Poseidon(constraintHash, agentPubkeyField)` as preliminary stand-in for Phase 6.2 circuit update
- Threaded `nullifier: Uint8Array` through `ProofResult` → `EngineProofResult` → `PrivateTaskExecutionResult` → all call sites
- Fixed `proofData` type mismatch in `agent.ts` (`Buffer.from()` instead of `toAnchorBytes()` for Anchor `bytes` type)

## Test plan

- [x] 28 registry client tests pass
- [x] 37 proof engine tests pass
- [x] 39 SDK proof tests pass (4 new nullifier tests)
- [x] Zero TypeScript errors (`tsc --noEmit`)

Closes #1089