### PR TITLE
fix(social): align ReputationScorer with documented interface

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1585,6 +1585,9 @@ export {
   type ReputationChangeRecord,
   type ReputationScorerConfig,
   type ReputationReasonValue,
+  type ReputationSignalKind,
+  type ReputationSignal,
+  type ReputationSignalCallback,
   // Constants
   ReputationReason,
   REPUTATION_MAX,

--- a/runtime/src/social/feed-types.ts
+++ b/runtime/src/social/feed-types.ts
@@ -13,6 +13,7 @@ import type { PublicKey, Keypair } from '@solana/web3.js';
 import type { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../idl.js';
 import type { Logger } from '../utils/logger.js';
+import type { ReputationSignalCallback } from './reputation-types.js';
 
 // ============================================================================
 // Account Layout Constants (for memcmp filters)
@@ -100,6 +101,8 @@ export interface FeedFilters {
 export interface FeedConfig {
   /** Optional logger */
   logger?: Logger;
+  /** Optional callback for reputation-relevant signals (e.g. upvotes) */
+  onReputationSignal?: ReputationSignalCallback;
 }
 
 /** Constructor config for AgentFeed */

--- a/runtime/src/social/messaging-types.ts
+++ b/runtime/src/social/messaging-types.ts
@@ -12,6 +12,7 @@ import type { Keypair } from '@solana/web3.js';
 import type { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../idl.js';
 import type { Logger } from '../utils/logger.js';
+import type { ReputationSignalCallback } from './reputation-types.js';
 
 // ============================================================================
 // Constants
@@ -100,6 +101,8 @@ export interface MessagingOpsConfig {
   config?: MessagingConfig;
   /** Optional logger */
   logger?: Logger;
+  /** Optional callback for reputation-relevant signals (e.g. message sent) */
+  onReputationSignal?: ReputationSignalCallback;
 }
 
 // ============================================================================

--- a/runtime/src/social/reputation-types.ts
+++ b/runtime/src/social/reputation-types.ts
@@ -9,6 +9,7 @@
  * @module
  */
 
+import type { PublicKey } from '@solana/web3.js';
 import type { Program } from '@coral-xyz/anchor';
 import type { AgencCoordination } from '../idl.js';
 import type { Logger } from '../utils/logger.js';
@@ -160,6 +161,34 @@ export interface ReputationScorerConfig {
   program: Program<AgencCoordination>;
   /** Scoring weight overrides */
   weights?: ReputationWeights;
+  /** Maximum number of history entries to retain (oldest evicted first). 0 = unlimited. */
+  maxHistoryEntries?: number;
   /** Optional logger */
   logger?: Logger;
 }
+
+// ============================================================================
+// Reputation Signal Callback (for feed/messaging integration)
+// ============================================================================
+
+/** Signal types emitted by social modules for reputation tracking. */
+export type ReputationSignalKind = 'upvote' | 'post' | 'message' | 'collaboration' | 'spam';
+
+/** A reputation-relevant signal from a social module. */
+export interface ReputationSignal {
+  /** The kind of social action */
+  kind: ReputationSignalKind;
+  /** Agent PDA that earned/lost reputation */
+  agent: PublicKey;
+  /** Reputation delta (positive or negative) */
+  delta: number;
+  /** Unix timestamp (seconds) */
+  timestamp: number;
+}
+
+/**
+ * Callback invoked when a social module detects a reputation-relevant event.
+ * Consumers can use this to accumulate SocialSignals or trigger on-chain updates.
+ */
+export type ReputationSignalCallback = (signal: ReputationSignal) => void;
+


### PR DESCRIPTION
## Summary

Audit of #1104 (reputation integration) revealed interface signature mismatches and missing integration hooks. This PR fixes all critical/high issues:

- **scorePost** now takes `(postId: string, upvotes: number)` matching the documented `ReputationScorer` interface
- **scoreCollaboration** now takes `(taskId: string, participants: Uint8Array[])` and returns `Map<string, number>` splitting reputation among participants (min 1 point each)
- **scoreMessage** now takes `(message: AgentMessage)` for future content-quality scoring
- **penalizeSpam** now takes `(agentId: Uint8Array, severity: number)` for tracking
- **maxHistoryEntries** config added to cap event history growth (oldest evicted)
- **ReputationSignalCallback** hook added to `FeedConfig` and `MessagingOpsConfig`
- `AgentFeed.upvote()` emits reputation signal for post author after successful upvote
- `AgentMessaging.send()` emits reputation signal for sender after successful message
- New `ReputationSignal`, `ReputationSignalKind`, `ReputationSignalCallback` types exported

## Test plan

- [x] 50 reputation unit tests pass (6 new for signatures + maxHistoryEntries)
- [x] 4466 total runtime tests pass (zero regressions)
- [x] 225 LiteSVM integration tests pass
- [x] Runtime builds cleanly