### PR TITLE
feat(runtime): message routing engine for multi-agent workspaces

### DIFF
--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -101,6 +101,10 @@ export {
   MEMORY_NAMESPACE_PREFIX,
 } from './workspace.js';
 
+// Routing rules (Phase 7.2)
+export type { RoutingMatch, RoutingRule } from './routing.js';
+export { MessageRouter, RoutingValidationError } from './routing.js';
+
 // Session isolation (Phase 7.3)
 export type { IsolatedSessionContext, SessionIsolationManagerConfig, AuthState } from './session-isolation.js';
 export { SessionIsolationManager } from './session-isolation.js';

--- a/runtime/src/gateway/routing.test.ts
+++ b/runtime/src/gateway/routing.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect } from 'vitest';
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+import {
+  MessageRouter,
+  RoutingValidationError,
+  type RoutingRule,
+  type GatewayMessage,
+} from './routing.js';
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+function makeMessage(overrides?: Partial<GatewayMessage>): GatewayMessage {
+  return {
+    id: 'test-id',
+    channel: 'telegram',
+    senderId: 'user-123',
+    senderName: 'Alice',
+    sessionId: 'session-abc',
+    content: 'Hello world',
+    timestamp: Date.now(),
+    scope: 'dm',
+    ...overrides,
+  };
+}
+
+function makeRule(overrides?: Partial<RoutingRule>): RoutingRule {
+  return {
+    name: 'rule-a',
+    match: {},
+    workspace: 'default',
+    priority: 0,
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// RoutingValidationError
+// ============================================================================
+
+describe('RoutingValidationError', () => {
+  it('has correct error code', () => {
+    const err = new RoutingValidationError('name', 'bad');
+    expect(err.code).toBe(RuntimeErrorCodes.GATEWAY_VALIDATION_ERROR);
+  });
+
+  it('has field and reason properties', () => {
+    const err = new RoutingValidationError('workspace', 'invalid format');
+    expect(err.field).toBe('workspace');
+    expect(err.reason).toBe('invalid format');
+  });
+
+  it('is instanceof RuntimeError', () => {
+    const err = new RoutingValidationError('x', 'y');
+    expect(err).toBeInstanceOf(RuntimeError);
+    expect(err).toBeInstanceOf(RoutingValidationError);
+  });
+
+  it('has descriptive message', () => {
+    const err = new RoutingValidationError('name', 'duplicate');
+    expect(err.message).toContain('name');
+    expect(err.message).toContain('duplicate');
+  });
+});
+
+// ============================================================================
+// MessageRouter — constructor
+// ============================================================================
+
+describe('MessageRouter', () => {
+  describe('constructor', () => {
+    it('accepts empty rules array', () => {
+      const router = new MessageRouter([], 'default');
+      expect(router.getRules()).toHaveLength(0);
+    });
+
+    it('validates defaultWorkspace format', () => {
+      expect(() => new MessageRouter([], 'INVALID')).toThrow(RoutingValidationError);
+    });
+
+    it('validates defaultWorkspace length', () => {
+      const longId = 'a'.repeat(65);
+      expect(() => new MessageRouter([], longId)).toThrow(RoutingValidationError);
+    });
+
+    it('rejects duplicate rule names', () => {
+      const rules: RoutingRule[] = [
+        makeRule({ name: 'dup' }),
+        makeRule({ name: 'dup', priority: 1 }),
+      ];
+      expect(() => new MessageRouter(rules, 'default')).toThrow(RoutingValidationError);
+    });
+
+    it('rejects invalid contentPattern regex', () => {
+      const rules: RoutingRule[] = [
+        makeRule({ name: 'bad', match: { contentPattern: '[invalid(' } }),
+      ];
+      expect(() => new MessageRouter(rules, 'default')).toThrow(RoutingValidationError);
+    });
+
+    it('rejects invalid workspace ID in rule', () => {
+      expect(() => new MessageRouter([makeRule({ workspace: 'BAD!' })], 'default')).toThrow(
+        RoutingValidationError,
+      );
+    });
+
+    it('rejects non-finite priority', () => {
+      expect(() => new MessageRouter([makeRule({ priority: Infinity })], 'default')).toThrow(
+        RoutingValidationError,
+      );
+      expect(() => new MessageRouter([makeRule({ priority: NaN })], 'default')).toThrow(
+        RoutingValidationError,
+      );
+    });
+
+    it('rejects invalid scope', () => {
+      const rules = [makeRule({ match: { scope: 'invalid' as 'dm' } })];
+      expect(() => new MessageRouter(rules, 'default')).toThrow(RoutingValidationError);
+    });
+
+    it('rejects empty rule name', () => {
+      expect(() => new MessageRouter([makeRule({ name: '' })], 'default')).toThrow(
+        RoutingValidationError,
+      );
+    });
+  });
+
+  // ==========================================================================
+  // route
+  // ==========================================================================
+
+  describe('route', () => {
+    it('returns defaultWorkspace when no rules match', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'nomatch', match: { peer: 'nobody' } })],
+        'fallback',
+      );
+      expect(router.route(makeMessage())).toBe('fallback');
+    });
+
+    it('returns defaultWorkspace with empty rules', () => {
+      const router = new MessageRouter([], 'fallback');
+      expect(router.route(makeMessage())).toBe('fallback');
+    });
+
+    it('matches by peer (senderId)', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'peer', match: { peer: 'user-123' }, workspace: 'work' })],
+        'default',
+      );
+      expect(router.route(makeMessage())).toBe('work');
+      expect(router.route(makeMessage({ senderId: 'other' }))).toBe('default');
+    });
+
+    it('matches by guildId from metadata', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'guild', match: { guildId: 'guild-42' }, workspace: 'work' })],
+        'default',
+      );
+      expect(router.route(makeMessage({ metadata: { guildId: 'guild-42' } }))).toBe('work');
+      expect(router.route(makeMessage({ metadata: { guildId: 'other' } }))).toBe('default');
+    });
+
+    it('guildId does not match when metadata is undefined', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'guild', match: { guildId: 'guild-42' }, workspace: 'work' })],
+        'default',
+      );
+      expect(router.route(makeMessage())).toBe('default');
+    });
+
+    it('guildId does not match when metadata.guildId is not a string', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'guild', match: { guildId: '42' }, workspace: 'work' })],
+        'default',
+      );
+      expect(router.route(makeMessage({ metadata: { guildId: 42 } }))).toBe('default');
+    });
+
+    it('matches by accountId (identityId)', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'acct', match: { accountId: 'identity-1' }, workspace: 'work' })],
+        'default',
+      );
+      expect(router.route(makeMessage({ identityId: 'identity-1' }))).toBe('work');
+      expect(router.route(makeMessage())).toBe('default');
+    });
+
+    it('matches by channel name', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'chan', match: { channel: 'discord' }, workspace: 'disc' })],
+        'default',
+      );
+      expect(router.route(makeMessage({ channel: 'discord' }))).toBe('disc');
+      expect(router.route(makeMessage({ channel: 'telegram' }))).toBe('default');
+    });
+
+    it('matches by scope (exact)', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'grp', match: { scope: 'group' }, workspace: 'group-ws' })],
+        'default',
+      );
+      expect(router.route(makeMessage({ scope: 'group' }))).toBe('group-ws');
+      expect(router.route(makeMessage({ scope: 'dm' }))).toBe('default');
+    });
+
+    it('matches by contentPattern (regex)', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'defi', match: { contentPattern: 'swap|trade' }, workspace: 'defi' })],
+        'default',
+      );
+      expect(router.route(makeMessage({ content: 'please swap USDC' }))).toBe('defi');
+      expect(router.route(makeMessage({ content: 'hello' }))).toBe('default');
+    });
+
+    it('glob wildcards work', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'wild', match: { peer: 'user-*' }, workspace: 'work' })],
+        'default',
+      );
+      expect(router.route(makeMessage({ senderId: 'user-999' }))).toBe('work');
+      expect(router.route(makeMessage({ senderId: 'admin-1' }))).toBe('default');
+    });
+
+    it('higher priority is evaluated first', () => {
+      const router = new MessageRouter(
+        [
+          makeRule({ name: 'low', match: { channel: 'telegram' }, workspace: 'low-ws', priority: 1 }),
+          makeRule({ name: 'high', match: { channel: 'telegram' }, workspace: 'high-ws', priority: 10 }),
+        ],
+        'default',
+      );
+      expect(router.route(makeMessage())).toBe('high-ws');
+    });
+
+    it('specificity tiebreak: peer beats guildId at same priority', () => {
+      const router = new MessageRouter(
+        [
+          makeRule({ name: 'guild', match: { guildId: 'g1' }, workspace: 'guild-ws', priority: 5 }),
+          makeRule({ name: 'peer', match: { peer: 'user-123' }, workspace: 'peer-ws', priority: 5 }),
+        ],
+        'default',
+      );
+      const msg = makeMessage({ metadata: { guildId: 'g1' } });
+      expect(router.route(msg)).toBe('peer-ws');
+    });
+
+    it('specificity tiebreak: peer beats combined guildId+channel at same priority', () => {
+      const router = new MessageRouter(
+        [
+          makeRule({
+            name: 'multi',
+            match: { guildId: 'g1', channel: 'discord' },
+            workspace: 'multi-ws',
+            priority: 5,
+          }),
+          makeRule({ name: 'peer', match: { peer: 'user-123' }, workspace: 'peer-ws', priority: 5 }),
+        ],
+        'default',
+      );
+      const msg = makeMessage({ channel: 'discord', metadata: { guildId: 'g1' } });
+      expect(router.route(msg)).toBe('peer-ws');
+    });
+
+    it('all match fields are ANDed', () => {
+      const router = new MessageRouter(
+        [
+          makeRule({
+            name: 'both',
+            match: { channel: 'discord', scope: 'group' },
+            workspace: 'work',
+          }),
+        ],
+        'default',
+      );
+      // Both conditions met
+      expect(router.route(makeMessage({ channel: 'discord', scope: 'group' }))).toBe('work');
+      // Only one condition met
+      expect(router.route(makeMessage({ channel: 'discord', scope: 'dm' }))).toBe('default');
+    });
+
+    it('empty match object matches everything (catch-all)', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'catchall', match: {}, workspace: 'catch' })],
+        'default',
+      );
+      expect(router.route(makeMessage())).toBe('catch');
+    });
+
+    it('deterministic alphabetical ordering for equal priority and specificity', () => {
+      const router = new MessageRouter(
+        [
+          makeRule({ name: 'beta', match: { channel: 'telegram' }, workspace: 'beta-ws', priority: 5 }),
+          makeRule({ name: 'alpha', match: { channel: 'telegram' }, workspace: 'alpha-ws', priority: 5 }),
+        ],
+        'default',
+      );
+      expect(router.route(makeMessage())).toBe('alpha-ws');
+    });
+  });
+
+  // ==========================================================================
+  // addRule
+  // ==========================================================================
+
+  describe('addRule', () => {
+    it('adds rule and routes to it', () => {
+      const router = new MessageRouter([], 'default');
+      router.addRule(makeRule({ name: 'new', match: { peer: 'user-123' }, workspace: 'new-ws' }));
+      expect(router.route(makeMessage())).toBe('new-ws');
+    });
+
+    it('rejects duplicate name', () => {
+      const router = new MessageRouter([makeRule({ name: 'existing' })], 'default');
+      expect(() => router.addRule(makeRule({ name: 'existing' }))).toThrow(RoutingValidationError);
+    });
+
+    it('rejects invalid rule', () => {
+      const router = new MessageRouter([], 'default');
+      expect(() => router.addRule(makeRule({ name: '' }))).toThrow(RoutingValidationError);
+    });
+  });
+
+  // ==========================================================================
+  // removeRule
+  // ==========================================================================
+
+  describe('removeRule', () => {
+    it('removes existing rule and returns true', () => {
+      const router = new MessageRouter([makeRule({ name: 'rm-me' })], 'default');
+      expect(router.removeRule('rm-me')).toBe(true);
+      expect(router.getRules()).toHaveLength(0);
+    });
+
+    it('returns false for non-existent rule', () => {
+      const router = new MessageRouter([], 'default');
+      expect(router.removeRule('nope')).toBe(false);
+    });
+
+    it('removed rule no longer matches', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'temp', match: { peer: 'user-123' }, workspace: 'temp-ws' })],
+        'default',
+      );
+      expect(router.route(makeMessage())).toBe('temp-ws');
+      router.removeRule('temp');
+      expect(router.route(makeMessage())).toBe('default');
+    });
+
+    it('allows re-adding a removed rule name', () => {
+      const router = new MessageRouter(
+        [makeRule({ name: 'reuse', workspace: 'old' })],
+        'default',
+      );
+      router.removeRule('reuse');
+      router.addRule(makeRule({ name: 'reuse', workspace: 'new-ws' }));
+      expect(router.route(makeMessage())).toBe('new-ws');
+    });
+  });
+
+  // ==========================================================================
+  // getRules
+  // ==========================================================================
+
+  describe('getRules', () => {
+    it('returns all rules', () => {
+      const rules = [
+        makeRule({ name: 'a', priority: 1 }),
+        makeRule({ name: 'b', priority: 2 }),
+      ];
+      const router = new MessageRouter(rules, 'default');
+      expect(router.getRules()).toHaveLength(2);
+    });
+
+    it('returned array is frozen', () => {
+      const router = new MessageRouter([makeRule()], 'default');
+      const result = router.getRules();
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+
+    it('does not expose internal array (mutation safety)', () => {
+      const router = new MessageRouter([makeRule({ name: 'a' })], 'default');
+      const r1 = router.getRules();
+      router.addRule(makeRule({ name: 'b' }));
+      const r2 = router.getRules();
+      expect(r1).toHaveLength(1);
+      expect(r2).toHaveLength(2);
+    });
+  });
+});

--- a/runtime/src/gateway/routing.ts
+++ b/runtime/src/gateway/routing.ts
@@ -1,0 +1,264 @@
+/**
+ * Message routing engine for multi-agent workspaces.
+ *
+ * Routes incoming {@link GatewayMessage}s to target workspace IDs based on
+ * configurable, priority-ordered rules with glob/regex matching.
+ *
+ * Precedence (matching the spec): peer > guildId > accountId > channel > scope > contentPattern > default.
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+import { globMatch } from './approvals.js';
+import { WORKSPACE_ID_PATTERN, MAX_WORKSPACE_ID_LENGTH } from './workspace.js';
+import type { GatewayMessage } from './message.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Specificity weights per match field.
+ * Used with MAX (not SUM) so that peer always beats guildId, etc.
+ */
+const SPECIFICITY_WEIGHTS: Readonly<Record<keyof RoutingMatch, number>> = {
+  peer: 6,
+  guildId: 5,
+  accountId: 4,
+  channel: 3,
+  scope: 2,
+  contentPattern: 1,
+};
+
+const VALID_SCOPES: ReadonlySet<string> = new Set(['dm', 'group', 'thread']);
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/** Match conditions for a routing rule. All defined fields are ANDed. */
+export interface RoutingMatch {
+  /** Glob pattern matched against message senderId. */
+  readonly peer?: string;
+  /** Glob pattern matched against message metadata.guildId. */
+  readonly guildId?: string;
+  /** Glob pattern matched against message identityId. */
+  readonly accountId?: string;
+  /** Glob pattern matched against message channel name. */
+  readonly channel?: string;
+  /** Exact match against message scope. */
+  readonly scope?: 'dm' | 'group' | 'thread';
+  /** Regex pattern matched against message content. */
+  readonly contentPattern?: string;
+}
+
+/** A routing rule that maps matching messages to a workspace. */
+export interface RoutingRule {
+  /** Unique rule name (used as key for removeRule). */
+  readonly name: string;
+  /** Match conditions. Empty object matches everything (catch-all). */
+  readonly match: RoutingMatch;
+  /** Target workspace ID. */
+  readonly workspace: string;
+  /** Priority — higher values are evaluated first. */
+  readonly priority: number;
+}
+
+// ============================================================================
+// Error class
+// ============================================================================
+
+/** Thrown when a routing rule fails validation. */
+export class RoutingValidationError extends RuntimeError {
+  public readonly field: string;
+  public readonly reason: string;
+
+  constructor(field: string, reason: string) {
+    super(
+      `Routing rule validation failed: ${field} — ${reason}`,
+      RuntimeErrorCodes.GATEWAY_VALIDATION_ERROR,
+    );
+    this.name = 'RoutingValidationError';
+    this.field = field;
+    this.reason = reason;
+  }
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+function computeSpecificity(match: RoutingMatch): number {
+  let max = 0;
+  for (const key of Object.keys(match) as Array<keyof RoutingMatch>) {
+    if (match[key] !== undefined) {
+      const w = SPECIFICITY_WEIGHTS[key];
+      if (w > max) max = w;
+    }
+  }
+  return max;
+}
+
+function compareRules(a: RoutingRule, b: RoutingRule): number {
+  // Higher priority first
+  if (a.priority !== b.priority) return b.priority - a.priority;
+  // Higher specificity first
+  const sa = computeSpecificity(a.match);
+  const sb = computeSpecificity(b.match);
+  if (sa !== sb) return sb - sa;
+  // Alphabetical by name for determinism
+  return a.name.localeCompare(b.name);
+}
+
+function matchesRule(
+  rule: RoutingRule,
+  message: GatewayMessage,
+  regexCache: ReadonlyMap<string, RegExp>,
+): boolean {
+  const m = rule.match;
+
+  if (m.peer !== undefined) {
+    if (!globMatch(m.peer, message.senderId)) return false;
+  }
+
+  if (m.guildId !== undefined) {
+    const guildId = message.metadata?.guildId;
+    if (typeof guildId !== 'string') return false;
+    if (!globMatch(m.guildId, guildId)) return false;
+  }
+
+  if (m.accountId !== undefined) {
+    if (message.identityId === undefined) return false;
+    if (!globMatch(m.accountId, message.identityId)) return false;
+  }
+
+  if (m.channel !== undefined) {
+    if (!globMatch(m.channel, message.channel)) return false;
+  }
+
+  if (m.scope !== undefined) {
+    if (m.scope !== message.scope) return false;
+  }
+
+  if (m.contentPattern !== undefined) {
+    const regex = regexCache.get(rule.name);
+    if (!regex || !regex.test(message.content)) return false;
+  }
+
+  return true;
+}
+
+function validateWorkspaceId(id: string, field: string): void {
+  if (!WORKSPACE_ID_PATTERN.test(id)) {
+    throw new RoutingValidationError(field, `Invalid workspace ID "${id}" — must match ${WORKSPACE_ID_PATTERN}`);
+  }
+  if (id.length > MAX_WORKSPACE_ID_LENGTH) {
+    throw new RoutingValidationError(field, `Workspace ID exceeds maximum length of ${MAX_WORKSPACE_ID_LENGTH} characters`);
+  }
+}
+
+function validateRule(rule: RoutingRule, existingNames: ReadonlySet<string>): void {
+  if (typeof rule.name !== 'string' || rule.name.length === 0) {
+    throw new RoutingValidationError('name', 'Rule name must be a non-empty string');
+  }
+  if (existingNames.has(rule.name)) {
+    throw new RoutingValidationError('name', `Duplicate rule name "${rule.name}"`);
+  }
+  validateWorkspaceId(rule.workspace, 'workspace');
+  if (typeof rule.priority !== 'number' || !Number.isFinite(rule.priority)) {
+    throw new RoutingValidationError('priority', 'Priority must be a finite number');
+  }
+  if (rule.match.scope !== undefined && !VALID_SCOPES.has(rule.match.scope)) {
+    throw new RoutingValidationError('match.scope', `Invalid scope "${rule.match.scope}" — must be one of: dm, group, thread`);
+  }
+  if (rule.match.contentPattern !== undefined) {
+    try {
+      new RegExp(rule.match.contentPattern);
+    } catch {
+      throw new RoutingValidationError('match.contentPattern', `Invalid regex: "${rule.match.contentPattern}"`);
+    }
+  }
+}
+
+// ============================================================================
+// MessageRouter
+// ============================================================================
+
+/**
+ * Routes incoming gateway messages to workspace IDs based on configurable rules.
+ *
+ * Rules are evaluated in priority order (highest first). Among equal-priority
+ * rules, the most specific match dimension wins (peer > guildId > accountId >
+ * channel > scope > contentPattern). A final alphabetical tiebreak ensures
+ * deterministic ordering.
+ */
+export class MessageRouter {
+  private readonly rules: RoutingRule[] = [];
+  private sorted: readonly RoutingRule[] = [];
+  private readonly defaultWorkspace: string;
+  private readonly nameSet = new Set<string>();
+  private regexCache = new Map<string, RegExp>();
+
+  constructor(rules: readonly RoutingRule[], defaultWorkspace: string) {
+    validateWorkspaceId(defaultWorkspace, 'defaultWorkspace');
+    this.defaultWorkspace = defaultWorkspace;
+
+    for (const rule of rules) {
+      validateRule(rule, this.nameSet);
+      this.rules.push(rule);
+      this.nameSet.add(rule.name);
+    }
+
+    this.rebuild();
+  }
+
+  /** Route a message to a workspace ID. Returns the default workspace if no rule matches. */
+  route(message: GatewayMessage): string {
+    for (const rule of this.sorted) {
+      if (matchesRule(rule, message, this.regexCache)) {
+        return rule.workspace;
+      }
+    }
+    return this.defaultWorkspace;
+  }
+
+  /** Add a rule. Throws {@link RoutingValidationError} on invalid input or duplicate name. */
+  addRule(rule: RoutingRule): void {
+    validateRule(rule, this.nameSet);
+    this.rules.push(rule);
+    this.nameSet.add(rule.name);
+    this.rebuild();
+  }
+
+  /** Remove a rule by name. Returns true if the rule existed. */
+  removeRule(name: string): boolean {
+    const idx = this.rules.findIndex((r) => r.name === name);
+    if (idx === -1) return false;
+    this.rules.splice(idx, 1);
+    this.nameSet.delete(name);
+    this.rebuild();
+    return true;
+  }
+
+  /** Return a frozen copy of the current rules (unsorted, insertion order). */
+  getRules(): readonly RoutingRule[] {
+    return Object.freeze([...this.rules]);
+  }
+
+  // --------------------------------------------------------------------------
+  // Private
+  // --------------------------------------------------------------------------
+
+  private rebuild(): void {
+    this.sorted = [...this.rules].sort(compareRules);
+
+    const cache = new Map<string, RegExp>();
+    for (const rule of this.rules) {
+      if (rule.match.contentPattern !== undefined) {
+        cache.set(rule.name, new RegExp(rule.match.contentPattern));
+      }
+    }
+    this.regexCache = cache;
+  }
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1302,6 +1302,11 @@ export {
   type ToolPolicy,
   type WorkspaceTemplate,
   type WorkspaceConfigJson,
+  // Routing rules (Phase 7.2)
+  MessageRouter,
+  RoutingValidationError,
+  type RoutingMatch,
+  type RoutingRule,
   // Session isolation (Phase 7.3)
   SessionIsolationManager,
   type IsolatedSessionContext,


### PR DESCRIPTION
## Summary

- Implements `MessageRouter` class that routes incoming `GatewayMessage`s to workspace IDs based on configurable, priority-ordered rules with glob/regex matching
- Supports 6 match dimensions: peer, guildId, accountId, channel, scope, contentPattern — all ANDed when combined
- Priority ordering with specificity tiebreaks (peer > guildId > accountId > channel > scope > contentPattern) and deterministic alphabetical fallback
- `RoutingValidationError` for rule validation (workspace ID format, regex syntax, duplicate names, scope values, priority finiteness)
- Dynamic rule management via `addRule`/`removeRule` with regex cache rebuild
- 40 unit tests covering all match dimensions, validation, ordering, and edge cases

Closes #1094

## Test plan

- [x] All 40 routing tests pass (`npx vitest run src/gateway/routing.test.ts`)
- [ ] CI runtime checks pass
- [ ] Typecheck passes