### PR TITLE
feat(runtime): session isolation per workspace (#1095)

### DIFF
--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -101,6 +101,10 @@ export {
   MEMORY_NAMESPACE_PREFIX,
 } from './workspace.js';
 
+// Session isolation (Phase 7.3)
+export type { IsolatedSessionContext, SessionIsolationManagerConfig, AuthState } from './session-isolation.js';
+export { SessionIsolationManager } from './session-isolation.js';
+
 // Slash commands (Phase 1.5)
 export {
   SlashCommandRegistry,

--- a/runtime/src/gateway/session-isolation.test.ts
+++ b/runtime/src/gateway/session-isolation.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SessionIsolationManager,
+  type SessionIsolationManagerConfig,
+  type AuthState,
+} from './session-isolation.js';
+import type { AgentWorkspace } from './workspace.js';
+import type { WorkspaceManager } from './workspace.js';
+import { InMemoryBackend } from '../memory/in-memory/backend.js';
+import { PolicyEngine } from '../policy/engine.js';
+import type { Tool, ToolResult } from '../tools/types.js';
+import type { LLMProvider, LLMResponse, LLMMessage, StreamProgressCallback } from '../llm/types.js';
+import type { MarkdownSkill } from '../skills/markdown/types.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Lightweight mock for Keypair/PublicKey to avoid importing @solana/web3.js */
+function makeMockKeypair(): { publicKey: { toBase58(): string } } {
+  const pubkey = { toBase58: () => `mock-pubkey-${Math.random().toString(36).slice(2, 10)}` };
+  return { publicKey: pubkey };
+}
+
+function makeWorkspace(
+  id: string,
+  overrides?: Partial<AgentWorkspace>,
+): AgentWorkspace {
+  return {
+    id,
+    name: id,
+    path: `/tmp/workspaces/${id}`,
+    files: { agent: '', system: '', style: '', knowledge: '' },
+    skills: [],
+    memoryNamespace: `agenc:memory:${id}:`,
+    capabilities: 0n,
+    ...overrides,
+  };
+}
+
+function makeMockWorkspaceManager(
+  workspaces: Map<string, AgentWorkspace>,
+): WorkspaceManager {
+  return {
+    basePath: '/tmp/workspaces',
+    load: vi.fn(async (id: string) => {
+      const ws = workspaces.get(id);
+      if (!ws) throw new Error(`Workspace not found: ${id}`);
+      return ws;
+    }),
+    listWorkspaces: vi.fn(async () => Array.from(workspaces.keys())),
+    createWorkspace: vi.fn(),
+    deleteWorkspace: vi.fn(),
+    getDefault: vi.fn(() => 'default'),
+  } as unknown as WorkspaceManager;
+}
+
+function makeMockLLMProvider(name = 'mock-llm'): LLMProvider {
+  return {
+    name,
+    chat: vi.fn(async (_msgs: LLMMessage[]): Promise<LLMResponse> => ({
+      content: 'mock response',
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: 'mock',
+      finishReason: 'stop',
+    })),
+    chatStream: vi.fn(async (_msgs: LLMMessage[], _cb: StreamProgressCallback): Promise<LLMResponse> => ({
+      content: 'mock stream',
+      toolCalls: [],
+      usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      model: 'mock',
+      finishReason: 'stop',
+    })),
+    healthCheck: vi.fn(async () => true),
+  };
+}
+
+function makeMockTool(name: string): Tool {
+  return {
+    name,
+    description: `Mock tool: ${name}`,
+    inputSchema: { type: 'object', properties: {} },
+    execute: vi.fn(async (): Promise<ToolResult> => ({
+      content: `${name} result`,
+    })),
+  };
+}
+
+function makeMockSkill(name: string): MarkdownSkill {
+  return {
+    name,
+    description: `Skill ${name}`,
+    version: '1.0.0',
+    metadata: {
+      requires: { binaries: [], env: [], channels: [], os: [] },
+      install: [],
+      tags: [],
+    },
+    body: `# ${name}`,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SessionIsolationManager', () => {
+  function makeManager(
+    overrides?: Partial<SessionIsolationManagerConfig>,
+    workspaces?: Map<string, AgentWorkspace>,
+  ): SessionIsolationManager {
+    const wsMap = workspaces ?? new Map([
+      ['ws-a', makeWorkspace('ws-a')],
+      ['ws-b', makeWorkspace('ws-b')],
+    ]);
+    return new SessionIsolationManager({
+      workspaceManager: makeMockWorkspaceManager(wsMap),
+      ...overrides,
+    });
+  }
+
+  // --- Isolation -----------------------------------------------------------
+
+  it('different workspaces get different memory backends', async () => {
+    const mgr = makeManager();
+    const ctxA = await mgr.getContext('ws-a');
+    const ctxB = await mgr.getContext('ws-b');
+    expect(ctxA.memoryBackend).not.toBe(ctxB.memoryBackend);
+  });
+
+  it('different workspaces get different policy engines', async () => {
+    const mgr = makeManager();
+    const ctxA = await mgr.getContext('ws-a');
+    const ctxB = await mgr.getContext('ws-b');
+    expect(ctxA.policyEngine).not.toBe(ctxB.policyEngine);
+  });
+
+  it('memory writes in workspace A not visible in workspace B', async () => {
+    const mgr = makeManager();
+    const ctxA = await mgr.getContext('ws-a');
+    const ctxB = await mgr.getContext('ws-b');
+
+    await ctxA.memoryBackend.addEntry({
+      sessionId: 'test-session',
+      role: 'user',
+      content: 'secret message from A',
+    });
+
+    const threadA = await ctxA.memoryBackend.getThread('test-session');
+    const threadB = await ctxB.memoryBackend.getThread('test-session');
+
+    expect(threadA).toHaveLength(1);
+    expect(threadA[0].content).toBe('secret message from A');
+    expect(threadB).toHaveLength(0);
+  });
+
+  // --- Caching -------------------------------------------------------------
+
+  it('getContext returns cached context on second call', async () => {
+    const mgr = makeManager();
+    const first = await mgr.getContext('ws-a');
+    const second = await mgr.getContext('ws-a');
+    expect(first).toBe(second);
+  });
+
+  // --- Destroy -------------------------------------------------------------
+
+  it('destroyContext removes from cache and closes memory backend', async () => {
+    const mgr = makeManager();
+    const ctx = await mgr.getContext('ws-a');
+    const closeSpy = vi.spyOn(ctx.memoryBackend, 'close');
+
+    await mgr.destroyContext('ws-a');
+
+    expect(closeSpy).toHaveBeenCalledOnce();
+    expect(mgr.listActiveContexts()).not.toContain('ws-a');
+  });
+
+  it('destroyContext for non-existent workspace is no-op', async () => {
+    const mgr = makeManager();
+    await expect(mgr.destroyContext('nonexistent')).resolves.toBeUndefined();
+  });
+
+  // --- Active contexts tracking --------------------------------------------
+
+  it('listActiveContexts tracks created and destroyed', async () => {
+    const mgr = makeManager();
+    expect(mgr.listActiveContexts()).toEqual([]);
+
+    await mgr.getContext('ws-a');
+    expect(mgr.listActiveContexts()).toEqual(['ws-a']);
+
+    await mgr.getContext('ws-b');
+    expect(mgr.listActiveContexts()).toContain('ws-a');
+    expect(mgr.listActiveContexts()).toContain('ws-b');
+
+    await mgr.destroyContext('ws-a');
+    expect(mgr.listActiveContexts()).toEqual(['ws-b']);
+  });
+
+  // --- LLM provider -------------------------------------------------------
+
+  it('default LLM provider inherited when no createLLMProvider', async () => {
+    const defaultProvider = makeMockLLMProvider('default-llm');
+    const mgr = makeManager({ defaultLLMProvider: defaultProvider });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.llmProvider).toBe(defaultProvider);
+  });
+
+  it('custom createLLMProvider factory called when provided', async () => {
+    const customProvider = makeMockLLMProvider('custom-llm');
+    const factory = vi.fn(() => customProvider);
+    const mgr = makeManager({ createLLMProvider: factory });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.llmProvider).toBe(customProvider);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it('NoopLLMProvider throws with workspace ID in error message', async () => {
+    const mgr = makeManager();
+    const ctx = await mgr.getContext('ws-a');
+    await expect(ctx.llmProvider.chat([])).rejects.toThrow(
+      "No LLM provider configured for workspace 'ws-a'",
+    );
+  });
+
+  // --- Tool permissions ----------------------------------------------------
+
+  it('workspace toolPermissions deny filters out tools from registry', async () => {
+    const toolA = makeMockTool('tool-a');
+    const toolB = makeMockTool('tool-b');
+    const toolC = makeMockTool('tool-c');
+
+    const wsMap = new Map([
+      ['ws-a', makeWorkspace('ws-a', {
+        toolPermissions: [
+          { tool: 'tool-b', allow: false },
+        ],
+      })],
+    ]);
+
+    const mgr = makeManager(
+      { defaultTools: [toolA, toolB, toolC] },
+      wsMap,
+    );
+    const ctx = await mgr.getContext('ws-a');
+
+    expect(ctx.toolRegistry.listNames()).toContain('tool-a');
+    expect(ctx.toolRegistry.listNames()).not.toContain('tool-b');
+    expect(ctx.toolRegistry.listNames()).toContain('tool-c');
+  });
+
+  // --- Skills --------------------------------------------------------------
+
+  it('resolves skills via resolveSkills factory', async () => {
+    const skill = makeMockSkill('search');
+    const wsMap = new Map([
+      ['ws-a', makeWorkspace('ws-a', { skills: ['search'] })],
+    ]);
+    const resolveSkills = vi.fn(async () => [skill]);
+    const mgr = makeManager({ resolveSkills }, wsMap);
+    const ctx = await mgr.getContext('ws-a');
+
+    expect(resolveSkills).toHaveBeenCalledWith(['search']);
+    expect(ctx.skills).toEqual([skill]);
+  });
+
+  it('falls back to defaultSkills when no resolveSkills factory', async () => {
+    const defaultSkill = makeMockSkill('default-skill');
+    const mgr = makeManager({ defaultSkills: [defaultSkill] });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.skills).toEqual([defaultSkill]);
+  });
+
+  // --- Keypair -------------------------------------------------------------
+
+  it('resolves keypair via resolveKeypair factory', async () => {
+    const kp = makeMockKeypair();
+    const resolveKeypair = vi.fn(() => kp);
+    const mgr = makeManager({ resolveKeypair: resolveKeypair as SessionIsolationManagerConfig['resolveKeypair'] });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.keypair).toBe(kp);
+    expect(resolveKeypair).toHaveBeenCalledWith('ws-a');
+  });
+
+  // --- Error propagation ---------------------------------------------------
+
+  it('getContext propagates error for nonexistent workspace', async () => {
+    const mgr = makeManager();
+    await expect(mgr.getContext('nonexistent')).rejects.toThrow('Workspace not found: nonexistent');
+  });
+
+  // --- Concurrent access ---------------------------------------------------
+
+  it('concurrent getContext calls for same workspace return same context', async () => {
+    const mgr = makeManager();
+    const [ctx1, ctx2, ctx3] = await Promise.all([
+      mgr.getContext('ws-a'),
+      mgr.getContext('ws-a'),
+      mgr.getContext('ws-a'),
+    ]);
+    expect(ctx1).toBe(ctx2);
+    expect(ctx2).toBe(ctx3);
+  });
+
+  // --- Auth state ----------------------------------------------------------
+
+  it('default auth when no resolver', async () => {
+    const mgr = makeManager();
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.authState.authenticated).toBe(false);
+    expect(ctx.authState.permissions.size).toBe(0);
+    expect(ctx.authState.walletAddress).toBeUndefined();
+  });
+
+  it('default auth uses keypair publicKey as walletAddress', async () => {
+    const kp = makeMockKeypair();
+    const mgr = makeManager({ resolveKeypair: () => kp as ReturnType<NonNullable<SessionIsolationManagerConfig['resolveKeypair']>> });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.authState.walletAddress).toBe(kp.publicKey);
+  });
+
+  it('custom resolveAuth provides per-workspace auth', async () => {
+    const mockPubkey = makeMockKeypair().publicKey;
+    const customAuth: AuthState = {
+      authenticated: true,
+      permissions: new Set(['admin', 'read']),
+      walletAddress: mockPubkey as AuthState['walletAddress'],
+    };
+    const resolveAuth = vi.fn(() => customAuth);
+    const mgr = makeManager({ resolveAuth });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.authState).toBe(customAuth);
+    expect(ctx.authState.authenticated).toBe(true);
+    expect(ctx.authState.permissions.has('admin')).toBe(true);
+  });
+
+  // --- Custom factory overrides -------------------------------------------
+
+  it('custom createMemoryBackend factory is used', async () => {
+    const customBackend = new InMemoryBackend();
+    const factory = vi.fn(() => customBackend);
+    const mgr = makeManager({ createMemoryBackend: factory });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.memoryBackend).toBe(customBackend);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it('custom createPolicyEngine factory is used', async () => {
+    const customEngine = new PolicyEngine();
+    const factory = vi.fn(() => customEngine);
+    const mgr = makeManager({ createPolicyEngine: factory });
+    const ctx = await mgr.getContext('ws-a');
+    expect(ctx.policyEngine).toBe(customEngine);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+});

--- a/runtime/src/gateway/session-isolation.ts
+++ b/runtime/src/gateway/session-isolation.ts
@@ -1,0 +1,235 @@
+/**
+ * Session isolation manager — produces fully isolated runtime contexts
+ * per workspace, each with dedicated memory, policy, tools, LLM, and auth.
+ *
+ * Gateway integration (wiring into Gateway.start() / message handling)
+ * is deferred to Phase 7 routing issues.
+ *
+ * @module
+ */
+
+import type { Keypair, PublicKey } from '@solana/web3.js';
+import type { MemoryBackend } from '../memory/types.js';
+import { InMemoryBackend } from '../memory/in-memory/backend.js';
+import { PolicyEngine } from '../policy/engine.js';
+import type { RuntimePolicyConfig } from '../policy/types.js';
+import { ToolRegistry } from '../tools/registry.js';
+import type { Tool } from '../tools/types.js';
+import type {
+  LLMProvider,
+  LLMResponse,
+  LLMMessage,
+  StreamProgressCallback,
+} from '../llm/types.js';
+import type { MarkdownSkill } from '../skills/markdown/types.js';
+import type { AgentWorkspace } from './workspace.js';
+import type { WorkspaceManager } from './workspace.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AuthState {
+  readonly authenticated: boolean;
+  readonly permissions: ReadonlySet<string>;
+  readonly walletAddress?: PublicKey;
+}
+
+export interface IsolatedSessionContext {
+  readonly workspaceId: string;
+  readonly memoryBackend: MemoryBackend;
+  readonly policyEngine: PolicyEngine;
+  readonly toolRegistry: ToolRegistry;
+  readonly llmProvider: LLMProvider;
+  readonly skills: readonly MarkdownSkill[];
+  readonly authState: AuthState;
+  readonly keypair?: Keypair;
+}
+
+export interface SessionIsolationManagerConfig {
+  readonly workspaceManager: WorkspaceManager;
+  readonly createMemoryBackend?: (workspace: AgentWorkspace) => MemoryBackend;
+  readonly createPolicyEngine?: (workspace: AgentWorkspace) => PolicyEngine;
+  readonly createLLMProvider?: (workspace: AgentWorkspace) => LLMProvider;
+  readonly defaultLLMProvider?: LLMProvider;
+  readonly defaultTools?: readonly Tool[];
+  readonly defaultSkills?: readonly MarkdownSkill[];
+  readonly resolveSkills?: (names: readonly string[]) => Promise<readonly MarkdownSkill[]>;
+  readonly resolveKeypair?: (workspaceId: string) => Keypair | undefined;
+  readonly resolveAuth?: (workspace: AgentWorkspace) => AuthState;
+  readonly logger?: Logger;
+}
+
+// ============================================================================
+// NoopLLMProvider (internal — not exported)
+// ============================================================================
+
+class NoopLLMProvider implements LLMProvider {
+  readonly name = 'noop';
+  private readonly workspaceId: string;
+
+  constructor(workspaceId: string) {
+    this.workspaceId = workspaceId;
+  }
+
+  async chat(_messages: LLMMessage[]): Promise<LLMResponse> {
+    throw new Error(`No LLM provider configured for workspace '${this.workspaceId}'`);
+  }
+
+  async chatStream(_messages: LLMMessage[], _onChunk: StreamProgressCallback): Promise<LLMResponse> {
+    throw new Error(`No LLM provider configured for workspace '${this.workspaceId}'`);
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return false;
+  }
+}
+
+// ============================================================================
+// SessionIsolationManager
+// ============================================================================
+
+export class SessionIsolationManager {
+  private readonly contexts = new Map<string, IsolatedSessionContext>();
+  private readonly pending = new Map<string, Promise<IsolatedSessionContext>>();
+  private readonly config: SessionIsolationManagerConfig;
+  private readonly logger: Logger;
+
+  constructor(config: SessionIsolationManagerConfig) {
+    this.config = config;
+    this.logger = config.logger ?? silentLogger;
+  }
+
+  async getContext(workspaceId: string): Promise<IsolatedSessionContext> {
+    const cached = this.contexts.get(workspaceId);
+    if (cached) return cached;
+
+    const inflight = this.pending.get(workspaceId);
+    if (inflight) return inflight;
+
+    const promise = this.createContext(workspaceId).finally(() => {
+      this.pending.delete(workspaceId);
+    });
+    this.pending.set(workspaceId, promise);
+    return promise;
+  }
+
+  async destroyContext(workspaceId: string): Promise<void> {
+    const ctx = this.contexts.get(workspaceId);
+    if (!ctx) return;
+
+    await ctx.memoryBackend.close();
+    this.contexts.delete(workspaceId);
+    this.logger.info(`Session context destroyed for workspace '${workspaceId}'`);
+  }
+
+  listActiveContexts(): string[] {
+    return Array.from(this.contexts.keys());
+  }
+
+  // --------------------------------------------------------------------------
+  // Private
+  // --------------------------------------------------------------------------
+
+  private async createContext(workspaceId: string): Promise<IsolatedSessionContext> {
+    const workspace = await this.config.workspaceManager.load(workspaceId);
+
+    const memoryBackend = this.createMemory(workspace);
+    const policyEngine = this.createPolicy(workspace);
+    const toolRegistry = this.createTools(workspace, policyEngine);
+    const llmProvider = this.createLLM(workspace);
+    const skills = await this.resolveSkills(workspace);
+    const keypair = this.config.resolveKeypair?.(workspaceId);
+    const authState = this.resolveAuth(workspace, keypair);
+
+    const ctx: IsolatedSessionContext = {
+      workspaceId,
+      memoryBackend,
+      policyEngine,
+      toolRegistry,
+      llmProvider,
+      skills,
+      authState,
+      keypair,
+    };
+
+    this.contexts.set(workspaceId, ctx);
+    this.logger.info(`Session context created for workspace '${workspaceId}'`);
+    return ctx;
+  }
+
+  private createMemory(workspace: AgentWorkspace): MemoryBackend {
+    if (this.config.createMemoryBackend) {
+      return this.config.createMemoryBackend(workspace);
+    }
+    return new InMemoryBackend();
+  }
+
+  private createPolicy(workspace: AgentWorkspace): PolicyEngine {
+    if (this.config.createPolicyEngine) {
+      return this.config.createPolicyEngine(workspace);
+    }
+
+    const engine = new PolicyEngine({ logger: this.logger });
+
+    if (workspace.toolPermissions?.length) {
+      const allowList: string[] = [];
+      const denyList: string[] = [];
+      for (const perm of workspace.toolPermissions) {
+        (perm.allow ? allowList : denyList).push(perm.tool);
+      }
+      const policyConfig: RuntimePolicyConfig = { enabled: true };
+      if (allowList.length > 0) policyConfig.toolAllowList = allowList;
+      if (denyList.length > 0) policyConfig.toolDenyList = denyList;
+      engine.setPolicy(policyConfig);
+    }
+
+    return engine;
+  }
+
+  private createTools(workspace: AgentWorkspace, policyEngine: PolicyEngine): ToolRegistry {
+    const registry = new ToolRegistry({ logger: this.logger, policyEngine });
+
+    if (this.config.defaultTools) {
+      const denied = new Set(
+        (workspace.toolPermissions ?? [])
+          .filter(p => !p.allow)
+          .map(p => p.tool),
+      );
+      const allowed = this.config.defaultTools.filter(t => !denied.has(t.name));
+      registry.registerAll(allowed);
+    }
+
+    return registry;
+  }
+
+  private createLLM(workspace: AgentWorkspace): LLMProvider {
+    if (this.config.createLLMProvider) {
+      return this.config.createLLMProvider(workspace);
+    }
+    if (this.config.defaultLLMProvider) {
+      return this.config.defaultLLMProvider;
+    }
+    return new NoopLLMProvider(workspace.id);
+  }
+
+  private async resolveSkills(workspace: AgentWorkspace): Promise<readonly MarkdownSkill[]> {
+    if (workspace.skills.length > 0 && this.config.resolveSkills) {
+      return this.config.resolveSkills(workspace.skills);
+    }
+    return this.config.defaultSkills ?? [];
+  }
+
+  private resolveAuth(workspace: AgentWorkspace, keypair?: Keypair): AuthState {
+    if (this.config.resolveAuth) {
+      return this.config.resolveAuth(workspace);
+    }
+    return {
+      authenticated: false,
+      permissions: new Set(),
+      walletAddress: keypair?.publicKey,
+    };
+  }
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1285,6 +1285,11 @@ export {
   type ToolPolicy,
   type WorkspaceTemplate,
   type WorkspaceConfigJson,
+  // Session isolation (Phase 7.3)
+  SessionIsolationManager,
+  type IsolatedSessionContext,
+  type SessionIsolationManagerConfig,
+  type AuthState,
   // Slash commands (Phase 1.5)
   SlashCommandRegistry,
   createDefaultCommands,

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       // Explicitly resolve @coral-xyz/anchor to node_modules
-      '@coral-xyz/anchor': resolve(__dirname, 'node_modules/@coral-xyz/anchor'),
+      '@coral-xyz/anchor': resolve(__dirname, '../node_modules/@coral-xyz/anchor'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Adds `SessionIsolationManager` that produces fully isolated `IsolatedSessionContext` objects per workspace, each with dedicated memory backend, policy engine, tool registry, LLM provider, skill set, auth state, and optional Solana keypair
- Pre-registration tool filtering from workspace `toolPermissions` deny lists prevents denied tools from appearing in LLM tool lists
- Concurrent `getContext()` calls for the same workspace are deduplicated via a pending-promise map
- Factory hooks enable custom resource creation (`createMemoryBackend`, `createPolicyEngine`, `createLLMProvider`, `resolveSkills`, `resolveKeypair`, `resolveAuth`)
- Fixes vitest config alias for `@coral-xyz/anchor` (was pointing to non-existent local path instead of hoisted root `node_modules`)

## Test plan

- [x] 21 new tests in `session-isolation.test.ts` covering isolation, caching, lifecycle, concurrency, error propagation, and all factory paths
- [x] All 507 gateway tests pass (16 files)
- [x] Typecheck clean
- [x] Build succeeds
- [x] Full runtime suite: 3724/3738 pass (5 pre-existing failures in integration/CLI tests)

Closes #1095