### PR TITLE
feat(runtime): implement SemanticMemoryRetriever (#1087)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -954,6 +954,13 @@ export {
   type MemoryGraphResult,
   type MemoryGraphConfig,
   type CompactOptions,
+  // Semantic memory retriever
+  SemanticMemoryRetriever,
+  computeRetrievalScore,
+  estimateMemoryTokens,
+  type SemanticMemoryRetrieverConfig,
+  type RetrievalResult,
+  type ScoredRetrievalEntry,
 } from './memory/index.js';
 
 // Dispute Operations (Phase 8)

--- a/runtime/src/memory/index.ts
+++ b/runtime/src/memory/index.ts
@@ -89,3 +89,13 @@ export {
   type StructuredMemoryEntry,
   type EntityExtractor,
 } from './structured.js';
+
+// Semantic memory retriever (Phase 5.5)
+export {
+  SemanticMemoryRetriever,
+  computeRetrievalScore,
+  estimateTokens as estimateMemoryTokens,
+  type SemanticMemoryRetrieverConfig,
+  type RetrievalResult,
+  type ScoredRetrievalEntry,
+} from './retriever.js';

--- a/runtime/src/memory/retriever.test.ts
+++ b/runtime/src/memory/retriever.test.ts
@@ -1,0 +1,558 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  SemanticMemoryRetriever,
+  estimateTokens,
+  computeRetrievalScore,
+  type SemanticMemoryRetrieverConfig,
+} from './retriever.js';
+import type { MemoryEntry } from './types.js';
+import type { VectorMemoryBackend, ScoredMemoryEntry } from './vector-store.js';
+import type { EmbeddingProvider } from './embeddings.js';
+import type { CuratedMemoryManager } from './structured.js';
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeEntry(
+  content: string,
+  timestamp = 1_000_000,
+  sessionId = 'sess-1',
+): MemoryEntry {
+  return {
+    id: `entry-${content.slice(0, 8)}`,
+    sessionId,
+    role: 'assistant',
+    content,
+    timestamp,
+  };
+}
+
+function makeScoredEntry(
+  content: string,
+  score: number,
+  timestamp = 1_000_000,
+): ScoredMemoryEntry {
+  return { entry: makeEntry(content, timestamp), score };
+}
+
+function createMockEmbedding(): EmbeddingProvider {
+  return {
+    name: 'mock',
+    dimension: 8,
+    embed: vi.fn().mockResolvedValue([1, 0, 0, 0, 0, 0, 0, 0]),
+    embedBatch: vi.fn().mockResolvedValue([[1, 0, 0, 0, 0, 0, 0, 0]]),
+    isAvailable: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function createMockVectorBackend(results: ScoredMemoryEntry[] = []): VectorMemoryBackend {
+  return {
+    name: 'mock-vector',
+    searchHybrid: vi.fn().mockResolvedValue(results),
+    searchSimilar: vi.fn().mockResolvedValue([]),
+    storeWithEmbedding: vi.fn(),
+    getVectorDimension: vi.fn().mockReturnValue(8),
+    addEntry: vi.fn(),
+    getThread: vi.fn().mockResolvedValue([]),
+    query: vi.fn().mockResolvedValue([]),
+    deleteThread: vi.fn().mockResolvedValue(0),
+    listSessions: vi.fn().mockResolvedValue([]),
+    set: vi.fn(),
+    get: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(false),
+    has: vi.fn().mockResolvedValue(false),
+    listKeys: vi.fn().mockResolvedValue([]),
+    getDurability: vi.fn().mockReturnValue({ level: 'none', supportsFlush: false, description: '' }),
+    flush: vi.fn(),
+    clear: vi.fn(),
+    close: vi.fn(),
+    healthCheck: vi.fn().mockResolvedValue(true),
+  } as unknown as VectorMemoryBackend;
+}
+
+function createMockCurated(content = ''): CuratedMemoryManager {
+  return {
+    load: vi.fn().mockResolvedValue(content),
+    proposeAddition: vi.fn(),
+    addFact: vi.fn(),
+    removeFact: vi.fn(),
+  } as unknown as CuratedMemoryManager;
+}
+
+function createRetriever(
+  overrides: Partial<SemanticMemoryRetrieverConfig> = {},
+): SemanticMemoryRetriever {
+  return new SemanticMemoryRetriever({
+    vectorBackend: createMockVectorBackend(),
+    embeddingProvider: createMockEmbedding(),
+    ...overrides,
+  });
+}
+
+// ============================================================================
+// estimateTokens
+// ============================================================================
+
+describe('estimateTokens', () => {
+  it('returns 0 for empty string', () => {
+    expect(estimateTokens('')).toBe(0);
+  });
+
+  it('returns 1 for a single character', () => {
+    expect(estimateTokens('a')).toBe(1);
+  });
+
+  it('returns 1 for exactly 4 characters', () => {
+    expect(estimateTokens('abcd')).toBe(1);
+  });
+
+  it('returns 2 for 5 characters', () => {
+    expect(estimateTokens('abcde')).toBe(2);
+  });
+
+  it('scales linearly', () => {
+    expect(estimateTokens('a'.repeat(16))).toBe(4);
+    expect(estimateTokens('a'.repeat(17))).toBe(5);
+    expect(estimateTokens('a'.repeat(100))).toBe(25);
+  });
+});
+
+// ============================================================================
+// computeRetrievalScore
+// ============================================================================
+
+describe('computeRetrievalScore', () => {
+  const now = 1_000_000;
+  const halfLife = 86_400_000; // 24h
+
+  it('returns pure relevance when recencyWeight=0', () => {
+    const score = computeRetrievalScore(0.8, now - halfLife, now, 0, halfLife);
+    expect(score).toBeCloseTo(0.8, 5);
+  });
+
+  it('returns pure recency when recencyWeight=1', () => {
+    // At exactly halfLife age, recency should be 0.5
+    const score = computeRetrievalScore(0.8, now - halfLife, now, 1, halfLife);
+    expect(score).toBeCloseTo(0.5, 5);
+  });
+
+  it('returns 1.0 for perfect relevance and zero age', () => {
+    const score = computeRetrievalScore(1.0, now, now, 0.5, halfLife);
+    // relevance * 0.5 + 1.0 * 0.5 = 0.5 + 0.5 = 1.0
+    expect(score).toBeCloseTo(1.0, 5);
+  });
+
+  it('recency decays to 0.5 at half-life', () => {
+    const score = computeRetrievalScore(0.0, now - halfLife, now, 1.0, halfLife);
+    expect(score).toBeCloseTo(0.5, 5);
+  });
+
+  it('recency decays to 0.25 at two half-lives', () => {
+    const score = computeRetrievalScore(0.0, now - 2 * halfLife, now, 1.0, halfLife);
+    expect(score).toBeCloseTo(0.25, 5);
+  });
+
+  it('handles future timestamps (clamped age to 0)', () => {
+    const score = computeRetrievalScore(0.5, now + 1000, now, 0.5, halfLife);
+    // age clamped to 0 → recency = 1.0
+    // 0.5 * 0.5 + 1.0 * 0.5 = 0.75
+    expect(score).toBeCloseTo(0.75, 5);
+  });
+
+  it('blends relevance and recency correctly', () => {
+    // weight=0.3, halfLife=24h, age=12h → recency ≈ 0.707
+    const age = halfLife / 2;
+    const score = computeRetrievalScore(0.6, now - age, now, 0.3, halfLife);
+    const expectedRecency = Math.exp(-Math.LN2 * 0.5); // ≈ 0.707
+    const expected = 0.6 * 0.7 + expectedRecency * 0.3;
+    expect(score).toBeCloseTo(expected, 5);
+  });
+});
+
+// ============================================================================
+// SemanticMemoryRetriever — basic flow
+// ============================================================================
+
+describe('SemanticMemoryRetriever', () => {
+  describe('basic flow', () => {
+    it('returns formatted memory blocks', async () => {
+      const results = [makeScoredEntry('relevant fact', 0.9)];
+      const backend = createMockVectorBackend(results);
+      const retriever = createRetriever({ vectorBackend: backend });
+
+      const content = await retriever.retrieve('query', 'sess-1');
+
+      expect(content).toContain('<memory source="vector"');
+      expect(content).toContain('relevant fact');
+      expect(content).toContain('</memory>');
+    });
+
+    it('returns undefined when no results found', async () => {
+      const retriever = createRetriever();
+      const content = await retriever.retrieve('query', 'sess-1');
+      expect(content).toBeUndefined();
+    });
+
+    it('retrieve() delegates to retrieveDetailed()', async () => {
+      const results = [makeScoredEntry('data', 0.8)];
+      const backend = createMockVectorBackend(results);
+      const retriever = createRetriever({ vectorBackend: backend });
+
+      const detailed = await retriever.retrieveDetailed('query', 'sess-1');
+      const simple = await retriever.retrieve('query', 'sess-1');
+
+      expect(simple).toBe(detailed.content);
+    });
+
+    it('returns correct result shape from retrieveDetailed', async () => {
+      const results = [makeScoredEntry('fact', 0.85)];
+      const backend = createMockVectorBackend(results);
+      const retriever = createRetriever({ vectorBackend: backend });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      expect(result.entries).toHaveLength(1);
+      expect(result.entries[0].relevanceScore).toBe(0.85);
+      expect(result.entries[0].combinedScore).toBeGreaterThan(0);
+      expect(result.estimatedTokens).toBeGreaterThan(0);
+    });
+
+    it('returns empty result when embedding is empty', async () => {
+      const embedding = createMockEmbedding();
+      (embedding.embed as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      const retriever = createRetriever({ embeddingProvider: embedding });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      expect(result.content).toBeUndefined();
+      expect(result.entries).toHaveLength(0);
+    });
+
+    it('logs debug when embedding is empty', async () => {
+      const embedding = createMockEmbedding();
+      (embedding.embed as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const retriever = createRetriever({
+        embeddingProvider: embedding,
+        logger: logger as any,
+      });
+
+      await retriever.retrieveDetailed('query', 'sess-1');
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Empty embedding'),
+      );
+    });
+  });
+
+  // ==========================================================================
+  // Token budget
+  // ==========================================================================
+
+  describe('token budget', () => {
+    it('curated memory takes priority over vector results', async () => {
+      const results = [makeScoredEntry('vector data', 0.9)];
+      const backend = createMockVectorBackend(results);
+      const curated = createMockCurated('important curated fact');
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        curatedMemory: curated,
+        maxTokenBudget: 2000,
+      });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      expect(result.curatedIncluded).toBe(true);
+      expect(result.content).toContain('source="curated"');
+      // Curated appears before vector in the output
+      const curatedIdx = result.content!.indexOf('source="curated"');
+      const vectorIdx = result.content!.indexOf('source="vector"');
+      expect(curatedIdx).toBeLessThan(vectorIdx);
+    });
+
+    it('greedy packing skips large entries and includes smaller ones', async () => {
+      // Create a tight budget
+      const largeContent = 'x'.repeat(200); // ~50 tokens content + block overhead
+      const smallContent = 'y'.repeat(20);  // ~5 tokens content + block overhead
+      const results = [
+        makeScoredEntry(largeContent, 0.9),
+        makeScoredEntry(smallContent, 0.8),
+      ];
+      const backend = createMockVectorBackend(results);
+      // Budget enough for only the small entry (with block markup overhead)
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        maxTokenBudget: 25, // ~100 chars — fits small block but not large
+      });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      expect(result.content).toContain(smallContent);
+      expect(result.content).not.toContain(largeContent);
+    });
+
+    it('returns undefined content when budget is zero', async () => {
+      const results = [makeScoredEntry('data', 0.9)];
+      const backend = createMockVectorBackend(results);
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        maxTokenBudget: 0,
+      });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+      expect(result.content).toBeUndefined();
+      expect(result.estimatedTokens).toBe(0);
+    });
+
+    it('logs warning when curated exceeds budget', async () => {
+      const curated = createMockCurated('x'.repeat(10_000));
+      const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+      const retriever = createRetriever({
+        curatedMemory: curated,
+        maxTokenBudget: 10,
+        logger: logger as any,
+      });
+
+      await retriever.retrieveDetailed('query', 'sess-1');
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('exceeds remaining budget'),
+      );
+    });
+
+    it('reports accurate estimatedTokens', async () => {
+      const content = 'short fact';
+      const results = [makeScoredEntry(content, 0.9)];
+      const backend = createMockVectorBackend(results);
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        maxTokenBudget: 2000,
+      });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      expect(result.estimatedTokens).toBe(estimateTokens(result.content!));
+    });
+  });
+
+  // ==========================================================================
+  // Curated memory
+  // ==========================================================================
+
+  describe('curated memory', () => {
+    it('includes curated content when available', async () => {
+      const curated = createMockCurated('User prefers TypeScript');
+      const retriever = createRetriever({ curatedMemory: curated });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+      expect(result.curatedIncluded).toBe(true);
+      expect(result.content).toContain('User prefers TypeScript');
+    });
+
+    it('curatedIncluded is false when load returns empty', async () => {
+      const curated = createMockCurated('');
+      const retriever = createRetriever({ curatedMemory: curated });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+      expect(result.curatedIncluded).toBe(false);
+    });
+
+    it('curatedIncluded is false when no curatedMemory configured', async () => {
+      const retriever = createRetriever();
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+      expect(result.curatedIncluded).toBe(false);
+    });
+
+    it('curated gets score="1.00" in block', async () => {
+      const curated = createMockCurated('important');
+      const retriever = createRetriever({ curatedMemory: curated });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+      expect(result.content).toContain('score="1.00"');
+    });
+  });
+
+  // ==========================================================================
+  // Curated caching
+  // ==========================================================================
+
+  describe('curated caching', () => {
+    it('caches within TTL', async () => {
+      const curated = createMockCurated('cached fact');
+      const retriever = createRetriever({
+        curatedMemory: curated,
+        curatedCacheTtlMs: 60_000,
+      });
+
+      await retriever.retrieveDetailed('q1', 'sess-1');
+      await retriever.retrieveDetailed('q2', 'sess-1');
+
+      expect(curated.load).toHaveBeenCalledTimes(1);
+    });
+
+    it('reloads after TTL expires', async () => {
+      const curated = createMockCurated('fact v1');
+      const retriever = createRetriever({
+        curatedMemory: curated,
+        curatedCacheTtlMs: 100,
+      });
+
+      await retriever.retrieveDetailed('q1', 'sess-1');
+
+      // Advance time past TTL
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 200);
+      (curated.load as ReturnType<typeof vi.fn>).mockResolvedValue('fact v2');
+
+      const result = await retriever.retrieveDetailed('q2', 'sess-1');
+
+      expect(curated.load).toHaveBeenCalledTimes(2);
+      expect(result.content).toContain('fact v2');
+
+      vi.restoreAllMocks();
+    });
+
+    it('clearCache forces reload on next call', async () => {
+      const curated = createMockCurated('original');
+      const retriever = createRetriever({ curatedMemory: curated });
+
+      await retriever.retrieveDetailed('q1', 'sess-1');
+      retriever.clearCache();
+      (curated.load as ReturnType<typeof vi.fn>).mockResolvedValue('updated');
+
+      const result = await retriever.retrieveDetailed('q2', 'sess-1');
+      expect(curated.load).toHaveBeenCalledTimes(2);
+      expect(result.content).toContain('updated');
+    });
+  });
+
+  // ==========================================================================
+  // Re-ranking
+  // ==========================================================================
+
+  describe('re-ranking', () => {
+    it('boosts recent entries', async () => {
+      const now = Date.now();
+      const old = makeScoredEntry('old fact', 0.8, now - 86_400_000 * 7); // 7 days old
+      const recent = makeScoredEntry('new fact', 0.8, now - 1000); // 1 second old
+      const backend = createMockVectorBackend([old, recent]);
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        recencyWeight: 0.5,
+      });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      // Recent entry should rank higher
+      expect(result.entries[0].entry.content).toBe('new fact');
+      expect(result.entries[0].combinedScore).toBeGreaterThan(result.entries[1].combinedScore);
+    });
+
+    it('uses pure relevance when recencyWeight=0', async () => {
+      const now = Date.now();
+      const highRelevance = makeScoredEntry('high', 0.9, now - 86_400_000 * 30);
+      const lowRelevance = makeScoredEntry('low', 0.3, now);
+      const backend = createMockVectorBackend([highRelevance, lowRelevance]);
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        recencyWeight: 0,
+      });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      expect(result.entries[0].entry.content).toBe('high');
+      expect(result.entries[0].combinedScore).toBeCloseTo(0.9, 2);
+    });
+
+    it('uses pure recency when recencyWeight=1', async () => {
+      const now = Date.now();
+      const oldHighRelevance = makeScoredEntry('old-high', 0.95, now - 86_400_000 * 10);
+      const recentLowRelevance = makeScoredEntry('new-low', 0.1, now - 1000);
+      const backend = createMockVectorBackend([oldHighRelevance, recentLowRelevance]);
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        recencyWeight: 1,
+      });
+
+      const result = await retriever.retrieveDetailed('query', 'sess-1');
+
+      expect(result.entries[0].entry.content).toBe('new-low');
+    });
+  });
+
+  // ==========================================================================
+  // Search params
+  // ==========================================================================
+
+  describe('search params', () => {
+    it('forwards sessionId to searchHybrid', async () => {
+      const backend = createMockVectorBackend();
+      const retriever = createRetriever({ vectorBackend: backend });
+
+      await retriever.retrieve('query', 'my-session');
+
+      expect(backend.searchHybrid).toHaveBeenCalledWith(
+        'query',
+        expect.any(Array),
+        expect.objectContaining({ sessionId: 'my-session' }),
+      );
+    });
+
+    it('forwards maxResults as limit', async () => {
+      const backend = createMockVectorBackend();
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        maxResults: 3,
+      });
+
+      await retriever.retrieve('query', 'sess-1');
+
+      expect(backend.searchHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({ limit: 3 }),
+      );
+    });
+
+    it('forwards hybrid weights', async () => {
+      const backend = createMockVectorBackend();
+      const retriever = createRetriever({
+        vectorBackend: backend,
+        hybridVectorWeight: 0.6,
+        hybridKeywordWeight: 0.4,
+      });
+
+      await retriever.retrieve('query', 'sess-1');
+
+      expect(backend.searchHybrid).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.any(Array),
+        expect.objectContaining({
+          vectorWeight: 0.6,
+          keywordWeight: 0.4,
+        }),
+      );
+    });
+  });
+
+  // ==========================================================================
+  // Config defaults
+  // ==========================================================================
+
+  describe('config defaults', () => {
+    it('applies sensible defaults with minimal config', async () => {
+      const backend = createMockVectorBackend();
+      const retriever = createRetriever({ vectorBackend: backend });
+
+      await retriever.retrieve('query', 'sess-1');
+
+      expect(backend.searchHybrid).toHaveBeenCalledWith(
+        'query',
+        expect.any(Array),
+        expect.objectContaining({
+          limit: 5,
+          vectorWeight: 0.7,
+          keywordWeight: 0.3,
+        }),
+      );
+    });
+  });
+});

--- a/runtime/src/memory/retriever.ts
+++ b/runtime/src/memory/retriever.ts
@@ -1,0 +1,258 @@
+/**
+ * Semantic memory retriever — context-aware retrieval for prompt assembly.
+ *
+ * Embeds user messages, runs hybrid search on a VectorMemoryBackend,
+ * re-ranks by recency * relevance, loads curated MEMORY.md, and
+ * formats results as `<memory>` blocks within a token budget.
+ *
+ * Implements the {@link MemoryRetriever} interface consumed by ChatExecutor.
+ *
+ * @module
+ */
+
+import type { MemoryEntry } from './types.js';
+import type { VectorMemoryBackend } from './vector-store.js';
+import type { EmbeddingProvider } from './embeddings.js';
+import type { CuratedMemoryManager } from './structured.js';
+import type { MemoryRetriever } from '../llm/chat-executor.js';
+import type { Logger } from '../utils/logger.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const CHARS_PER_TOKEN = 4;
+const DEFAULT_MAX_TOKEN_BUDGET = 2000;
+const DEFAULT_MAX_RESULTS = 5;
+const DEFAULT_RECENCY_WEIGHT = 0.3;
+const DEFAULT_RECENCY_HALF_LIFE_MS = 86_400_000; // 24h
+const DEFAULT_CURATED_CACHE_TTL_MS = 60_000; // 1min
+const DEFAULT_MIN_SCORE = 0.01;
+const DEFAULT_HYBRID_VECTOR_WEIGHT = 0.7;
+const DEFAULT_HYBRID_KEYWORD_WEIGHT = 0.3;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SemanticMemoryRetrieverConfig {
+  vectorBackend: VectorMemoryBackend;
+  embeddingProvider: EmbeddingProvider;
+  curatedMemory?: CuratedMemoryManager;
+  maxTokenBudget?: number;
+  maxResults?: number;
+  recencyWeight?: number;
+  recencyHalfLifeMs?: number;
+  curatedCacheTtlMs?: number;
+  minScore?: number;
+  hybridVectorWeight?: number;
+  hybridKeywordWeight?: number;
+  logger?: Logger;
+}
+
+export interface RetrievalResult {
+  content: string | undefined;
+  entries: readonly ScoredRetrievalEntry[];
+  curatedIncluded: boolean;
+  estimatedTokens: number;
+}
+
+export interface ScoredRetrievalEntry {
+  entry: MemoryEntry;
+  relevanceScore: number;
+  recencyScore: number;
+  combinedScore: number;
+}
+
+// ============================================================================
+// Pure helpers
+// ============================================================================
+
+/** Estimate token count from text (~4 chars per token). */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Compute a blended retrieval score from relevance and recency.
+ *
+ * `recency = exp(-ln2 * age / halfLife)` — decays to 0.5 at halfLife.
+ * `combined = relevance * (1 - recencyWeight) + recency * recencyWeight`
+ */
+export function computeRetrievalScore(
+  relevanceScore: number,
+  entryTimestamp: number,
+  now: number,
+  recencyWeight: number,
+  halfLifeMs: number,
+): number {
+  const age = Math.max(0, now - entryTimestamp);
+  const recencyScore = halfLifeMs > 0
+    ? Math.exp(-Math.LN2 * age / halfLifeMs)
+    : (age === 0 ? 1 : 0);
+  return relevanceScore * (1 - recencyWeight) + recencyScore * recencyWeight;
+}
+
+// ============================================================================
+// SemanticMemoryRetriever
+// ============================================================================
+
+export class SemanticMemoryRetriever implements MemoryRetriever {
+  private readonly vectorBackend: VectorMemoryBackend;
+  private readonly embeddingProvider: EmbeddingProvider;
+  private readonly curatedMemory: CuratedMemoryManager | undefined;
+  private readonly maxTokenBudget: number;
+  private readonly maxResults: number;
+  private readonly recencyWeight: number;
+  private readonly recencyHalfLifeMs: number;
+  private readonly curatedCacheTtlMs: number;
+  private readonly minScore: number;
+  private readonly hybridVectorWeight: number;
+  private readonly hybridKeywordWeight: number;
+  private readonly logger: Logger | undefined;
+
+  // Curated memory cache
+  private curatedCacheContent: string | undefined;
+  private curatedCacheTimestamp = 0;
+
+  constructor(config: SemanticMemoryRetrieverConfig) {
+    this.vectorBackend = config.vectorBackend;
+    this.embeddingProvider = config.embeddingProvider;
+    this.curatedMemory = config.curatedMemory;
+    this.maxTokenBudget = config.maxTokenBudget ?? DEFAULT_MAX_TOKEN_BUDGET;
+    this.maxResults = config.maxResults ?? DEFAULT_MAX_RESULTS;
+    this.recencyWeight = config.recencyWeight ?? DEFAULT_RECENCY_WEIGHT;
+    this.recencyHalfLifeMs = config.recencyHalfLifeMs ?? DEFAULT_RECENCY_HALF_LIFE_MS;
+    this.curatedCacheTtlMs = config.curatedCacheTtlMs ?? DEFAULT_CURATED_CACHE_TTL_MS;
+    this.minScore = config.minScore ?? DEFAULT_MIN_SCORE;
+    this.hybridVectorWeight = config.hybridVectorWeight ?? DEFAULT_HYBRID_VECTOR_WEIGHT;
+    this.hybridKeywordWeight = config.hybridKeywordWeight ?? DEFAULT_HYBRID_KEYWORD_WEIGHT;
+    this.logger = config.logger;
+  }
+
+  /** Retrieve formatted memory context for prompt assembly. */
+  async retrieve(message: string, sessionId: string): Promise<string | undefined> {
+    const result = await this.retrieveDetailed(message, sessionId);
+    return result.content;
+  }
+
+  /** Retrieve with full scoring details. */
+  async retrieveDetailed(message: string, sessionId: string): Promise<RetrievalResult> {
+    // 1. Embed user message
+    const embedding = await this.embeddingProvider.embed(message);
+    if (embedding.length === 0) {
+      this.logger?.debug('Empty embedding returned, skipping retrieval');
+      return { content: undefined, entries: [], curatedIncluded: false, estimatedTokens: 0 };
+    }
+
+    // 2. Hybrid search
+    const searchResults = await this.vectorBackend.searchHybrid(
+      message,
+      embedding,
+      {
+        limit: this.maxResults,
+        sessionId,
+        vectorWeight: this.hybridVectorWeight,
+        keywordWeight: this.hybridKeywordWeight,
+      },
+    );
+
+    // 3. Re-rank with recency
+    const now = Date.now();
+    const scored: ScoredRetrievalEntry[] = searchResults.map((sr) => {
+      const recencyScore = this.computeRecency(sr.entry.timestamp, now);
+      const combinedScore = computeRetrievalScore(
+        sr.score,
+        sr.entry.timestamp,
+        now,
+        this.recencyWeight,
+        this.recencyHalfLifeMs,
+      );
+      return {
+        entry: sr.entry,
+        relevanceScore: sr.score,
+        recencyScore,
+        combinedScore,
+      };
+    });
+
+    // 4. Filter by minScore and sort descending
+    const filtered = scored
+      .filter((e) => e.combinedScore >= this.minScore)
+      .sort((a, b) => b.combinedScore - a.combinedScore);
+
+    // 5. Load curated memory (with cache)
+    const curatedContent = await this.loadCurated();
+
+    // 6. Pack into token budget
+    let remainingBudget = this.maxTokenBudget;
+    const blocks: string[] = [];
+    let curatedIncluded = false;
+
+    // Curated memory first
+    if (curatedContent) {
+      const curatedTokens = estimateTokens(curatedContent);
+      if (curatedTokens <= remainingBudget) {
+        blocks.push(`<memory source="curated" score="1.00">\n${curatedContent}\n</memory>`);
+        remainingBudget -= estimateTokens(blocks[blocks.length - 1]);
+        curatedIncluded = true;
+      } else {
+        this.logger?.warn(
+          `Curated memory (${curatedTokens} tokens) exceeds remaining budget (${remainingBudget})`,
+        );
+      }
+    }
+
+    // Vector results — greedy packing with skip
+    for (const entry of filtered) {
+      const block = `<memory source="vector" score="${entry.combinedScore.toFixed(2)}">\n${entry.entry.content}\n</memory>`;
+      const blockTokens = estimateTokens(block);
+      if (blockTokens <= remainingBudget) {
+        blocks.push(block);
+        remainingBudget -= blockTokens;
+      }
+      // Skip (not break) — try smaller entries
+    }
+
+    const content = blocks.length > 0 ? blocks.join('\n') : undefined;
+    const totalTokens = this.maxTokenBudget - remainingBudget;
+
+    return {
+      content,
+      entries: filtered,
+      curatedIncluded,
+      estimatedTokens: totalTokens,
+    };
+  }
+
+  /** Invalidate the curated memory cache. */
+  clearCache(): void {
+    this.curatedCacheContent = undefined;
+    this.curatedCacheTimestamp = 0;
+  }
+
+  // ---------- Private helpers ----------
+
+  private computeRecency(entryTimestamp: number, now: number): number {
+    const age = Math.max(0, now - entryTimestamp);
+    if (this.recencyHalfLifeMs <= 0) return age === 0 ? 1 : 0;
+    return Math.exp(-Math.LN2 * age / this.recencyHalfLifeMs);
+  }
+
+  private async loadCurated(): Promise<string | undefined> {
+    if (!this.curatedMemory) return undefined;
+
+    const now = Date.now();
+    if (
+      this.curatedCacheContent !== undefined &&
+      now - this.curatedCacheTimestamp < this.curatedCacheTtlMs
+    ) {
+      return this.curatedCacheContent || undefined;
+    }
+
+    const content = await this.curatedMemory.load();
+    this.curatedCacheContent = content;
+    this.curatedCacheTimestamp = now;
+    return content || undefined;
+  }
+}


### PR DESCRIPTION
## Summary

- Implement `SemanticMemoryRetriever` class that fulfills the `MemoryRetriever` interface already consumed by `ChatExecutor`
- Hybrid vector + BM25 keyword search via `VectorMemoryBackend.searchHybrid()`, re-ranked with exponential recency decay
- Curated MEMORY.md loading with configurable TTL cache, greedy token budget packing with skip semantics
- 37 tests covering scoring math, budget packing, caching, re-ranking, search param forwarding, and config defaults

## Test plan

- [x] `npx vitest run src/memory/retriever.test.ts` — 37/37 pass
- [x] `npx tsc --noEmit` — no new type errors
- [x] Full runtime suite — no regressions (1566 pass)

Closes #1087