### PR TITLE
feat(marketplace): service marketplace for human-posted requests with agent bidding (#1109)

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1187,6 +1187,22 @@ export {
   type TaskBidBookState,
   type WeightedScoringBreakdown,
   type TaskBidSelection,
+  ServiceMarketplace,
+  type ServiceRequestStatus,
+  type ServiceRequest,
+  type ServiceBid,
+  type ServiceRequestRecord,
+  type ServiceRequestSnapshot,
+  type CreateServiceRequestInput,
+  type BidOnServiceInput,
+  type AcceptServiceBidInput,
+  type StartServiceInput,
+  type CompleteServiceInput,
+  type CancelServiceInput,
+  type DisputeServiceInput,
+  type ResolveServiceDisputeInput,
+  type ListServiceRequestsInput,
+  type ServiceMarketplaceConfig,
 } from './marketplace/index.js';
 
 // Connection Manager

--- a/runtime/src/marketplace/index.ts
+++ b/runtime/src/marketplace/index.ts
@@ -63,3 +63,25 @@ export type {
   WeightedScoringBreakdown,
   TaskBidSelection,
 } from './types.js';
+
+export {
+  ServiceMarketplace,
+} from './service-marketplace.js';
+
+export type {
+  ServiceRequestStatus,
+  ServiceRequest,
+  ServiceBid,
+  ServiceRequestRecord,
+  ServiceRequestSnapshot,
+  CreateServiceRequestInput,
+  BidOnServiceInput,
+  AcceptServiceBidInput,
+  StartServiceInput,
+  CompleteServiceInput,
+  CancelServiceInput,
+  DisputeServiceInput,
+  ResolveServiceDisputeInput,
+  ListServiceRequestsInput,
+  ServiceMarketplaceConfig,
+} from './types.js';

--- a/runtime/src/marketplace/service-marketplace.test.ts
+++ b/runtime/src/marketplace/service-marketplace.test.ts
@@ -1,0 +1,609 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MarketplaceAuthorizationError,
+  MarketplaceStateError,
+  MarketplaceValidationError,
+} from './errors.js';
+import { TaskBidMarketplace } from './engine.js';
+import { ServiceMarketplace } from './service-marketplace.js';
+import type { ServiceRequest, ServiceMarketplaceConfig } from './types.js';
+
+function makeServiceMarketplace(config: Partial<ServiceMarketplaceConfig> = {}) {
+  let nowMs = 1_000;
+  const bidMarketplace = new TaskBidMarketplace({
+    now: () => nowMs,
+    bidIdGenerator: (taskId, bidderId, seq) => `${taskId}:${bidderId}:${seq}`,
+  });
+  const marketplace = new ServiceMarketplace({
+    now: () => nowMs,
+    bidMarketplace,
+    ...config,
+  });
+
+  return {
+    marketplace,
+    bidMarketplace,
+    setNow: (nextNow: number) => {
+      nowMs = nextNow;
+    },
+  };
+}
+
+function validRequest(overrides: Partial<ServiceRequest> = {}): ServiceRequest {
+  return {
+    title: 'Monitor DeFi Positions',
+    description: 'Need an agent to monitor my DeFi positions 24/7',
+    requiredCapabilities: 3n,
+    budget: 1_000_000n,
+    deliverables: ['daily report', 'alert on significant changes'],
+    ...overrides,
+  };
+}
+
+describe('ServiceMarketplace', () => {
+  it('creates a service request with status open and registers owner in bid marketplace', () => {
+    const { marketplace, bidMarketplace } = makeServiceMarketplace();
+
+    const snapshot = marketplace.createRequest({
+      actorId: 'requester-1',
+      serviceId: 'svc-1',
+      request: validRequest(),
+    });
+
+    expect(snapshot.serviceId).toBe('svc-1');
+    expect(snapshot.requesterId).toBe('requester-1');
+    expect(snapshot.status).toBe('open');
+    expect(snapshot.version).toBe(0);
+    expect(snapshot.acceptedBidId).toBeNull();
+    expect(snapshot.awardedAgentId).toBeNull();
+    expect(snapshot.completionProof).toBeNull();
+    expect(snapshot.disputeReason).toBeNull();
+    expect(snapshot.disputeOutcome).toBeNull();
+    expect(snapshot.activeBids).toBe(0);
+    expect(snapshot.totalBids).toBe(0);
+    expect(snapshot.request.title).toBe('Monitor DeFi Positions');
+    expect(snapshot.request.deliverables).toEqual(['daily report', 'alert on significant changes']);
+
+    const bookState = bidMarketplace.getTaskState('svc-1');
+    expect(bookState).not.toBeNull();
+    expect(bookState!.ownerId).toBe('requester-1');
+  });
+
+  it('rejects duplicate serviceId', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'requester-1',
+      serviceId: 'svc-dup',
+      request: validRequest(),
+    });
+
+    expect(() =>
+      marketplace.createRequest({
+        actorId: 'requester-1',
+        serviceId: 'svc-dup',
+        request: validRequest(),
+      }),
+    ).toThrow(MarketplaceStateError);
+  });
+
+  it('validates request inputs', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    expect(() =>
+      marketplace.createRequest({
+        actorId: 'r1',
+        serviceId: 'svc-bad-1',
+        request: validRequest({ title: '' }),
+      }),
+    ).toThrow('title must be non-empty');
+
+    expect(() =>
+      marketplace.createRequest({
+        actorId: 'r1',
+        serviceId: 'svc-bad-2',
+        request: validRequest({ title: 'x'.repeat(257) }),
+      }),
+    ).toThrow('title exceeds max length');
+
+    expect(() =>
+      marketplace.createRequest({
+        actorId: 'r1',
+        serviceId: 'svc-bad-3',
+        request: validRequest({ budget: 0n }),
+      }),
+    ).toThrow('budget must be > 0');
+
+    expect(() =>
+      marketplace.createRequest({
+        actorId: 'r1',
+        serviceId: 'svc-bad-4',
+        request: validRequest({ deliverables: [] }),
+      }),
+    ).toThrow('deliverables must be a non-empty array');
+
+    expect(() =>
+      marketplace.createRequest({
+        actorId: 'r1',
+        serviceId: 'svc-bad-5',
+        request: validRequest({ requiredCapabilities: 0n }),
+      }),
+    ).toThrow('requiredCapabilities must be > 0');
+
+    expect(() =>
+      marketplace.createRequest({
+        actorId: 'r1',
+        serviceId: 'svc-bad-6',
+        request: validRequest({ deliverables: ['valid', '  '] }),
+      }),
+    ).toThrow('each deliverable must be non-empty');
+  });
+
+  it('agent bids on service, transitions open to bidding, maps bid fields correctly', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'requester-1',
+      serviceId: 'svc-bid-1',
+      request: validRequest(),
+    });
+
+    const bid = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-bid-1',
+      bid: {
+        price: 500_000n,
+        deliveryTime: 3600,
+        proposal: 'I will monitor using my DeFi toolkit',
+        portfolioLinks: ['https://example.com/portfolio'],
+      },
+    });
+
+    expect(bid.rewardLamports).toBe(500_000n);
+    expect(bid.etaSeconds).toBe(3600);
+    expect(bid.metadata?.proposal).toBe('I will monitor using my DeFi toolkit');
+    expect(bid.metadata?.portfolioLinks).toEqual(['https://example.com/portfolio']);
+
+    const snapshot = marketplace.getService('svc-bid-1');
+    expect(snapshot!.status).toBe('bidding');
+    expect(snapshot!.activeBids).toBe(1);
+    expect(snapshot!.totalBids).toBe(1);
+  });
+
+  it('rejects self-bidding', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'requester-1',
+      serviceId: 'svc-self',
+      request: validRequest(),
+    });
+
+    expect(() =>
+      marketplace.bidOnService({
+        actorId: 'requester-1',
+        serviceId: 'svc-self',
+        bid: { price: 100n, deliveryTime: 60, proposal: 'self bid' },
+      }),
+    ).toThrow(MarketplaceAuthorizationError);
+  });
+
+  it('rejects bid on cancelled service, bid with price > budget, and empty proposal', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-cancelled',
+      request: validRequest(),
+    });
+    marketplace.cancelService({ actorId: 'r1', serviceId: 'svc-cancelled' });
+
+    expect(() =>
+      marketplace.bidOnService({
+        actorId: 'agent-1',
+        serviceId: 'svc-cancelled',
+        bid: { price: 100n, deliveryTime: 60, proposal: 'ok' },
+      }),
+    ).toThrow(MarketplaceStateError);
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-over-budget',
+      request: validRequest({ budget: 100n }),
+    });
+
+    expect(() =>
+      marketplace.bidOnService({
+        actorId: 'agent-1',
+        serviceId: 'svc-over-budget',
+        bid: { price: 200n, deliveryTime: 60, proposal: 'too expensive' },
+      }),
+    ).toThrow('exceeds service budget');
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-empty-proposal',
+      request: validRequest(),
+    });
+
+    expect(() =>
+      marketplace.bidOnService({
+        actorId: 'agent-1',
+        serviceId: 'svc-empty-proposal',
+        bid: { price: 100n, deliveryTime: 60, proposal: '  ' },
+      }),
+    ).toThrow('proposal must be non-empty');
+  });
+
+  it('requester accepts bid, transitions bidding to awarded, rejects other bids', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-accept',
+      request: validRequest(),
+    });
+
+    marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-accept',
+      bid: { price: 500_000n, deliveryTime: 3600, proposal: 'bid-a' },
+    });
+
+    const bidB = marketplace.bidOnService({
+      actorId: 'agent-2',
+      serviceId: 'svc-accept',
+      bid: { price: 400_000n, deliveryTime: 1800, proposal: 'bid-b' },
+    });
+
+    const snapshot = marketplace.acceptBid({
+      actorId: 'r1',
+      serviceId: 'svc-accept',
+      bidId: bidB.bidId,
+    });
+
+    expect(snapshot.status).toBe('awarded');
+    expect(snapshot.acceptedBidId).toBe(bidB.bidId);
+    expect(snapshot.awardedAgentId).toBe('agent-2');
+
+    const bids = marketplace.listBids('svc-accept');
+    const bidAStatus = bids.find((b) => b.bidderId === 'agent-1')?.status;
+    const bidBStatus = bids.find((b) => b.bidderId === 'agent-2')?.status;
+    expect(bidAStatus).toBe('rejected');
+    expect(bidBStatus).toBe('accepted');
+  });
+
+  it('rejects accept by non-requester and enforces OCC versioning', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-occ',
+      request: validRequest(),
+    });
+
+    const bid = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-occ',
+      bid: { price: 500_000n, deliveryTime: 3600, proposal: 'my proposal' },
+    });
+
+    expect(() =>
+      marketplace.acceptBid({
+        actorId: 'intruder',
+        serviceId: 'svc-occ',
+        bidId: bid.bidId,
+      }),
+    ).toThrow(MarketplaceAuthorizationError);
+
+    const snapshot = marketplace.getService('svc-occ')!;
+
+    marketplace.bidOnService({
+      actorId: 'agent-2',
+      serviceId: 'svc-occ',
+      bid: { price: 300_000n, deliveryTime: 1200, proposal: 'another' },
+    });
+
+    expect(() =>
+      marketplace.acceptBid({
+        actorId: 'r1',
+        serviceId: 'svc-occ',
+        bidId: bid.bidId,
+        expectedVersion: snapshot.version,
+      }),
+    ).toThrow('version mismatch');
+  });
+
+  it('awarded agent starts service, rejects non-agent and wrong state', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-start',
+      request: validRequest(),
+    });
+
+    const bid = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-start',
+      bid: { price: 500_000n, deliveryTime: 3600, proposal: 'i will deliver' },
+    });
+
+    marketplace.acceptBid({ actorId: 'r1', serviceId: 'svc-start', bidId: bid.bidId });
+
+    expect(() =>
+      marketplace.startService({ actorId: 'r1', serviceId: 'svc-start' }),
+    ).toThrow(MarketplaceAuthorizationError);
+
+    expect(() =>
+      marketplace.startService({ actorId: 'agent-2', serviceId: 'svc-start' }),
+    ).toThrow(MarketplaceAuthorizationError);
+
+    const snapshot = marketplace.startService({ actorId: 'agent-1', serviceId: 'svc-start' });
+    expect(snapshot.status).toBe('active');
+
+    expect(() =>
+      marketplace.startService({ actorId: 'agent-1', serviceId: 'svc-start' }),
+    ).toThrow(MarketplaceStateError);
+  });
+
+  it('agent completes service with proof, rejects non-agent', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-complete',
+      request: validRequest(),
+    });
+
+    const bid = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-complete',
+      bid: { price: 500_000n, deliveryTime: 3600, proposal: 'will do' },
+    });
+
+    marketplace.acceptBid({ actorId: 'r1', serviceId: 'svc-complete', bidId: bid.bidId });
+    marketplace.startService({ actorId: 'agent-1', serviceId: 'svc-complete' });
+
+    expect(() =>
+      marketplace.completeService({ actorId: 'r1', serviceId: 'svc-complete', proof: 'proof' }),
+    ).toThrow(MarketplaceAuthorizationError);
+
+    const snapshot = marketplace.completeService({
+      actorId: 'agent-1',
+      serviceId: 'svc-complete',
+      proof: 'task-output-hash-abc123',
+    });
+
+    expect(snapshot.status).toBe('completed');
+    expect(snapshot.completionProof).toBe('task-output-hash-abc123');
+  });
+
+  it('requester cancels from open, bidding, awarded but not active; rejects non-requester', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-cancel-open',
+      request: validRequest(),
+    });
+    const s1 = marketplace.cancelService({ actorId: 'r1', serviceId: 'svc-cancel-open' });
+    expect(s1.status).toBe('cancelled');
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-cancel-bidding',
+      request: validRequest(),
+    });
+    marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-cancel-bidding',
+      bid: { price: 100n, deliveryTime: 60, proposal: 'hi' },
+    });
+    const s2 = marketplace.cancelService({ actorId: 'r1', serviceId: 'svc-cancel-bidding' });
+    expect(s2.status).toBe('cancelled');
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-cancel-awarded',
+      request: validRequest(),
+    });
+    const bid = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-cancel-awarded',
+      bid: { price: 100n, deliveryTime: 60, proposal: 'hi' },
+    });
+    marketplace.acceptBid({ actorId: 'r1', serviceId: 'svc-cancel-awarded', bidId: bid.bidId });
+    const s3 = marketplace.cancelService({ actorId: 'r1', serviceId: 'svc-cancel-awarded' });
+    expect(s3.status).toBe('cancelled');
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-cancel-active',
+      request: validRequest(),
+    });
+    const bid2 = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-cancel-active',
+      bid: { price: 100n, deliveryTime: 60, proposal: 'hi' },
+    });
+    marketplace.acceptBid({ actorId: 'r1', serviceId: 'svc-cancel-active', bidId: bid2.bidId });
+    marketplace.startService({ actorId: 'agent-1', serviceId: 'svc-cancel-active' });
+
+    expect(() =>
+      marketplace.cancelService({ actorId: 'r1', serviceId: 'svc-cancel-active' }),
+    ).toThrow(MarketplaceStateError);
+
+    expect(() =>
+      marketplace.cancelService({ actorId: 'agent-1', serviceId: 'svc-cancel-active' }),
+    ).toThrow(MarketplaceAuthorizationError);
+  });
+
+  it('dispute lifecycle: requester or agent disputes, resolver resolves', () => {
+    const { marketplace } = makeServiceMarketplace({
+      authorizedDisputeResolverIds: ['resolver-1'],
+    });
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-dispute',
+      request: validRequest(),
+    });
+    const bid = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-dispute',
+      bid: { price: 500_000n, deliveryTime: 3600, proposal: 'deliver' },
+    });
+    marketplace.acceptBid({ actorId: 'r1', serviceId: 'svc-dispute', bidId: bid.bidId });
+    marketplace.startService({ actorId: 'agent-1', serviceId: 'svc-dispute' });
+
+    const disputed = marketplace.disputeService({
+      actorId: 'r1',
+      serviceId: 'svc-dispute',
+      reason: 'agent not delivering',
+    });
+    expect(disputed.status).toBe('disputed');
+    expect(disputed.disputeReason).toBe('agent not delivering');
+
+    const resolved = marketplace.resolveDispute({
+      actorId: 'resolver-1',
+      serviceId: 'svc-dispute',
+      outcome: 'refund',
+    });
+    expect(resolved.status).toBe('resolved');
+    expect(resolved.disputeOutcome).toBe('refund');
+  });
+
+  it('rejects dispute by unauthorized actor and resolve by non-resolver', () => {
+    const { marketplace } = makeServiceMarketplace({
+      authorizedDisputeResolverIds: ['resolver-1'],
+    });
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-dispute-auth',
+      request: validRequest(),
+    });
+    const bid = marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-dispute-auth',
+      bid: { price: 500_000n, deliveryTime: 3600, proposal: 'deliver' },
+    });
+    marketplace.acceptBid({ actorId: 'r1', serviceId: 'svc-dispute-auth', bidId: bid.bidId });
+    marketplace.startService({ actorId: 'agent-1', serviceId: 'svc-dispute-auth' });
+
+    expect(() =>
+      marketplace.disputeService({
+        actorId: 'random-bystander',
+        serviceId: 'svc-dispute-auth',
+        reason: 'none of my business',
+      }),
+    ).toThrow(MarketplaceAuthorizationError);
+
+    marketplace.disputeService({
+      actorId: 'agent-1',
+      serviceId: 'svc-dispute-auth',
+      reason: 'requester unreasonable',
+    });
+
+    expect(() =>
+      marketplace.resolveDispute({
+        actorId: 'r1',
+        serviceId: 'svc-dispute-auth',
+        outcome: 'pay_agent',
+      }),
+    ).toThrow(MarketplaceAuthorizationError);
+  });
+
+  it('getService returns null for non-existent and returns snapshot with bid counts', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    expect(marketplace.getService('non-existent')).toBeNull();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-get',
+      request: validRequest(),
+    });
+
+    marketplace.bidOnService({
+      actorId: 'agent-1',
+      serviceId: 'svc-get',
+      bid: { price: 100n, deliveryTime: 60, proposal: 'proposal-1' },
+    });
+    marketplace.bidOnService({
+      actorId: 'agent-2',
+      serviceId: 'svc-get',
+      bid: { price: 200n, deliveryTime: 120, proposal: 'proposal-2' },
+    });
+
+    const snapshot = marketplace.getService('svc-get')!;
+    expect(snapshot.activeBids).toBe(2);
+    expect(snapshot.totalBids).toBe(2);
+    expect(snapshot.status).toBe('bidding');
+  });
+
+  it('listServices filters by status, requester, capabilities, and budget range', () => {
+    const { marketplace } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-list-1',
+      request: validRequest({ budget: 100n, requiredCapabilities: 1n }),
+    });
+    marketplace.createRequest({
+      actorId: 'r2',
+      serviceId: 'svc-list-2',
+      request: validRequest({ budget: 500n, requiredCapabilities: 3n }),
+    });
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-list-3',
+      request: validRequest({ budget: 1000n, requiredCapabilities: 7n }),
+    });
+    marketplace.cancelService({ actorId: 'r1', serviceId: 'svc-list-3' });
+
+    const all = marketplace.listServices();
+    expect(all).toHaveLength(3);
+
+    const openOnly = marketplace.listServices({ status: 'open' });
+    expect(openOnly).toHaveLength(2);
+
+    const byRequester = marketplace.listServices({ requesterId: 'r1' });
+    expect(byRequester).toHaveLength(2);
+
+    const byCap = marketplace.listServices({ requiredCapabilities: 3n, status: 'open' });
+    expect(byCap).toHaveLength(1);
+    expect(byCap[0].serviceId).toBe('svc-list-2');
+
+    const byBudget = marketplace.listServices({ minBudget: 200n, maxBudget: 600n });
+    expect(byBudget).toHaveLength(1);
+    expect(byBudget[0].serviceId).toBe('svc-list-2');
+  });
+
+  it('lazy deadline expiry transitions to cancelled on read', () => {
+    const { marketplace, setNow } = makeServiceMarketplace();
+
+    marketplace.createRequest({
+      actorId: 'r1',
+      serviceId: 'svc-expiry',
+      request: validRequest({ deadline: 5_000 }),
+    });
+
+    const before = marketplace.getService('svc-expiry')!;
+    expect(before.status).toBe('open');
+
+    setNow(5_000);
+
+    const after = marketplace.getService('svc-expiry')!;
+    expect(after.status).toBe('cancelled');
+
+    expect(() =>
+      marketplace.bidOnService({
+        actorId: 'agent-1',
+        serviceId: 'svc-expiry',
+        bid: { price: 100n, deliveryTime: 60, proposal: 'too late' },
+      }),
+    ).toThrow(MarketplaceStateError);
+  });
+});

--- a/runtime/src/marketplace/service-marketplace.ts
+++ b/runtime/src/marketplace/service-marketplace.ts
@@ -1,0 +1,525 @@
+/**
+ * Service marketplace for human-posted service requests with agent bidding.
+ *
+ * Wraps {@link TaskBidMarketplace} — manages service-level lifecycle state
+ * in its own Map and delegates all bid management to the existing engine.
+ *
+ * @module
+ */
+
+import {
+  BPS_BASE,
+  canonicalizeMarketplaceId,
+  validateMarketplaceId,
+} from '@agenc/sdk';
+import {
+  MarketplaceAuthorizationError,
+  MarketplaceStateError,
+  MarketplaceValidationError,
+} from './errors.js';
+import { TaskBidMarketplace } from './engine.js';
+import type {
+  ServiceMarketplaceConfig,
+  ServiceRequestRecord,
+  ServiceRequestSnapshot,
+  ServiceRequestStatus,
+  CreateServiceRequestInput,
+  BidOnServiceInput,
+  AcceptServiceBidInput,
+  StartServiceInput,
+  CompleteServiceInput,
+  CancelServiceInput,
+  DisputeServiceInput,
+  ResolveServiceDisputeInput,
+  ListServiceRequestsInput,
+} from './types.js';
+import type { TaskBid } from '@agenc/sdk';
+
+const DEFAULT_MAX_TITLE_LENGTH = 256;
+const DEFAULT_MAX_DESCRIPTION_LENGTH = 4096;
+const DEFAULT_MAX_DELIVERABLES = 50;
+const DEFAULT_MAX_DELIVERABLE_LENGTH = 512;
+
+function normalizeIdOrThrow(raw: string, label: string): string {
+  const normalized = canonicalizeMarketplaceId(raw);
+  const validationError = validateMarketplaceId(normalized);
+  if (validationError) {
+    throw new MarketplaceValidationError(`${label} ${validationError}`);
+  }
+  return normalized;
+}
+
+export class ServiceMarketplace {
+  private readonly services = new Map<string, ServiceRequestRecord>();
+  private readonly bidMarketplace: TaskBidMarketplace;
+  private readonly now: () => number;
+  private readonly authorizedResolvers: Set<string>;
+  private readonly maxTitleLength: number;
+  private readonly maxDescriptionLength: number;
+  private readonly maxDeliverables: number;
+  private readonly maxDeliverableLength: number;
+
+  constructor(config: ServiceMarketplaceConfig = {}) {
+    this.now = config.now ?? Date.now;
+    this.bidMarketplace = config.bidMarketplace ?? new TaskBidMarketplace({ now: this.now });
+    this.authorizedResolvers = new Set(
+      (config.authorizedDisputeResolverIds ?? []).map((id) => normalizeIdOrThrow(id, 'resolver id')),
+    );
+    this.maxTitleLength = config.maxTitleLength ?? DEFAULT_MAX_TITLE_LENGTH;
+    this.maxDescriptionLength = config.maxDescriptionLength ?? DEFAULT_MAX_DESCRIPTION_LENGTH;
+    this.maxDeliverables = config.maxDeliverables ?? DEFAULT_MAX_DELIVERABLES;
+    this.maxDeliverableLength = config.maxDeliverableLength ?? DEFAULT_MAX_DELIVERABLE_LENGTH;
+  }
+
+  createRequest(input: CreateServiceRequestInput): ServiceRequestSnapshot {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+
+    if (this.services.has(serviceId)) {
+      throw new MarketplaceStateError(`service "${serviceId}" already exists`);
+    }
+
+    this.validateRequest(input.request);
+
+    const nowMs = this.now();
+
+    const record: ServiceRequestRecord = {
+      serviceId,
+      request: cloneRequest(input.request),
+      requesterId: actorId,
+      status: 'open',
+      acceptedBidId: null,
+      awardedAgentId: null,
+      completionProof: null,
+      disputeReason: null,
+      disputeOutcome: null,
+      createdAtMs: nowMs,
+      updatedAtMs: nowMs,
+      version: 0,
+    };
+
+    this.services.set(serviceId, record);
+
+    this.bidMarketplace.setTaskOwner({ taskId: serviceId, ownerId: actorId });
+
+    return this.toSnapshot(record);
+  }
+
+  bidOnService(input: BidOnServiceInput): TaskBid {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+
+    const record = this.getRecordOrThrow(serviceId);
+    this.applyLazyDeadlineExpiry(record);
+
+    if (actorId === record.requesterId) {
+      throw new MarketplaceAuthorizationError('requester cannot bid on own service');
+    }
+
+    if (record.status !== 'open' && record.status !== 'bidding') {
+      throw new MarketplaceStateError(
+        `cannot bid on service "${serviceId}" in status "${record.status}"`,
+      );
+    }
+
+    this.validateBid(input.bid, record.request.budget);
+
+    const bid = this.bidMarketplace.createBid({
+      actorId,
+      taskOwnerId: record.requesterId,
+      bid: {
+        taskId: serviceId,
+        bidderId: actorId,
+        rewardLamports: input.bid.price,
+        etaSeconds: input.bid.deliveryTime,
+        confidenceBps: BPS_BASE,
+        expiresAtMs: record.request.deadline ?? this.now() + 365 * 24 * 60 * 60 * 1000,
+        metadata: {
+          proposal: input.bid.proposal.trim(),
+          ...(input.bid.portfolioLinks ? { portfolioLinks: [...input.bid.portfolioLinks] } : {}),
+        },
+      },
+    });
+
+    if (record.status === 'open') {
+      record.status = 'bidding';
+    }
+    record.updatedAtMs = this.now();
+    record.version += 1;
+
+    return bid;
+  }
+
+  acceptBid(input: AcceptServiceBidInput): ServiceRequestSnapshot {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+    const bidId = normalizeIdOrThrow(input.bidId, 'bid id');
+
+    const record = this.getRecordOrThrow(serviceId);
+    this.applyLazyDeadlineExpiry(record);
+    this.assertVersion(record, input.expectedVersion);
+
+    if (actorId !== record.requesterId) {
+      throw new MarketplaceAuthorizationError(
+        `actor "${actorId}" is not the requester of service "${serviceId}"`,
+      );
+    }
+
+    if (record.status !== 'bidding') {
+      throw new MarketplaceStateError(
+        `cannot accept bid on service "${serviceId}" in status "${record.status}"`,
+      );
+    }
+
+    const result = this.bidMarketplace.acceptBid({
+      actorId,
+      taskId: serviceId,
+      bidId,
+    });
+
+    record.status = 'awarded';
+    record.acceptedBidId = result.acceptedBid.bidId;
+    record.awardedAgentId = result.acceptedBid.bidderId;
+    record.updatedAtMs = this.now();
+    record.version += 1;
+
+    return this.toSnapshot(record);
+  }
+
+  startService(input: StartServiceInput): ServiceRequestSnapshot {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+
+    const record = this.getRecordOrThrow(serviceId);
+    this.applyLazyDeadlineExpiry(record);
+
+    if (actorId !== record.awardedAgentId) {
+      throw new MarketplaceAuthorizationError(
+        `actor "${actorId}" is not the awarded agent for service "${serviceId}"`,
+      );
+    }
+
+    if (record.status !== 'awarded') {
+      throw new MarketplaceStateError(
+        `cannot start service "${serviceId}" in status "${record.status}"`,
+      );
+    }
+
+    record.status = 'active';
+    record.updatedAtMs = this.now();
+    record.version += 1;
+
+    return this.toSnapshot(record);
+  }
+
+  completeService(input: CompleteServiceInput): ServiceRequestSnapshot {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+
+    const record = this.getRecordOrThrow(serviceId);
+
+    if (actorId !== record.awardedAgentId) {
+      throw new MarketplaceAuthorizationError(
+        `actor "${actorId}" is not the awarded agent for service "${serviceId}"`,
+      );
+    }
+
+    if (record.status !== 'active') {
+      throw new MarketplaceStateError(
+        `cannot complete service "${serviceId}" in status "${record.status}"`,
+      );
+    }
+
+    const proof = input.proof?.trim();
+    if (!proof) {
+      throw new MarketplaceValidationError('completion proof must be non-empty');
+    }
+
+    record.status = 'completed';
+    record.completionProof = proof;
+    record.updatedAtMs = this.now();
+    record.version += 1;
+
+    return this.toSnapshot(record);
+  }
+
+  cancelService(input: CancelServiceInput): ServiceRequestSnapshot {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+
+    const record = this.getRecordOrThrow(serviceId);
+    this.applyLazyDeadlineExpiry(record);
+
+    if (actorId !== record.requesterId) {
+      throw new MarketplaceAuthorizationError(
+        `actor "${actorId}" is not the requester of service "${serviceId}"`,
+      );
+    }
+
+    const cancellable: ServiceRequestStatus[] = ['open', 'bidding', 'awarded'];
+    if (!cancellable.includes(record.status)) {
+      throw new MarketplaceStateError(
+        `cannot cancel service "${serviceId}" in status "${record.status}"`,
+      );
+    }
+
+    record.status = 'cancelled';
+    record.updatedAtMs = this.now();
+    record.version += 1;
+
+    return this.toSnapshot(record);
+  }
+
+  disputeService(input: DisputeServiceInput): ServiceRequestSnapshot {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+
+    const record = this.getRecordOrThrow(serviceId);
+
+    if (actorId !== record.requesterId && actorId !== record.awardedAgentId) {
+      throw new MarketplaceAuthorizationError(
+        `actor "${actorId}" is not a party to service "${serviceId}"`,
+      );
+    }
+
+    if (record.status !== 'active') {
+      throw new MarketplaceStateError(
+        `cannot dispute service "${serviceId}" in status "${record.status}"`,
+      );
+    }
+
+    const reason = input.reason?.trim();
+    if (!reason) {
+      throw new MarketplaceValidationError('dispute reason must be non-empty');
+    }
+
+    record.status = 'disputed';
+    record.disputeReason = reason;
+    record.updatedAtMs = this.now();
+    record.version += 1;
+
+    return this.toSnapshot(record);
+  }
+
+  resolveDispute(input: ResolveServiceDisputeInput): ServiceRequestSnapshot {
+    const actorId = normalizeIdOrThrow(input.actorId, 'actor id');
+    const serviceId = normalizeIdOrThrow(input.serviceId, 'service id');
+
+    const record = this.getRecordOrThrow(serviceId);
+
+    if (!this.authorizedResolvers.has(actorId)) {
+      throw new MarketplaceAuthorizationError(
+        `actor "${actorId}" is not an authorized dispute resolver`,
+      );
+    }
+
+    if (record.status !== 'disputed') {
+      throw new MarketplaceStateError(
+        `cannot resolve service "${serviceId}" in status "${record.status}"`,
+      );
+    }
+
+    const validOutcomes = ['refund', 'pay_agent', 'split'] as const;
+    if (!validOutcomes.includes(input.outcome)) {
+      throw new MarketplaceValidationError(
+        `invalid outcome "${input.outcome as string}", expected one of: ${validOutcomes.join(', ')}`,
+      );
+    }
+
+    record.status = 'resolved';
+    record.disputeOutcome = input.outcome;
+    record.updatedAtMs = this.now();
+    record.version += 1;
+
+    return this.toSnapshot(record);
+  }
+
+  getService(serviceIdRaw: string): ServiceRequestSnapshot | null {
+    const serviceId = normalizeIdOrThrow(serviceIdRaw, 'service id');
+    const record = this.services.get(serviceId);
+    if (!record) return null;
+
+    this.applyLazyDeadlineExpiry(record);
+    return this.toSnapshot(record);
+  }
+
+  listServices(input?: ListServiceRequestsInput): ServiceRequestSnapshot[] {
+    const results: ServiceRequestSnapshot[] = [];
+
+    for (const record of this.services.values()) {
+      this.applyLazyDeadlineExpiry(record);
+
+      if (input?.status !== undefined && record.status !== input.status) continue;
+      if (input?.requesterId !== undefined && record.requesterId !== input.requesterId) continue;
+      if (input?.requiredCapabilities !== undefined &&
+          (record.request.requiredCapabilities & input.requiredCapabilities) !== input.requiredCapabilities) continue;
+      if (input?.minBudget !== undefined && record.request.budget < input.minBudget) continue;
+      if (input?.maxBudget !== undefined && record.request.budget > input.maxBudget) continue;
+
+      results.push(this.toSnapshot(record));
+    }
+
+    return results.sort((a, b) => a.createdAtMs - b.createdAtMs);
+  }
+
+  listBids(serviceIdRaw: string): TaskBid[] {
+    const serviceId = normalizeIdOrThrow(serviceIdRaw, 'service id');
+    return this.bidMarketplace.listBids({ taskId: serviceId });
+  }
+
+  getBidMarketplace(): TaskBidMarketplace {
+    return this.bidMarketplace;
+  }
+
+  private getRecordOrThrow(serviceId: string): ServiceRequestRecord {
+    const record = this.services.get(serviceId);
+    if (!record) {
+      throw new MarketplaceStateError(`service "${serviceId}" not found`);
+    }
+    return record;
+  }
+
+  private assertVersion(record: ServiceRequestRecord, expectedVersion: number | undefined): void {
+    if (expectedVersion === undefined) return;
+
+    if (!Number.isInteger(expectedVersion) || expectedVersion < 0) {
+      throw new MarketplaceValidationError('expectedVersion must be a non-negative integer');
+    }
+
+    if (record.version !== expectedVersion) {
+      throw new MarketplaceStateError(
+        `version mismatch for service "${record.serviceId}": expected ${expectedVersion}, current ${record.version}`,
+      );
+    }
+  }
+
+  private applyLazyDeadlineExpiry(record: ServiceRequestRecord): void {
+    if (record.request.deadline === undefined) return;
+
+    const expirable: ServiceRequestStatus[] = ['open', 'bidding'];
+    if (!expirable.includes(record.status)) return;
+
+    if (this.now() >= record.request.deadline) {
+      record.status = 'cancelled';
+      record.updatedAtMs = this.now();
+      record.version += 1;
+    }
+  }
+
+  private validateRequest(request: {
+    title: string;
+    description: string;
+    requiredCapabilities: bigint;
+    budget: bigint;
+    deliverables: string[];
+  }): void {
+    const title = request.title?.trim();
+    if (!title || title.length === 0) {
+      throw new MarketplaceValidationError('title must be non-empty');
+    }
+    if (title.length > this.maxTitleLength) {
+      throw new MarketplaceValidationError(
+        `title exceeds max length of ${this.maxTitleLength}`,
+      );
+    }
+
+    const description = request.description?.trim();
+    if (!description || description.length === 0) {
+      throw new MarketplaceValidationError('description must be non-empty');
+    }
+    if (description.length > this.maxDescriptionLength) {
+      throw new MarketplaceValidationError(
+        `description exceeds max length of ${this.maxDescriptionLength}`,
+      );
+    }
+
+    if (request.requiredCapabilities <= 0n) {
+      throw new MarketplaceValidationError('requiredCapabilities must be > 0');
+    }
+
+    if (request.budget <= 0n) {
+      throw new MarketplaceValidationError('budget must be > 0');
+    }
+
+    if (!Array.isArray(request.deliverables) || request.deliverables.length === 0) {
+      throw new MarketplaceValidationError('deliverables must be a non-empty array');
+    }
+    if (request.deliverables.length > this.maxDeliverables) {
+      throw new MarketplaceValidationError(
+        `deliverables exceeds max count of ${this.maxDeliverables}`,
+      );
+    }
+    for (const d of request.deliverables) {
+      const trimmed = typeof d === 'string' ? d.trim() : '';
+      if (!trimmed) {
+        throw new MarketplaceValidationError('each deliverable must be non-empty');
+      }
+      if (trimmed.length > this.maxDeliverableLength) {
+        throw new MarketplaceValidationError(
+          `deliverable exceeds max length of ${this.maxDeliverableLength}`,
+        );
+      }
+    }
+  }
+
+  private validateBid(bid: { price: bigint; deliveryTime: number; proposal: string }, budget: bigint): void {
+    if (bid.price <= 0n) {
+      throw new MarketplaceValidationError('bid price must be > 0');
+    }
+    if (bid.price > budget) {
+      throw new MarketplaceValidationError(
+        `bid price ${bid.price.toString()} exceeds service budget ${budget.toString()}`,
+      );
+    }
+
+    if (!Number.isInteger(bid.deliveryTime) || bid.deliveryTime <= 0) {
+      throw new MarketplaceValidationError('deliveryTime must be a positive integer');
+    }
+
+    const proposal = bid.proposal?.trim();
+    if (!proposal) {
+      throw new MarketplaceValidationError('proposal must be non-empty');
+    }
+  }
+
+  private toSnapshot(record: ServiceRequestRecord): ServiceRequestSnapshot {
+    const bookState = this.bidMarketplace.getTaskState(record.serviceId);
+
+    return {
+      serviceId: record.serviceId,
+      request: cloneRequest(record.request),
+      requesterId: record.requesterId,
+      status: record.status,
+      acceptedBidId: record.acceptedBidId,
+      awardedAgentId: record.awardedAgentId,
+      completionProof: record.completionProof,
+      disputeReason: record.disputeReason,
+      disputeOutcome: record.disputeOutcome,
+      activeBids: bookState?.activeBids ?? 0,
+      totalBids: bookState?.totalBids ?? 0,
+      version: record.version,
+      createdAtMs: record.createdAtMs,
+      updatedAtMs: record.updatedAtMs,
+    };
+  }
+}
+
+function cloneRequest(request: {
+  title: string;
+  description: string;
+  requiredCapabilities: bigint;
+  budget: bigint;
+  budgetMint?: string;
+  deadline?: number;
+  deliverables: string[];
+}): typeof request {
+  return {
+    title: request.title,
+    description: request.description,
+    requiredCapabilities: request.requiredCapabilities,
+    budget: request.budget,
+    budgetMint: request.budgetMint,
+    deadline: request.deadline,
+    deliverables: [...request.deliverables],
+  };
+}

--- a/runtime/src/marketplace/types.ts
+++ b/runtime/src/marketplace/types.ts
@@ -16,6 +16,8 @@ import type {
   WeightedScoringBreakdown,
 } from '@agenc/sdk';
 
+import type { TaskBidMarketplace } from './engine.js';
+
 export type {
   BidStatus,
   MatchingPolicy,
@@ -101,4 +103,132 @@ export interface AcceptTaskBidResult {
 
 export interface RankedTaskBid extends TaskBidSelection {
   weightedBreakdown?: WeightedScoringBreakdown;
+}
+
+// ---------------------------------------------------------------------------
+// Service Marketplace (Issue #1109)
+// ---------------------------------------------------------------------------
+
+export type ServiceRequestStatus =
+  | 'open'
+  | 'bidding'
+  | 'awarded'
+  | 'active'
+  | 'completed'
+  | 'cancelled'
+  | 'disputed'
+  | 'resolved';
+
+export interface ServiceRequest {
+  title: string;
+  description: string;
+  requiredCapabilities: bigint;
+  budget: bigint;
+  budgetMint?: string;
+  deadline?: number;
+  deliverables: string[];
+}
+
+export interface ServiceBid {
+  price: bigint;
+  deliveryTime: number;
+  proposal: string;
+  portfolioLinks?: string[];
+}
+
+export interface ServiceRequestRecord {
+  serviceId: string;
+  request: ServiceRequest;
+  requesterId: string;
+  status: ServiceRequestStatus;
+  acceptedBidId: string | null;
+  awardedAgentId: string | null;
+  completionProof: string | null;
+  disputeReason: string | null;
+  disputeOutcome: 'refund' | 'pay_agent' | 'split' | null;
+  createdAtMs: number;
+  updatedAtMs: number;
+  version: number;
+}
+
+export interface ServiceRequestSnapshot {
+  serviceId: string;
+  request: ServiceRequest;
+  requesterId: string;
+  status: ServiceRequestStatus;
+  acceptedBidId: string | null;
+  awardedAgentId: string | null;
+  completionProof: string | null;
+  disputeReason: string | null;
+  disputeOutcome: 'refund' | 'pay_agent' | 'split' | null;
+  activeBids: number;
+  totalBids: number;
+  version: number;
+  createdAtMs: number;
+  updatedAtMs: number;
+}
+
+export interface CreateServiceRequestInput {
+  actorId: string;
+  serviceId: string;
+  request: ServiceRequest;
+}
+
+export interface BidOnServiceInput {
+  actorId: string;
+  serviceId: string;
+  bid: ServiceBid;
+}
+
+export interface AcceptServiceBidInput {
+  actorId: string;
+  serviceId: string;
+  bidId: string;
+  expectedVersion?: number;
+}
+
+export interface StartServiceInput {
+  actorId: string;
+  serviceId: string;
+}
+
+export interface CompleteServiceInput {
+  actorId: string;
+  serviceId: string;
+  proof: string;
+}
+
+export interface CancelServiceInput {
+  actorId: string;
+  serviceId: string;
+}
+
+export interface DisputeServiceInput {
+  actorId: string;
+  serviceId: string;
+  reason: string;
+}
+
+export interface ResolveServiceDisputeInput {
+  actorId: string;
+  serviceId: string;
+  outcome: 'refund' | 'pay_agent' | 'split';
+}
+
+export interface ListServiceRequestsInput {
+  status?: ServiceRequestStatus;
+  requesterId?: string;
+  requiredCapabilities?: bigint;
+  minBudget?: bigint;
+  maxBudget?: bigint;
+}
+
+export interface ServiceMarketplaceConfig {
+  now?: () => number;
+  bidMarketplace?: TaskBidMarketplace;
+  authorizedDisputeResolverIds?: string[];
+  maxTitleLength?: number;
+  maxDescriptionLength?: number;
+  maxDeliverables?: number;
+  maxDeliverableLength?: number;
 }


### PR DESCRIPTION
## Summary

- Adds `ServiceMarketplace` class that wraps `TaskBidMarketplace` as a composition layer, managing service-level lifecycle state while delegating all bid management to the existing engine
- Implements full service lifecycle state machine: open → bidding → awarded → active → completed, with cancel/dispute/resolve branches
- Includes 16 test cases covering lifecycle transitions, authorization checks, OCC versioning, lazy deadline expiry, self-bid prevention, and dispute resolution

## Test plan

- [x] `npx vitest run src/marketplace/service-marketplace.test.ts` — 16/16 pass
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [x] `npm run test` — 4528/4528 pass (3 pre-existing LiteSVM failures unrelated)

Closes #1109