### PR TITLE
feat(social): reputation integration — social signals to reputation score (#1104)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1575,6 +1575,33 @@ export {
   AgentFeed,
 } from './social/index.js';
 
+// Social / Reputation (Phase 8.4)
+export {
+  // Types
+  type ReputationWeights,
+  type SocialSignals,
+  type ScoredAgent,
+  type ScoredPost,
+  type ReputationChangeRecord,
+  type ReputationScorerConfig,
+  type ReputationReasonValue,
+  // Constants
+  ReputationReason,
+  REPUTATION_MAX,
+  REPUTATION_MIN,
+  DEFAULT_UPVOTE_WEIGHT,
+  DEFAULT_POST_WEIGHT,
+  DEFAULT_COLLABORATION_WEIGHT,
+  DEFAULT_MESSAGE_WEIGHT,
+  DEFAULT_SPAM_PENALTY,
+  DEFAULT_ON_CHAIN_WEIGHT,
+  // Error classes
+  ReputationScoringError,
+  ReputationTrackingError,
+  // Operations class
+  ReputationScorer,
+} from './social/index.js';
+
 // Agent Builder (Phase 10)
 export { AgentBuilder, BuiltAgent } from './builder.js';
 

--- a/runtime/src/social/index.ts
+++ b/runtime/src/social/index.ts
@@ -14,3 +14,6 @@ export * from './messaging.js';
 export * from './feed-types.js';
 export * from './feed-errors.js';
 export * from './feed.js';
+export * from './reputation-types.js';
+export * from './reputation-errors.js';
+export * from './reputation.js';

--- a/runtime/src/social/reputation-errors.ts
+++ b/runtime/src/social/reputation-errors.ts
@@ -1,0 +1,41 @@
+/**
+ * Reputation-specific error classes for @agenc/runtime.
+ *
+ * All reputation errors extend RuntimeError and use codes from RuntimeErrorCodes.
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Error thrown when reputation scoring fails (invalid input, overflow, etc.).
+ */
+export class ReputationScoringError extends RuntimeError {
+  public readonly reason: string;
+
+  constructor(reason: string) {
+    super(
+      `Reputation scoring failed: ${reason}`,
+      RuntimeErrorCodes.REPUTATION_SCORING_ERROR,
+    );
+    this.name = 'ReputationScoringError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Error thrown when reputation event tracking fails (subscription, history query).
+ */
+export class ReputationTrackingError extends RuntimeError {
+  public readonly reason: string;
+
+  constructor(reason: string) {
+    super(
+      `Reputation tracking failed: ${reason}`,
+      RuntimeErrorCodes.REPUTATION_TRACKING_ERROR,
+    );
+    this.name = 'ReputationTrackingError';
+    this.reason = reason;
+  }
+}

--- a/runtime/src/social/reputation-types.ts
+++ b/runtime/src/social/reputation-types.ts
@@ -1,0 +1,165 @@
+/**
+ * Reputation scoring types, constants, and interfaces.
+ *
+ * Provides the type system for Phase 8.4 — social signals feed into
+ * agent reputation scores.  The on-chain reputation (u16, 0-10000) is
+ * combined with off-chain social signal scoring to produce composite
+ * scores used for ranking posts, agents, and recommendations.
+ *
+ * @module
+ */
+
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../idl.js';
+import type { Logger } from '../utils/logger.js';
+import type { FeedPost } from './feed-types.js';
+import type { AgentProfile } from './types.js';
+
+// ============================================================================
+// On-chain Reputation Constants
+// ============================================================================
+
+/**
+ * Reason codes for on-chain reputation changes.
+ * Mirrors `reputation_reason` constants in events.rs.
+ */
+export const ReputationReason = {
+  /** Reputation increased from task completion */
+  COMPLETION: 0,
+  /** Reputation decreased from losing a dispute */
+  DISPUTE_SLASH: 1,
+  /** Reputation decreased from inactivity decay */
+  DECAY: 2,
+} as const;
+
+export type ReputationReasonValue =
+  (typeof ReputationReason)[keyof typeof ReputationReason];
+
+/** Maximum on-chain reputation value (u16) */
+export const REPUTATION_MAX = 10_000;
+
+/** Minimum on-chain reputation value */
+export const REPUTATION_MIN = 0;
+
+// ============================================================================
+// Scoring Weight Defaults
+// ============================================================================
+
+/** Default points per upvote received on a post */
+export const DEFAULT_UPVOTE_WEIGHT = 5;
+
+/** Default points per post authored */
+export const DEFAULT_POST_WEIGHT = 2;
+
+/** Default points per collaboration (multi-agent task) completed */
+export const DEFAULT_COLLABORATION_WEIGHT = 10;
+
+/** Default points per message sent */
+export const DEFAULT_MESSAGE_WEIGHT = 1;
+
+/** Default base penalty per spam report */
+export const DEFAULT_SPAM_PENALTY = 50;
+
+/**
+ * Default weight (0-1) given to on-chain reputation when computing
+ * the composite score.  Social score receives `1 - ON_CHAIN_WEIGHT`.
+ */
+export const DEFAULT_ON_CHAIN_WEIGHT = 0.7;
+
+// ============================================================================
+// Scoring Configuration
+// ============================================================================
+
+/** Configurable weights for social signal scoring. */
+export interface ReputationWeights {
+  /** Points per upvote received (default: 5) */
+  upvoteWeight?: number;
+  /** Points per post authored (default: 2) */
+  postWeight?: number;
+  /** Points per collaboration completed (default: 10) */
+  collaborationWeight?: number;
+  /** Points per message sent (default: 1) */
+  messageWeight?: number;
+  /** Base penalty per spam report (default: 50) */
+  spamPenaltyBase?: number;
+  /** Weight of on-chain reputation in composite score, 0-1 (default: 0.7) */
+  onChainWeight?: number;
+}
+
+// ============================================================================
+// Social Signal Aggregates
+// ============================================================================
+
+/** Aggregated social signal counts for a single agent. */
+export interface SocialSignals {
+  /** Number of top-level posts authored */
+  postsAuthored: number;
+  /** Total upvotes received across all posts */
+  upvotesReceived: number;
+  /** Number of collaborative tasks completed */
+  collaborationsCompleted: number;
+  /** Number of messages sent */
+  messagesSent: number;
+  /** Number of spam reports received */
+  spamReports: number;
+}
+
+// ============================================================================
+// Scored Results
+// ============================================================================
+
+/** An agent with computed reputation scores. */
+export interface ScoredAgent {
+  /** Agent profile */
+  profile: AgentProfile;
+  /** On-chain reputation (0-10000) */
+  onChainReputation: number;
+  /** Social signal score (unbounded, >= 0) */
+  socialScore: number;
+  /** Composite score combining on-chain + social (0-10000) */
+  compositeScore: number;
+}
+
+/** A feed post with reputation-weighted score. */
+export interface ScoredPost {
+  /** The feed post */
+  post: FeedPost;
+  /** Author's on-chain reputation (0-10000, or 0 if unknown) */
+  authorReputation: number;
+  /** Reputation-weighted upvote score */
+  weightedUpvotes: number;
+  /** Final composite post score (higher = more relevant) */
+  score: number;
+}
+
+// ============================================================================
+// Reputation History
+// ============================================================================
+
+/** A single reputation change record from on-chain events. */
+export interface ReputationChangeRecord {
+  /** Agent identifier */
+  agentId: Uint8Array;
+  /** Reputation before the change */
+  oldReputation: number;
+  /** Reputation after the change */
+  newReputation: number;
+  /** Reason code (see ReputationReason) */
+  reason: ReputationReasonValue;
+  /** Unix timestamp of the change */
+  timestamp: number;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Configuration for ReputationScorer. */
+export interface ReputationScorerConfig {
+  /** Anchor program instance */
+  program: Program<AgencCoordination>;
+  /** Scoring weight overrides */
+  weights?: ReputationWeights;
+  /** Optional logger */
+  logger?: Logger;
+}

--- a/runtime/src/social/reputation.test.ts
+++ b/runtime/src/social/reputation.test.ts
@@ -1,0 +1,626 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
+import { PROGRAM_ID } from '@agenc/sdk';
+import { RuntimeErrorCodes } from '../types/errors.js';
+import { ReputationScoringError, ReputationTrackingError } from './reputation-errors.js';
+import { ReputationScorer } from './reputation.js';
+import {
+  ReputationReason,
+  REPUTATION_MAX,
+  REPUTATION_MIN,
+  DEFAULT_UPVOTE_WEIGHT,
+  DEFAULT_POST_WEIGHT,
+  DEFAULT_COLLABORATION_WEIGHT,
+  DEFAULT_MESSAGE_WEIGHT,
+  DEFAULT_SPAM_PENALTY,
+  DEFAULT_ON_CHAIN_WEIGHT,
+  type SocialSignals,
+  type ReputationChangeRecord,
+} from './reputation-types.js';
+import type { AgentProfile } from './types.js';
+import type { FeedPost } from './feed-types.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function randomPubkey(): PublicKey {
+  return Keypair.generate().publicKey;
+}
+
+function randomBytes32(): Uint8Array {
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) bytes[i] = Math.floor(Math.random() * 256);
+  return bytes;
+}
+
+/** Create a minimal mock program with addEventListener for event tracking. */
+function createMockProgram() {
+  const listeners = new Map<string, Function>();
+  let listenerId = 0;
+
+  return {
+    programId: PROGRAM_ID,
+    addEventListener: vi.fn((eventName: string, callback: Function) => {
+      const id = listenerId++;
+      listeners.set(`${eventName}:${id}`, callback);
+      return id;
+    }),
+    removeEventListener: vi.fn().mockResolvedValue(undefined),
+    _listeners: listeners,
+    _emit(eventName: string, data: unknown, slot: number, signature: string) {
+      for (const [key, cb] of listeners.entries()) {
+        if (key.startsWith(`${eventName}:`)) {
+          cb(data, slot, signature);
+        }
+      }
+    },
+  } as any;
+}
+
+function createScorer(overrides?: Record<string, unknown>) {
+  const program = createMockProgram();
+  const scorer = new ReputationScorer({
+    program,
+    ...overrides,
+  });
+  return { scorer, program };
+}
+
+function createMockAgentProfile(overrides: Partial<AgentProfile> = {}): AgentProfile {
+  return {
+    pda: randomPubkey(),
+    agentId: randomBytes32(),
+    authority: randomPubkey(),
+    capabilities: 3n,
+    status: 1,
+    endpoint: 'https://agent.example.com',
+    metadataUri: '',
+    registeredAt: 1700000000,
+    lastActive: 1700001000,
+    tasksCompleted: 10n,
+    totalEarned: 1_000_000_000n,
+    reputation: 5000,
+    activeTasks: 0,
+    stake: 1_000_000_000n,
+    ...overrides,
+  };
+}
+
+function createMockFeedPost(overrides: Partial<FeedPost> = {}): FeedPost {
+  return {
+    pda: randomPubkey(),
+    author: randomPubkey(),
+    contentHash: randomBytes32(),
+    topic: randomBytes32(),
+    parentPost: null,
+    nonce: randomBytes32(),
+    upvoteCount: 0,
+    createdAt: 1700000000,
+    ...overrides,
+  };
+}
+
+function zeroSignals(): SocialSignals {
+  return {
+    postsAuthored: 0,
+    upvotesReceived: 0,
+    collaborationsCompleted: 0,
+    messagesSent: 0,
+    spamReports: 0,
+  };
+}
+
+// ============================================================================
+// Constants Tests
+// ============================================================================
+
+describe('ReputationReason constants', () => {
+  it('matches on-chain values', () => {
+    expect(ReputationReason.COMPLETION).toBe(0);
+    expect(ReputationReason.DISPUTE_SLASH).toBe(1);
+    expect(ReputationReason.DECAY).toBe(2);
+  });
+
+  it('has expected bound constants', () => {
+    expect(REPUTATION_MAX).toBe(10_000);
+    expect(REPUTATION_MIN).toBe(0);
+  });
+
+  it('has reasonable default weights', () => {
+    expect(DEFAULT_UPVOTE_WEIGHT).toBe(5);
+    expect(DEFAULT_POST_WEIGHT).toBe(2);
+    expect(DEFAULT_COLLABORATION_WEIGHT).toBe(10);
+    expect(DEFAULT_MESSAGE_WEIGHT).toBe(1);
+    expect(DEFAULT_SPAM_PENALTY).toBe(50);
+    expect(DEFAULT_ON_CHAIN_WEIGHT).toBe(0.7);
+  });
+});
+
+// ============================================================================
+// Error Class Tests
+// ============================================================================
+
+describe('ReputationScoringError', () => {
+  it('has correct code and message', () => {
+    const err = new ReputationScoringError('negative upvotes');
+    expect(err.code).toBe(RuntimeErrorCodes.REPUTATION_SCORING_ERROR);
+    expect(err.name).toBe('ReputationScoringError');
+    expect(err.reason).toBe('negative upvotes');
+    expect(err.message).toContain('negative upvotes');
+  });
+});
+
+describe('ReputationTrackingError', () => {
+  it('has correct code and message', () => {
+    const err = new ReputationTrackingError('subscription failed');
+    expect(err.code).toBe(RuntimeErrorCodes.REPUTATION_TRACKING_ERROR);
+    expect(err.name).toBe('ReputationTrackingError');
+    expect(err.reason).toBe('subscription failed');
+    expect(err.message).toContain('subscription failed');
+  });
+});
+
+// ============================================================================
+// Individual Signal Scoring
+// ============================================================================
+
+describe('ReputationScorer — signal scoring', () => {
+  let scorer: ReputationScorer;
+
+  beforeEach(() => {
+    ({ scorer } = createScorer());
+  });
+
+  describe('scorePost', () => {
+    it('returns upvoteWeight * upvotes + postWeight', () => {
+      expect(scorer.scorePost(0)).toBe(DEFAULT_POST_WEIGHT);
+      expect(scorer.scorePost(1)).toBe(DEFAULT_UPVOTE_WEIGHT + DEFAULT_POST_WEIGHT);
+      expect(scorer.scorePost(10)).toBe(10 * DEFAULT_UPVOTE_WEIGHT + DEFAULT_POST_WEIGHT);
+    });
+
+    it('throws on negative upvotes', () => {
+      expect(() => scorer.scorePost(-1)).toThrow(ReputationScoringError);
+    });
+  });
+
+  describe('scoreCollaboration', () => {
+    it('returns collaborationWeight', () => {
+      expect(scorer.scoreCollaboration(1)).toBe(DEFAULT_COLLABORATION_WEIGHT);
+      expect(scorer.scoreCollaboration(5)).toBe(DEFAULT_COLLABORATION_WEIGHT);
+    });
+
+    it('throws on zero participants', () => {
+      expect(() => scorer.scoreCollaboration(0)).toThrow(ReputationScoringError);
+    });
+  });
+
+  describe('scoreMessage', () => {
+    it('returns messageWeight', () => {
+      expect(scorer.scoreMessage()).toBe(DEFAULT_MESSAGE_WEIGHT);
+    });
+  });
+
+  describe('penalizeSpam', () => {
+    it('returns negative spamPenaltyBase * severity', () => {
+      expect(scorer.penalizeSpam(1)).toBe(-DEFAULT_SPAM_PENALTY);
+      expect(scorer.penalizeSpam(2)).toBe(-2 * DEFAULT_SPAM_PENALTY);
+      expect(scorer.penalizeSpam(0)).toBe(-0);
+    });
+
+    it('throws on negative severity', () => {
+      expect(() => scorer.penalizeSpam(-1)).toThrow(ReputationScoringError);
+    });
+  });
+});
+
+// ============================================================================
+// Custom Weights
+// ============================================================================
+
+describe('ReputationScorer — custom weights', () => {
+  it('uses custom weights when provided', () => {
+    const { scorer } = createScorer({
+      weights: {
+        upvoteWeight: 10,
+        postWeight: 3,
+        collaborationWeight: 20,
+        messageWeight: 2,
+        spamPenaltyBase: 100,
+      },
+    });
+
+    expect(scorer.scorePost(5)).toBe(5 * 10 + 3);
+    expect(scorer.scoreCollaboration(1)).toBe(20);
+    expect(scorer.scoreMessage()).toBe(2);
+    expect(scorer.penalizeSpam(1)).toBe(-100);
+  });
+
+  it('clamps onChainWeight to [0,1]', () => {
+    const { scorer: s1 } = createScorer({ weights: { onChainWeight: 2 } });
+    // onChainWeight clamped to 1.0 → composite = 1.0 * onChainRep + 0 * social
+    expect(s1.computeCompositeScore(8000, 5000)).toBe(8000);
+
+    const { scorer: s2 } = createScorer({ weights: { onChainWeight: -1 } });
+    // onChainWeight clamped to 0.0 → composite = 0 * onChainRep + 1.0 * social
+    expect(s2.computeCompositeScore(8000, 5000)).toBe(5000);
+  });
+});
+
+// ============================================================================
+// Aggregate Scoring
+// ============================================================================
+
+describe('ReputationScorer — aggregate scoring', () => {
+  let scorer: ReputationScorer;
+
+  beforeEach(() => {
+    ({ scorer } = createScorer());
+  });
+
+  describe('computeSocialScore', () => {
+    it('returns 0 for zero signals', () => {
+      expect(scorer.computeSocialScore(zeroSignals())).toBe(0);
+    });
+
+    it('sums weighted signal counts', () => {
+      const signals: SocialSignals = {
+        postsAuthored: 5,
+        upvotesReceived: 10,
+        collaborationsCompleted: 2,
+        messagesSent: 100,
+        spamReports: 0,
+      };
+      const expected =
+        5 * DEFAULT_POST_WEIGHT +
+        10 * DEFAULT_UPVOTE_WEIGHT +
+        2 * DEFAULT_COLLABORATION_WEIGHT +
+        100 * DEFAULT_MESSAGE_WEIGHT;
+      expect(scorer.computeSocialScore(signals)).toBe(expected);
+    });
+
+    it('subtracts spam penalty', () => {
+      const signals: SocialSignals = {
+        postsAuthored: 1,
+        upvotesReceived: 0,
+        collaborationsCompleted: 0,
+        messagesSent: 0,
+        spamReports: 1,
+      };
+      const raw = 1 * DEFAULT_POST_WEIGHT - 1 * DEFAULT_SPAM_PENALTY;
+      // Clamped to 0
+      expect(scorer.computeSocialScore(signals)).toBe(Math.max(0, raw));
+    });
+
+    it('clamps to zero floor', () => {
+      const signals: SocialSignals = {
+        postsAuthored: 0,
+        upvotesReceived: 0,
+        collaborationsCompleted: 0,
+        messagesSent: 0,
+        spamReports: 10,
+      };
+      expect(scorer.computeSocialScore(signals)).toBe(0);
+    });
+  });
+
+  describe('computeCompositeScore', () => {
+    it('returns on-chain reputation when social is 0', () => {
+      // 0.7 * 5000 + 0.3 * 0 = 3500
+      expect(scorer.computeCompositeScore(5000, 0)).toBe(3500);
+    });
+
+    it('blends on-chain and social scores', () => {
+      // 0.7 * 5000 + 0.3 * 3000 = 3500 + 900 = 4400
+      expect(scorer.computeCompositeScore(5000, 3000)).toBe(4400);
+    });
+
+    it('clamps to REPUTATION_MAX', () => {
+      expect(scorer.computeCompositeScore(REPUTATION_MAX, REPUTATION_MAX)).toBe(REPUTATION_MAX);
+      expect(scorer.computeCompositeScore(20000, 20000)).toBe(REPUTATION_MAX);
+    });
+
+    it('clamps to REPUTATION_MIN', () => {
+      expect(scorer.computeCompositeScore(-100, 0)).toBe(0);
+    });
+
+    it('caps social score at REPUTATION_MAX before blending', () => {
+      // social = 50000 normalized to 10000
+      // 0.7 * 0 + 0.3 * 10000 = 3000
+      expect(scorer.computeCompositeScore(0, 50000)).toBe(3000);
+    });
+  });
+});
+
+// ============================================================================
+// Post Ranking
+// ============================================================================
+
+describe('ReputationScorer — rankPosts', () => {
+  let scorer: ReputationScorer;
+
+  beforeEach(() => {
+    ({ scorer } = createScorer());
+  });
+
+  it('returns posts sorted by score descending', () => {
+    const author1 = randomPubkey();
+    const author2 = randomPubkey();
+    const posts = [
+      createMockFeedPost({ author: author1, upvoteCount: 5 }),
+      createMockFeedPost({ author: author2, upvoteCount: 10 }),
+    ];
+    const reputationMap = new Map<string, number>([
+      [author1.toBase58(), 5000],
+      [author2.toBase58(), 5000],
+    ]);
+
+    const ranked = scorer.rankPosts(posts, reputationMap);
+    expect(ranked).toHaveLength(2);
+    // Post with 10 upvotes should rank higher
+    expect(ranked[0].post.upvoteCount).toBe(10);
+    expect(ranked[1].post.upvoteCount).toBe(5);
+  });
+
+  it('weights posts by author reputation', () => {
+    const highRepAuthor = randomPubkey();
+    const lowRepAuthor = randomPubkey();
+    const posts = [
+      createMockFeedPost({ author: lowRepAuthor, upvoteCount: 10 }),
+      createMockFeedPost({ author: highRepAuthor, upvoteCount: 10 }),
+    ];
+    const reputationMap = new Map<string, number>([
+      [highRepAuthor.toBase58(), 9000],
+      [lowRepAuthor.toBase58(), 1000],
+    ]);
+
+    const ranked = scorer.rankPosts(posts, reputationMap);
+    expect(ranked[0].authorReputation).toBe(9000);
+    expect(ranked[1].authorReputation).toBe(1000);
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+  });
+
+  it('uses 0 reputation for unknown authors', () => {
+    const post = createMockFeedPost({ upvoteCount: 5 });
+    const ranked = scorer.rankPosts([post], new Map());
+    expect(ranked[0].authorReputation).toBe(0);
+    // rep multiplier = 1 + 0/10000 = 1.0
+    expect(ranked[0].weightedUpvotes).toBe(5);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(scorer.rankPosts([], new Map())).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Agent Ranking
+// ============================================================================
+
+describe('ReputationScorer — rankAgents', () => {
+  let scorer: ReputationScorer;
+
+  beforeEach(() => {
+    ({ scorer } = createScorer());
+  });
+
+  it('sorts by composite score descending', () => {
+    const agents = [
+      createMockAgentProfile({ reputation: 3000 }),
+      createMockAgentProfile({ reputation: 8000 }),
+      createMockAgentProfile({ reputation: 5000 }),
+    ];
+
+    const ranked = scorer.rankAgents(agents);
+    expect(ranked[0].onChainReputation).toBe(8000);
+    expect(ranked[1].onChainReputation).toBe(5000);
+    expect(ranked[2].onChainReputation).toBe(3000);
+  });
+
+  it('incorporates social signals when provided', () => {
+    const lowRepAgent = createMockAgentProfile({ reputation: 2000 });
+    const highRepAgent = createMockAgentProfile({ reputation: 7000 });
+    const agents = [lowRepAgent, highRepAgent];
+
+    // Give the low-rep agent massive social signals
+    const signalsMap = new Map<string, SocialSignals>([
+      [lowRepAgent.pda.toBase58(), {
+        postsAuthored: 100,
+        upvotesReceived: 500,
+        collaborationsCompleted: 50,
+        messagesSent: 1000,
+        spamReports: 0,
+      }],
+    ]);
+
+    const ranked = scorer.rankAgents(agents, signalsMap);
+    // Low-rep agent should still have high composite score from social signals
+    const lowRepResult = ranked.find(r => r.onChainReputation === 2000)!;
+    expect(lowRepResult.socialScore).toBeGreaterThan(0);
+    expect(lowRepResult.compositeScore).toBeGreaterThan(0);
+  });
+
+  it('uses zero social score for agents not in signals map', () => {
+    const agent = createMockAgentProfile({ reputation: 5000 });
+    const ranked = scorer.rankAgents([agent]);
+    expect(ranked[0].socialScore).toBe(0);
+    // Composite = 0.7 * 5000 + 0.3 * 0 = 3500
+    expect(ranked[0].compositeScore).toBe(3500);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(scorer.rankAgents([])).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Event Tracking
+// ============================================================================
+
+describe('ReputationScorer — event tracking', () => {
+  let scorer: ReputationScorer;
+  let program: ReturnType<typeof createMockProgram>;
+
+  beforeEach(() => {
+    ({ scorer, program } = createScorer());
+  });
+
+  afterEach(async () => {
+    await scorer.dispose();
+  });
+
+  it('starts tracking and records events', () => {
+    expect(scorer.isTracking).toBe(false);
+    scorer.startTracking();
+    expect(scorer.isTracking).toBe(true);
+    expect(program.addEventListener).toHaveBeenCalledWith(
+      'reputationChanged',
+      expect.any(Function),
+    );
+  });
+
+  it('throws when starting tracking twice', () => {
+    scorer.startTracking();
+    expect(() => scorer.startTracking()).toThrow(ReputationTrackingError);
+  });
+
+  it('records reputation change events in history', () => {
+    scorer.startTracking();
+    const agentId = Array.from(randomBytes32());
+
+    program._emit('reputationChanged', {
+      agentId,
+      oldReputation: 5000,
+      newReputation: 5100,
+      reason: ReputationReason.COMPLETION,
+      timestamp: { toNumber: () => 1700000000 },
+    }, 100, 'sig1');
+
+    expect(scorer.historySize).toBe(1);
+    const history = scorer.getHistory();
+    expect(history).toHaveLength(1);
+    expect(history[0].oldReputation).toBe(5000);
+    expect(history[0].newReputation).toBe(5100);
+    expect(history[0].reason).toBe(ReputationReason.COMPLETION);
+    expect(history[0].timestamp).toBe(1700000000);
+  });
+
+  it('filters history by agentId', () => {
+    scorer.startTracking();
+    const agent1 = new Uint8Array(32).fill(1);
+    const agent2 = new Uint8Array(32).fill(2);
+
+    program._emit('reputationChanged', {
+      agentId: Array.from(agent1),
+      oldReputation: 5000,
+      newReputation: 5100,
+      reason: 0,
+      timestamp: { toNumber: () => 1700000000 },
+    }, 100, 'sig1');
+
+    program._emit('reputationChanged', {
+      agentId: Array.from(agent2),
+      oldReputation: 3000,
+      newReputation: 2900,
+      reason: 1,
+      timestamp: { toNumber: () => 1700000001 },
+    }, 101, 'sig2');
+
+    expect(scorer.getHistory()).toHaveLength(2);
+    expect(scorer.getHistory(agent1)).toHaveLength(1);
+    expect(scorer.getHistory(agent1)[0].newReputation).toBe(5100);
+    expect(scorer.getHistory(agent2)).toHaveLength(1);
+    expect(scorer.getHistory(agent2)[0].newReputation).toBe(2900);
+  });
+
+  it('returns history newest-first', () => {
+    scorer.startTracking();
+    const agentId = Array.from(randomBytes32());
+
+    for (let i = 0; i < 3; i++) {
+      program._emit('reputationChanged', {
+        agentId,
+        oldReputation: 5000 + i * 100,
+        newReputation: 5100 + i * 100,
+        reason: 0,
+        timestamp: { toNumber: () => 1700000000 + i },
+      }, 100 + i, `sig${i}`);
+    }
+
+    const history = scorer.getHistory();
+    expect(history).toHaveLength(3);
+    expect(history[0].timestamp).toBe(1700000002);
+    expect(history[2].timestamp).toBe(1700000000);
+  });
+
+  it('stopTracking unsubscribes', async () => {
+    scorer.startTracking();
+    expect(scorer.isTracking).toBe(true);
+    await scorer.stopTracking();
+    expect(scorer.isTracking).toBe(false);
+    expect(program.removeEventListener).toHaveBeenCalled();
+  });
+
+  it('stopTracking is idempotent', async () => {
+    await scorer.stopTracking(); // no-op when not tracking
+    expect(scorer.isTracking).toBe(false);
+  });
+
+  it('dispose stops tracking', async () => {
+    scorer.startTracking();
+    await scorer.dispose();
+    expect(scorer.isTracking).toBe(false);
+  });
+
+  it('returns empty history when no events received', () => {
+    expect(scorer.getHistory()).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+describe('ReputationScorer — edge cases', () => {
+  let scorer: ReputationScorer;
+
+  beforeEach(() => {
+    ({ scorer } = createScorer());
+  });
+
+  it('handles max reputation values', () => {
+    const score = scorer.computeCompositeScore(REPUTATION_MAX, REPUTATION_MAX);
+    expect(score).toBe(REPUTATION_MAX);
+  });
+
+  it('handles min reputation values', () => {
+    const score = scorer.computeCompositeScore(REPUTATION_MIN, 0);
+    expect(score).toBe(REPUTATION_MIN);
+  });
+
+  it('handles very large social scores', () => {
+    const signals: SocialSignals = {
+      postsAuthored: 100_000,
+      upvotesReceived: 1_000_000,
+      collaborationsCompleted: 50_000,
+      messagesSent: 10_000_000,
+      spamReports: 0,
+    };
+    const social = scorer.computeSocialScore(signals);
+    expect(social).toBeGreaterThan(0);
+    // Composite should still be capped at REPUTATION_MAX
+    const composite = scorer.computeCompositeScore(REPUTATION_MAX, social);
+    expect(composite).toBe(REPUTATION_MAX);
+  });
+
+  it('rankPosts with zero-upvote posts still produces valid scores', () => {
+    const author = randomPubkey();
+    const posts = [
+      createMockFeedPost({ author, upvoteCount: 0 }),
+    ];
+    const reputationMap = new Map([[author.toBase58(), 5000]]);
+    const ranked = scorer.rankPosts(posts, reputationMap);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].score).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/runtime/src/social/reputation.ts
+++ b/runtime/src/social/reputation.ts
@@ -1,0 +1,314 @@
+/**
+ * ReputationScorer — social signals feed into agent reputation scores.
+ *
+ * Combines on-chain reputation (u16, 0-10000) with off-chain social signal
+ * scoring to produce composite scores for ranking posts, agents, and
+ * recommendations.  Tracks on-chain ReputationChanged events for history.
+ *
+ * Pattern: follows AgentMessaging constructor / event subscription style.
+ *
+ * @module
+ */
+
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../idl.js';
+import type { Logger } from '../utils/logger.js';
+import type { EventSubscription, ReputationChangedEvent, EventCallback } from '../events/types.js';
+import { subscribeToReputationChanged } from '../events/protocol.js';
+import type { AgentProfile } from './types.js';
+import type { FeedPost } from './feed-types.js';
+import type {
+  ReputationWeights,
+  SocialSignals,
+  ScoredAgent,
+  ScoredPost,
+  ReputationChangeRecord,
+  ReputationScorerConfig,
+  ReputationReasonValue,
+} from './reputation-types.js';
+import {
+  REPUTATION_MAX,
+  REPUTATION_MIN,
+  DEFAULT_UPVOTE_WEIGHT,
+  DEFAULT_POST_WEIGHT,
+  DEFAULT_COLLABORATION_WEIGHT,
+  DEFAULT_MESSAGE_WEIGHT,
+  DEFAULT_SPAM_PENALTY,
+  DEFAULT_ON_CHAIN_WEIGHT,
+} from './reputation-types.js';
+import { ReputationScoringError, ReputationTrackingError } from './reputation-errors.js';
+
+/** Resolved weights with all defaults applied. */
+interface ResolvedWeights {
+  upvoteWeight: number;
+  postWeight: number;
+  collaborationWeight: number;
+  messageWeight: number;
+  spamPenaltyBase: number;
+  onChainWeight: number;
+}
+
+/**
+ * Computes reputation scores from social signals and ranks agents/posts.
+ *
+ * The scorer is **read-only** — it does not submit on-chain transactions.
+ * It reads on-chain reputation from AgentProfile and enhances it with
+ * off-chain social signal scoring.
+ */
+export class ReputationScorer {
+  private readonly program: Program<AgencCoordination>;
+  private readonly weights: ResolvedWeights;
+  private readonly logger?: Logger;
+  private readonly history: ReputationChangeRecord[] = [];
+  private subscription: EventSubscription | null = null;
+
+  constructor(config: ReputationScorerConfig) {
+    this.program = config.program;
+    this.logger = config.logger;
+    this.weights = ReputationScorer.resolveWeights(config.weights);
+  }
+
+  // ==========================================================================
+  // Individual Signal Scoring (matches docs ReputationScorer interface)
+  // ==========================================================================
+
+  /**
+   * Score a post based on its upvote count.
+   * @returns Reputation points earned by the post author.
+   */
+  scorePost(upvotes: number): number {
+    if (upvotes < 0) {
+      throw new ReputationScoringError('upvote count cannot be negative');
+    }
+    return upvotes * this.weights.upvoteWeight + this.weights.postWeight;
+  }
+
+  /**
+   * Score a completed collaboration for each participant.
+   * @param participantCount - Number of agents in the collaboration.
+   * @returns Reputation points earned per participant.
+   */
+  scoreCollaboration(participantCount: number): number {
+    if (participantCount < 1) {
+      throw new ReputationScoringError('participant count must be >= 1');
+    }
+    return this.weights.collaborationWeight;
+  }
+
+  /**
+   * Score a sent message.
+   * @returns Reputation points earned.
+   */
+  scoreMessage(): number {
+    return this.weights.messageWeight;
+  }
+
+  /**
+   * Compute a spam penalty.
+   * @param severity - Severity multiplier (1 = normal, higher = worse).
+   * @returns Negative reputation delta.
+   */
+  penalizeSpam(severity: number): number {
+    if (severity < 0) {
+      throw new ReputationScoringError('severity cannot be negative');
+    }
+    return -(this.weights.spamPenaltyBase * severity);
+  }
+
+  // ==========================================================================
+  // Aggregate Scoring
+  // ==========================================================================
+
+  /**
+   * Compute an aggregate social score from signal counts.
+   * Result is >= 0 (clamped).
+   */
+  computeSocialScore(signals: SocialSignals): number {
+    const raw =
+      signals.postsAuthored * this.weights.postWeight +
+      signals.upvotesReceived * this.weights.upvoteWeight +
+      signals.collaborationsCompleted * this.weights.collaborationWeight +
+      signals.messagesSent * this.weights.messageWeight -
+      signals.spamReports * this.weights.spamPenaltyBase;
+    return Math.max(0, raw);
+  }
+
+  /**
+   * Combine on-chain reputation with a social score into a composite value
+   * in the range [0, REPUTATION_MAX].
+   *
+   * `composite = onChainWeight * onChainRep + (1-onChainWeight) * normalizedSocial`
+   *
+   * Social score is normalized to [0, REPUTATION_MAX] via `min(social, REPUTATION_MAX)`.
+   */
+  computeCompositeScore(onChainReputation: number, socialScore: number): number {
+    const clampedOnChain = Math.max(REPUTATION_MIN, Math.min(REPUTATION_MAX, onChainReputation));
+    const normalizedSocial = Math.min(socialScore, REPUTATION_MAX);
+    const w = this.weights.onChainWeight;
+    const composite = w * clampedOnChain + (1 - w) * normalizedSocial;
+    return Math.round(Math.max(REPUTATION_MIN, Math.min(REPUTATION_MAX, composite)));
+  }
+
+  // ==========================================================================
+  // Ranking Helpers
+  // ==========================================================================
+
+  /**
+   * Rank feed posts by a reputation-weighted score.
+   *
+   * Score formula: `upvoteCount * (1 + authorReputation / REPUTATION_MAX)`
+   *
+   * Posts from higher-reputation agents are ranked higher when upvote counts
+   * are similar.
+   *
+   * @param posts - Feed posts to rank.
+   * @param reputationMap - Map of agent PDA (base58) → on-chain reputation.
+   * @returns Posts sorted descending by score.
+   */
+  rankPosts(
+    posts: FeedPost[],
+    reputationMap: Map<string, number>,
+  ): ScoredPost[] {
+    return posts
+      .map((post) => {
+        const authorKey = post.author.toBase58();
+        const authorReputation = reputationMap.get(authorKey) ?? 0;
+        const repMultiplier = 1 + authorReputation / REPUTATION_MAX;
+        const weightedUpvotes = post.upvoteCount * repMultiplier;
+        // Base score includes a small boost for having any reputation
+        const score = weightedUpvotes + (authorReputation / REPUTATION_MAX) * this.weights.postWeight;
+        return { post, authorReputation, weightedUpvotes, score };
+      })
+      .sort((a, b) => b.score - a.score);
+  }
+
+  /**
+   * Rank agents by composite reputation score.
+   *
+   * @param agents - Agent profiles to rank.
+   * @param signalsMap - Optional map of agent PDA (base58) → SocialSignals.
+   *   Agents not in the map are scored with zero social signals.
+   * @returns Agents sorted descending by composite score.
+   */
+  rankAgents(
+    agents: AgentProfile[],
+    signalsMap?: Map<string, SocialSignals>,
+  ): ScoredAgent[] {
+    return agents
+      .map((profile) => {
+        const key = profile.pda.toBase58();
+        const signals = signalsMap?.get(key);
+        const socialScore = signals ? this.computeSocialScore(signals) : 0;
+        const compositeScore = this.computeCompositeScore(profile.reputation, socialScore);
+        return {
+          profile,
+          onChainReputation: profile.reputation,
+          socialScore,
+          compositeScore,
+        };
+      })
+      .sort((a, b) => b.compositeScore - a.compositeScore);
+  }
+
+  // ==========================================================================
+  // Event Tracking
+  // ==========================================================================
+
+  /**
+   * Start tracking on-chain ReputationChanged events.
+   * Stores events in local history for later querying.
+   *
+   * @returns Subscription handle.
+   * @throws ReputationTrackingError if already tracking.
+   */
+  startTracking(): EventSubscription {
+    if (this.subscription) {
+      throw new ReputationTrackingError('already tracking reputation events');
+    }
+
+    const callback: EventCallback<ReputationChangedEvent> = (event) => {
+      this.history.push({
+        agentId: event.agentId,
+        oldReputation: event.oldReputation,
+        newReputation: event.newReputation,
+        reason: event.reason as ReputationReasonValue,
+        timestamp: event.timestamp,
+      });
+      this.logger?.debug?.(
+        `ReputationChanged: rep ${event.oldReputation} → ${event.newReputation} (reason=${event.reason})`,
+      );
+    };
+
+    this.subscription = subscribeToReputationChanged(this.program, callback);
+    this.logger?.info?.('Reputation event tracking started');
+    return this.subscription;
+  }
+
+  /**
+   * Stop tracking reputation events.
+   */
+  async stopTracking(): Promise<void> {
+    if (this.subscription) {
+      await this.subscription.unsubscribe();
+      this.subscription = null;
+      this.logger?.info?.('Reputation event tracking stopped');
+    }
+  }
+
+  /**
+   * Get recorded reputation change history.
+   *
+   * @param agentId - Optional filter by agent ID (32 bytes). If omitted, returns all.
+   * @returns Reputation change records, newest first.
+   */
+  getHistory(agentId?: Uint8Array): ReputationChangeRecord[] {
+    let records = this.history;
+    if (agentId) {
+      records = records.filter((r) => {
+        if (r.agentId.length !== agentId.length) return false;
+        for (let i = 0; i < agentId.length; i++) {
+          if (r.agentId[i] !== agentId[i]) return false;
+        }
+        return true;
+      });
+    }
+    return [...records].reverse();
+  }
+
+  /** Whether event tracking is currently active. */
+  get isTracking(): boolean {
+    return this.subscription !== null;
+  }
+
+  /** Number of recorded reputation change events. */
+  get historySize(): number {
+    return this.history.length;
+  }
+
+  // ==========================================================================
+  // Lifecycle
+  // ==========================================================================
+
+  /**
+   * Stop tracking and release resources.
+   */
+  async dispose(): Promise<void> {
+    await this.stopTracking();
+  }
+
+  // ==========================================================================
+  // Internals
+  // ==========================================================================
+
+  /** Resolve user-provided weights with defaults. */
+  private static resolveWeights(weights?: ReputationWeights): ResolvedWeights {
+    return {
+      upvoteWeight: weights?.upvoteWeight ?? DEFAULT_UPVOTE_WEIGHT,
+      postWeight: weights?.postWeight ?? DEFAULT_POST_WEIGHT,
+      collaborationWeight: weights?.collaborationWeight ?? DEFAULT_COLLABORATION_WEIGHT,
+      messageWeight: weights?.messageWeight ?? DEFAULT_MESSAGE_WEIGHT,
+      spamPenaltyBase: weights?.spamPenaltyBase ?? DEFAULT_SPAM_PENALTY,
+      onChainWeight: Math.max(0, Math.min(1, weights?.onChainWeight ?? DEFAULT_ON_CHAIN_WEIGHT)),
+    };
+  }
+}

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -50,23 +50,23 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.MARKETPLACE_MATCHING_ERROR).toBe('MARKETPLACE_MATCHING_ERROR');
   });
 
-  it('has exactly 81 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(81);
+  it('has exactly 86 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(86);
   });
 });
 
 describe('AnchorErrorCodes', () => {
-  it('has exactly 169 error codes (6000-6168)', () => {
-    expect(Object.keys(AnchorErrorCodes)).toHaveLength(169);
+  it('has exactly 173 error codes (6000-6172)', () => {
+    expect(Object.keys(AnchorErrorCodes)).toHaveLength(173);
   });
 
-  it('has codes in range 6000-6168', () => {
+  it('has codes in range 6000-6172', () => {
     const codes = Object.values(AnchorErrorCodes);
     const minCode = Math.min(...codes);
     const maxCode = Math.max(...codes);
 
     expect(minCode).toBe(6000);
-    expect(maxCode).toBe(6168);
+    expect(maxCode).toBe(6172);
   });
 
   it('has sequential codes (no gaps)', () => {
@@ -563,7 +563,7 @@ describe('parseAnchorError', () => {
 
   it('returns null for code outside range', () => {
     expect(parseAnchorError({ code: 5999 })).toBeNull();
-    expect(parseAnchorError({ code: 6169 })).toBeNull();
+    expect(parseAnchorError({ code: 6173 })).toBeNull();
   });
 
   it('returns null for null/undefined', () => {
@@ -603,12 +603,12 @@ describe('getAnchorErrorName', () => {
 
   it('returns undefined for invalid code', () => {
     expect(getAnchorErrorName(5999)).toBeUndefined();
-    expect(getAnchorErrorName(6169)).toBeUndefined();
+    expect(getAnchorErrorName(6173)).toBeUndefined();
     expect(getAnchorErrorName(0)).toBeUndefined();
   });
 
-  it('returns name for all 169 codes', () => {
-    for (let code = 6000; code <= 6168; code++) {
+  it('returns name for all 173 codes', () => {
+    for (let code = 6000; code <= 6172; code++) {
       const name = getAnchorErrorName(code);
       expect(name).toBeDefined();
       expect(typeof name).toBe('string');

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -184,6 +184,10 @@ export const RuntimeErrorCodes = {
   FEED_UPVOTE_ERROR: 'FEED_UPVOTE_ERROR',
   /** Feed query operation failed */
   FEED_QUERY_ERROR: 'FEED_QUERY_ERROR',
+  /** Reputation scoring computation failed */
+  REPUTATION_SCORING_ERROR: 'REPUTATION_SCORING_ERROR',
+  /** Reputation event tracking or history query failed */
+  REPUTATION_TRACKING_ERROR: 'REPUTATION_TRACKING_ERROR',
 } as const;
 
 /** Union type of all runtime error code values */
@@ -1447,7 +1451,7 @@ export function parseAnchorError(error: unknown): ParsedAnchorError | null {
   }
 
   // Validate code is in our known range
-  if (code === undefined || code < 6000 || code > 6168) {
+  if (code === undefined || code < 6000 || code > 6172) {
     return null;
   }
 


### PR DESCRIPTION
## Summary

- Phase 8.4: ReputationScorer class that combines on-chain reputation (u16, 0-10000) with off-chain social signal scoring to produce composite scores for ranking posts, agents, and recommendations
- Signal scoring: scorePost (upvotes), scoreCollaboration, scoreMessage, penalizeSpam
- Aggregate scoring: computeSocialScore (weighted signal sum), computeCompositeScore (blends on-chain + social with configurable weights)
- Ranking helpers: rankPosts (reputation-weighted upvote scoring), rankAgents (composite score sorting)
- Event tracking: subscribes to on-chain ReputationChanged events, maintains local history with agent filtering
- Fixes stale error code counts in errors.test.ts (6168->6172 range from #1103 feed errors) and parseAnchorError range check

## Changes

**New files (4):**
- `runtime/src/social/reputation-types.ts` — ReputationReason constants, scoring weights, SocialSignals/ScoredAgent/ScoredPost interfaces
- `runtime/src/social/reputation-errors.ts` — ReputationScoringError, ReputationTrackingError classes
- `runtime/src/social/reputation.ts` — ReputationScorer class
- `runtime/src/social/reputation.test.ts` — 44 vitest unit tests

**Modified files (4):**
- `runtime/src/types/errors.ts` — Added REPUTATION_SCORING_ERROR, REPUTATION_TRACKING_ERROR codes; fixed parseAnchorError range (6168->6172)
- `runtime/src/types/errors.test.ts` — Updated stale counts (81->86 runtime codes, 169->173 anchor codes, range 6168->6172)
- `runtime/src/social/index.ts` — Added reputation barrel exports
- `runtime/src/index.ts` — Added Phase 8.4 barrel exports section

## Test plan

- [x] 44 new reputation unit tests pass (`npx vitest run src/social/reputation.test.ts`)
- [x] 4460 runtime tests pass (`cd runtime && npm run test`)
- [x] 225 LiteSVM integration tests pass (`npm run test:fast`)
- [x] Runtime builds cleanly with DTS (`npm run build`)