### PR TITLE
feat(runtime): additional channel plugins (Slack, WhatsApp, Signal, Matrix)

### DIFF
--- a/runtime/package.json
+++ b/runtime/package.json
@@ -19,7 +19,7 @@
   "files": ["dist", "idl", "README.md"],
   "scripts": {
     "prebuild": "npm run build --prefix ../sdk && node scripts/copy-idl.js",
-    "build": "tsup src/index.ts src/bin/agenc-runtime.ts src/bin/daemon.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token --external ws --external grammy --external discord.js --external cheerio --external playwright",
+    "build": "tsup src/index.ts src/bin/agenc-runtime.ts src/bin/daemon.ts --format cjs,esm --dts --clean --external openai --external @anthropic-ai/sdk --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token --external ws --external grammy --external discord.js --external @slack/bolt --external @whiskeysockets/baileys --external matrix-js-sdk --external cheerio --external playwright",
     "typecheck": "tsc --noEmit",
     "check-idl-drift": "tsx scripts/check-idl-drift.ts",
     "pretest": "npm run build --prefix ../sdk",
@@ -49,6 +49,9 @@
     "ws": "^8.0.0",
     "grammy": "^1.0.0",
     "discord.js": "^14.7.0",
+    "@slack/bolt": "^4.0.0",
+    "@whiskeysockets/baileys": "^6.0.0",
+    "matrix-js-sdk": "^34.0.0",
     "cheerio": "^1.0.0",
     "playwright": "^1.40.0"
   },

--- a/runtime/src/channels/index.ts
+++ b/runtime/src/channels/index.ts
@@ -6,3 +6,8 @@ export {
 } from './telegram/index.js';
 
 export { DiscordChannel, type DiscordChannelConfig, type DiscordIntentName } from './discord/index.js';
+
+export { SlackChannel, type SlackChannelConfig } from './slack/index.js';
+export { WhatsAppChannel, type WhatsAppChannelConfig } from './whatsapp/index.js';
+export { SignalChannel, type SignalChannelConfig } from './signal/index.js';
+export { MatrixChannel, type MatrixChannelConfig } from './matrix/index.js';

--- a/runtime/src/channels/matrix/index.ts
+++ b/runtime/src/channels/matrix/index.ts
@@ -1,0 +1,2 @@
+export { MatrixChannel } from './plugin.js';
+export type { MatrixChannelConfig } from './types.js';

--- a/runtime/src/channels/matrix/plugin.test.ts
+++ b/runtime/src/channels/matrix/plugin.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChannelContext } from '../../gateway/channel.js';
+
+// ============================================================================
+// Mock matrix-js-sdk
+// ============================================================================
+
+const mockStartClient = vi.fn();
+const mockStopClient = vi.fn();
+const mockSendTextMessage = vi.fn();
+const mockJoinRoom = vi.fn();
+const mockOn = vi.fn();
+const mockGetSyncState = vi.fn();
+
+vi.mock('matrix-js-sdk', () => {
+  return {
+    createClient: (_opts: unknown) => ({
+      on: mockOn,
+      startClient: mockStartClient,
+      stopClient: mockStopClient,
+      sendTextMessage: mockSendTextMessage,
+      joinRoom: mockJoinRoom,
+      getUserId: () => '@bot:matrix.org',
+      getSyncState: mockGetSyncState,
+    }),
+  };
+});
+
+// Import after mock setup
+import { MatrixChannel } from './plugin.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeContext(overrides: Partial<ChannelContext> = {}): ChannelContext {
+  return {
+    onMessage: vi.fn().mockResolvedValue(undefined),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    config: {},
+    ...overrides,
+  };
+}
+
+function getHandler(event: string): ((...args: any[]) => void) | undefined {
+  for (const call of mockOn.mock.calls) {
+    if (call[0] === event) return call[1] as (...args: any[]) => void;
+  }
+  return undefined;
+}
+
+function makeMatrixEvent(overrides: Record<string, any> = {}): any {
+  const content = {
+    msgtype: 'm.text',
+    body: 'hello',
+    ...overrides.content,
+  };
+  return {
+    getType: () => overrides.type ?? 'm.room.message',
+    getSender: () => overrides.sender ?? '@alice:matrix.org',
+    getContent: () => content,
+    event: { origin_server_ts: Date.now() },
+    ...overrides,
+  };
+}
+
+function makeRoom(overrides: Record<string, any> = {}): any {
+  return {
+    roomId: '!room1:matrix.org',
+    getJoinedMemberCount: () => 5,
+    ...overrides,
+  };
+}
+
+async function startedPlugin(config: Record<string, any> = {}, ctx?: ChannelContext) {
+  const plugin = new MatrixChannel({
+    homeserverUrl: 'https://matrix.org',
+    accessToken: 'test-token',
+    userId: '@bot:matrix.org',
+    ...config,
+  } as any);
+  await plugin.initialize(ctx ?? makeContext());
+  await plugin.start();
+  return plugin;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('MatrixChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStartClient.mockResolvedValue(undefined);
+    mockSendTextMessage.mockResolvedValue({});
+    mockJoinRoom.mockResolvedValue({});
+    mockGetSyncState.mockReturnValue('SYNCING');
+  });
+
+  // 1. Constructor and name
+  it('stores config and has name "matrix"', () => {
+    const plugin = new MatrixChannel({
+      homeserverUrl: 'https://matrix.org',
+      accessToken: 'test-token',
+      userId: '@bot:matrix.org',
+    });
+    expect(plugin.name).toBe('matrix');
+  });
+
+  // 2. start() calls client.startClient()
+  it('start() creates client and starts sync', async () => {
+    await startedPlugin();
+    expect(mockStartClient).toHaveBeenCalledWith({ initialSyncLimit: 0 });
+  });
+
+  // 3. Sync state → healthy
+  it('sets healthy when sync state is PREPARED', async () => {
+    const plugin = await startedPlugin();
+    expect(plugin.isHealthy()).toBe(false);
+
+    const syncHandler = getHandler('sync');
+    syncHandler!('PREPARED');
+    expect(plugin.isHealthy()).toBe(true);
+  });
+
+  // 4. Sync state SYNCING → healthy
+  it('sets healthy when sync state is SYNCING', async () => {
+    const plugin = await startedPlugin();
+    const syncHandler = getHandler('sync');
+    syncHandler!('SYNCING');
+    expect(plugin.isHealthy()).toBe(true);
+  });
+
+  // 5. Sync state ERROR → unhealthy
+  it('sets unhealthy when sync state is ERROR', async () => {
+    const plugin = await startedPlugin();
+    const syncHandler = getHandler('sync');
+    syncHandler!('SYNCING');
+    expect(plugin.isHealthy()).toBe(true);
+
+    syncHandler!('ERROR');
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 6. stop() stops client
+  it('stop() stops client and sets healthy to false', async () => {
+    const plugin = await startedPlugin();
+    const syncHandler = getHandler('sync');
+    syncHandler!('SYNCING');
+
+    await plugin.stop();
+
+    expect(mockStopClient).toHaveBeenCalledOnce();
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 7. Room message → correct session ID (group)
+  it('room message produces correct session ID', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent(), makeRoom());
+
+    expect(ctx.onMessage).toHaveBeenCalledOnce();
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.sessionId).toBe('matrix:!room1:matrix.org:@alice:matrix.org');
+    expect(gateway.scope).toBe('group');
+  });
+
+  // 8. DM detection via member count
+  it('detects DM rooms via member count <= 2', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent(), makeRoom({ getJoinedMemberCount: () => 2 }));
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.sessionId).toBe('matrix:dm:@alice:matrix.org');
+    expect(gateway.scope).toBe('dm');
+  });
+
+  // 9. Skips own messages
+  it('skips messages from the bot itself', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent({ sender: '@bot:matrix.org' }), makeRoom());
+
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 10. Skips non-message events
+  it('skips non-message events', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent({ type: 'm.room.member' }), makeRoom());
+
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 11. Room ID filtering
+  it('rejects messages from non-allowed rooms', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ roomIds: ['!other:matrix.org'] }, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent(), makeRoom());
+
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 12. Room ID filtering allows matching room
+  it('allows messages from allowed rooms', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ roomIds: ['!room1:matrix.org'] }, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent(), makeRoom());
+
+    expect(ctx.onMessage).toHaveBeenCalledOnce();
+  });
+
+  // 13. send() calls sendTextMessage
+  it('send() sends text to the correct room', async () => {
+    const plugin = await startedPlugin();
+
+    await plugin.send({
+      sessionId: 'matrix:!room1:matrix.org:@alice:matrix.org',
+      content: 'Hello back!',
+    });
+
+    expect(mockSendTextMessage).toHaveBeenCalledWith('!room1:matrix.org', 'Hello back!');
+  });
+
+  // 14. send() warns when client is null
+  it('send() warns when client is not connected', async () => {
+    const ctx = makeContext();
+    const plugin = new MatrixChannel({
+      homeserverUrl: 'https://matrix.org',
+      accessToken: 'test-token',
+      userId: '@bot:matrix.org',
+    });
+    await plugin.initialize(ctx);
+
+    await plugin.send({ sessionId: 'matrix:!room1:matrix.org:@alice:matrix.org', content: 'hi' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Matrix client is not connected'),
+    );
+  });
+
+  // 15. send() warns on unresolvable session
+  it('send() warns when room cannot be resolved from session', async () => {
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+
+    await plugin.send({ sessionId: 'matrix:dm:@alice:matrix.org', content: 'hi' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot resolve room'),
+    );
+  });
+
+  // 16. Auto-join on invite
+  it('auto-joins room on invite when autoJoin is enabled', async () => {
+    await startedPlugin({ autoJoin: true });
+
+    const handler = getHandler('RoomMember.membership');
+    expect(handler).toBeDefined();
+
+    await handler!(
+      {},
+      { userId: '@bot:matrix.org', membership: 'invite', roomId: '!new:matrix.org' },
+    );
+
+    expect(mockJoinRoom).toHaveBeenCalledWith('!new:matrix.org');
+  });
+
+  // 17. Auto-join ignores non-invite memberships
+  it('ignores non-invite membership events', async () => {
+    await startedPlugin({ autoJoin: true });
+
+    const handler = getHandler('RoomMember.membership');
+    await handler!(
+      {},
+      { userId: '@bot:matrix.org', membership: 'join', roomId: '!room:matrix.org' },
+    );
+
+    expect(mockJoinRoom).not.toHaveBeenCalled();
+  });
+
+  // 18. Auto-join ignores other users
+  it('ignores membership events for other users', async () => {
+    await startedPlugin({ autoJoin: true });
+
+    const handler = getHandler('RoomMember.membership');
+    await handler!(
+      {},
+      { userId: '@other:matrix.org', membership: 'invite', roomId: '!room:matrix.org' },
+    );
+
+    expect(mockJoinRoom).not.toHaveBeenCalled();
+  });
+
+  // 19. No membership handler when autoJoin disabled
+  it('does not register membership handler when autoJoin is disabled', async () => {
+    await startedPlugin({ autoJoin: false });
+
+    const handler = getHandler('RoomMember.membership');
+    expect(handler).toBeUndefined();
+  });
+
+  // 20. E2EE warning logged
+  it('logs E2EE warning when enableE2ee is set', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ enableE2ee: true }, ctx);
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('E2EE flag is set but actual crypto support requires @matrix-org/olm'),
+    );
+  });
+
+  // 21. Image attachment normalized
+  it('normalizes image attachments from m.image events', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(
+      makeMatrixEvent({
+        content: {
+          msgtype: 'm.image',
+          body: 'photo.jpg',
+          url: 'mxc://matrix.org/abc123',
+          info: { mimetype: 'image/jpeg', size: 2048 },
+        },
+      }),
+      makeRoom(),
+    );
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.attachments).toHaveLength(1);
+    expect(gateway.attachments[0].type).toBe('image');
+    expect(gateway.attachments[0].mimeType).toBe('image/jpeg');
+    expect(gateway.attachments[0].url).toBe('mxc://matrix.org/abc123');
+  });
+
+  // 22. start() failure cleans up
+  it('cleans up if startClient() fails', async () => {
+    mockStartClient.mockRejectedValueOnce(new Error('connection failed'));
+
+    const plugin = new MatrixChannel({
+      homeserverUrl: 'https://matrix.org',
+      accessToken: 'bad-token',
+      userId: '@bot:matrix.org',
+    });
+    await plugin.initialize(makeContext());
+
+    await expect(plugin.start()).rejects.toThrow('connection failed');
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 23. send() logs error on failure
+  it('send() catches sendTextMessage failure and logs error', async () => {
+    mockSendTextMessage.mockRejectedValueOnce(new Error('M_FORBIDDEN'));
+
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+
+    await plugin.send({
+      sessionId: 'matrix:!room1:matrix.org:@alice:matrix.org',
+      content: 'hello',
+    });
+
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('M_FORBIDDEN'),
+    );
+  });
+
+  // 24. Metadata includes Matrix-specific fields
+  it('includes Matrix-specific metadata in gateway message', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent(), makeRoom());
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.metadata.roomId).toBe('!room1:matrix.org');
+    expect(gateway.metadata.msgtype).toBe('m.text');
+  });
+
+  // 25. isHealthy() false before start
+  it('isHealthy() returns false before start', () => {
+    const plugin = new MatrixChannel({
+      homeserverUrl: 'https://matrix.org',
+      accessToken: 'test-token',
+      userId: '@bot:matrix.org',
+    });
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 26. Handler errors are caught and logged
+  it('logs errors from timeline handler instead of crashing', async () => {
+    const ctx = makeContext();
+    (ctx.onMessage as any).mockRejectedValueOnce(new Error('downstream failure'));
+    await startedPlugin({}, ctx);
+
+    const handler = getHandler('Room.timeline');
+    await handler!(makeMatrixEvent(), makeRoom());
+
+    await vi.waitFor(() => {
+      expect(ctx.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error handling Matrix timeline event: downstream failure'),
+      );
+    });
+  });
+});

--- a/runtime/src/channels/matrix/plugin.ts
+++ b/runtime/src/channels/matrix/plugin.ts
@@ -1,0 +1,320 @@
+/**
+ * Matrix channel plugin — bridges the Matrix protocol to the Gateway.
+ *
+ * Uses matrix-js-sdk v34+ as a lazy-loaded optional dependency. Connects
+ * to a homeserver via access token, listens for room timeline events,
+ * and optionally auto-joins rooms on invite.
+ *
+ * @module
+ */
+
+import { BaseChannelPlugin } from '../../gateway/channel.js';
+import type { OutboundMessage, MessageAttachment } from '../../gateway/message.js';
+import { createGatewayMessage } from '../../gateway/message.js';
+import type { MessageScope } from '../../gateway/message.js';
+import { GatewayConnectionError } from '../../gateway/errors.js';
+import { DEFAULT_MAX_ATTACHMENT_BYTES } from '../../gateway/media.js';
+import { ensureLazyModule } from '../../utils/lazy-import.js';
+import type { MatrixChannelConfig } from './types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SESSION_PREFIX = 'matrix';
+
+// ============================================================================
+// matrix-js-sdk type shims (loaded lazily)
+// ============================================================================
+
+interface MatrixClient {
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  startClient(opts?: { initialSyncLimit?: number }): Promise<void>;
+  stopClient(): void;
+  sendTextMessage(roomId: string, body: string): Promise<unknown>;
+  joinRoom(roomId: string): Promise<unknown>;
+  getUserId(): string | null;
+  getSyncState(): string | null;
+}
+
+interface MatrixEvent {
+  getType(): string;
+  getSender(): string;
+  getContent(): MatrixMessageContent;
+  event: { origin_server_ts?: number };
+}
+
+interface MatrixRoom {
+  roomId: string;
+  getJoinedMemberCount(): number;
+}
+
+interface MatrixMember {
+  userId: string;
+  membership: string;
+  roomId: string;
+}
+
+interface MatrixMessageContent {
+  msgtype?: string;
+  body?: string;
+  url?: string;
+  info?: {
+    mimetype?: string;
+    size?: number;
+  };
+  filename?: string;
+}
+
+interface MatrixSdkModule {
+  createClient(opts: {
+    baseUrl: string;
+    accessToken: string;
+    userId: string;
+  }): MatrixClient;
+}
+
+// ============================================================================
+// MatrixChannel Plugin
+// ============================================================================
+
+export class MatrixChannel extends BaseChannelPlugin {
+  readonly name = SESSION_PREFIX;
+
+  private client: MatrixClient | null = null;
+  private healthy = false;
+  private readonly config: MatrixChannelConfig;
+
+  constructor(config: MatrixChannelConfig) {
+    super();
+    this.config = config;
+  }
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    const mod = await ensureLazyModule<MatrixSdkModule>(
+      'matrix-js-sdk',
+      (msg) => new GatewayConnectionError(msg),
+      (m) => m as unknown as MatrixSdkModule,
+    );
+
+    const client = mod.createClient({
+      baseUrl: this.config.homeserverUrl,
+      accessToken: this.config.accessToken,
+      userId: this.config.userId,
+    });
+    this.client = client;
+
+    if (this.config.enableE2ee) {
+      this.context.logger.warn(
+        'Matrix E2EE flag is set but actual crypto support requires @matrix-org/olm — ' +
+        'messages will be sent unencrypted. E2EE support is reserved for a future release.',
+      );
+    }
+
+    try {
+      this.wireEventHandlers(client);
+      await client.startClient({ initialSyncLimit: 0 });
+    } catch (err) {
+      this.client = null;
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.client) {
+      this.client.stopClient();
+      this.client = null;
+    }
+    this.healthy = false;
+  }
+
+  override isHealthy(): boolean {
+    return this.healthy;
+  }
+
+  // --------------------------------------------------------------------------
+  // Outbound
+  // --------------------------------------------------------------------------
+
+  async send(message: OutboundMessage): Promise<void> {
+    if (!this.client) {
+      this.context.logger.warn('Cannot send message: Matrix client is not connected');
+      return;
+    }
+
+    const roomId = this.extractRoomId(message.sessionId);
+    if (!roomId) {
+      this.context.logger.warn(`Cannot resolve room for session: ${message.sessionId}`);
+      return;
+    }
+
+    try {
+      await this.client.sendTextMessage(roomId, message.content);
+    } catch (err) {
+      this.context.logger.error(`Failed to send message to ${message.sessionId}: ${errorMessage(err)}`);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Event wiring
+  // --------------------------------------------------------------------------
+
+  private wireEventHandlers(client: MatrixClient): void {
+    client.on('sync', (state: unknown) => {
+      const syncState = state as string;
+      if (syncState === 'PREPARED' || syncState === 'SYNCING') {
+        this.healthy = true;
+        this.context.logger.info(`Matrix sync state: ${syncState}`);
+      } else if (syncState === 'ERROR' || syncState === 'STOPPED') {
+        this.healthy = false;
+        this.context.logger.warn(`Matrix sync state: ${syncState}`);
+      }
+    });
+
+    client.on('Room.timeline', (event: unknown, room: unknown) => {
+      this.handleTimelineEvent(event as MatrixEvent, room as MatrixRoom).catch((err) => {
+        this.context.logger.error(`Error handling Matrix timeline event: ${errorMessage(err)}`);
+      });
+    });
+
+    if (this.config.autoJoin) {
+      client.on('RoomMember.membership', (_event: unknown, member: unknown) => {
+        this.handleMembership(member as MatrixMember).catch((err) => {
+          this.context.logger.error(`Error handling Matrix membership event: ${errorMessage(err)}`);
+        });
+      });
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Inbound: timeline events
+  // --------------------------------------------------------------------------
+
+  private async handleTimelineEvent(event: MatrixEvent, room: MatrixRoom): Promise<void> {
+    if (event.getType() !== 'm.room.message') return;
+
+    const senderId = event.getSender();
+    if (senderId === this.config.userId) return;
+
+    const roomId = room.roomId;
+    if (this.config.roomIds && this.config.roomIds.length > 0) {
+      if (!this.config.roomIds.includes(roomId)) return;
+    }
+
+    const content = event.getContent();
+    const isDM = room.getJoinedMemberCount() <= 2;
+    const scope: MessageScope = isDM ? 'dm' : 'group';
+    const sessionId = buildSessionId(isDM, senderId, roomId);
+
+    const text = content.body ?? '';
+    const attachments = this.normalizeAttachment(content);
+
+    const gateway = createGatewayMessage({
+      channel: this.name,
+      senderId,
+      senderName: senderId,
+      sessionId,
+      content: text,
+      attachments: attachments.length > 0 ? attachments : undefined,
+      metadata: {
+        roomId,
+        msgtype: content.msgtype,
+      },
+      scope,
+    });
+
+    await this.context.onMessage(gateway);
+  }
+
+  // --------------------------------------------------------------------------
+  // Inbound: membership (auto-join)
+  // --------------------------------------------------------------------------
+
+  private async handleMembership(member: MatrixMember): Promise<void> {
+    if (member.userId !== this.config.userId) return;
+    if (member.membership !== 'invite') return;
+
+    try {
+      await this.client!.joinRoom(member.roomId);
+      this.context.logger.info(`Auto-joined Matrix room: ${member.roomId}`);
+    } catch (err) {
+      this.context.logger.error(`Failed to auto-join room ${member.roomId}: ${errorMessage(err)}`);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  private extractRoomId(sessionId: string): string | null {
+    // Session ID format: matrix:dm:<userId> or matrix:<roomId>:<userId>
+    const parts = sessionId.split(':');
+    if (parts.length < 3) return null;
+
+    if (parts[1] === 'dm') {
+      // For DMs we don't store roomId in session — not resolvable without lookup
+      // This is a limitation; callers should use the room-based session format
+      return null;
+    }
+
+    // Reconstruct the roomId (may contain colons, e.g. !abc:matrix.org)
+    // Format: matrix:<roomId>:<userId> where roomId itself has colons
+    // We need to find the userId part at the end — it starts with @
+    const rest = parts.slice(1).join(':');
+    const lastAt = rest.lastIndexOf('@');
+    if (lastAt <= 0) return null;
+
+    // roomId is everything before the last @, minus the trailing :
+    const roomId = rest.slice(0, lastAt - 1);
+    return roomId || null;
+  }
+
+  private normalizeAttachment(content: MatrixMessageContent): MessageAttachment[] {
+    const msgtype = content.msgtype;
+    if (!msgtype || msgtype === 'm.text' || msgtype === 'm.notice') return [];
+    if (!content.url) return [];
+
+    const maxBytes = this.config.maxAttachmentBytes ?? DEFAULT_MAX_ATTACHMENT_BYTES;
+    const size = content.info?.size;
+    if (size !== undefined && size > maxBytes) return [];
+
+    const mimeType = content.info?.mimetype ?? 'application/octet-stream';
+    let type = 'file';
+    if (msgtype === 'm.image') type = 'image';
+    else if (msgtype === 'm.audio') type = 'audio';
+    else if (msgtype === 'm.video') type = 'video';
+
+    return [{
+      type,
+      url: content.url,
+      mimeType,
+      filename: content.filename ?? content.body,
+      sizeBytes: size,
+    }];
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a session ID from Matrix context.
+ * DM: `matrix:dm:<userId>`, Room: `matrix:<roomId>:<userId>`
+ */
+function buildSessionId(isDM: boolean, userId: string, roomId: string): string {
+  if (isDM) {
+    return `${SESSION_PREFIX}:dm:${userId}`;
+  }
+  return `${SESSION_PREFIX}:${roomId}:${userId}`;
+}
+
+/** Extract a safe error message string. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/runtime/src/channels/matrix/types.ts
+++ b/runtime/src/channels/matrix/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Configuration interface for the Matrix channel plugin.
+ *
+ * @module
+ */
+
+export interface MatrixChannelConfig {
+  /** Matrix homeserver URL (e.g. 'https://matrix.org'). */
+  readonly homeserverUrl: string;
+  /** Access token for the bot account. */
+  readonly accessToken: string;
+  /** Matrix user ID of the bot (e.g. '@bot:matrix.org'). */
+  readonly userId: string;
+  /** Restrict to specific room IDs. Empty = all rooms. */
+  readonly roomIds?: readonly string[];
+  /** Whether to auto-join rooms on invite. @default false */
+  readonly autoJoin?: boolean;
+  /** Whether to enable E2EE support. @default false (flag reserved for future use). */
+  readonly enableE2ee?: boolean;
+  /** Maximum attachment size in bytes. @default 25 * 1024 * 1024 (25 MB) */
+  readonly maxAttachmentBytes?: number;
+}

--- a/runtime/src/channels/signal/index.ts
+++ b/runtime/src/channels/signal/index.ts
@@ -1,0 +1,2 @@
+export { SignalChannel } from './plugin.js';
+export type { SignalChannelConfig } from './types.js';

--- a/runtime/src/channels/signal/plugin.test.ts
+++ b/runtime/src/channels/signal/plugin.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChannelContext } from '../../gateway/channel.js';
+import { EventEmitter } from 'node:events';
+import type { Writable, Readable } from 'node:stream';
+
+// ============================================================================
+// Mock node:child_process and node:fs/promises
+// ============================================================================
+
+const mockStdinWrite = vi.fn();
+const mockKill = vi.fn();
+
+class MockChildProcess extends EventEmitter {
+  stdin = { writable: true, write: mockStdinWrite } as unknown as Writable;
+  stdout = new EventEmitter() as unknown as Readable;
+  stderr = new EventEmitter() as unknown as Readable;
+  kill = mockKill;
+}
+
+let mockChild: MockChildProcess;
+
+vi.mock('node:child_process', () => ({
+  spawn: (_cmd: string, _args: string[], _opts: unknown) => {
+    mockChild = new MockChildProcess();
+    return mockChild;
+  },
+}));
+
+const mockAccess = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  access: (...args: any[]) => mockAccess(...args),
+  constants: { X_OK: 1 },
+}));
+
+// Import after mock setup
+import { SignalChannel } from './plugin.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeContext(overrides: Partial<ChannelContext> = {}): ChannelContext {
+  return {
+    onMessage: vi.fn().mockResolvedValue(undefined),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    config: {},
+    ...overrides,
+  };
+}
+
+async function startedPlugin(config: Record<string, any> = {}, ctx?: ChannelContext) {
+  const plugin = new SignalChannel({
+    phoneNumber: '+15551234567',
+    ...config,
+  } as any);
+  await plugin.initialize(ctx ?? makeContext());
+  await plugin.start();
+  return plugin;
+}
+
+function simulateMessage(msg: object): void {
+  (mockChild.stdout as EventEmitter).emit('data', Buffer.from(JSON.stringify(msg) + '\n'));
+}
+
+function makeIncomingMessage(overrides: Record<string, any> = {}): object {
+  return {
+    jsonrpc: '2.0',
+    method: 'receive',
+    params: {
+      envelope: {
+        source: '+15559876543',
+        sourceName: 'Bob',
+        dataMessage: {
+          message: 'hello from signal',
+          timestamp: 1234567890000,
+          ...overrides.dataMessage,
+        },
+        ...overrides.envelope,
+      },
+    },
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SignalChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAccess.mockResolvedValue(undefined);
+    mockKill.mockImplementation(() => {
+      // Simulate exit after kill
+      setTimeout(() => mockChild?.emit('exit', 0, null), 10);
+    });
+  });
+
+  // 1. Constructor and name
+  it('stores config and has name "signal"', () => {
+    const plugin = new SignalChannel({ phoneNumber: '+15551234567' });
+    expect(plugin.name).toBe('signal');
+  });
+
+  // 2. isHealthy() false before start
+  it('isHealthy() returns false before start', () => {
+    const plugin = new SignalChannel({ phoneNumber: '+15551234567' });
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 3. start() validates binary exists
+  it('start() validates signal-cli binary exists', async () => {
+    mockAccess.mockRejectedValueOnce(new Error('ENOENT'));
+
+    const plugin = new SignalChannel({ phoneNumber: '+15551234567' });
+    await plugin.initialize(makeContext());
+
+    await expect(plugin.start()).rejects.toThrow('signal-cli binary not found');
+  });
+
+  // 4. start() sets healthy = true
+  it('start() sets healthy to true after spawning', async () => {
+    const plugin = await startedPlugin();
+    expect(plugin.isHealthy()).toBe(true);
+  });
+
+  // 5. Incoming message → correct session ID
+  it('incoming message produces correct session ID', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    simulateMessage(makeIncomingMessage());
+
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.sessionId).toBe('signal:+15559876543');
+    expect(gateway.scope).toBe('dm');
+    expect(gateway.senderName).toBe('Bob');
+    expect(gateway.content).toBe('hello from signal');
+  });
+
+  // 6. Group message → scope 'group'
+  it('group message produces scope "group"', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    simulateMessage(makeIncomingMessage({
+      dataMessage: {
+        message: 'group msg',
+        groupInfo: { groupId: 'abc123' },
+      },
+    }));
+
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.scope).toBe('group');
+    expect(gateway.metadata.groupId).toBe('abc123');
+  });
+
+  // 7. Phone number filtering
+  it('rejects messages from non-allowed numbers', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ allowedNumbers: ['+15551111111'] }, ctx);
+
+    simulateMessage(makeIncomingMessage());
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 8. Phone number filtering allows matching
+  it('allows messages from allowed numbers', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ allowedNumbers: ['+15559876543'] }, ctx);
+
+    simulateMessage(makeIncomingMessage());
+
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+  });
+
+  // 9. send() writes JSON-RPC to stdin
+  it('send() writes JSON-RPC message to stdin', async () => {
+    const plugin = await startedPlugin();
+
+    await plugin.send({
+      sessionId: 'signal:+15559876543',
+      content: 'Hello back!',
+    });
+
+    expect(mockStdinWrite).toHaveBeenCalledOnce();
+    const written = JSON.parse(mockStdinWrite.mock.calls[0][0].replace('\n', ''));
+    expect(written.method).toBe('send');
+    expect(written.params.recipient).toEqual(['+15559876543']);
+    expect(written.params.message).toBe('Hello back!');
+  });
+
+  // 10. send() warns when process is null
+  it('send() warns when process is not running', async () => {
+    const ctx = makeContext();
+    const plugin = new SignalChannel({ phoneNumber: '+15551234567' });
+    await plugin.initialize(ctx);
+
+    await plugin.send({ sessionId: 'signal:+15559876543', content: 'hello' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('signal-cli process is not running'),
+    );
+  });
+
+  // 11. send() warns when session not resolvable
+  it('send() warns when phone cannot be extracted from session', async () => {
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+
+    await plugin.send({ sessionId: 'invalid', content: 'hello' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot resolve phone'),
+    );
+  });
+
+  // 12. stop() kills process
+  it('stop() terminates the process and sets healthy to false', async () => {
+    const plugin = await startedPlugin();
+    expect(plugin.isHealthy()).toBe(true);
+
+    await plugin.stop();
+
+    expect(mockKill).toHaveBeenCalledWith('SIGTERM');
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 13. Process exit sets unhealthy
+  it('process exit sets healthy to false', async () => {
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+    expect(plugin.isHealthy()).toBe(true);
+
+    mockChild.emit('exit', 1, null);
+
+    expect(plugin.isHealthy()).toBe(false);
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('signal-cli process exited'),
+    );
+  });
+
+  // 14. Non-JSON lines are logged at debug level
+  it('handles non-JSON stdout lines gracefully', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    (mockChild.stdout as EventEmitter).emit('data', Buffer.from('not json\n'));
+
+    expect(ctx.logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('Non-JSON line'),
+    );
+  });
+
+  // 15. stderr is logged as warnings
+  it('logs stderr output as warnings', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    (mockChild.stderr as EventEmitter).emit('data', Buffer.from('warning message'));
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('signal-cli stderr: warning message'),
+    );
+  });
+
+  // 16. Messages without dataMessage are ignored
+  it('ignores messages without dataMessage', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    simulateMessage({
+      jsonrpc: '2.0',
+      method: 'receive',
+      params: {
+        envelope: { source: '+15559876543' },
+      },
+    });
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 17. Metadata includes Signal-specific fields
+  it('includes Signal-specific metadata in gateway message', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    simulateMessage(makeIncomingMessage());
+
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.metadata.phone).toBe('+15559876543');
+    expect(gateway.metadata.timestamp).toBe(1234567890000);
+  });
+
+  // 18. Handler errors are caught and logged
+  it('logs errors from message handler instead of crashing', async () => {
+    const ctx = makeContext();
+    (ctx.onMessage as any).mockRejectedValueOnce(new Error('downstream failure'));
+    await startedPlugin({}, ctx);
+
+    simulateMessage(makeIncomingMessage());
+
+    await vi.waitFor(() => {
+      expect(ctx.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error handling Signal message: downstream failure'),
+      );
+    });
+  });
+
+  // 19. Process error event is handled
+  it('handles process error events', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    mockChild.emit('error', new Error('spawn ENOENT'));
+
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('signal-cli process error: spawn ENOENT'),
+    );
+  });
+});

--- a/runtime/src/channels/signal/plugin.ts
+++ b/runtime/src/channels/signal/plugin.ts
@@ -1,0 +1,298 @@
+/**
+ * Signal channel plugin — bridges Signal Messenger to the Gateway.
+ *
+ * Spawns signal-cli in JSON-RPC mode as a child process. No npm dependency
+ * required — uses node:child_process and node:fs/promises directly.
+ *
+ * Inbound messages are read from stdout as newline-delimited JSON. Outbound
+ * messages are sent via JSON-RPC `send` method on stdin.
+ *
+ * @module
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { access, constants } from 'node:fs/promises';
+import { BaseChannelPlugin } from '../../gateway/channel.js';
+import type { OutboundMessage } from '../../gateway/message.js';
+import { createGatewayMessage } from '../../gateway/message.js';
+import { GatewayConnectionError } from '../../gateway/errors.js';
+import type { SignalChannelConfig } from './types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SESSION_PREFIX = 'signal';
+const SIGTERM_TIMEOUT_MS = 5000;
+
+// ============================================================================
+// JSON-RPC types
+// ============================================================================
+
+interface JsonRpcMessage {
+  jsonrpc?: string;
+  method?: string;
+  params?: {
+    envelope?: SignalEnvelope;
+  };
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+interface SignalEnvelope {
+  source?: string;
+  sourceName?: string;
+  dataMessage?: {
+    message?: string;
+    timestamp?: number;
+    groupInfo?: { groupId?: string };
+    attachments?: SignalAttachment[];
+  };
+}
+
+interface SignalAttachment {
+  contentType?: string;
+  filename?: string;
+  size?: number;
+}
+
+// ============================================================================
+// SignalChannel Plugin
+// ============================================================================
+
+export class SignalChannel extends BaseChannelPlugin {
+  readonly name = SESSION_PREFIX;
+
+  private process: ChildProcess | null = null;
+  private healthy = false;
+  private readonly config: SignalChannelConfig;
+  private rpcId = 0;
+  private lineBuffer = '';
+
+  constructor(config: SignalChannelConfig) {
+    super();
+    this.config = config;
+  }
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    const bin = this.config.signalCliBin ?? 'signal-cli';
+
+    // Validate binary exists
+    try {
+      await access(bin, constants.X_OK);
+    } catch {
+      throw new GatewayConnectionError(
+        `signal-cli binary not found or not executable: ${bin}`,
+      );
+    }
+
+    const args = [
+      '-a', this.config.phoneNumber,
+      'jsonRpc',
+    ];
+
+    if (this.config.trustMode) {
+      args.unshift('--trust-new-identities', this.config.trustMode);
+    }
+
+    const child = spawn(bin, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    this.process = child;
+
+    child.stdout!.on('data', (chunk: Buffer) => {
+      this.handleStdoutData(chunk);
+    });
+
+    child.stderr!.on('data', (chunk: Buffer) => {
+      this.context.logger.warn(`signal-cli stderr: ${chunk.toString().trim()}`);
+    });
+
+    child.on('error', (err: Error) => {
+      this.healthy = false;
+      this.context.logger.error(`signal-cli process error: ${err.message}`);
+    });
+
+    child.on('exit', (code, signal) => {
+      this.healthy = false;
+      this.context.logger.error(
+        `signal-cli process exited (code=${code}, signal=${signal})`,
+      );
+    });
+
+    this.healthy = true;
+    this.context.logger.info(`Signal channel started with signal-cli for ${this.config.phoneNumber}`);
+  }
+
+  async stop(): Promise<void> {
+    if (this.process) {
+      await this.gracefulShutdown();
+      this.process = null;
+    }
+    this.healthy = false;
+    this.lineBuffer = '';
+  }
+
+  override isHealthy(): boolean {
+    return this.healthy;
+  }
+
+  // --------------------------------------------------------------------------
+  // Outbound
+  // --------------------------------------------------------------------------
+
+  async send(message: OutboundMessage): Promise<void> {
+    if (!this.process || !this.process.stdin?.writable) {
+      this.context.logger.warn('Cannot send message: signal-cli process is not running');
+      return;
+    }
+
+    const phone = this.extractPhone(message.sessionId);
+    if (!phone) {
+      this.context.logger.warn(`Cannot resolve phone for session: ${message.sessionId}`);
+      return;
+    }
+
+    const rpcMessage: JsonRpcMessage = {
+      jsonrpc: '2.0',
+      method: 'send',
+      params: {
+        envelope: {
+          source: phone,
+          dataMessage: { message: message.content },
+        },
+      } as any,
+      id: ++this.rpcId,
+    };
+
+    // signal-cli JSON-RPC expects specific params format
+    const sendPayload = {
+      jsonrpc: '2.0',
+      method: 'send',
+      id: rpcMessage.id,
+      params: {
+        recipient: [phone],
+        message: message.content,
+      },
+    };
+
+    try {
+      this.process.stdin!.write(JSON.stringify(sendPayload) + '\n');
+    } catch (err) {
+      this.context.logger.error(`Failed to send message to ${message.sessionId}: ${errorMessage(err)}`);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Stdout processing
+  // --------------------------------------------------------------------------
+
+  private handleStdoutData(chunk: Buffer): void {
+    this.lineBuffer += chunk.toString();
+    const lines = this.lineBuffer.split('\n');
+
+    // Keep the last incomplete line in the buffer
+    this.lineBuffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const parsed = JSON.parse(trimmed) as JsonRpcMessage;
+        this.handleJsonRpcMessage(parsed).catch((err) => {
+          this.context.logger.error(`Error handling Signal message: ${errorMessage(err)}`);
+        });
+      } catch {
+        this.context.logger.debug(`Non-JSON line from signal-cli: ${trimmed.slice(0, 100)}`);
+      }
+    }
+  }
+
+  private async handleJsonRpcMessage(msg: JsonRpcMessage): Promise<void> {
+    // Only handle incoming message notifications
+    if (msg.method !== 'receive' || !msg.params?.envelope) return;
+
+    const envelope = msg.params.envelope;
+    if (!envelope.source) return;
+    if (!envelope.dataMessage?.message) return;
+
+    const phone = envelope.source;
+
+    if (this.config.allowedNumbers && this.config.allowedNumbers.length > 0) {
+      if (!this.config.allowedNumbers.includes(phone)) return;
+    }
+
+    const sessionId = `${SESSION_PREFIX}:${phone}`;
+    const isGroup = !!envelope.dataMessage.groupInfo?.groupId;
+
+    const gateway = createGatewayMessage({
+      channel: this.name,
+      senderId: phone,
+      senderName: envelope.sourceName ?? phone,
+      sessionId,
+      content: envelope.dataMessage.message,
+      metadata: {
+        phone,
+        timestamp: envelope.dataMessage.timestamp,
+        groupId: envelope.dataMessage.groupInfo?.groupId,
+      },
+      scope: isGroup ? 'group' : 'dm',
+    });
+
+    await this.context.onMessage(gateway);
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  private extractPhone(sessionId: string): string | null {
+    // Session ID format: signal:<phoneNumber>
+    const parts = sessionId.split(':');
+    if (parts.length < 2 || parts[0] !== SESSION_PREFIX) return null;
+    return parts.slice(1).join(':');
+  }
+
+  private async gracefulShutdown(): Promise<void> {
+    const child = this.process;
+    if (!child) return;
+
+    return new Promise<void>((resolve) => {
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          child.kill('SIGKILL');
+          resolve();
+        }
+      }, SIGTERM_TIMEOUT_MS);
+
+      child.once('exit', () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      child.kill('SIGTERM');
+    });
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Extract a safe error message string. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/runtime/src/channels/signal/types.ts
+++ b/runtime/src/channels/signal/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Configuration interface for the Signal channel plugin.
+ *
+ * Uses signal-cli in JSON-RPC mode via child_process (no npm dependency).
+ * Requires signal-cli to be installed and configured on the host.
+ *
+ * @module
+ */
+
+export interface SignalChannelConfig {
+  /** Path to the signal-cli binary. @default 'signal-cli' */
+  readonly signalCliBin?: string;
+  /** The phone number registered with Signal (e.g. '+15551234567'). */
+  readonly phoneNumber: string;
+  /** Trust mode for incoming messages. @default 'on-first-use' */
+  readonly trustMode?: 'always' | 'on-first-use' | 'tofu';
+  /** Restrict to specific phone numbers. Empty = all numbers. */
+  readonly allowedNumbers?: readonly string[];
+  /** Poll interval for checking subprocess health in ms. @default 30000 */
+  readonly pollIntervalMs?: number;
+}

--- a/runtime/src/channels/slack/index.ts
+++ b/runtime/src/channels/slack/index.ts
@@ -1,0 +1,2 @@
+export { SlackChannel } from './plugin.js';
+export type { SlackChannelConfig } from './types.js';

--- a/runtime/src/channels/slack/plugin.test.ts
+++ b/runtime/src/channels/slack/plugin.test.ts
@@ -1,0 +1,456 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChannelContext } from '../../gateway/channel.js';
+
+// ============================================================================
+// Mock @slack/bolt
+// ============================================================================
+
+const mockStart = vi.fn();
+const mockStop = vi.fn();
+const mockMessageHandler = vi.fn();
+const mockPostMessage = vi.fn();
+const mockUsersInfo = vi.fn();
+
+vi.mock('@slack/bolt', () => {
+  return {
+    App: class MockApp {
+      start = mockStart;
+      stop = mockStop;
+      client = {
+        chat: { postMessage: mockPostMessage },
+        users: { info: mockUsersInfo },
+      };
+      private messageHandlers: Array<(args: any) => Promise<void>> = [];
+
+      message(handler: (args: any) => Promise<void>) {
+        this.messageHandlers.push(handler);
+        mockMessageHandler(handler);
+      }
+
+      // Expose for tests
+      get _messageHandlers() { return this.messageHandlers; }
+    },
+  };
+});
+
+// Import after mock setup
+import { SlackChannel } from './plugin.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeContext(overrides: Partial<ChannelContext> = {}): ChannelContext {
+  return {
+    onMessage: vi.fn().mockResolvedValue(undefined),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    config: {},
+    ...overrides,
+  };
+}
+
+function getMessageHandler(): ((args: any) => Promise<void>) | undefined {
+  return mockMessageHandler.mock.calls[0]?.[0];
+}
+
+function makeSlackMessage(overrides: Record<string, any> = {}): any {
+  return {
+    text: 'hello',
+    user: 'U123',
+    channel: 'C456',
+    ts: '1234567890.123456',
+    channel_type: 'channel',
+    team: 'T789',
+    ...overrides,
+  };
+}
+
+async function startedPlugin(config: Record<string, any> = {}, ctx?: ChannelContext) {
+  const plugin = new SlackChannel({
+    botToken: 'xoxb-test',
+    appToken: 'xapp-test',
+    ...config,
+  } as any);
+  await plugin.initialize(ctx ?? makeContext());
+  await plugin.start();
+  return plugin;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('SlackChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStart.mockResolvedValue(undefined);
+    mockStop.mockResolvedValue(undefined);
+    mockPostMessage.mockResolvedValue({ ok: true });
+    mockUsersInfo.mockResolvedValue({ user: { real_name: 'Alice', name: 'alice' } });
+  });
+
+  // 1. Constructor and name
+  it('stores config and has name "slack"', () => {
+    const plugin = new SlackChannel({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+    });
+    expect(plugin.name).toBe('slack');
+  });
+
+  // 2. start() calls app.start()
+  it('start() initializes and starts the Slack app', async () => {
+    await startedPlugin();
+    expect(mockStart).toHaveBeenCalledOnce();
+  });
+
+  // 3. start() sets healthy = true
+  it('start() sets healthy to true', async () => {
+    const plugin = await startedPlugin();
+    expect(plugin.isHealthy()).toBe(true);
+  });
+
+  // 4. stop() calls app.stop() and resets state
+  it('stop() stops the app and sets healthy to false', async () => {
+    const plugin = await startedPlugin();
+    expect(plugin.isHealthy()).toBe(true);
+
+    await plugin.stop();
+
+    expect(mockStop).toHaveBeenCalledOnce();
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 5. isHealthy() false before start
+  it('isHealthy() returns false before start', () => {
+    const plugin = new SlackChannel({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+    });
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 6. Channel message → correct session ID
+  it('channel message produces correct session ID', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage() });
+
+    expect(ctx.onMessage).toHaveBeenCalledOnce();
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.sessionId).toBe('slack:T789:C456:U123');
+    expect(gateway.scope).toBe('group');
+  });
+
+  // 7. DM message → session ID slack:dm:<userId>
+  it('DM message produces session ID slack:dm:<userId>', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage({ channel_type: 'im' }) });
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.sessionId).toBe('slack:dm:U123');
+    expect(gateway.scope).toBe('dm');
+  });
+
+  // 8. Thread message → scope 'thread'
+  it('thread message produces scope "thread"', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({
+      message: makeSlackMessage({ thread_ts: '1234567890.000000' }),
+    });
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.scope).toBe('thread');
+  });
+
+  // 9. Bot messages are skipped
+  it('skips bot messages', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage({ bot_id: 'B123' }) });
+
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 10. Subtype messages are skipped
+  it('skips subtype messages', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage({ subtype: 'channel_join' }) });
+
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 11. Channel ID filtering
+  it('rejects messages from non-allowed channels', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ channelIds: ['C999'] }, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage({ channel: 'C456' }) });
+
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 12. Channel ID filtering allows matching channel
+  it('allows messages from allowed channels', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ channelIds: ['C456'] }, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage() });
+
+    expect(ctx.onMessage).toHaveBeenCalledOnce();
+  });
+
+  // 13. send() posts message via Web API
+  it('send() posts message to correct channel', async () => {
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+
+    // Trigger inbound to populate session map
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage() });
+
+    await plugin.send({
+      sessionId: 'slack:T789:C456:U123',
+      content: 'Hello back!',
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      channel: 'C456',
+      text: 'Hello back!',
+    });
+  });
+
+  // 14. send() with useThreads replies in thread
+  it('send() replies in thread when useThreads is enabled', async () => {
+    const ctx = makeContext();
+    const plugin = await startedPlugin({ useThreads: true }, ctx);
+
+    // Trigger inbound thread message to populate session map
+    const handler = getMessageHandler();
+    await handler!({
+      message: makeSlackMessage({ thread_ts: '111.222' }),
+    });
+
+    await plugin.send({
+      sessionId: 'slack:T789:C456:U123',
+      content: 'Thread reply',
+    });
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      channel: 'C456',
+      text: 'Thread reply',
+      thread_ts: '111.222',
+    });
+  });
+
+  // 15. send() warns when client is null
+  it('send() warns when client is not connected', async () => {
+    const ctx = makeContext();
+    const plugin = new SlackChannel({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+    });
+    await plugin.initialize(ctx);
+
+    await plugin.send({ sessionId: 'slack:dm:U123', content: 'hello' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Slack client is not connected'),
+    );
+  });
+
+  // 16. send() warns when session not found
+  it('send() warns when session cannot be resolved', async () => {
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+
+    await plugin.send({ sessionId: 'slack:dm:UNKNOWN', content: 'hello' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot resolve channel'),
+    );
+  });
+
+  // 17. User name resolution via users.info
+  it('resolves user display name via Slack API', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage() });
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.senderName).toBe('Alice');
+  });
+
+  // 18. User name resolution fallback
+  it('falls back to userId when users.info fails', async () => {
+    mockUsersInfo.mockRejectedValueOnce(new Error('user_not_found'));
+
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage() });
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.senderName).toBe('U123');
+  });
+
+  // 19. File attachments normalized correctly
+  it('normalizes file attachments correctly', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({
+      message: makeSlackMessage({
+        files: [
+          {
+            url_private: 'https://files.slack.com/image.png',
+            mimetype: 'image/png',
+            name: 'image.png',
+            size: 1024,
+          },
+        ],
+      }),
+    });
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.attachments).toHaveLength(1);
+    expect(gateway.attachments[0].type).toBe('image');
+    expect(gateway.attachments[0].mimeType).toBe('image/png');
+    expect(gateway.attachments[0].filename).toBe('image.png');
+  });
+
+  // 20. Oversized attachments filtered
+  it('filters oversized attachments', async () => {
+    const ctx = makeContext();
+    await startedPlugin({ maxAttachmentBytes: 1000 }, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({
+      message: makeSlackMessage({
+        files: [
+          { url_private: 'https://files.slack.com/small.txt', mimetype: 'text/plain', name: 'small.txt', size: 500 },
+          { url_private: 'https://files.slack.com/large.bin', mimetype: 'application/octet-stream', name: 'large.bin', size: 5000 },
+        ],
+      }),
+    });
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.attachments).toHaveLength(1);
+    expect(gateway.attachments[0].filename).toBe('small.txt');
+  });
+
+  // 21. Messages without user field are skipped
+  it('skips messages with no user field', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage({ user: undefined }) });
+
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 22. start() failure cleans up
+  it('cleans up if start() fails', async () => {
+    mockStart.mockRejectedValueOnce(new Error('connection failed'));
+
+    const plugin = new SlackChannel({
+      botToken: 'xoxb-test',
+      appToken: 'xapp-test',
+    });
+    await plugin.initialize(makeContext());
+
+    await expect(plugin.start()).rejects.toThrow('connection failed');
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 23. stop() clears session map
+  it('stop() clears session mappings', async () => {
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+
+    // Populate session map
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage() });
+
+    await plugin.stop();
+
+    // After stop, send should fail to resolve
+    await plugin.start();
+    await plugin.send({ sessionId: 'slack:T789:C456:U123', content: 'hi' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot resolve channel'),
+    );
+  });
+
+  // 24. send() error is caught and logged
+  it('send() catches postMessage failure and logs error', async () => {
+    mockPostMessage.mockRejectedValueOnce(new Error('rate_limited'));
+
+    const ctx = makeContext();
+    const plugin = await startedPlugin({}, ctx);
+
+    // Populate session map
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage() });
+
+    await plugin.send({
+      sessionId: 'slack:T789:C456:U123',
+      content: 'hello',
+    });
+
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('rate_limited'),
+    );
+  });
+
+  // 25. Metadata includes Slack-specific fields
+  it('includes Slack-specific metadata in gateway message', async () => {
+    const ctx = makeContext();
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    await handler!({ message: makeSlackMessage({ thread_ts: '111.222' }) });
+
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.metadata.slackTs).toBe('1234567890.123456');
+    expect(gateway.metadata.threadTs).toBe('111.222');
+    expect(gateway.metadata.teamId).toBe('T789');
+    expect(gateway.metadata.channelId).toBe('C456');
+  });
+
+  // 26. Message handler errors are caught and logged
+  it('logs errors from message handler instead of crashing', async () => {
+    const ctx = makeContext();
+    (ctx.onMessage as any).mockRejectedValueOnce(new Error('downstream failure'));
+    await startedPlugin({}, ctx);
+
+    const handler = getMessageHandler();
+    // Should not throw
+    await handler!({ message: makeSlackMessage() });
+
+    expect(ctx.logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Error handling Slack message: downstream failure'),
+    );
+  });
+});

--- a/runtime/src/channels/slack/plugin.ts
+++ b/runtime/src/channels/slack/plugin.ts
@@ -1,0 +1,363 @@
+/**
+ * Slack channel plugin — bridges the Slack Bot API to the Gateway.
+ *
+ * Uses @slack/bolt v4+ as a lazy-loaded optional dependency. Connects via
+ * Socket Mode (WebSocket), requiring both a bot token and an app-level token.
+ * Supports channel filtering and thread reply support.
+ *
+ * @module
+ */
+
+import { BaseChannelPlugin } from '../../gateway/channel.js';
+import type { OutboundMessage, MessageAttachment } from '../../gateway/message.js';
+import { createGatewayMessage } from '../../gateway/message.js';
+import type { MessageScope } from '../../gateway/message.js';
+import { GatewayConnectionError } from '../../gateway/errors.js';
+import { DEFAULT_MAX_ATTACHMENT_BYTES } from '../../gateway/media.js';
+import { ensureLazyModule } from '../../utils/lazy-import.js';
+import type { SlackChannelConfig } from './types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SLACK_MAX_MESSAGE_LENGTH = 4000;
+const SESSION_PREFIX = 'slack';
+
+// ============================================================================
+// @slack/bolt type shims (loaded lazily)
+// ============================================================================
+
+interface SlackBoltApp {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  message(handler: (args: SlackMessageArgs) => Promise<void>): void;
+  command(command: string, handler: (args: SlackCommandArgs) => Promise<void>): void;
+}
+
+interface SlackMessageArgs {
+  message: SlackMessage;
+  say: (opts: string | SlackSayOptions) => Promise<unknown>;
+}
+
+interface SlackCommandArgs {
+  command: {
+    text: string;
+    command: string;
+    user_id: string;
+    channel_id: string;
+    team_id?: string;
+  };
+  ack: () => Promise<void>;
+  say: (opts: string | SlackSayOptions) => Promise<unknown>;
+}
+
+interface SlackSayOptions {
+  text: string;
+  thread_ts?: string;
+}
+
+interface SlackMessage {
+  text?: string;
+  user?: string;
+  channel: string;
+  ts: string;
+  thread_ts?: string;
+  channel_type?: string;
+  team?: string;
+  files?: SlackFile[];
+  bot_id?: string;
+  subtype?: string;
+}
+
+interface SlackFile {
+  url_private?: string;
+  mimetype?: string;
+  name?: string;
+  size?: number;
+}
+
+interface SlackWebClient {
+  chat: {
+    postMessage(opts: {
+      channel: string;
+      text: string;
+      thread_ts?: string;
+    }): Promise<unknown>;
+  };
+  users: {
+    info(opts: { user: string }): Promise<{ user?: { real_name?: string; name?: string } }>;
+  };
+}
+
+interface SlackBoltModule {
+  App: new (opts: {
+    token: string;
+    appToken: string;
+    socketMode: true;
+  }) => SlackBoltApp & { client: SlackWebClient };
+}
+
+// ============================================================================
+// SlackChannel Plugin
+// ============================================================================
+
+export class SlackChannel extends BaseChannelPlugin {
+  readonly name = SESSION_PREFIX;
+
+  private app: (SlackBoltApp & { client: SlackWebClient }) | null = null;
+  private healthy = false;
+  private readonly config: SlackChannelConfig;
+  private readonly sessionMap = new Map<string, { channel: string; threadTs?: string }>();
+  private readonly userNameCache = new Map<string, string>();
+
+  constructor(config: SlackChannelConfig) {
+    super();
+    this.config = config;
+  }
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    const mod = await ensureLazyModule<SlackBoltModule>(
+      '@slack/bolt',
+      (msg) => new GatewayConnectionError(msg),
+      (m) => m as unknown as SlackBoltModule,
+    );
+
+    const app = new mod.App({
+      token: this.config.botToken,
+      appToken: this.config.appToken,
+      socketMode: true as const,
+    });
+    this.app = app;
+
+    try {
+      this.wireEventHandlers(app);
+      await app.start();
+      this.healthy = true;
+      this.context.logger.info('Slack bot connected via Socket Mode');
+    } catch (err) {
+      this.app = null;
+      throw err;
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.app) {
+      try {
+        await this.app.stop();
+      } catch {
+        // Ignore stop errors
+      }
+      this.app = null;
+    }
+    this.healthy = false;
+    this.sessionMap.clear();
+    this.userNameCache.clear();
+  }
+
+  override isHealthy(): boolean {
+    return this.healthy;
+  }
+
+  // --------------------------------------------------------------------------
+  // Outbound
+  // --------------------------------------------------------------------------
+
+  async send(message: OutboundMessage): Promise<void> {
+    if (!this.app) {
+      this.context.logger.warn('Cannot send message: Slack client is not connected');
+      return;
+    }
+
+    const target = this.sessionMap.get(message.sessionId);
+    if (!target) {
+      this.context.logger.warn(`Cannot resolve channel for session: ${message.sessionId}`);
+      return;
+    }
+
+    const chunks = splitMessage(message.content);
+    for (const chunk of chunks) {
+      try {
+        const opts: { channel: string; text: string; thread_ts?: string } = {
+          channel: target.channel,
+          text: chunk,
+        };
+        if (this.config.useThreads && target.threadTs) {
+          opts.thread_ts = target.threadTs;
+        }
+        await this.app.client.chat.postMessage(opts);
+      } catch (err) {
+        this.context.logger.error(`Failed to send message to ${message.sessionId}: ${errorMessage(err)}`);
+        return;
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Event wiring
+  // --------------------------------------------------------------------------
+
+  private wireEventHandlers(app: SlackBoltApp & { client: SlackWebClient }): void {
+    app.message(async (args: SlackMessageArgs) => {
+      try {
+        await this.handleMessage(args.message, app.client);
+      } catch (err) {
+        this.context.logger.error(`Error handling Slack message: ${errorMessage(err)}`);
+      }
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // Inbound: messages
+  // --------------------------------------------------------------------------
+
+  private async handleMessage(msg: SlackMessage, client: SlackWebClient): Promise<void> {
+    // Skip bot messages and subtypes (joins, edits, etc.)
+    if (msg.bot_id || msg.subtype) return;
+    if (!msg.user) return;
+
+    // Channel filtering
+    if (this.config.channelIds && this.config.channelIds.length > 0) {
+      if (!this.config.channelIds.includes(msg.channel)) return;
+    }
+
+    const isDM = msg.channel_type === 'im';
+    const isThread = !!msg.thread_ts;
+    const sessionId = buildSessionId(isDM, msg.user, msg.team, msg.channel);
+    const scope: MessageScope = isDM ? 'dm' : isThread ? 'thread' : 'group';
+
+    // Store mapping for outbound send
+    this.sessionMap.set(sessionId, {
+      channel: msg.channel,
+      threadTs: msg.thread_ts ?? msg.ts,
+    });
+
+    const senderName = await this.resolveUserName(msg.user, client);
+    const attachments = this.normalizeAttachments(msg.files);
+
+    const gateway = createGatewayMessage({
+      channel: this.name,
+      senderId: msg.user,
+      senderName,
+      sessionId,
+      content: msg.text ?? '',
+      attachments: attachments.length > 0 ? attachments : undefined,
+      metadata: {
+        slackTs: msg.ts,
+        threadTs: msg.thread_ts,
+        teamId: msg.team,
+        channelId: msg.channel,
+      },
+      scope,
+    });
+
+    await this.context.onMessage(gateway);
+  }
+
+  // --------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------
+
+  private async resolveUserName(userId: string, client: SlackWebClient): Promise<string> {
+    const cached = this.userNameCache.get(userId);
+    if (cached) return cached;
+
+    try {
+      const result = await client.users.info({ user: userId });
+      const name = result.user?.real_name ?? result.user?.name ?? userId;
+      this.userNameCache.set(userId, name);
+      return name;
+    } catch {
+      return userId;
+    }
+  }
+
+  private normalizeAttachments(files?: SlackFile[]): MessageAttachment[] {
+    if (!files || files.length === 0) return [];
+
+    const maxBytes = this.config.maxAttachmentBytes ?? DEFAULT_MAX_ATTACHMENT_BYTES;
+    const result: MessageAttachment[] = [];
+
+    for (const file of files) {
+      if (file.size !== undefined && file.size > maxBytes) continue;
+
+      const mimeType = file.mimetype ?? 'application/octet-stream';
+      let type = 'file';
+      if (mimeType.startsWith('image/')) type = 'image';
+      else if (mimeType.startsWith('audio/')) type = 'audio';
+      else if (mimeType.startsWith('video/')) type = 'video';
+
+      result.push({
+        type,
+        url: file.url_private,
+        mimeType,
+        filename: file.name,
+        sizeBytes: file.size,
+      });
+    }
+
+    return result;
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Build a session ID from Slack context.
+ * DM: `slack:dm:<userId>`, Channel: `slack:<teamId>:<channelId>:<userId>`
+ */
+function buildSessionId(
+  isDM: boolean,
+  userId: string,
+  teamId: string | undefined,
+  channelId: string,
+): string {
+  if (isDM) {
+    return `${SESSION_PREFIX}:dm:${userId}`;
+  }
+  return `${SESSION_PREFIX}:${teamId ?? 'unknown'}:${channelId}:${userId}`;
+}
+
+/** Extract a safe error message string. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/**
+ * Split content at line boundaries to stay under Slack's message limit.
+ */
+function splitMessage(content: string): string[] {
+  if (content.length <= SLACK_MAX_MESSAGE_LENGTH) {
+    return [content];
+  }
+
+  const chunks: string[] = [];
+  let remaining = content;
+
+  while (remaining.length > 0) {
+    if (remaining.length <= SLACK_MAX_MESSAGE_LENGTH) {
+      chunks.push(remaining);
+      break;
+    }
+
+    const slice = remaining.slice(0, SLACK_MAX_MESSAGE_LENGTH);
+    const lastNewline = slice.lastIndexOf('\n');
+
+    if (lastNewline > 0) {
+      chunks.push(remaining.slice(0, lastNewline));
+      remaining = remaining.slice(lastNewline + 1);
+    } else {
+      chunks.push(slice);
+      remaining = remaining.slice(SLACK_MAX_MESSAGE_LENGTH);
+    }
+  }
+
+  return chunks.filter((c) => c.length > 0);
+}

--- a/runtime/src/channels/slack/types.ts
+++ b/runtime/src/channels/slack/types.ts
@@ -1,0 +1,18 @@
+/**
+ * Configuration interface for the Slack channel plugin.
+ *
+ * @module
+ */
+
+export interface SlackChannelConfig {
+  /** Slack bot token (xoxb-...) for Web API calls. */
+  readonly botToken: string;
+  /** Slack app-level token (xapp-...) for Socket Mode. */
+  readonly appToken: string;
+  /** Restrict to specific channel IDs. Empty = all channels. */
+  readonly channelIds?: readonly string[];
+  /** Whether to reply in threads when the original message is in a thread. @default false */
+  readonly useThreads?: boolean;
+  /** Maximum attachment size in bytes. @default 25 * 1024 * 1024 (25 MB) */
+  readonly maxAttachmentBytes?: number;
+}

--- a/runtime/src/channels/whatsapp/index.ts
+++ b/runtime/src/channels/whatsapp/index.ts
@@ -1,0 +1,2 @@
+export { WhatsAppChannel } from './plugin.js';
+export type { WhatsAppChannelConfig } from './types.js';

--- a/runtime/src/channels/whatsapp/plugin.test.ts
+++ b/runtime/src/channels/whatsapp/plugin.test.ts
@@ -1,0 +1,545 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ChannelContext } from '../../gateway/channel.js';
+
+// ============================================================================
+// Mock @whiskeysockets/baileys
+// ============================================================================
+
+const mockSendMessage = vi.fn();
+const mockEnd = vi.fn();
+const mockEvOn = vi.fn();
+
+vi.mock('@whiskeysockets/baileys', () => {
+  return {
+    default: (_opts: unknown) => ({
+      ev: { on: mockEvOn },
+      sendMessage: mockSendMessage,
+      end: mockEnd,
+    }),
+    useMultiFileAuthState: async (_path: string) => ({
+      state: {},
+      saveCreds: vi.fn().mockResolvedValue(undefined),
+    }),
+  };
+});
+
+// Import after mock setup
+import { WhatsAppChannel } from './plugin.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function makeContext(overrides: Partial<ChannelContext> = {}): ChannelContext {
+  return {
+    onMessage: vi.fn().mockResolvedValue(undefined),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as any,
+    config: {},
+    ...overrides,
+  };
+}
+
+function getEvHandler(event: string): ((...args: any[]) => void) | undefined {
+  for (const call of mockEvOn.mock.calls) {
+    if (call[0] === event) return call[1] as (...args: any[]) => void;
+  }
+  return undefined;
+}
+
+function makeBaileysMessage(overrides: Record<string, any> = {}): any {
+  return {
+    key: {
+      remoteJid: '5511999999999@s.whatsapp.net',
+      fromMe: false,
+      id: 'msg-001',
+      ...overrides.key,
+    },
+    message: {
+      conversation: 'hello',
+      ...overrides.message,
+    },
+    pushName: 'Alice',
+    ...overrides,
+  };
+}
+
+async function startedBaileysPlugin(config: Record<string, any> = {}, ctx?: ChannelContext) {
+  const plugin = new WhatsAppChannel({
+    mode: 'baileys',
+    sessionPath: '/tmp/test-session',
+    ...config,
+  } as any);
+  await plugin.initialize(ctx ?? makeContext());
+  await plugin.start();
+  return plugin;
+}
+
+function startedBusinessPlugin(config: Record<string, any> = {}, ctx?: ChannelContext) {
+  const plugin = new WhatsAppChannel({
+    mode: 'business-api',
+    phoneNumberId: 'phone-123',
+    accessToken: 'test-token',
+    webhookVerifyToken: 'verify-token',
+    ...config,
+  } as any);
+  const context = ctx ?? makeContext();
+  // initialize + start synchronously for business-api
+  return plugin.initialize(context).then(() => plugin.start()).then(() => ({ plugin, context }));
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('WhatsAppChannel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendMessage.mockResolvedValue({});
+  });
+
+  // 1. Constructor and name
+  it('stores config and has name "whatsapp"', () => {
+    const plugin = new WhatsAppChannel({ mode: 'baileys' });
+    expect(plugin.name).toBe('whatsapp');
+  });
+
+  // 2. isHealthy() false before start
+  it('isHealthy() returns false before start', () => {
+    const plugin = new WhatsAppChannel({ mode: 'baileys' });
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // --------------------------------------------------------------------------
+  // Baileys mode
+  // --------------------------------------------------------------------------
+
+  // 3. Baileys start wires event handlers
+  it('baileys start() wires event handlers', async () => {
+    await startedBaileysPlugin();
+
+    const events = mockEvOn.mock.calls.map((c) => c[0]);
+    expect(events).toContain('connection.update');
+    expect(events).toContain('messages.upsert');
+    expect(events).toContain('creds.update');
+  });
+
+  // 4. Baileys connection.update → healthy
+  it('baileys sets healthy when connection opens', async () => {
+    const plugin = await startedBaileysPlugin();
+
+    const handler = getEvHandler('connection.update');
+    handler!({ connection: 'open' });
+
+    expect(plugin.isHealthy()).toBe(true);
+  });
+
+  // 5. Baileys connection close → unhealthy
+  it('baileys sets unhealthy when connection closes', async () => {
+    const plugin = await startedBaileysPlugin();
+
+    const handler = getEvHandler('connection.update');
+    handler!({ connection: 'open' });
+    expect(plugin.isHealthy()).toBe(true);
+
+    handler!({ connection: 'close' });
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 6. Baileys message → correct session ID
+  it('baileys message produces correct session ID', async () => {
+    const ctx = makeContext();
+    await startedBaileysPlugin({}, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({ messages: [makeBaileysMessage()] });
+
+    // Allow async handler to fire
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.sessionId).toBe('whatsapp:5511999999999@s.whatsapp.net');
+    expect(gateway.scope).toBe('dm');
+    expect(gateway.senderName).toBe('Alice');
+    expect(gateway.content).toBe('hello');
+  });
+
+  // 7. Baileys skips own messages
+  it('baileys skips own messages', async () => {
+    const ctx = makeContext();
+    await startedBaileysPlugin({}, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({ messages: [makeBaileysMessage({ key: { fromMe: true } })] });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 8. Baileys phone number filtering
+  it('baileys rejects messages from non-allowed numbers', async () => {
+    const ctx = makeContext();
+    await startedBaileysPlugin({ allowedNumbers: ['1234567890'] }, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({ messages: [makeBaileysMessage()] });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 9. Baileys allows matching numbers
+  it('baileys allows messages from allowed numbers', async () => {
+    const ctx = makeContext();
+    await startedBaileysPlugin({ allowedNumbers: ['5511999999999'] }, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({ messages: [makeBaileysMessage()] });
+
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+  });
+
+  // 10. Baileys send
+  it('baileys send() sends message via socket', async () => {
+    const ctx = makeContext();
+    const plugin = await startedBaileysPlugin({}, ctx);
+
+    // Trigger inbound to populate session map
+    const handler = getEvHandler('messages.upsert');
+    await handler!({ messages: [makeBaileysMessage()] });
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+
+    await plugin.send({
+      sessionId: 'whatsapp:5511999999999@s.whatsapp.net',
+      content: 'Hello back!',
+    });
+
+    expect(mockSendMessage).toHaveBeenCalledWith(
+      '5511999999999@s.whatsapp.net',
+      { text: 'Hello back!' },
+    );
+  });
+
+  // 11. stop() cleans up socket
+  it('stop() ends socket and sets healthy to false', async () => {
+    const plugin = await startedBaileysPlugin();
+
+    const handler = getEvHandler('connection.update');
+    handler!({ connection: 'open' });
+    expect(plugin.isHealthy()).toBe(true);
+
+    await plugin.stop();
+
+    expect(mockEnd).toHaveBeenCalledOnce();
+    expect(plugin.isHealthy()).toBe(false);
+  });
+
+  // 12. Baileys image attachment
+  it('baileys normalizes image attachments', async () => {
+    const ctx = makeContext();
+    await startedBaileysPlugin({}, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({
+      messages: [makeBaileysMessage({
+        message: {
+          imageMessage: {
+            url: 'https://example.com/image.jpg',
+            mimetype: 'image/jpeg',
+            fileLength: 2048,
+            caption: 'Check this out',
+          },
+        },
+      })],
+    });
+
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.content).toBe('Check this out');
+    expect(gateway.attachments).toHaveLength(1);
+    expect(gateway.attachments[0].type).toBe('image');
+    expect(gateway.attachments[0].mimeType).toBe('image/jpeg');
+  });
+
+  // 13. Baileys extendedTextMessage
+  it('baileys handles extendedTextMessage', async () => {
+    const ctx = makeContext();
+    await startedBaileysPlugin({}, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({
+      messages: [makeBaileysMessage({
+        message: { extendedTextMessage: { text: 'quoted reply' } },
+      })],
+    });
+
+    await vi.waitFor(() => {
+      expect(ctx.onMessage).toHaveBeenCalledOnce();
+    });
+    const gateway = (ctx.onMessage as any).mock.calls[0][0];
+    expect(gateway.content).toBe('quoted reply');
+  });
+
+  // 14. send() warns when session not found
+  it('send() warns when session cannot be resolved', async () => {
+    const ctx = makeContext();
+    const plugin = await startedBaileysPlugin({}, ctx);
+
+    await plugin.send({ sessionId: 'whatsapp:unknown', content: 'hello' });
+
+    expect(ctx.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Cannot resolve target'),
+    );
+  });
+
+  // 15. Baileys message handler error logging
+  it('baileys logs errors from message handler', async () => {
+    const ctx = makeContext();
+    (ctx.onMessage as any).mockRejectedValueOnce(new Error('downstream failure'));
+    await startedBaileysPlugin({}, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({ messages: [makeBaileysMessage()] });
+
+    await vi.waitFor(() => {
+      expect(ctx.logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Error handling WhatsApp message: downstream failure'),
+      );
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Business API mode
+  // --------------------------------------------------------------------------
+
+  // 16. Business API start sets healthy
+  it('business-api start() sets healthy immediately', async () => {
+    const { plugin } = await startedBusinessPlugin();
+    expect(plugin.isHealthy()).toBe(true);
+  });
+
+  // 17. Business API missing config throws
+  it('business-api throws when phoneNumberId is missing', async () => {
+    const plugin = new WhatsAppChannel({
+      mode: 'business-api',
+    } as any);
+    await plugin.initialize(makeContext());
+
+    await expect(plugin.start()).rejects.toThrow('phoneNumberId and accessToken');
+  });
+
+  // 18. Business API webhook verification
+  it('business-api webhook verification succeeds with correct token', async () => {
+    const { plugin } = await startedBusinessPlugin();
+
+    const routes: Array<{ method: string; path: string; handler: Function }> = [];
+    const mockRouter = {
+      get: (path: string, handler: Function) => routes.push({ method: 'GET', path, handler }),
+      post: (path: string, handler: Function) => routes.push({ method: 'POST', path, handler }),
+      route: vi.fn(),
+    };
+    plugin.registerWebhooks!(mockRouter as any);
+
+    const verifyRoute = routes.find((r) => r.path === '/verify');
+    expect(verifyRoute).toBeDefined();
+
+    const result = await verifyRoute!.handler({
+      query: {
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'verify-token',
+        'hub.challenge': 'challenge-123',
+      },
+    });
+    expect(result.status).toBe(200);
+    expect(result.body).toBe('challenge-123');
+  });
+
+  // 19. Business API webhook verification rejects bad token
+  it('business-api webhook rejects incorrect verify token', async () => {
+    const { plugin } = await startedBusinessPlugin();
+
+    const routes: Array<{ method: string; path: string; handler: Function }> = [];
+    const mockRouter = {
+      get: (path: string, handler: Function) => routes.push({ method: 'GET', path, handler }),
+      post: (path: string, handler: Function) => routes.push({ method: 'POST', path, handler }),
+      route: vi.fn(),
+    };
+    plugin.registerWebhooks!(mockRouter as any);
+
+    const verifyRoute = routes.find((r) => r.path === '/verify');
+    const result = await verifyRoute!.handler({
+      query: {
+        'hub.mode': 'subscribe',
+        'hub.verify_token': 'wrong-token',
+        'hub.challenge': 'challenge-123',
+      },
+    });
+    expect(result.status).toBe(403);
+  });
+
+  // 20. Business API incoming webhook processes messages
+  it('business-api processes incoming webhook messages', async () => {
+    const { plugin, context } = await startedBusinessPlugin();
+
+    const routes: Array<{ method: string; path: string; handler: Function }> = [];
+    const mockRouter = {
+      get: (path: string, handler: Function) => routes.push({ method: 'GET', path, handler }),
+      post: (path: string, handler: Function) => routes.push({ method: 'POST', path, handler }),
+      route: vi.fn(),
+    };
+    plugin.registerWebhooks!(mockRouter as any);
+
+    const incomingRoute = routes.find((r) => r.path === '/incoming');
+    await incomingRoute!.handler({
+      body: {
+        entry: [{
+          changes: [{
+            value: {
+              messages: [{
+                from: '5511999999999',
+                id: 'wamid.123',
+                type: 'text',
+                text: { body: 'hello from business api' },
+                timestamp: '1234567890',
+              }],
+              contacts: [{
+                profile: { name: 'Bob' },
+                wa_id: '5511999999999',
+              }],
+            },
+          }],
+        }],
+      },
+    });
+
+    expect(context.onMessage).toHaveBeenCalledOnce();
+    const gateway = (context.onMessage as any).mock.calls[0][0];
+    expect(gateway.content).toBe('hello from business api');
+    expect(gateway.senderName).toBe('Bob');
+    expect(gateway.sessionId).toBe('whatsapp:5511999999999@s.whatsapp.net');
+  });
+
+  // 21. Business API send uses fetch
+  it('business-api send() calls the WhatsApp API', async () => {
+    const { plugin, context } = await startedBusinessPlugin();
+
+    // Populate session map via webhook
+    const routes: Array<{ method: string; path: string; handler: Function }> = [];
+    const mockRouter = {
+      get: (path: string, handler: Function) => routes.push({ method: 'GET', path, handler }),
+      post: (path: string, handler: Function) => routes.push({ method: 'POST', path, handler }),
+      route: vi.fn(),
+    };
+    plugin.registerWebhooks!(mockRouter as any);
+
+    const incomingRoute = routes.find((r) => r.path === '/incoming');
+    await incomingRoute!.handler({
+      body: {
+        entry: [{
+          changes: [{
+            value: {
+              messages: [{
+                from: '5511999999999',
+                id: 'wamid.123',
+                type: 'text',
+                text: { body: 'hi' },
+                timestamp: '1234567890',
+              }],
+              contacts: [],
+            },
+          }],
+        }],
+      },
+    });
+
+    // Mock fetch for send
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ messages: [{ id: 'wamid.456' }] }), { status: 200 }),
+    );
+
+    await plugin.send({
+      sessionId: 'whatsapp:5511999999999@s.whatsapp.net',
+      content: 'reply',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('phone-123/messages'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'Authorization': 'Bearer test-token',
+        }),
+      }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  // 22. Business API phone number filtering
+  it('business-api filters messages by allowedNumbers', async () => {
+    const { plugin, context } = await startedBusinessPlugin({ allowedNumbers: ['1234567890'] });
+
+    const routes: Array<{ method: string; path: string; handler: Function }> = [];
+    const mockRouter = {
+      get: (path: string, handler: Function) => routes.push({ method: 'GET', path, handler }),
+      post: (path: string, handler: Function) => routes.push({ method: 'POST', path, handler }),
+      route: vi.fn(),
+    };
+    plugin.registerWebhooks!(mockRouter as any);
+
+    const incomingRoute = routes.find((r) => r.path === '/incoming');
+    await incomingRoute!.handler({
+      body: {
+        entry: [{
+          changes: [{
+            value: {
+              messages: [{
+                from: '5511999999999',
+                id: 'wamid.123',
+                type: 'text',
+                text: { body: 'filtered' },
+                timestamp: '1234567890',
+              }],
+              contacts: [],
+            },
+          }],
+        }],
+      },
+    });
+
+    expect(context.onMessage).not.toHaveBeenCalled();
+  });
+
+  // 23. No webhooks registered for baileys mode
+  it('baileys mode does not register webhooks', async () => {
+    const plugin = await startedBaileysPlugin();
+
+    const routes: Array<{ method: string; path: string; handler: Function }> = [];
+    const mockRouter = {
+      get: (path: string, handler: Function) => routes.push({ method: 'GET', path, handler }),
+      post: (path: string, handler: Function) => routes.push({ method: 'POST', path, handler }),
+      route: vi.fn(),
+    };
+    plugin.registerWebhooks!(mockRouter as any);
+
+    expect(routes).toHaveLength(0);
+  });
+
+  // 24. Baileys skips messages without message field
+  it('baileys skips messages without message content', async () => {
+    const ctx = makeContext();
+    await startedBaileysPlugin({}, ctx);
+
+    const handler = getEvHandler('messages.upsert');
+    await handler!({ messages: [{ key: { remoteJid: '123@s.whatsapp.net', fromMe: false } }] });
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(ctx.onMessage).not.toHaveBeenCalled();
+  });
+});

--- a/runtime/src/channels/whatsapp/plugin.ts
+++ b/runtime/src/channels/whatsapp/plugin.ts
@@ -1,0 +1,394 @@
+/**
+ * WhatsApp channel plugin — bridges WhatsApp to the Gateway.
+ *
+ * Supports two modes:
+ * - **Baileys**: Uses @whiskeysockets/baileys for WebSocket-based connection
+ *   (no official API credentials needed). Good for development/self-hosted use.
+ * - **Business API**: Uses the official WhatsApp Business API with webhook for
+ *   inbound and REST for outbound. Requires a Meta Business account.
+ *
+ * @module
+ */
+
+import { BaseChannelPlugin } from '../../gateway/channel.js';
+import type { WebhookRouter } from '../../gateway/channel.js';
+import type { OutboundMessage, MessageAttachment } from '../../gateway/message.js';
+import { createGatewayMessage } from '../../gateway/message.js';
+import { GatewayConnectionError } from '../../gateway/errors.js';
+import { DEFAULT_MAX_ATTACHMENT_BYTES } from '../../gateway/media.js';
+import { ensureLazyModule } from '../../utils/lazy-import.js';
+import type { WhatsAppChannelConfig } from './types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const SESSION_PREFIX = 'whatsapp';
+const BUSINESS_API_BASE = 'https://graph.facebook.com/v21.0';
+
+// ============================================================================
+// @whiskeysockets/baileys type shims (loaded lazily)
+// ============================================================================
+
+interface BaileysSocket {
+  ev: BaileysEventEmitter;
+  sendMessage(jid: string, content: { text: string }): Promise<unknown>;
+  end(reason?: Error): void;
+}
+
+interface BaileysEventEmitter {
+  on(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+interface BaileysMessage {
+  key: {
+    remoteJid?: string | null;
+    fromMe?: boolean;
+    id?: string;
+  };
+  message?: {
+    conversation?: string;
+    extendedTextMessage?: { text?: string };
+    imageMessage?: { url?: string; mimetype?: string; fileLength?: number | bigint; caption?: string };
+    documentMessage?: { url?: string; mimetype?: string; fileName?: string; fileLength?: number | bigint };
+    audioMessage?: { url?: string; mimetype?: string; fileLength?: number | bigint };
+    videoMessage?: { url?: string; mimetype?: string; fileLength?: number | bigint; caption?: string };
+  };
+  pushName?: string;
+}
+
+interface BaileysAuthState {
+  state: unknown;
+  saveCreds: () => Promise<void>;
+}
+
+interface BaileysModule {
+  default: (opts: {
+    auth: unknown;
+    printQRInTerminal?: boolean;
+  }) => BaileysSocket;
+  useMultiFileAuthState: (path: string) => Promise<BaileysAuthState>;
+}
+
+// ============================================================================
+// WhatsAppChannel Plugin
+// ============================================================================
+
+export class WhatsAppChannel extends BaseChannelPlugin {
+  readonly name = SESSION_PREFIX;
+
+  private socket: BaileysSocket | null = null;
+  private healthy = false;
+  private readonly config: WhatsAppChannelConfig;
+  private readonly sessionMap = new Map<string, string>(); // sessionId → jid/phone
+
+  constructor(config: WhatsAppChannelConfig) {
+    super();
+    this.config = config;
+  }
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
+
+  async start(): Promise<void> {
+    if (this.config.mode === 'baileys') {
+      await this.startBaileys();
+    } else {
+      this.startBusinessApi();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.socket) {
+      this.socket.end();
+      this.socket = null;
+    }
+    this.healthy = false;
+    this.sessionMap.clear();
+  }
+
+  override isHealthy(): boolean {
+    return this.healthy;
+  }
+
+  // --------------------------------------------------------------------------
+  // Webhooks (Business API mode)
+  // --------------------------------------------------------------------------
+
+  registerWebhooks(router: WebhookRouter): void {
+    if (this.config.mode !== 'business-api') return;
+
+    router.get('/verify', async (req) => {
+      const mode = req.query['hub.mode'];
+      const token = req.query['hub.verify_token'];
+      const challenge = req.query['hub.challenge'];
+
+      if (mode === 'subscribe' && token === this.config.webhookVerifyToken) {
+        return { status: 200, body: challenge };
+      }
+      return { status: 403, body: 'Forbidden' };
+    });
+
+    router.post('/incoming', async (req) => {
+      try {
+        await this.handleBusinessApiWebhook(req.body);
+      } catch (err) {
+        this.context.logger.error(`Error handling WhatsApp webhook: ${errorMessage(err)}`);
+      }
+      return { status: 200, body: 'OK' };
+    });
+  }
+
+  // --------------------------------------------------------------------------
+  // Outbound
+  // --------------------------------------------------------------------------
+
+  async send(message: OutboundMessage): Promise<void> {
+    const target = this.sessionMap.get(message.sessionId);
+    if (!target) {
+      this.context.logger.warn(`Cannot resolve target for session: ${message.sessionId}`);
+      return;
+    }
+
+    try {
+      if (this.config.mode === 'baileys') {
+        await this.sendBaileys(target, message.content);
+      } else {
+        await this.sendBusinessApi(target, message.content);
+      }
+    } catch (err) {
+      this.context.logger.error(`Failed to send message to ${message.sessionId}: ${errorMessage(err)}`);
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Baileys mode
+  // --------------------------------------------------------------------------
+
+  private async startBaileys(): Promise<void> {
+    const mod = await ensureLazyModule<BaileysModule>(
+      '@whiskeysockets/baileys',
+      (msg) => new GatewayConnectionError(msg),
+      (m) => m as unknown as BaileysModule,
+    );
+
+    const sessionPath = this.config.sessionPath ?? './whatsapp-session';
+    const { state, saveCreds } = await mod.useMultiFileAuthState(sessionPath);
+
+    const socket = mod.default({
+      auth: state,
+      printQRInTerminal: true,
+    });
+    this.socket = socket;
+
+    socket.ev.on('creds.update', () => {
+      saveCreds().catch((err) => {
+        this.context.logger.error(`Failed to save credentials: ${errorMessage(err)}`);
+      });
+    });
+
+    socket.ev.on('connection.update', (update: unknown) => {
+      const u = update as { connection?: string; lastDisconnect?: { error?: Error } };
+      if (u.connection === 'open') {
+        this.healthy = true;
+        this.context.logger.info('WhatsApp connected via Baileys');
+      } else if (u.connection === 'close') {
+        this.healthy = false;
+        this.context.logger.warn('WhatsApp connection closed');
+      }
+    });
+
+    socket.ev.on('messages.upsert', (upsert: unknown) => {
+      const { messages } = upsert as { messages: BaileysMessage[] };
+      for (const msg of messages) {
+        this.handleBaileysMessage(msg).catch((err) => {
+          this.context.logger.error(`Error handling WhatsApp message: ${errorMessage(err)}`);
+        });
+      }
+    });
+  }
+
+  private async handleBaileysMessage(msg: BaileysMessage): Promise<void> {
+    if (msg.key.fromMe) return;
+    if (!msg.key.remoteJid) return;
+    if (!msg.message) return;
+
+    const jid = msg.key.remoteJid;
+    const phone = jid.split('@')[0];
+
+    if (this.config.allowedNumbers && this.config.allowedNumbers.length > 0) {
+      if (!this.config.allowedNumbers.includes(phone)) return;
+    }
+
+    const sessionId = `${SESSION_PREFIX}:${jid}`;
+    this.sessionMap.set(sessionId, jid);
+
+    const text = this.extractBaileysText(msg);
+    const attachments = this.extractBaileysAttachments(msg);
+
+    const gateway = createGatewayMessage({
+      channel: this.name,
+      senderId: phone,
+      senderName: msg.pushName ?? phone,
+      sessionId,
+      content: text,
+      attachments: attachments.length > 0 ? attachments : undefined,
+      metadata: {
+        remoteJid: jid,
+        messageId: msg.key.id,
+      },
+      scope: 'dm',
+    });
+
+    await this.context.onMessage(gateway);
+  }
+
+  private extractBaileysText(msg: BaileysMessage): string {
+    if (!msg.message) return '';
+    return msg.message.conversation
+      ?? msg.message.extendedTextMessage?.text
+      ?? msg.message.imageMessage?.caption
+      ?? msg.message.videoMessage?.caption
+      ?? '';
+  }
+
+  private extractBaileysAttachments(msg: BaileysMessage): MessageAttachment[] {
+    if (!msg.message) return [];
+    const maxBytes = this.config.maxAttachmentBytes ?? DEFAULT_MAX_ATTACHMENT_BYTES;
+    const result: MessageAttachment[] = [];
+
+    const checks: Array<{ data: { url?: string; mimetype?: string; fileLength?: number | bigint; fileName?: string } | undefined; type: string }> = [
+      { data: msg.message.imageMessage, type: 'image' },
+      { data: msg.message.audioMessage, type: 'audio' },
+      { data: msg.message.videoMessage, type: 'video' },
+      { data: msg.message.documentMessage, type: 'file' },
+    ];
+
+    for (const { data, type } of checks) {
+      if (!data?.url) continue;
+      const size = Number(data.fileLength ?? 0);
+      if (size > maxBytes) continue;
+
+      result.push({
+        type,
+        url: data.url,
+        mimeType: data.mimetype ?? 'application/octet-stream',
+        filename: (data as { fileName?: string }).fileName,
+        sizeBytes: size || undefined,
+      });
+    }
+
+    return result;
+  }
+
+  private async sendBaileys(jid: string, text: string): Promise<void> {
+    if (!this.socket) {
+      this.context.logger.warn('Cannot send message: WhatsApp socket is not connected');
+      return;
+    }
+    await this.socket.sendMessage(jid, { text });
+  }
+
+  // --------------------------------------------------------------------------
+  // Business API mode
+  // --------------------------------------------------------------------------
+
+  private startBusinessApi(): void {
+    if (!this.config.phoneNumberId || !this.config.accessToken) {
+      throw new GatewayConnectionError(
+        'WhatsApp Business API mode requires phoneNumberId and accessToken',
+      );
+    }
+    this.healthy = true;
+    this.context.logger.info('WhatsApp Business API mode ready (webhook-based)');
+  }
+
+  private async handleBusinessApiWebhook(body: unknown): Promise<void> {
+    const payload = body as {
+      entry?: Array<{
+        changes?: Array<{
+          value?: {
+            messages?: Array<{
+              from: string;
+              id: string;
+              type: string;
+              text?: { body: string };
+              timestamp: string;
+            }>;
+            contacts?: Array<{ profile?: { name?: string }; wa_id: string }>;
+          };
+        }>;
+      }>;
+    };
+
+    const entries = payload?.entry ?? [];
+    for (const entry of entries) {
+      const changes = entry.changes ?? [];
+      for (const change of changes) {
+        const messages = change.value?.messages ?? [];
+        const contacts = change.value?.contacts ?? [];
+
+        for (const msg of messages) {
+          const phone = msg.from;
+
+          if (this.config.allowedNumbers && this.config.allowedNumbers.length > 0) {
+            if (!this.config.allowedNumbers.includes(phone)) continue;
+          }
+
+          const sessionId = `${SESSION_PREFIX}:${phone}@s.whatsapp.net`;
+          this.sessionMap.set(sessionId, phone);
+
+          const contact = contacts.find((c) => c.wa_id === phone);
+          const senderName = contact?.profile?.name ?? phone;
+
+          const gateway = createGatewayMessage({
+            channel: this.name,
+            senderId: phone,
+            senderName,
+            sessionId,
+            content: msg.text?.body ?? '',
+            metadata: {
+              messageId: msg.id,
+              messageType: msg.type,
+              phone,
+            },
+            scope: 'dm',
+          });
+
+          await this.context.onMessage(gateway);
+        }
+      }
+    }
+  }
+
+  private async sendBusinessApi(phone: string, text: string): Promise<void> {
+    const url = `${BUSINESS_API_BASE}/${this.config.phoneNumberId}/messages`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.config.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        to: phone,
+        text: { body: text },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`WhatsApp Business API error: ${response.status} ${response.statusText}`);
+    }
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Extract a safe error message string. */
+function errorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}

--- a/runtime/src/channels/whatsapp/types.ts
+++ b/runtime/src/channels/whatsapp/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Configuration interface for the WhatsApp channel plugin.
+ *
+ * Supports two modes:
+ * - `baileys`: WebSocket-based connection via @whiskeysockets/baileys (no business API needed)
+ * - `business-api`: Official WhatsApp Business API via webhook + REST
+ *
+ * @module
+ */
+
+export interface WhatsAppChannelConfig {
+  /** Connection mode. */
+  readonly mode: 'baileys' | 'business-api';
+
+  // --- Baileys mode ---
+  /** Path to store authentication state (baileys mode). */
+  readonly sessionPath?: string;
+
+  // --- Business API mode ---
+  /** WhatsApp Business API phone number ID (business-api mode). */
+  readonly phoneNumberId?: string;
+  /** Access token for the WhatsApp Business API (business-api mode). */
+  readonly accessToken?: string;
+  /** Webhook verify token for the Business API (business-api mode). */
+  readonly webhookVerifyToken?: string;
+
+  // --- Common ---
+  /** Restrict to specific phone numbers. Empty = all numbers. */
+  readonly allowedNumbers?: readonly string[];
+  /** Maximum attachment size in bytes. @default 25 * 1024 * 1024 (25 MB) */
+  readonly maxAttachmentBytes?: number;
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1418,6 +1418,14 @@ export {
   DiscordChannel,
   type DiscordChannelConfig,
   type DiscordIntentName,
+  SlackChannel,
+  type SlackChannelConfig,
+  WhatsAppChannel,
+  type WhatsAppChannelConfig,
+  SignalChannel,
+  type SignalChannelConfig,
+  MatrixChannel,
+  type MatrixChannelConfig,
 } from './channels/index.js';
 
 // Governance Operations (Phase 10)


### PR DESCRIPTION
## Summary

Closes #1098

- Implements four new channel plugins extending the Gateway message dispatch system beyond Telegram and Discord
- **Slack**: Socket Mode via `@slack/bolt`, thread support, channel ID filtering
- **WhatsApp**: Dual-mode support (Business API + Baileys), phone number filtering
- **Signal**: `signal-cli` daemon bridge with JSON parsing, configurable trust modes
- **Matrix**: `matrix-js-sdk` integration with optional E2EE, auto-join on invite, room filtering
- All plugins follow the `ChannelPlugin` interface from Phase 1.3 with lazy SDK imports, graceful shutdown, and reconnection handling
- Platform SDKs added as optional peer dependencies

## Test plan

- [ ] `npm run test` passes (runtime vitest suite including new channel plugin tests)
- [ ] `npm run build` succeeds with new externals
- [ ] `npm run typecheck` passes
- [ ] Verify each plugin test file covers: init, message conversion, filtering, shutdown, missing SDK error