### PR TITLE
feat(gateway,mobile): remote Gateway access with JWT auth and React Native app (#1102)

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,101 @@
+import React, { useState, useCallback } from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import { NavigationContainer } from '@react-navigation/native';
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import { Text } from 'react-native';
+import type { GatewayConnection, GatewayStatusInfo } from './src/types';
+import { useRemoteGateway } from './src/hooks/useRemoteGateway';
+import { useChat } from './src/hooks/useChat';
+import { ChatScreen } from './src/screens/ChatScreen';
+import { DashboardScreen } from './src/screens/DashboardScreen';
+import { ApprovalScreen } from './src/screens/ApprovalScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function App() {
+  // Gateway connection state — loaded from settings or deep link
+  const [connection, setConnection] = useState<GatewayConnection | null>(null);
+  const [gatewayInfo, setGatewayInfo] = useState<GatewayStatusInfo | null>(null);
+
+  const { status, send, disconnect, switchGateway, queueSize } = useRemoteGateway({
+    connection,
+    onMessage: (data) => {
+      handleIncoming(data);
+
+      // Handle status broadcasts
+      if (data && typeof data === 'object') {
+        const msg = data as Record<string, unknown>;
+        if (msg.type === 'status' && msg.payload && typeof msg.payload === 'object') {
+          const p = msg.payload as Record<string, unknown>;
+          setGatewayInfo({
+            state: typeof p.state === 'string' ? p.state : 'unknown',
+            uptimeMs: typeof p.uptimeMs === 'number' ? p.uptimeMs : 0,
+            channels: Array.isArray(p.channels) ? (p.channels as string[]) : [],
+            activeSessions: typeof p.activeSessions === 'number' ? p.activeSessions : 0,
+          });
+        }
+      }
+    },
+    onAuthFailed: (reason) => {
+      console.warn('Auth failed:', reason);
+    },
+  });
+
+  const { messages, approvalRequests, sendMessage, handleIncoming, clearMessages, respondToApproval } = useChat(send);
+
+  const handleApprove = useCallback((id: string) => respondToApproval(id, true), [respondToApproval]);
+  const handleDeny = useCallback((id: string) => respondToApproval(id, false), [respondToApproval]);
+
+  return (
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <Tab.Navigator
+          screenOptions={{
+            headerShown: false,
+            tabBarActiveTintColor: '#007AFF',
+          }}
+        >
+          <Tab.Screen
+            name="Chat"
+            options={{
+              tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 20 }}>&#x1F4AC;</Text>,
+            }}
+          >
+            {() => (
+              <ChatScreen
+                connection={connection}
+                status={status}
+                queueSize={queueSize}
+                messages={messages}
+                sendMessage={sendMessage}
+              />
+            )}
+          </Tab.Screen>
+          <Tab.Screen
+            name="Dashboard"
+            options={{
+              tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 20 }}>&#x1F4CA;</Text>,
+            }}
+          >
+            {() => <DashboardScreen status={status} gatewayInfo={gatewayInfo} />}
+          </Tab.Screen>
+          <Tab.Screen
+            name="Approvals"
+            options={{
+              tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 20 }}>&#x2705;</Text>,
+              tabBarBadge: approvalRequests.length > 0 ? approvalRequests.length : undefined,
+            }}
+          >
+            {() => (
+              <ApprovalScreen
+                requests={approvalRequests}
+                onApprove={handleApprove}
+                onDeny={handleDeny}
+              />
+            )}
+          </Tab.Screen>
+        </Tab.Navigator>
+      </NavigationContainer>
+    </SafeAreaProvider>
+  );
+}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,24 @@
+{
+  "expo": {
+    "name": "AgenC Mobile",
+    "slug": "agenc-mobile",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "light",
+    "scheme": "agenc",
+    "splash": {
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "ios": {
+      "supportsTablet": true,
+      "bundleIdentifier": "ai.tetsuo.agenc"
+    },
+    "android": {
+      "adaptiveIcon": {
+        "backgroundColor": "#ffffff"
+      },
+      "package": "ai.tetsuo.agenc"
+    }
+  }
+}

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@agenc/mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@react-navigation/bottom-tabs": "^6.5.20",
+    "@react-navigation/native": "^6.1.17",
+    "expo": "~51.0.0",
+    "expo-status-bar": "~1.12.1",
+    "react": "18.2.0",
+    "react-native": "0.74.5",
+    "react-native-safe-area-context": "4.10.5",
+    "react-native-screens": "~3.31.1"
+  },
+  "devDependencies": {
+    "@types/react": "~18.2.0",
+    "typescript": "~5.3.3"
+  }
+}

--- a/mobile/src/components/MessageBubble.tsx
+++ b/mobile/src/components/MessageBubble.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import type { ChatMessage } from '../types';
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+}
+
+export function MessageBubble({ message }: MessageBubbleProps) {
+  const isUser = message.sender === 'user';
+
+  return (
+    <View style={[styles.container, isUser ? styles.userContainer : styles.agentContainer]}>
+      <View style={[styles.bubble, isUser ? styles.userBubble : styles.agentBubble]}>
+        <Text style={[styles.text, isUser ? styles.userText : styles.agentText]}>
+          {message.content}
+        </Text>
+        <Text style={[styles.timestamp, isUser ? styles.userTimestamp : styles.agentTimestamp]}>
+          {new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 12,
+    paddingVertical: 4,
+  },
+  userContainer: {
+    alignItems: 'flex-end',
+  },
+  agentContainer: {
+    alignItems: 'flex-start',
+  },
+  bubble: {
+    maxWidth: '80%',
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 16,
+  },
+  userBubble: {
+    backgroundColor: '#007AFF',
+    borderBottomRightRadius: 4,
+  },
+  agentBubble: {
+    backgroundColor: '#E9E9EB',
+    borderBottomLeftRadius: 4,
+  },
+  text: {
+    fontSize: 16,
+    lineHeight: 22,
+  },
+  userText: {
+    color: '#FFFFFF',
+  },
+  agentText: {
+    color: '#000000',
+  },
+  timestamp: {
+    fontSize: 11,
+    marginTop: 4,
+    alignSelf: 'flex-end',
+  },
+  userTimestamp: {
+    color: 'rgba(255, 255, 255, 0.7)',
+  },
+  agentTimestamp: {
+    color: '#8E8E93',
+  },
+});

--- a/mobile/src/hooks/useChat.ts
+++ b/mobile/src/hooks/useChat.ts
@@ -1,0 +1,81 @@
+/**
+ * Chat message handling hook.
+ *
+ * Manages the message list and provides send/receive helpers
+ * that integrate with useRemoteGateway.
+ */
+
+import { useState, useCallback } from 'react';
+import type { ChatMessage, ApprovalRequest } from '../types';
+
+let messageCounter = 0;
+
+function generateId(): string {
+  return `msg_${Date.now()}_${++messageCounter}`;
+}
+
+interface UseChatResult {
+  messages: ChatMessage[];
+  approvalRequests: ApprovalRequest[];
+  sendMessage: (content: string) => void;
+  handleIncoming: (data: unknown) => void;
+  clearMessages: () => void;
+  respondToApproval: (id: string, approved: boolean) => void;
+}
+
+export function useChat(
+  gatewaySend: (msg: Record<string, unknown>) => void,
+): UseChatResult {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [approvalRequests, setApprovalRequests] = useState<ApprovalRequest[]>([]);
+
+  const sendMessage = useCallback((content: string) => {
+    const msg: ChatMessage = {
+      id: generateId(),
+      content,
+      sender: 'user',
+      timestamp: Date.now(),
+    };
+    setMessages((prev) => [...prev, msg]);
+    gatewaySend({ type: 'chat.message', payload: { content } });
+  }, [gatewaySend]);
+
+  const handleIncoming = useCallback((data: unknown) => {
+    if (!data || typeof data !== 'object') return;
+    const msg = data as Record<string, unknown>;
+
+    if (msg.type === 'chat.response' && msg.payload && typeof msg.payload === 'object') {
+      const payload = msg.payload as Record<string, unknown>;
+      const chatMsg: ChatMessage = {
+        id: typeof payload.id === 'string' ? payload.id : generateId(),
+        content: typeof payload.content === 'string' ? payload.content : '',
+        sender: 'agent',
+        timestamp: typeof payload.timestamp === 'number' ? payload.timestamp : Date.now(),
+      };
+      setMessages((prev) => [...prev, chatMsg]);
+    }
+
+    if (msg.type === 'approval.request' && msg.payload && typeof msg.payload === 'object') {
+      const payload = msg.payload as Record<string, unknown>;
+      const request: ApprovalRequest = {
+        id: typeof payload.id === 'string' ? payload.id : generateId(),
+        tool: typeof payload.tool === 'string' ? payload.tool : 'unknown',
+        args: typeof payload.args === 'object' && payload.args ? payload.args as Record<string, unknown> : {},
+        reason: typeof payload.reason === 'string' ? payload.reason : '',
+        timestamp: typeof payload.timestamp === 'number' ? payload.timestamp : Date.now(),
+      };
+      setApprovalRequests((prev) => [...prev, request]);
+    }
+  }, []);
+
+  const respondToApproval = useCallback((id: string, approved: boolean) => {
+    gatewaySend({ type: 'approval.response', payload: { id, approved } });
+    setApprovalRequests((prev) => prev.filter((r) => r.id !== id));
+  }, [gatewaySend]);
+
+  const clearMessages = useCallback(() => {
+    setMessages([]);
+  }, []);
+
+  return { messages, approvalRequests, sendMessage, handleIncoming, clearMessages, respondToApproval };
+}

--- a/mobile/src/hooks/useRemoteGateway.ts
+++ b/mobile/src/hooks/useRemoteGateway.ts
@@ -1,0 +1,212 @@
+/**
+ * React hook for WebSocket connection to Gateway with JWT auth,
+ * offline queue, and automatic reconnection.
+ *
+ * Uses browser-native WebSocket (not ws npm package).
+ */
+
+import { useRef, useState, useCallback, useEffect } from 'react';
+import type { ConnectionStatus, GatewayConnection } from '../types';
+
+const MAX_OFFLINE_QUEUE = 1000;
+const PING_INTERVAL_MS = 30_000;
+const RECONNECT_BASE_DELAY_MS = 1_000;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+const JITTER_FACTOR = 0.2;
+
+interface UseRemoteGatewayOptions {
+  connection: GatewayConnection | null;
+  onMessage?: (data: unknown) => void;
+  onAuthFailed?: (reason: string) => void;
+}
+
+interface UseRemoteGatewayResult {
+  status: ConnectionStatus;
+  send: (msg: Record<string, unknown>) => void;
+  sendMessage: (content: string) => void;
+  disconnect: () => void;
+  switchGateway: (url: string, token: string) => void;
+  queueSize: number;
+}
+
+export function useRemoteGateway({
+  connection,
+  onMessage,
+  onAuthFailed,
+}: UseRemoteGatewayOptions): UseRemoteGatewayResult {
+  const [status, setStatus] = useState<ConnectionStatus>('disconnected');
+  const wsRef = useRef<WebSocket | null>(null);
+  const offlineQueueRef = useRef<string[]>([]);
+  const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptRef = useRef(0);
+  const intentionalCloseRef = useRef(false);
+  const [queueSize, setQueueSize] = useState(0);
+
+  // Store latest callbacks in refs to avoid reconnect on every render
+  const onMessageRef = useRef(onMessage);
+  onMessageRef.current = onMessage;
+  const onAuthFailedRef = useRef(onAuthFailed);
+  onAuthFailedRef.current = onAuthFailed;
+  const connectionRef = useRef(connection);
+  connectionRef.current = connection;
+
+  const stopPing = useCallback(() => {
+    if (pingTimerRef.current) {
+      clearInterval(pingTimerRef.current);
+      pingTimerRef.current = null;
+    }
+  }, []);
+
+  const startPing = useCallback(() => {
+    stopPing();
+    pingTimerRef.current = setInterval(() => {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        wsRef.current.send(JSON.stringify({ type: 'ping' }));
+      }
+    }, PING_INTERVAL_MS);
+  }, [stopPing]);
+
+  const clearReconnect = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  const flushQueue = useCallback(() => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    while (offlineQueueRef.current.length > 0) {
+      ws.send(offlineQueueRef.current.shift()!);
+    }
+    setQueueSize(0);
+  }, []);
+
+  const enqueue = useCallback((msg: string) => {
+    if (offlineQueueRef.current.length >= MAX_OFFLINE_QUEUE) {
+      offlineQueueRef.current.shift();
+    }
+    offlineQueueRef.current.push(msg);
+    setQueueSize(offlineQueueRef.current.length);
+  }, []);
+
+  const connect = useCallback(() => {
+    const conn = connectionRef.current;
+    if (!conn) return;
+
+    intentionalCloseRef.current = false;
+    setStatus('connecting');
+
+    const ws = new WebSocket(conn.url);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setStatus('authenticating');
+      ws.send(JSON.stringify({ type: 'auth', payload: { token: conn.token } }));
+    };
+
+    ws.onmessage = (event) => {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(event.data as string);
+      } catch {
+        onMessageRef.current?.(event.data);
+        return;
+      }
+
+      if (parsed && typeof parsed === 'object') {
+        const msg = parsed as Record<string, unknown>;
+        if (msg.type === 'auth') {
+          if (msg.error) {
+            offlineQueueRef.current.length = 0;
+            setQueueSize(0);
+            setStatus('disconnected');
+            onAuthFailedRef.current?.(String(msg.error));
+            ws.close();
+            return;
+          }
+          reconnectAttemptRef.current = 0;
+          setStatus('connected');
+          startPing();
+          flushQueue();
+          return;
+        }
+      }
+
+      onMessageRef.current?.(parsed);
+    };
+
+    ws.onclose = () => {
+      stopPing();
+      wsRef.current = null;
+
+      if (intentionalCloseRef.current) {
+        setStatus('disconnected');
+        return;
+      }
+
+      setStatus('reconnecting');
+      const base = Math.min(
+        RECONNECT_BASE_DELAY_MS * Math.pow(2, reconnectAttemptRef.current),
+        RECONNECT_MAX_DELAY_MS,
+      );
+      const jitter = 1 + Math.random() * JITTER_FACTOR;
+      const delay = Math.round(base * jitter);
+      reconnectAttemptRef.current++;
+      reconnectTimerRef.current = setTimeout(connect, delay);
+    };
+
+    ws.onerror = () => {
+      // Error handling is done in onclose
+    };
+  }, [startPing, stopPing, flushQueue]);
+
+  const disconnect = useCallback(() => {
+    intentionalCloseRef.current = true;
+    stopPing();
+    clearReconnect();
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+    setStatus('disconnected');
+  }, [stopPing, clearReconnect]);
+
+  const switchGateway = useCallback((url: string, token: string) => {
+    disconnect();
+    connectionRef.current = { url, token };
+    // Trigger reconnect on next tick so state settles
+    setTimeout(() => {
+      connect();
+    }, 0);
+  }, [disconnect, connect]);
+
+  const send = useCallback((msg: Record<string, unknown>) => {
+    const serialized = JSON.stringify(msg);
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(serialized);
+    } else {
+      enqueue(serialized);
+    }
+  }, [enqueue]);
+
+  const sendMessage = useCallback((content: string) => {
+    send({ type: 'chat.message', payload: { content } });
+  }, [send]);
+
+  // Connect when connection config changes
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (connection) {
+      connect();
+    } else {
+      disconnect();
+    }
+    return () => {
+      disconnect();
+    };
+  }, [connection?.url, connection?.token]);
+
+  return { status, send, sendMessage, disconnect, switchGateway, queueSize };
+}

--- a/mobile/src/screens/ApprovalScreen.tsx
+++ b/mobile/src/screens/ApprovalScreen.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, FlatList, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { ApprovalRequest } from '../types';
+
+interface ApprovalScreenProps {
+  requests: ApprovalRequest[];
+  onApprove: (id: string) => void;
+  onDeny: (id: string) => void;
+}
+
+export function ApprovalScreen({ requests, onApprove, onDeny }: ApprovalScreenProps) {
+  const renderItem = ({ item }: { item: ApprovalRequest }) => (
+    <View style={styles.card}>
+      <Text style={styles.tool}>{item.tool}</Text>
+      <Text style={styles.reason}>{item.reason}</Text>
+      <Text style={styles.timestamp}>
+        {new Date(item.timestamp).toLocaleTimeString()}
+      </Text>
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={[styles.button, styles.denyButton]}
+          onPress={() => onDeny(item.id)}
+        >
+          <Text style={styles.denyText}>Deny</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.button, styles.approveButton]}
+          onPress={() => onApprove(item.id)}
+        >
+          <Text style={styles.approveText}>Approve</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Pending Approvals</Text>
+      {requests.length === 0 ? (
+        <View style={styles.empty}>
+          <Text style={styles.emptyText}>No pending approvals</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={requests}
+          renderItem={renderItem}
+          keyExtractor={(item) => item.id}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F2F2F7',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 16,
+    color: '#000000',
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  tool: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#000000',
+    marginBottom: 4,
+  },
+  reason: {
+    fontSize: 14,
+    color: '#3C3C43',
+    marginBottom: 8,
+  },
+  timestamp: {
+    fontSize: 12,
+    color: '#8E8E93',
+    marginBottom: 12,
+  },
+  actions: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 8,
+  },
+  button: {
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  approveButton: {
+    backgroundColor: '#34C759',
+  },
+  denyButton: {
+    backgroundColor: '#FF3B30',
+  },
+  approveText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  denyText: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+    fontSize: 14,
+  },
+  empty: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 16,
+    color: '#8E8E93',
+  },
+});

--- a/mobile/src/screens/ChatScreen.tsx
+++ b/mobile/src/screens/ChatScreen.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useRef, useCallback } from 'react';
+import {
+  View,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { ChatMessage, ConnectionStatus, GatewayConnection } from '../types';
+import { MessageBubble } from '../components/MessageBubble';
+
+const STATUS_COLORS: Record<string, string> = {
+  connected: '#34C759',
+  connecting: '#FF9500',
+  authenticating: '#FF9500',
+  reconnecting: '#FF9500',
+  disconnected: '#FF3B30',
+};
+
+interface ChatScreenProps {
+  connection: GatewayConnection | null;
+  status: ConnectionStatus;
+  queueSize: number;
+  messages: ChatMessage[];
+  sendMessage: (content: string) => void;
+}
+
+export function ChatScreen({ connection, status, queueSize, messages, sendMessage }: ChatScreenProps) {
+  const [input, setInput] = useState('');
+  const flatListRef = useRef<FlatList<ChatMessage>>(null);
+
+  const handleSend = useCallback(() => {
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    sendMessage(trimmed);
+    setInput('');
+    setTimeout(() => {
+      flatListRef.current?.scrollToEnd({ animated: true });
+    }, 100);
+  }, [input, sendMessage]);
+
+  const renderMessage = useCallback(({ item }: { item: ChatMessage }) => (
+    <MessageBubble message={item} />
+  ), []);
+
+  const keyExtractor = useCallback((item: ChatMessage) => item.id, []);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {/* Header */}
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>AgenC</Text>
+        <View style={styles.statusRow}>
+          <View style={[styles.statusDot, { backgroundColor: STATUS_COLORS[status] ?? '#8E8E93' }]} />
+          <Text style={styles.statusText}>{status}</Text>
+          {queueSize > 0 && (
+            <Text style={styles.queueText}> ({queueSize} queued)</Text>
+          )}
+        </View>
+      </View>
+
+      {/* Messages */}
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={0}
+      >
+        <FlatList
+          ref={flatListRef}
+          data={messages}
+          renderItem={renderMessage}
+          keyExtractor={keyExtractor}
+          contentContainerStyle={styles.messageList}
+          onContentSizeChange={() => flatListRef.current?.scrollToEnd({ animated: false })}
+        />
+
+        {/* Input */}
+        <View style={styles.inputContainer}>
+          <TextInput
+            style={styles.input}
+            value={input}
+            onChangeText={setInput}
+            placeholder={connection ? 'Type a message...' : 'No gateway configured'}
+            placeholderTextColor="#8E8E93"
+            editable={!!connection}
+            multiline
+            maxLength={4096}
+            onSubmitEditing={handleSend}
+            blurOnSubmit={false}
+          />
+          <TouchableOpacity
+            style={[styles.sendButton, !input.trim() && styles.sendButtonDisabled]}
+            onPress={handleSend}
+            disabled={!input.trim() || !connection}
+          >
+            <Text style={styles.sendButtonText}>Send</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#FFFFFF',
+  },
+  flex: {
+    flex: 1,
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#C6C6C8',
+  },
+  headerTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#000000',
+  },
+  statusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  statusDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    marginRight: 6,
+  },
+  statusText: {
+    fontSize: 13,
+    color: '#8E8E93',
+  },
+  queueText: {
+    fontSize: 13,
+    color: '#8E8E93',
+  },
+  messageList: {
+    paddingVertical: 8,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: '#C6C6C8',
+  },
+  input: {
+    flex: 1,
+    minHeight: 36,
+    maxHeight: 120,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: '#F2F2F7',
+    borderRadius: 18,
+    fontSize: 16,
+    color: '#000000',
+  },
+  sendButton: {
+    marginLeft: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    backgroundColor: '#007AFF',
+    borderRadius: 18,
+    justifyContent: 'center',
+  },
+  sendButtonDisabled: {
+    opacity: 0.5,
+  },
+  sendButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/mobile/src/screens/DashboardScreen.tsx
+++ b/mobile/src/screens/DashboardScreen.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import type { ConnectionStatus, GatewayStatusInfo } from '../types';
+
+interface DashboardScreenProps {
+  status: ConnectionStatus;
+  gatewayInfo: GatewayStatusInfo | null;
+}
+
+export function DashboardScreen({ status, gatewayInfo }: DashboardScreenProps) {
+  return (
+    <SafeAreaView style={styles.container}>
+      <Text style={styles.title}>Gateway Status</Text>
+
+      <View style={styles.card}>
+        <Text style={styles.label}>Connection</Text>
+        <Text style={[styles.value, { color: status === 'connected' ? '#34C759' : '#FF3B30' }]}>
+          {status}
+        </Text>
+      </View>
+
+      {gatewayInfo && (
+        <>
+          <View style={styles.card}>
+            <Text style={styles.label}>Gateway State</Text>
+            <Text style={styles.value}>{gatewayInfo.state}</Text>
+          </View>
+
+          <View style={styles.card}>
+            <Text style={styles.label}>Uptime</Text>
+            <Text style={styles.value}>
+              {Math.floor(gatewayInfo.uptimeMs / 1000)}s
+            </Text>
+          </View>
+
+          <View style={styles.card}>
+            <Text style={styles.label}>Active Sessions</Text>
+            <Text style={styles.value}>{gatewayInfo.activeSessions}</Text>
+          </View>
+
+          <View style={styles.card}>
+            <Text style={styles.label}>Channels</Text>
+            <Text style={styles.value}>
+              {gatewayInfo.channels.length > 0
+                ? gatewayInfo.channels.join(', ')
+                : 'None'}
+            </Text>
+          </View>
+        </>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#F2F2F7',
+    padding: 16,
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: '700',
+    marginBottom: 16,
+    color: '#000000',
+  },
+  card: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 8,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  label: {
+    fontSize: 16,
+    color: '#8E8E93',
+  },
+  value: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#000000',
+  },
+});

--- a/mobile/src/services/gateway-client.ts
+++ b/mobile/src/services/gateway-client.ts
@@ -1,0 +1,27 @@
+/**
+ * Gateway connection management service.
+ *
+ * Handles URL and token storage for connecting to a remote Gateway.
+ * In a production app this would persist to AsyncStorage or SecureStore.
+ */
+
+import type { GatewayConnection } from '../types';
+
+let currentConnection: GatewayConnection | null = null;
+
+export function getConnection(): GatewayConnection | null {
+  return currentConnection;
+}
+
+export function setConnection(url: string, token: string): GatewayConnection {
+  currentConnection = { url, token };
+  return currentConnection;
+}
+
+export function clearConnection(): void {
+  currentConnection = null;
+}
+
+export function isConfigured(): boolean {
+  return currentConnection !== null;
+}

--- a/mobile/src/services/push-notifications.ts
+++ b/mobile/src/services/push-notifications.ts
@@ -1,0 +1,40 @@
+/**
+ * Push notification types and stubs.
+ *
+ * Full implementation is deferred — this module defines the interface
+ * for future Expo push notification integration.
+ */
+
+export interface PushNotificationConfig {
+  /** Expo push token */
+  expoPushToken?: string;
+  /** Whether notifications are enabled */
+  enabled: boolean;
+}
+
+export interface PushNotificationPayload {
+  messageId: string;
+  sender: string;
+  preview: string;
+  timestamp: number;
+}
+
+/**
+ * Register for push notifications.
+ * Stub — returns null until Expo notification setup is implemented.
+ */
+export async function registerForPushNotifications(): Promise<string | null> {
+  // TODO: Implement with expo-notifications
+  // 1. Request permissions
+  // 2. Get Expo push token
+  // 3. Send token to Gateway for server-side notification dispatch
+  return null;
+}
+
+/**
+ * Handle incoming push notification.
+ * Stub — no-op until implemented.
+ */
+export function handlePushNotification(_payload: PushNotificationPayload): void {
+  // TODO: Route to appropriate screen / update badge count
+}

--- a/mobile/src/types.ts
+++ b/mobile/src/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Mobile app types.
+ *
+ * Mirrors relevant types from the runtime for browser/RN isolation —
+ * the mobile app does NOT import from @agenc/runtime.
+ */
+
+export interface ChatMessage {
+  id: string;
+  content: string;
+  sender: 'user' | 'agent';
+  timestamp: number;
+}
+
+export type ConnectionStatus = 'disconnected' | 'connecting' | 'authenticating' | 'connected' | 'reconnecting';
+
+export interface GatewayConnection {
+  url: string;
+  token: string;
+}
+
+export interface ApprovalRequest {
+  id: string;
+  tool: string;
+  args: Record<string, unknown>;
+  reason: string;
+  timestamp: number;
+}
+
+export interface GatewayStatusInfo {
+  state: string;
+  uptimeMs: number;
+  channels: string[];
+  activeSessions: number;
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -130,6 +130,27 @@ export function validateGatewayConfig(obj: unknown): ValidationResult {
     }
   }
 
+  // auth (optional)
+  if (obj.auth !== undefined) {
+    if (!isRecord(obj.auth)) {
+      errors.push('auth must be an object');
+    } else {
+      if (obj.auth.secret !== undefined) {
+        if (typeof obj.auth.secret !== 'string') {
+          errors.push('auth.secret must be a string');
+        } else if (obj.auth.secret.length < 32) {
+          errors.push('auth.secret must be at least 32 characters');
+        }
+      }
+      if (obj.auth.expirySeconds !== undefined && typeof obj.auth.expirySeconds !== 'number') {
+        errors.push('auth.expirySeconds must be a number');
+      }
+      if (obj.auth.localBypass !== undefined && typeof obj.auth.localBypass !== 'boolean') {
+        errors.push('auth.localBypass must be a boolean');
+      }
+    }
+  }
+
   return validationResult(errors);
 }
 

--- a/runtime/src/gateway/errors.ts
+++ b/runtime/src/gateway/errors.ts
@@ -94,3 +94,10 @@ export class SubAgentNotFoundError extends RuntimeError {
     this.sessionId = sessionId;
   }
 }
+
+export class GatewayAuthError extends RuntimeError {
+  constructor(message: string) {
+    super(message, RuntimeErrorCodes.REMOTE_AUTH_ERROR);
+    this.name = 'GatewayAuthError';
+  }
+}

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -29,6 +29,7 @@ export {
   SubAgentSpawnError,
   SubAgentTimeoutError,
   SubAgentNotFoundError,
+  GatewayAuthError,
 } from './errors.js';
 
 export {
@@ -43,6 +44,20 @@ export {
 } from './config-watcher.js';
 
 export { Gateway, type GatewayOptions } from './gateway.js';
+
+// Remote access (Phase 11 — Issue #1102)
+export { createToken, verifyToken } from './jwt.js';
+export { RemoteGatewayClient } from './remote.js';
+export type {
+  GatewayAuthConfig,
+  JWTPayload,
+  RemoteGatewayConfig,
+  RemoteGatewayState,
+  RemoteGatewayEvents,
+  RemoteChatMessage,
+  OfflineQueueEntry,
+  PushNotification,
+} from './remote-types.js';
 
 export type {
   GatewayMessage,

--- a/runtime/src/gateway/jwt.test.ts
+++ b/runtime/src/gateway/jwt.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createHmac } from 'node:crypto';
+import { createToken, verifyToken } from './jwt.js';
+
+const SECRET = 'a-very-secure-secret-key-at-least-32-chars!!';
+const SUBJECT = 'agent_001';
+
+describe('JWT utility', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('createToken returns a 3-part JWT string', () => {
+    const token = createToken(SECRET, SUBJECT);
+    const parts = token.split('.');
+    expect(parts).toHaveLength(3);
+  });
+
+  it('verifyToken accepts a valid token', () => {
+    const token = createToken(SECRET, SUBJECT, 3600);
+    const payload = verifyToken(SECRET, token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.sub).toBe(SUBJECT);
+    expect(payload!.exp).toBeGreaterThan(payload!.iat);
+  });
+
+  it('verifyToken returns null for wrong secret', () => {
+    const token = createToken(SECRET, SUBJECT);
+    const payload = verifyToken('wrong-secret-that-is-at-least-32-chars', token);
+
+    expect(payload).toBeNull();
+  });
+
+  it('verifyToken returns null for expired token', () => {
+    // Create a token that expired 10 seconds ago
+    const now = Math.floor(Date.now() / 1000);
+    vi.spyOn(Date, 'now').mockReturnValue((now - 100) * 1000);
+    const token = createToken(SECRET, SUBJECT, 10);
+    vi.restoreAllMocks();
+
+    // Now Date.now() is back to real time — token expired ~90s ago
+    const payload = verifyToken(SECRET, token);
+    expect(payload).toBeNull();
+  });
+
+  it('verifyToken returns null for malformed token (too few parts)', () => {
+    expect(verifyToken(SECRET, 'only.two')).toBeNull();
+    expect(verifyToken(SECRET, 'single')).toBeNull();
+    expect(verifyToken(SECRET, '')).toBeNull();
+  });
+
+  it('verifyToken returns null for tampered payload', () => {
+    const token = createToken(SECRET, SUBJECT);
+    const parts = token.split('.');
+    // Tamper with the payload
+    parts[1] = parts[1] + 'x';
+    const tampered = parts.join('.');
+
+    expect(verifyToken(SECRET, tampered)).toBeNull();
+  });
+
+  it('verifyToken returns null for tampered signature', () => {
+    const token = createToken(SECRET, SUBJECT);
+    const parts = token.split('.');
+    parts[2] = 'invalid_signature';
+    const tampered = parts.join('.');
+
+    expect(verifyToken(SECRET, tampered)).toBeNull();
+  });
+
+  it('verifyToken returns null for invalid JSON in payload', () => {
+    const token = createToken(SECRET, SUBJECT);
+    const parts = token.split('.');
+    // Replace payload with invalid base64url-encoded JSON
+    parts[1] = Buffer.from('not-json', 'utf-8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    // Re-sign won't match, so this also tests signature mismatch
+    expect(verifyToken(SECRET, parts.join('.'))).toBeNull();
+  });
+
+  it('creates tokens with custom expiry', () => {
+    const token = createToken(SECRET, SUBJECT, 60);
+    const payload = verifyToken(SECRET, token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.exp - payload!.iat).toBe(60);
+  });
+
+  it('default expiry is 3600 seconds', () => {
+    const token = createToken(SECRET, SUBJECT);
+    const payload = verifyToken(SECRET, token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.exp - payload!.iat).toBe(3600);
+  });
+
+  it('verifyToken preserves scope field when present', () => {
+    // Build a token manually with scope
+    const now = Math.floor(Date.now() / 1000);
+    const headerB64 = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' }), 'utf-8')
+      .toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ sub: 'scoped', iat: now, exp: now + 3600, scope: 'admin' }),
+      'utf-8',
+    )
+      .toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const sig = createHmac('sha256', SECRET)
+      .update(`${headerB64}.${payloadB64}`)
+      .digest('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+    const token = `${headerB64}.${payloadB64}.${sig}`;
+    const payload = verifyToken(SECRET, token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.scope).toBe('admin');
+  });
+
+  it('verifyToken returns undefined scope when not present', () => {
+    const token = createToken(SECRET, SUBJECT);
+    const payload = verifyToken(SECRET, token);
+
+    expect(payload).not.toBeNull();
+    expect(payload!.scope).toBeUndefined();
+  });
+
+  it('round-trip: multiple tokens with different subjects', () => {
+    const subjects = ['agent_001', 'agent_002', 'cli_user'];
+    for (const sub of subjects) {
+      const token = createToken(SECRET, sub);
+      const payload = verifyToken(SECRET, token);
+      expect(payload).not.toBeNull();
+      expect(payload!.sub).toBe(sub);
+    }
+  });
+
+  it('createToken throws for secret shorter than 32 characters', () => {
+    expect(() => createToken('short', SUBJECT)).toThrow('at least 32 characters');
+  });
+
+  it('verifyToken returns null for secret shorter than 32 characters', () => {
+    const token = createToken(SECRET, SUBJECT);
+    expect(verifyToken('short', token)).toBeNull();
+  });
+
+  it('verifyToken returns null for token with missing sub field', () => {
+    const now = Math.floor(Date.now() / 1000);
+    const headerB64 = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' }), 'utf-8')
+      .toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    // Payload without sub
+    const payloadB64 = Buffer.from(
+      JSON.stringify({ iat: now, exp: now + 3600 }),
+      'utf-8',
+    )
+      .toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const sig = createHmac('sha256', SECRET)
+      .update(`${headerB64}.${payloadB64}`)
+      .digest('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+    expect(verifyToken(SECRET, `${headerB64}.${payloadB64}.${sig}`)).toBeNull();
+  });
+});

--- a/runtime/src/gateway/jwt.ts
+++ b/runtime/src/gateway/jwt.ts
@@ -1,0 +1,130 @@
+/**
+ * Minimal HS256 JWT implementation using Node.js crypto.
+ *
+ * No external dependencies — uses `crypto.createHmac('sha256', secret)`.
+ *
+ * @module
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { JWTPayload } from './remote-types.js';
+
+// ============================================================================
+// Base64url helpers
+// ============================================================================
+
+function base64urlEncode(data: string): string {
+  return Buffer.from(data, 'utf-8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function base64urlDecode(str: string): string {
+  // Restore standard base64 chars
+  let base64 = str.replace(/-/g, '+').replace(/_/g, '/');
+  // Add padding
+  const padLen = (4 - (base64.length % 4)) % 4;
+  base64 += '='.repeat(padLen);
+  return Buffer.from(base64, 'base64').toString('utf-8');
+}
+
+// ============================================================================
+// HMAC-SHA256 signing
+// ============================================================================
+
+function sign(input: string, secret: string): string {
+  return createHmac('sha256', secret)
+    .update(input)
+    .digest('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+const DEFAULT_EXPIRY_SECONDS = 3600;
+const MIN_SECRET_LENGTH = 32;
+
+/**
+ * Create an HS256 JWT token.
+ *
+ * @param secret - HMAC shared secret
+ * @param subject - Token subject (e.g. agent ID)
+ * @param expirySeconds - Token lifetime in seconds (default: 3600)
+ * @returns Encoded JWT string
+ */
+export function createToken(
+  secret: string,
+  subject: string,
+  expirySeconds: number = DEFAULT_EXPIRY_SECONDS,
+): string {
+  if (secret.length < MIN_SECRET_LENGTH) {
+    throw new Error(`JWT secret must be at least ${MIN_SECRET_LENGTH} characters`);
+  }
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64urlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = base64urlEncode(
+    JSON.stringify({
+      sub: subject,
+      iat: now,
+      exp: now + expirySeconds,
+    }),
+  );
+
+  const signature = sign(`${header}.${payload}`, secret);
+  return `${header}.${payload}.${signature}`;
+}
+
+/**
+ * Verify an HS256 JWT token.
+ *
+ * @param secret - HMAC shared secret
+ * @param token - JWT string to verify
+ * @returns Decoded payload if valid and not expired, `null` otherwise
+ */
+export function verifyToken(secret: string, token: string): JWTPayload | null {
+  if (secret.length < MIN_SECRET_LENGTH) return null;
+
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+
+  const [header, payload, signature] = parts;
+
+  // Verify signature with constant-time comparison to prevent timing attacks
+  const expected = sign(`${header}.${payload}`, secret);
+  if (signature.length !== expected.length) return null;
+  const sigBuf = Buffer.from(signature, 'utf-8');
+  const expBuf = Buffer.from(expected, 'utf-8');
+  if (!timingSafeEqual(sigBuf, expBuf)) return null;
+
+  // Decode and parse payload
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(base64urlDecode(payload));
+  } catch {
+    return null;
+  }
+
+  if (!decoded || typeof decoded !== 'object') return null;
+
+  const jwt = decoded as Record<string, unknown>;
+  if (typeof jwt.sub !== 'string') return null;
+  if (typeof jwt.iat !== 'number') return null;
+  if (typeof jwt.exp !== 'number') return null;
+
+  // Check expiry
+  const now = Math.floor(Date.now() / 1000);
+  if (jwt.exp <= now) return null;
+
+  return {
+    sub: jwt.sub,
+    iat: jwt.iat,
+    exp: jwt.exp,
+    scope: typeof jwt.scope === 'string' ? jwt.scope : undefined,
+  };
+}

--- a/runtime/src/gateway/remote-types.ts
+++ b/runtime/src/gateway/remote-types.ts
@@ -1,0 +1,95 @@
+/**
+ * Type definitions for remote Gateway access and JWT authentication.
+ *
+ * Used by both the Gateway auth layer and the RemoteGatewayClient.
+ *
+ * @module
+ */
+
+// ============================================================================
+// Authentication Configuration
+// ============================================================================
+
+export interface GatewayAuthConfig {
+  /** HMAC-SHA256 shared secret (minimum 32 characters) */
+  secret?: string;
+  /** Token expiry in seconds (default: 3600 — 1 hour) */
+  expirySeconds?: number;
+  /** Allow unauthenticated access from localhost (default: true) */
+  localBypass?: boolean;
+}
+
+export interface JWTPayload {
+  /** Subject — typically an agent or user identifier */
+  sub: string;
+  /** Issued-at timestamp (Unix seconds) */
+  iat: number;
+  /** Expiry timestamp (Unix seconds) */
+  exp: number;
+  /** Access scope (reserved for future use) */
+  scope?: string;
+}
+
+// ============================================================================
+// Remote Client Configuration
+// ============================================================================
+
+export interface RemoteGatewayConfig {
+  /** WebSocket URL of the Gateway control plane (e.g. wss://gateway.example.com) */
+  url: string;
+  /** JWT token for authentication */
+  token: string;
+  /** Ping keepalive interval in ms (default: 30000) */
+  pingIntervalMs?: number;
+  /** Enable automatic reconnection (default: true) */
+  reconnect?: boolean;
+  /** Base delay for exponential backoff in ms (default: 1000) */
+  reconnectBaseDelayMs?: number;
+  /** Maximum reconnect delay in ms (default: 30000) */
+  reconnectMaxDelayMs?: number;
+  /** Maximum number of messages to queue while disconnected (default: 1000) */
+  maxOfflineQueueSize?: number;
+}
+
+// ============================================================================
+// Remote Client State & Events
+// ============================================================================
+
+export type RemoteGatewayState =
+  | 'disconnected'
+  | 'connecting'
+  | 'authenticating'
+  | 'connected'
+  | 'reconnecting';
+
+export interface RemoteGatewayEvents {
+  connected: () => void;
+  disconnected: (reason?: string) => void;
+  message: (data: unknown) => void;
+  error: (error: Error) => void;
+  authFailed: (reason: string) => void;
+  stateChanged: (state: RemoteGatewayState) => void;
+}
+
+// ============================================================================
+// Chat & Notification Types
+// ============================================================================
+
+export interface RemoteChatMessage {
+  id: string;
+  content: string;
+  sender: 'user' | 'agent';
+  timestamp: number;
+}
+
+export interface OfflineQueueEntry {
+  message: string;
+  enqueuedAt: number;
+}
+
+export interface PushNotification {
+  messageId: string;
+  sender: string;
+  preview: string;
+  timestamp: number;
+}

--- a/runtime/src/gateway/remote.test.ts
+++ b/runtime/src/gateway/remote.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RemoteGatewayClient } from './remote.js';
+import type { RemoteGatewayState } from './remote-types.js';
+
+// ============================================================================
+// Mock ws module
+// ============================================================================
+
+let mockWsInstance: MockWs;
+
+class MockWs {
+  readonly url: string;
+  readyState = 0; // CONNECTING
+  private handlers = new Map<string, ((...args: unknown[]) => void)[]>();
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = 3; // CLOSED
+    this.trigger('close');
+  });
+
+  constructor(url: string) {
+    this.url = url;
+    mockWsInstance = this;
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    const list = this.handlers.get(event) ?? [];
+    list.push(handler);
+    this.handlers.set(event, list);
+  }
+
+  trigger(event: string, ...args: unknown[]) {
+    const list = this.handlers.get(event);
+    if (list) {
+      for (const h of list) h(...args);
+    }
+  }
+
+  /** Simulate the WebSocket connection opening. */
+  simulateOpen() {
+    this.readyState = 1; // OPEN
+    this.trigger('open');
+  }
+}
+
+vi.mock('ws', () => ({
+  default: MockWs,
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Wait for async operations to complete.
+ * Uses the real setTimeout saved before any test file can mock timers.
+ */
+const nativeSetTimeout = globalThis.setTimeout;
+async function tick(): Promise<void> {
+  await new Promise<void>((r) => nativeSetTimeout(r, 50));
+}
+
+/**
+ * Start a connection and wait until MockWs is created + fires 'open'.
+ */
+async function connectAndOpen(client: RemoteGatewayClient): Promise<void> {
+  void client.connect();
+  await tick();
+  mockWsInstance.simulateOpen();
+}
+
+function makeConfig(overrides?: Record<string, unknown>) {
+  return {
+    url: 'ws://localhost:9100',
+    token: 'test-token',
+    reconnect: false, // Disable reconnect by default for cleaner tests
+    ...overrides,
+  };
+}
+
+function simulateAuthSuccess(sub = 'agent_001') {
+  // The client sends auth on open; we respond with success
+  const authMsg = JSON.parse(mockWsInstance.send.mock.calls[0][0]);
+  expect(authMsg.type).toBe('auth');
+  mockWsInstance.trigger(
+    'message',
+    JSON.stringify({ type: 'auth', payload: { authenticated: true, sub } }),
+  );
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('RemoteGatewayClient', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockWsInstance = undefined as unknown as MockWs;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('starts in disconnected state', () => {
+    const client = new RemoteGatewayClient(makeConfig());
+    expect(client.state).toBe('disconnected');
+  });
+
+  it('transitions through connecting → authenticating → connected', async () => {
+    const states: RemoteGatewayState[] = [];
+    const client = new RemoteGatewayClient(makeConfig());
+    client.on('stateChanged', (s) => states.push(s));
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(states).toContain('connecting');
+    expect(states).toContain('authenticating');
+    expect(states).toContain('connected');
+    expect(client.state).toBe('connected');
+
+    client.disconnect();
+  });
+
+  it('emits connected event on successful auth', async () => {
+    const connected = vi.fn();
+    const client = new RemoteGatewayClient(makeConfig());
+    client.on('connected', connected);
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(connected).toHaveBeenCalledTimes(1);
+
+    client.disconnect();
+  });
+
+  it('emits authFailed when auth response has error', async () => {
+    const authFailed = vi.fn();
+    const client = new RemoteGatewayClient(makeConfig());
+    client.on('authFailed', authFailed);
+
+    await connectAndOpen(client);
+
+    // Simulate auth failure
+    mockWsInstance.trigger(
+      'message',
+      JSON.stringify({ type: 'auth', error: 'Invalid or expired token' }),
+    );
+
+    expect(authFailed).toHaveBeenCalledWith('Invalid or expired token');
+    expect(client.state).toBe('disconnected');
+  });
+
+  it('sends auth message with token on connect', async () => {
+    const client = new RemoteGatewayClient(makeConfig({ token: 'my-jwt' }));
+
+    await connectAndOpen(client);
+
+    expect(mockWsInstance.send).toHaveBeenCalledTimes(1);
+    const msg = JSON.parse(mockWsInstance.send.mock.calls[0][0]);
+    expect(msg.type).toBe('auth');
+    expect(msg.payload.token).toBe('my-jwt');
+
+    client.disconnect();
+  });
+
+  it('send() delivers when connected', async () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    client.send({ type: 'status' });
+
+    // First call is auth, second is status
+    expect(mockWsInstance.send).toHaveBeenCalledTimes(2);
+    const msg = JSON.parse(mockWsInstance.send.mock.calls[1][0]);
+    expect(msg.type).toBe('status');
+
+    client.disconnect();
+  });
+
+  it('send() queues when disconnected', () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    client.send({ type: 'status' });
+
+    expect(client.queueSize).toBe(1);
+  });
+
+  it('flushes offline queue on connect', async () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    // Queue messages before connecting
+    client.send({ type: 'msg1' });
+    client.send({ type: 'msg2' });
+    expect(client.queueSize).toBe(2);
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    // Auth + 2 flushed messages
+    expect(mockWsInstance.send).toHaveBeenCalledTimes(3);
+    expect(client.queueSize).toBe(0);
+
+    client.disconnect();
+  });
+
+  it('drops oldest when offline queue exceeds max size', () => {
+    const client = new RemoteGatewayClient(makeConfig({ maxOfflineQueueSize: 3 }));
+
+    client.send({ type: 'a' });
+    client.send({ type: 'b' });
+    client.send({ type: 'c' });
+    client.send({ type: 'd' }); // Should drop 'a'
+
+    expect(client.queueSize).toBe(3);
+  });
+
+  it('sendMessage() is a convenience wrapper', async () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    client.sendMessage('hello agent');
+
+    const msg = JSON.parse(mockWsInstance.send.mock.calls[1][0]);
+    expect(msg.type).toBe('chat.message');
+    expect(msg.payload.content).toBe('hello agent');
+
+    client.disconnect();
+  });
+
+  it('disconnect stops connection and goes to disconnected', async () => {
+    const disconnected = vi.fn();
+    const client = new RemoteGatewayClient(makeConfig());
+    client.on('disconnected', disconnected);
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    client.disconnect();
+
+    expect(client.state).toBe('disconnected');
+  });
+
+  it('emits message events for non-auth messages', async () => {
+    const onMessage = vi.fn();
+    const client = new RemoteGatewayClient(makeConfig());
+    client.on('message', onMessage);
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    mockWsInstance.trigger(
+      'message',
+      JSON.stringify({ type: 'status', payload: { state: 'running' } }),
+    );
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual({ type: 'status', payload: { state: 'running' } });
+
+    client.disconnect();
+  });
+
+  it('emits error events on ws errors', async () => {
+    const onError = vi.fn();
+    const client = new RemoteGatewayClient(makeConfig());
+    client.on('error', onError);
+
+    await connectAndOpen(client);
+
+    mockWsInstance.trigger('error', new Error('connection refused'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0].message).toBe('connection refused');
+
+    client.disconnect();
+  });
+
+  it('switchGateway disconnects and reconnects to new URL', async () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(client.state).toBe('connected');
+
+    // Switch to new gateway — reset instance tracker
+    mockWsInstance = undefined as unknown as MockWs;
+    const switchPromise = client.switchGateway('ws://other:9200', 'new-token');
+    await tick();
+    mockWsInstance.simulateOpen();
+
+    // New WS instance created with new URL
+    expect(mockWsInstance.url).toBe('ws://other:9200');
+
+    // Simulate auth on new connection
+    const authMsg = JSON.parse(mockWsInstance.send.mock.calls[0][0]);
+    expect(authMsg.payload.token).toBe('new-token');
+    mockWsInstance.trigger(
+      'message',
+      JSON.stringify({ type: 'auth', payload: { authenticated: true } }),
+    );
+
+    await switchPromise;
+    expect(client.state).toBe('connected');
+
+    client.disconnect();
+  });
+
+  it('on() returns a dispose function', async () => {
+    const handler = vi.fn();
+    const client = new RemoteGatewayClient(makeConfig());
+    const dispose = client.on('connected', handler);
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    dispose();
+
+    // Reconnecting should not trigger handler again
+    client.disconnect();
+    mockWsInstance = undefined as unknown as MockWs;
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    client.disconnect();
+  });
+
+  it('transitions to reconnecting on unexpected close when reconnect=true', async () => {
+    const stateChanges: RemoteGatewayState[] = [];
+    const client = new RemoteGatewayClient(makeConfig({ reconnect: true }));
+    client.on('stateChanged', (s) => stateChanges.push(s));
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(client.state).toBe('connected');
+
+    // Simulate unexpected close by triggering the close handler directly.
+    // Override close() to prevent the MockWs close from calling trigger recursively.
+    mockWsInstance.close = vi.fn();
+    mockWsInstance.trigger('close');
+
+    expect(client.state).toBe('reconnecting');
+    expect(stateChanges).toContain('reconnecting');
+
+    client.disconnect(); // Stop reconnect loop
+  });
+
+  it('does not reconnect when reconnect=false', async () => {
+    const client = new RemoteGatewayClient(makeConfig({ reconnect: false }));
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(client.state).toBe('connected');
+
+    // Simulate unexpected close
+    mockWsInstance.close = vi.fn();
+    mockWsInstance.trigger('close');
+
+    expect(client.state).toBe('disconnected');
+  });
+
+  it('clearQueue empties the offline queue', () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    client.send({ type: 'a' });
+    client.send({ type: 'b' });
+    expect(client.queueSize).toBe(2);
+
+    client.clearQueue();
+    expect(client.queueSize).toBe(0);
+  });
+
+  it('clears offline queue on auth failure', async () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    // Queue messages before connecting
+    client.send({ type: 'queued' });
+    expect(client.queueSize).toBe(1);
+
+    await connectAndOpen(client);
+
+    // Simulate auth failure
+    mockWsInstance.trigger(
+      'message',
+      JSON.stringify({ type: 'auth', error: 'bad token' }),
+    );
+
+    expect(client.queueSize).toBe(0);
+  });
+
+  it('connect is idempotent when already connected', async () => {
+    const client = new RemoteGatewayClient(makeConfig());
+
+    await connectAndOpen(client);
+    simulateAuthSuccess();
+
+    expect(client.state).toBe('connected');
+
+    // Second connect should be a no-op — no additional state changes
+    await client.connect();
+    expect(client.state).toBe('connected');
+
+    client.disconnect();
+  });
+});

--- a/runtime/src/gateway/remote.ts
+++ b/runtime/src/gateway/remote.ts
@@ -1,0 +1,309 @@
+/**
+ * Remote Gateway client for connecting to a Gateway control plane over WebSocket.
+ *
+ * Provides JWT authentication, automatic reconnection with exponential backoff,
+ * offline message queueing, and ping keepalive.
+ *
+ * Uses `ws` package (loaded lazily via `ensureLazyModule`).
+ *
+ * @module
+ */
+
+import { ensureLazyModule } from '../utils/lazy-import.js';
+import { GatewayAuthError } from './errors.js';
+import type {
+  RemoteGatewayConfig,
+  RemoteGatewayState,
+  RemoteGatewayEvents,
+  OfflineQueueEntry,
+} from './remote-types.js';
+
+// ============================================================================
+// WebSocket type shim (matches ws package interface)
+// ============================================================================
+
+interface WsInstance {
+  send(data: string): void;
+  close(): void;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  readyState: number;
+}
+
+interface WsModule {
+  default: new (url: string) => WsInstance;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_PING_INTERVAL_MS = 30_000;
+const DEFAULT_RECONNECT_BASE_DELAY_MS = 1_000;
+const DEFAULT_RECONNECT_MAX_DELAY_MS = 30_000;
+const DEFAULT_MAX_OFFLINE_QUEUE_SIZE = 1_000;
+const JITTER_FACTOR = 0.2;
+
+// ============================================================================
+// RemoteGatewayClient
+// ============================================================================
+
+type EventKey = keyof RemoteGatewayEvents;
+
+export class RemoteGatewayClient {
+  private ws: WsInstance | null = null;
+  private _state: RemoteGatewayState = 'disconnected';
+  private config: RemoteGatewayConfig;
+  private readonly listeners = new Map<EventKey, Set<(...args: unknown[]) => void>>();
+  private readonly offlineQueue: OfflineQueueEntry[] = [];
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private intentionalClose = false;
+  private readonly maxQueueSize: number;
+
+  constructor(config: RemoteGatewayConfig) {
+    this.config = config;
+    this.maxQueueSize = config.maxOfflineQueueSize ?? DEFAULT_MAX_OFFLINE_QUEUE_SIZE;
+  }
+
+  get state(): RemoteGatewayState {
+    return this._state;
+  }
+
+  // --------------------------------------------------------------------------
+  // Event emitter
+  // --------------------------------------------------------------------------
+
+  on<K extends EventKey>(event: K, handler: RemoteGatewayEvents[K]): () => void {
+    let handlers = this.listeners.get(event);
+    if (!handlers) {
+      handlers = new Set();
+      this.listeners.set(event, handlers);
+    }
+    handlers.add(handler as (...args: unknown[]) => void);
+    return () => {
+      handlers!.delete(handler as (...args: unknown[]) => void);
+    };
+  }
+
+  private emit<K extends EventKey>(event: K, ...args: Parameters<RemoteGatewayEvents[K]>): void {
+    const handlers = this.listeners.get(event);
+    if (!handlers) return;
+    for (const handler of handlers) {
+      try {
+        (handler as (...a: unknown[]) => void)(...args);
+      } catch {
+        // Swallow listener errors
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // State management
+  // --------------------------------------------------------------------------
+
+  private setState(state: RemoteGatewayState): void {
+    if (this._state === state) return;
+    this._state = state;
+    this.emit('stateChanged', state);
+  }
+
+  // --------------------------------------------------------------------------
+  // Connection lifecycle
+  // --------------------------------------------------------------------------
+
+  async connect(): Promise<void> {
+    if (this._state === 'connected' || this._state === 'connecting' || this._state === 'authenticating') {
+      return;
+    }
+
+    this.intentionalClose = false;
+    this.setState('connecting');
+
+    const wsMod = await ensureLazyModule<WsModule>(
+      'ws',
+      (msg) => new GatewayAuthError(msg),
+      (mod) => mod as unknown as WsModule,
+    );
+
+    const WsConstructor = wsMod.default;
+    this.ws = new WsConstructor(this.config.url);
+
+    this.ws.on('open', () => {
+      this.setState('authenticating');
+      this.ws!.send(JSON.stringify({
+        type: 'auth',
+        payload: { token: this.config.token },
+      }));
+    });
+
+    this.ws.on('message', (data: unknown) => {
+      const text = typeof data === 'string' ? data : String(data);
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        this.emit('message', text);
+        return;
+      }
+
+      if (parsed && typeof parsed === 'object') {
+        const msg = parsed as Record<string, unknown>;
+
+        // Handle auth response
+        if (msg.type === 'auth') {
+          if (msg.error) {
+            this.offlineQueue.length = 0;
+            this.setState('disconnected');
+            this.emit('authFailed', String(msg.error));
+            this.ws?.close();
+            return;
+          }
+          this.reconnectAttempt = 0;
+          this.setState('connected');
+          this.emit('connected');
+          this.startPing();
+          this.flushOfflineQueue();
+          return;
+        }
+      }
+
+      this.emit('message', parsed);
+    });
+
+    this.ws.on('close', () => {
+      this.stopPing();
+      const wasConnected = this._state === 'connected';
+      this.ws = null;
+
+      if (this.intentionalClose) {
+        this.setState('disconnected');
+        this.emit('disconnected', 'intentional');
+        return;
+      }
+
+      const shouldReconnect = this.config.reconnect !== false;
+      if (shouldReconnect) {
+        this.setState('reconnecting');
+        this.emit('disconnected', wasConnected ? 'connection lost' : 'failed to connect');
+        this.scheduleReconnect();
+      } else {
+        this.setState('disconnected');
+        this.emit('disconnected', 'connection closed');
+      }
+    });
+
+    this.ws.on('error', (err: unknown) => {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+    });
+  }
+
+  disconnect(): void {
+    this.intentionalClose = true;
+    this.stopPing();
+    this.clearReconnectTimer();
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.setState('disconnected');
+  }
+
+  async switchGateway(url: string, token: string): Promise<void> {
+    this.disconnect();
+    this.config = { ...this.config, url, token };
+    await this.connect();
+  }
+
+  // --------------------------------------------------------------------------
+  // Messaging
+  // --------------------------------------------------------------------------
+
+  send(msg: Record<string, unknown>): void {
+    const serialized = JSON.stringify(msg);
+    if (this._state === 'connected' && this.ws) {
+      this.ws.send(serialized);
+    } else {
+      this.enqueue(serialized);
+    }
+  }
+
+  sendMessage(content: string): void {
+    this.send({ type: 'chat.message', payload: { content } });
+  }
+
+  // --------------------------------------------------------------------------
+  // Offline queue
+  // --------------------------------------------------------------------------
+
+  private enqueue(message: string): void {
+    if (this.offlineQueue.length >= this.maxQueueSize) {
+      this.offlineQueue.shift(); // Drop oldest
+    }
+    this.offlineQueue.push({ message, enqueuedAt: Date.now() });
+  }
+
+  private flushOfflineQueue(): void {
+    while (this.offlineQueue.length > 0) {
+      const entry = this.offlineQueue.shift()!;
+      if (this.ws && this._state === 'connected') {
+        this.ws.send(entry.message);
+      }
+    }
+  }
+
+  get queueSize(): number {
+    return this.offlineQueue.length;
+  }
+
+  clearQueue(): void {
+    this.offlineQueue.length = 0;
+  }
+
+  // --------------------------------------------------------------------------
+  // Ping keepalive
+  // --------------------------------------------------------------------------
+
+  private startPing(): void {
+    this.stopPing();
+    const interval = this.config.pingIntervalMs ?? DEFAULT_PING_INTERVAL_MS;
+    this.pingTimer = setInterval(() => {
+      if (this.ws && this._state === 'connected') {
+        this.ws.send(JSON.stringify({ type: 'ping' }));
+      }
+    }, interval);
+  }
+
+  private stopPing(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Reconnection
+  // --------------------------------------------------------------------------
+
+  private scheduleReconnect(): void {
+    this.clearReconnectTimer();
+
+    const baseDelay = this.config.reconnectBaseDelayMs ?? DEFAULT_RECONNECT_BASE_DELAY_MS;
+    const maxDelay = this.config.reconnectMaxDelayMs ?? DEFAULT_RECONNECT_MAX_DELAY_MS;
+    const base = Math.min(baseDelay * Math.pow(2, this.reconnectAttempt), maxDelay);
+    const jitter = 1 + Math.random() * JITTER_FACTOR;
+    const delay = Math.round(base * jitter);
+    this.reconnectAttempt++;
+
+    this.reconnectTimer = setTimeout(() => {
+      void this.connect();
+    }, delay);
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+}

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -7,6 +7,8 @@
  * @module
  */
 
+import type { GatewayAuthConfig } from './remote-types.js';
+
 // ============================================================================
 // Gateway Configuration
 // ============================================================================
@@ -61,6 +63,7 @@ export interface GatewayConfig {
   memory?: GatewayMemoryConfig;
   channels?: Record<string, GatewayChannelConfig>;
   logging?: GatewayLoggingConfig;
+  auth?: GatewayAuthConfig;
 }
 
 // ============================================================================
@@ -104,7 +107,7 @@ export interface GatewayEventSubscription {
 // Control Plane Messages
 // ============================================================================
 
-export type ControlMessageType = 'ping' | 'status' | 'reload' | 'channels' | 'sessions' | 'sessions.kill';
+export type ControlMessageType = 'ping' | 'status' | 'reload' | 'channels' | 'sessions' | 'sessions.kill' | 'auth';
 
 export interface ControlMessage {
   type: ControlMessageType;

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1481,6 +1481,19 @@ export {
   type SubAgentManagerConfig,
   type SubAgentStatus,
   type SubAgentInfo,
+  // Remote access (Issue #1102)
+  RemoteGatewayClient,
+  createToken,
+  verifyToken,
+  GatewayAuthError,
+  type GatewayAuthConfig,
+  type JWTPayload,
+  type RemoteGatewayConfig,
+  type RemoteGatewayState,
+  type RemoteGatewayEvents,
+  type RemoteChatMessage,
+  type OfflineQueueEntry,
+  type PushNotification,
 } from './gateway/index.js';
 
 // Channel Plugins (Phase 1.5)

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -50,8 +50,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.MARKETPLACE_MATCHING_ERROR).toBe('MARKETPLACE_MATCHING_ERROR');
   });
 
-  it('has exactly 91 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(91);
+  it('has exactly 92 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(92);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -198,6 +198,8 @@ export const RuntimeErrorCodes = {
   SKILL_SUBSCRIPTION_ERROR: 'SKILL_SUBSCRIPTION_ERROR',
   /** Skill revenue share computation failed */
   SKILL_REVENUE_ERROR: 'SKILL_REVENUE_ERROR',
+  /** Remote Gateway authentication failed */
+  REMOTE_AUTH_ERROR: 'REMOTE_AUTH_ERROR',
 } as const;
 
 /** Union type of all runtime error code values */


### PR DESCRIPTION
## Summary

- Adds JWT authentication (HS256, node:crypto only) to the Gateway WebSocket control plane for secure remote access from mobile/external clients
- Implements `RemoteGatewayClient` for Node.js consumers with auto-reconnect, offline queue, and ping keepalive
- Creates a minimal React Native (Expo) mobile app with Chat, Dashboard, and Approval screens connected to the Gateway

## Details

**Runtime — JWT & Auth:**
- `jwt.ts`: Minimal HS256 JWT with timing-safe signature verification and 32-char minimum secret enforcement
- Gateway auth guard as early-return before the control message switch — only `auth` and `ping` bypass
- Localhost auto-authentication covers `127.0.0.1`, `::1`, `::ffff:127.0.0.1`, and unix sockets
- `localBypass` config option (default: true) to disable auto-auth for local connections
- `GatewayAuthConfig` added to `GatewayConfig`, validated in `config-watcher.ts`

**Runtime — RemoteGatewayClient:**
- WebSocket connection with JWT auth handshake
- Exponential backoff with jitter (0.2 factor) matching `ConnectionManager` pattern
- Bounded offline queue (default 1000, drops oldest), cleared on auth failure
- Ping keepalive (30s default), event emitter with dispose pattern
- `switchGateway(url, token)` for seamless gateway switching

**Mobile (Expo):**
- Bottom tab navigation: Chat, Dashboard, Approvals
- `useRemoteGateway` hook: browser-native WebSocket, JWT auth, offline queue, reconnect with jitter
- `useChat` hook: message list management, approval request handling
- Push notification types (stub — full Expo integration deferred)

**Error handling:**
- `GatewayAuthError` class, `REMOTE_AUTH_ERROR` runtime error code
- All types exported via barrel (`gateway/index.ts`, `index.ts`)

## Test plan

- [x] `jwt.test.ts` — 16 tests (valid/expired/malformed tokens, timing-safe comparison, secret length)
- [x] `remote.test.ts` — 20 tests (connection lifecycle, auth, offline queue, reconnect, switchGateway)
- [x] `gateway.test.ts` — 12 new auth tests (valid/invalid token, local bypass variants, cleanup)
- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] Full runtime suite — 68/68 gateway tests pass, no regressions

Closes #1102