### PR TITLE
feat(runtime): built-in heartbeat actions (#1084)

### DIFF
--- a/runtime/src/gateway/heartbeat-actions.test.ts
+++ b/runtime/src/gateway/heartbeat-actions.test.ts
@@ -1,0 +1,531 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PublicKey } from '@solana/web3.js';
+import {
+  createTaskScanAction,
+  createSummaryAction,
+  createPortfolioAction,
+  createPollingAction,
+  createDefaultHeartbeatActions,
+} from './heartbeat-actions.js';
+import type { HeartbeatContext, HeartbeatResult } from './heartbeat.js';
+import type { TaskScanner } from '../autonomous/scanner.js';
+import type { Task } from '../autonomous/types.js';
+import type { MemoryBackend, MemoryEntry } from '../memory/types.js';
+import type { LLMProvider, LLMResponse } from '../llm/types.js';
+import type { Connection } from '@solana/web3.js';
+
+// ============================================================================
+// Shared mocks
+// ============================================================================
+
+function makeContext(): HeartbeatContext {
+  return {
+    logger: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+    sendToChannels: vi.fn<(content: string) => Promise<void>>().mockResolvedValue(undefined),
+  };
+}
+
+function makeTask(overrides?: Partial<Task>): Task {
+  return {
+    pda: new PublicKey('11111111111111111111111111111112'),
+    taskId: new Uint8Array(32),
+    creator: new PublicKey('11111111111111111111111111111112'),
+    requiredCapabilities: 1n,
+    reward: 2_000_000_000n,
+    description: new Uint8Array(64),
+    constraintHash: new Uint8Array(32),
+    deadline: 0,
+    maxWorkers: 1,
+    currentClaims: 0,
+    status: 0,
+    rewardMint: null,
+    ...overrides,
+  };
+}
+
+function makeScanner(tasks: Task[] = []): TaskScanner {
+  return { scan: vi.fn().mockResolvedValue(tasks) } as unknown as TaskScanner;
+}
+
+function makeMemoryBackend(overrides?: Partial<MemoryBackend>): MemoryBackend {
+  return {
+    name: 'mock',
+    query: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(undefined),
+    set: vi.fn().mockResolvedValue(undefined),
+    addEntry: vi.fn(),
+    getThread: vi.fn(),
+    deleteThread: vi.fn(),
+    listSessions: vi.fn(),
+    delete: vi.fn(),
+    has: vi.fn(),
+    listKeys: vi.fn(),
+    getDurability: vi.fn(),
+    flush: vi.fn(),
+    clear: vi.fn(),
+    close: vi.fn(),
+    healthCheck: vi.fn(),
+    ...overrides,
+  } as unknown as MemoryBackend;
+}
+
+function makeLLMResponse(content: string): LLMResponse {
+  return {
+    content,
+    toolCalls: [],
+    usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+    model: 'test-model',
+    finishReason: 'stop',
+  };
+}
+
+function makeLLMProvider(content = 'Test summary'): LLMProvider {
+  return {
+    name: 'mock-llm',
+    chat: vi.fn().mockResolvedValue(makeLLMResponse(content)),
+    chatStream: vi.fn(),
+    healthCheck: vi.fn().mockResolvedValue(true),
+  };
+}
+
+function makeEntry(role: 'user' | 'assistant', content: string): MemoryEntry {
+  return {
+    id: crypto.randomUUID(),
+    sessionId: 'sess-1',
+    role,
+    content,
+    timestamp: Date.now(),
+  };
+}
+
+function makeConnection(balance = 5_000_000_000): Connection {
+  return {
+    getBalance: vi.fn().mockResolvedValue(balance),
+  } as unknown as Connection;
+}
+
+// ============================================================================
+// Task scan action
+// ============================================================================
+
+describe('createTaskScanAction', () => {
+  it('returns quiet when scanner finds no tasks', async () => {
+    const action = createTaskScanAction({ scanner: makeScanner([]) });
+    const result = await action.execute(makeContext());
+    expect(result.hasOutput).toBe(false);
+    expect(result.quiet).toBe(true);
+  });
+
+  it('returns formatted output when tasks are found', async () => {
+    const tasks = [makeTask({ reward: 1_500_000_000n })];
+    const action = createTaskScanAction({ scanner: makeScanner(tasks) });
+    const result = await action.execute(makeContext());
+
+    expect(result.hasOutput).toBe(true);
+    expect(result.quiet).toBe(false);
+    expect(result.output).toContain('Found 1 claimable task(s)');
+    expect(result.output).toContain('1.5000 SOL');
+  });
+
+  it('formats SPL token tasks with mint address', async () => {
+    const mint = new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+    const tasks = [makeTask({ reward: 1_000_000n, rewardMint: mint })];
+    const action = createTaskScanAction({ scanner: makeScanner(tasks) });
+    const result = await action.execute(makeContext());
+
+    expect(result.hasOutput).toBe(true);
+    expect(result.output).toContain('1000000 lamports');
+    expect(result.output).toContain(mint.toBase58());
+  });
+
+  it('returns quiet and logs on scanner error', async () => {
+    const scanner = { scan: vi.fn().mockRejectedValue(new Error('rpc fail')) } as unknown as TaskScanner;
+    const action = createTaskScanAction({ scanner });
+    const ctx = makeContext();
+    const result = await action.execute(ctx);
+
+    expect(result.quiet).toBe(true);
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+
+  it('has name "task-scan" and enabled true', () => {
+    const action = createTaskScanAction({ scanner: makeScanner() });
+    expect(action.name).toBe('task-scan');
+    expect(action.enabled).toBe(true);
+  });
+
+  it('includes truncated PDA in output', async () => {
+    const pda = new PublicKey('9WzDXwBbmPdCBoccS9W9J4nAjBD2VBaRqmptzYTfBKSU');
+    const tasks = [makeTask({ pda, reward: 1_000_000_000n })];
+    const action = createTaskScanAction({ scanner: makeScanner(tasks) });
+    const result = await action.execute(makeContext());
+
+    expect(result.output).toContain(pda.toBase58().slice(0, 8));
+  });
+});
+
+// ============================================================================
+// Summary action
+// ============================================================================
+
+describe('createSummaryAction', () => {
+  it('returns quiet when no memory entries', async () => {
+    const action = createSummaryAction({
+      memory: makeMemoryBackend(),
+      llm: makeLLMProvider(),
+      sessionId: 'sess-1',
+    });
+    const result = await action.execute(makeContext());
+
+    expect(result.hasOutput).toBe(false);
+    expect(result.quiet).toBe(true);
+  });
+
+  it('calls LLM with correct system and user prompts', async () => {
+    const entries = [makeEntry('user', 'Hello'), makeEntry('assistant', 'Hi there')];
+    const memory = makeMemoryBackend({ query: vi.fn().mockResolvedValue(entries) });
+    const llm = makeLLMProvider('A concise summary.');
+    const action = createSummaryAction({ memory, llm, sessionId: 'sess-1' });
+    const result = await action.execute(makeContext());
+
+    expect(result.hasOutput).toBe(true);
+    expect(result.output).toBe('A concise summary.');
+
+    const chatCall = (llm.chat as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(chatCall[0].role).toBe('system');
+    expect(chatCall[0].content).toContain('concise summarizer');
+    expect(chatCall[1].role).toBe('user');
+    expect(chatCall[1].content).toContain('Summarize this conversation');
+    expect(chatCall[1].content).toContain('[user]: Hello');
+    expect(chatCall[1].content).toContain('[assistant]: Hi there');
+  });
+
+  it('returns quiet on LLM error', async () => {
+    const entries = [makeEntry('user', 'Hello')];
+    const memory = makeMemoryBackend({ query: vi.fn().mockResolvedValue(entries) });
+    const llm = {
+      name: 'mock-llm',
+      chat: vi.fn().mockRejectedValue(new Error('LLM down')),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(),
+    } as LLMProvider;
+    const action = createSummaryAction({ memory, llm, sessionId: 'sess-1' });
+    const ctx = makeContext();
+    const result = await action.execute(ctx);
+
+    expect(result.quiet).toBe(true);
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+
+  it('returns quiet when LLM returns empty content', async () => {
+    const entries = [makeEntry('user', 'Hello')];
+    const memory = makeMemoryBackend({ query: vi.fn().mockResolvedValue(entries) });
+    const llm = makeLLMProvider('');
+    const action = createSummaryAction({ memory, llm, sessionId: 'sess-1' });
+    const result = await action.execute(makeContext());
+
+    expect(result.quiet).toBe(true);
+  });
+
+  it('passes correct query params with defaults', async () => {
+    const queryFn = vi.fn().mockResolvedValue([]);
+    const memory = makeMemoryBackend({ query: queryFn });
+    const action = createSummaryAction({ memory, llm: makeLLMProvider(), sessionId: 'sess-1' });
+
+    vi.setSystemTime(1700000000000);
+    await action.execute(makeContext());
+
+    expect(queryFn).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      after: 1700000000000 - 86_400_000,
+      limit: 50,
+      order: 'asc',
+    });
+  });
+
+  it('respects custom lookbackMs and maxEntries', async () => {
+    const queryFn = vi.fn().mockResolvedValue([]);
+    const memory = makeMemoryBackend({ query: queryFn });
+    const action = createSummaryAction({
+      memory,
+      llm: makeLLMProvider(),
+      sessionId: 'sess-1',
+      lookbackMs: 3_600_000,
+      maxEntries: 10,
+    });
+
+    vi.setSystemTime(1700000000000);
+    await action.execute(makeContext());
+
+    expect(queryFn).toHaveBeenCalledWith({
+      sessionId: 'sess-1',
+      after: 1700000000000 - 3_600_000,
+      limit: 10,
+      order: 'asc',
+    });
+  });
+
+  it('has name "summary" and enabled true', () => {
+    const action = createSummaryAction({
+      memory: makeMemoryBackend(),
+      llm: makeLLMProvider(),
+      sessionId: 'sess-1',
+    });
+    expect(action.name).toBe('summary');
+    expect(action.enabled).toBe(true);
+  });
+});
+
+// ============================================================================
+// Portfolio action
+// ============================================================================
+
+describe('createPortfolioAction', () => {
+  const wallet = new PublicKey('11111111111111111111111111111112');
+
+  it('returns quiet on first run (no previous balance)', async () => {
+    const memory = makeMemoryBackend();
+    const action = createPortfolioAction({
+      connection: makeConnection(5_000_000_000),
+      wallet,
+      memory,
+    });
+    const result = await action.execute(makeContext());
+
+    expect(result.quiet).toBe(true);
+    expect(memory.set).toHaveBeenCalled();
+  });
+
+  it('returns quiet when delta is below threshold', async () => {
+    const memory = makeMemoryBackend({
+      get: vi.fn().mockResolvedValue(5_000_000_000),
+    });
+    const action = createPortfolioAction({
+      connection: makeConnection(5_500_000_000),
+      wallet,
+      memory,
+    });
+    const result = await action.execute(makeContext());
+
+    expect(result.quiet).toBe(true);
+  });
+
+  it('alerts when delta exceeds threshold (positive)', async () => {
+    const memory = makeMemoryBackend({
+      get: vi.fn().mockResolvedValue(5_000_000_000),
+    });
+    const action = createPortfolioAction({
+      connection: makeConnection(7_000_000_000),
+      wallet,
+      memory,
+    });
+    const result = await action.execute(makeContext());
+
+    expect(result.hasOutput).toBe(true);
+    expect(result.quiet).toBe(false);
+    expect(result.output).toContain('+2.0000 SOL');
+    expect(result.output).toContain('7.0000 SOL');
+  });
+
+  it('alerts when delta exceeds threshold (negative)', async () => {
+    const memory = makeMemoryBackend({
+      get: vi.fn().mockResolvedValue(5_000_000_000),
+    });
+    const action = createPortfolioAction({
+      connection: makeConnection(3_000_000_000),
+      wallet,
+      memory,
+    });
+    const result = await action.execute(makeContext());
+
+    expect(result.hasOutput).toBe(true);
+    expect(result.output).toContain('-2.0000 SOL');
+    expect(result.output).toContain('3.0000 SOL');
+  });
+
+  it('respects custom alertThresholdLamports', async () => {
+    const memory = makeMemoryBackend({
+      get: vi.fn().mockResolvedValue(5_000_000_000),
+    });
+    const action = createPortfolioAction({
+      connection: makeConnection(5_100_000_000),
+      wallet,
+      memory,
+      alertThresholdLamports: 50_000_000, // 0.05 SOL
+    });
+    const result = await action.execute(makeContext());
+
+    expect(result.hasOutput).toBe(true);
+    expect(result.quiet).toBe(false);
+  });
+
+  it('returns quiet and logs on connection error', async () => {
+    const conn = {
+      getBalance: vi.fn().mockRejectedValue(new Error('RPC timeout')),
+    } as unknown as Connection;
+    const action = createPortfolioAction({ connection: conn, wallet, memory: makeMemoryBackend() });
+    const ctx = makeContext();
+    const result = await action.execute(ctx);
+
+    expect(result.quiet).toBe(true);
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+
+  it('has name "portfolio" and enabled true', () => {
+    const action = createPortfolioAction({
+      connection: makeConnection(),
+      wallet,
+      memory: makeMemoryBackend(),
+    });
+    expect(action.name).toBe('portfolio');
+    expect(action.enabled).toBe(true);
+  });
+
+  it('always stores current balance', async () => {
+    const memory = makeMemoryBackend({
+      get: vi.fn().mockResolvedValue(5_000_000_000),
+    });
+    const action = createPortfolioAction({
+      connection: makeConnection(5_100_000_000),
+      wallet,
+      memory,
+    });
+    await action.execute(makeContext());
+
+    expect(memory.set).toHaveBeenCalledWith(
+      `heartbeat:portfolio:${wallet.toBase58()}`,
+      5_100_000_000,
+    );
+  });
+});
+
+// ============================================================================
+// Polling action
+// ============================================================================
+
+describe('createPollingAction', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('calls checkFn with parsed JSON on success', async () => {
+    const data = { status: 'ok', value: 42 };
+    const response = new Response(JSON.stringify(data), { status: 200 });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(response);
+
+    const checkFn = vi.fn<(r: unknown) => HeartbeatResult>().mockReturnValue({
+      hasOutput: true,
+      output: 'Value is 42',
+      quiet: false,
+    });
+
+    const action = createPollingAction({ name: 'api-check', url: 'https://api.example.com/status', checkFn });
+    const result = await action.execute(makeContext());
+
+    expect(checkFn).toHaveBeenCalledWith(data);
+    expect(result.hasOutput).toBe(true);
+    expect(result.output).toBe('Value is 42');
+  });
+
+  it('returns quiet on HTTP error', async () => {
+    const response = new Response('Internal Server Error', { status: 500 });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(response);
+
+    const checkFn = vi.fn<(r: unknown) => HeartbeatResult>();
+    const action = createPollingAction({ name: 'api-check', url: 'https://api.example.com/status', checkFn });
+    const ctx = makeContext();
+    const result = await action.execute(ctx);
+
+    expect(result.quiet).toBe(true);
+    expect(checkFn).not.toHaveBeenCalled();
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+
+  it('returns quiet on fetch error', async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('network error'));
+
+    const checkFn = vi.fn<(r: unknown) => HeartbeatResult>();
+    const action = createPollingAction({ name: 'api-check', url: 'https://api.example.com/status', checkFn });
+    const ctx = makeContext();
+    const result = await action.execute(ctx);
+
+    expect(result.quiet).toBe(true);
+    expect(ctx.logger.error).toHaveBeenCalled();
+  });
+
+  it('passes custom headers to fetch', async () => {
+    const response = new Response('{}', { status: 200 });
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValue(response);
+
+    const checkFn = vi.fn().mockReturnValue({ hasOutput: false, quiet: true });
+    const headers = { Authorization: 'Bearer token123' };
+    const action = createPollingAction({ name: 'auth-check', url: 'https://api.example.com', checkFn, headers });
+    await action.execute(makeContext());
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('https://api.example.com', { headers });
+  });
+
+  it('uses config name as action name', () => {
+    const action = createPollingAction({
+      name: 'custom-poll',
+      url: 'https://example.com',
+      checkFn: () => ({ hasOutput: false, quiet: true }),
+    });
+    expect(action.name).toBe('custom-poll');
+    expect(action.enabled).toBe(true);
+  });
+});
+
+// ============================================================================
+// Default actions factory
+// ============================================================================
+
+describe('createDefaultHeartbeatActions', () => {
+  it('returns 3 actions', () => {
+    const actions = createDefaultHeartbeatActions({
+      scanner: makeScanner(),
+      memory: makeMemoryBackend(),
+      llm: makeLLMProvider(),
+      connection: makeConnection(),
+      wallet: new PublicKey('11111111111111111111111111111112'),
+      sessionId: 'sess-1',
+    });
+
+    expect(actions).toHaveLength(3);
+  });
+
+  it('returns actions with correct names', () => {
+    const actions = createDefaultHeartbeatActions({
+      scanner: makeScanner(),
+      memory: makeMemoryBackend(),
+      llm: makeLLMProvider(),
+      connection: makeConnection(),
+      wallet: new PublicKey('11111111111111111111111111111112'),
+      sessionId: 'sess-1',
+    });
+
+    expect(actions.map((a) => a.name)).toEqual(['task-scan', 'summary', 'portfolio']);
+  });
+
+  it('all actions are enabled', () => {
+    const actions = createDefaultHeartbeatActions({
+      scanner: makeScanner(),
+      memory: makeMemoryBackend(),
+      llm: makeLLMProvider(),
+      connection: makeConnection(),
+      wallet: new PublicKey('11111111111111111111111111111112'),
+      sessionId: 'sess-1',
+    });
+
+    expect(actions.every((a) => a.enabled)).toBe(true);
+  });
+});

--- a/runtime/src/gateway/heartbeat-actions.ts
+++ b/runtime/src/gateway/heartbeat-actions.ts
@@ -1,0 +1,231 @@
+/**
+ * Built-in heartbeat actions for @agenc/runtime.
+ *
+ * Each factory creates a {@link HeartbeatAction} that follows the "quiet
+ * heartbeat" contract — nothing is reported unless something noteworthy
+ * happens.
+ *
+ * Actions:
+ * - **task-scan** — scans for claimable on-chain tasks
+ * - **summary** — generates a conversation summary via LLM
+ * - **portfolio** — monitors SOL balance changes
+ * - **polling** — generic external endpoint polling
+ *
+ * @module
+ */
+
+import type { Connection, PublicKey } from '@solana/web3.js';
+import type { HeartbeatAction, HeartbeatContext, HeartbeatResult } from './heartbeat.js';
+import type { TaskScanner } from '../autonomous/scanner.js';
+import type { MemoryBackend } from '../memory/types.js';
+import { entryToMessage } from '../memory/types.js';
+import type { LLMProvider } from '../llm/types.js';
+
+// ============================================================================
+// Quiet result helpers
+// ============================================================================
+
+const QUIET: HeartbeatResult = Object.freeze({ hasOutput: false, quiet: true });
+
+function output(text: string): HeartbeatResult {
+  return { hasOutput: true, output: text, quiet: false };
+}
+
+// ============================================================================
+// Task scan action
+// ============================================================================
+
+export interface TaskScanActionConfig {
+  scanner: TaskScanner;
+}
+
+export function createTaskScanAction(config: TaskScanActionConfig): HeartbeatAction {
+  const { scanner } = config;
+
+  return {
+    name: 'task-scan',
+    enabled: true,
+    async execute(context: HeartbeatContext): Promise<HeartbeatResult> {
+      try {
+        const tasks = await scanner.scan();
+        if (tasks.length === 0) return QUIET;
+
+        const lines = tasks.map((t) => {
+          const pda = t.pda.toBase58().slice(0, 8);
+          const reward =
+            t.rewardMint === null
+              ? `${(Number(t.reward) / 1e9).toFixed(4)} SOL`
+              : `${t.reward.toString()} lamports (mint: ${t.rewardMint.toBase58()})`;
+          return `- Task ${pda}: ${reward}`;
+        });
+
+        return output(`Found ${tasks.length} claimable task(s):\n${lines.join('\n')}`);
+      } catch (err) {
+        context.logger.error('task-scan heartbeat failed:', err);
+        return QUIET;
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Summary action
+// ============================================================================
+
+export interface SummaryActionConfig {
+  memory: MemoryBackend;
+  llm: LLMProvider;
+  sessionId: string;
+  /** Lookback window in ms (default: 86_400_000 = 24 h). */
+  lookbackMs?: number;
+  /** Max entries to feed the summarizer (default: 50). */
+  maxEntries?: number;
+}
+
+const DEFAULT_LOOKBACK_MS = 86_400_000;
+const DEFAULT_MAX_ENTRIES = 50;
+
+const SUMMARY_SYSTEM_PROMPT =
+  'You are a concise summarizer. Summarize the following conversation in 2-3 sentences, highlighting key decisions, completed actions, and outstanding items.';
+
+export function createSummaryAction(config: SummaryActionConfig): HeartbeatAction {
+  const { memory, llm, sessionId } = config;
+  const lookbackMs = config.lookbackMs ?? DEFAULT_LOOKBACK_MS;
+  const maxEntries = config.maxEntries ?? DEFAULT_MAX_ENTRIES;
+
+  return {
+    name: 'summary',
+    enabled: true,
+    async execute(context: HeartbeatContext): Promise<HeartbeatResult> {
+      try {
+        const entries = await memory.query({
+          sessionId,
+          after: Date.now() - lookbackMs,
+          limit: maxEntries,
+          order: 'asc',
+        });
+
+        if (entries.length === 0) return QUIET;
+
+        const messages = entries.map(entryToMessage);
+        const formatted = messages
+          .map((m) => `[${m.role}]: ${m.content}`)
+          .join('\n');
+
+        const response = await llm.chat([
+          { role: 'system', content: SUMMARY_SYSTEM_PROMPT },
+          { role: 'user', content: `Summarize this conversation:\n\n${formatted}` },
+        ]);
+
+        if (!response.content) return QUIET;
+
+        return output(response.content);
+      } catch (err) {
+        context.logger.error('summary heartbeat failed:', err);
+        return QUIET;
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Portfolio action
+// ============================================================================
+
+export interface PortfolioActionConfig {
+  connection: Connection;
+  wallet: PublicKey;
+  memory: MemoryBackend;
+  /** Minimum lamport delta to trigger an alert (default: 1_000_000_000 = 1 SOL). */
+  alertThresholdLamports?: number;
+}
+
+const DEFAULT_ALERT_THRESHOLD = 1_000_000_000; // 1 SOL
+
+export function createPortfolioAction(config: PortfolioActionConfig): HeartbeatAction {
+  const { connection, wallet, memory } = config;
+  const threshold = config.alertThresholdLamports ?? DEFAULT_ALERT_THRESHOLD;
+  const storageKey = `heartbeat:portfolio:${wallet.toBase58()}`;
+
+  return {
+    name: 'portfolio',
+    enabled: true,
+    async execute(context: HeartbeatContext): Promise<HeartbeatResult> {
+      try {
+        const balance = await connection.getBalance(wallet);
+        const prev = await memory.get<number>(storageKey);
+
+        await memory.set(storageKey, balance);
+
+        if (prev === undefined) return QUIET;
+
+        const delta = balance - prev;
+        if (Math.abs(delta) < threshold) return QUIET;
+
+        const sign = delta >= 0 ? '+' : '';
+        const deltaSOL = (delta / 1e9).toFixed(4);
+        const currentSOL = (balance / 1e9).toFixed(4);
+
+        return output(`Portfolio alert: balance changed by ${sign}${deltaSOL} SOL (now ${currentSOL} SOL)`);
+      } catch (err) {
+        context.logger.error('portfolio heartbeat failed:', err);
+        return QUIET;
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Polling action
+// ============================================================================
+
+export interface PollingActionConfig {
+  name: string;
+  url: string;
+  checkFn: (response: unknown) => HeartbeatResult;
+  headers?: Record<string, string>;
+}
+
+export function createPollingAction(config: PollingActionConfig): HeartbeatAction {
+  const { name, url, checkFn, headers } = config;
+
+  return {
+    name,
+    enabled: true,
+    async execute(context: HeartbeatContext): Promise<HeartbeatResult> {
+      try {
+        const res = await fetch(url, { headers });
+        if (!res.ok) {
+          context.logger.error(`polling action "${name}" HTTP ${res.status}`);
+          return QUIET;
+        }
+        const data: unknown = await res.json();
+        return checkFn(data);
+      } catch (err) {
+        context.logger.error(`polling action "${name}" failed:`, err);
+        return QUIET;
+      }
+    },
+  };
+}
+
+// ============================================================================
+// Default actions factory
+// ============================================================================
+
+export interface DefaultHeartbeatActionsConfig {
+  scanner: TaskScanner;
+  memory: MemoryBackend;
+  llm: LLMProvider;
+  connection: Connection;
+  wallet: PublicKey;
+  sessionId: string;
+}
+
+export function createDefaultHeartbeatActions(config: DefaultHeartbeatActionsConfig): HeartbeatAction[] {
+  return [
+    createTaskScanAction({ scanner: config.scanner }),
+    createSummaryAction({ memory: config.memory, llm: config.llm, sessionId: config.sessionId }),
+    createPortfolioAction({ connection: config.connection, wallet: config.wallet, memory: config.memory }),
+  ];
+}

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -251,6 +251,20 @@ export {
   defaultHeartbeatConfig,
 } from './heartbeat.js';
 
+// Heartbeat actions (Phase 2.2)
+export {
+  createTaskScanAction,
+  createSummaryAction,
+  createPortfolioAction,
+  createPollingAction,
+  createDefaultHeartbeatActions,
+  type TaskScanActionConfig,
+  type SummaryActionConfig,
+  type PortfolioActionConfig,
+  type PollingActionConfig,
+  type DefaultHeartbeatActionsConfig,
+} from './heartbeat-actions.js';
+
 // Execution sandboxing (Phase 4.5)
 export type {
   SandboxConfig,


### PR DESCRIPTION
## Summary

- Implements four heartbeat action factories for the gateway heartbeat scheduler: task scanning (`createTaskScanAction`), conversation summaries (`createSummaryAction`), portfolio monitoring (`createPortfolioAction`), and generic external polling (`createPollingAction`)
- Adds `createDefaultHeartbeatActions` convenience factory returning the three built-in actions
- All actions follow the quiet heartbeat contract — only report when something noteworthy happens, errors are caught and logged silently

## Test plan

- [x] 29 new vitest tests covering all four actions plus the default factory
- [x] Task scan: no tasks → quiet, tasks found → formatted SOL/SPL output, scanner error → quiet
- [x] Summary: no entries → quiet, LLM called with correct prompts, LLM error → quiet, empty response → quiet
- [x] Portfolio: first run → quiet, delta below/above threshold, custom threshold, connection error → quiet
- [x] Polling: successful fetch → checkFn called, HTTP error → quiet, fetch error → quiet, custom headers
- [x] Default factory: returns 3 actions with correct names, all enabled
- [x] Build succeeds, full runtime test suite passes (3878 tests)

Closes #1084