### PR TITLE
feat(runtime): tool permission policy evaluator (#1077)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -805,6 +805,11 @@ export {
   type AuditTrailEntry,
   type AuditTrailStore,
   type AuditTrailVerification,
+  ToolPolicyEvaluator,
+  type ToolPermissionPolicy,
+  type ToolPolicyConditions,
+  type ToolPolicyContext,
+  type ToolPolicyDecision,
 } from './policy/index.js';
 
 // Tool System (Phase 5)

--- a/runtime/src/policy/index.ts
+++ b/runtime/src/policy/index.ts
@@ -56,3 +56,11 @@ export {
   type AuditTrailStore,
   type AuditTrailVerification,
 } from './audit-trail.js';
+
+export {
+  ToolPolicyEvaluator,
+  type ToolPermissionPolicy,
+  type ToolPolicyConditions,
+  type ToolPolicyContext,
+  type ToolPolicyDecision,
+} from './tool-policy.js';

--- a/runtime/src/policy/tool-policy.test.ts
+++ b/runtime/src/policy/tool-policy.test.ts
@@ -1,0 +1,407 @@
+import { describe, it, expect } from 'vitest';
+import { ToolPolicyEvaluator, type ToolPermissionPolicy, type ToolPolicyContext } from './tool-policy.js';
+
+function ctx(overrides: Partial<ToolPolicyContext> = {}): ToolPolicyContext {
+  return {
+    toolName: 'system.bash',
+    sessionId: 'sess-1',
+    channel: 'telegram',
+    isHeartbeat: false,
+    isSandboxed: false,
+    ...overrides,
+  };
+}
+
+describe('ToolPolicyEvaluator', () => {
+  // -------------------------------------------------------------------
+  // Basic allow / deny
+  // -------------------------------------------------------------------
+
+  it('denies when a deny rule matches', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'deny' },
+    ]);
+    const decision = evaluator.evaluate(ctx());
+    expect(decision.allowed).toBe(false);
+    expect(decision.matchedRule?.tool).toBe('system.bash');
+  });
+
+  it('allows when an allow rule matches', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow' },
+    ]);
+    const decision = evaluator.evaluate(ctx());
+    expect(decision.allowed).toBe(true);
+    expect(decision.matchedRule?.tool).toBe('system.bash');
+  });
+
+  it('deny takes precedence over allow when deny comes first', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'deny' },
+      { tool: 'system.bash', effect: 'allow' },
+    ]);
+    const decision = evaluator.evaluate(ctx());
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('deny takes precedence over allow even when allow comes first', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow' },
+      { tool: 'system.bash', effect: 'deny' },
+    ]);
+    const decision = evaluator.evaluate(ctx());
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('defaults to deny when no rule matches', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'agenc.listTasks', effect: 'allow' },
+    ]);
+    const decision = evaluator.evaluate(ctx());
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('No matching allow rule');
+  });
+
+  // -------------------------------------------------------------------
+  // Glob pattern matching
+  // -------------------------------------------------------------------
+
+  it('glob pattern system.* matches system.bash', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.*', effect: 'allow' },
+    ]);
+    const decision = evaluator.evaluate(ctx({ toolName: 'system.bash' }));
+    expect(decision.allowed).toBe(true);
+  });
+
+  it('glob pattern system.* matches system.http', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.*', effect: 'allow' },
+    ]);
+    const decision = evaluator.evaluate(ctx({ toolName: 'system.http' }));
+    expect(decision.allowed).toBe(true);
+  });
+
+  it('glob pattern system.* does NOT match systemd', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.*', effect: 'allow' },
+    ]);
+    const decision = evaluator.evaluate(ctx({ toolName: 'systemd' }));
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('No matching allow rule');
+  });
+
+  it('wildcard * matches everything', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: '*', effect: 'allow' },
+    ]);
+    expect(evaluator.evaluate(ctx({ toolName: 'anything' })).allowed).toBe(true);
+    expect(evaluator.evaluate(ctx({ toolName: 'system.bash' })).allowed).toBe(true);
+  });
+
+  it('exact name matches exactly', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'agenc.listTasks', effect: 'allow' },
+    ]);
+    expect(evaluator.evaluate(ctx({ toolName: 'agenc.listTasks' })).allowed).toBe(true);
+    expect(evaluator.evaluate(ctx({ toolName: 'agenc.getTask' })).allowed).toBe(false);
+  });
+
+  it('glob pattern works with deny rules', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.*', effect: 'deny' },
+      { tool: '*', effect: 'allow' },
+    ]);
+    // system.bash denied by glob deny
+    expect(evaluator.evaluate(ctx({ toolName: 'system.bash' })).allowed).toBe(false);
+    // agenc.listTasks allowed by wildcard allow (no deny match)
+    expect(evaluator.evaluate(ctx({ toolName: 'agenc.listTasks' })).allowed).toBe(true);
+  });
+
+  it('glob does not match across dot segments', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.*', effect: 'allow' },
+    ]);
+    // Two segments deep — should not match single * glob
+    expect(evaluator.evaluate(ctx({ toolName: 'system.bash.sub' })).allowed).toBe(false);
+  });
+
+  // -------------------------------------------------------------------
+  // heartbeatOnly condition
+  // -------------------------------------------------------------------
+
+  it('heartbeatOnly blocks user-initiated calls', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { heartbeatOnly: true } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ isHeartbeat: false }));
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('heartbeatOnly allows heartbeat-initiated calls', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { heartbeatOnly: true } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ isHeartbeat: true }));
+    expect(decision.allowed).toBe(true);
+  });
+
+  // -------------------------------------------------------------------
+  // sessionIds condition
+  // -------------------------------------------------------------------
+
+  it('sessionIds restriction blocks non-matching sessions', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { sessionIds: ['sess-admin'] } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ sessionId: 'sess-user' }));
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('sessionIds allows matching sessions', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { sessionIds: ['sess-admin'] } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ sessionId: 'sess-admin' }));
+    expect(decision.allowed).toBe(true);
+  });
+
+  // -------------------------------------------------------------------
+  // channels condition
+  // -------------------------------------------------------------------
+
+  it('channels restriction blocks non-matching channels', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { channels: ['discord'] } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ channel: 'telegram' }));
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('channels allows matching channels', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { channels: ['telegram'] } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ channel: 'telegram' }));
+    expect(decision.allowed).toBe(true);
+  });
+
+  // -------------------------------------------------------------------
+  // sandboxOnly condition
+  // -------------------------------------------------------------------
+
+  it('sandboxOnly blocks non-sandboxed calls', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { sandboxOnly: true } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ isSandboxed: false }));
+    expect(decision.allowed).toBe(false);
+  });
+
+  it('sandboxOnly allows sandboxed calls', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { sandboxOnly: true } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ isSandboxed: true }));
+    expect(decision.allowed).toBe(true);
+  });
+
+  // -------------------------------------------------------------------
+  // Rate limiting
+  // -------------------------------------------------------------------
+
+  it('allows calls within rate limit', () => {
+    let nowMs = 1_000;
+    const evaluator = new ToolPolicyEvaluator(
+      [{ tool: 'system.bash', effect: 'allow', conditions: { rateLimit: 3 } }],
+      () => nowMs,
+    );
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+    nowMs += 100;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+    nowMs += 100;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+  });
+
+  it('blocks calls exceeding rate limit', () => {
+    let nowMs = 1_000;
+    const evaluator = new ToolPolicyEvaluator(
+      [{ tool: 'system.bash', effect: 'allow', conditions: { rateLimit: 2 } }],
+      () => nowMs,
+    );
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+    nowMs += 100;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+    nowMs += 100;
+    const decision = evaluator.evaluate(ctx());
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toContain('Rate limit exceeded');
+  });
+
+  it('rate limit window resets after expiry', () => {
+    let nowMs = 1_000;
+    const evaluator = new ToolPolicyEvaluator(
+      [{ tool: 'system.bash', effect: 'allow', conditions: { rateLimit: 1 } }],
+      () => nowMs,
+    );
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+    nowMs += 100;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(false);
+
+    // Advance past the 60s window
+    nowMs += 60_000;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+  });
+
+  // -------------------------------------------------------------------
+  // Multiple conditions (AND logic)
+  // -------------------------------------------------------------------
+
+  it('all conditions must be met (AND logic)', () => {
+    const policies: ToolPermissionPolicy[] = [
+      {
+        tool: 'system.bash',
+        effect: 'allow',
+        conditions: {
+          heartbeatOnly: true,
+          channels: ['telegram'],
+          sandboxOnly: true,
+        },
+      },
+    ];
+    const evaluator = new ToolPolicyEvaluator(policies);
+
+    // All conditions met
+    expect(evaluator.evaluate(ctx({
+      isHeartbeat: true,
+      channel: 'telegram',
+      isSandboxed: true,
+    })).allowed).toBe(true);
+
+    // heartbeat missing
+    expect(evaluator.evaluate(ctx({
+      isHeartbeat: false,
+      channel: 'telegram',
+      isSandboxed: true,
+    })).allowed).toBe(false);
+
+    // wrong channel
+    expect(evaluator.evaluate(ctx({
+      isHeartbeat: true,
+      channel: 'discord',
+      isSandboxed: true,
+    })).allowed).toBe(false);
+
+    // not sandboxed
+    expect(evaluator.evaluate(ctx({
+      isHeartbeat: true,
+      channel: 'telegram',
+      isSandboxed: false,
+    })).allowed).toBe(false);
+  });
+
+  it('rate limit combined with channel condition', () => {
+    let nowMs = 1_000;
+    const evaluator = new ToolPolicyEvaluator(
+      [{ tool: 'system.bash', effect: 'allow', conditions: { channels: ['telegram'], rateLimit: 1 } }],
+      () => nowMs,
+    );
+    // Wrong channel — no allow rule matches
+    expect(evaluator.evaluate(ctx({ channel: 'discord' })).allowed).toBe(false);
+    // Right channel — allowed
+    expect(evaluator.evaluate(ctx({ channel: 'telegram' })).allowed).toBe(true);
+    nowMs += 100;
+    // Right channel but rate limited
+    const decision = evaluator.evaluate(ctx({ channel: 'telegram' }));
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toContain('Rate limit exceeded');
+  });
+
+  // -------------------------------------------------------------------
+  // updatePolicies
+  // -------------------------------------------------------------------
+
+  it('updatePolicies replaces policy set and clears rate counters', () => {
+    let nowMs = 1_000;
+    const evaluator = new ToolPolicyEvaluator(
+      [{ tool: 'system.bash', effect: 'allow', conditions: { rateLimit: 1 } }],
+      () => nowMs,
+    );
+
+    // Exhaust rate limit
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+    nowMs += 100;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(false);
+
+    // Update policies — rate counters reset
+    evaluator.updatePolicies([
+      { tool: 'system.bash', effect: 'allow', conditions: { rateLimit: 1 } },
+    ]);
+    nowMs += 100;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+  });
+
+  it('updatePolicies changes which tools are allowed', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow' },
+    ]);
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+
+    evaluator.updatePolicies([
+      { tool: 'system.bash', effect: 'deny' },
+    ]);
+    expect(evaluator.evaluate(ctx()).allowed).toBe(false);
+  });
+
+  // -------------------------------------------------------------------
+  // recordCall
+  // -------------------------------------------------------------------
+
+  it('recordCall tracks calls for rate limit externally', () => {
+    let nowMs = 1_000;
+    const evaluator = new ToolPolicyEvaluator(
+      [{ tool: 'system.bash', effect: 'allow', conditions: { rateLimit: 2 } }],
+      () => nowMs,
+    );
+
+    // Record one call externally
+    evaluator.recordCall('system.bash');
+    nowMs += 100;
+
+    // Only one more allowed via evaluate
+    expect(evaluator.evaluate(ctx()).allowed).toBe(true);
+    nowMs += 100;
+    expect(evaluator.evaluate(ctx()).allowed).toBe(false);
+  });
+
+  // -------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------
+
+  it('empty policies list defaults to deny', () => {
+    const evaluator = new ToolPolicyEvaluator([]);
+    const decision = evaluator.evaluate(ctx());
+    expect(decision.allowed).toBe(false);
+    expect(decision.reason).toBe('No matching allow rule');
+  });
+
+  it('deny rule with unmet conditions does not block', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'deny', conditions: { channels: ['discord'] } },
+      { tool: 'system.bash', effect: 'allow' },
+    ]);
+    // Deny rule targets discord only; we're on telegram → deny doesn't fire
+    const decision = evaluator.evaluate(ctx({ channel: 'telegram' }));
+    expect(decision.allowed).toBe(true);
+  });
+
+  it('first matching allow rule wins', () => {
+    const evaluator = new ToolPolicyEvaluator([
+      { tool: 'system.bash', effect: 'allow', conditions: { channels: ['telegram'] } },
+      { tool: 'system.bash', effect: 'allow', conditions: { channels: ['discord'] } },
+    ]);
+    const decision = evaluator.evaluate(ctx({ channel: 'telegram' }));
+    expect(decision.allowed).toBe(true);
+    expect(decision.matchedRule?.conditions?.channels).toEqual(['telegram']);
+  });
+});

--- a/runtime/src/policy/tool-policy.ts
+++ b/runtime/src/policy/tool-policy.ts
@@ -1,0 +1,192 @@
+/**
+ * Granular, condition-based tool permission policy evaluator.
+ *
+ * Designed to be composed alongside PolicyEngine (called from Gateway's
+ * `tool:before` hook). Does NOT modify PolicyEngine internals.
+ *
+ * @module
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ToolPermissionPolicy {
+  readonly tool: string;
+  readonly effect: 'allow' | 'deny';
+  readonly conditions?: ToolPolicyConditions;
+}
+
+export interface ToolPolicyConditions {
+  readonly heartbeatOnly?: boolean;
+  readonly sessionIds?: readonly string[];
+  readonly channels?: readonly string[];
+  readonly rateLimit?: number; // calls per minute
+  readonly sandboxOnly?: boolean;
+}
+
+export interface ToolPolicyContext {
+  readonly toolName: string;
+  readonly sessionId: string;
+  readonly channel: string;
+  readonly isHeartbeat: boolean;
+  readonly isSandboxed: boolean;
+}
+
+export interface ToolPolicyDecision {
+  readonly allowed: boolean;
+  readonly reason?: string;
+  readonly matchedRule?: ToolPermissionPolicy;
+}
+
+// ---------------------------------------------------------------------------
+// Evaluator
+// ---------------------------------------------------------------------------
+
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+export class ToolPolicyEvaluator {
+  private policies: readonly ToolPermissionPolicy[];
+  private readonly now: () => number;
+
+  /** Sliding-window timestamps per tool name for rate limiting. */
+  private rateCounts = new Map<string, number[]>();
+
+  constructor(policies: readonly ToolPermissionPolicy[], now?: () => number) {
+    this.policies = policies;
+    this.now = now ?? Date.now;
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Evaluate whether a tool call is permitted.
+   *
+   * Deny-first, default-deny:
+   * 1. Iterate policies in order.
+   * 2. Matching deny rule whose conditions are met → deny immediately.
+   * 3. First matching allow rule whose conditions are met → candidate.
+   * 4. If candidate exists, check rate limit → allow (auto-records call).
+   * 5. No matching allow → deny.
+   */
+  evaluate(context: ToolPolicyContext): ToolPolicyDecision {
+    let candidateAllow: ToolPermissionPolicy | undefined;
+
+    for (const policy of this.policies) {
+      if (!this.matchesPattern(context.toolName, policy.tool)) {
+        continue;
+      }
+
+      const { met, reason } = this.checkConditions(policy, context);
+
+      if (policy.effect === 'deny' && met) {
+        return { allowed: false, reason: reason ?? `Denied by rule: ${policy.tool}`, matchedRule: policy };
+      }
+
+      if (policy.effect === 'allow' && met && !candidateAllow) {
+        candidateAllow = policy;
+      }
+    }
+
+    if (!candidateAllow) {
+      return { allowed: false, reason: 'No matching allow rule' };
+    }
+
+    // Rate limit check (applied after condition matching, before final allow)
+    if (candidateAllow.conditions?.rateLimit !== undefined) {
+      const limit = candidateAllow.conditions.rateLimit;
+      const now = this.now();
+      const cutoff = now - RATE_LIMIT_WINDOW_MS;
+      const bucket = this.rateCounts.get(context.toolName) ?? [];
+      const recent = bucket.filter((t) => t >= cutoff);
+
+      if (recent.length >= limit) {
+        this.rateCounts.set(context.toolName, recent);
+        return {
+          allowed: false,
+          reason: `Rate limit exceeded: ${limit} calls/min for "${context.toolName}"`,
+          matchedRule: candidateAllow,
+        };
+      }
+
+      recent.push(now);
+      this.rateCounts.set(context.toolName, recent);
+    }
+
+    return { allowed: true, matchedRule: candidateAllow };
+  }
+
+  /** Record a tool call for rate-limit tracking. Called internally for rate-limited allows. */
+  recordCall(toolName: string): void {
+    const bucket = this.rateCounts.get(toolName) ?? [];
+    bucket.push(this.now());
+    this.rateCounts.set(toolName, bucket);
+  }
+
+  /** Hot-reload policies, clearing rate counters. */
+  updatePolicies(policies: readonly ToolPermissionPolicy[]): void {
+    this.policies = policies;
+    this.rateCounts.clear();
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Simple glob matching with `*` wildcard.
+   *
+   * - `*` alone matches everything.
+   * - `system.*` matches `system.bash` but not `systemd`.
+   * - Exact names match exactly.
+   */
+  private matchesPattern(toolName: string, pattern: string): boolean {
+    if (pattern === '*') return true;
+
+    if (!pattern.includes('*')) {
+      return toolName === pattern;
+    }
+
+    // Convert glob pattern to regex: escape dots, replace * with [^.]*
+    const escaped = pattern.replace(/\./g, '\\.').replace(/\*/g, '[^.]*');
+    return new RegExp(`^${escaped}$`).test(toolName);
+  }
+
+  /**
+   * Check all non-rate-limit conditions (AND logic).
+   *
+   * Conditions describe *when* a rule activates. If any condition is not
+   * satisfied, the rule does not match (regardless of deny/allow effect).
+   */
+  private checkConditions(
+    policy: ToolPermissionPolicy,
+    context: ToolPolicyContext,
+  ): { met: boolean; reason?: string } {
+    const cond = policy.conditions;
+    if (!cond) return { met: true };
+
+    if (cond.heartbeatOnly && !context.isHeartbeat) {
+      return { met: false, reason: 'Restricted to heartbeat-initiated calls' };
+    }
+
+    if (cond.sessionIds && cond.sessionIds.length > 0) {
+      if (!cond.sessionIds.includes(context.sessionId)) {
+        return { met: false, reason: `Session "${context.sessionId}" not in allowed sessions` };
+      }
+    }
+
+    if (cond.channels && cond.channels.length > 0) {
+      if (!cond.channels.includes(context.channel)) {
+        return { met: false, reason: `Channel "${context.channel}" not in allowed channels` };
+      }
+    }
+
+    if (cond.sandboxOnly && !context.isSandboxed) {
+      return { met: false, reason: 'Restricted to sandboxed execution' };
+    }
+
+    return { met: true };
+  }
+}


### PR DESCRIPTION
## Summary

- Add `ToolPolicyEvaluator` class for granular, condition-based tool permission policies
- Support glob pattern matching (`system.*`, `*`), deny-first/default-deny evaluation
- Per-tool sliding-window rate limiting (60s window) with injectable `now` for deterministic tests
- Conditional rules: `heartbeatOnly`, `sessionIds`, `channels`, `sandboxOnly` (AND logic)
- Hot-reload via `updatePolicies()`, external tracking via `recordCall()`
- Standalone module — does not modify existing PolicyEngine internals

Closes #1077

## Test plan

- [x] 31 vitest tests covering all acceptance criteria
- [x] Basic allow/deny, deny-first precedence regardless of rule order
- [x] Glob matching: `system.*` matches `system.bash`, not `systemd` or `system.bash.sub`
- [x] All 5 condition types individually tested (block + allow)
- [x] Rate limiting: within limit, exceeding limit, window reset
- [x] Combined conditions (AND logic), rate limit + channel
- [x] `updatePolicies` clears counters, `recordCall` external tracking
- [x] Edge cases: empty policies, unmet deny conditions, first-match wins
- [x] Typecheck clean, full build passes