### PR TITLE
feat(runtime): browser tools — fetch, extract, convert with Playwright support

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -19,7 +19,7 @@
   "files": ["dist", "idl", "README.md"],
   "scripts": {
     "prebuild": "npm run build --prefix ../sdk && node scripts/copy-idl.js",
-    "build": "tsup src/index.ts src/bin/agenc-runtime.ts src/bin/daemon.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token --external ws --external grammy --external discord.js",
+    "build": "tsup src/index.ts src/bin/agenc-runtime.ts src/bin/daemon.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token --external ws --external grammy --external discord.js --external cheerio --external playwright",
     "typecheck": "tsc --noEmit",
     "check-idl-drift": "tsx scripts/check-idl-drift.ts",
     "pretest": "npm run build --prefix ../sdk",
@@ -48,7 +48,9 @@
     "ioredis": "^5.0.0",
     "ws": "^8.0.0",
     "grammy": "^1.0.0",
-    "discord.js": "^14.7.0"
+    "discord.js": "^14.7.0",
+    "cheerio": "^1.0.0",
+    "playwright": "^1.40.0"
   },
   "dependencies": {
     "@agenc/sdk": "file:../sdk"

--- a/runtime/src/tools/index.ts
+++ b/runtime/src/tools/index.ts
@@ -63,4 +63,8 @@ export {
   isPathAllowed,
   safePath,
   type FilesystemToolConfig,
+  // Browser
+  createBrowserTools,
+  closeBrowser,
+  type BrowserToolConfig,
 } from './system/index.js';

--- a/runtime/src/tools/system/browser.test.ts
+++ b/runtime/src/tools/system/browser.test.ts
@@ -1,0 +1,1393 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { silentLogger } from '../../utils/logger.js';
+
+// ============================================================================
+// Mock cheerio — intercept import('cheerio') used by ensureLazyModule
+// ============================================================================
+
+interface MockItem {
+  text: string;
+  html?: string;
+  href?: string;
+  tagName?: string;
+  __children?: Record<string, MockItem[]>;
+}
+
+/** Create a cheerio-like selection mock. */
+function makeSelection(opts: {
+  text?: string;
+  html?: string;
+  href?: string;
+  items?: MockItem[];
+  children?: Record<string, MockItem[]>;
+}): Record<string, unknown> {
+  const sel: Record<string, unknown> = {
+    text: vi.fn().mockReturnValue(opts.text ?? ''),
+    html: vi.fn().mockReturnValue(opts.html ?? opts.text ?? null),
+    attr: vi.fn().mockImplementation((name: string) =>
+      name === 'href' ? (opts.href ?? undefined) : undefined,
+    ),
+    find: vi.fn().mockImplementation((selector: string) => {
+      if (opts.children?.[selector]) {
+        return makeSelection({ items: opts.children[selector] });
+      }
+      return makeSelection({});
+    }),
+    each: vi.fn().mockImplementation((fn: (i: number, el: unknown) => void) => {
+      if (opts.items) {
+        opts.items.forEach((item, i) => fn(i, {
+          __text: item.text,
+          __html: item.html ?? item.text,
+          __href: item.href,
+          tagName: item.tagName,
+          __children: item.__children,
+        }));
+      }
+      return sel;
+    }),
+    length: opts.items?.length ?? (opts.text ? 1 : 0),
+  };
+  return sel;
+}
+
+/**
+ * Build a mock cheerio `$` function from parsed HTML.
+ * Parses simple patterns: <title>, <h1>-<h6>, <p>, <li>, <pre>, <blockquote>, <a>.
+ */
+function buildMockCheerio(html: string) {
+  const titleMatch = html.match(/<title>(.*?)<\/title>/i);
+  const titleText = titleMatch ? titleMatch[1] : '';
+
+  const links: Array<{ text: string; href: string }> = [];
+  let m: RegExpExecArray | null;
+  const linkRe = /<a[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/gi;
+  while ((m = linkRe.exec(html)) !== null) links.push({ href: m[1], text: m[2] });
+
+  // Headings: store per-level and all in document order
+  const headingsPerLevel: Record<number, Array<{ text: string; html: string }>> = {};
+  const allHeadings: Array<{ level: number; text: string; html: string }> = [];
+  const hRe = /<h([1-6])[^>]*>(.*?)<\/h[1-6]>/gi;
+  while ((m = hRe.exec(html)) !== null) {
+    const lvl = parseInt(m[1], 10);
+    const rawHtml = m[2];
+    const text = rawHtml.replace(/<[^>]*>/g, '');
+    const item = { text, html: rawHtml };
+    (headingsPerLevel[lvl] ??= []).push(item);
+    allHeadings.push({ level: lvl, ...item });
+  }
+
+  const paragraphs: Array<{ text: string; html: string }> = [];
+  const pRe = /<p[^>]*>(.*?)<\/p>/gi;
+  while ((m = pRe.exec(html)) !== null) {
+    const rawHtml = m[1];
+    paragraphs.push({ html: rawHtml, text: rawHtml.replace(/<[^>]*>/g, '') });
+  }
+
+  const listItems: Array<{ text: string; html: string }> = [];
+  const liRe = /<li[^>]*>(.*?)<\/li>/gi;
+  while ((m = liRe.exec(html)) !== null) {
+    const rawHtml = m[1];
+    listItems.push({ html: rawHtml, text: rawHtml.replace(/<[^>]*>/g, '') });
+  }
+
+  const codeBlocks: Array<{ text: string; html: string }> = [];
+  const preRe = /<pre[^>]*>(.*?)<\/pre>/gis;
+  while ((m = preRe.exec(html)) !== null) {
+    const rawHtml = m[1];
+    const text = rawHtml.replace(/<\/?code[^>]*>/gi, '');
+    codeBlocks.push({ html: rawHtml, text });
+  }
+
+  const blockquotes: Array<{ text: string; html: string }> = [];
+  const bqRe = /<blockquote[^>]*>(.*?)<\/blockquote>/gi;
+  while ((m = bqRe.exec(html)) !== null) {
+    const rawHtml = m[1];
+    blockquotes.push({ html: rawHtml, text: rawHtml.replace(/<[^>]*>/g, '') });
+  }
+
+  // Parse <ul> blocks and their <li> items
+  const ulItems: MockItem[] = [];
+  const ulRe = /<ul[^>]*>(.*?)<\/ul>/gis;
+  while ((m = ulRe.exec(html)) !== null) {
+    const ulHtml = m[1];
+    const liInUlRe = /<li[^>]*>(.*?)<\/li>/gi;
+    let liMatch: RegExpExecArray | null;
+    while ((liMatch = liInUlRe.exec(ulHtml)) !== null) {
+      ulItems.push({ html: liMatch[1], text: liMatch[1].replace(/<[^>]*>/g, '') });
+    }
+  }
+
+  // Parse <ol> blocks with nested <li> items
+  const olBlocks: MockItem[] = [];
+  const olRe = /<ol[^>]*>(.*?)<\/ol>/gis;
+  while ((m = olRe.exec(html)) !== null) {
+    const olHtml = m[1];
+    const liItems: MockItem[] = [];
+    const liInOlRe = /<li[^>]*>(.*?)<\/li>/gi;
+    let liMatch: RegExpExecArray | null;
+    while ((liMatch = liInOlRe.exec(olHtml)) !== null) {
+      liItems.push({ html: liMatch[1], text: liMatch[1].replace(/<[^>]*>/g, ''), tagName: 'li' });
+    }
+    olBlocks.push({ text: '', html: m[0], tagName: 'ol', __children: { 'li': liItems } });
+  }
+
+  // Parse <table> blocks with <tr> and <th>/<td> cells
+  const tableBlocks: MockItem[] = [];
+  const tableRe = /<table[^>]*>(.*?)<\/table>/gis;
+  while ((m = tableRe.exec(html)) !== null) {
+    const tableHtml = m[1];
+    const trItems: MockItem[] = [];
+    const trRe = /<tr[^>]*>(.*?)<\/tr>/gis;
+    let trMatch: RegExpExecArray | null;
+    while ((trMatch = trRe.exec(tableHtml)) !== null) {
+      const trHtml = trMatch[1];
+      const cellItems: MockItem[] = [];
+      const cellRe = /<(th|td)[^>]*>(.*?)<\/(?:th|td)>/gi;
+      let cellMatch: RegExpExecArray | null;
+      while ((cellMatch = cellRe.exec(trHtml)) !== null) {
+        cellItems.push({ html: cellMatch[2], text: cellMatch[2].replace(/<[^>]*>/g, ''), tagName: cellMatch[1].toLowerCase() });
+      }
+      trItems.push({ text: '', html: trMatch[0], tagName: 'tr', __children: { 'th, td': cellItems } });
+    }
+    tableBlocks.push({ text: '', html: m[0], tagName: 'table', __children: { 'tr': trItems } });
+  }
+
+  // $ function
+  const $ = function (selectorOrEl: unknown) {
+    if (typeof selectorOrEl === 'string') {
+      const s = selectorOrEl;
+      if (s === 'title') return makeSelection({ text: titleText, items: titleText ? [{ text: titleText }] : [] });
+      if (s === 'body') return makeSelection({ text: paragraphs.map((p) => p.text).join(' '), items: paragraphs.length ? [{ text: '' }] : [] });
+      if (s === 'a') return makeSelection({ items: links.map((l) => ({ text: l.text, href: l.href })) });
+
+      // Combined heading selector: 'h1, h2, h3, h4, h5, h6'
+      if (/^h[1-6](?:\s*,\s*h[1-6])*$/.test(s)) {
+        const requestedLevels = new Set(
+          s.split(',').map((p) => parseInt(p.trim().replace('h', ''), 10)),
+        );
+        const items = allHeadings
+          .filter((h) => requestedLevels.has(h.level))
+          .map((h) => ({ text: h.text, html: h.html, tagName: `h${h.level}` }));
+        return makeSelection({ items });
+      }
+
+      // Single heading selector
+      const hMatch = s.match(/^h([1-6])$/);
+      if (hMatch) {
+        const lvl = parseInt(hMatch[1], 10);
+        const hItems = headingsPerLevel[lvl] ?? [];
+        return makeSelection({ items: hItems.map((h) => ({ text: h.text, html: h.html, tagName: `h${lvl}` })) });
+      }
+
+      if (s === 'p') return makeSelection({ items: paragraphs.map((p) => ({ text: p.text, html: p.html })) });
+      if (s === 'li') return makeSelection({ items: listItems.map((li) => ({ text: li.text, html: li.html })) });
+      if (s === 'ul > li') return makeSelection({ items: ulItems });
+      if (s === 'ol') return makeSelection({ items: olBlocks });
+      if (s === 'table') return makeSelection({ items: tableBlocks });
+      if (s === 'pre') return makeSelection({ items: codeBlocks.map((c) => ({ text: c.text, html: c.html })) });
+      if (s === 'blockquote') return makeSelection({ items: blockquotes.map((b) => ({ text: b.text, html: b.html })) });
+      if (s === 'script' || s === 'style') return makeSelection({});
+
+      return makeSelection({});
+    }
+
+    // Element wrapping: $(el) where el came from each() callback
+    if (typeof selectorOrEl === 'object' && selectorOrEl !== null) {
+      const el = selectorOrEl as { __text?: string; __html?: string; __href?: string; tagName?: string; __children?: Record<string, MockItem[]> };
+      return makeSelection({ text: el.__text ?? '', html: el.__html ?? el.__text ?? '', href: el.__href, children: el.__children });
+    }
+
+    return makeSelection({});
+  };
+
+  ($ as Record<string, unknown>).root = vi.fn().mockReturnValue(makeSelection({ text: '' }));
+  ($ as Record<string, unknown>).html = vi.fn().mockReturnValue(html);
+
+  return $;
+}
+
+vi.mock('cheerio', () => ({
+  load: vi.fn().mockImplementation((html: string) => buildMockCheerio(html)),
+}));
+
+// ============================================================================
+// Mock playwright
+// ============================================================================
+
+const mockPage = {
+  setViewportSize: vi.fn().mockResolvedValue(undefined),
+  goto: vi.fn().mockResolvedValue(undefined),
+  screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png-data')),
+  pdf: vi.fn().mockResolvedValue(Buffer.from('fake-pdf-data')),
+  click: vi.fn().mockResolvedValue(undefined),
+  fill: vi.fn().mockResolvedValue(undefined),
+  evaluate: vi.fn().mockResolvedValue('eval-result'),
+  waitForSelector: vi.fn().mockResolvedValue(undefined),
+  close: vi.fn().mockResolvedValue(undefined),
+  mouse: { wheel: vi.fn().mockResolvedValue(undefined) },
+};
+
+const mockBrowser = {
+  newPage: vi.fn().mockResolvedValue(mockPage),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockLaunch = vi.fn().mockResolvedValue(mockBrowser);
+
+vi.mock('playwright', () => ({
+  chromium: {
+    launch: mockLaunch,
+  },
+}));
+
+// ============================================================================
+// Mock fetch
+// ============================================================================
+
+function makeHtmlResponse(
+  body: string,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  const allHeaders = { 'content-type': 'text/html; charset=utf-8', ...headers };
+  const headersObj = new Headers(Object.entries(allHeaders));
+  const encoder = new TextEncoder();
+  const encoded = encoder.encode(body);
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoded);
+      controller.close();
+    },
+  });
+
+  return {
+    status,
+    statusText: status === 200 ? 'OK' : `Status ${status}`,
+    ok: status >= 200 && status < 300,
+    headers: headersObj,
+    url: '',
+    text: vi.fn().mockResolvedValue(body),
+    body: stream,
+    redirected: false,
+  } as unknown as Response;
+}
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+// ============================================================================
+// Import after mocks
+// ============================================================================
+
+const { createBrowserTools, closeBrowser, sanitizeHref, _resetForTesting } =
+  await import('./browser.js');
+
+beforeEach(() => {
+  mockFetch = vi.fn().mockResolvedValue(
+    makeHtmlResponse('<html><head><title>Test</title></head><body><p>Hello World</p></body></html>'),
+  );
+  vi.stubGlobal('fetch', mockFetch);
+
+  _resetForTesting();
+
+  mockPage.setViewportSize.mockClear();
+  mockPage.goto.mockClear();
+  mockPage.screenshot.mockClear().mockResolvedValue(Buffer.from('fake-png-data'));
+  mockPage.pdf.mockClear().mockResolvedValue(Buffer.from('fake-pdf-data'));
+  mockPage.click.mockClear();
+  mockPage.fill.mockClear();
+  mockPage.evaluate.mockClear().mockResolvedValue('eval-result');
+  mockPage.waitForSelector.mockClear();
+  mockPage.close.mockClear();
+  mockPage.mouse.wheel.mockClear();
+  mockBrowser.newPage.mockClear().mockResolvedValue(mockPage);
+  mockBrowser.close.mockClear();
+  mockLaunch.mockClear().mockResolvedValue(mockBrowser);
+});
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+describe('createBrowserTools', () => {
+  it('basic mode creates 3 tools', () => {
+    const tools = createBrowserTools({ mode: 'basic' }, silentLogger);
+    expect(tools).toHaveLength(3);
+    expect(tools.map((t) => t.name)).toEqual([
+      'system.browse',
+      'system.extractLinks',
+      'system.htmlToMarkdown',
+    ]);
+  });
+
+  it('advanced mode creates 7 tools', () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    expect(tools).toHaveLength(7);
+    expect(tools.map((t) => t.name)).toEqual([
+      'system.browse',
+      'system.extractLinks',
+      'system.htmlToMarkdown',
+      'system.screenshot',
+      'system.browserAction',
+      'system.evaluateJs',
+      'system.exportPdf',
+    ]);
+  });
+
+  it('defaults to basic mode', () => {
+    const tools = createBrowserTools(undefined, silentLogger);
+    expect(tools).toHaveLength(3);
+  });
+
+  it('throws on invalid mode', () => {
+    expect(() =>
+      createBrowserTools({ mode: 'invalid' as 'basic' }, silentLogger),
+    ).toThrow('Invalid browser tool mode');
+  });
+
+  it('throws on invalid maxResponseBytes', () => {
+    expect(() =>
+      createBrowserTools({ mode: 'basic', maxResponseBytes: -1 }, silentLogger),
+    ).toThrow('maxResponseBytes must be a positive number');
+  });
+
+  it('throws on invalid timeoutMs', () => {
+    expect(() =>
+      createBrowserTools({ mode: 'basic', timeoutMs: 0 }, silentLogger),
+    ).toThrow('timeoutMs must be a positive number');
+  });
+});
+
+// ============================================================================
+// system.browse
+// ============================================================================
+
+describe('system.browse', () => {
+  it('fetches and extracts text from HTML', async () => {
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://example.com' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.text).toBeDefined();
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('respects domain blocklist', async () => {
+    const [browse] = createBrowserTools(
+      { mode: 'basic', blockedDomains: ['evil.com'] },
+      silentLogger,
+    );
+    const result = await browse.execute({ url: 'https://evil.com/page' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('blocked');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid URL', async () => {
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'not-a-url' });
+
+    expect(result.isError).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing URL', async () => {
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({});
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Missing or invalid url');
+  });
+
+  it('handles timeout errors', async () => {
+    const timeoutError = new Error('The operation was aborted');
+    timeoutError.name = 'TimeoutError';
+    mockFetch.mockRejectedValueOnce(timeoutError);
+
+    const [browse] = createBrowserTools(
+      { mode: 'basic', timeoutMs: 100 },
+      silentLogger,
+    );
+    const result = await browse.execute({ url: 'https://slow.example.com' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('timed out');
+  });
+
+  it('handles connection errors', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://down.example.com' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Connection failed');
+  });
+
+  it('truncates at maxResponseBytes', async () => {
+    const longBody = '<html><body>' + 'x'.repeat(500) + '</body></html>';
+    mockFetch.mockResolvedValueOnce(makeHtmlResponse(longBody));
+
+    const [browse] = createBrowserTools(
+      { mode: 'basic', maxResponseBytes: 50 },
+      silentLogger,
+    );
+    const result = await browse.execute({ url: 'https://example.com' });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('notes non-HTML content type', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeHtmlResponse('{"data": "json"}', 200, { 'content-type': 'application/json' }),
+    );
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://api.example.com/data' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.text).toContain('Content-Type');
+  });
+
+  it('includes links when requested', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeHtmlResponse(
+        '<html><body><a href="https://example.com/link1">Link 1</a></body></html>',
+      ),
+    );
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({
+      url: 'https://example.com',
+      includeLinks: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.text).toContain('Links');
+  });
+
+  it('returns empty text for empty page', async () => {
+    mockFetch.mockResolvedValueOnce(makeHtmlResponse('<html><body></body></html>'));
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://example.com/empty' });
+
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('renders 404 page content without error', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeHtmlResponse('<html><body><h1>Not Found</h1><p>Page missing</p></body></html>', 404),
+    );
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://example.com/missing' });
+
+    // Non-2xx pages are rendered, not treated as errors (mirrors browser behavior)
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.text).toContain('Not Found');
+  });
+});
+
+// ============================================================================
+// system.extractLinks
+// ============================================================================
+
+describe('system.extractLinks', () => {
+  it('extracts links from a page', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeHtmlResponse(
+        '<html><body>' +
+        '<a href="https://example.com/one">One</a>' +
+        '<a href="https://example.com/two">Two</a>' +
+        '</body></html>',
+      ),
+    );
+
+    const [, extractLinks] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await extractLinks.execute({ url: 'https://example.com' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.links).toHaveLength(2);
+    expect(parsed.links[0]).toEqual({ text: 'One', href: 'https://example.com/one' });
+    expect(parsed.links[1]).toEqual({ text: 'Two', href: 'https://example.com/two' });
+  });
+
+  it('filters links by text', async () => {
+    mockFetch.mockResolvedValueOnce(
+      makeHtmlResponse(
+        '<html><body>' +
+        '<a href="https://example.com/docs">Documentation</a>' +
+        '<a href="https://example.com/about">About Us</a>' +
+        '</body></html>',
+      ),
+    );
+
+    const [, extractLinks] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await extractLinks.execute({
+      url: 'https://example.com',
+      filterText: 'doc',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.links).toHaveLength(1);
+    expect(parsed.links[0].text).toBe('Documentation');
+  });
+
+  it('rejects blocked domains', async () => {
+    const [, extractLinks] = createBrowserTools(
+      { mode: 'basic', blockedDomains: ['evil.com'] },
+      silentLogger,
+    );
+    const result = await extractLinks.execute({ url: 'https://evil.com/links' });
+
+    expect(result.isError).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// system.htmlToMarkdown
+// ============================================================================
+
+describe('system.htmlToMarkdown', () => {
+  it('converts headings to markdown', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<h1>Title</h1><p>Content here</p>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('# Title');
+    expect(parsed.markdown).toContain('Content here');
+  });
+
+  it('handles empty input', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({ html: '' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toBe('');
+  });
+
+  it('rejects missing html', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({});
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Missing or invalid html');
+  });
+
+  it('converts list items', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<ul><li>Item one</li><li>Item two</li></ul>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('- Item one');
+    expect(parsed.markdown).toContain('- Item two');
+  });
+
+  it('converts code blocks', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<pre><code>const x = 1;</code></pre>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('```');
+    expect(parsed.markdown).toContain('const x = 1;');
+  });
+
+  it('converts blockquotes', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<blockquote>Important note</blockquote>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('> Important note');
+  });
+
+  it('extracts page title', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<html><head><title>My Page</title></head><body></body></html>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('# My Page');
+  });
+
+  it('renders inline links as markdown', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<p>Visit <a href="https://example.com">Example</a> for more.</p>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('[Example](https://example.com)');
+  });
+
+  it('renders strong/bold as markdown', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<p>This is <strong>important</strong> text.</p>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('**important**');
+  });
+
+  it('renders emphasis/italic as markdown', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<p>This is <em>emphasized</em> text.</p>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('*emphasized*');
+  });
+
+  it('sanitizes javascript: links in inline markdown', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<p>Click <a href="javascript:alert(1)">here</a></p>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).not.toContain('javascript:');
+    // Link text should still be present, just without the href
+    expect(parsed.markdown).toContain('here');
+  });
+
+  it('preserves document order for mixed heading levels', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<h2>Second</h2><h1>First</h1><h3>Third</h3>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    const md = parsed.markdown;
+    const secondIdx = md.indexOf('## Second');
+    const firstIdx = md.indexOf('# First');
+    const thirdIdx = md.indexOf('### Third');
+    expect(secondIdx).toBeLessThan(firstIdx);
+    expect(firstIdx).toBeLessThan(thirdIdx);
+  });
+
+  it('does not duplicate paragraphs nested inside blockquotes', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<blockquote><p>Quote text</p></blockquote><p>Standalone</p>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    // "Quote text" should appear exactly once (from blockquote), not twice
+    const matches = parsed.markdown.match(/Quote text/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(parsed.markdown).toContain('> Quote text');
+    expect(parsed.markdown).toContain('Standalone');
+  });
+
+  it('does not duplicate paragraphs nested inside list items', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<ul><li><p>List text</p></li></ul><p>After list</p>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    const matches = parsed.markdown.match(/List text/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(parsed.markdown).toContain('- List text');
+    expect(parsed.markdown).toContain('After list');
+  });
+
+  it('handles single-quoted href in inline links', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: "<p>Visit <a href='https://example.com'>Example</a> here.</p>",
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('[Example](https://example.com)');
+  });
+
+  it('numbers ordered list items', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<ol><li>First</li><li>Second</li><li>Third</li></ol>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('1. First');
+    expect(parsed.markdown).toContain('2. Second');
+    expect(parsed.markdown).toContain('3. Third');
+  });
+
+  it('distinguishes ordered and unordered lists', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<ul><li>Bullet</li></ul><ol><li>Number</li></ol>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('- Bullet');
+    expect(parsed.markdown).toContain('1. Number');
+  });
+
+  it('converts simple table to markdown', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<table><tr><th>Name</th><th>Age</th></tr><tr><td>Alice</td><td>30</td></tr></table>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('| Name | Age |');
+    expect(parsed.markdown).toContain('| --- | --- |');
+    expect(parsed.markdown).toContain('| Alice | 30 |');
+  });
+
+  it('converts table with inline formatting', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<table><tr><th>Link</th></tr><tr><td><a href="https://x.com">X</a></td></tr></table>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('[X](https://x.com)');
+  });
+
+  it('pads table rows with empty cells', async () => {
+    const [, , htmlToMd] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await htmlToMd.execute({
+      html: '<table><tr><th>A</th><th>B</th><th>C</th></tr><tr><td>1</td><td></td><td>3</td></tr></table>',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.markdown).toContain('| A | B | C |');
+    expect(parsed.markdown).toContain('| 1 |  | 3 |');
+  });
+});
+
+// ============================================================================
+// sanitizeHref
+// ============================================================================
+
+describe('sanitizeHref', () => {
+  it('allows http links', () => {
+    expect(sanitizeHref('http://example.com')).toBe('http://example.com');
+  });
+
+  it('allows https links', () => {
+    expect(sanitizeHref('https://example.com')).toBe('https://example.com');
+  });
+
+  it('allows mailto links', () => {
+    expect(sanitizeHref('mailto:test@example.com')).toBe('mailto:test@example.com');
+  });
+
+  it('allows relative links', () => {
+    expect(sanitizeHref('/about')).toBe('/about');
+    expect(sanitizeHref('page.html')).toBe('page.html');
+  });
+
+  it('strips javascript: hrefs', () => {
+    expect(sanitizeHref('javascript:alert(1)')).toBe('');
+  });
+
+  it('strips data: hrefs', () => {
+    expect(sanitizeHref('data:text/html,<script>alert(1)</script>')).toBe('');
+  });
+
+  it('strips vbscript: hrefs', () => {
+    expect(sanitizeHref('vbscript:MsgBox("XSS")')).toBe('');
+  });
+
+  it('strips case-insensitive dangerous schemes', () => {
+    expect(sanitizeHref('JAVASCRIPT:alert(1)')).toBe('');
+    expect(sanitizeHref('JavaScript:void(0)')).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(sanitizeHref('')).toBe('');
+  });
+
+  it('strips control characters in scheme position', () => {
+    expect(sanitizeHref('java\tscript:alert(1)')).toBe('');
+    expect(sanitizeHref('java\nscript:alert(1)')).toBe('');
+    expect(sanitizeHref('java\x00script:alert(1)')).toBe('');
+  });
+
+  it('strips file: scheme', () => {
+    expect(sanitizeHref('file:///etc/passwd')).toBe('');
+  });
+
+  it('allows fragment-only links', () => {
+    expect(sanitizeHref('#section')).toBe('#section');
+  });
+});
+
+// ============================================================================
+// Redirect handling
+// ============================================================================
+
+describe('redirect handling', () => {
+  it('follows redirects', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 302,
+      statusText: 'Found',
+      headers: new Headers({ location: 'https://example.com/redirected' }),
+      url: 'https://example.com/start',
+      text: vi.fn().mockResolvedValue(''),
+      body: null,
+    } as unknown as Response);
+    mockFetch.mockResolvedValueOnce(
+      makeHtmlResponse('<html><body><p>Final</p></body></html>'),
+    );
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://example.com/start' });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('redirect to blocked domain is stopped', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 302,
+      statusText: 'Found',
+      headers: new Headers({ location: 'https://evil.com/trap' }),
+      url: 'https://safe.com/start',
+      text: vi.fn().mockResolvedValue(''),
+      body: null,
+    } as unknown as Response);
+
+    const [browse] = createBrowserTools(
+      { mode: 'basic', blockedDomains: ['evil.com'] },
+      silentLogger,
+    );
+    const result = await browse.execute({ url: 'https://safe.com/start' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('blocked');
+  });
+
+  it('stops after max redirects', async () => {
+    for (let i = 0; i < 6; i++) {
+      mockFetch.mockResolvedValueOnce({
+        status: 302,
+        statusText: 'Found',
+        headers: new Headers({ location: `https://example.com/r${i + 1}` }),
+        url: `https://example.com/r${i}`,
+        text: vi.fn().mockResolvedValue(''),
+        body: null,
+      } as unknown as Response);
+    }
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://example.com/r0' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Too many redirects');
+  });
+
+  it('errors on redirect without Location header', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 301,
+      statusText: 'Moved Permanently',
+      headers: new Headers({}),
+      url: 'https://example.com/old',
+      text: vi.fn().mockResolvedValue(''),
+      body: null,
+    } as unknown as Response);
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://example.com/old' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Location header');
+  });
+});
+
+// ============================================================================
+// Domain validation
+// ============================================================================
+
+describe('domain validation', () => {
+  it('respects allowed domains', async () => {
+    const [browse] = createBrowserTools(
+      { mode: 'basic', allowedDomains: ['api.example.com'] },
+      silentLogger,
+    );
+    const result = await browse.execute({ url: 'https://other.com/page' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('not in allowed list');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('blocks SSRF targets', async () => {
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'http://localhost:3000/api' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('blocked');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('blocks non-HTTP schemes', async () => {
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'ftp://files.example.com/data' });
+
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ============================================================================
+// Advanced: system.screenshot
+// ============================================================================
+
+describe('system.screenshot', () => {
+  it('captures a screenshot', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+
+    const result = await screenshot.execute({ url: 'https://example.com' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.image).toContain('data:image/png;base64,');
+    expect(mockPage.goto).toHaveBeenCalledWith('https://example.com', expect.any(Object));
+    expect(mockPage.screenshot).toHaveBeenCalled();
+  });
+
+  it('sets custom viewport', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+
+    await screenshot.execute({ url: 'https://example.com', width: 800, height: 600 });
+
+    expect(mockPage.setViewportSize).toHaveBeenCalledWith({ width: 800, height: 600 });
+  });
+
+  it('supports fullPage option', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+
+    await screenshot.execute({ url: 'https://example.com', fullPage: true });
+
+    expect(mockPage.screenshot).toHaveBeenCalledWith({ fullPage: true });
+  });
+
+  it('rejects blocked domains', async () => {
+    const tools = createBrowserTools(
+      { mode: 'advanced', blockedDomains: ['evil.com'] },
+      silentLogger,
+    );
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+
+    const result = await screenshot.execute({ url: 'https://evil.com' });
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ============================================================================
+// Advanced: system.browserAction
+// ============================================================================
+
+describe('system.browserAction', () => {
+  it('clicks an element', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'click',
+      selector: '#submit-btn',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.action).toBe('click');
+    expect(parsed.description).toContain('#submit-btn');
+    expect(mockPage.click).toHaveBeenCalledWith('#submit-btn');
+  });
+
+  it('types text into element', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'type',
+      selector: '#search',
+      text: 'hello world',
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockPage.fill).toHaveBeenCalledWith('#search', 'hello world');
+  });
+
+  it('scrolls the page', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'scroll',
+      x: 0,
+      y: 500,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockPage.mouse.wheel).toHaveBeenCalledWith(0, 500);
+  });
+
+  it('waits for selector', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'waitForSelector',
+      selector: '.loaded',
+      waitMs: 3000,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(mockPage.waitForSelector).toHaveBeenCalledWith('.loaded', { timeout: 3000 });
+  });
+
+  it('returnScreenshot includes image', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'click',
+      selector: '#btn',
+      returnScreenshot: true,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.image).toContain('data:image/png;base64,');
+  });
+
+  it('rejects click without selector before opening page', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'click',
+    });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('selector is required');
+    // Page should not have been opened
+    expect(mockBrowser.newPage).not.toHaveBeenCalled();
+  });
+
+  it('rejects type without selector before opening page', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'type',
+      text: 'hello',
+    });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('selector is required');
+    expect(mockBrowser.newPage).not.toHaveBeenCalled();
+  });
+
+  it('rejects type without text before opening page', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'type',
+      selector: '#input',
+    });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('text is required');
+    expect(mockBrowser.newPage).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown action before opening page', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const action = tools.find((t) => t.name === 'system.browserAction')!;
+
+    const result = await action.execute({
+      url: 'https://example.com',
+      action: 'destroy',
+    });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Unknown action');
+    expect(mockBrowser.newPage).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// Advanced: system.evaluateJs
+// ============================================================================
+
+describe('system.evaluateJs', () => {
+  it('evaluates JS and returns result', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const evalJs = tools.find((t) => t.name === 'system.evaluateJs')!;
+
+    const result = await evalJs.execute({
+      url: 'https://example.com',
+      code: 'document.title',
+    });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.result).toBe('eval-result');
+    expect(mockPage.evaluate).toHaveBeenCalledWith('document.title');
+  });
+
+  it('handles eval errors', async () => {
+    mockPage.evaluate.mockRejectedValueOnce(new Error('ReferenceError: x is not defined'));
+
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const evalJs = tools.find((t) => t.name === 'system.evaluateJs')!;
+
+    const result = await evalJs.execute({
+      url: 'https://example.com',
+      code: 'x.y.z',
+    });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('JS evaluation failed');
+  });
+
+  it('rejects missing code', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const evalJs = tools.find((t) => t.name === 'system.evaluateJs')!;
+
+    const result = await evalJs.execute({ url: 'https://example.com' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Missing or invalid code');
+  });
+
+  it('rejects empty code string', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const evalJs = tools.find((t) => t.name === 'system.evaluateJs')!;
+
+    const result = await evalJs.execute({ url: 'https://example.com', code: '' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('Missing or invalid code');
+  });
+
+  it('rejects blocked domains', async () => {
+    const tools = createBrowserTools(
+      { mode: 'advanced', blockedDomains: ['evil.com'] },
+      silentLogger,
+    );
+    const evalJs = tools.find((t) => t.name === 'system.evaluateJs')!;
+
+    const result = await evalJs.execute({
+      url: 'https://evil.com',
+      code: 'document.cookie',
+    });
+
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ============================================================================
+// Advanced: system.exportPdf
+// ============================================================================
+
+describe('system.exportPdf', () => {
+  it('generates a PDF', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const exportPdf = tools.find((t) => t.name === 'system.exportPdf')!;
+
+    const result = await exportPdf.execute({ url: 'https://example.com' });
+
+    expect(result.isError).toBeUndefined();
+    const parsed = JSON.parse(result.content);
+    expect(parsed.url).toBe('https://example.com');
+    expect(parsed.pdf).toContain('data:application/pdf;base64,');
+  });
+
+  it('supports landscape option', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const exportPdf = tools.find((t) => t.name === 'system.exportPdf')!;
+
+    await exportPdf.execute({ url: 'https://example.com', landscape: true });
+
+    expect(mockPage.pdf).toHaveBeenCalledWith(expect.objectContaining({ landscape: true }));
+  });
+
+  it('supports margin option', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const exportPdf = tools.find((t) => t.name === 'system.exportPdf')!;
+
+    await exportPdf.execute({ url: 'https://example.com', margin: '1cm' });
+
+    expect(mockPage.pdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        margin: { top: '1cm', right: '1cm', bottom: '1cm', left: '1cm' },
+      }),
+    );
+  });
+
+  it('rejects blocked domains', async () => {
+    const tools = createBrowserTools(
+      { mode: 'advanced', blockedDomains: ['evil.com'] },
+      silentLogger,
+    );
+    const exportPdf = tools.find((t) => t.name === 'system.exportPdf')!;
+
+    const result = await exportPdf.execute({ url: 'https://evil.com' });
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ============================================================================
+// Sandbox flag stripping
+// ============================================================================
+
+describe('getBrowser sandbox protection', () => {
+  it('strips --no-sandbox from launch args', async () => {
+    const tools = createBrowserTools(
+      { mode: 'advanced', launchOptions: { args: ['--no-sandbox', '--headless'] } },
+      silentLogger,
+    );
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+    await screenshot.execute({ url: 'https://example.com' });
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: ['--headless'],
+      }),
+    );
+  });
+
+  it('strips --disable-setuid-sandbox from launch args', async () => {
+    const tools = createBrowserTools(
+      { mode: 'advanced', launchOptions: { args: ['--disable-setuid-sandbox'] } },
+      silentLogger,
+    );
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+    await screenshot.execute({ url: 'https://example.com' });
+
+    expect(mockLaunch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: [],
+      }),
+    );
+  });
+});
+
+// ============================================================================
+// closeBrowser
+// ============================================================================
+
+describe('closeBrowser', () => {
+  it('closes the browser instance', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+    await screenshot.execute({ url: 'https://example.com' });
+
+    await closeBrowser();
+    expect(mockBrowser.close).toHaveBeenCalled();
+  });
+
+  it('is safe to call when no browser is running', async () => {
+    await closeBrowser();
+  });
+
+  it('nulls the reference even if close() throws', async () => {
+    const tools = createBrowserTools({ mode: 'advanced' }, silentLogger);
+    const screenshot = tools.find((t) => t.name === 'system.screenshot')!;
+    await screenshot.execute({ url: 'https://example.com' });
+
+    mockBrowser.close.mockRejectedValueOnce(new Error('Browser crashed'));
+
+    await expect(closeBrowser()).rejects.toThrow('Browser crashed');
+    // A subsequent call should not try to close the dead browser again
+    mockBrowser.close.mockClear();
+    await closeBrowser(); // should be a no-op
+    expect(mockBrowser.close).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// AbortError handling
+// ============================================================================
+
+describe('AbortError handling', () => {
+  it('handles AbortError from fetch', async () => {
+    const abortError = new Error('The operation was aborted');
+    abortError.name = 'AbortError';
+    mockFetch.mockRejectedValueOnce(abortError);
+
+    const [browse] = createBrowserTools({ mode: 'basic' }, silentLogger);
+    const result = await browse.execute({ url: 'https://example.com/abort' });
+
+    expect(result.isError).toBe(true);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.error).toContain('timed out');
+  });
+});

--- a/runtime/src/tools/system/browser.ts
+++ b/runtime/src/tools/system/browser.ts
@@ -1,0 +1,971 @@
+/**
+ * Browser tools for web content extraction.
+ *
+ * Basic mode (fetch + cheerio): system.browse, system.extractLinks, system.htmlToMarkdown
+ * Advanced mode (Playwright): + system.screenshot, system.browserAction, system.evaluateJs, system.exportPdf
+ *
+ * Domain allow/deny lists from HTTP tool config are respected via shared isDomainAllowed().
+ *
+ * @module
+ */
+
+import type { Tool, ToolResult } from '../types.js';
+import { safeStringify } from '../types.js';
+import type { Logger } from '../../utils/logger.js';
+import { silentLogger } from '../../utils/logger.js';
+import { isDomainAllowed } from './http.js';
+import { ensureLazyModule } from '../../utils/lazy-import.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface BrowserToolConfig {
+  readonly mode: 'basic' | 'advanced';
+  readonly allowedDomains?: readonly string[];
+  readonly blockedDomains?: readonly string[];
+  /** Maximum response body size in bytes. Default: 1_048_576 (1 MB). */
+  readonly maxResponseBytes?: number;
+  /** Request timeout in milliseconds. Default: 30_000. */
+  readonly timeoutMs?: number;
+  /** Playwright launch options (advanced mode). */
+  readonly launchOptions?: Record<string, unknown>;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_MAX_RESPONSE_BYTES = 1_048_576; // 1 MB
+const DEFAULT_TIMEOUT_MS = 30_000;
+const MAX_REDIRECTS = 5;
+const USER_AGENT = 'AgenC-Runtime/0.1 (compatible)';
+
+/** Schemes allowed in href attributes. Everything else is stripped. */
+const SAFE_HREF_SCHEMES = new Set(['http:', 'https:', 'mailto:']);
+
+// ============================================================================
+// Shared Helpers
+// ============================================================================
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+/**
+ * Validate a URL string against domain allow/deny lists.
+ * Returns an error ToolResult if invalid, or null if OK.
+ */
+function validateUrl(
+  url: unknown,
+  config: BrowserToolConfig,
+): ToolResult | null {
+  if (typeof url !== 'string' || url.length === 0) {
+    return errorResult('Missing or invalid url');
+  }
+  const check = isDomainAllowed(url, config.allowedDomains, config.blockedDomains);
+  if (!check.allowed) {
+    return errorResult(check.reason!);
+  }
+  return null;
+}
+
+/**
+ * Sanitize an href value — only allow http/https/mailto and relative links.
+ * Returns empty string for dangerous schemes (javascript:, data:, vbscript:, etc.).
+ * Strips ASCII control characters and zero-width characters before checking.
+ */
+export function sanitizeHref(href: string): string {
+  // Strip ASCII control chars (0x00-0x1F, 0x7F) that browsers may ignore in schemes
+  // eslint-disable-next-line no-control-regex
+  const trimmed = href.replace(/[\x00-\x1f\x7f]/g, '').trim();
+  if (trimmed.length === 0) return '';
+
+  // Relative links (no colon before first slash) are safe
+  const colonIdx = trimmed.indexOf(':');
+  if (colonIdx === -1) return trimmed;
+
+  // Check if anything before the colon looks like a scheme (letters only)
+  const maybescheme = trimmed.slice(0, colonIdx);
+  if (!/^[a-zA-Z][a-zA-Z0-9+\-.]*$/.test(maybescheme)) {
+    // Not a valid scheme prefix — treat as relative
+    return trimmed;
+  }
+
+  // It has a scheme — check if it's in the safe list
+  const scheme = maybescheme.toLowerCase() + ':';
+  if (SAFE_HREF_SCHEMES.has(scheme)) return trimmed;
+
+  return '';
+}
+
+/**
+ * Convert inline HTML elements to markdown via regex.
+ * Handles: <a> → [text](href), <strong>/<b> → **text**, <em>/<i> → *text*, <code> → `text`.
+ * Strips all remaining HTML tags.
+ */
+function inlineToMd(html: string): string {
+  let md = html;
+  // Links: <a href="url">text</a> or <a href='url'>text</a> → [text](sanitized_url)
+  md = md.replace(/<a[^>]*href=(["'])([^"']*)\1[^>]*>(.*?)<\/a>/gi, (_match, _quote: string, href: string, text: string) => {
+    const safe = sanitizeHref(href);
+    return safe ? `[${text}](${safe})` : text;
+  });
+  // Strong/bold: <strong>text</strong> or <b>text</b> → **text**
+  md = md.replace(/<(?:strong|b)>(.*?)<\/(?:strong|b)>/gi, '**$1**');
+  // Emphasis/italic: <em>text</em> or <i>text</i> → *text*
+  md = md.replace(/<(?:em|i)>(.*?)<\/(?:em|i)>/gi, '*$1*');
+  // Inline code: <code>text</code> → `text`
+  md = md.replace(/<code>(.*?)<\/code>/gi, '`$1`');
+  // Strip remaining tags
+  md = md.replace(/<[^>]*>/g, '');
+  return md.trim();
+}
+
+/**
+ * Fetch HTML content from a URL with redirect following and size limits.
+ * Mirrors the redirect-following pattern from http.ts.
+ */
+async function fetchHtml(
+  url: string,
+  config: BrowserToolConfig,
+  logger: Logger,
+  redirectCount = 0,
+): Promise<{ html: string; contentType: string; finalUrl: string } | ToolResult> {
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBytes = config.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: 'manual',
+    });
+
+    // Manual redirect handling with domain re-validation
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        return errorResult(`Redirect (${response.status}) without Location header`);
+      }
+      if (redirectCount >= MAX_REDIRECTS) {
+        return errorResult(`Too many redirects (max: ${MAX_REDIRECTS})`);
+      }
+      const redirectUrl = new URL(location, url).toString();
+      const domainCheck = isDomainAllowed(
+        redirectUrl,
+        config.allowedDomains,
+        config.blockedDomains,
+      );
+      if (!domainCheck.allowed) {
+        return errorResult(domainCheck.reason!);
+      }
+      logger.debug(`Following redirect ${response.status} → ${redirectUrl}`);
+      return fetchHtml(redirectUrl, config, logger, redirectCount + 1);
+    }
+
+    // Read body with streaming size limit
+    const reader = response.body?.getReader();
+    let body: string;
+    if (!reader) {
+      const text = await response.text();
+      body = text.length > maxBytes ? text.slice(0, maxBytes) : text;
+    } else {
+      const decoder = new TextDecoder();
+      const chunks: string[] = [];
+      let totalBytes = 0;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          totalBytes += value.byteLength;
+          if (totalBytes > maxBytes) {
+            const excess = totalBytes - maxBytes;
+            const keep = value.byteLength - excess;
+            if (keep > 0) {
+              chunks.push(decoder.decode(value.slice(0, keep), { stream: false }));
+            }
+            await reader.cancel();
+            break;
+          }
+          chunks.push(decoder.decode(value, { stream: true }));
+        }
+      } finally {
+        reader.releaseLock();
+      }
+      body = chunks.join('');
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    return { html: body, contentType, finalUrl: response.url || url };
+  } catch (err) {
+    if (err instanceof Error) {
+      if (err.name === 'TimeoutError' || err.name === 'AbortError') {
+        return errorResult('Request timed out');
+      }
+      return errorResult(`Connection failed: ${err.message}`);
+    }
+    return errorResult(`Connection failed: ${String(err)}`);
+  }
+}
+
+/** Check if a fetchHtml result is an error ToolResult. */
+function isFetchError(result: unknown): result is ToolResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'isError' in result &&
+    (result as ToolResult).isError === true
+  );
+}
+
+// ============================================================================
+// Cheerio (lazy-loaded)
+// ============================================================================
+
+/** Minimal cheerio type surface used by this module. */
+interface CheerioSelection {
+  find(selector: string): CheerioSelection;
+  each(fn: (index: number, el: unknown) => void): CheerioSelection;
+  text(): string;
+  html(): string | null;
+  attr(name: string): string | undefined;
+  length: number;
+}
+
+/** Cheerio's `$` — callable with string selectors or element wrappers. */
+interface CheerioAPI {
+  (selectorOrElement: string | unknown): CheerioSelection;
+  root(): CheerioSelection;
+  html(): string;
+}
+
+type CheerioLoad = (html: string) => CheerioAPI;
+
+let cheerioLoad: CheerioLoad | null = null;
+
+async function loadCheerio(): Promise<CheerioLoad> {
+  if (cheerioLoad) return cheerioLoad;
+  cheerioLoad = await ensureLazyModule<CheerioLoad>(
+    'cheerio',
+    (msg) => new Error(msg),
+    (mod) => mod.load as CheerioLoad,
+  );
+  return cheerioLoad;
+}
+
+// ============================================================================
+// HTML → Markdown conversion
+// ============================================================================
+
+/**
+ * Convert HTML to markdown using cheerio.
+ * Uses flat selectors for each block type — no recursive DOM traversal.
+ * Handles: title, headings, paragraphs, links, emphasis/strong, code/pre, ul/ol lists, blockquotes.
+ * Tables are skipped for v1.
+ *
+ * To avoid duplicating content for nested elements (e.g. `<blockquote><p>text</p></blockquote>`),
+ * we collect all processed elements and skip any element whose content is a subset of an
+ * already-processed parent block.
+ */
+function htmlToMd($: CheerioAPI): string {
+  const lines: string[] = [];
+  // Track raw inner HTML of processed block elements to avoid duplicate content
+  const processedContent = new Set<string>();
+
+  // Extract title
+  const titleEl = $('title');
+  if (titleEl.length > 0) {
+    const title = titleEl.text().trim();
+    if (title) {
+      lines.push(`# ${title}`, '');
+    }
+  }
+
+  // Headings — combined selector preserves document order
+  $('h1, h2, h3, h4, h5, h6').each((_i, el) => {
+    const node = el as { tagName?: string };
+    const tag = (node.tagName ?? '').toLowerCase();
+    const level = parseInt(tag.replace('h', ''), 10) || 1;
+    const inner = $(el).html() ?? $(el).text();
+    const text = inlineToMd(inner).trim();
+    if (text) {
+      lines.push('', `${'#'.repeat(level)} ${text}`, '');
+      processedContent.add(inner.trim());
+    }
+  });
+
+  // Code blocks — process before paragraphs so <pre><code>x</code></pre> isn't duplicated
+  $('pre').each((_i, el) => {
+    const code = $(el).text().trim();
+    if (code) {
+      lines.push('', '```', code, '```', '');
+      const inner = $(el).html() ?? code;
+      processedContent.add(inner.trim());
+    }
+  });
+
+  // Blockquotes — process before paragraphs so nested <p> inside <blockquote> is skipped
+  $('blockquote').each((_i, el) => {
+    const inner = $(el).html() ?? $(el).text();
+    const text = inlineToMd(inner).trim();
+    if (text) {
+      lines.push('', `> ${text}`, '');
+      processedContent.add(inner.trim());
+    }
+  });
+
+  // Unordered list items — process before paragraphs so nested <p> inside <li> is skipped
+  $('ul > li').each((_i, el) => {
+    const inner = $(el).html() ?? $(el).text();
+    const text = inlineToMd(inner).trim();
+    if (text) {
+      lines.push(`- ${text}`);
+      processedContent.add(inner.trim());
+    }
+  });
+
+  // Ordered list items — number within each <ol>
+  $('ol').each((_i, olEl) => {
+    let num = 1;
+    $(olEl).find('li').each((_j, liEl) => {
+      const inner = $(liEl).html() ?? $(liEl).text();
+      const text = inlineToMd(inner).trim();
+      if (text) {
+        lines.push(`${num}. ${text}`);
+        processedContent.add(inner.trim());
+        num++;
+      }
+    });
+  });
+
+  // Tables — convert to markdown tables
+  $('table').each((_i, tableEl) => {
+    const rows: string[][] = [];
+    $(tableEl).find('tr').each((_j, trEl) => {
+      const cells: string[] = [];
+      $(trEl).find('th, td').each((_k, cellEl) => {
+        const inner = $(cellEl).html() ?? $(cellEl).text();
+        cells.push(inlineToMd(inner).trim());
+      });
+      if (cells.length > 0) rows.push(cells);
+    });
+
+    if (rows.length === 0) return;
+
+    // Determine max columns and pad rows
+    const maxCols = Math.max(...rows.map(r => r.length));
+    const padded = rows.map(r => [...r, ...Array(maxCols - r.length).fill('')]);
+
+    // First row is header
+    const header = padded[0];
+    lines.push('', '| ' + header.join(' | ') + ' |');
+    lines.push('| ' + header.map(() => '---').join(' | ') + ' |');
+
+    // Remaining rows
+    for (let r = 1; r < padded.length; r++) {
+      lines.push('| ' + padded[r].join(' | ') + ' |');
+    }
+    lines.push('');
+
+    // Track processed content
+    const inner = $(tableEl).html() ?? $(tableEl).text();
+    processedContent.add(inner.trim());
+  });
+
+  // Paragraphs — skip if content was already captured by a parent block
+  $('p').each((_i, el) => {
+    const inner = $(el).html() ?? $(el).text();
+    const trimmedInner = inner.trim();
+    // Skip if this paragraph's HTML was already processed as part of a parent block
+    if (processedContent.has(trimmedInner)) return;
+    // Also check if any processed block contains this paragraph's content
+    let alreadyCaptured = false;
+    for (const processed of processedContent) {
+      if (processed.includes(trimmedInner)) {
+        alreadyCaptured = true;
+        break;
+      }
+    }
+    if (alreadyCaptured) return;
+
+    const text = inlineToMd(trimmedInner).trim();
+    if (text) {
+      lines.push('', text, '');
+    }
+  });
+
+  return lines
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+// ============================================================================
+// Playwright (lazy-loaded, singleton)
+// ============================================================================
+
+interface PlaywrightBrowser {
+  newPage(): Promise<PlaywrightPage>;
+  close(): Promise<void>;
+}
+
+interface PlaywrightPage {
+  setViewportSize(size: { width: number; height: number }): Promise<void>;
+  goto(url: string, options?: { timeout?: number; waitUntil?: string }): Promise<void>;
+  screenshot(options?: { fullPage?: boolean }): Promise<Buffer>;
+  pdf(options?: Record<string, unknown>): Promise<Buffer>;
+  click(selector: string): Promise<void>;
+  fill(selector: string, value: string): Promise<void>;
+  evaluate(code: string | (() => unknown)): Promise<unknown>;
+  waitForSelector(selector: string, options?: { timeout?: number }): Promise<void>;
+  close(): Promise<void>;
+  mouse: { wheel(deltaX: number, deltaY: number): Promise<void> };
+}
+
+let browserInstance: PlaywrightBrowser | null = null;
+/** Guard against concurrent launches — stores the in-flight launch promise. */
+let browserLaunchPromise: Promise<PlaywrightBrowser> | null = null;
+
+async function getBrowser(config: BrowserToolConfig, logger: Logger): Promise<PlaywrightBrowser> {
+  if (browserInstance) return browserInstance;
+  // If a launch is already in-flight, wait for it instead of launching a second browser
+  if (browserLaunchPromise) return browserLaunchPromise;
+
+  browserLaunchPromise = (async () => {
+    const pw = await ensureLazyModule<{
+      chromium: { launch(opts?: Record<string, unknown>): Promise<PlaywrightBrowser> };
+    }>(
+      'playwright',
+      (msg) => new Error(msg),
+      (mod) => mod as { chromium: { launch(opts?: Record<string, unknown>): Promise<PlaywrightBrowser> } },
+    );
+
+    // Sanitize launch options: always strip sandbox-disabling flags
+    const opts = { ...(config.launchOptions ?? {}) };
+    if (Array.isArray(opts.args)) {
+      const blockedFlags = new Set(['--no-sandbox', '--disable-setuid-sandbox']);
+      opts.args = (opts.args as string[]).filter(
+        (arg: string) => !blockedFlags.has(arg),
+      );
+    }
+
+    logger.debug('Launching Playwright browser');
+    return pw.chromium.launch(opts);
+  })();
+
+  try {
+    browserInstance = await browserLaunchPromise;
+    return browserInstance;
+  } finally {
+    browserLaunchPromise = null;
+  }
+}
+
+/**
+ * Close the Playwright browser instance.
+ * Safe to call even if no browser is running.
+ * Nulls the reference before awaiting close to prevent stale-reference issues on error.
+ */
+export async function closeBrowser(): Promise<void> {
+  if (browserInstance) {
+    const b = browserInstance;
+    browserInstance = null;
+    await b.close();
+  }
+}
+
+/** Reset module-level caches. Exported only for test teardown. */
+export function _resetForTesting(): void {
+  cheerioLoad = null;
+  browserInstance = null;
+  browserLaunchPromise = null;
+}
+
+// ============================================================================
+// Basic Mode Tools
+// ============================================================================
+
+function createBrowseTool(config: BrowserToolConfig, logger: Logger): Tool {
+  return {
+    name: 'system.browse',
+    description:
+      'Fetch a web page and extract its readable text content. ' +
+      'Returns the page title and cleaned text in markdown format. ' +
+      'Optionally includes links found on the page.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'URL to fetch' },
+        includeLinks: {
+          type: 'boolean',
+          description: 'Include links in the output (default: false)',
+        },
+      },
+      required: ['url'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const urlErr = validateUrl(args.url, config);
+      if (urlErr) return urlErr;
+      const url = args.url as string;
+      const includeLinks = args.includeLinks === true;
+
+      const result = await fetchHtml(url, config, logger);
+      if (isFetchError(result)) return result;
+
+      const { html, contentType } = result;
+
+      let load: CheerioLoad;
+      try {
+        load = await loadCheerio();
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+
+      const $ = load(html);
+      const text = htmlToMd($);
+
+      // Build links section if requested
+      let linksSection = '';
+      if (includeLinks) {
+        const links: Array<{ text: string; href: string }> = [];
+        $('a').each((_i, el) => {
+          const aEl = $(el);
+          const linkText = aEl.text().trim();
+          const href = sanitizeHref(aEl.attr('href') ?? '');
+          if (href) {
+            links.push({ text: linkText || href, href });
+          }
+        });
+        if (links.length > 0) {
+          linksSection = '\n\n---\n## Links\n' +
+            links.map((l) => `- [${l.text}](${l.href})`).join('\n');
+        }
+      }
+
+      const contentTypeNote =
+        contentType && !contentType.includes('html')
+          ? `\n\n_Note: Content-Type was ${contentType}_`
+          : '';
+
+      return {
+        content: safeStringify({
+          url,
+          text: text + linksSection + contentTypeNote,
+        }),
+      };
+    },
+  };
+}
+
+function createExtractLinksTool(config: BrowserToolConfig, logger: Logger): Tool {
+  return {
+    name: 'system.extractLinks',
+    description:
+      'Extract all links from a web page. Returns a JSON array of { text, href } objects. ' +
+      'Optionally filter links by text (case-insensitive substring match).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'URL to fetch' },
+        filterText: {
+          type: 'string',
+          description: 'Filter links by text (case-insensitive substring match)',
+        },
+      },
+      required: ['url'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const urlErr = validateUrl(args.url, config);
+      if (urlErr) return urlErr;
+      const url = args.url as string;
+      const filterText = typeof args.filterText === 'string' ? args.filterText.toLowerCase() : null;
+
+      const result = await fetchHtml(url, config, logger);
+      if (isFetchError(result)) return result;
+
+      let load: CheerioLoad;
+      try {
+        load = await loadCheerio();
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+
+      const $ = load(result.html);
+      const links: Array<{ text: string; href: string }> = [];
+
+      $('a').each((_i, el) => {
+        const aEl = $(el);
+        const text = aEl.text().trim();
+        const href = sanitizeHref(aEl.attr('href') ?? '');
+        if (!href) return;
+        if (filterText && !text.toLowerCase().includes(filterText)) return;
+        links.push({ text: text || href, href });
+      });
+
+      return { content: safeStringify({ url, links }) };
+    },
+  };
+}
+
+function createHtmlToMarkdownTool(): Tool {
+  return {
+    name: 'system.htmlToMarkdown',
+    description:
+      'Convert a raw HTML string to markdown. Handles headings, paragraphs, links, ' +
+      'emphasis/strong, code/pre blocks, and simple lists (ul/ol). ' +
+      'Does not fetch any URL — operates on the provided HTML string directly.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        html: { type: 'string', description: 'HTML content to convert' },
+      },
+      required: ['html'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      if (typeof args.html !== 'string') {
+        return errorResult('Missing or invalid html');
+      }
+      if (args.html.length === 0) {
+        return { content: safeStringify({ markdown: '' }) };
+      }
+
+      let load: CheerioLoad;
+      try {
+        load = await loadCheerio();
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+
+      const $ = load(args.html);
+      const markdown = htmlToMd($);
+      return { content: safeStringify({ markdown }) };
+    },
+  };
+}
+
+// ============================================================================
+// Advanced Mode Tools (Playwright)
+// ============================================================================
+
+function createScreenshotTool(config: BrowserToolConfig, logger: Logger): Tool {
+  return {
+    name: 'system.screenshot',
+    description:
+      'Capture a screenshot of a web page as a PNG image. ' +
+      'Returns a base64-encoded PNG with data URI prefix.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'URL to capture' },
+        width: { type: 'number', description: 'Viewport width (default: 1280)' },
+        height: { type: 'number', description: 'Viewport height (default: 720)' },
+        fullPage: { type: 'boolean', description: 'Capture full page (default: false)' },
+      },
+      required: ['url'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const urlErr = validateUrl(args.url, config);
+      if (urlErr) return urlErr;
+      const url = args.url as string;
+      const width = typeof args.width === 'number' ? args.width : 1280;
+      const height = typeof args.height === 'number' ? args.height : 720;
+      const fullPage = args.fullPage === true;
+
+      try {
+        const browser = await getBrowser(config, logger);
+        const page = await browser.newPage();
+        try {
+          await page.setViewportSize({ width, height });
+          await page.goto(url, {
+            timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            waitUntil: 'networkidle',
+          });
+          const buffer = await page.screenshot({ fullPage });
+          const base64 = buffer.toString('base64');
+          return {
+            content: safeStringify({
+              url,
+              image: `data:image/png;base64,${base64}`,
+            }),
+          };
+        } finally {
+          await page.close();
+        }
+      } catch (err) {
+        return errorResult(`Screenshot failed: ${(err as Error).message}`);
+      }
+    },
+  };
+}
+
+function createBrowserActionTool(config: BrowserToolConfig, logger: Logger): Tool {
+  return {
+    name: 'system.browserAction',
+    description:
+      'Perform a browser interaction on a web page. ' +
+      'Actions: click, type, scroll, waitForSelector. ' +
+      'Each call navigates fresh — multi-step interactions do not persist state between calls. ' +
+      'Optionally returns a screenshot of the result.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'URL to navigate to' },
+        action: {
+          type: 'string',
+          description: 'Action to perform: click, type, scroll, waitForSelector',
+          enum: ['click', 'type', 'scroll', 'waitForSelector'],
+        },
+        selector: { type: 'string', description: 'CSS selector for click/type/waitForSelector' },
+        text: { type: 'string', description: 'Text to type (for "type" action)' },
+        x: { type: 'number', description: 'Horizontal scroll amount in pixels (for "scroll" action)' },
+        y: { type: 'number', description: 'Vertical scroll amount in pixels (for "scroll" action)' },
+        waitMs: { type: 'number', description: 'Wait timeout in ms for waitForSelector (default: 5000)' },
+        returnScreenshot: { type: 'boolean', description: 'Include a screenshot in the response (default: false)' },
+      },
+      required: ['url', 'action'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const urlErr = validateUrl(args.url, config);
+      if (urlErr) return urlErr;
+      const url = args.url as string;
+      const action = args.action as string;
+      const selector = typeof args.selector === 'string' ? args.selector : undefined;
+      const text = typeof args.text === 'string' ? args.text : undefined;
+      const x = typeof args.x === 'number' ? args.x : 0;
+      const y = typeof args.y === 'number' ? args.y : 0;
+      const waitMs = typeof args.waitMs === 'number' ? args.waitMs : 5000;
+      const returnScreenshot = args.returnScreenshot === true;
+
+      // Validate required args before opening a page
+      switch (action) {
+        case 'click':
+        case 'waitForSelector':
+          if (!selector) return errorResult(`selector is required for ${action} action`);
+          break;
+        case 'type':
+          if (!selector) return errorResult('selector is required for type action');
+          if (!text) return errorResult('text is required for type action');
+          break;
+        case 'scroll':
+          break;
+        default:
+          return errorResult(`Unknown action: ${action}`);
+      }
+
+      try {
+        const browser = await getBrowser(config, logger);
+        const page = await browser.newPage();
+        try {
+          await page.goto(url, {
+            timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            waitUntil: 'networkidle',
+          });
+
+          let description: string;
+          switch (action) {
+            case 'click':
+              await page.click(selector!);
+              description = `Clicked: ${selector}`;
+              break;
+            case 'type':
+              await page.fill(selector!, text!);
+              description = `Typed "${text}" into ${selector}`;
+              break;
+            case 'scroll':
+              await page.mouse.wheel(x, y);
+              description = `Scrolled by (${x}, ${y})`;
+              break;
+            case 'waitForSelector':
+              await page.waitForSelector(selector!, { timeout: waitMs });
+              description = `Selector found: ${selector}`;
+              break;
+            default:
+              // Unreachable — validated above
+              description = '';
+          }
+
+          const resultObj: Record<string, unknown> = { url, action, description };
+
+          if (returnScreenshot) {
+            const buffer = await page.screenshot();
+            resultObj.image = `data:image/png;base64,${buffer.toString('base64')}`;
+          }
+
+          return { content: safeStringify(resultObj) };
+        } finally {
+          await page.close();
+        }
+      } catch (err) {
+        return errorResult(`Browser action failed: ${(err as Error).message}`);
+      }
+    },
+  };
+}
+
+function createEvaluateJsTool(config: BrowserToolConfig, logger: Logger): Tool {
+  return {
+    name: 'system.evaluateJs',
+    description:
+      'Run JavaScript code in the context of a web page and return the result. ' +
+      'WARNING: This executes arbitrary JavaScript and requires explicit approval. ' +
+      'The code runs in the page context with access to the DOM.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'URL to navigate to' },
+        code: { type: 'string', description: 'JavaScript code to evaluate' },
+      },
+      required: ['url', 'code'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const urlErr = validateUrl(args.url, config);
+      if (urlErr) return urlErr;
+      const url = args.url as string;
+
+      if (typeof args.code !== 'string' || args.code.length === 0) {
+        return errorResult('Missing or invalid code');
+      }
+
+      try {
+        const browser = await getBrowser(config, logger);
+        const page = await browser.newPage();
+        try {
+          await page.goto(url, {
+            timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            waitUntil: 'networkidle',
+          });
+          const result = await page.evaluate(args.code);
+          return {
+            content: safeStringify({ url, result: result ?? null }),
+          };
+        } finally {
+          await page.close();
+        }
+      } catch (err) {
+        return errorResult(`JS evaluation failed: ${(err as Error).message}`);
+      }
+    },
+  };
+}
+
+function createExportPdfTool(config: BrowserToolConfig, logger: Logger): Tool {
+  return {
+    name: 'system.exportPdf',
+    description:
+      'Export a web page as a PDF document. ' +
+      'Returns a base64-encoded PDF with data URI prefix.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: { type: 'string', description: 'URL to export' },
+        landscape: { type: 'boolean', description: 'Use landscape orientation (default: false)' },
+        margin: {
+          type: 'string',
+          description: 'Page margin (e.g. "1cm", "0.5in"). Applied to all sides.',
+        },
+      },
+      required: ['url'],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const urlErr = validateUrl(args.url, config);
+      if (urlErr) return urlErr;
+      const url = args.url as string;
+      const landscape = args.landscape === true;
+      const margin = typeof args.margin === 'string' ? args.margin : undefined;
+
+      try {
+        const browser = await getBrowser(config, logger);
+        const page = await browser.newPage();
+        try {
+          await page.goto(url, {
+            timeout: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+            waitUntil: 'networkidle',
+          });
+
+          const pdfOptions: Record<string, unknown> = { landscape };
+          if (margin) {
+            pdfOptions.margin = {
+              top: margin,
+              right: margin,
+              bottom: margin,
+              left: margin,
+            };
+          }
+
+          const buffer = await page.pdf(pdfOptions);
+          const base64 = buffer.toString('base64');
+          return {
+            content: safeStringify({
+              url,
+              pdf: `data:application/pdf;base64,${base64}`,
+            }),
+          };
+        } finally {
+          await page.close();
+        }
+      } catch (err) {
+        return errorResult(`PDF export failed: ${(err as Error).message}`);
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Create browser tools for web content extraction.
+ *
+ * - Basic mode (default): 3 tools using fetch + cheerio (system.browse, system.extractLinks, system.htmlToMarkdown)
+ * - Advanced mode: 7 tools (3 basic + 4 Playwright tools: system.screenshot, system.browserAction, system.evaluateJs, system.exportPdf)
+ *
+ * @param config - Optional configuration for mode, domain control, timeouts, etc.
+ * @param logger - Optional logger instance (defaults to silent).
+ *
+ * @example
+ * ```typescript
+ * const tools = createBrowserTools({
+ *   mode: 'basic',
+ *   allowedDomains: ['*.example.com'],
+ *   blockedDomains: ['evil.com'],
+ * });
+ * registry.registerAll(tools);
+ * ```
+ */
+export function createBrowserTools(config?: BrowserToolConfig, logger?: Logger): Tool[] {
+  const cfg: BrowserToolConfig = config ?? { mode: 'basic' };
+  const log = logger ?? silentLogger;
+
+  // Validate config
+  if (cfg.mode !== 'basic' && cfg.mode !== 'advanced') {
+    throw new Error(`Invalid browser tool mode: ${cfg.mode as string}. Must be 'basic' or 'advanced'.`);
+  }
+  if (cfg.maxResponseBytes !== undefined && (typeof cfg.maxResponseBytes !== 'number' || cfg.maxResponseBytes <= 0)) {
+    throw new Error('maxResponseBytes must be a positive number');
+  }
+  if (cfg.timeoutMs !== undefined && (typeof cfg.timeoutMs !== 'number' || cfg.timeoutMs <= 0)) {
+    throw new Error('timeoutMs must be a positive number');
+  }
+
+  const basicTools: Tool[] = [
+    createBrowseTool(cfg, log),
+    createExtractLinksTool(cfg, log),
+    createHtmlToMarkdownTool(),
+  ];
+
+  if (cfg.mode === 'basic') {
+    return basicTools;
+  }
+
+  const advancedTools: Tool[] = [
+    createScreenshotTool(cfg, log),
+    createBrowserActionTool(cfg, log),
+    createEvaluateJsTool(cfg, log),
+    createExportPdfTool(cfg, log),
+  ];
+
+  return [...basicTools, ...advancedTools];
+}

--- a/runtime/src/tools/system/index.ts
+++ b/runtime/src/tools/system/index.ts
@@ -17,3 +17,9 @@ export {
   safePath,
   type FilesystemToolConfig,
 } from './filesystem.js';
+
+export {
+  createBrowserTools,
+  closeBrowser,
+  type BrowserToolConfig,
+} from './browser.js';

--- a/runtime/yarn.lock
+++ b/runtime/yarn.lock
@@ -83,6 +83,78 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
+"@discordjs/builders@^1.13.0":
+  version "1.13.1"
+  resolved "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz"
+  integrity sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==
+  dependencies:
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/util" "^1.2.0"
+    "@sapphire/shapeshift" "^4.0.0"
+    discord-api-types "^0.38.33"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.4"
+    tslib "^2.6.3"
+
+"@discordjs/collection@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/collection@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/collection@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz"
+  integrity sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==
+
+"@discordjs/formatters@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz"
+  integrity sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==
+  dependencies:
+    discord-api-types "^0.38.33"
+
+"@discordjs/rest@^2.5.1", "@discordjs/rest@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz"
+  integrity sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==
+  dependencies:
+    "@discordjs/collection" "^2.1.1"
+    "@discordjs/util" "^1.1.1"
+    "@sapphire/async-queue" "^1.5.3"
+    "@sapphire/snowflake" "^3.5.3"
+    "@vladfrangu/async_event_emitter" "^2.4.6"
+    discord-api-types "^0.38.16"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
+
+"@discordjs/util@^1.1.0", "@discordjs/util@^1.1.1", "@discordjs/util@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz"
+  integrity sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==
+  dependencies:
+    discord-api-types "^0.38.33"
+
+"@discordjs/ws@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz"
+  integrity sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==
+  dependencies:
+    "@discordjs/collection" "^2.1.0"
+    "@discordjs/rest" "^2.5.1"
+    "@discordjs/util" "^1.1.0"
+    "@sapphire/async-queue" "^1.5.2"
+    "@types/ws" "^8.5.10"
+    "@vladfrangu/async_event_emitter" "^2.2.4"
+    discord-api-types "^0.38.1"
+    tslib "^2.6.2"
+    ws "^8.17.0"
+
 "@esbuild/linux-x64@0.21.5":
   version "0.21.5"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"
@@ -151,10 +223,23 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.2.tgz"
   integrity sha512-1e30XAuaBP1MAizaOBApsgeGZge2/Byd6wV4a8oa6jPdHELbRHBiw7wvo4dp7Ie2PE8TZT4pj9RLGZv9N4qwlw==
 
-"@rollup/rollup-linux-x64-musl@4.55.2":
-  version "4.55.2"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.2.tgz"
-  integrity sha512-4BJucJBGbuGnH6q7kpPqGJGzZnYrpAzRd60HQSt3OpX/6/YVgSsJnNzR8Ot74io50SeVT4CtCWe/RYIAymFPwA==
+"@sapphire/async-queue@^1.5.2", "@sapphire/async-queue@^1.5.3":
+  version "1.5.5"
+  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz"
+  integrity sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==
+
+"@sapphire/shapeshift@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz"
+  integrity sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lodash "^4.17.21"
+
+"@sapphire/snowflake@^3.5.3", "@sapphire/snowflake@3.5.3":
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz"
+  integrity sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==
 
 "@solana/buffer-layout-utils@^0.2.0":
   version "0.2.0"
@@ -370,7 +455,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^8.0.0", "@types/ws@^8.2.2":
+"@types/ws@^8.0.0", "@types/ws@^8.2.2", "@types/ws@^8.5.10":
   version "8.18.1"
   resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
   integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
@@ -435,6 +520,11 @@
     "@vitest/pretty-format" "2.1.9"
     loupe "^3.1.2"
     tinyrainbow "^1.2.0"
+
+"@vladfrangu/async_event_emitter@^2.2.4", "@vladfrangu/async_event_emitter@^2.4.6":
+  version "2.4.7"
+  resolved "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz"
+  integrity sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -537,6 +627,11 @@ bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.2"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz"
   integrity sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==
+
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 borsh@^0.7.0:
   version "0.7.0"
@@ -642,6 +737,35 @@ check-error@^2.1.1:
   resolved "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz"
   integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz"
+  integrity sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    encoding-sniffer "^0.2.1"
+    htmlparser2 "^10.1.0"
+    parse5 "^7.3.0"
+    parse5-htmlparser2-tree-adapter "^7.1.0"
+    parse5-parser-stream "^7.1.2"
+    undici "^7.19.0"
+    whatwg-mimetype "^4.0.0"
+
 chokidar@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz"
@@ -703,6 +827,22 @@ cross-fetch@^3.1.5:
   dependencies:
     node-fetch "^2.7.0"
 
+css-select@^5.1.0:
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz"
+  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz"
+  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
+
 debug@^4.3.4, debug@^4.3.7, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
@@ -747,6 +887,60 @@ detect-libc@^2.0.0:
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
 
+discord-api-types@^0.38.1, discord-api-types@^0.38.16, discord-api-types@^0.38.33:
+  version "0.38.39"
+  resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.39.tgz"
+  integrity sha512-XRdDQvZvID1XvcFftjSmd4dcmMi/RL/jSy5sduBDAvCGFcNFHThdIQXCEBDZFe52lCNEzuIL0QJoKYAmRmxLUA==
+
+discord.js@^14.7.0:
+  version "14.25.1"
+  resolved "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz"
+  integrity sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==
+  dependencies:
+    "@discordjs/builders" "^1.13.0"
+    "@discordjs/collection" "1.5.3"
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/rest" "^2.6.0"
+    "@discordjs/util" "^1.2.0"
+    "@discordjs/ws" "^1.2.3"
+    "@sapphire/snowflake" "3.5.3"
+    discord-api-types "^0.38.33"
+    fast-deep-equal "3.1.3"
+    lodash.snakecase "4.1.1"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
+
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1, domutils@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"
@@ -756,12 +950,35 @@ dunder-proto@^1.0.1:
     es-errors "^1.3.0"
     gopd "^1.2.0"
 
+encoding-sniffer@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz"
+  integrity sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==
+  dependencies:
+    iconv-lite "^0.6.3"
+    whatwg-encoding "^3.1.1"
+
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.5"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz"
   integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
   dependencies:
     once "^1.4.0"
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 es-define-property@^1.0.1:
   version "1.0.1"
@@ -905,6 +1122,11 @@ eyes@^0.1.8:
   resolved "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
+fast-deep-equal@^3.1.3, fast-deep-equal@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
 fast-stable-stringify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz"
@@ -1038,12 +1260,29 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+htmlparser2@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
+
 humanize-ms@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz"
   integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
   dependencies:
     ms "^2.0.0"
+
+iconv-lite@^0.6.3, iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
@@ -1128,16 +1367,6 @@ litesvm-linux-x64-gnu@0.5.0:
   resolved "https://registry.npmjs.org/litesvm-linux-x64-gnu/-/litesvm-linux-x64-gnu-0.5.0.tgz"
   integrity sha512-W8IIBVlLSBN5RkM88292TImBmYmDMgiYGecin6Qan+dRsBxUffFjRSFHgZRzJQ6X7pfhjlXI6kzuqwsZYchUHA==
 
-litesvm-linux-x64-musl@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.npmjs.org/litesvm-linux-x64-musl/-/litesvm-linux-x64-musl-0.3.3.tgz"
-  integrity sha512-bpWZ2f506hbfu1y6bkmuZf+qqtnLDxggpOMTQbibjd+q6faEO3sETWwKGlIgHB99P8wyU+aXKwLSGQX2sJEw6Q==
-
-litesvm-linux-x64-musl@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/litesvm-linux-x64-musl/-/litesvm-linux-x64-musl-0.5.0.tgz"
-  integrity sha512-MECozYJjeEiuAEv04FucrFCA0ivdIxisuiK7Fxzx5uSda0W6AieuDx6rnkMXXTgEsR3PKQUA18KmHR93CN1cdw==
-
 litesvm@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/litesvm/-/litesvm-0.3.3.tgz"
@@ -1183,10 +1412,25 @@ lodash.isarguments@^3.1.0:
   resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
   integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
+lodash.snakecase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
+
+lodash@^4.17.21:
+  version "4.17.23"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+
 loupe@^3.1.0, loupe@^3.1.2:
   version "3.2.1"
   resolved "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz"
   integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
+magic-bytes.js@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz"
+  integrity sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==
 
 magic-string@^0.30.12, magic-string@^0.30.17:
   version "0.30.21"
@@ -1285,6 +1529,13 @@ node-gyp-build@^4.3.0:
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
@@ -1321,6 +1572,28 @@ pako@^2.0.3:
   version "2.1.0"
   resolved "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
+
+parse5-htmlparser2-tree-adapter@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz"
+  integrity sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==
+  dependencies:
+    domhandler "^5.0.3"
+    parse5 "^7.0.0"
+
+parse5-parser-stream@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz"
+  integrity sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==
+  dependencies:
+    parse5 "^7.0.0"
+
+parse5@^7.0.0, parse5@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
 
 pathe@^1.1.2:
   version "1.1.2"
@@ -1360,6 +1633,20 @@ pkg-types@^1.3.1:
     confbox "^0.1.8"
     mlly "^1.7.4"
     pathe "^2.0.1"
+
+playwright-core@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz"
+  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+
+playwright@^1.40.0:
+  version "1.58.2"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz"
+  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+  dependencies:
+    playwright-core "1.58.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 postcss-load-config@^6.0.1:
   version "6.0.1"
@@ -1503,6 +1790,11 @@ safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^7.3.5:
   version "7.7.4"
@@ -1693,7 +1985,12 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
-tslib@^2.8.0:
+ts-mixer@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz"
+  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
+
+tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -1757,6 +2054,16 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@^7.19.0:
+  version "7.22.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz"
+  integrity sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==
+
+undici@6.21.3:
+  version "6.21.3"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 utf-8-validate@^5.0.2, utf-8-validate@>=5.0.2:
   version "5.0.10"
@@ -1833,10 +2140,22 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@^3.6.20:
   version "3.6.20"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -1859,7 +2178,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^8.0.0, ws@^8.18.0, ws@^8.5.0:
+ws@*, ws@^8.0.0, ws@^8.17.0, ws@^8.18.0, ws@^8.5.0:
   version "8.19.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz"
   integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==

--- a/sdk/yarn.lock
+++ b/sdk/yarn.lock
@@ -107,11 +107,6 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz"
   integrity sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==
 
-"@rollup/rollup-linux-x64-musl@4.55.1":
-  version "4.55.1"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz"
-  integrity sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==
-
 "@solana/buffer-layout-utils@^0.2.0":
   version "0.2.0"
   resolved "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz"


### PR DESCRIPTION
## Summary
- Adds 7 browser tools across basic (fetch+cheerio) and advanced (Playwright) modes: `system.browse`, `system.extractLinks`, `system.htmlToMarkdown`, `system.screenshot`, `system.browserAction`, `system.evaluateJs`, `system.exportPdf`
- HTML-to-markdown conversion handles headings, paragraphs, inline formatting, code blocks, blockquotes, ordered/unordered lists with numbering, and tables
- Domain allow/deny lists from HTTP tool config are respected with SSRF protection and redirect following with domain re-validation at each hop

Closes #1072

## Test plan
- [x] 87 unit tests covering all 7 tools, edge cases, and security boundaries
- [x] `npx tsc --noEmit` passes cleanly
- [x] All 204 system tool tests pass (`vitest run src/tools/system/`)