### PR TITLE
feat(runtime): OpenClaw skill import bridge (#1088)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -448,6 +448,11 @@ export {
   type DiscoveredSkill,
   type MissingRequirement,
   SkillDiscovery,
+  // OpenClaw compatibility bridge
+  detectNamespace,
+  convertOpenClawSkill,
+  mapOpenClawMetadata,
+  importSkill,
   // Remote skill registry client (Phase 6.1)
   type SkillListing,
   type SkillListingEntry,

--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -102,6 +102,11 @@ export {
   MarkdownSkillInjector,
   estimateTokens,
   scoreRelevance,
+  // OpenClaw compatibility bridge
+  detectNamespace,
+  convertOpenClawSkill,
+  mapOpenClawMetadata,
+  importSkill,
 } from './markdown/index.js';
 
 // Remote skill registry client (Phase 6.1)

--- a/runtime/src/skills/markdown/compat.test.ts
+++ b/runtime/src/skills/markdown/compat.test.ts
@@ -1,0 +1,488 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { writeFile, mkdtemp, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  detectNamespace,
+  convertOpenClawSkill,
+  mapOpenClawMetadata,
+  importSkill,
+} from './compat.js';
+import { parseSkillContent } from './parser.js';
+import { ValidationError } from '../../types/errors.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const OPENCLAW_SKILL_MD = `---
+name: openclaw-tool
+description: An OpenClaw-compatible skill
+version: 2.0.0
+metadata:
+  openclaw:
+    emoji: "\u{1F4E6}"
+    primaryEnv: node
+    tags:
+      - compat
+      - defi
+    requires:
+      binaries:
+        - node
+      env:
+        - API_KEY
+      channels:
+        - solana
+      os:
+        - linux
+        - macos
+    install:
+      - type: npm
+        package: openclaw-tool
+      - type: download
+        url: https://example.com/tool
+        path: /usr/local/bin/tool
+---
+# OpenClaw Tool
+
+Usage instructions here.
+`;
+
+const AGENC_SKILL_MD = `---
+name: agenc-native
+description: An AgenC-native skill
+version: 1.0.0
+metadata:
+  agenc:
+    emoji: "\u{1F680}"
+    tags:
+      - zk
+    requires:
+      binaries:
+        - nargo
+---
+# AgenC Native
+
+Native skill body.
+`;
+
+const BOTH_NS_MD = `---
+name: dual-ns
+description: Both namespaces present
+version: 1.0.0
+metadata:
+  agenc:
+    emoji: "\u{1F680}"
+    tags:
+      - agenc-tag
+  openclaw:
+    emoji: "\u{1F4E6}"
+    tags:
+      - openclaw-tag
+---
+Body.
+`;
+
+const MINIMAL_MD = `---
+name: minimal
+description: Minimal skill
+version: 0.1.0
+---
+Minimal body.
+`;
+
+const NOT_SKILL = `# Just a heading
+
+Some plain markdown content.
+`;
+
+const FOUR_SPACE_OPENCLAW_MD = `---
+name: indented-skill
+description: Uses 4-space indentation
+version: 1.0.0
+metadata:
+    openclaw:
+        emoji: "\u{2728}"
+        tags:
+            - test
+---
+Body.
+`;
+
+// ---------------------------------------------------------------------------
+// detectNamespace
+// ---------------------------------------------------------------------------
+
+describe('detectNamespace', () => {
+  it('detects openclaw namespace', () => {
+    expect(detectNamespace(OPENCLAW_SKILL_MD)).toBe('openclaw');
+  });
+
+  it('detects agenc namespace', () => {
+    expect(detectNamespace(AGENC_SKILL_MD)).toBe('agenc');
+  });
+
+  it('returns unknown for no metadata block', () => {
+    expect(detectNamespace(MINIMAL_MD)).toBe('unknown');
+  });
+
+  it('returns agenc when both namespaces present (precedence)', () => {
+    expect(detectNamespace(BOTH_NS_MD)).toBe('agenc');
+  });
+
+  it('returns unknown for non-SKILL.md content', () => {
+    expect(detectNamespace(NOT_SKILL)).toBe('unknown');
+    expect(detectNamespace('')).toBe('unknown');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// convertOpenClawSkill
+// ---------------------------------------------------------------------------
+
+describe('convertOpenClawSkill', () => {
+  it('maps openclaw: to agenc: in YAML frontmatter', () => {
+    const result = convertOpenClawSkill(OPENCLAW_SKILL_MD);
+
+    expect(result).toContain('  agenc:');
+    expect(result).not.toContain('  openclaw:');
+  });
+
+  it('preserves markdown body verbatim', () => {
+    const result = convertOpenClawSkill(OPENCLAW_SKILL_MD);
+
+    expect(result).toContain('# OpenClaw Tool');
+    expect(result).toContain('Usage instructions here.');
+  });
+
+  it('returns unchanged content for already-agenc skills', () => {
+    const result = convertOpenClawSkill(AGENC_SKILL_MD);
+    expect(result).toBe(AGENC_SKILL_MD);
+  });
+
+  it('returns unchanged content for non-SKILL.md content', () => {
+    const result = convertOpenClawSkill(NOT_SKILL);
+    expect(result).toBe(NOT_SKILL);
+  });
+
+  it('handles 4-space indentation', () => {
+    const result = convertOpenClawSkill(FOUR_SPACE_OPENCLAW_MD);
+
+    expect(result).toContain('    agenc:');
+    expect(result).not.toContain('    openclaw:');
+  });
+
+  it('preserves all frontmatter fields', () => {
+    const result = convertOpenClawSkill(OPENCLAW_SKILL_MD);
+
+    expect(result).toContain('emoji:');
+    expect(result).toContain('primaryEnv: node');
+    expect(result).toContain('- compat');
+    expect(result).toContain('- defi');
+    expect(result).toContain('- node');
+    expect(result).toContain('- API_KEY');
+    expect(result).toContain('type: npm');
+    expect(result).toContain('package: openclaw-tool');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip test
+// ---------------------------------------------------------------------------
+
+describe('convertOpenClawSkill round-trip', () => {
+  it('converted skill parses correctly via parseSkillContent', () => {
+    const converted = convertOpenClawSkill(OPENCLAW_SKILL_MD);
+    const skill = parseSkillContent(converted);
+
+    expect(skill.name).toBe('openclaw-tool');
+    expect(skill.description).toBe('An OpenClaw-compatible skill');
+    expect(skill.version).toBe('2.0.0');
+    expect(skill.metadata.emoji).toBe('\u{1F4E6}');
+    expect(skill.metadata.primaryEnv).toBe('node');
+    expect(skill.metadata.tags).toEqual(['compat', 'defi']);
+    expect(skill.metadata.requires.binaries).toEqual(['node']);
+    expect(skill.metadata.requires.env).toEqual(['API_KEY']);
+    expect(skill.metadata.requires.channels).toEqual(['solana']);
+    expect(skill.metadata.requires.os).toEqual(['linux', 'macos']);
+    expect(skill.metadata.install).toHaveLength(2);
+    expect(skill.metadata.install[0]).toEqual({
+      type: 'npm',
+      package: 'openclaw-tool',
+    });
+    expect(skill.metadata.install[1]).toEqual({
+      type: 'download',
+      url: 'https://example.com/tool',
+      path: '/usr/local/bin/tool',
+    });
+    expect(skill.body).toContain('# OpenClaw Tool');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapOpenClawMetadata
+// ---------------------------------------------------------------------------
+
+describe('mapOpenClawMetadata', () => {
+  it('maps all known fields', () => {
+    const meta = mapOpenClawMetadata({
+      emoji: '\u{1F4E6}',
+      primaryEnv: 'node',
+      requires: {
+        binaries: ['node', 'npm'],
+        env: ['API_KEY'],
+        channels: ['solana'],
+        os: ['linux'],
+      },
+      install: [
+        { type: 'npm', package: 'my-tool' },
+        { type: 'download', url: 'https://example.com/bin', path: '/usr/local/bin/tool' },
+      ],
+      tags: ['defi', 'swap'],
+    });
+
+    expect(meta.emoji).toBe('\u{1F4E6}');
+    expect(meta.primaryEnv).toBe('node');
+    expect(meta.requires.binaries).toEqual(['node', 'npm']);
+    expect(meta.requires.env).toEqual(['API_KEY']);
+    expect(meta.requires.channels).toEqual(['solana']);
+    expect(meta.requires.os).toEqual(['linux']);
+    expect(meta.install).toHaveLength(2);
+    expect(meta.install[0]).toEqual({ type: 'npm', package: 'my-tool' });
+    expect(meta.install[1]).toEqual({
+      type: 'download',
+      url: 'https://example.com/bin',
+      path: '/usr/local/bin/tool',
+    });
+    expect(meta.tags).toEqual(['defi', 'swap']);
+  });
+
+  it('leaves AgenC-only fields undefined when absent', () => {
+    const meta = mapOpenClawMetadata({
+      emoji: '\u{1F4E6}',
+      tags: ['test'],
+    });
+
+    expect(meta.requiredCapabilities).toBeUndefined();
+    expect(meta.onChainAuthor).toBeUndefined();
+    expect(meta.contentHash).toBeUndefined();
+  });
+
+  it('handles empty/missing fields gracefully', () => {
+    const meta = mapOpenClawMetadata({});
+
+    expect(meta.emoji).toBeUndefined();
+    expect(meta.primaryEnv).toBeUndefined();
+    expect(meta.requires.binaries).toEqual([]);
+    expect(meta.requires.env).toEqual([]);
+    expect(meta.requires.channels).toEqual([]);
+    expect(meta.requires.os).toEqual([]);
+    expect(meta.install).toEqual([]);
+    expect(meta.tags).toEqual([]);
+  });
+
+  it('maps install instructions correctly', () => {
+    const meta = mapOpenClawMetadata({
+      install: [
+        { type: 'brew', package: 'my-brew-pkg' },
+        { type: 'npm', package: '@scope/pkg' },
+        { type: 'download', url: 'https://example.com/bin' },
+      ],
+    });
+
+    expect(meta.install).toHaveLength(3);
+    expect(meta.install[0]).toEqual({ type: 'brew', package: 'my-brew-pkg' });
+    expect(meta.install[1]).toEqual({ type: 'npm', package: '@scope/pkg' });
+    expect(meta.install[2]).toEqual({ type: 'download', url: 'https://example.com/bin' });
+  });
+
+  it('preserves requirements structure', () => {
+    const meta = mapOpenClawMetadata({
+      requires: {
+        binaries: ['python3'],
+        env: ['HOME', 'PATH'],
+        channels: ['telegram'],
+        os: ['macos', 'linux'],
+      },
+    });
+
+    expect(meta.requires.binaries).toEqual(['python3']);
+    expect(meta.requires.env).toEqual(['HOME', 'PATH']);
+    expect(meta.requires.channels).toEqual(['telegram']);
+    expect(meta.requires.os).toEqual(['macos', 'linux']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// importSkill
+// ---------------------------------------------------------------------------
+
+describe('importSkill', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'import-skill-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true });
+  });
+
+  it('imports and converts an openclaw skill from local path', async () => {
+    const srcPath = join(tmpDir, 'source.md');
+    await writeFile(srcPath, OPENCLAW_SKILL_MD, 'utf-8');
+
+    const targetDir = join(tmpDir, 'imported');
+    const result = await importSkill(srcPath, targetDir);
+
+    expect(result.converted).toBe(true);
+    expect(result.path).toBe(join(targetDir, 'openclaw-tool.md'));
+
+    const written = await readFile(result.path, 'utf-8');
+    expect(written).toContain('  agenc:');
+    expect(written).not.toContain('  openclaw:');
+  });
+
+  it('imports an agenc skill without conversion', async () => {
+    const srcPath = join(tmpDir, 'source.md');
+    await writeFile(srcPath, AGENC_SKILL_MD, 'utf-8');
+
+    const targetDir = join(tmpDir, 'imported');
+    const result = await importSkill(srcPath, targetDir);
+
+    expect(result.converted).toBe(false);
+    expect(result.path).toBe(join(targetDir, 'agenc-native.md'));
+
+    const written = await readFile(result.path, 'utf-8');
+    expect(written).toBe(AGENC_SKILL_MD);
+  });
+
+  it('throws for non-existent file', async () => {
+    await expect(
+      importSkill(join(tmpDir, 'does-not-exist.md'), join(tmpDir, 'out')),
+    ).rejects.toThrow();
+  });
+
+  it('sanitizes unsafe skill names', async () => {
+    // Skill with spaces in name
+    const md = `---
+name: my cool skill
+description: Spaces in name
+version: 1.0.0
+---
+Body.
+`;
+    const srcPath = join(tmpDir, 'source.md');
+    await writeFile(srcPath, md, 'utf-8');
+
+    const targetDir = join(tmpDir, 'imported');
+    const result = await importSkill(srcPath, targetDir);
+
+    expect(result.path).toBe(join(targetDir, 'my-cool-skill.md'));
+  });
+
+  it('rejects skill names with path traversal', async () => {
+    const md = `---
+name: ../evil
+description: Traversal attempt
+version: 1.0.0
+---
+Body.
+`;
+    const srcPath = join(tmpDir, 'source.md');
+    await writeFile(srcPath, md, 'utf-8');
+
+    await expect(
+      importSkill(srcPath, join(tmpDir, 'out')),
+    ).rejects.toThrow(ValidationError);
+    await expect(
+      importSkill(srcPath, join(tmpDir, 'out')),
+    ).rejects.toThrow('Invalid skill name');
+  });
+
+  it('rejects skill names with path separators', async () => {
+    const md = `---
+name: foo/bar
+description: Slash in name
+version: 1.0.0
+---
+Body.
+`;
+    const srcPath = join(tmpDir, 'source.md');
+    await writeFile(srcPath, md, 'utf-8');
+
+    await expect(
+      importSkill(srcPath, join(tmpDir, 'out')),
+    ).rejects.toThrow(ValidationError);
+    await expect(
+      importSkill(srcPath, join(tmpDir, 'out')),
+    ).rejects.toThrow('Invalid skill name');
+  });
+
+  it('creates target directory if missing', async () => {
+    const srcPath = join(tmpDir, 'source.md');
+    await writeFile(srcPath, AGENC_SKILL_MD, 'utf-8');
+
+    const nested = join(tmpDir, 'deep', 'nested', 'dir');
+    const result = await importSkill(srcPath, nested);
+
+    expect(result.path).toBe(join(nested, 'agenc-native.md'));
+    const written = await readFile(result.path, 'utf-8');
+    expect(written).toBe(AGENC_SKILL_MD);
+  });
+
+  describe('URL fetch', () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('fetches and imports from URL', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'content-length': String(Buffer.byteLength(OPENCLAW_SKILL_MD)) }),
+        text: () => Promise.resolve(OPENCLAW_SKILL_MD),
+      });
+
+      const targetDir = join(tmpDir, 'imported');
+      const result = await importSkill('https://example.com/SKILL.md', targetDir);
+
+      expect(result.converted).toBe(true);
+      expect(result.path).toBe(join(targetDir, 'openclaw-tool.md'));
+
+      const written = await readFile(result.path, 'utf-8');
+      expect(written).toContain('  agenc:');
+    });
+
+    it('throws on fetch failure (404)', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+        headers: new Headers(),
+      });
+
+      await expect(
+        importSkill('https://example.com/missing.md', join(tmpDir, 'out')),
+      ).rejects.toThrow(ValidationError);
+      await expect(
+        importSkill('https://example.com/missing.md', join(tmpDir, 'out')),
+      ).rejects.toThrow('Failed to fetch skill: HTTP 404');
+    });
+
+    it('throws when content-length exceeds limit', async () => {
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        headers: new Headers({ 'content-length': '2000000' }),
+        text: () => Promise.resolve(''),
+      });
+
+      await expect(
+        importSkill('https://example.com/huge.md', join(tmpDir, 'out')),
+      ).rejects.toThrow(ValidationError);
+      await expect(
+        importSkill('https://example.com/huge.md', join(tmpDir, 'out')),
+      ).rejects.toThrow('1MB size limit');
+    });
+  });
+});

--- a/runtime/src/skills/markdown/compat.ts
+++ b/runtime/src/skills/markdown/compat.ts
@@ -1,0 +1,264 @@
+/**
+ * OpenClaw ↔ AgenC SKILL.md compatibility bridge.
+ *
+ * Provides detection, mapping, conversion, and import of OpenClaw-format
+ * SKILL.md files into the AgenC namespace. The SKILL.md parser already
+ * reads both `metadata.openclaw` and `metadata.agenc` at parse time; this
+ * module adds the ability to **permanently convert** a file for import.
+ *
+ * @module
+ */
+
+import { readFile, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { isSkillMarkdown, parseSkillContent } from './parser.js';
+import type {
+  MarkdownSkillMetadata,
+  SkillInstallStep,
+  SkillRequirements,
+} from './types.js';
+import { ValidationError } from '../../types/errors.js';
+
+/** Maximum file size accepted by {@link importSkill} (1 MB). */
+const MAX_IMPORT_SIZE = 1_048_576;
+
+/** Timeout for URL fetches in {@link importSkill}. */
+const FETCH_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Type-safe YAML accessors (mirrors parser.ts helpers, inlined to avoid
+// coupling to parser internals)
+// ---------------------------------------------------------------------------
+
+function getString(obj: Record<string, unknown>, key: string): string | undefined {
+  const val = obj[key];
+  return val !== undefined && val !== null ? String(val) : undefined;
+}
+
+function getObject(
+  obj: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
+  const val = obj[key];
+  if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
+    return val as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+function getArray(obj: Record<string, unknown>, key: string): unknown[] {
+  const val = obj[key];
+  return Array.isArray(val) ? val : [];
+}
+
+function getStringArray(obj: Record<string, unknown>, key: string): string[] {
+  return getArray(obj, key)
+    .filter((item) => item !== null && item !== undefined)
+    .map(String);
+}
+
+// ---------------------------------------------------------------------------
+// detectNamespace
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect whether a SKILL.md file uses the `openclaw` or `agenc` metadata
+ * namespace.
+ *
+ * When both namespaces are present, returns `'agenc'` to match the parser
+ * precedence at `parser.ts:136`. Returns `'unknown'` for non-SKILL.md
+ * content or when neither namespace is found.
+ */
+export function detectNamespace(content: string): 'openclaw' | 'agenc' | 'unknown' {
+  if (!isSkillMarkdown(content)) return 'unknown';
+
+  // Extract frontmatter between the two --- delimiters
+  const afterOpening = content.indexOf('\n') + 1;
+  const closingIndex = content.indexOf('\n---', afterOpening);
+  const frontmatter = closingIndex === -1
+    ? content.slice(afterOpening)
+    : content.slice(afterOpening, closingIndex);
+
+  let hasAgenc = false;
+  let hasOpenclaw = false;
+
+  for (const line of frontmatter.split(/\r?\n/)) {
+    if (/^\s+agenc:\s*$/.test(line)) hasAgenc = true;
+    if (/^\s+openclaw:\s*$/.test(line)) hasOpenclaw = true;
+  }
+
+  if (hasAgenc) return 'agenc';
+  if (hasOpenclaw) return 'openclaw';
+  return 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// mapOpenClawMetadata
+// ---------------------------------------------------------------------------
+
+/**
+ * Map an OpenClaw metadata record to the AgenC {@link MarkdownSkillMetadata}
+ * structure.
+ *
+ * The OpenClaw and AgenC namespaces share the same field names; this function
+ * applies type-safe extraction identical to the parser's `extractMetadata`.
+ * AgenC-only fields (`requiredCapabilities`, `onChainAuthor`, `contentHash`)
+ * are included when present in the input but will typically be `undefined`
+ * for OpenClaw sources.
+ */
+export function mapOpenClawMetadata(
+  openclawMeta: Record<string, unknown>,
+): MarkdownSkillMetadata {
+  const requiresObj = getObject(openclawMeta, 'requires') ?? {};
+  const requires: SkillRequirements = {
+    binaries: getStringArray(requiresObj, 'binaries'),
+    env: getStringArray(requiresObj, 'env'),
+    channels: getStringArray(requiresObj, 'channels'),
+    os: getStringArray(requiresObj, 'os'),
+  };
+
+  const rawInstall = getArray(openclawMeta, 'install');
+  const install: SkillInstallStep[] = [];
+  for (const item of rawInstall) {
+    if (typeof item === 'object' && item !== null && !Array.isArray(item)) {
+      const stepObj = item as Record<string, unknown>;
+      const type = getString(stepObj, 'type') ?? '';
+      install.push({
+        type: type as SkillInstallStep['type'],
+        ...(stepObj.package !== undefined ? { package: String(stepObj.package) } : {}),
+        ...(stepObj.url !== undefined ? { url: String(stepObj.url) } : {}),
+        ...(stepObj.path !== undefined ? { path: String(stepObj.path) } : {}),
+      });
+    }
+  }
+
+  return {
+    ...(openclawMeta.emoji !== undefined ? { emoji: String(openclawMeta.emoji) } : {}),
+    requires,
+    ...(openclawMeta.primaryEnv !== undefined
+      ? { primaryEnv: String(openclawMeta.primaryEnv) }
+      : {}),
+    install,
+    tags: getStringArray(openclawMeta, 'tags'),
+    ...(openclawMeta.requiredCapabilities !== undefined
+      ? { requiredCapabilities: String(openclawMeta.requiredCapabilities) }
+      : {}),
+    ...(openclawMeta.onChainAuthor !== undefined
+      ? { onChainAuthor: String(openclawMeta.onChainAuthor) }
+      : {}),
+    ...(openclawMeta.contentHash !== undefined
+      ? { contentHash: String(openclawMeta.contentHash) }
+      : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// convertOpenClawSkill
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an OpenClaw SKILL.md file to AgenC format by replacing the
+ * `openclaw:` namespace key with `agenc:` inside the YAML frontmatter.
+ *
+ * All other content (fields, comments, unknown keys, markdown body) is
+ * preserved verbatim. Indentation is maintained by using a capture group
+ * on the leading whitespace.
+ *
+ * Returns the content unchanged when it is not a valid SKILL.md or already
+ * uses the `agenc` namespace.
+ */
+export function convertOpenClawSkill(content: string): string {
+  if (!isSkillMarkdown(content)) return content;
+  if (detectNamespace(content) !== 'openclaw') return content;
+
+  // Find frontmatter boundaries
+  const afterOpening = content.indexOf('\n') + 1;
+  const closingIndex = content.indexOf('\n---', afterOpening);
+
+  const frontmatter = closingIndex === -1
+    ? content.slice(afterOpening)
+    : content.slice(afterOpening, closingIndex);
+
+  // Replace only within frontmatter, preserving indentation
+  const converted = frontmatter.replace(
+    /^(\s+)openclaw:(\s*)$/m,
+    '$1agenc:$2',
+  );
+
+  if (closingIndex === -1) {
+    return content.slice(0, afterOpening) + converted;
+  }
+
+  return content.slice(0, afterOpening) + converted + content.slice(closingIndex);
+}
+
+// ---------------------------------------------------------------------------
+// importSkill
+// ---------------------------------------------------------------------------
+
+/**
+ * Import a SKILL.md file from a local path or URL into a target directory,
+ * converting from OpenClaw format if necessary.
+ *
+ * Safety checks mirror `skills-cli.ts`:
+ * - 1 MB size limit (checked via `content-length` header and body size)
+ * - 30 s fetch timeout
+ * - Filename sanitization (no traversal, no path separators)
+ *
+ * @returns The written file path and whether a conversion was applied.
+ */
+export async function importSkill(
+  source: string,
+  targetDir: string,
+): Promise<{ path: string; converted: boolean }> {
+  let content: string;
+  const isUrl = /^https?:\/\//i.test(source);
+
+  if (isUrl) {
+    const response = await fetch(source, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      throw new ValidationError(`Failed to fetch skill: HTTP ${response.status}`);
+    }
+    const contentLength = response.headers.get('content-length');
+    if (contentLength && Number(contentLength) > MAX_IMPORT_SIZE) {
+      throw new ValidationError('Skill file exceeds 1MB size limit');
+    }
+    content = await response.text();
+  } else {
+    content = await readFile(source, 'utf-8');
+  }
+
+  if (Buffer.byteLength(content, 'utf-8') > MAX_IMPORT_SIZE) {
+    throw new ValidationError('Skill file exceeds 1MB size limit');
+  }
+
+  const ns = detectNamespace(content);
+  let converted = false;
+
+  if (ns === 'openclaw') {
+    content = convertOpenClawSkill(content);
+    converted = true;
+  }
+
+  // Parse to extract skill name for the output filename
+  const skill = parseSkillContent(content);
+  const rawName = skill.name || 'unnamed-skill';
+
+  // Sanitize filename: reject path separators and traversal
+  if (rawName.includes('/') || rawName.includes('\\') || rawName.includes('..')) {
+    throw new ValidationError(`Invalid skill name: "${rawName}"`);
+  }
+  const safeName = rawName.replace(/[^a-zA-Z0-9._-]/g, '-');
+  if (!safeName) {
+    throw new ValidationError(`Invalid skill name: "${rawName}"`);
+  }
+
+  await mkdir(targetDir, { recursive: true });
+
+  const outPath = join(targetDir, `${safeName}.md`);
+  await writeFile(outPath, content, 'utf-8');
+
+  return { path: outPath, converted };
+}

--- a/runtime/src/skills/markdown/index.ts
+++ b/runtime/src/skills/markdown/index.ts
@@ -31,3 +31,11 @@ export { SkillDiscovery } from './discovery.js';
 // Skill injection engine (Phase 3.3)
 export type { SkillInjectorConfig, InjectionResult } from './injector.js';
 export { MarkdownSkillInjector, estimateTokens, scoreRelevance } from './injector.js';
+
+// OpenClaw compatibility bridge
+export {
+  detectNamespace,
+  convertOpenClawSkill,
+  mapOpenClawMetadata,
+  importSkill,
+} from './compat.js';


### PR DESCRIPTION
## Summary

- Add `runtime/src/skills/markdown/compat.ts` with four functions: `detectNamespace`, `mapOpenClawMetadata`, `convertOpenClawSkill`, `importSkill`
- Add `runtime/src/skills/markdown/compat.test.ts` with 27 tests covering all functions, edge cases, and round-trip parsing
- Export all four functions through the barrel chain (markdown/index → skills/index → src/index)

Closes #1088

## Test plan

- [x] 27 compat tests pass (`npx vitest run src/skills/markdown/compat.test.ts`)
- [x] 18 parser tests pass with no regressions
- [x] Build succeeds, all 4 symbols in ESM/CJS/.d.ts output
- [x] No new typecheck errors