### PR TITLE
feat(social): agent collaboration protocol — team formation via feed (#1105)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1605,6 +1605,25 @@ export {
   ReputationScorer,
 } from './social/index.js';
 
+// Social / Collaboration (Phase 8.5)
+export {
+  type CollaborationRequest,
+  type CollaborationRequestState,
+  type CollaborationRequestStatus,
+  type CollaborationResponse,
+  type CollaborationRequestMetadata,
+  type CollaborationConfig,
+  type CollaborationOpsConfig,
+  COLLABORATION_TOPIC,
+  MAX_TITLE_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_COLLABORATION_MEMBERS,
+  CollaborationRequestError,
+  CollaborationResponseError,
+  CollaborationFormationError,
+  CollaborationProtocol,
+} from './social/index.js';
+
 // Agent Builder (Phase 10)
 export { AgentBuilder, BuiltAgent } from './builder.js';
 

--- a/runtime/src/social/collaboration-errors.ts
+++ b/runtime/src/social/collaboration-errors.ts
@@ -1,0 +1,66 @@
+/**
+ * Collaboration-specific error classes for @agenc/runtime
+ *
+ * All collaboration errors extend RuntimeError and use codes from RuntimeErrorCodes.
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../types/errors.js';
+
+/**
+ * Error thrown when a collaboration request operation fails.
+ */
+export class CollaborationRequestError extends RuntimeError {
+  /** The reason the operation failed */
+  public readonly reason: string;
+
+  constructor(reason: string) {
+    super(
+      `Collaboration request failed: ${reason}`,
+      RuntimeErrorCodes.COLLABORATION_REQUEST_ERROR,
+    );
+    this.name = 'CollaborationRequestError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Error thrown when a collaboration response operation fails.
+ */
+export class CollaborationResponseError extends RuntimeError {
+  /** The request ID that the response targeted */
+  public readonly requestId: string;
+  /** The reason the response failed */
+  public readonly reason: string;
+
+  constructor(requestId: string, reason: string) {
+    super(
+      `Collaboration response failed for request ${requestId}: ${reason}`,
+      RuntimeErrorCodes.COLLABORATION_RESPONSE_ERROR,
+    );
+    this.name = 'CollaborationResponseError';
+    this.requestId = requestId;
+    this.reason = reason;
+  }
+}
+
+/**
+ * Error thrown when team formation from a collaboration fails.
+ */
+export class CollaborationFormationError extends RuntimeError {
+  /** The request ID for the formation attempt */
+  public readonly requestId: string;
+  /** The reason formation failed */
+  public readonly reason: string;
+
+  constructor(requestId: string, reason: string) {
+    super(
+      `Collaboration formation failed for request ${requestId}: ${reason}`,
+      RuntimeErrorCodes.COLLABORATION_FORMATION_ERROR,
+    );
+    this.name = 'CollaborationFormationError';
+    this.requestId = requestId;
+    this.reason = reason;
+  }
+}

--- a/runtime/src/social/collaboration-types.ts
+++ b/runtime/src/social/collaboration-types.ts
@@ -1,0 +1,151 @@
+/**
+ * Collaboration protocol types, constants, and configuration interfaces.
+ *
+ * Provides types for agent team formation via the feed:
+ * - CollaborationRequest (what an agent posts to find collaborators)
+ * - CollaborationResponse (how agents respond to requests)
+ * - CollaborationRequestState (internal tracking of request lifecycle)
+ *
+ * @module
+ */
+
+import type { PublicKey, Keypair } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../idl.js';
+import type { Logger } from '../utils/logger.js';
+import type { TeamPayoutConfig } from '../team/types.js';
+import type { TeamContractEngine } from '../team/engine.js';
+import type { AgentFeed } from './feed.js';
+import type { AgentMessaging } from './messaging.js';
+import type { AgentDiscovery } from './discovery.js';
+import type { ReputationSignalCallback } from './reputation-types.js';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Well-known 32-byte topic for collaboration request feed posts ("collab\0\0" + 24 zero bytes) */
+export const COLLABORATION_TOPIC = new Uint8Array([
+  0x63, 0x6f, 0x6c, 0x6c, 0x61, 0x62, 0x00, 0x00, // "collab\0\0"
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0,
+]);
+
+/** Maximum length of a collaboration request title */
+export const MAX_TITLE_LENGTH = 128;
+
+/** Maximum length of a collaboration request description */
+export const MAX_DESCRIPTION_LENGTH = 2048;
+
+/** Maximum number of members in a collaboration */
+export const MAX_COLLABORATION_MEMBERS = 20;
+
+// ============================================================================
+// Core Types
+// ============================================================================
+
+/** A collaboration request posted to the feed */
+export interface CollaborationRequest {
+  /** Short title describing the collaboration need */
+  title: string;
+  /** Detailed description of the task/collaboration */
+  description: string;
+  /** Required capability bitmask (agents must match) */
+  requiredCapabilities: bigint;
+  /** Maximum number of team members */
+  maxMembers: number;
+  /** Payout configuration for the team contract */
+  payoutModel: TeamPayoutConfig;
+  /** Optional deadline (Unix seconds) */
+  deadline?: number;
+}
+
+/** Status of a collaboration request */
+export type CollaborationRequestStatus =
+  | 'open'
+  | 'forming'
+  | 'formed'
+  | 'expired'
+  | 'cancelled';
+
+/** A response from an agent to a collaboration request */
+export interface CollaborationResponse {
+  /** PDA of the responding agent */
+  agentPda: PublicKey;
+  /** Whether the agent accepted the collaboration */
+  accepted: boolean;
+  /** Capabilities offered by the responding agent */
+  capabilities: bigint;
+  /** Unix timestamp of response */
+  respondedAt: number;
+}
+
+/** Internal state tracking for a collaboration request */
+export interface CollaborationRequestState {
+  /** Unique request identifier (postPda base58) */
+  requestId: string;
+  /** The original collaboration request */
+  request: CollaborationRequest;
+  /** PDA of the feed post */
+  postPda: PublicKey;
+  /** PDA of the requesting agent */
+  requesterPda: PublicKey;
+  /** Current status */
+  status: CollaborationRequestStatus;
+  /** Collected responses */
+  responses: CollaborationResponse[];
+  /** Team contract ID (set after formation) */
+  teamContractId: string | null;
+  /** SHA-256 hash of the request metadata */
+  contentHash: Uint8Array;
+  /** Random nonce used for the feed post */
+  nonce: Uint8Array;
+  /** Creation timestamp (Unix seconds) */
+  createdAt: number;
+}
+
+/** JSON metadata structure hashed for contentHash */
+export interface CollaborationRequestMetadata {
+  type: 'collaboration_request';
+  version: 1;
+  title: string;
+  description: string;
+  requiredCapabilities: string;
+  maxMembers: number;
+  payoutModel: TeamPayoutConfig;
+  deadline?: number;
+}
+
+// ============================================================================
+// Configuration
+// ============================================================================
+
+/** Optional configuration for CollaborationProtocol */
+export interface CollaborationConfig {
+  /** Optional logger */
+  logger?: Logger;
+  /** Optional callback for reputation-relevant signals */
+  onReputationSignal?: ReputationSignalCallback;
+  /** Override the collaboration topic (default: COLLABORATION_TOPIC) */
+  collaborationTopic?: Uint8Array;
+}
+
+/** Constructor config for CollaborationProtocol */
+export interface CollaborationOpsConfig {
+  /** Anchor program instance */
+  program: Program<AgencCoordination>;
+  /** 32-byte agent identifier */
+  agentId: Uint8Array;
+  /** Keypair for signing transactions */
+  wallet: Keypair;
+  /** AgentFeed instance for posting collaboration requests */
+  feed: AgentFeed;
+  /** AgentMessaging instance for communicating with collaborators */
+  messaging: AgentMessaging;
+  /** AgentDiscovery instance for finding collaborators */
+  discovery: AgentDiscovery;
+  /** TeamContractEngine for forming and managing teams */
+  teamEngine: TeamContractEngine;
+  /** Optional configuration */
+  config?: CollaborationConfig;
+}

--- a/runtime/src/social/collaboration.test.ts
+++ b/runtime/src/social/collaboration.test.ts
@@ -1,0 +1,797 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
+import { PROGRAM_ID } from '@agenc/sdk';
+import { generateAgentId } from '../utils/encoding.js';
+import { RuntimeErrorCodes } from '../types/errors.js';
+import {
+  CollaborationRequestError,
+  CollaborationResponseError,
+  CollaborationFormationError,
+} from './collaboration-errors.js';
+import { CollaborationProtocol } from './collaboration.js';
+import {
+  COLLABORATION_TOPIC,
+  MAX_TITLE_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_COLLABORATION_MEMBERS,
+  type CollaborationRequest,
+} from './collaboration-types.js';
+import type { TeamPayoutConfig } from '../team/types.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function randomPubkey(): PublicKey {
+  return Keypair.generate().publicKey;
+}
+
+function randomBytes32(): Uint8Array {
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) bytes[i] = Math.floor(Math.random() * 256);
+  return bytes;
+}
+
+function createMockProgram() {
+  return {
+    programId: PROGRAM_ID,
+    provider: { publicKey: randomPubkey() },
+  } as any;
+}
+
+function createMockFeed() {
+  return {
+    post: vi.fn().mockResolvedValue('mock-sig'),
+    getPost: vi.fn().mockResolvedValue(null),
+    getFeed: vi.fn().mockResolvedValue([]),
+  } as any;
+}
+
+function createMockMessaging() {
+  return {
+    send: vi.fn().mockResolvedValue({
+      id: 'mock-msg-id',
+      sender: randomPubkey(),
+      recipient: randomPubkey(),
+      content: '{}',
+      mode: 'on-chain' as const,
+      signature: new Uint8Array(64),
+      timestamp: Math.floor(Date.now() / 1000),
+      nonce: 0,
+      onChain: true,
+    }),
+  } as any;
+}
+
+function createMockDiscovery() {
+  return {
+    search: vi.fn().mockResolvedValue([]),
+    getProfile: vi.fn().mockResolvedValue(null),
+  } as any;
+}
+
+function createMockTeamEngine() {
+  return {
+    createContract: vi.fn().mockImplementation((input: { contractId: string }) => ({
+      id: input.contractId.toLowerCase(),
+      status: 'draft',
+      template: {},
+      members: [],
+    })),
+    joinContract: vi.fn().mockReturnValue({ id: 'mock-contract', status: 'draft' }),
+    assignRole: vi.fn().mockReturnValue({ id: 'mock-contract', status: 'draft' }),
+    getContract: vi.fn().mockReturnValue({ id: 'mock-contract', status: 'draft', members: [] }),
+    startRun: vi.fn().mockReturnValue({ id: 'mock-contract', status: 'active' }),
+  } as any;
+}
+
+function createValidRequest(overrides: Partial<CollaborationRequest> = {}): CollaborationRequest {
+  return {
+    title: 'Multi-agent data processing',
+    description: 'Need help processing a large dataset collaboratively.',
+    requiredCapabilities: 3n, // COMPUTE | INFERENCE
+    maxMembers: 3,
+    payoutModel: { mode: 'fixed', rolePayoutBps: { collaborator: 10_000 } } as TeamPayoutConfig,
+    ...overrides,
+  };
+}
+
+function createTestCollaboration(overrides: Record<string, unknown> = {}) {
+  const wallet = Keypair.generate();
+  const agentId = generateAgentId(wallet.publicKey);
+  const program = createMockProgram();
+  const feed = createMockFeed();
+  const messaging = createMockMessaging();
+  const discovery = createMockDiscovery();
+  const teamEngine = createMockTeamEngine();
+
+  const collab = new CollaborationProtocol({
+    program,
+    agentId,
+    wallet,
+    feed,
+    messaging,
+    discovery,
+    teamEngine,
+    ...overrides,
+  });
+
+  return { collab, program, feed, messaging, discovery, teamEngine, wallet, agentId };
+}
+
+// ============================================================================
+// Constructor Tests
+// ============================================================================
+
+describe('CollaborationProtocol constructor', () => {
+  it('creates instance with valid config', () => {
+    const { collab } = createTestCollaboration();
+    expect(collab).toBeInstanceOf(CollaborationProtocol);
+  });
+
+  it('uses silentLogger by default', () => {
+    const { collab } = createTestCollaboration();
+    // No errors means silentLogger is working
+    expect(collab).toBeDefined();
+  });
+
+  it('accepts custom collaboration topic', () => {
+    const customTopic = randomBytes32();
+    const { collab } = createTestCollaboration({
+      config: { collaborationTopic: customTopic },
+    });
+    expect(collab).toBeDefined();
+  });
+});
+
+// ============================================================================
+// requestCollaboration Tests
+// ============================================================================
+
+describe('CollaborationProtocol.requestCollaboration()', () => {
+  it('posts to feed and returns requestId', async () => {
+    const { collab, feed } = createTestCollaboration();
+    const request = createValidRequest();
+
+    const requestId = await collab.requestCollaboration(request);
+
+    expect(requestId).toEqual(expect.any(String));
+    expect(feed.post).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes collaboration topic to feed.post', async () => {
+    const { collab, feed } = createTestCollaboration();
+    const request = createValidRequest();
+
+    await collab.requestCollaboration(request);
+
+    const postCall = feed.post.mock.calls[0][0];
+    expect(postCall.topic).toEqual(COLLABORATION_TOPIC);
+  });
+
+  it('stores request state after posting', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest();
+
+    const requestId = await collab.requestCollaboration(request);
+    const state = collab.getRequest(requestId);
+
+    expect(state).not.toBeNull();
+    expect(state!.status).toBe('open');
+    expect(state!.request.title).toBe(request.title);
+    expect(state!.responses).toHaveLength(0);
+  });
+
+  it('generates 32-byte contentHash', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest();
+
+    const requestId = await collab.requestCollaboration(request);
+    const state = collab.getRequest(requestId);
+
+    expect(state!.contentHash).toBeInstanceOf(Uint8Array);
+    expect(state!.contentHash).toHaveLength(32);
+  });
+
+  it('generates 32-byte nonce', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest();
+
+    const requestId = await collab.requestCollaboration(request);
+    const state = collab.getRequest(requestId);
+
+    expect(state!.nonce).toBeInstanceOf(Uint8Array);
+    expect(state!.nonce).toHaveLength(32);
+  });
+
+  it('throws on empty title', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest({ title: '' });
+
+    await expect(collab.requestCollaboration(request)).rejects.toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('throws on title exceeding max length', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest({ title: 'x'.repeat(MAX_TITLE_LENGTH + 1) });
+
+    await expect(collab.requestCollaboration(request)).rejects.toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('throws on empty description', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest({ description: '' });
+
+    await expect(collab.requestCollaboration(request)).rejects.toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('throws on description exceeding max length', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest({ description: 'x'.repeat(MAX_DESCRIPTION_LENGTH + 1) });
+
+    await expect(collab.requestCollaboration(request)).rejects.toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('throws on maxMembers less than 2', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest({ maxMembers: 1 });
+
+    await expect(collab.requestCollaboration(request)).rejects.toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('throws on maxMembers exceeding limit', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest({ maxMembers: MAX_COLLABORATION_MEMBERS + 1 });
+
+    await expect(collab.requestCollaboration(request)).rejects.toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('throws on zero capabilities', async () => {
+    const { collab } = createTestCollaboration();
+    const request = createValidRequest({ requiredCapabilities: 0n });
+
+    await expect(collab.requestCollaboration(request)).rejects.toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('wraps feed.post errors as CollaborationRequestError', async () => {
+    const feed = createMockFeed();
+    feed.post.mockRejectedValue(new Error('Feed unavailable'));
+    const { collab } = createTestCollaboration({ feed });
+
+    await expect(
+      collab.requestCollaboration(createValidRequest()),
+    ).rejects.toThrow(CollaborationRequestError);
+  });
+});
+
+// ============================================================================
+// respondToRequest Tests
+// ============================================================================
+
+describe('CollaborationProtocol.respondToRequest()', () => {
+  it('sends message to requester', async () => {
+    const { collab, messaging } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+
+    await collab.respondToRequest(requestId, true);
+
+    expect(messaging.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends correct JSON content', async () => {
+    const { collab, messaging } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+
+    await collab.respondToRequest(requestId, true);
+
+    const content = JSON.parse(messaging.send.mock.calls[0][1]);
+    expect(content.type).toBe('collaboration_response');
+    expect(content.requestId).toBe(requestId);
+    expect(content.accepted).toBe(true);
+    expect(content).not.toHaveProperty('capabilities');
+  });
+
+  it('sends decline message when accept is false', async () => {
+    const { collab, messaging } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+
+    await collab.respondToRequest(requestId, false);
+
+    const content = JSON.parse(messaging.send.mock.calls[0][1]);
+    expect(content.accepted).toBe(false);
+  });
+
+  it('throws on unknown request', async () => {
+    const { collab } = createTestCollaboration();
+
+    await expect(
+      collab.respondToRequest('nonexistent', true),
+    ).rejects.toThrow(CollaborationResponseError);
+  });
+
+  it('throws on cancelled request', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+    collab.cancelRequest(requestId);
+
+    await expect(
+      collab.respondToRequest(requestId, true),
+    ).rejects.toThrow(CollaborationResponseError);
+  });
+
+  it('wraps messaging errors as CollaborationResponseError', async () => {
+    const messaging = createMockMessaging();
+    messaging.send.mockRejectedValue(new Error('Connection failed'));
+    const { collab } = createTestCollaboration({ messaging });
+    const requestId = await collab.requestCollaboration(createValidRequest());
+
+    await expect(
+      collab.respondToRequest(requestId, true),
+    ).rejects.toThrow(CollaborationResponseError);
+  });
+});
+
+// ============================================================================
+// processResponse Tests
+// ============================================================================
+
+describe('CollaborationProtocol.processResponse()', () => {
+  it('records accepted response', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+    const agentPda = randomPubkey();
+
+    collab.processResponse(requestId, agentPda, true, 3n);
+
+    const state = collab.getRequest(requestId)!;
+    expect(state.responses).toHaveLength(1);
+    expect(state.responses[0].accepted).toBe(true);
+    expect(state.responses[0].agentPda.equals(agentPda)).toBe(true);
+  });
+
+  it('records rejected response', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+    const agentPda = randomPubkey();
+
+    collab.processResponse(requestId, agentPda, false, 3n);
+
+    const state = collab.getRequest(requestId)!;
+    expect(state.responses).toHaveLength(1);
+    expect(state.responses[0].accepted).toBe(false);
+  });
+
+  it('throws on unknown request', () => {
+    const { collab } = createTestCollaboration();
+
+    expect(() =>
+      collab.processResponse('nonexistent', randomPubkey(), true, 3n),
+    ).toThrow(CollaborationResponseError);
+  });
+
+  it('throws on cancelled request', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+    collab.cancelRequest(requestId);
+
+    expect(() =>
+      collab.processResponse(requestId, randomPubkey(), true, 3n),
+    ).toThrow(CollaborationResponseError);
+  });
+
+  it('throws on duplicate response from same agent', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+    const agentPda = randomPubkey();
+
+    collab.processResponse(requestId, agentPda, true, 3n);
+
+    expect(() =>
+      collab.processResponse(requestId, agentPda, true, 3n),
+    ).toThrow(CollaborationResponseError);
+  });
+
+  it('transitions to forming when maxMembers accepted', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(
+      createValidRequest({ maxMembers: 2 }),
+    );
+
+    collab.processResponse(requestId, randomPubkey(), true, 3n);
+    expect(collab.getRequest(requestId)!.status).toBe('open');
+
+    collab.processResponse(requestId, randomPubkey(), true, 3n);
+    expect(collab.getRequest(requestId)!.status).toBe('forming');
+  });
+
+  it('does not transition to forming on rejections only', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(
+      createValidRequest({ maxMembers: 2 }),
+    );
+
+    collab.processResponse(requestId, randomPubkey(), false, 3n);
+    collab.processResponse(requestId, randomPubkey(), false, 3n);
+    expect(collab.getRequest(requestId)!.status).toBe('open');
+  });
+});
+
+// ============================================================================
+// formTeam Tests
+// ============================================================================
+
+describe('CollaborationProtocol.formTeam()', () => {
+  async function setupFormableRequest(collab: CollaborationProtocol) {
+    const requestId = await collab.requestCollaboration(
+      createValidRequest({ maxMembers: 2 }),
+    );
+    const member1 = randomPubkey();
+    const member2 = randomPubkey();
+
+    collab.processResponse(requestId, member1, true, 3n);
+    collab.processResponse(requestId, member2, true, 3n);
+
+    return { requestId, member1, member2 };
+  }
+
+  it('creates team contract via teamEngine', async () => {
+    const { collab, teamEngine } = createTestCollaboration();
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    await collab.formTeam(requestId, [
+      member1.toBytes(),
+      member2.toBytes(),
+    ]);
+
+    expect(teamEngine.createContract).toHaveBeenCalledTimes(1);
+  });
+
+  it('joins all members to the contract with normalized ID', async () => {
+    const { collab, teamEngine } = createTestCollaboration();
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    const contractId = await collab.formTeam(requestId, [
+      member1.toBytes(),
+      member2.toBytes(),
+    ]);
+
+    expect(teamEngine.joinContract).toHaveBeenCalledTimes(2);
+    // Verify joinContract uses the normalized ID from createContract snapshot
+    expect(teamEngine.joinContract.mock.calls[0][0].contractId).toBe(contractId);
+    expect(teamEngine.joinContract.mock.calls[1][0].contractId).toBe(contractId);
+  });
+
+  it('returns contract ID', async () => {
+    const { collab } = createTestCollaboration();
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    const contractId = await collab.formTeam(requestId, [
+      member1.toBytes(),
+      member2.toBytes(),
+    ]);
+
+    expect(contractId).toEqual(expect.any(String));
+    expect(contractId).toContain('collab-');
+  });
+
+  it('sets status to formed', async () => {
+    const { collab } = createTestCollaboration();
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    await collab.formTeam(requestId, [
+      member1.toBytes(),
+      member2.toBytes(),
+    ]);
+
+    expect(collab.getRequest(requestId)!.status).toBe('formed');
+  });
+
+  it('stores teamContractId on state', async () => {
+    const { collab } = createTestCollaboration();
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    const contractId = await collab.formTeam(requestId, [
+      member1.toBytes(),
+      member2.toBytes(),
+    ]);
+
+    expect(collab.getRequest(requestId)!.teamContractId).toBe(contractId);
+  });
+
+  it('throws on unknown request', async () => {
+    const { collab } = createTestCollaboration();
+
+    await expect(
+      collab.formTeam('nonexistent', [randomBytes32()]),
+    ).rejects.toThrow(CollaborationFormationError);
+  });
+
+  it('throws on already formed request', async () => {
+    const { collab } = createTestCollaboration();
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    await collab.formTeam(requestId, [
+      member1.toBytes(),
+      member2.toBytes(),
+    ]);
+
+    await expect(
+      collab.formTeam(requestId, [member1.toBytes()]),
+    ).rejects.toThrow(CollaborationFormationError);
+  });
+
+  it('throws on unaccepted member', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(
+      createValidRequest({ maxMembers: 2 }),
+    );
+    const accepted = randomPubkey();
+    const stranger = randomPubkey();
+
+    collab.processResponse(requestId, accepted, true, 3n);
+
+    await expect(
+      collab.formTeam(requestId, [stranger.toBytes()]),
+    ).rejects.toThrow(CollaborationFormationError);
+  });
+
+  it('wraps teamEngine errors as CollaborationFormationError', async () => {
+    const teamEngine = createMockTeamEngine();
+    teamEngine.createContract.mockImplementation(() => {
+      throw new Error('Template validation failed');
+    });
+    const { collab } = createTestCollaboration({ teamEngine });
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    await expect(
+      collab.formTeam(requestId, [member1.toBytes(), member2.toBytes()]),
+    ).rejects.toThrow(CollaborationFormationError);
+  });
+
+  it('passes payout model through to team template', async () => {
+    const { collab, teamEngine } = createTestCollaboration();
+    const payoutModel = {
+      mode: 'weighted' as const,
+      roleWeights: { collaborator: 1 },
+    };
+    const requestId = await collab.requestCollaboration(
+      createValidRequest({ maxMembers: 2, payoutModel }),
+    );
+    const m1 = randomPubkey();
+    const m2 = randomPubkey();
+    collab.processResponse(requestId, m1, true, 3n);
+    collab.processResponse(requestId, m2, true, 3n);
+
+    await collab.formTeam(requestId, [m1.toBytes(), m2.toBytes()]);
+
+    const createCall = teamEngine.createContract.mock.calls[0][0];
+    expect(createCall.template.payout).toEqual(payoutModel);
+  });
+
+  it('creates team template with correct role and checkpoints', async () => {
+    const { collab, teamEngine } = createTestCollaboration();
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    await collab.formTeam(requestId, [member1.toBytes(), member2.toBytes()]);
+
+    const createCall = teamEngine.createContract.mock.calls[0][0];
+    expect(createCall.template.roles).toHaveLength(1);
+    expect(createCall.template.roles[0].id).toBe('collaborator');
+    expect(createCall.template.roles[0].maxMembers).toBe(2);
+    expect(createCall.template.checkpoints).toHaveLength(2);
+    expect(createCall.template.checkpoints[0].roleId).toBe('collaborator');
+    expect(createCall.template.checkpoints[1].roleId).toBe('collaborator');
+  });
+
+  it('emits reputation signal on formation', async () => {
+    const onReputationSignal = vi.fn();
+    const { collab } = createTestCollaboration({
+      config: { onReputationSignal },
+    });
+    const { requestId, member1, member2 } = await setupFormableRequest(collab);
+
+    await collab.formTeam(requestId, [
+      member1.toBytes(),
+      member2.toBytes(),
+    ]);
+
+    expect(onReputationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'collaboration',
+        delta: 1,
+      }),
+    );
+  });
+});
+
+// ============================================================================
+// delegateTask Tests
+// ============================================================================
+
+describe('CollaborationProtocol.delegateTask()', () => {
+  it('assigns role via teamEngine', async () => {
+    const { collab, teamEngine } = createTestCollaboration();
+
+    await collab.delegateTask('contract-1', 'task-1', randomBytes32());
+
+    expect(teamEngine.assignRole).toHaveBeenCalledTimes(1);
+    expect(teamEngine.assignRole.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        contractId: 'contract-1',
+        roleId: 'collaborator',
+      }),
+    );
+  });
+
+  it('throws on unknown contract', async () => {
+    const teamEngine = createMockTeamEngine();
+    teamEngine.getContract.mockReturnValue(null);
+    const { collab } = createTestCollaboration({ teamEngine });
+
+    await expect(
+      collab.delegateTask('unknown', 'task-1', randomBytes32()),
+    ).rejects.toThrow(CollaborationFormationError);
+  });
+
+  it('wraps teamEngine.assignRole errors', async () => {
+    const teamEngine = createMockTeamEngine();
+    teamEngine.assignRole.mockImplementation(() => {
+      throw new Error('Member not found');
+    });
+    const { collab } = createTestCollaboration({ teamEngine });
+
+    await expect(
+      collab.delegateTask('contract-1', 'task-1', randomBytes32()),
+    ).rejects.toThrow(CollaborationFormationError);
+  });
+
+  it('passes correct memberId as hex', async () => {
+    const { collab, teamEngine } = createTestCollaboration();
+    const assignee = randomBytes32();
+
+    await collab.delegateTask('contract-1', 'task-1', assignee);
+
+    const call = teamEngine.assignRole.mock.calls[0][0];
+    expect(call.memberId).toBe(Buffer.from(assignee).toString('hex'));
+  });
+});
+
+// ============================================================================
+// Getters and Cancel Tests
+// ============================================================================
+
+describe('CollaborationProtocol getters and cancel', () => {
+  it('getRequest returns null for unknown ID', () => {
+    const { collab } = createTestCollaboration();
+    expect(collab.getRequest('nonexistent')).toBeNull();
+  });
+
+  it('getRequest returns state for known ID', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+
+    const state = collab.getRequest(requestId);
+    expect(state).not.toBeNull();
+    expect(state!.requestId).toBe(requestId);
+  });
+
+  it('getActiveRequests filters by status', async () => {
+    const { collab } = createTestCollaboration();
+    const id1 = await collab.requestCollaboration(createValidRequest());
+    const id2 = await collab.requestCollaboration(createValidRequest());
+
+    collab.cancelRequest(id1);
+
+    const active = collab.getActiveRequests();
+    expect(active).toHaveLength(1);
+    expect(active[0].requestId).toBe(id2);
+  });
+
+  it('cancelRequest sets status to cancelled', async () => {
+    const { collab } = createTestCollaboration();
+    const requestId = await collab.requestCollaboration(createValidRequest());
+
+    collab.cancelRequest(requestId);
+
+    expect(collab.getRequest(requestId)!.status).toBe('cancelled');
+  });
+
+  it('cancelRequest throws on unknown request', () => {
+    const { collab } = createTestCollaboration();
+
+    expect(() => collab.cancelRequest('nonexistent')).toThrow(
+      CollaborationRequestError,
+    );
+  });
+
+  it('getRequest returns expired state for past-deadline requests', async () => {
+    const { collab } = createTestCollaboration();
+    const pastDeadline = Math.floor(Date.now() / 1000) - 3600; // 1 hour ago
+    const requestId = await collab.requestCollaboration(
+      createValidRequest({ deadline: pastDeadline }),
+    );
+
+    const state = collab.getRequest(requestId);
+    expect(state!.status).toBe('expired');
+  });
+});
+
+// ============================================================================
+// findCollaborators Tests
+// ============================================================================
+
+describe('CollaborationProtocol.findCollaborators()', () => {
+  it('delegates to discovery.search', async () => {
+    const { collab, discovery } = createTestCollaboration();
+
+    await collab.findCollaborators(3n);
+
+    expect(discovery.search).toHaveBeenCalledWith({
+      capabilities: 3n,
+      minReputation: undefined,
+    });
+  });
+
+  it('passes minReputation to search', async () => {
+    const { collab, discovery } = createTestCollaboration();
+
+    await collab.findCollaborators(3n, 5000);
+
+    expect(discovery.search).toHaveBeenCalledWith({
+      capabilities: 3n,
+      minReputation: 5000,
+    });
+  });
+
+  it('returns profiles from discovery', async () => {
+    const mockProfile = { pda: randomPubkey(), capabilities: 3n, reputation: 8000 };
+    const discovery = createMockDiscovery();
+    discovery.search.mockResolvedValue([mockProfile]);
+    const { collab } = createTestCollaboration({ discovery });
+
+    const results = await collab.findCollaborators(3n);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toBe(mockProfile);
+  });
+});
+
+// ============================================================================
+// Error Code Tests
+// ============================================================================
+
+describe('Collaboration error codes', () => {
+  it('CollaborationRequestError uses correct code', () => {
+    const err = new CollaborationRequestError('test');
+    expect(err.code).toBe(RuntimeErrorCodes.COLLABORATION_REQUEST_ERROR);
+    expect(err.name).toBe('CollaborationRequestError');
+  });
+
+  it('CollaborationResponseError uses correct code', () => {
+    const err = new CollaborationResponseError('req-1', 'test');
+    expect(err.code).toBe(RuntimeErrorCodes.COLLABORATION_RESPONSE_ERROR);
+    expect(err.name).toBe('CollaborationResponseError');
+    expect(err.requestId).toBe('req-1');
+  });
+
+  it('CollaborationFormationError uses correct code', () => {
+    const err = new CollaborationFormationError('req-1', 'test');
+    expect(err.code).toBe(RuntimeErrorCodes.COLLABORATION_FORMATION_ERROR);
+    expect(err.name).toBe('CollaborationFormationError');
+    expect(err.requestId).toBe('req-1');
+  });
+});

--- a/runtime/src/social/collaboration.ts
+++ b/runtime/src/social/collaboration.ts
@@ -1,0 +1,517 @@
+/**
+ * CollaborationProtocol - Agent team formation via feed posts and messaging.
+ *
+ * One agent discovers a task too complex for a single agent, posts a
+ * collaboration request to the feed, other agents respond via messaging,
+ * and once enough members accept, the requester forms a team contract.
+ *
+ * This is a runtime-only coordination layer — no new on-chain instructions.
+ * It composes existing subsystems (feed, messaging, discovery, team engine)
+ * via dependency injection.
+ *
+ * @module
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import type { PublicKey } from '@solana/web3.js';
+import type { Program } from '@coral-xyz/anchor';
+import type { AgencCoordination } from '../idl.js';
+import type { Logger } from '../utils/logger.js';
+import { silentLogger } from '../utils/logger.js';
+import { findAgentPda } from '../agent/pda.js';
+import type { AgentFeed } from './feed.js';
+import { deriveFeedPostPda } from './feed.js';
+import type { AgentMessaging } from './messaging.js';
+import type { AgentDiscovery } from './discovery.js';
+import type { AgentProfile } from './types.js';
+import type { ReputationSignalCallback } from './reputation-types.js';
+import type { TeamContractEngine } from '../team/engine.js';
+import type { TeamRoleTemplate, TeamCheckpointTemplate } from '../team/types.js';
+import {
+  CollaborationRequestError,
+  CollaborationResponseError,
+  CollaborationFormationError,
+} from './collaboration-errors.js';
+import {
+  COLLABORATION_TOPIC,
+  MAX_TITLE_LENGTH,
+  MAX_DESCRIPTION_LENGTH,
+  MAX_COLLABORATION_MEMBERS,
+  type CollaborationRequest,
+  type CollaborationResponse,
+  type CollaborationRequestState,
+  type CollaborationRequestMetadata,
+  type CollaborationOpsConfig,
+} from './collaboration-types.js';
+
+// ============================================================================
+// CollaborationProtocol
+// ============================================================================
+
+export class CollaborationProtocol {
+  private readonly program: Program<AgencCoordination>;
+  private readonly agentId: Uint8Array;
+  private readonly feed: AgentFeed;
+  private readonly messaging: AgentMessaging;
+  private readonly discovery: AgentDiscovery;
+  private readonly teamEngine: TeamContractEngine;
+  private readonly logger: Logger;
+  private readonly agentPda: PublicKey;
+  private readonly collaborationTopic: Uint8Array;
+  private readonly onReputationSignal?: ReputationSignalCallback;
+
+  /** In-memory store of collaboration requests created by this agent */
+  private readonly requests = new Map<string, CollaborationRequestState>();
+
+  constructor(opsConfig: CollaborationOpsConfig) {
+    this.program = opsConfig.program;
+    this.agentId = new Uint8Array(opsConfig.agentId);
+    this.feed = opsConfig.feed;
+    this.messaging = opsConfig.messaging;
+    this.discovery = opsConfig.discovery;
+    this.teamEngine = opsConfig.teamEngine;
+    this.logger = opsConfig.config?.logger ?? silentLogger;
+    this.onReputationSignal = opsConfig.config?.onReputationSignal;
+    this.collaborationTopic =
+      opsConfig.config?.collaborationTopic ?? COLLABORATION_TOPIC;
+
+    this.agentPda = findAgentPda(this.agentId, this.program.programId);
+  }
+
+  // ==========================================================================
+  // Public API: Write Operations
+  // ==========================================================================
+
+  /**
+   * Post a collaboration request to the feed.
+   *
+   * @param request - The collaboration request details
+   * @returns The request ID (postPda base58)
+   */
+  async requestCollaboration(request: CollaborationRequest): Promise<string> {
+    this.validateRequest(request);
+
+    const metadata: CollaborationRequestMetadata = {
+      type: 'collaboration_request',
+      version: 1,
+      title: request.title,
+      description: request.description,
+      requiredCapabilities: request.requiredCapabilities.toString(),
+      maxMembers: request.maxMembers,
+      payoutModel: request.payoutModel,
+      deadline: request.deadline,
+    };
+
+    const contentHash = createHash('sha256')
+      .update(JSON.stringify(metadata))
+      .digest();
+
+    const nonce = randomBytes(32);
+
+    const postPda = deriveFeedPostPda(
+      this.agentPda,
+      nonce,
+      this.program.programId,
+    );
+
+    try {
+      await this.feed.post({
+        contentHash: new Uint8Array(contentHash),
+        nonce: new Uint8Array(nonce),
+        topic: this.collaborationTopic,
+      });
+    } catch (err) {
+      throw new CollaborationRequestError(
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    const requestId = postPda.toBase58();
+    const state: CollaborationRequestState = {
+      requestId,
+      request,
+      postPda,
+      requesterPda: this.agentPda,
+      status: 'open',
+      responses: [],
+      teamContractId: null,
+      contentHash: new Uint8Array(contentHash),
+      nonce: new Uint8Array(nonce),
+      createdAt: Math.floor(Date.now() / 1000),
+    };
+
+    this.requests.set(requestId, state);
+    this.logger.info(`Collaboration request created: ${requestId}`);
+    return requestId;
+  }
+
+  /**
+   * Respond to a collaboration request by sending a message to the requester.
+   *
+   * @param requestId - The request ID (postPda base58)
+   * @param accept - Whether to accept the collaboration
+   */
+  async respondToRequest(requestId: string, accept: boolean): Promise<void> {
+    const state = this.requests.get(requestId);
+    if (!state) {
+      throw new CollaborationResponseError(requestId, 'Request not found');
+    }
+
+    this.checkExpiration(state);
+    if (state.status !== 'open' && state.status !== 'forming') {
+      throw new CollaborationResponseError(
+        requestId,
+        `Request is ${state.status}, not accepting responses`,
+      );
+    }
+
+    const content = JSON.stringify({
+      type: 'collaboration_response',
+      requestId,
+      accepted: accept,
+    });
+
+    try {
+      await this.messaging.send(state.requesterPda, content);
+    } catch (err) {
+      throw new CollaborationResponseError(
+        requestId,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    this.logger.info(
+      `Responded to collaboration ${requestId}: ${accept ? 'accepted' : 'declined'}`,
+    );
+  }
+
+  /**
+   * Process a collaboration response (requester-side).
+   * Records the response and transitions to 'forming' when maxMembers reached.
+   *
+   * @param requestId - The request ID
+   * @param agentPda - PDA of the responding agent
+   * @param accepted - Whether the agent accepted
+   * @param capabilities - Capabilities of the responding agent
+   */
+  processResponse(
+    requestId: string,
+    agentPda: PublicKey,
+    accepted: boolean,
+    capabilities: bigint,
+  ): void {
+    const state = this.requests.get(requestId);
+    if (!state) {
+      throw new CollaborationResponseError(requestId, 'Request not found');
+    }
+
+    this.checkExpiration(state);
+    if (state.status !== 'open' && state.status !== 'forming') {
+      throw new CollaborationResponseError(
+        requestId,
+        `Request is ${state.status}, not accepting responses`,
+      );
+    }
+
+    // Check for duplicate response from same agent
+    const existing = state.responses.find(
+      (r) => r.agentPda.equals(agentPda),
+    );
+    if (existing) {
+      throw new CollaborationResponseError(
+        requestId,
+        `Agent ${agentPda.toBase58()} already responded`,
+      );
+    }
+
+    const response: CollaborationResponse = {
+      agentPda,
+      accepted,
+      capabilities,
+      respondedAt: Math.floor(Date.now() / 1000),
+    };
+    state.responses.push(response);
+
+    // Transition to 'forming' when enough accepted responses
+    const acceptedCount = state.responses.filter((r) => r.accepted).length;
+    if (acceptedCount >= state.request.maxMembers) {
+      state.status = 'forming';
+      this.logger.info(
+        `Collaboration ${requestId} has enough members (${acceptedCount}/${state.request.maxMembers}), ready to form team`,
+      );
+    }
+  }
+
+  /**
+   * Form a team contract from a collaboration request.
+   *
+   * @param requestId - The request ID
+   * @param members - Agent PDA bytes (32-byte Uint8Array) of accepted members to include
+   * @returns The team contract ID (normalized by the team engine)
+   */
+  async formTeam(requestId: string, members: Uint8Array[]): Promise<string> {
+    const state = this.requests.get(requestId);
+    if (!state) {
+      throw new CollaborationFormationError(requestId, 'Request not found');
+    }
+
+    if (state.status !== 'open' && state.status !== 'forming') {
+      throw new CollaborationFormationError(
+        requestId,
+        `Request is ${state.status}, cannot form team`,
+      );
+    }
+
+    // Validate all members have accepted
+    for (const memberId of members) {
+      const memberHex = Buffer.from(memberId).toString('hex');
+      const response = this.findResponseByHex(state, memberHex);
+      if (!response || !response.accepted) {
+        throw new CollaborationFormationError(
+          requestId,
+          `Member ${memberHex} has not accepted the collaboration`,
+        );
+      }
+    }
+
+    // Build team template — use hex-encoded contentHash prefix for team-ID-compatible strings
+    const hashHex = Buffer.from(state.contentHash).toString('hex');
+    const roleId = 'collaborator';
+    const role: TeamRoleTemplate = {
+      id: roleId,
+      requiredCapabilities: state.request.requiredCapabilities,
+      minMembers: 1,
+      maxMembers: members.length,
+    };
+
+    const checkpoints: TeamCheckpointTemplate[] = members.map((_m, i) => ({
+      id: `checkpoint-${i}`,
+      roleId,
+      label: `Member ${i} contribution`,
+    }));
+
+    const contractId = `collab-${hashHex.slice(0, 16)}-${Date.now()}`;
+
+    try {
+      // Create the contract — the engine normalizes/validates the ID
+      const snapshot = this.teamEngine.createContract({
+        contractId,
+        creatorId: Buffer.from(this.agentPda.toBytes()).toString('hex'),
+        template: {
+          id: `collab-tmpl-${hashHex.slice(0, 12)}`,
+          name: state.request.title,
+          roles: [role],
+          checkpoints,
+          payout: state.request.payoutModel,
+        },
+      });
+
+      // Use the normalized ID from the engine's snapshot
+      const normalizedId = snapshot.id;
+
+      // Join all members
+      for (const memberId of members) {
+        const memberHex = Buffer.from(memberId).toString('hex');
+        const response = this.findResponseByHex(state, memberHex);
+
+        this.teamEngine.joinContract({
+          contractId: normalizedId,
+          member: {
+            id: memberHex,
+            capabilities: response!.capabilities,
+            roles: [roleId],
+          },
+        });
+      }
+
+      state.status = 'formed';
+      state.teamContractId = normalizedId;
+
+      this.logger.info(
+        `Team formed for collaboration ${requestId}: contract ${normalizedId} with ${members.length} members`,
+      );
+
+      // Emit reputation signal for collaboration formation
+      if (this.onReputationSignal) {
+        this.onReputationSignal({
+          kind: 'collaboration',
+          agent: this.agentPda,
+          delta: 1,
+          timestamp: Math.floor(Date.now() / 1000),
+        });
+      }
+
+      return normalizedId;
+    } catch (err) {
+      if (err instanceof CollaborationFormationError) {
+        throw err;
+      }
+      throw new CollaborationFormationError(
+        requestId,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /**
+   * Delegate a task to a team member via the team engine.
+   *
+   * @param teamId - The team contract ID
+   * @param taskId - The task identifier
+   * @param assignee - The assignee's agent PDA bytes (32-byte Uint8Array)
+   */
+  async delegateTask(
+    teamId: string,
+    taskId: string,
+    assignee: Uint8Array,
+  ): Promise<void> {
+    const contract = this.teamEngine.getContract(teamId);
+    if (!contract) {
+      throw new CollaborationFormationError(teamId, 'Team contract not found');
+    }
+
+    const memberId = Buffer.from(assignee).toString('hex');
+
+    try {
+      this.teamEngine.assignRole({
+        contractId: teamId,
+        memberId,
+        roleId: 'collaborator',
+      });
+    } catch (err) {
+      throw new CollaborationFormationError(
+        teamId,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+
+    this.logger.info(
+      `Delegated task ${taskId} to member ${memberId} in team ${teamId}`,
+    );
+  }
+
+  // ==========================================================================
+  // Public API: Read Operations
+  // ==========================================================================
+
+  /**
+   * Get a collaboration request by ID.
+   * Returns null if not found. Performs lazy deadline expiration check.
+   */
+  getRequest(requestId: string): CollaborationRequestState | null {
+    const state = this.requests.get(requestId);
+    if (!state) return null;
+    this.checkExpiration(state);
+    return state;
+  }
+
+  /**
+   * Get all active (open or forming) collaboration requests.
+   */
+  getActiveRequests(): CollaborationRequestState[] {
+    const results: CollaborationRequestState[] = [];
+    for (const state of this.requests.values()) {
+      this.checkExpiration(state);
+      if (state.status === 'open' || state.status === 'forming') {
+        results.push(state);
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Cancel a collaboration request.
+   */
+  cancelRequest(requestId: string): void {
+    const state = this.requests.get(requestId);
+    if (!state) {
+      throw new CollaborationRequestError(`Request ${requestId} not found`);
+    }
+    state.status = 'cancelled';
+    this.logger.info(`Collaboration request cancelled: ${requestId}`);
+  }
+
+  /**
+   * Find potential collaborators matching capability requirements.
+   *
+   * @param capabilities - Required capability bitmask
+   * @param minReputation - Optional minimum reputation threshold
+   * @returns Matching agent profiles
+   */
+  async findCollaborators(
+    capabilities: bigint,
+    minReputation?: number,
+  ): Promise<AgentProfile[]> {
+    return this.discovery.search({
+      capabilities,
+      minReputation,
+    });
+  }
+
+  // ==========================================================================
+  // Private: Validation
+  // ==========================================================================
+
+  private validateRequest(request: CollaborationRequest): void {
+    if (!request.title || request.title.length === 0) {
+      throw new CollaborationRequestError('Title is required');
+    }
+    if (request.title.length > MAX_TITLE_LENGTH) {
+      throw new CollaborationRequestError(
+        `Title exceeds ${MAX_TITLE_LENGTH} characters`,
+      );
+    }
+    if (!request.description || request.description.length === 0) {
+      throw new CollaborationRequestError('Description is required');
+    }
+    if (request.description.length > MAX_DESCRIPTION_LENGTH) {
+      throw new CollaborationRequestError(
+        `Description exceeds ${MAX_DESCRIPTION_LENGTH} characters`,
+      );
+    }
+    if (request.maxMembers < 2) {
+      throw new CollaborationRequestError(
+        'maxMembers must be at least 2',
+      );
+    }
+    if (request.maxMembers > MAX_COLLABORATION_MEMBERS) {
+      throw new CollaborationRequestError(
+        `maxMembers exceeds ${MAX_COLLABORATION_MEMBERS}`,
+      );
+    }
+    if (request.requiredCapabilities === 0n) {
+      throw new CollaborationRequestError(
+        'requiredCapabilities must not be zero',
+      );
+    }
+    if (!request.payoutModel || !request.payoutModel.mode) {
+      throw new CollaborationRequestError(
+        'payoutModel is required',
+      );
+    }
+  }
+
+  private checkExpiration(state: CollaborationRequestState): void {
+    if (
+      state.status === 'open' ||
+      state.status === 'forming'
+    ) {
+      if (
+        state.request.deadline &&
+        Math.floor(Date.now() / 1000) > state.request.deadline
+      ) {
+        state.status = 'expired';
+      }
+    }
+  }
+
+  private findResponseByHex(
+    state: CollaborationRequestState,
+    memberHex: string,
+  ): CollaborationResponse | undefined {
+    return state.responses.find((r) => {
+      const rHex = Buffer.from(r.agentPda.toBytes()).toString('hex');
+      return rHex === memberHex;
+    });
+  }
+}

--- a/runtime/src/social/index.ts
+++ b/runtime/src/social/index.ts
@@ -17,3 +17,6 @@ export * from './feed.js';
 export * from './reputation-types.js';
 export * from './reputation-errors.js';
 export * from './reputation.js';
+export * from './collaboration-types.js';
+export * from './collaboration-errors.js';
+export * from './collaboration.js';

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -50,8 +50,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.MARKETPLACE_MATCHING_ERROR).toBe('MARKETPLACE_MATCHING_ERROR');
   });
 
-  it('has exactly 86 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(86);
+  it('has exactly 89 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(89);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -188,6 +188,12 @@ export const RuntimeErrorCodes = {
   REPUTATION_SCORING_ERROR: 'REPUTATION_SCORING_ERROR',
   /** Reputation event tracking or history query failed */
   REPUTATION_TRACKING_ERROR: 'REPUTATION_TRACKING_ERROR',
+  /** Collaboration request creation or retrieval failed */
+  COLLABORATION_REQUEST_ERROR: 'COLLABORATION_REQUEST_ERROR',
+  /** Collaboration response send or processing failed */
+  COLLABORATION_RESPONSE_ERROR: 'COLLABORATION_RESPONSE_ERROR',
+  /** Team formation from collaboration failed */
+  COLLABORATION_FORMATION_ERROR: 'COLLABORATION_FORMATION_ERROR',
 } as const;
 
 /** Union type of all runtime error code values */


### PR DESCRIPTION
## Summary

- Implements `CollaborationProtocol` class composing feed, messaging, discovery, and team engine subsystems for agent team formation
- Agents post collaboration requests to the feed, others respond via messaging, requester forms a team contract once enough members accept
- 8 public methods: `requestCollaboration`, `respondToRequest`, `processResponse`, `formTeam`, `delegateTask`, `getRequest`, `getActiveRequests`, `cancelRequest`, `findCollaborators`
- 3 new `RuntimeErrorCodes` and error classes (`CollaborationRequestError`, `CollaborationResponseError`, `CollaborationFormationError`)
- 57 unit tests covering all methods, validation, error paths, and edge cases

## Test plan

- [x] 57/57 collaboration unit tests pass
- [x] Runtime build succeeds (CJS + ESM + DTS)
- [x] Full runtime suite passes (4523 tests, 211 files)
- [x] LiteSVM integration tests pass (225 tests)
- [x] Audited against docs MCP architecture spec

Closes #1105