### PR TITLE
feat(program): on-chain skill registration instructions (#1091)

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -511,4 +511,29 @@ pub enum CoordinationError {
 
     #[msg("Treasury must be a program-owned PDA")]
     TreasuryNotProgramOwned,
+
+    // Skill registry errors (sequential from enum position)
+    #[msg("Skill ID cannot be all zeros")]
+    SkillInvalidId,
+
+    #[msg("Skill name cannot be all zeros")]
+    SkillInvalidName,
+
+    #[msg("Skill content hash cannot be all zeros")]
+    SkillInvalidContentHash,
+
+    #[msg("Skill is not active")]
+    SkillNotActive,
+
+    #[msg("Rating must be between 1 and 5")]
+    SkillInvalidRating,
+
+    #[msg("Cannot rate own skill")]
+    SkillSelfRating,
+
+    #[msg("Only the skill author can update this skill")]
+    SkillUnauthorizedUpdate,
+
+    #[msg("Cannot purchase own skill")]
+    SkillSelfPurchase,
 }

--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -401,3 +401,54 @@ pub struct ReputationChanged {
     pub reason: u8,
     pub timestamp: i64,
 }
+
+// ============================================================================
+// Skill registry events
+// ============================================================================
+
+/// Emitted when a new skill is registered
+#[event]
+pub struct SkillRegistered {
+    pub skill: Pubkey,
+    pub author: Pubkey,
+    pub skill_id: [u8; 32],
+    pub name: [u8; 32],
+    pub content_hash: [u8; 32],
+    pub price: u64,
+    pub price_mint: Option<Pubkey>,
+    pub timestamp: i64,
+}
+
+/// Emitted when a skill is updated by its author
+#[event]
+pub struct SkillUpdated {
+    pub skill: Pubkey,
+    pub author: Pubkey,
+    pub content_hash: [u8; 32],
+    pub price: u64,
+    pub version: u8,
+    pub timestamp: i64,
+}
+
+/// Emitted when a skill is rated by another agent
+#[event]
+pub struct SkillRated {
+    pub skill: Pubkey,
+    pub rater: Pubkey,
+    pub rating: u8,
+    pub rater_reputation: u16,
+    pub new_total_rating: u64,
+    pub new_rating_count: u32,
+    pub timestamp: i64,
+}
+
+/// Emitted when a skill is purchased
+#[event]
+pub struct SkillPurchased {
+    pub skill: Pubkey,
+    pub buyer: Pubkey,
+    pub author: Pubkey,
+    pub price_paid: u64,
+    pub protocol_fee: u64,
+    pub timestamp: i64,
+}

--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -58,6 +58,10 @@ pub mod create_proposal;
 pub mod execute_proposal;
 pub mod initialize_governance;
 pub mod vote_proposal;
+pub mod purchase_skill;
+pub mod rate_skill;
+pub mod register_skill;
+pub mod update_skill;
 
 // Glob re-exports are required for Anchor's #[program] macro to access generated
 // types from #[derive(Accounts)]. See module documentation for details.
@@ -117,3 +121,11 @@ pub use execute_proposal::*;
 pub use initialize_governance::*;
 #[allow(ambiguous_glob_reexports)]
 pub use vote_proposal::*;
+#[allow(ambiguous_glob_reexports)]
+pub use purchase_skill::*;
+#[allow(ambiguous_glob_reexports)]
+pub use rate_skill::*;
+#[allow(ambiguous_glob_reexports)]
+pub use register_skill::*;
+#[allow(ambiguous_glob_reexports)]
+pub use update_skill::*;

--- a/programs/agenc-coordination/src/instructions/purchase_skill.rs
+++ b/programs/agenc-coordination/src/instructions/purchase_skill.rs
@@ -1,0 +1,276 @@
+//! Purchase a skill (SOL or SPL token, with protocol fee)
+
+use crate::errors::CoordinationError;
+use crate::events::SkillPurchased;
+use crate::instructions::constants::BASIS_POINTS_DIVISOR;
+use crate::state::{
+    AgentRegistration, AgentStatus, ProtocolConfig, PurchaseRecord, SkillRegistration,
+};
+use crate::utils::version::check_version_compatible;
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+use anchor_spl::token::{self, Mint, Token, TokenAccount, Transfer};
+
+#[derive(Accounts)]
+pub struct PurchaseSkill<'info> {
+    #[account(
+        mut,
+        seeds = [b"skill", skill.author.as_ref(), skill.skill_id.as_ref()],
+        bump = skill.bump
+    )]
+    pub skill: Box<Account<'info, SkillRegistration>>,
+
+    #[account(
+        init,
+        payer = authority,
+        space = PurchaseRecord::SIZE,
+        seeds = [b"skill_purchase", skill.key().as_ref(), buyer.key().as_ref()],
+        bump
+    )]
+    pub purchase_record: Account<'info, PurchaseRecord>,
+
+    #[account(
+        seeds = [b"agent", buyer.agent_id.as_ref()],
+        bump = buyer.bump,
+        has_one = authority @ CoordinationError::UnauthorizedAgent
+    )]
+    pub buyer: Box<Account<'info, AgentRegistration>>,
+
+    /// Skill author's agent registration
+    #[account(
+        seeds = [b"agent", author_agent.agent_id.as_ref()],
+        bump = author_agent.bump,
+        constraint = skill.author == author_agent.key() @ CoordinationError::InvalidInput
+    )]
+    pub author_agent: Box<Account<'info, AgentRegistration>>,
+
+    /// CHECK: Validated as author_agent.authority
+    #[account(
+        mut,
+        constraint = author_wallet.key() == author_agent.authority @ CoordinationError::InvalidInput
+    )]
+    pub author_wallet: UncheckedAccount<'info>,
+
+    #[account(
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Box<Account<'info, ProtocolConfig>>,
+
+    /// CHECK: Validated as protocol_config.treasury
+    #[account(
+        mut,
+        constraint = treasury.key() == protocol_config.treasury @ CoordinationError::InvalidTreasury
+    )]
+    pub treasury: UncheckedAccount<'info>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+
+    // === Optional SPL Token accounts ===
+
+    /// SPL token mint for price denomination (optional)
+    pub price_mint: Option<Account<'info, Mint>>,
+
+    /// Buyer's token account (optional)
+    #[account(mut)]
+    pub buyer_token_account: Option<Account<'info, TokenAccount>>,
+
+    /// Author's token account (optional)
+    #[account(mut)]
+    pub author_token_account: Option<Account<'info, TokenAccount>>,
+
+    /// Treasury's token account (optional)
+    #[account(mut)]
+    pub treasury_token_account: Option<Account<'info, TokenAccount>>,
+
+    /// SPL Token program (optional)
+    pub token_program: Option<Program<'info, Token>>,
+}
+
+pub fn handler(ctx: Context<PurchaseSkill>) -> Result<()> {
+    let config = &ctx.accounts.protocol_config;
+    check_version_compatible(config)?;
+
+    let buyer = &ctx.accounts.buyer;
+    require!(
+        buyer.status == AgentStatus::Active,
+        CoordinationError::AgentNotActive
+    );
+
+    let skill = &ctx.accounts.skill;
+    require!(
+        skill.is_active,
+        CoordinationError::SkillNotActive
+    );
+
+    require!(
+        buyer.key() != skill.author,
+        CoordinationError::SkillSelfPurchase
+    );
+
+    let clock = Clock::get()?;
+    let price = skill.price;
+    let mut protocol_fee = 0u64;
+
+    if price > 0 || skill.price_mint.is_some() {
+        if skill.price_mint.is_some() {
+            // SPL token payment path
+            require!(
+                ctx.accounts.price_mint.is_some()
+                    && ctx.accounts.buyer_token_account.is_some()
+                    && ctx.accounts.author_token_account.is_some()
+                    && ctx.accounts.treasury_token_account.is_some()
+                    && ctx.accounts.token_program.is_some(),
+                CoordinationError::MissingTokenAccounts
+            );
+
+            let mint = ctx.accounts.price_mint.as_ref().unwrap();
+            require!(
+                mint.key() == skill.price_mint.unwrap(),
+                CoordinationError::InvalidTokenMint
+            );
+
+            // Calculate fee
+            protocol_fee = price
+                .checked_mul(config.protocol_fee_bps as u64)
+                .ok_or(CoordinationError::ArithmeticOverflow)?
+                .checked_div(BASIS_POINTS_DIVISOR)
+                .ok_or(CoordinationError::ArithmeticOverflow)?;
+            let author_share = price
+                .checked_sub(protocol_fee)
+                .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+            let buyer_ta = ctx.accounts.buyer_token_account.as_ref().unwrap();
+            let author_ta = ctx.accounts.author_token_account.as_ref().unwrap();
+            let treasury_ta = ctx.accounts.treasury_token_account.as_ref().unwrap();
+            let token_program = ctx.accounts.token_program.as_ref().unwrap();
+
+            // Validate token account mints match the skill's price mint
+            let expected_mint = mint.key();
+            require!(
+                buyer_ta.mint == expected_mint,
+                CoordinationError::InvalidTokenMint
+            );
+            require!(
+                author_ta.mint == expected_mint,
+                CoordinationError::InvalidTokenMint
+            );
+            require!(
+                treasury_ta.mint == expected_mint,
+                CoordinationError::InvalidTokenMint
+            );
+
+            // Validate token account ownership
+            require!(
+                buyer_ta.owner == ctx.accounts.authority.key(),
+                CoordinationError::InvalidInput
+            );
+            require!(
+                author_ta.owner == ctx.accounts.author_wallet.key(),
+                CoordinationError::InvalidInput
+            );
+            require!(
+                treasury_ta.owner == ctx.accounts.treasury.key(),
+                CoordinationError::InvalidInput
+            );
+
+            // Transfer author_share to author
+            if author_share > 0 {
+                token::transfer(
+                    CpiContext::new(
+                        token_program.to_account_info(),
+                        Transfer {
+                            from: buyer_ta.to_account_info(),
+                            to: author_ta.to_account_info(),
+                            authority: ctx.accounts.authority.to_account_info(),
+                        },
+                    ),
+                    author_share,
+                )?;
+            }
+
+            // Transfer protocol_fee to treasury
+            if protocol_fee > 0 {
+                token::transfer(
+                    CpiContext::new(
+                        token_program.to_account_info(),
+                        Transfer {
+                            from: buyer_ta.to_account_info(),
+                            to: treasury_ta.to_account_info(),
+                            authority: ctx.accounts.authority.to_account_info(),
+                        },
+                    ),
+                    protocol_fee,
+                )?;
+            }
+        } else {
+            // SOL payment path
+            protocol_fee = price
+                .checked_mul(config.protocol_fee_bps as u64)
+                .ok_or(CoordinationError::ArithmeticOverflow)?
+                .checked_div(BASIS_POINTS_DIVISOR)
+                .ok_or(CoordinationError::ArithmeticOverflow)?;
+            let author_share = price
+                .checked_sub(protocol_fee)
+                .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+            // Transfer author_share to author wallet
+            if author_share > 0 {
+                system_program::transfer(
+                    CpiContext::new(
+                        ctx.accounts.system_program.to_account_info(),
+                        system_program::Transfer {
+                            from: ctx.accounts.authority.to_account_info(),
+                            to: ctx.accounts.author_wallet.to_account_info(),
+                        },
+                    ),
+                    author_share,
+                )?;
+            }
+
+            // Transfer protocol_fee to treasury
+            if protocol_fee > 0 {
+                system_program::transfer(
+                    CpiContext::new(
+                        ctx.accounts.system_program.to_account_info(),
+                        system_program::Transfer {
+                            from: ctx.accounts.authority.to_account_info(),
+                            to: ctx.accounts.treasury.to_account_info(),
+                        },
+                    ),
+                    protocol_fee,
+                )?;
+            }
+        }
+    }
+
+    // Update skill download count
+    let skill = &mut ctx.accounts.skill;
+    skill.download_count = skill
+        .download_count
+        .checked_add(1)
+        .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+    // Record purchase
+    let purchase_record = &mut ctx.accounts.purchase_record;
+    purchase_record.skill = skill.key();
+    purchase_record.buyer = buyer.key();
+    purchase_record.price_paid = price;
+    purchase_record.timestamp = clock.unix_timestamp;
+    purchase_record.bump = ctx.bumps.purchase_record;
+    purchase_record._reserved = [0u8; 4];
+
+    emit!(SkillPurchased {
+        skill: skill.key(),
+        buyer: buyer.key(),
+        author: ctx.accounts.author_agent.key(),
+        price_paid: price,
+        protocol_fee,
+        timestamp: clock.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/instructions/rate_skill.rs
+++ b/programs/agenc-coordination/src/instructions/rate_skill.rs
@@ -1,0 +1,115 @@
+//! Rate a skill (reputation-weighted, one rating per agent per skill)
+
+use crate::errors::CoordinationError;
+use crate::events::SkillRated;
+use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig, SkillRating, SkillRegistration};
+use crate::utils::version::check_version_compatible;
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct RateSkill<'info> {
+    #[account(
+        mut,
+        seeds = [b"skill", skill.author.as_ref(), skill.skill_id.as_ref()],
+        bump = skill.bump
+    )]
+    pub skill: Account<'info, SkillRegistration>,
+
+    #[account(
+        init,
+        payer = authority,
+        space = SkillRating::SIZE,
+        seeds = [b"skill_rating", skill.key().as_ref(), rater.key().as_ref()],
+        bump
+    )]
+    pub rating_account: Account<'info, SkillRating>,
+
+    #[account(
+        seeds = [b"agent", rater.agent_id.as_ref()],
+        bump = rater.bump,
+        has_one = authority @ CoordinationError::UnauthorizedAgent
+    )]
+    pub rater: Account<'info, AgentRegistration>,
+
+    #[account(
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(
+    ctx: Context<RateSkill>,
+    rating: u8,
+    review_hash: Option<[u8; 32]>,
+) -> Result<()> {
+    let config = &ctx.accounts.protocol_config;
+    check_version_compatible(config)?;
+
+    let rater = &ctx.accounts.rater;
+    require!(
+        rater.status == AgentStatus::Active,
+        CoordinationError::AgentNotActive
+    );
+
+    require!(
+        rating >= 1 && rating <= 5,
+        CoordinationError::SkillInvalidRating
+    );
+
+    let skill = &ctx.accounts.skill;
+    require!(
+        skill.is_active,
+        CoordinationError::SkillNotActive
+    );
+
+    require!(
+        rater.key() != skill.author,
+        CoordinationError::SkillSelfRating
+    );
+
+    let clock = Clock::get()?;
+
+    // Reputation-weighted rating: rating * rater_reputation
+    let weighted = (rating as u64)
+        .checked_mul(rater.reputation as u64)
+        .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+    let skill = &mut ctx.accounts.skill;
+    skill.total_rating = skill
+        .total_rating
+        .checked_add(weighted)
+        .ok_or(CoordinationError::ArithmeticOverflow)?;
+    skill.rating_count = skill
+        .rating_count
+        .checked_add(1)
+        .ok_or(CoordinationError::ArithmeticOverflow)?;
+
+    // Record rating
+    let rating_account = &mut ctx.accounts.rating_account;
+    rating_account.skill = skill.key();
+    rating_account.rater = rater.key();
+    rating_account.rating = rating;
+    rating_account.review_hash = review_hash;
+    rating_account.rater_reputation = rater.reputation;
+    rating_account.timestamp = clock.unix_timestamp;
+    rating_account.bump = ctx.bumps.rating_account;
+    rating_account._reserved = [0u8; 4];
+
+    emit!(SkillRated {
+        skill: skill.key(),
+        rater: rater.key(),
+        rating,
+        rater_reputation: rater.reputation,
+        new_total_rating: skill.total_rating,
+        new_rating_count: skill.rating_count,
+        timestamp: clock.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/instructions/register_skill.rs
+++ b/programs/agenc-coordination/src/instructions/register_skill.rs
@@ -1,0 +1,103 @@
+//! Register a new skill on-chain
+
+use crate::errors::CoordinationError;
+use crate::events::SkillRegistered;
+use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig, SkillRegistration};
+use crate::utils::version::check_version_compatible;
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+#[instruction(skill_id: [u8; 32])]
+pub struct RegisterSkill<'info> {
+    #[account(
+        init,
+        payer = authority,
+        space = SkillRegistration::SIZE,
+        seeds = [b"skill", author.key().as_ref(), skill_id.as_ref()],
+        bump
+    )]
+    pub skill: Account<'info, SkillRegistration>,
+
+    #[account(
+        seeds = [b"agent", author.agent_id.as_ref()],
+        bump = author.bump,
+        has_one = authority @ CoordinationError::UnauthorizedAgent
+    )]
+    pub author: Account<'info, AgentRegistration>,
+
+    #[account(
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+
+    #[account(mut)]
+    pub authority: Signer<'info>,
+
+    pub system_program: Program<'info, System>,
+}
+
+pub fn handler(
+    ctx: Context<RegisterSkill>,
+    skill_id: [u8; 32],
+    name: [u8; 32],
+    content_hash: [u8; 32],
+    price: u64,
+    price_mint: Option<Pubkey>,
+    tags: [u8; 64],
+) -> Result<()> {
+    let config = &ctx.accounts.protocol_config;
+    check_version_compatible(config)?;
+
+    let author = &ctx.accounts.author;
+    require!(
+        author.status == AgentStatus::Active,
+        CoordinationError::AgentNotActive
+    );
+
+    require!(
+        skill_id != [0u8; 32],
+        CoordinationError::SkillInvalidId
+    );
+    require!(
+        name != [0u8; 32],
+        CoordinationError::SkillInvalidName
+    );
+    require!(
+        content_hash != [0u8; 32],
+        CoordinationError::SkillInvalidContentHash
+    );
+
+    let clock = Clock::get()?;
+    let skill = &mut ctx.accounts.skill;
+
+    skill.author = ctx.accounts.author.key();
+    skill.skill_id = skill_id;
+    skill.name = name;
+    skill.content_hash = content_hash;
+    skill.price = price;
+    skill.price_mint = price_mint;
+    skill.tags = tags;
+    skill.total_rating = 0;
+    skill.rating_count = 0;
+    skill.download_count = 0;
+    skill.version = 1;
+    skill.is_active = true;
+    skill.created_at = clock.unix_timestamp;
+    skill.updated_at = clock.unix_timestamp;
+    skill.bump = ctx.bumps.skill;
+    skill._reserved = [0u8; 8];
+
+    emit!(SkillRegistered {
+        skill: skill.key(),
+        author: author.key(),
+        skill_id,
+        name,
+        content_hash,
+        price,
+        price_mint,
+        timestamp: clock.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/instructions/update_skill.rs
+++ b/programs/agenc-coordination/src/instructions/update_skill.rs
@@ -1,0 +1,80 @@
+//! Update an existing skill's content and pricing
+
+use crate::errors::CoordinationError;
+use crate::events::SkillUpdated;
+use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig, SkillRegistration};
+use crate::utils::version::check_version_compatible;
+use anchor_lang::prelude::*;
+
+#[derive(Accounts)]
+pub struct UpdateSkill<'info> {
+    #[account(
+        mut,
+        seeds = [b"skill", author.key().as_ref(), skill.skill_id.as_ref()],
+        bump = skill.bump,
+        constraint = skill.author == author.key() @ CoordinationError::SkillUnauthorizedUpdate
+    )]
+    pub skill: Account<'info, SkillRegistration>,
+
+    #[account(
+        seeds = [b"agent", author.agent_id.as_ref()],
+        bump = author.bump,
+        has_one = authority @ CoordinationError::UnauthorizedAgent
+    )]
+    pub author: Account<'info, AgentRegistration>,
+
+    #[account(
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+
+    pub authority: Signer<'info>,
+}
+
+pub fn handler(
+    ctx: Context<UpdateSkill>,
+    content_hash: [u8; 32],
+    price: u64,
+    tags: Option<[u8; 64]>,
+    is_active: Option<bool>,
+) -> Result<()> {
+    let config = &ctx.accounts.protocol_config;
+    check_version_compatible(config)?;
+
+    let author = &ctx.accounts.author;
+    require!(
+        author.status == AgentStatus::Active,
+        CoordinationError::AgentNotActive
+    );
+
+    require!(
+        content_hash != [0u8; 32],
+        CoordinationError::SkillInvalidContentHash
+    );
+
+    let clock = Clock::get()?;
+    let skill = &mut ctx.accounts.skill;
+
+    skill.content_hash = content_hash;
+    skill.price = price;
+    if let Some(new_tags) = tags {
+        skill.tags = new_tags;
+    }
+    if let Some(active) = is_active {
+        skill.is_active = active;
+    }
+    skill.version = skill.version.saturating_add(1);
+    skill.updated_at = clock.unix_timestamp;
+
+    emit!(SkillUpdated {
+        skill: skill.key(),
+        author: author.key(),
+        content_hash,
+        price,
+        version: skill.version,
+        timestamp: clock.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -427,4 +427,55 @@ pub mod agenc_coordination {
     pub fn cancel_proposal(ctx: Context<CancelProposal>) -> Result<()> {
         instructions::cancel_proposal::handler(ctx)
     }
+
+    /// Register a new skill on-chain.
+    /// Author must be an active agent.
+    #[allow(clippy::too_many_arguments)]
+    pub fn register_skill(
+        ctx: Context<RegisterSkill>,
+        skill_id: [u8; 32],
+        name: [u8; 32],
+        content_hash: [u8; 32],
+        price: u64,
+        price_mint: Option<Pubkey>,
+        tags: [u8; 64],
+    ) -> Result<()> {
+        instructions::register_skill::handler(
+            ctx,
+            skill_id,
+            name,
+            content_hash,
+            price,
+            price_mint,
+            tags,
+        )
+    }
+
+    /// Update a skill's content, price, tags, or active status.
+    /// Only the skill author can update.
+    pub fn update_skill(
+        ctx: Context<UpdateSkill>,
+        content_hash: [u8; 32],
+        price: u64,
+        tags: Option<[u8; 64]>,
+        is_active: Option<bool>,
+    ) -> Result<()> {
+        instructions::update_skill::handler(ctx, content_hash, price, tags, is_active)
+    }
+
+    /// Rate a skill (1-5, reputation-weighted).
+    /// One rating per agent per skill, enforced by PDA uniqueness.
+    pub fn rate_skill(
+        ctx: Context<RateSkill>,
+        rating: u8,
+        review_hash: Option<[u8; 32]>,
+    ) -> Result<()> {
+        instructions::rate_skill::handler(ctx, rating, review_hash)
+    }
+
+    /// Purchase a skill (SOL or SPL token).
+    /// Protocol fee is deducted and sent to treasury.
+    pub fn purchase_skill(ctx: Context<PurchaseSkill>) -> Result<()> {
+        instructions::purchase_skill::handler(ctx)
+    }
 }

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -1116,6 +1116,133 @@ impl GovernanceVote {
         8;   // _reserved
 }
 
+// ============================================================================
+// Skill Registry
+// ============================================================================
+
+/// Skill registration account
+/// PDA seeds: ["skill", author_agent_pda, skill_id]
+#[account]
+#[derive(InitSpace)]
+pub struct SkillRegistration {
+    /// Author's agent PDA
+    pub author: Pubkey,
+    /// Unique skill identifier
+    pub skill_id: [u8; 32],
+    /// Skill display name
+    pub name: [u8; 32],
+    /// Content hash (IPFS CID, Arweave tx, etc.)
+    pub content_hash: [u8; 32],
+    /// Price in lamports (SOL) or token smallest units
+    pub price: u64,
+    /// Optional SPL token mint for price denomination (None = SOL)
+    pub price_mint: Option<Pubkey>,
+    /// Tags for discovery (encoded by client)
+    pub tags: [u8; 64],
+    /// Sum of reputation-weighted ratings
+    pub total_rating: u64,
+    /// Number of ratings received
+    pub rating_count: u32,
+    /// Number of purchases
+    pub download_count: u32,
+    /// Content version (monotonically increasing)
+    pub version: u8,
+    /// Whether the skill is currently active
+    pub is_active: bool,
+    /// Creation timestamp
+    pub created_at: i64,
+    /// Last update timestamp
+    pub updated_at: i64,
+    /// Bump seed
+    pub bump: u8,
+    /// Reserved for future use
+    pub _reserved: [u8; 8],
+}
+
+impl SkillRegistration {
+    pub const SIZE: usize = 8 +  // discriminator
+        32 + // author
+        32 + // skill_id
+        32 + // name
+        32 + // content_hash
+        8 +  // price
+        33 + // price_mint (Option<Pubkey>)
+        64 + // tags
+        8 +  // total_rating
+        4 +  // rating_count
+        4 +  // download_count
+        1 +  // version
+        1 +  // is_active
+        8 +  // created_at
+        8 +  // updated_at
+        1 +  // bump
+        8;   // _reserved
+}
+
+/// Skill rating record (one per rater per skill)
+/// PDA seeds: ["skill_rating", skill_pda, rater_agent_pda]
+#[account]
+#[derive(InitSpace)]
+pub struct SkillRating {
+    /// Skill being rated
+    pub skill: Pubkey,
+    /// Rater's agent PDA
+    pub rater: Pubkey,
+    /// Rating value (1-5)
+    pub rating: u8,
+    /// Optional review content hash
+    pub review_hash: Option<[u8; 32]>,
+    /// Rater's reputation at time of rating
+    pub rater_reputation: u16,
+    /// Rating timestamp
+    pub timestamp: i64,
+    /// Bump seed
+    pub bump: u8,
+    /// Reserved for future use
+    pub _reserved: [u8; 4],
+}
+
+impl SkillRating {
+    pub const SIZE: usize = 8 +  // discriminator
+        32 + // skill
+        32 + // rater
+        1 +  // rating
+        33 + // review_hash (Option<[u8;32]>)
+        2 +  // rater_reputation
+        8 +  // timestamp
+        1 +  // bump
+        4;   // _reserved
+}
+
+/// Purchase record (one per buyer per skill, prevents double purchase)
+/// PDA seeds: ["skill_purchase", skill_pda, buyer_agent_pda]
+#[account]
+#[derive(InitSpace)]
+pub struct PurchaseRecord {
+    /// Skill purchased
+    pub skill: Pubkey,
+    /// Buyer's agent PDA
+    pub buyer: Pubkey,
+    /// Price paid at time of purchase
+    pub price_paid: u64,
+    /// Purchase timestamp
+    pub timestamp: i64,
+    /// Bump seed
+    pub bump: u8,
+    /// Reserved for future use
+    pub _reserved: [u8; 4],
+}
+
+impl PurchaseRecord {
+    pub const SIZE: usize = 8 +  // discriminator
+        32 + // skill
+        32 + // buyer
+        8 +  // price_paid
+        8 +  // timestamp
+        1 +  // bump
+        4;   // _reserved
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1206,6 +1333,21 @@ mod tests {
     #[test]
     fn test_governance_vote_size() {
         test_size_constant!(GovernanceVote);
+    }
+
+    #[test]
+    fn test_skill_registration_size() {
+        test_size_constant!(SkillRegistration);
+    }
+
+    #[test]
+    fn test_skill_rating_size() {
+        test_size_constant!(SkillRating);
+    }
+
+    #[test]
+    fn test_purchase_record_size() {
+        test_size_constant!(PurchaseRecord);
     }
 
     #[test]

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -187,4 +187,7 @@ export const SEEDS = {
   PROPOSAL: Buffer.from('proposal'),
   GOVERNANCE_VOTE: Buffer.from('governance_vote'),
   GOVERNANCE: Buffer.from('governance'),
+  SKILL: Buffer.from('skill'),
+  SKILL_RATING: Buffer.from('skill_rating'),
+  SKILL_PURCHASE: Buffer.from('skill_purchase'),
 } as const;

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -275,5 +275,22 @@ export {
   RECOMMENDED_CU_CANCEL_PROPOSAL,
 } from './governance';
 
+export {
+  deriveSkillPda,
+  deriveSkillRatingPda,
+  deriveSkillPurchasePda,
+  RECOMMENDED_CU_REGISTER_SKILL,
+  RECOMMENDED_CU_UPDATE_SKILL,
+  RECOMMENDED_CU_RATE_SKILL,
+  RECOMMENDED_CU_PURCHASE_SKILL,
+  RECOMMENDED_CU_PURCHASE_SKILL_TOKEN,
+  type RegisterSkillParams,
+  type UpdateSkillParams,
+  type RateSkillParams,
+  type SkillState,
+  type SkillRatingState,
+  type PurchaseRecordState,
+} from './skills';
+
 // Version info
 export const VERSION = '1.3.0';

--- a/sdk/src/skills.ts
+++ b/sdk/src/skills.ts
@@ -1,0 +1,123 @@
+/**
+ * Skills module — PDA helpers, types, and CU budget constants.
+ */
+
+import { PublicKey } from '@solana/web3.js';
+import { PROGRAM_ID, SEEDS } from './constants.js';
+
+// ============================================================================
+// PDA helpers
+// ============================================================================
+
+export function deriveSkillPda(
+  authorAgentPda: PublicKey,
+  skillId: Uint8Array | Buffer,
+  programId: PublicKey = PROGRAM_ID,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [SEEDS.SKILL, authorAgentPda.toBuffer(), Buffer.from(skillId)],
+    programId,
+  );
+}
+
+export function deriveSkillRatingPda(
+  skillPda: PublicKey,
+  raterAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [SEEDS.SKILL_RATING, skillPda.toBuffer(), raterAgentPda.toBuffer()],
+    programId,
+  );
+}
+
+export function deriveSkillPurchasePda(
+  skillPda: PublicKey,
+  buyerAgentPda: PublicKey,
+  programId: PublicKey = PROGRAM_ID,
+): [PublicKey, number] {
+  return PublicKey.findProgramAddressSync(
+    [SEEDS.SKILL_PURCHASE, skillPda.toBuffer(), buyerAgentPda.toBuffer()],
+    programId,
+  );
+}
+
+// ============================================================================
+// Compute unit budgets
+// ============================================================================
+
+/** CU budget for register_skill instruction */
+export const RECOMMENDED_CU_REGISTER_SKILL = 50_000;
+
+/** CU budget for update_skill instruction */
+export const RECOMMENDED_CU_UPDATE_SKILL = 30_000;
+
+/** CU budget for rate_skill instruction */
+export const RECOMMENDED_CU_RATE_SKILL = 40_000;
+
+/** CU budget for purchase_skill instruction (SOL path) */
+export const RECOMMENDED_CU_PURCHASE_SKILL = 60_000;
+
+/** CU budget for purchase_skill instruction (SPL token path) */
+export const RECOMMENDED_CU_PURCHASE_SKILL_TOKEN = 100_000;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RegisterSkillParams {
+  skillId: Uint8Array;
+  name: Uint8Array;
+  contentHash: Uint8Array;
+  price: bigint;
+  priceMint?: PublicKey;
+  tags: Uint8Array;
+}
+
+export interface UpdateSkillParams {
+  contentHash: Uint8Array;
+  price: bigint;
+  tags?: Uint8Array;
+  isActive?: boolean;
+}
+
+export interface RateSkillParams {
+  rating: number;
+  reviewHash?: Uint8Array;
+}
+
+export interface SkillState {
+  author: PublicKey;
+  skillId: Uint8Array;
+  name: Uint8Array;
+  contentHash: Uint8Array;
+  price: bigint;
+  priceMint: PublicKey | null;
+  tags: Uint8Array;
+  totalRating: bigint;
+  ratingCount: number;
+  downloadCount: number;
+  version: number;
+  isActive: boolean;
+  createdAt: bigint;
+  updatedAt: bigint;
+  bump: number;
+}
+
+export interface SkillRatingState {
+  skill: PublicKey;
+  rater: PublicKey;
+  rating: number;
+  reviewHash: Uint8Array | null;
+  raterReputation: number;
+  timestamp: bigint;
+  bump: number;
+}
+
+export interface PurchaseRecordState {
+  skill: PublicKey;
+  buyer: PublicKey;
+  pricePaid: bigint;
+  timestamp: bigint;
+  bump: number;
+}


### PR DESCRIPTION
## Summary

- Adds 4 new Anchor instructions (`register_skill`, `update_skill`, `rate_skill`, `purchase_skill`) for a fully decentralized, censorship-resistant skill registry
- Adds 3 new account structs (`SkillRegistration`, `SkillRating`, `PurchaseRecord`) with SIZE tests and `_reserved` fields
- Adds SDK PDA helpers, CU budget constants, and TypeScript types

## Details

**Solana Program (Rust):**
- `register_skill` — Author (active agent) registers a skill with content hash, price, optional SPL token mint, and tags
- `update_skill` — Author updates content, price, tags, and active status (enables deactivation)
- `rate_skill` — Reputation-weighted ratings (1-5), one per agent per skill, self-rating prevented
- `purchase_skill` — SOL or SPL token payment with protocol fee split, self-purchase prevented
- 8 new error variants, 4 new events
- Token account mint/owner validation on SPL path prevents fund misdirection
- PDA double-action prevention via `init` on rating and purchase records

**SDK (TypeScript):**
- `deriveSkillPda`, `deriveSkillRatingPda`, `deriveSkillPurchasePda`
- CU constants: `RECOMMENDED_CU_REGISTER_SKILL` (50k), `RECOMMENDED_CU_UPDATE_SKILL` (30k), `RECOMMENDED_CU_RATE_SKILL` (40k), `RECOMMENDED_CU_PURCHASE_SKILL` (60k/100k)
- Types: `RegisterSkillParams`, `UpdateSkillParams`, `RateSkillParams`, `SkillState`, `SkillRatingState`, `PurchaseRecordState`

## Test plan

- [x] `anchor build` compiles cleanly (release + test profiles)
- [x] `cargo test --lib` passes 91/91 (includes 3 new SIZE constant tests)
- [x] `npm run build` (SDK) succeeds
- [x] `npm run typecheck` (SDK + runtime) passes
- [x] `npm run test:fast` — 196/196 pass, no regressions (1 pre-existing SPL test failure)

Closes #1091