### PR TITLE
feat(runtime): vector memory store with hybrid BM25 search

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -924,6 +924,13 @@ export {
   createEmbeddingProvider,
   cosineSimilarity,
   normalizeVector,
+  // Vector store
+  InMemoryVectorStore,
+  type InMemoryVectorStoreConfig,
+  type VectorMemoryBackend,
+  type VectorSearchOptions,
+  type HybridSearchOptions,
+  type ScoredMemoryEntry,
   // Memory graph
   MemoryGraph,
   type ProvenanceSourceType,

--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -70,6 +70,16 @@ export {
   type CompactOptions,
 } from './graph.js';
 
+// Vector store (Phase 5.2)
+export {
+  InMemoryVectorStore,
+  type InMemoryVectorStoreConfig,
+  type VectorMemoryBackend,
+  type VectorSearchOptions,
+  type HybridSearchOptions,
+  type ScoredMemoryEntry,
+} from './vector-store.js';
+
 // Structured memory (daily logs, curated facts, entity extraction)
 export {
   formatLogDate,

--- a/runtime/src/memory/vector-store.test.ts
+++ b/runtime/src/memory/vector-store.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryVectorStore } from './vector-store.js';
+import type { AddEntryOptions } from './types.js';
+
+function makeEntry(
+  content: string,
+  sessionId = 'sess-1',
+  metadata?: Record<string, unknown>,
+): AddEntryOptions {
+  return { sessionId, role: 'user', content, metadata };
+}
+
+/** Create a unit vector pointing in a specific direction (for deterministic tests). */
+function basisVector(dim: number, index: number, scale = 1): number[] {
+  const v = new Array(dim).fill(0);
+  v[index] = scale;
+  return v;
+}
+
+/** Create a vector with specific values for first N dimensions, rest zeros. */
+function sparseVector(dim: number, values: number[]): number[] {
+  const v = new Array(dim).fill(0);
+  for (let i = 0; i < values.length && i < dim; i++) {
+    v[i] = values[i];
+  }
+  return v;
+}
+
+describe('InMemoryVectorStore', () => {
+  let store: InMemoryVectorStore;
+
+  beforeEach(() => {
+    store = new InMemoryVectorStore();
+  });
+
+  // ==========================================================================
+  // storeWithEmbedding
+  // ==========================================================================
+
+  describe('storeWithEmbedding', () => {
+    it('stores entry and infers dimension from first vector', async () => {
+      const entry = await store.storeWithEmbedding(
+        makeEntry('hello world'),
+        basisVector(64, 0),
+      );
+
+      expect(entry.id).toBeDefined();
+      expect(entry.content).toBe('hello world');
+      expect(store.getVectorDimension()).toBe(64);
+    });
+
+    it('rejects embedding with mismatched dimension', async () => {
+      await store.storeWithEmbedding(makeEntry('first'), basisVector(64, 0));
+
+      await expect(
+        store.storeWithEmbedding(makeEntry('second'), basisVector(128, 0)),
+      ).rejects.toThrow('dimension mismatch');
+    });
+
+    it('respects explicit dimension config', async () => {
+      const s = new InMemoryVectorStore({ dimension: 32 });
+      expect(s.getVectorDimension()).toBe(32);
+
+      await expect(
+        s.storeWithEmbedding(makeEntry('wrong dim'), basisVector(64, 0)),
+      ).rejects.toThrow('dimension mismatch');
+    });
+
+    it('returns valid MemoryEntry with generated ID', async () => {
+      const entry = await store.storeWithEmbedding(
+        makeEntry('test entry'),
+        basisVector(8, 0),
+      );
+
+      expect(entry.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(entry.sessionId).toBe('sess-1');
+      expect(entry.role).toBe('user');
+      expect(entry.timestamp).toBeGreaterThan(0);
+    });
+
+    it('rejects empty embedding', async () => {
+      await expect(
+        store.storeWithEmbedding(makeEntry('empty'), []),
+      ).rejects.toThrow('must not be empty');
+    });
+  });
+
+  // ==========================================================================
+  // searchSimilar
+  // ==========================================================================
+
+  describe('searchSimilar', () => {
+    it('returns entries sorted by cosine similarity descending', async () => {
+      // Basis vectors in 4D: e0, e1, e2
+      await store.storeWithEmbedding(makeEntry('exact match'), basisVector(4, 0));
+      await store.storeWithEmbedding(makeEntry('partial match'), sparseVector(4, [0.7, 0.7]));
+      await store.storeWithEmbedding(makeEntry('no match'), basisVector(4, 2));
+
+      // Query along e0
+      const results = await store.searchSimilar(basisVector(4, 0));
+
+      expect(results.length).toBe(3);
+      expect(results[0].entry.content).toBe('exact match');
+      expect(results[0].score).toBeCloseTo(1.0, 5);
+      expect(results[1].entry.content).toBe('partial match');
+      expect(results[1].score).toBeGreaterThan(0);
+      expect(results[2].entry.content).toBe('no match');
+      expect(results[2].score).toBeCloseTo(0, 5);
+    });
+
+    it('respects limit parameter', async () => {
+      for (let i = 0; i < 20; i++) {
+        await store.storeWithEmbedding(makeEntry(`entry ${i}`), basisVector(8, i % 8));
+      }
+
+      const results = await store.searchSimilar(basisVector(8, 0), { limit: 5 });
+      expect(results.length).toBe(5);
+    });
+
+    it('respects threshold cutoff', async () => {
+      await store.storeWithEmbedding(makeEntry('high sim'), basisVector(4, 0));
+      await store.storeWithEmbedding(makeEntry('low sim'), basisVector(4, 1));
+
+      const results = await store.searchSimilar(basisVector(4, 0), { threshold: 0.5 });
+      expect(results.length).toBe(1);
+      expect(results[0].entry.content).toBe('high sim');
+    });
+
+    it('filters by sessionId', async () => {
+      await store.storeWithEmbedding(makeEntry('sess A', 'a'), basisVector(4, 0));
+      await store.storeWithEmbedding(makeEntry('sess B', 'b'), basisVector(4, 0));
+
+      const results = await store.searchSimilar(basisVector(4, 0), { sessionId: 'a' });
+      expect(results.length).toBe(1);
+      expect(results[0].entry.content).toBe('sess A');
+    });
+
+    it('filters by time range (after/before)', async () => {
+      const e1 = await store.storeWithEmbedding(makeEntry('old'), basisVector(4, 0));
+      // Small delay to ensure different timestamps
+      await new Promise((r) => setTimeout(r, 5));
+      const e2 = await store.storeWithEmbedding(makeEntry('new'), basisVector(4, 0));
+
+      const results = await store.searchSimilar(basisVector(4, 0), { after: e1.timestamp });
+      expect(results.length).toBe(1);
+      expect(results[0].entry.content).toBe('new');
+
+      const resultsBefore = await store.searchSimilar(basisVector(4, 0), { before: e2.timestamp });
+      expect(resultsBefore.length).toBe(1);
+      expect(resultsBefore[0].entry.content).toBe('old');
+    });
+
+    it('filters by metadata tags', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('tagged', 'sess-1', { tags: ['solana', 'zk'] }),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('untagged', 'sess-1'),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('partial tag', 'sess-1', { tags: ['solana'] }),
+        basisVector(4, 0),
+      );
+
+      const results = await store.searchSimilar(basisVector(4, 0), {
+        tags: ['solana', 'zk'],
+      });
+      expect(results.length).toBe(1);
+      expect(results[0].entry.content).toBe('tagged');
+    });
+
+    it('returns empty for empty store', async () => {
+      const results = await store.searchSimilar(basisVector(4, 0));
+      expect(results).toEqual([]);
+    });
+
+    it('filters by channel', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('telegram msg', 'sess-1', { channel: 'telegram' }),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('discord msg', 'sess-1', { channel: 'discord' }),
+        basisVector(4, 0),
+      );
+
+      const results = await store.searchSimilar(basisVector(4, 0), { channel: 'telegram' });
+      expect(results.length).toBe(1);
+      expect(results[0].entry.content).toBe('telegram msg');
+    });
+  });
+
+  // ==========================================================================
+  // searchHybrid
+  // ==========================================================================
+
+  describe('searchHybrid', () => {
+    it('combines vector and BM25 with default weights', async () => {
+      // Entry with matching keywords but weak vector
+      await store.storeWithEmbedding(
+        makeEntry('solana blockchain protocol'),
+        basisVector(4, 1),
+      );
+      // Entry with strong vector but no keyword match
+      await store.storeWithEmbedding(
+        makeEntry('unrelated text here'),
+        basisVector(4, 0),
+      );
+
+      const results = await store.searchHybrid('solana protocol', basisVector(4, 0));
+      // Both should appear since one has keyword match and one has vector match
+      expect(results.length).toBe(2);
+    });
+
+    it('with vectorWeight=1 keywordWeight=0 gives pure vector results', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('keyword match solana'),
+        basisVector(4, 1),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('no keyword match'),
+        basisVector(4, 0),
+      );
+
+      const results = await store.searchHybrid('solana', basisVector(4, 0), {
+        vectorWeight: 1,
+        keywordWeight: 0,
+      });
+
+      // The entry with basisVector(4, 0) should be first (perfect vector match)
+      expect(results[0].entry.content).toBe('no keyword match');
+    });
+
+    it('with vectorWeight=0 keywordWeight=1 gives pure keyword results', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('solana blockchain'),
+        basisVector(4, 1),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('no keyword match'),
+        basisVector(4, 0),
+      );
+
+      const results = await store.searchHybrid('solana', basisVector(4, 0), {
+        vectorWeight: 0,
+        keywordWeight: 1,
+      });
+
+      // Only the keyword match should have nonzero score
+      expect(results[0].entry.content).toBe('solana blockchain');
+    });
+
+    it('deduplicates entries appearing in both searches', async () => {
+      // Entry that matches both vector AND keyword
+      await store.storeWithEmbedding(
+        makeEntry('solana protocol'),
+        basisVector(4, 0),
+      );
+
+      const results = await store.searchHybrid('solana', basisVector(4, 0));
+      // Should appear only once, not duplicated
+      expect(results.length).toBe(1);
+      expect(results[0].vectorScore).toBeDefined();
+      expect(results[0].keywordScore).toBeDefined();
+    });
+
+    it('applies threshold after merging', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('weak match'),
+        basisVector(4, 1),
+      );
+
+      const results = await store.searchHybrid('unrelated query', basisVector(4, 2), {
+        threshold: 0.9,
+      });
+
+      // Low similarity + low keyword match should be filtered by threshold
+      expect(results.length).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // BM25 scoring
+  // ==========================================================================
+
+  describe('BM25 scoring (via searchHybrid)', () => {
+    it('exact keyword match scores higher than partial', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('solana blockchain network'),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('solana is great for building'),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('ethereum blockchain network'),
+        basisVector(4, 0),
+      );
+
+      // Pure keyword search
+      const results = await store.searchHybrid(
+        'solana blockchain',
+        new Array(4).fill(0), // zero vector = no vector contribution
+        { vectorWeight: 0, keywordWeight: 1 },
+      );
+
+      // "solana blockchain network" matches both terms
+      expect(results[0].entry.content).toBe('solana blockchain network');
+    });
+
+    it('returns zero score for no matching terms', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('completely unrelated content'),
+        basisVector(4, 0),
+      );
+
+      const results = await store.searchHybrid(
+        'xyz123 nevermatches',
+        new Array(4).fill(0),
+        { vectorWeight: 0, keywordWeight: 1, threshold: 0.01 },
+      );
+
+      // No keyword matches and vectorWeight=0, so no results above threshold
+      expect(results.length).toBe(0);
+    });
+
+    it('handles empty query gracefully', async () => {
+      await store.storeWithEmbedding(makeEntry('some content'), basisVector(4, 0));
+
+      const results = await store.searchHybrid(
+        '',
+        basisVector(4, 0),
+        { vectorWeight: 0, keywordWeight: 1, threshold: 0.01 },
+      );
+
+      // Empty query = no keyword matches, no results above threshold
+      expect(results.length).toBe(0);
+    });
+  });
+
+  // ==========================================================================
+  // MemoryBackend delegation
+  // ==========================================================================
+
+  describe('MemoryBackend delegation', () => {
+    it('addEntry works without embedding', async () => {
+      const entry = await store.addEntry(makeEntry('plain entry'));
+      expect(entry.id).toBeDefined();
+      expect(entry.content).toBe('plain entry');
+
+      // Should not appear in vector search
+      await store.storeWithEmbedding(makeEntry('with vec'), basisVector(4, 0));
+      const results = await store.searchSimilar(basisVector(4, 0));
+      expect(results.length).toBe(1);
+      expect(results[0].entry.content).toBe('with vec');
+    });
+
+    it('deleteThread cleans up embeddings', async () => {
+      await store.storeWithEmbedding(
+        makeEntry('entry 1', 'sess-del'),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry('entry 2', 'sess-del'),
+        basisVector(4, 1),
+      );
+
+      const deleted = await store.deleteThread('sess-del');
+      expect(deleted).toBe(2);
+
+      // Embeddings should be cleaned up — no results
+      const results = await store.searchSimilar(basisVector(4, 0));
+      expect(results).toEqual([]);
+    });
+
+    it('clear resets all vector data', async () => {
+      await store.storeWithEmbedding(makeEntry('data'), basisVector(8, 0));
+      expect(store.getVectorDimension()).toBe(8);
+
+      await store.clear();
+      expect(store.getVectorDimension()).toBe(0);
+
+      // Can now store with different dimension
+      await store.storeWithEmbedding(makeEntry('new data'), basisVector(4, 0));
+      expect(store.getVectorDimension()).toBe(4);
+    });
+
+    it('KV operations delegate correctly', async () => {
+      await store.set('key1', 'value1');
+      expect(await store.get('key1')).toBe('value1');
+      expect(await store.has('key1')).toBe(true);
+
+      await store.delete('key1');
+      expect(await store.has('key1')).toBe(false);
+    });
+
+    it('listSessions delegates correctly', async () => {
+      await store.storeWithEmbedding(makeEntry('a', 'sess-a'), basisVector(4, 0));
+      await store.storeWithEmbedding(makeEntry('b', 'sess-b'), basisVector(4, 0));
+
+      const sessions = await store.listSessions();
+      expect(sessions).toContain('sess-a');
+      expect(sessions).toContain('sess-b');
+    });
+
+    it('healthCheck delegates correctly', async () => {
+      expect(await store.healthCheck()).toBe(true);
+      await store.close();
+      expect(await store.healthCheck()).toBe(false);
+    });
+  });
+
+  // ==========================================================================
+  // Edge cases
+  // ==========================================================================
+
+  describe('edge cases', () => {
+    it('zero-vector query returns entries with score 0', async () => {
+      await store.storeWithEmbedding(makeEntry('some entry'), basisVector(4, 0));
+
+      const results = await store.searchSimilar(new Array(4).fill(0));
+      // Score should be 0, but 0 >= 0 threshold, so it's included
+      expect(results.length).toBe(1);
+      expect(results[0].score).toBe(0);
+    });
+
+    it('single entry corpus works correctly', async () => {
+      await store.storeWithEmbedding(makeEntry('only entry'), basisVector(4, 0));
+
+      const vectorResults = await store.searchSimilar(basisVector(4, 0));
+      expect(vectorResults.length).toBe(1);
+      expect(vectorResults[0].score).toBeCloseTo(1.0, 5);
+
+      const hybridResults = await store.searchHybrid('only entry', basisVector(4, 0));
+      expect(hybridResults.length).toBe(1);
+      expect(hybridResults[0].score).toBeGreaterThan(0);
+    });
+
+    it('entries evicted by backend capacity do not appear in search', async () => {
+      const s = new InMemoryVectorStore({ maxEntriesPerSession: 2 });
+
+      await s.storeWithEmbedding(makeEntry('first'), basisVector(4, 0));
+      await s.storeWithEmbedding(makeEntry('second'), basisVector(4, 1));
+      // Third entry evicts "first" from both backend and vector maps
+      await s.storeWithEmbedding(makeEntry('third'), basisVector(4, 2));
+
+      // Backend thread reflects eviction
+      const thread = await s.getThread('sess-1');
+      expect(thread.length).toBe(2);
+      expect(thread[0].content).toBe('second');
+      expect(thread[1].content).toBe('third');
+
+      // Vector search also reflects eviction — "first" (basisVector 0) should be gone
+      const results = await s.searchSimilar(basisVector(4, 0));
+      expect(results.length).toBe(2);
+      const contents = results.map((r) => r.entry.content);
+      expect(contents).not.toContain('first');
+      expect(contents).toContain('second');
+      expect(contents).toContain('third');
+    });
+
+    it('rejects query embedding with wrong dimension', async () => {
+      await store.storeWithEmbedding(makeEntry('entry'), basisVector(4, 0));
+
+      await expect(
+        store.searchSimilar(basisVector(8, 0)),
+      ).rejects.toThrow('dimension mismatch');
+    });
+
+    it('getDurability returns none level', () => {
+      const info = store.getDurability();
+      expect(info.level).toBe('none');
+    });
+  });
+});

--- a/runtime/src/memory/vector-store.ts
+++ b/runtime/src/memory/vector-store.ts
@@ -1,0 +1,528 @@
+/**
+ * Vector memory store with semantic search and BM25 hybrid retrieval.
+ *
+ * Provides in-memory vector storage backed by InMemoryBackend via composition.
+ * Supports cosine similarity search, BM25 keyword search, and hybrid
+ * (weighted combination) search modes.
+ *
+ * @module
+ */
+
+import type {
+  MemoryBackend,
+  MemoryEntry,
+  MemoryQuery,
+  AddEntryOptions,
+  DurabilityInfo,
+} from './types.js';
+import { InMemoryBackend, type InMemoryBackendConfig } from './in-memory/index.js';
+import { MemoryBackendError } from './errors.js';
+
+// ============================================================================
+// Interfaces
+// ============================================================================
+
+/** Options for vector similarity search. */
+export interface VectorSearchOptions {
+  /** Maximum number of results to return. Default: 10 */
+  limit?: number;
+  /** Minimum cosine similarity threshold. Default: 0 */
+  threshold?: number;
+  /** Filter by session ID. */
+  sessionId?: string;
+  /** Filter by channel (entry.metadata.channel). */
+  channel?: string;
+  /** Filter entries after this timestamp (exclusive). */
+  after?: number;
+  /** Filter entries before this timestamp (exclusive). */
+  before?: number;
+  /** Filter entries that have ALL of these tags (entry.metadata.tags). */
+  tags?: string[];
+}
+
+/** Options for hybrid vector + keyword search. */
+export interface HybridSearchOptions extends VectorSearchOptions {
+  /** Weight for vector similarity score. Default: 0.7 */
+  vectorWeight?: number;
+  /** Weight for BM25 keyword score. Default: 0.3 */
+  keywordWeight?: number;
+}
+
+/** A memory entry with a relevance score. */
+export interface ScoredMemoryEntry {
+  entry: MemoryEntry;
+  score: number;
+  vectorScore?: number;
+  keywordScore?: number;
+}
+
+/** Memory backend extended with vector storage and semantic search. */
+export interface VectorMemoryBackend extends MemoryBackend {
+  /** Store an entry with its embedding vector. */
+  storeWithEmbedding(options: AddEntryOptions, embedding: number[]): Promise<MemoryEntry>;
+  /** Search by cosine similarity to a query embedding. */
+  searchSimilar(queryEmbedding: number[], options?: VectorSearchOptions): Promise<ScoredMemoryEntry[]>;
+  /** Hybrid search combining vector similarity and BM25 keyword scoring. */
+  searchHybrid(queryText: string, queryEmbedding: number[], options?: HybridSearchOptions): Promise<ScoredMemoryEntry[]>;
+  /** Get the embedding dimension (0 if not yet inferred). */
+  getVectorDimension(): number;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Configuration for InMemoryVectorStore. */
+export interface InMemoryVectorStoreConfig extends InMemoryBackendConfig {
+  /** Expected embedding dimension. If omitted, inferred from first store call. */
+  dimension?: number;
+}
+
+// ============================================================================
+// BM25 Implementation
+// ============================================================================
+
+const BM25_K1 = 1.5;
+const BM25_B = 0.75;
+
+/** Tokenize text: lowercase, strip punctuation, split on whitespace. */
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+interface CorpusStats {
+  avgDocLen: number;
+  docCount: number;
+  termDocFreq: Map<string, number>;
+}
+
+/** Compute corpus-level statistics for BM25 scoring. */
+function computeCorpusStats(docs: string[][]): CorpusStats {
+  const termDocFreq = new Map<string, number>();
+  let totalLen = 0;
+
+  for (const doc of docs) {
+    totalLen += doc.length;
+    const seen = new Set<string>();
+    for (const term of doc) {
+      if (!seen.has(term)) {
+        seen.add(term);
+        termDocFreq.set(term, (termDocFreq.get(term) ?? 0) + 1);
+      }
+    }
+  }
+
+  return {
+    avgDocLen: docs.length > 0 ? totalLen / docs.length : 0,
+    docCount: docs.length,
+    termDocFreq,
+  };
+}
+
+/** Compute BM25 score for a single document against query terms. */
+function bm25Score(
+  queryTerms: string[],
+  docTerms: string[],
+  stats: CorpusStats,
+): number {
+  if (queryTerms.length === 0 || docTerms.length === 0 || stats.docCount === 0) {
+    return 0;
+  }
+
+  const termFreq = new Map<string, number>();
+  for (const term of docTerms) {
+    termFreq.set(term, (termFreq.get(term) ?? 0) + 1);
+  }
+
+  let score = 0;
+  for (const term of queryTerms) {
+    const tf = termFreq.get(term) ?? 0;
+    if (tf === 0) continue;
+
+    const df = stats.termDocFreq.get(term) ?? 0;
+    // IDF: log((N - df + 0.5) / (df + 0.5) + 1)
+    const idf = Math.log((stats.docCount - df + 0.5) / (df + 0.5) + 1);
+    // TF component with length normalization
+    const tfNorm = (tf * (BM25_K1 + 1)) /
+      (tf + BM25_K1 * (1 - BM25_B + BM25_B * (docTerms.length / stats.avgDocLen)));
+    score += idf * tfNorm;
+  }
+
+  return score;
+}
+
+// ============================================================================
+// Score normalization and merge
+// ============================================================================
+
+/** Min-max normalize scores to [0, 1]. */
+function normalizeScores(scored: ScoredMemoryEntry[]): void {
+  if (scored.length === 0) return;
+
+  let min = Infinity;
+  let max = -Infinity;
+  for (const s of scored) {
+    if (s.score < min) min = s.score;
+    if (s.score > max) max = s.score;
+  }
+
+  const range = max - min;
+  if (range === 0) {
+    // All entries equally relevant — normalize to 1 (not 0)
+    for (const s of scored) {
+      s.score = 1;
+    }
+    return;
+  }
+
+  for (const s of scored) {
+    s.score = (s.score - min) / range;
+  }
+}
+
+/** Merge vector and keyword results with weighted combination. */
+function mergeSearchResults(
+  vectorResults: ScoredMemoryEntry[],
+  keywordResults: ScoredMemoryEntry[],
+  vectorWeight: number,
+  keywordWeight: number,
+): ScoredMemoryEntry[] {
+  const merged = new Map<string, ScoredMemoryEntry>();
+
+  for (const r of vectorResults) {
+    merged.set(r.entry.id, {
+      entry: r.entry,
+      score: r.score * vectorWeight,
+      vectorScore: r.score,
+      keywordScore: 0,
+    });
+  }
+
+  for (const r of keywordResults) {
+    const existing = merged.get(r.entry.id);
+    if (existing) {
+      existing.keywordScore = r.score;
+      existing.score = (existing.vectorScore ?? 0) * vectorWeight + r.score * keywordWeight;
+    } else {
+      merged.set(r.entry.id, {
+        entry: r.entry,
+        score: r.score * keywordWeight,
+        vectorScore: 0,
+        keywordScore: r.score,
+      });
+    }
+  }
+
+  const results = Array.from(merged.values());
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}
+
+// ============================================================================
+// InMemoryVectorStore
+// ============================================================================
+
+export class InMemoryVectorStore implements VectorMemoryBackend {
+  readonly name = 'in-memory-vector';
+
+  private readonly backend: InMemoryBackend;
+  private readonly embeddings = new Map<string, number[]>();
+  private readonly entryCache = new Map<string, MemoryEntry>();
+  private readonly vectorNorms = new Map<string, number>();
+  /** Per-session entry IDs in insertion order, for eviction sync with backend. */
+  private readonly sessionEntryIds = new Map<string, string[]>();
+  private readonly maxEntriesPerSession: number;
+  private dimension: number;
+
+  constructor(config: InMemoryVectorStoreConfig = {}) {
+    this.backend = new InMemoryBackend(config);
+    this.dimension = config.dimension ?? 0;
+    this.maxEntriesPerSession = config.maxEntriesPerSession ?? 1000;
+  }
+
+  // ---------- Vector Operations ----------
+
+  async storeWithEmbedding(options: AddEntryOptions, embedding: number[]): Promise<MemoryEntry> {
+    // Validate / infer dimension
+    if (this.dimension === 0) {
+      if (embedding.length === 0) {
+        throw new MemoryBackendError(this.name, 'Embedding must not be empty');
+      }
+      this.dimension = embedding.length;
+    } else if (embedding.length !== this.dimension) {
+      throw new MemoryBackendError(
+        this.name,
+        `Embedding dimension mismatch: expected ${this.dimension}, got ${embedding.length}`,
+      );
+    }
+
+    const entry = await this.backend.addEntry(options);
+
+    // Store embedding and pre-compute norm
+    this.embeddings.set(entry.id, embedding);
+    this.entryCache.set(entry.id, entry);
+    this.vectorNorms.set(entry.id, computeNorm(embedding));
+
+    // Track per-session entry order and evict to stay in sync with backend
+    let sessionIds = this.sessionEntryIds.get(options.sessionId);
+    if (!sessionIds) {
+      sessionIds = [];
+      this.sessionEntryIds.set(options.sessionId, sessionIds);
+    }
+    sessionIds.push(entry.id);
+    while (sessionIds.length > this.maxEntriesPerSession) {
+      const evictedId = sessionIds.shift()!;
+      this.embeddings.delete(evictedId);
+      this.entryCache.delete(evictedId);
+      this.vectorNorms.delete(evictedId);
+    }
+
+    return entry;
+  }
+
+  async searchSimilar(
+    queryEmbedding: number[],
+    options: VectorSearchOptions = {},
+  ): Promise<ScoredMemoryEntry[]> {
+    const limit = options.limit ?? 10;
+    const threshold = options.threshold ?? 0;
+
+    if (this.dimension > 0 && queryEmbedding.length !== this.dimension) {
+      throw new MemoryBackendError(
+        this.name,
+        `Query embedding dimension mismatch: expected ${this.dimension}, got ${queryEmbedding.length}`,
+      );
+    }
+
+    const queryNorm = computeNorm(queryEmbedding);
+    const candidates = this.getFilteredEntries(options);
+    const scored: ScoredMemoryEntry[] = [];
+
+    for (const entry of candidates) {
+      const embedding = this.embeddings.get(entry.id);
+      if (!embedding) continue;
+
+      const entryNorm = this.vectorNorms.get(entry.id) ?? 0;
+      const score = fastCosineSimilarity(queryEmbedding, embedding, queryNorm, entryNorm);
+
+      if (score >= threshold) {
+        scored.push({ entry, score, vectorScore: score });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, limit);
+  }
+
+  async searchHybrid(
+    queryText: string,
+    queryEmbedding: number[],
+    options: HybridSearchOptions = {},
+  ): Promise<ScoredMemoryEntry[]> {
+    const vectorWeight = options.vectorWeight ?? 0.7;
+    const keywordWeight = options.keywordWeight ?? 0.3;
+    const limit = options.limit ?? 10;
+    const threshold = options.threshold ?? 0;
+
+    // Run vector search (without limit/threshold — merge first)
+    const vectorResults = await this.searchSimilar(queryEmbedding, {
+      ...options,
+      limit: undefined,
+      threshold: 0,
+    });
+
+    // Run BM25 keyword search
+    const keywordResults = this.searchBM25(queryText, options);
+
+    // Normalize scores independently
+    normalizeScores(vectorResults);
+    normalizeScores(keywordResults);
+
+    // Merge with weights
+    const merged = mergeSearchResults(vectorResults, keywordResults, vectorWeight, keywordWeight);
+
+    // Apply threshold and limit
+    return merged.filter((r) => r.score >= threshold).slice(0, limit);
+  }
+
+  getVectorDimension(): number {
+    return this.dimension;
+  }
+
+  // ---------- MemoryBackend Delegation ----------
+
+  async addEntry(options: AddEntryOptions): Promise<MemoryEntry> {
+    return this.backend.addEntry(options);
+  }
+
+  async getThread(sessionId: string, limit?: number): Promise<MemoryEntry[]> {
+    return this.backend.getThread(sessionId, limit);
+  }
+
+  async query(query: MemoryQuery): Promise<MemoryEntry[]> {
+    return this.backend.query(query);
+  }
+
+  async deleteThread(sessionId: string): Promise<number> {
+    // Clean up vector data using our tracking (covers entries the backend may have evicted)
+    const ids = this.sessionEntryIds.get(sessionId);
+    if (ids) {
+      for (const id of ids) {
+        this.embeddings.delete(id);
+        this.entryCache.delete(id);
+        this.vectorNorms.delete(id);
+      }
+      this.sessionEntryIds.delete(sessionId);
+    }
+    return this.backend.deleteThread(sessionId);
+  }
+
+  async listSessions(prefix?: string): Promise<string[]> {
+    return this.backend.listSessions(prefix);
+  }
+
+  async set(key: string, value: unknown, ttlMs?: number): Promise<void> {
+    return this.backend.set(key, value, ttlMs);
+  }
+
+  async get<T = unknown>(key: string): Promise<T | undefined> {
+    return this.backend.get<T>(key);
+  }
+
+  async delete(key: string): Promise<boolean> {
+    return this.backend.delete(key);
+  }
+
+  async has(key: string): Promise<boolean> {
+    return this.backend.has(key);
+  }
+
+  async listKeys(prefix?: string): Promise<string[]> {
+    return this.backend.listKeys(prefix);
+  }
+
+  getDurability(): DurabilityInfo {
+    return this.backend.getDurability();
+  }
+
+  async flush(): Promise<void> {
+    return this.backend.flush();
+  }
+
+  async clear(): Promise<void> {
+    this.embeddings.clear();
+    this.entryCache.clear();
+    this.vectorNorms.clear();
+    this.sessionEntryIds.clear();
+    this.dimension = 0;
+    return this.backend.clear();
+  }
+
+  async close(): Promise<void> {
+    this.embeddings.clear();
+    this.entryCache.clear();
+    this.vectorNorms.clear();
+    this.sessionEntryIds.clear();
+    return this.backend.close();
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return this.backend.healthCheck();
+  }
+
+  // ---------- Private Helpers ----------
+
+  private getFilteredEntries(options: VectorSearchOptions): MemoryEntry[] {
+    const entries: MemoryEntry[] = [];
+
+    for (const [id, entry] of this.entryCache) {
+      // Must have an embedding
+      if (!this.embeddings.has(id)) continue;
+
+      // Session filter
+      if (options.sessionId && entry.sessionId !== options.sessionId) continue;
+
+      // Time range filters
+      if (options.after !== undefined && entry.timestamp <= options.after) continue;
+      if (options.before !== undefined && entry.timestamp >= options.before) continue;
+
+      // Channel filter (metadata.channel)
+      if (options.channel) {
+        const entryChannel = entry.metadata?.channel;
+        if (entryChannel !== options.channel) continue;
+      }
+
+      // Tags filter (metadata.tags must contain ALL specified tags)
+      if (options.tags && options.tags.length > 0) {
+        const entryTags = entry.metadata?.tags;
+        if (!Array.isArray(entryTags)) continue;
+        const tagSet = new Set(entryTags as string[]);
+        if (!options.tags.every((t) => tagSet.has(t))) continue;
+      }
+
+      entries.push(entry);
+    }
+
+    return entries;
+  }
+
+  private searchBM25(queryText: string, options: VectorSearchOptions): ScoredMemoryEntry[] {
+    const queryTerms = tokenize(queryText);
+    if (queryTerms.length === 0) return [];
+
+    const candidates = this.getFilteredEntries(options);
+    if (candidates.length === 0) return [];
+
+    // Tokenize all docs and compute corpus stats
+    const docTokens: string[][] = [];
+    for (const entry of candidates) {
+      docTokens.push(tokenize(entry.content));
+    }
+    const stats = computeCorpusStats(docTokens);
+
+    const scored: ScoredMemoryEntry[] = [];
+    for (let i = 0; i < candidates.length; i++) {
+      const score = bm25Score(queryTerms, docTokens[i], stats);
+      if (score > 0) {
+        scored.push({ entry: candidates[i], score, keywordScore: score });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored;
+  }
+}
+
+// ============================================================================
+// Vector math helpers
+// ============================================================================
+
+/** Compute the L2 norm of a vector. */
+function computeNorm(v: number[]): number {
+  let sum = 0;
+  for (let i = 0; i < v.length; i++) {
+    sum += v[i] * v[i];
+  }
+  return Math.sqrt(sum);
+}
+
+/** Cosine similarity using pre-computed norms. */
+function fastCosineSimilarity(
+  a: number[],
+  b: number[],
+  normA: number,
+  normB: number,
+): number {
+  const denom = normA * normB;
+  if (denom === 0) return 0;
+
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+  }
+  return dot / denom;
+}

--- a/runtime/vitest.config.ts
+++ b/runtime/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   resolve: {
     alias: {
       // Explicitly resolve @coral-xyz/anchor to node_modules
-      '@coral-xyz/anchor': resolve(__dirname, 'node_modules/@coral-xyz/anchor'),
+      '@coral-xyz/anchor': resolve(__dirname, '../node_modules/@coral-xyz/anchor'),
     },
   },
   test: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,14 @@
   optionalDependencies:
     "@anthropic-ai/sdk" "^0.30.0"
     better-sqlite3 "^12.0.0"
+    cheerio "^1.0.0"
+    discord.js "^14.7.0"
+    grammy "^1.0.0"
     ioredis "^5.0.0"
     ollama "^0.5.0"
     openai "^4.0.0"
+    playwright "^1.40.0"
+    ws "^8.0.0"
 
 "@agenc/sdk@file:../sdk", "@agenc/sdk@file:./sdk":
   version "1.3.0"
@@ -104,6 +109,78 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
+"@discordjs/builders@^1.13.0":
+  version "1.13.1"
+  resolved "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz"
+  integrity sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==
+  dependencies:
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/util" "^1.2.0"
+    "@sapphire/shapeshift" "^4.0.0"
+    discord-api-types "^0.38.33"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.4"
+    tslib "^2.6.3"
+
+"@discordjs/collection@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/collection@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/collection@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz"
+  integrity sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==
+
+"@discordjs/formatters@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz"
+  integrity sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==
+  dependencies:
+    discord-api-types "^0.38.33"
+
+"@discordjs/rest@^2.5.1", "@discordjs/rest@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz"
+  integrity sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==
+  dependencies:
+    "@discordjs/collection" "^2.1.1"
+    "@discordjs/util" "^1.1.1"
+    "@sapphire/async-queue" "^1.5.3"
+    "@sapphire/snowflake" "^3.5.3"
+    "@vladfrangu/async_event_emitter" "^2.4.6"
+    discord-api-types "^0.38.16"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
+
+"@discordjs/util@^1.1.0", "@discordjs/util@^1.1.1", "@discordjs/util@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz"
+  integrity sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==
+  dependencies:
+    discord-api-types "^0.38.33"
+
+"@discordjs/ws@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz"
+  integrity sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==
+  dependencies:
+    "@discordjs/collection" "^2.1.0"
+    "@discordjs/rest" "^2.5.1"
+    "@discordjs/util" "^1.1.0"
+    "@sapphire/async-queue" "^1.5.2"
+    "@types/ws" "^8.5.10"
+    "@vladfrangu/async_event_emitter" "^2.2.4"
+    discord-api-types "^0.38.1"
+    tslib "^2.6.2"
+    ws "^8.17.0"
+
 "@esbuild/linux-x64@0.21.5":
   version "0.21.5"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"
@@ -113,6 +190,11 @@
   version "0.27.2"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz"
   integrity sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==
+
+"@grammyjs/types@3.24.0":
+  version "3.24.0"
+  resolved "https://registry.npmjs.org/@grammyjs/types/-/types-3.24.0.tgz"
+  integrity sha512-qQIEs4lN5WqUdr4aT8MeU6UFpMbGYAvcvYSW1A4OO1PABGJQHz/KLON6qvpf+5RxaNDQBxiY2k2otIhg/AG7RQ==
 
 "@hono/node-server@^1.19.9":
   version "1.19.9"
@@ -208,10 +290,23 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz"
   integrity sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==
 
-"@rollup/rollup-linux-x64-musl@4.57.1":
-  version "4.57.1"
-  resolved "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz"
-  integrity sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==
+"@sapphire/async-queue@^1.5.2", "@sapphire/async-queue@^1.5.3":
+  version "1.5.5"
+  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz"
+  integrity sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==
+
+"@sapphire/shapeshift@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz"
+  integrity sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lodash "^4.17.21"
+
+"@sapphire/snowflake@^3.5.3", "@sapphire/snowflake@3.5.3":
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz"
+  integrity sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==
 
 "@solana/buffer-layout-utils@^0.2.0":
   version "0.2.0"
@@ -493,7 +588,14 @@
     "@types/node" "*"
     form-data "^4.0.4"
 
-"@types/node@*", "@types/node@^12.12.54", "@types/node@^18.0.0 || >=20.0.0":
+"@types/node@*", "@types/node@^18.0.0 || >=20.0.0", "@types/node@^20.0.0":
+  version "20.19.33"
+  resolved "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz"
+  integrity sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==
+  dependencies:
+    undici-types "~6.21.0"
+
+"@types/node@^12.12.54":
   version "12.20.55"
   resolved "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
@@ -504,13 +606,6 @@
   integrity sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==
   dependencies:
     undici-types "~5.26.4"
-
-"@types/node@^20.0.0":
-  version "20.19.33"
-  resolved "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz"
-  integrity sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==
-  dependencies:
-    undici-types "~6.21.0"
 
 "@types/uuid@^8.3.4":
   version "8.3.4"
@@ -524,14 +619,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^8.0.0":
-  version "8.18.1"
-  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
-  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
-  dependencies:
-    "@types/node" "*"
-
-"@types/ws@^8.2.2":
+"@types/ws@^8.0.0", "@types/ws@^8.2.2", "@types/ws@^8.5.10":
   version "8.18.1"
   resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
   integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
@@ -596,6 +684,11 @@
     "@vitest/pretty-format" "2.1.9"
     loupe "^3.1.2"
     tinyrainbow "^1.2.0"
+
+"@vladfrangu/async_event_emitter@^2.2.4", "@vladfrangu/async_event_emitter@^2.4.6":
+  version "2.4.7"
+  resolved "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz"
+  integrity sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -810,6 +903,11 @@ body-parser@^2.2.1:
     raw-body "^3.0.1"
     type-is "^2.0.1"
 
+boolbase@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+  integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
+
 borsh@^0.7.0:
   version "0.7.0"
   resolved "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz"
@@ -838,7 +936,14 @@ browser-stdout@^1.3.1:
   resolved "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-bs58@^4.0.0, bs58@^4.0.1:
+bs58@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz"
+  integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
+  dependencies:
+    base-x "^3.0.2"
+
+bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz"
   integrity sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==
@@ -992,6 +1097,35 @@ check-types@^11.2.3:
   resolved "https://registry.npmjs.org/check-types/-/check-types-11.2.3.tgz"
   integrity sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==
 
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz"
+  integrity sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    encoding-sniffer "^0.2.1"
+    htmlparser2 "^10.1.0"
+    parse5 "^7.3.0"
+    parse5-htmlparser2-tree-adapter "^7.1.0"
+    parse5-parser-stream "^7.1.2"
+    undici "^7.19.0"
+    whatwg-mimetype "^4.0.0"
+
 chokidar@^3.5.3:
   version "3.6.0"
   resolved "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz"
@@ -1076,12 +1210,7 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^12.0.0:
-  version "12.1.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
-  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
-
-commander@^12.1.0:
+commander@^12.0.0, commander@^12.1.0:
   version "12.1.0"
   resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
   integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
@@ -1154,6 +1283,22 @@ cross-spawn@^7.0.5:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+css-select@^5.1.0:
+  version "5.2.2"
+  resolved "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz"
+  integrity sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
+css-what@^6.1.0:
+  version "6.2.2"
+  resolved "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz"
+  integrity sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==
 
 debug@^4.3.4, debug@^4.3.5, debug@^4.3.7, debug@^4.4.0, debug@^4.4.3:
   version "4.4.3"
@@ -1233,6 +1378,60 @@ diff@^5.2.0:
   resolved "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz"
   integrity sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==
 
+discord-api-types@^0.38.1, discord-api-types@^0.38.16, discord-api-types@^0.38.33:
+  version "0.38.39"
+  resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.39.tgz"
+  integrity sha512-XRdDQvZvID1XvcFftjSmd4dcmMi/RL/jSy5sduBDAvCGFcNFHThdIQXCEBDZFe52lCNEzuIL0QJoKYAmRmxLUA==
+
+discord.js@^14.7.0:
+  version "14.25.1"
+  resolved "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz"
+  integrity sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==
+  dependencies:
+    "@discordjs/builders" "^1.13.0"
+    "@discordjs/collection" "1.5.3"
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/rest" "^2.6.0"
+    "@discordjs/util" "^1.2.0"
+    "@discordjs/ws" "^1.2.3"
+    "@sapphire/snowflake" "3.5.3"
+    discord-api-types "^0.38.33"
+    fast-deep-equal "3.1.3"
+    lodash.snakecase "4.1.1"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
+
+dom-serializer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz"
+  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.2"
+    entities "^4.2.0"
+
+domelementtype@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
+  integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
+
+domhandler@^5.0.2, domhandler@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz"
+  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
+  dependencies:
+    domelementtype "^2.3.0"
+
+domutils@^3.0.1, domutils@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"
@@ -1264,12 +1463,35 @@ encodeurl@^2.0.0:
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
   integrity sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==
 
+encoding-sniffer@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz"
+  integrity sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==
+  dependencies:
+    iconv-lite "^0.6.3"
+    whatwg-encoding "^3.1.1"
+
 end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.5"
   resolved "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz"
   integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
   dependencies:
     once "^1.4.0"
+
+entities@^4.2.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 es-define-property@^1.0.1:
   version "1.0.1"
@@ -1517,7 +1739,7 @@ eyes@^0.1.8:
   resolved "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
   integrity sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==
 
-fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.3, fast-deep-equal@3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -1736,6 +1958,16 @@ gopd@^1.2.0:
   resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
+grammy@^1.0.0:
+  version "1.40.0"
+  resolved "https://registry.npmjs.org/grammy/-/grammy-1.40.0.tgz"
+  integrity sha512-ssuE7fc1AwqlUxHr931OCVW3fU+oFDjHZGgvIedPKXfTdjXvzP19xifvVGCnPtYVUig1Kz+gwxe4A9M5WdkT4Q==
+  dependencies:
+    "@grammyjs/types" "3.24.0"
+    abort-controller "^3.0.0"
+    debug "^4.4.3"
+    node-fetch "^2.7.0"
+
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
@@ -1775,6 +2007,16 @@ hoopy@^0.1.4:
   resolved "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz"
   integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
+htmlparser2@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
+
 http-errors@^2.0.0, http-errors@^2.0.1, http-errors@~2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz"
@@ -1793,7 +2035,21 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-iconv-lite@^0.7.0, iconv-lite@~0.7.0:
+iconv-lite@^0.6.3, iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@^0.7.0:
+  version "0.7.2"
+  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz"
+  integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+iconv-lite@~0.7.0:
   version "0.7.2"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz"
   integrity sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==
@@ -2002,16 +2258,6 @@ litesvm-linux-x64-gnu@0.5.0:
   resolved "https://registry.npmjs.org/litesvm-linux-x64-gnu/-/litesvm-linux-x64-gnu-0.5.0.tgz"
   integrity sha512-W8IIBVlLSBN5RkM88292TImBmYmDMgiYGecin6Qan+dRsBxUffFjRSFHgZRzJQ6X7pfhjlXI6kzuqwsZYchUHA==
 
-litesvm-linux-x64-musl@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.npmjs.org/litesvm-linux-x64-musl/-/litesvm-linux-x64-musl-0.3.3.tgz"
-  integrity sha512-bpWZ2f506hbfu1y6bkmuZf+qqtnLDxggpOMTQbibjd+q6faEO3sETWwKGlIgHB99P8wyU+aXKwLSGQX2sJEw6Q==
-
-litesvm-linux-x64-musl@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.npmjs.org/litesvm-linux-x64-musl/-/litesvm-linux-x64-musl-0.5.0.tgz"
-  integrity sha512-MECozYJjeEiuAEv04FucrFCA0ivdIxisuiK7Fxzx5uSda0W6AieuDx6rnkMXXTgEsR3PKQUA18KmHR93CN1cdw==
-
 litesvm@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/litesvm/-/litesvm-0.3.3.tgz"
@@ -2064,6 +2310,16 @@ lodash.isarguments@^3.1.0:
   resolved "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
   integrity sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==
 
+lodash.snakecase@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
+
+lodash@^4.17.21:
+  version "4.17.23"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+
 log-symbols@^4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz"
@@ -2093,6 +2349,11 @@ loupe@^3.1.2:
   version "3.2.1"
   resolved "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz"
   integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
+magic-bytes.js@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz"
+  integrity sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==
 
 magic-string@^0.30.12, magic-string@^0.30.17:
   version "0.30.21"
@@ -2138,7 +2399,14 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-mime-types@^3.0.0, mime-types@^3.0.2:
+mime-types@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz"
+  integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
+  dependencies:
+    mime-db "^1.54.0"
+
+mime-types@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz"
   integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
@@ -2273,6 +2541,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+nth-check@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz"
+  integrity sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==
+  dependencies:
+    boolbase "^1.0.0"
+
 object-assign@^4, object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
@@ -2363,6 +2638,28 @@ pako@^2.0.3:
   resolved "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz"
   integrity sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==
 
+parse5-htmlparser2-tree-adapter@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz"
+  integrity sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==
+  dependencies:
+    domhandler "^5.0.3"
+    parse5 "^7.0.0"
+
+parse5-parser-stream@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz"
+  integrity sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==
+  dependencies:
+    parse5 "^7.0.0"
+
+parse5@^7.0.0, parse5@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
 parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz"
@@ -2436,6 +2733,20 @@ pkg-types@^1.3.1:
     confbox "^0.1.8"
     mlly "^1.7.4"
     pathe "^2.0.1"
+
+playwright-core@1.58.2:
+  version "1.58.2"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz"
+  integrity sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==
+
+playwright@^1.40.0:
+  version "1.58.2"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz"
+  integrity sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==
+  dependencies:
+    playwright-core "1.58.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 poseidon-lite@^0.3.0:
   version "0.3.0"
@@ -3055,6 +3366,11 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+ts-mixer@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz"
+  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
+
 ts-mocha@^10.0.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.1.0.tgz"
@@ -3088,7 +3404,7 @@ tsconfig-paths@^3.5.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.8.0:
+tslib@^2.6.2, tslib@^2.6.3, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -3171,6 +3487,16 @@ undici-types@~6.21.0:
   version "6.21.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+
+undici@^7.19.0:
+  version "7.22.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz"
+  integrity sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==
+
+undici@6.21.3:
+  version "6.21.3"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -3281,10 +3607,22 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@^3.6.20:
   version "3.6.20"
   resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz"
   integrity sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -3328,7 +3666,7 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@*, ws@^8.0.0, ws@^8.18.0, ws@^8.5.0:
+ws@*, ws@^8.0.0, ws@^8.17.0, ws@^8.18.0, ws@^8.5.0:
   version "8.19.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz"
   integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==


### PR DESCRIPTION
## Summary

- Adds `InMemoryVectorStore` wrapping `InMemoryBackend` via composition with vector storage, cosine similarity search, BM25 keyword scoring, and hybrid (weighted merge) search
- Exports `VectorMemoryBackend` interface, `VectorSearchOptions`, `HybridSearchOptions`, `ScoredMemoryEntry` types from runtime public API
- Fixes `vitest.config.ts` alias resolving `@coral-xyz/anchor` from the correct root `node_modules`

Closes #1082

## Test plan

- [x] 32 new tests in `vector-store.test.ts` covering:
  - `storeWithEmbedding`: dimension inference, mismatch rejection, empty rejection
  - `searchSimilar`: sorting, limit, threshold, session/time/tag/channel filters
  - `searchHybrid`: weighted combination, pure vector, pure keyword, dedup, threshold
  - BM25 scoring: exact vs partial match, empty query
  - MemoryBackend delegation: addEntry, deleteThread cleanup, clear, KV ops, healthCheck
  - Edge cases: zero-vector, single entry, backend eviction sync, dimension validation
- [x] All 228 memory tests pass (zero regressions)
- [x] Full build clean across sdk, runtime, mcp, docs-mcp