### PR TITLE
feat(runtime): registry CLI commands for on-chain skill operations (#1090)

### DIFF
--- a/runtime/src/cli/registry-cli.test.ts
+++ b/runtime/src/cli/registry-cli.test.ts
@@ -1,0 +1,652 @@
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CliRuntimeContext } from './types.js';
+import type { SkillRegistryClient, SkillListing, SkillListingEntry } from '../skills/registry/types.js';
+import {
+  SkillRegistryNotFoundError,
+  SkillDownloadError,
+  SkillVerificationError,
+  SkillPublishError,
+} from '../skills/registry/errors.js';
+import {
+  runRegistrySearchCommand,
+  runRegistryInstallCommand,
+  runRegistryPublishCommand,
+  runRegistryRateCommand,
+  runRegistryVerifyCommand,
+  runImportOpenclawCommand,
+} from './registry-cli.js';
+
+function createContextCapture(): { context: CliRuntimeContext; outputs: unknown[]; errors: unknown[] } {
+  const outputs: unknown[] = [];
+  const errors: unknown[] = [];
+  return {
+    context: {
+      logger: {
+        error: vi.fn(),
+        warn: vi.fn(),
+        info: vi.fn(),
+        debug: vi.fn(),
+      },
+      outputFormat: 'json',
+      output: (value) => outputs.push(value),
+      error: (value) => errors.push(value),
+    },
+    outputs,
+    errors,
+  };
+}
+
+function makeListing(overrides: Partial<SkillListing> = {}): SkillListing {
+  return {
+    id: 'test-skill',
+    name: 'Test Skill',
+    description: 'A test skill',
+    version: '1.0.0',
+    author: '11111111111111111111111111111111',
+    downloads: 42,
+    rating: 4.5,
+    ratingCount: 10,
+    tags: ['defi'],
+    contentHash: 'abc123',
+    priceLamports: 0n,
+    registeredAt: new Date('2025-01-01'),
+    updatedAt: new Date('2025-06-01'),
+    ...overrides,
+  };
+}
+
+function makeEntry(overrides: Partial<SkillListingEntry> = {}): SkillListingEntry {
+  return {
+    id: 'test-skill',
+    name: 'Test Skill',
+    author: '11111111111111111111111111111111',
+    rating: 4.5,
+    tags: ['defi'],
+    priceLamports: 0n,
+    ...overrides,
+  };
+}
+
+function createMockClient(overrides: Partial<SkillRegistryClient> = {}): SkillRegistryClient {
+  return {
+    search: vi.fn().mockResolvedValue([makeEntry()]),
+    get: vi.fn().mockResolvedValue(makeListing()),
+    install: vi.fn().mockResolvedValue(makeListing()),
+    publish: vi.fn().mockResolvedValue('abc123hash'),
+    rate: vi.fn().mockResolvedValue(undefined),
+    listByAuthor: vi.fn().mockResolvedValue([makeEntry()]),
+    verify: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+const VALID_SKILL_MD = `---
+name: test-skill
+description: A test skill
+version: 1.0.0
+metadata:
+  agenc:
+    tags:
+      - testing
+    requires:
+      binaries: []
+      env: []
+      channels: []
+      os: []
+    install: []
+---
+
+# Test Skill
+
+This is a test skill body.
+`;
+
+const OPENCLAW_SKILL_MD = `---
+name: openclaw-test
+description: An OpenClaw skill
+version: 0.1.0
+metadata:
+  openclaw:
+    tags:
+      - compat
+    requires:
+      binaries: []
+      env: []
+      channels: []
+      os: []
+    install: []
+---
+
+# OpenClaw Skill
+
+Body.
+`;
+
+describe('registry-cli', () => {
+  let workspace: string;
+  let userSkillsDir: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'agenc-registry-cli-'));
+    userSkillsDir = join(workspace, 'skills');
+    mkdirSync(userSkillsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  // =========================================================================
+  // search
+  // =========================================================================
+
+  describe('search', () => {
+    it('returns results with correct schema', async () => {
+      const client = createMockClient();
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistrySearchCommand(
+        context,
+        { query: 'defi', rpcUrl: 'http://localhost:8899' },
+        { client },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.status).toBe('ok');
+      expect(payload.command).toBe('skill.search');
+      expect(payload.schema).toBe('skill.search.output.v1');
+      expect(payload.query).toBe('defi');
+      expect(payload.count).toBe(1);
+      expect(payload.results).toHaveLength(1);
+    });
+
+    it('returns empty results', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockResolvedValue([]),
+      });
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistrySearchCommand(
+        context,
+        { query: 'nonexistent', rpcUrl: 'http://localhost:8899' },
+        { client },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.count).toBe(0);
+      expect(payload.results).toEqual([]);
+    });
+
+    it('passes tags and limit to client', async () => {
+      const searchFn = vi.fn().mockResolvedValue([]);
+      const client = createMockClient({ search: searchFn });
+      const { context } = createContextCapture();
+
+      await runRegistrySearchCommand(
+        context,
+        { query: 'swap', tags: ['defi', 'dex'], limit: 5, rpcUrl: 'http://localhost:8899' },
+        { client },
+      );
+
+      expect(searchFn).toHaveBeenCalledWith('swap', { tags: ['defi', 'dex'], limit: 5 });
+    });
+
+    it('errors on network failure', async () => {
+      const client = createMockClient({
+        search: vi.fn().mockRejectedValue(new Error('Connection refused')),
+      });
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistrySearchCommand(
+        context,
+        { query: 'defi', rpcUrl: 'http://localhost:8899' },
+        { client },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('REGISTRY_ERROR');
+    });
+
+    it('errors when no RPC configured', async () => {
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistrySearchCommand(context, { query: 'defi' });
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('RPC_NOT_CONFIGURED');
+    });
+  });
+
+  // =========================================================================
+  // registry-install
+  // =========================================================================
+
+  describe('registry-install', () => {
+    it('installs a skill successfully', async () => {
+      const client = createMockClient();
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistryInstallCommand(
+        context,
+        { skillId: 'test-skill', rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.status).toBe('ok');
+      expect(payload.command).toBe('skill.registry-install');
+      expect(payload.skillId).toBe('test-skill');
+    });
+
+    it('errors on SkillRegistryNotFoundError', async () => {
+      const client = createMockClient({
+        install: vi.fn().mockRejectedValue(new SkillRegistryNotFoundError('missing-skill')),
+      });
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryInstallCommand(
+        context,
+        { skillId: 'missing-skill', rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('SKILL_NOT_FOUND');
+    });
+
+    it('errors on SkillDownloadError', async () => {
+      const client = createMockClient({
+        install: vi.fn().mockRejectedValue(new SkillDownloadError('test-skill', 'timeout')),
+      });
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryInstallCommand(
+        context,
+        { skillId: 'test-skill', rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('DOWNLOAD_FAILED');
+    });
+
+    it('errors on SkillVerificationError', async () => {
+      const client = createMockClient({
+        install: vi.fn().mockRejectedValue(new SkillVerificationError('test-skill', 'abc', 'def')),
+      });
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryInstallCommand(
+        context,
+        { skillId: 'test-skill', rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('VERIFICATION_FAILED');
+    });
+
+    it('errors when no RPC configured', async () => {
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryInstallCommand(
+        context,
+        { skillId: 'test-skill' },
+        { userSkillsDir },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('RPC_NOT_CONFIGURED');
+    });
+  });
+
+  // =========================================================================
+  // publish
+  // =========================================================================
+
+  describe('publish', () => {
+    it('publishes successfully with hash output', async () => {
+      const skillPath = join(workspace, 'skill.md');
+      writeFileSync(skillPath, VALID_SKILL_MD, 'utf-8');
+
+      const client = createMockClient();
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistryPublishCommand(
+        context,
+        { skillPath, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.status).toBe('ok');
+      expect(payload.command).toBe('skill.publish');
+      expect(payload.contentHash).toBe('abc123hash');
+      expect(payload.name).toBe('test-skill');
+    });
+
+    it('errors when no wallet', async () => {
+      const skillPath = join(workspace, 'skill.md');
+      writeFileSync(skillPath, VALID_SKILL_MD, 'utf-8');
+
+      const client = createMockClient();
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryPublishCommand(
+        context,
+        { skillPath, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: undefined },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('WALLET_NOT_FOUND');
+    });
+
+    it('errors when file not found', async () => {
+      const client = createMockClient();
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryPublishCommand(
+        context,
+        { skillPath: '/nonexistent/path.md', rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('SOURCE_NOT_FOUND');
+    });
+
+    it('errors on SkillPublishError', async () => {
+      const skillPath = join(workspace, 'skill.md');
+      writeFileSync(skillPath, VALID_SKILL_MD, 'utf-8');
+
+      const client = createMockClient({
+        publish: vi.fn().mockRejectedValue(new SkillPublishError(skillPath, 'invalid format')),
+      });
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryPublishCommand(
+        context,
+        { skillPath, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('PUBLISH_FAILED');
+    });
+
+    it('converts --price string to bigint', async () => {
+      const skillPath = join(workspace, 'skill.md');
+      writeFileSync(skillPath, VALID_SKILL_MD, 'utf-8');
+
+      const publishFn = vi.fn().mockResolvedValue('hash123');
+      const client = createMockClient({ publish: publishFn });
+      const { context } = createContextCapture();
+
+      await runRegistryPublishCommand(
+        context,
+        { skillPath, priceLamports: '1000000', rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      const metadata = publishFn.mock.calls[0][1];
+      expect(metadata.priceLamports).toBe(1000000n);
+    });
+  });
+
+  // =========================================================================
+  // rate
+  // =========================================================================
+
+  describe('rate', () => {
+    it('rates successfully', async () => {
+      const client = createMockClient();
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistryRateCommand(
+        context,
+        { skillId: 'test-skill', rating: 5, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.status).toBe('ok');
+      expect(payload.command).toBe('skill.rate');
+      expect(payload.skillId).toBe('test-skill');
+      expect(payload.rating).toBe(5);
+    });
+
+    it('rejects rating 0', async () => {
+      const client = createMockClient();
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryRateCommand(
+        context,
+        { skillId: 'test-skill', rating: 0, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('INVALID_VALUE');
+    });
+
+    it('rejects rating 6', async () => {
+      const client = createMockClient();
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryRateCommand(
+        context,
+        { skillId: 'test-skill', rating: 6, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('INVALID_VALUE');
+    });
+
+    it('rejects non-integer rating', async () => {
+      const client = createMockClient();
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryRateCommand(
+        context,
+        { skillId: 'test-skill', rating: 3.5, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('INVALID_VALUE');
+    });
+
+    it('errors when no wallet', async () => {
+      const client = createMockClient();
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryRateCommand(
+        context,
+        { skillId: 'test-skill', rating: 4, rpcUrl: 'http://localhost:8899' },
+        { client, wallet: undefined },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('WALLET_NOT_FOUND');
+    });
+
+    it('passes review text', async () => {
+      const rateFn = vi.fn().mockResolvedValue(undefined);
+      const client = createMockClient({ rate: rateFn });
+      const { context, outputs } = createContextCapture();
+
+      await runRegistryRateCommand(
+        context,
+        { skillId: 'test-skill', rating: 5, review: 'Excellent!', rpcUrl: 'http://localhost:8899' },
+        { client, wallet: {} },
+      );
+
+      expect(rateFn).toHaveBeenCalledWith('test-skill', 5, 'Excellent!');
+      const payload = outputs[0] as any;
+      expect(payload.review).toBe('Excellent!');
+    });
+  });
+
+  // =========================================================================
+  // verify
+  // =========================================================================
+
+  describe('verify', () => {
+    it('verified true when hashes match', async () => {
+      const content = VALID_SKILL_MD;
+      const hash = createHash('sha256').update(Buffer.from(content, 'utf-8')).digest('hex');
+
+      const filePath = join(userSkillsDir, 'test-skill.md');
+      writeFileSync(filePath, content, 'utf-8');
+
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue(makeListing({ contentHash: hash })),
+      });
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistryVerifyCommand(
+        context,
+        { skillId: 'test-skill', rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.verified).toBe(true);
+      expect(payload.localHash).toBe(hash);
+      expect(payload.onChainHash).toBe(hash);
+    });
+
+    it('reports on-chain hash when no local file exists', async () => {
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue(makeListing({ contentHash: 'onchain123' })),
+      });
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistryVerifyCommand(
+        context,
+        { skillId: 'nonexistent-skill', rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.verified).toBeNull();
+      expect(payload.onChainHash).toBe('onchain123');
+      expect(payload.localFile).toBeNull();
+    });
+
+    it('errors when skill not found', async () => {
+      const client = createMockClient({
+        get: vi.fn().mockRejectedValue(new SkillRegistryNotFoundError('missing')),
+      });
+      const { context, errors } = createContextCapture();
+
+      const code = await runRegistryVerifyCommand(
+        context,
+        { skillId: 'missing', rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('SKILL_NOT_FOUND');
+    });
+
+    it('uses explicit --path flag', async () => {
+      const content = 'custom content';
+      const hash = createHash('sha256').update(Buffer.from(content, 'utf-8')).digest('hex');
+
+      const customPath = join(workspace, 'custom.md');
+      writeFileSync(customPath, content, 'utf-8');
+
+      const client = createMockClient({
+        get: vi.fn().mockResolvedValue(makeListing({ contentHash: hash })),
+      });
+      const { context, outputs } = createContextCapture();
+
+      const code = await runRegistryVerifyCommand(
+        context,
+        { skillId: 'test-skill', localPath: customPath, rpcUrl: 'http://localhost:8899' },
+        { client, userSkillsDir },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.verified).toBe(true);
+      expect(payload.localFile).toBe(customPath);
+    });
+  });
+
+  // =========================================================================
+  // import-openclaw
+  // =========================================================================
+
+  describe('import-openclaw', () => {
+    it('converts openclaw skill', async () => {
+      const sourcePath = join(workspace, 'openclaw.md');
+      writeFileSync(sourcePath, OPENCLAW_SKILL_MD, 'utf-8');
+
+      const { context, outputs } = createContextCapture();
+
+      const code = await runImportOpenclawCommand(
+        context,
+        { source: sourcePath },
+        { userSkillsDir },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.status).toBe('ok');
+      expect(payload.command).toBe('skill.import-openclaw');
+      expect(payload.converted).toBe(true);
+      expect(payload.filePath).toContain('openclaw-test.md');
+
+      // Verify the file was written and converted
+      const written = readFileSync(payload.filePath, 'utf-8');
+      expect(written).toContain('agenc:');
+      expect(written).not.toContain('openclaw:');
+    });
+
+    it('passes through agenc skill unchanged', async () => {
+      const sourcePath = join(workspace, 'agenc.md');
+      writeFileSync(sourcePath, VALID_SKILL_MD, 'utf-8');
+
+      const { context, outputs } = createContextCapture();
+
+      const code = await runImportOpenclawCommand(
+        context,
+        { source: sourcePath },
+        { userSkillsDir },
+      );
+
+      expect(code).toBe(0);
+      const payload = outputs[0] as any;
+      expect(payload.converted).toBe(false);
+    });
+
+    it('errors for nonexistent source', async () => {
+      const { context, errors } = createContextCapture();
+
+      const code = await runImportOpenclawCommand(
+        context,
+        { source: '/nonexistent/file.md' },
+        { userSkillsDir },
+      );
+
+      expect(code).toBe(1);
+      expect((errors[0] as any).code).toBe('IMPORT_FAILED');
+    });
+  });
+});

--- a/runtime/src/cli/registry-cli.ts
+++ b/runtime/src/cli/registry-cli.ts
@@ -1,0 +1,390 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { Connection } from '@solana/web3.js';
+import { OnChainSkillRegistryClient } from '../skills/registry/client.js';
+import type { SkillRegistryClient } from '../skills/registry/types.js';
+import {
+  SkillRegistryNotFoundError,
+  SkillDownloadError,
+  SkillVerificationError,
+  SkillPublishError,
+} from '../skills/registry/errors.js';
+import { parseSkillContent } from '../skills/markdown/parser.js';
+import { importSkill } from '../skills/markdown/compat.js';
+import {
+  loadKeypairFromFile,
+  keypairToWallet,
+  getDefaultKeypairPath,
+} from '../types/wallet.js';
+import { getUserSkillsDir } from './skills-cli.js';
+import type { CliRuntimeContext, CliStatusCode } from './types.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createRegistryClient(
+  rpcUrl?: string,
+  logger?: Logger,
+): OnChainSkillRegistryClient | null {
+  if (!rpcUrl) return null;
+  return new OnChainSkillRegistryClient({
+    connection: new Connection(rpcUrl),
+    logger: logger ?? silentLogger,
+  });
+}
+
+async function loadWallet(
+  logger?: Logger,
+): Promise<ReturnType<typeof keypairToWallet> | undefined> {
+  const keypairPath = process.env.SOLANA_KEYPAIR_PATH ?? getDefaultKeypairPath();
+  try {
+    const keypair = await loadKeypairFromFile(keypairPath);
+    return keypairToWallet(keypair);
+  } catch {
+    (logger ?? silentLogger).debug(`Failed to load wallet from ${keypairPath}`);
+    return undefined;
+  }
+}
+
+// ============================================================================
+// Commands
+// ============================================================================
+
+export async function runRegistrySearchCommand(
+  context: CliRuntimeContext,
+  options: { query: string; tags?: string[]; limit?: number; rpcUrl?: string },
+  overrides?: { client?: SkillRegistryClient },
+): Promise<CliStatusCode> {
+  const client = overrides?.client ?? createRegistryClient(options.rpcUrl);
+  if (!client) {
+    context.error({
+      status: 'error',
+      code: 'RPC_NOT_CONFIGURED',
+      message: 'RPC URL is required for registry operations. Use --rpc <url>.',
+    });
+    return 1;
+  }
+
+  try {
+    const results = await client.search(options.query, {
+      tags: options.tags,
+      limit: options.limit,
+    });
+
+    context.output({
+      status: 'ok',
+      command: 'skill.search',
+      schema: 'skill.search.output.v1',
+      query: options.query,
+      count: results.length,
+      results,
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'REGISTRY_ERROR',
+      message: `Registry search failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runRegistryInstallCommand(
+  context: CliRuntimeContext,
+  options: { skillId: string; rpcUrl?: string },
+  overrides?: { client?: SkillRegistryClient; userSkillsDir?: string },
+): Promise<CliStatusCode> {
+  const client = overrides?.client ?? createRegistryClient(options.rpcUrl);
+  if (!client) {
+    context.error({
+      status: 'error',
+      code: 'RPC_NOT_CONFIGURED',
+      message: 'RPC URL is required for registry operations. Use --rpc <url>.',
+    });
+    return 1;
+  }
+
+  const dir = overrides?.userSkillsDir ?? getUserSkillsDir();
+
+  try {
+    const listing = await client.install(options.skillId, join(dir, `${options.skillId}.md`));
+
+    context.output({
+      status: 'ok',
+      command: 'skill.registry-install',
+      schema: 'skill.registry-install.output.v1',
+      skillId: listing.id,
+      skillName: listing.name,
+      filePath: join(dir, `${options.skillId}.md`),
+    });
+    return 0;
+  } catch (error) {
+    if (error instanceof SkillRegistryNotFoundError) {
+      context.error({
+        status: 'error',
+        code: 'SKILL_NOT_FOUND',
+        message: error.message,
+      });
+      return 1;
+    }
+    if (error instanceof SkillDownloadError) {
+      context.error({
+        status: 'error',
+        code: 'DOWNLOAD_FAILED',
+        message: error.message,
+      });
+      return 1;
+    }
+    if (error instanceof SkillVerificationError) {
+      context.error({
+        status: 'error',
+        code: 'VERIFICATION_FAILED',
+        message: error.message,
+      });
+      return 1;
+    }
+    context.error({
+      status: 'error',
+      code: 'REGISTRY_ERROR',
+      message: `Registry install failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runRegistryPublishCommand(
+  context: CliRuntimeContext,
+  options: { skillPath: string; tags?: string[]; priceLamports?: string; rpcUrl?: string },
+  overrides?: { client?: SkillRegistryClient; wallet?: unknown },
+): Promise<CliStatusCode> {
+  const client = overrides?.client ?? createRegistryClient(options.rpcUrl);
+  if (!client) {
+    context.error({
+      status: 'error',
+      code: 'RPC_NOT_CONFIGURED',
+      message: 'RPC URL is required for registry operations. Use --rpc <url>.',
+    });
+    return 1;
+  }
+
+  const wallet = overrides && 'wallet' in overrides ? overrides.wallet : await loadWallet();
+  if (!wallet) {
+    context.error({
+      status: 'error',
+      code: 'WALLET_NOT_FOUND',
+      message: 'Wallet is required for publishing. Set SOLANA_KEYPAIR_PATH or place a keypair at ~/.config/solana/id.json.',
+    });
+    return 1;
+  }
+
+  if (!existsSync(options.skillPath)) {
+    context.error({
+      status: 'error',
+      code: 'SOURCE_NOT_FOUND',
+      message: `Skill file not found: ${options.skillPath}`,
+    });
+    return 1;
+  }
+
+  try {
+    const content = await readFile(options.skillPath, 'utf-8');
+    const parsed = parseSkillContent(content, options.skillPath);
+
+    const priceLamports = options.priceLamports
+      ? BigInt(options.priceLamports)
+      : undefined;
+
+    const hash = await client.publish(options.skillPath, {
+      name: parsed.name,
+      description: parsed.description,
+      tags: options.tags,
+      priceLamports,
+    });
+
+    context.output({
+      status: 'ok',
+      command: 'skill.publish',
+      schema: 'skill.publish.output.v1',
+      skillPath: options.skillPath,
+      contentHash: hash,
+      name: parsed.name,
+    });
+    return 0;
+  } catch (error) {
+    if (error instanceof SkillPublishError) {
+      context.error({
+        status: 'error',
+        code: 'PUBLISH_FAILED',
+        message: error.message,
+      });
+      return 1;
+    }
+    context.error({
+      status: 'error',
+      code: 'REGISTRY_ERROR',
+      message: `Publish failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runRegistryRateCommand(
+  context: CliRuntimeContext,
+  options: { skillId: string; rating: number; review?: string; rpcUrl?: string },
+  overrides?: { client?: SkillRegistryClient; wallet?: unknown },
+): Promise<CliStatusCode> {
+  const client = overrides?.client ?? createRegistryClient(options.rpcUrl);
+  if (!client) {
+    context.error({
+      status: 'error',
+      code: 'RPC_NOT_CONFIGURED',
+      message: 'RPC URL is required for registry operations. Use --rpc <url>.',
+    });
+    return 1;
+  }
+
+  const wallet = overrides && 'wallet' in overrides ? overrides.wallet : await loadWallet();
+  if (!wallet) {
+    context.error({
+      status: 'error',
+      code: 'WALLET_NOT_FOUND',
+      message: 'Wallet is required for rating. Set SOLANA_KEYPAIR_PATH or place a keypair at ~/.config/solana/id.json.',
+    });
+    return 1;
+  }
+
+  if (!Number.isInteger(options.rating) || options.rating < 1 || options.rating > 5) {
+    context.error({
+      status: 'error',
+      code: 'INVALID_VALUE',
+      message: 'Rating must be an integer between 1 and 5.',
+    });
+    return 1;
+  }
+
+  try {
+    await client.rate(options.skillId, options.rating, options.review);
+
+    context.output({
+      status: 'ok',
+      command: 'skill.rate',
+      schema: 'skill.rate.output.v1',
+      skillId: options.skillId,
+      rating: options.rating,
+      ...(options.review ? { review: options.review } : {}),
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'REGISTRY_ERROR',
+      message: `Rating failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runRegistryVerifyCommand(
+  context: CliRuntimeContext,
+  options: { skillId: string; localPath?: string; rpcUrl?: string },
+  overrides?: { client?: SkillRegistryClient; userSkillsDir?: string },
+): Promise<CliStatusCode> {
+  const client = overrides?.client ?? createRegistryClient(options.rpcUrl);
+  if (!client) {
+    context.error({
+      status: 'error',
+      code: 'RPC_NOT_CONFIGURED',
+      message: 'RPC URL is required for registry operations. Use --rpc <url>.',
+    });
+    return 1;
+  }
+
+  try {
+    const listing = await client.get(options.skillId);
+    const dir = overrides?.userSkillsDir ?? getUserSkillsDir();
+
+    // Determine local file path: explicit --path or auto-detect from skills dir
+    const localFile = options.localPath ?? join(dir, `${options.skillId}.md`);
+    const hasLocalFile = existsSync(localFile);
+
+    if (!hasLocalFile) {
+      context.output({
+        status: 'ok',
+        command: 'skill.verify',
+        schema: 'skill.verify.output.v1',
+        skillId: options.skillId,
+        onChainHash: listing.contentHash,
+        localFile: null,
+        verified: null,
+        message: 'No local file found. On-chain hash reported.',
+      });
+      return 0;
+    }
+
+    const content = await readFile(localFile);
+    const localHash = createHash('sha256').update(content).digest('hex');
+    const verified = localHash === listing.contentHash;
+
+    context.output({
+      status: 'ok',
+      command: 'skill.verify',
+      schema: 'skill.verify.output.v1',
+      skillId: options.skillId,
+      onChainHash: listing.contentHash,
+      localHash,
+      localFile,
+      verified,
+    });
+    return 0;
+  } catch (error) {
+    if (error instanceof SkillRegistryNotFoundError) {
+      context.error({
+        status: 'error',
+        code: 'SKILL_NOT_FOUND',
+        message: error.message,
+      });
+      return 1;
+    }
+    context.error({
+      status: 'error',
+      code: 'REGISTRY_ERROR',
+      message: `Verification failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}
+
+export async function runImportOpenclawCommand(
+  context: CliRuntimeContext,
+  options: { source: string },
+  overrides?: { userSkillsDir?: string },
+): Promise<CliStatusCode> {
+  const dir = overrides?.userSkillsDir ?? getUserSkillsDir();
+
+  try {
+    const result = await importSkill(options.source, dir);
+
+    context.output({
+      status: 'ok',
+      command: 'skill.import-openclaw',
+      schema: 'skill.import-openclaw.output.v1',
+      source: options.source,
+      filePath: result.path,
+      converted: result.converted,
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: 'error',
+      code: 'IMPORT_FAILED',
+      message: `Import failed: ${error instanceof Error ? error.message : String(error)}`,
+    });
+    return 1;
+  }
+}

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -84,6 +84,13 @@ export interface SkillInstallOptions extends BaseCliOptions { source: string; }
 export interface SkillUninstallOptions extends BaseCliOptions { skillName: string; }
 export interface SkillToggleOptions extends BaseCliOptions { skillName: string; }
 
+export interface RegistrySearchOptions extends BaseCliOptions { query: string; tags?: string[]; limit?: number; }
+export interface RegistryInstallOptions extends BaseCliOptions { skillId: string; }
+export interface RegistryPublishOptions extends BaseCliOptions { skillPath: string; tags?: string[]; priceLamports?: string; }
+export interface RegistryRateOptions extends BaseCliOptions { skillId: string; rating: number; review?: string; }
+export interface RegistryVerifyOptions extends BaseCliOptions { skillId: string; localPath?: string; }
+export interface RegistryImportOpenclawOptions extends BaseCliOptions { source: string; }
+
 export type SkillCommandOptions =
   | SkillListOptions
   | SkillInfoOptions
@@ -91,7 +98,13 @@ export type SkillCommandOptions =
   | SkillCreateOptions
   | SkillInstallOptions
   | SkillUninstallOptions
-  | SkillToggleOptions;
+  | SkillToggleOptions
+  | RegistrySearchOptions
+  | RegistryInstallOptions
+  | RegistryPublishOptions
+  | RegistryRateOptions
+  | RegistryVerifyOptions
+  | RegistryImportOpenclawOptions;
 
 export interface CliUsage {
   command: string;


### PR DESCRIPTION
## Summary

- Add 6 CLI subcommands under `agenc-runtime skill` for on-chain registry operations: `search`, `registry-install`, `publish`, `rate`, `verify`, `import-openclaw`
- Each command wraps the `SkillRegistryClient` with structured JSON output, typed error mapping, and wallet/RPC validation
- Comprehensive test suite (25 tests) covering success paths, error variants, flag parsing, and edge cases

Closes #1090

## Test plan

- [ ] `npm run test` passes (runtime vitest suite)
- [ ] New tests in `registry-cli.test.ts` all pass
- [ ] No regressions in existing CLI tests