### PR TITLE
feat(gateway): wire ChatExecutor with tool calling and skill injection

### DIFF
--- a/runtime/src/channels/webchat/handlers.ts
+++ b/runtime/src/channels/webchat/handlers.ts
@@ -44,16 +44,14 @@ export function handleStatusGet(
 // ============================================================================
 
 export function handleSkillsList(
-  _deps: WebChatDeps,
+  deps: WebChatDeps,
   _payload: Record<string, unknown> | undefined,
   id: string | undefined,
   send: SendFn,
 ): void {
-  // MVP: Return empty list — full skill registry integration requires
-  // SkillRegistry to be wired into the Gateway.
   send({
     type: 'skills.list',
-    payload: [],
+    payload: deps.skills ?? [],
     id,
   });
 }

--- a/runtime/src/channels/webchat/types.ts
+++ b/runtime/src/channels/webchat/types.ts
@@ -42,6 +42,8 @@ export interface WebChatDeps {
     getStatus(): { state: string; uptimeMs: number; channels: string[]; activeSessions: number; controlPlanePort: number };
     config: { agent?: { name?: string } };
   };
+  /** Optional skill listing for skills.list handler. */
+  skills?: ReadonlyArray<{ name: string; description: string; enabled: boolean }>;
 }
 
 // ============================================================================

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -10,15 +10,25 @@
 
 import { mkdir, readFile, unlink, writeFile, access } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve as resolvePath } from 'node:path';
 import { homedir } from 'node:os';
 import { Gateway } from './gateway.js';
 import { loadGatewayConfig } from './config-watcher.js';
 import { GatewayLifecycleError, GatewayStateError } from './errors.js';
 import { toErrorMessage } from '../utils/async.js';
-import type { GatewayStatus } from './types.js';
+import type { GatewayConfig, GatewayStatus } from './types.js';
 import type { Logger } from '../utils/logger.js';
 import { silentLogger } from '../utils/logger.js';
+import { WebChatChannel } from '../channels/webchat/plugin.js';
+import type { LLMProvider, LLMMessage, LLMTool } from '../llm/types.js';
+import type { GatewayMessage } from './message.js';
+import { ChatExecutor } from '../llm/chat-executor.js';
+import type { SkillInjector } from '../llm/chat-executor.js';
+import { ToolRegistry } from '../tools/registry.js';
+import { createBashTool } from '../tools/system/bash.js';
+import { createHttpTools } from '../tools/system/http.js';
+import { SkillDiscovery } from '../skills/markdown/discovery.js';
+import type { DiscoveredSkill } from '../skills/markdown/discovery.js';
 
 // ============================================================================
 // PID File Types
@@ -139,6 +149,7 @@ export interface DaemonStatus {
 
 export class DaemonManager {
   private gateway: Gateway | null = null;
+  private _webChatChannel: WebChatChannel | null = null;
   private shutdownInProgress = false;
   private startedAt = 0;
   private signalHandlersRegistered = false;
@@ -166,6 +177,9 @@ export class DaemonManager {
 
     await gateway.start();
 
+    // Wire up WebChat channel with LLM pipeline
+    await this.wireWebChat(gateway, gatewayConfig);
+
     try {
       await writePidFile(
         {
@@ -192,6 +206,204 @@ export class DaemonManager {
     });
   }
 
+  /**
+   * Wire the WebChat channel plugin to the Gateway's WebSocket control plane
+   * and connect it to an LLM provider with tool execution and skill injection.
+   */
+  private async wireWebChat(gateway: Gateway, config: GatewayConfig): Promise<void> {
+    // Discover bundled + user skills
+    const discovered = await this.discoverSkills();
+    const skillList = discovered.map((d) => ({
+      name: d.skill.name,
+      description: d.skill.description,
+      enabled: d.available,
+    }));
+
+    // Create tool registry with system tools
+    const registry = new ToolRegistry({ logger: this.logger });
+    const processEnv: Record<string, string> = {};
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined) processEnv[key] = value;
+    }
+    registry.register(createBashTool({ logger: this.logger, env: processEnv }));
+    registry.registerAll(createHttpTools({}, this.logger));
+
+    const llmTools = registry.toLLMTools();
+
+    // Create LLM provider with tools configured
+    const llm = await this.createLLMProvider(config, llmTools);
+
+    // Build skill injector — injects available skill instructions as system context
+    const availableSkills = discovered.filter((d) => d.available);
+    const skillInjector: SkillInjector = {
+      async inject(_message: string, _sessionId: string): Promise<string | undefined> {
+        if (availableSkills.length === 0) return undefined;
+        const sections = availableSkills.map((s) =>
+          `## Skill: ${s.skill.name}\n${s.skill.description}\n\n${s.skill.body}`,
+        );
+        return (
+          '# Available Skills\n\n' +
+          'You have the following skills available. Use the system.bash tool to execute commands. ' +
+          'The system.bash tool takes a `command` (executable name) and `args` (array of argument strings). ' +
+          'Do NOT use shell syntax — pass the executable and its arguments separately.\n\n' +
+          sections.join('\n\n---\n\n')
+        );
+      },
+    };
+
+    // Create ChatExecutor with tool-calling loop
+    const chatExecutor = llm ? new ChatExecutor({
+      providers: [llm],
+      toolHandler: registry.createToolHandler(),
+      maxToolRounds: 10,
+      skillInjector,
+    }) : null;
+
+    // Per-session conversation history
+    const sessionHistory = new Map<string, LLMMessage[]>();
+    const MAX_HISTORY = 50;
+    const MAX_SESSIONS = 100;
+
+    const webChat = new WebChatChannel(
+      { gateway: { getStatus: () => gateway.getStatus(), config }, skills: skillList },
+    );
+
+    const systemPrompt = config.agent?.name
+      ? `You are ${config.agent.name}, an AI agent on the AgenC protocol. Be helpful, concise, and use your tools when appropriate.`
+      : 'You are an AI agent on the AgenC protocol. Be helpful, concise, and use your tools when appropriate.';
+
+    const onMessage = async (msg: GatewayMessage): Promise<void> => {
+      if (!msg.content.trim()) return;
+
+      if (!chatExecutor) {
+        await webChat.send({
+          sessionId: msg.sessionId,
+          content: 'No LLM provider configured. Add an `llm` section to ~/.agenc/config.json.',
+        });
+        return;
+      }
+
+      try {
+        const history = sessionHistory.get(msg.sessionId) ?? [];
+
+        const result = await chatExecutor.execute({
+          message: msg,
+          history,
+          systemPrompt,
+          sessionId: msg.sessionId,
+        });
+
+        // Update session history
+        const updated: LLMMessage[] = [
+          ...history,
+          { role: 'user', content: msg.content },
+          { role: 'assistant', content: result.content },
+        ];
+        sessionHistory.set(
+          msg.sessionId,
+          updated.length > MAX_HISTORY ? updated.slice(-MAX_HISTORY) : updated,
+        );
+
+        // Evict oldest session if over capacity
+        if (sessionHistory.size > MAX_SESSIONS) {
+          const oldest = sessionHistory.keys().next().value;
+          if (oldest !== undefined) sessionHistory.delete(oldest);
+        }
+
+        const text = result.content || '(no response)';
+        await webChat.send({ sessionId: msg.sessionId, content: text });
+
+        if (result.toolCalls.length > 0) {
+          this.logger.info(`Chat used ${result.toolCalls.length} tool call(s)`, {
+            tools: result.toolCalls.map((tc) => tc.name),
+            provider: result.provider,
+          });
+        }
+      } catch (err) {
+        this.logger.error('LLM chat error:', err);
+        await webChat.send({
+          sessionId: msg.sessionId,
+          content: `Error: ${(err as Error).message}`,
+        });
+      }
+    };
+
+    await webChat.initialize({ onMessage, logger: this.logger, config: {} });
+    await webChat.start();
+
+    gateway.setWebChatHandler(webChat);
+    this._webChatChannel = webChat;
+
+    const toolCount = registry.size;
+    const skillCount = availableSkills.length;
+    this.logger.info(
+      `WebChat wired` +
+      (llm ? ` with ${llm.name} LLM` : ' (no LLM)') +
+      `, ${toolCount} tools, ${skillCount} skills`,
+    );
+  }
+
+  /**
+   * Create an LLM provider from gateway config. Returns null if no LLM is configured.
+   */
+  private async createLLMProvider(config: GatewayConfig, tools: LLMTool[] = []): Promise<LLMProvider | null> {
+    if (!config.llm) return null;
+
+    const { provider, apiKey, model, baseUrl } = config.llm;
+
+    switch (provider) {
+      case 'grok': {
+        const { GrokProvider } = await import('../llm/grok/adapter.js');
+        return new GrokProvider({
+          apiKey: apiKey ?? '',
+          model: model ?? 'grok-3',
+          baseURL: baseUrl,
+          tools,
+        });
+      }
+      case 'anthropic': {
+        const { AnthropicProvider } = await import('../llm/anthropic/adapter.js');
+        return new AnthropicProvider({
+          apiKey: apiKey ?? '',
+          model: model ?? 'claude-sonnet-4-5-20250929',
+          tools,
+        });
+      }
+      case 'ollama': {
+        const { OllamaProvider } = await import('../llm/ollama/adapter.js');
+        return new OllamaProvider({
+          model: model ?? 'llama3',
+          host: baseUrl,
+          tools,
+        });
+      }
+      default:
+        this.logger.warn(`Unknown LLM provider: ${provider}`);
+        return null;
+    }
+  }
+
+  /**
+   * Discover bundled and user skills. Returns full DiscoveredSkill objects
+   * so skill bodies can be injected into LLM context.
+   */
+  private async discoverSkills(): Promise<DiscoveredSkill[]> {
+    try {
+      // __filename = runtime/dist/bin/agenc-runtime.js (tsup entry point).
+      // We need the package root (runtime/) to find src/skills/bundled/.
+      // dist/bin/ → dist/ → runtime/ (2 levels up from dirname)
+      const pkgRoot = resolvePath(dirname(__filename), '..', '..');
+      const builtinSkills = join(pkgRoot, 'src', 'skills', 'bundled');
+      const userSkills = join(homedir(), '.agenc', 'skills');
+
+      const discovery = new SkillDiscovery({ builtinSkills, userSkills });
+      return await discovery.discoverAll();
+    } catch (err) {
+      this.logger.warn('Skill discovery failed:', err);
+      return [];
+    }
+  }
+
   async stop(): Promise<void> {
     if (this.shutdownInProgress) {
       return;
@@ -199,6 +411,11 @@ export class DaemonManager {
     this.shutdownInProgress = true;
 
     try {
+      // Stop WebChat channel before gateway
+      if (this._webChatChannel !== null) {
+        await this._webChatChannel.stop();
+        this._webChatChannel = null;
+      }
       if (this.gateway !== null) {
         await this.gateway.stop();
         this.gateway = null;

--- a/runtime/src/skills/bundled/github.md
+++ b/runtime/src/skills/bundled/github.md
@@ -8,8 +8,6 @@ metadata:
       binaries:
         - gh
         - git
-      env:
-        - GITHUB_TOKEN
     install:
       - type: brew
         package: gh

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ConnectionState, WSMessage } from '../types';
 
-const DEFAULT_URL = 'ws://127.0.0.1:9100';
+const DEFAULT_URL = 'ws://127.0.0.1:3100';
 const PING_INTERVAL_MS = 30_000;
 const INITIAL_RECONNECT_MS = 1_000;
 const MAX_RECONNECT_MS = 8_000;


### PR DESCRIPTION
## Summary

- Wire full ChatExecutor pipeline into DaemonManager replacing bare `llm.chat()` call
- Register system.bash and HTTP tools in ToolRegistry so the LLM can execute commands
- Inject all available bundled skill markdown as system context so the agent knows how to use gh, solana, jupiter, etc.
- Track per-session conversation history (50 message cap, 100 session cap)
- Fix WebChat skill listing to return discovered skills instead of empty stub
- Fix web portal WebSocket port default (9100 → 3100)
- Fix bundled skill discovery path resolution
- Remove GITHUB_TOKEN env requirement from github skill (gh authenticates via keyring)

## Files changed

- `runtime/src/gateway/daemon.ts` — Main wiring: ToolRegistry, ChatExecutor, SkillInjector, session history
- `runtime/src/channels/webchat/handlers.ts` — Return real skills from deps
- `runtime/src/channels/webchat/types.ts` — Add skills to WebChatDeps
- `runtime/src/skills/bundled/github.md` — Drop env requirement
- `web/src/hooks/useWebSocket.ts` — Fix default port

## Test plan

- [ ] Start daemon with `npx agenc start`, verify skills discovered in logs
- [ ] Open web portal, send a message, verify agent responds
- [ ] Ask agent to run a command (e.g. "list my git branches") and verify tool calling works
- [ ] Verify conversation history persists within a session
- [ ] Verify skills show up in the web portal skills panel