### PR TITLE
feat(voice): xAI Realtime Voice API + Grok 4.1 upgrade

### DIFF
--- a/runtime/src/channels/webchat/types.ts
+++ b/runtime/src/channels/webchat/types.ts
@@ -44,6 +44,8 @@ export interface WebChatDeps {
   };
   /** Optional skill listing for skills.list handler. */
   skills?: ReadonlyArray<{ name: string; description: string; enabled: boolean }>;
+  /** Optional voice bridge for real-time voice sessions. */
+  voiceBridge?: import('../../gateway/voice-bridge.js').VoiceBridge;
 }
 
 // ============================================================================
@@ -269,5 +271,31 @@ export interface EventsEventResponse {
 export interface ErrorResponse {
   type: 'error';
   error: string;
+  id?: string;
+}
+
+// ============================================================================
+// Voice WebSocket Protocol — Client → Server
+// Keep in sync with web/src/types.ts voice types
+// ============================================================================
+
+export interface VoiceStartRequest {
+  type: 'voice.start';
+  id?: string;
+}
+
+export interface VoiceAudioRequest {
+  type: 'voice.audio';
+  audio: string; // base64-encoded PCM
+  id?: string;
+}
+
+export interface VoiceCommitRequest {
+  type: 'voice.commit';
+  id?: string;
+}
+
+export interface VoiceStopRequest {
+  type: 'voice.stop';
   id?: string;
 }

--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -7,6 +7,7 @@ export type {
   GatewayConnectionConfig,
   GatewayLoggingConfig,
   GatewayBindConfig,
+  GatewayVoiceConfig,
   GatewayState,
   GatewayStatus,
   GatewayEvent,
@@ -156,6 +157,9 @@ export {
   type PidFileInfo,
   type StalePidResult,
 } from './daemon.js';
+
+// Voice Bridge (xAI Realtime)
+export { VoiceBridge, type VoiceBridgeConfig } from './voice-bridge.js';
 
 // Media pipeline (Phase 1.12)
 export type { MediaPipelineConfig, MediaProcessingResult, TranscriptionProvider, ImageDescriptionProvider, MediaLogger } from './media.js';

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -55,6 +55,12 @@ export interface GatewayBindConfig {
   bind?: string;
 }
 
+export interface GatewayVoiceConfig {
+  enabled?: boolean;
+  voice?: 'Ara' | 'Rex' | 'Sal' | 'Eve' | 'Leo';
+  mode?: 'vad' | 'push-to-talk';
+}
+
 export interface GatewayConfig {
   gateway: GatewayBindConfig;
   agent: GatewayAgentConfig;
@@ -64,6 +70,7 @@ export interface GatewayConfig {
   channels?: Record<string, GatewayChannelConfig>;
   logging?: GatewayLoggingConfig;
   auth?: GatewayAuthConfig;
+  voice?: GatewayVoiceConfig;
 }
 
 // ============================================================================

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -1,0 +1,255 @@
+/**
+ * Voice bridge — manages per-client xAI Realtime voice sessions.
+ *
+ * Each WebSocket client that activates voice gets its own XaiRealtimeClient
+ * connected to xAI's realtime API. Audio and events are relayed between
+ * the browser client and xAI in both directions.
+ *
+ * @module
+ */
+
+import { XaiRealtimeClient } from '../voice/realtime/client.js';
+import type {
+  VoiceSessionConfig,
+  VoiceTool,
+  XaiVoice,
+} from '../voice/realtime/types.js';
+import type { ControlResponse } from './types.js';
+import type { Logger } from '../utils/logger.js';
+import type { ToolHandler, LLMTool } from '../llm/types.js';
+
+const DEFAULT_MAX_SESSIONS = 10;
+
+export interface VoiceBridgeConfig {
+  /** xAI API key. */
+  apiKey: string;
+  /** Tools available during voice sessions. */
+  tools: LLMTool[];
+  /** Tool execution handler. */
+  toolHandler: ToolHandler;
+  /** System prompt injected into voice sessions. */
+  systemPrompt: string;
+  /** Default voice persona. */
+  voice?: XaiVoice;
+  /** Default model. */
+  model?: string;
+  /** VAD mode or push-to-talk. Default: 'vad'. */
+  mode?: 'vad' | 'push-to-talk';
+  /** Max concurrent voice sessions. Default: 10. */
+  maxSessions?: number;
+  /** Logger. */
+  logger?: Logger;
+}
+
+interface ActiveSession {
+  client: XaiRealtimeClient;
+  send: (response: ControlResponse) => void;
+}
+
+/**
+ * Manages per-client real-time voice sessions bridging browser audio
+ * to the xAI Realtime API.
+ */
+export class VoiceBridge {
+  private readonly sessions = new Map<string, ActiveSession>();
+  private readonly config: VoiceBridgeConfig;
+  private readonly maxSessions: number;
+  private readonly logger: Logger | undefined;
+
+  constructor(config: VoiceBridgeConfig) {
+    this.config = config;
+    this.maxSessions = config.maxSessions ?? DEFAULT_MAX_SESSIONS;
+    this.logger = config.logger;
+  }
+
+  /** Number of active voice sessions. */
+  get activeSessionCount(): number {
+    return this.sessions.size;
+  }
+
+  /**
+   * Start a voice session for a client.
+   *
+   * Creates an XaiRealtimeClient, connects to xAI, and wires callbacks
+   * to forward events to the browser via the `send` function.
+   */
+  async startSession(
+    clientId: string,
+    send: (response: ControlResponse) => void,
+  ): Promise<void> {
+    // Clean up any existing session for this client
+    if (this.sessions.has(clientId)) {
+      await this.stopSession(clientId);
+    }
+
+    if (this.sessions.size >= this.maxSessions) {
+      send({
+        type: 'voice.error',
+        payload: { message: 'Maximum concurrent voice sessions reached' },
+      });
+      return;
+    }
+
+    const voiceTools = this.convertTools(this.config.tools);
+
+    const sessionConfig: VoiceSessionConfig = {
+      model: this.config.model ?? 'grok-4-1-fast-reasoning',
+      voice: this.config.voice ?? 'Ara',
+      modalities: ['text', 'audio'],
+      instructions: this.config.systemPrompt,
+      input_audio_format: 'pcm16',
+      output_audio_format: 'pcm16',
+      turn_detection: this.config.mode === 'push-to-talk'
+        ? null
+        : { type: 'server_vad', threshold: 0.5, silence_duration_ms: 500 },
+      tools: voiceTools,
+    };
+
+    const client = new XaiRealtimeClient({
+      apiKey: this.config.apiKey,
+      sessionConfig,
+      logger: this.logger,
+      callbacks: {
+        onAudioDeltaBase64: (base64) => {
+          send({
+            type: 'voice.audio',
+            payload: { audio: base64 },
+          });
+        },
+        onTranscriptDelta: (text) => {
+          send({
+            type: 'voice.transcript',
+            payload: { delta: text, done: false },
+          });
+        },
+        onTranscriptDone: (text) => {
+          send({
+            type: 'voice.transcript',
+            payload: { text, done: true },
+          });
+        },
+        onFunctionCall: async (name, args, _callId) => {
+          // Notify browser that a tool is executing
+          send({
+            type: 'voice.tool_call',
+            payload: { toolName: name, status: 'executing' },
+          });
+
+          try {
+            const parsed = JSON.parse(args) as Record<string, unknown>;
+            const resultStr = await this.config.toolHandler(name, parsed);
+
+            send({
+              type: 'voice.tool_call',
+              payload: { toolName: name, status: 'completed', result: resultStr },
+            });
+
+            return resultStr;
+          } catch (err) {
+            const errorMsg = (err as Error).message;
+            send({
+              type: 'voice.tool_call',
+              payload: { toolName: name, status: 'error', error: errorMsg },
+            });
+            return JSON.stringify({ error: errorMsg });
+          }
+        },
+        onSpeechStarted: () => {
+          send({ type: 'voice.speech_started' });
+        },
+        onSpeechStopped: () => {
+          send({ type: 'voice.speech_stopped' });
+        },
+        onResponseDone: () => {
+          send({ type: 'voice.response_done' });
+        },
+        onError: (error) => {
+          this.logger?.warn?.('Voice session error:', error);
+          send({
+            type: 'voice.error',
+            payload: { message: error.message, code: error.code },
+          });
+        },
+        onConnectionStateChange: (state) => {
+          send({
+            type: 'voice.state',
+            payload: { connectionState: state },
+          });
+        },
+      },
+    });
+
+    this.sessions.set(clientId, { client, send });
+
+    try {
+      await client.connect();
+      send({ type: 'voice.started' });
+      this.logger?.info?.(`Voice session started for client ${clientId}`);
+    } catch (err) {
+      this.sessions.delete(clientId);
+      send({
+        type: 'voice.error',
+        payload: { message: (err as Error).message },
+      });
+    }
+  }
+
+  /** Forward audio data from the browser to the xAI session. */
+  sendAudio(clientId: string, base64Audio: string): void {
+    const session = this.sessions.get(clientId);
+    if (!session) return;
+
+    // Pass base64 directly — avoids unnecessary decode/re-encode cycle
+    session.client.sendAudioBase64(base64Audio);
+  }
+
+  /** Commit the audio buffer (push-to-talk mode). */
+  commitAudio(clientId: string): void {
+    const session = this.sessions.get(clientId);
+    if (!session) return;
+    session.client.commitAudio();
+  }
+
+  /** Stop a specific client's voice session. */
+  async stopSession(clientId: string): Promise<void> {
+    const session = this.sessions.get(clientId);
+    if (!session) return;
+
+    session.client.close();
+    this.sessions.delete(clientId);
+    session.send({ type: 'voice.stopped' });
+    this.logger?.info?.(`Voice session stopped for client ${clientId}`);
+  }
+
+  /** Stop all active voice sessions (for shutdown). */
+  async stopAll(): Promise<void> {
+    const clientIds = Array.from(this.sessions.keys());
+    for (const clientId of clientIds) {
+      await this.stopSession(clientId);
+    }
+  }
+
+  /** Check if a client has an active voice session. */
+  hasSession(clientId: string): boolean {
+    return this.sessions.has(clientId);
+  }
+
+  // --------------------------------------------------------------------------
+  // Internal
+  // --------------------------------------------------------------------------
+
+  /** Convert LLMTool[] to VoiceTool[] for xAI session config. */
+  private convertTools(tools: LLMTool[]): VoiceTool[] {
+    return tools
+      .filter((t) => t.type === 'function' && t.function)
+      .map((t) => ({
+        type: 'function' as const,
+        function: {
+          name: t.function!.name,
+          description: t.function!.description,
+          parameters: t.function!.parameters as Record<string, unknown>,
+        },
+      }));
+  }
+}
+

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -261,6 +261,8 @@ export {
   bigintsToProofHash,
   proofHashToBigints,
   toAnchorBytes,
+  uint8ToBase64,
+  base64ToUint8,
 } from './utils/index.js';
 
 // Validation utilities
@@ -1293,6 +1295,7 @@ export {
   type GatewayConnectionConfig,
   type GatewayLoggingConfig,
   type GatewayBindConfig,
+  type GatewayVoiceConfig,
   type GatewayState,
   type GatewayStatus,
   type GatewayEvent,
@@ -1391,6 +1394,9 @@ export {
   type DaemonStatus,
   type PidFileInfo,
   type StalePidResult,
+  // Voice Bridge (xAI Realtime)
+  VoiceBridge,
+  type VoiceBridgeConfig,
   // Media pipeline (Phase 1.12)
   MediaPipeline,
   NoopTranscriptionProvider,
@@ -1697,6 +1703,7 @@ export {
   type TextToSpeechProvider,
   type STTConfig,
   type TTSConfig,
+  type RealtimeVoiceConfig,
   type VoiceConfig,
   // Error classes
   VoiceTranscriptionError,
@@ -1712,6 +1719,18 @@ export {
   type ElevenLabsProviderConfig,
   type OpenAITTSProviderConfig,
   type EdgeTTSProviderConfig,
+  // Realtime voice (xAI Realtime API)
+  XaiRealtimeClient,
+  VoiceRealtimeError,
+  type XaiVoice,
+  type XaiAudioFormat,
+  type VadConfig,
+  type VoiceTool,
+  type VoiceSessionConfig,
+  type VoiceClientEvent,
+  type VoiceServerEvent,
+  type VoiceSessionCallbacks,
+  type XaiRealtimeClientConfig,
 } from './voice/index.js';
 
 // Cross-Protocol Bridges (Phase 10)

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -34,7 +34,7 @@ function makeCompletion(overrides: Record<string, any> = {}) {
       },
     ],
     usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
-    model: 'grok-3',
+    model: 'grok-4-1-fast-reasoning',
     ...overrides,
   };
 }
@@ -57,7 +57,7 @@ describe('GrokProvider', () => {
 
     expect(mockCreate).toHaveBeenCalledOnce();
     const params = mockCreate.mock.calls[0][0];
-    expect(params.model).toBe('grok-3');
+    expect(params.model).toBe('grok-4-1-fast-reasoning');
     expect(params.messages).toEqual([
       { role: 'system', content: 'You are helpful.' },
       { role: 'user', content: 'Hello' },

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -23,7 +23,7 @@ import { ensureLazyImport } from '../lazy-import.js';
 import { withTimeout } from '../timeout.js';
 
 const DEFAULT_BASE_URL = 'https://api.x.ai/v1';
-const DEFAULT_MODEL = 'grok-3';
+const DEFAULT_MODEL = 'grok-4-1-fast-reasoning';
 
 export class GrokProvider implements LLMProvider {
   readonly name = 'grok';

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -50,8 +50,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.MARKETPLACE_MATCHING_ERROR).toBe('MARKETPLACE_MATCHING_ERROR');
   });
 
-  it('has exactly 92 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(92);
+  it('has exactly 97 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(97);
   });
 });
 

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -162,6 +162,8 @@ export const RuntimeErrorCodes = {
   VOICE_TRANSCRIPTION_ERROR: 'VOICE_TRANSCRIPTION_ERROR',
   /** Text-to-speech synthesis failed */
   VOICE_SYNTHESIS_ERROR: 'VOICE_SYNTHESIS_ERROR',
+  /** Real-time voice session error (xAI Realtime API) */
+  VOICE_REALTIME_ERROR: 'VOICE_REALTIME_ERROR',
   /** Cross-protocol bridge operation failed */
   BRIDGE_ERROR: 'BRIDGE_ERROR',
   /** x402 payment transfer failed */

--- a/runtime/src/utils/encoding.ts
+++ b/runtime/src/utils/encoding.ts
@@ -313,6 +313,41 @@ export function toAnchorBytes(bytes: Uint8Array): number[] {
 }
 
 // ============================================================================
+// Base64 ↔ Uint8Array conversion
+// ============================================================================
+
+/**
+ * Encode a Uint8Array to a base64 string.
+ * Uses Node.js Buffer when available, falls back to btoa for browsers.
+ */
+export function uint8ToBase64(data: Uint8Array): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(data).toString('base64');
+  }
+  let binary = '';
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Decode a base64 string to a Uint8Array.
+ * Uses Node.js Buffer when available, falls back to atob for browsers.
+ */
+export function base64ToUint8(base64: string): Uint8Array {
+  if (typeof Buffer !== 'undefined') {
+    return new Uint8Array(Buffer.from(base64, 'base64'));
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ============================================================================
 // Array → Uint8Array conversion
 // ============================================================================
 

--- a/runtime/src/utils/index.ts
+++ b/runtime/src/utils/index.ts
@@ -21,6 +21,8 @@ export {
   proofHashToBigints,
   toAnchorBytes,
   toUint8Array,
+  uint8ToBase64,
+  base64ToUint8,
 } from './encoding.js';
 
 export { PdaWithBump, derivePda, validateIdLength } from './pda.js';

--- a/runtime/src/voice/index.ts
+++ b/runtime/src/voice/index.ts
@@ -17,6 +17,7 @@ export type {
   TextToSpeechProvider,
   STTConfig,
   TTSConfig,
+  RealtimeVoiceConfig,
   VoiceConfig,
 } from './types.js';
 
@@ -42,3 +43,18 @@ export {
   type OpenAITTSProviderConfig,
   type EdgeTTSProviderConfig,
 } from './tts.js';
+
+// Realtime voice (xAI Realtime API)
+export {
+  XaiRealtimeClient,
+  VoiceRealtimeError,
+  type XaiVoice,
+  type XaiAudioFormat,
+  type VadConfig,
+  type VoiceTool,
+  type VoiceSessionConfig,
+  type ClientEvent as VoiceClientEvent,
+  type ServerEvent as VoiceServerEvent,
+  type VoiceSessionCallbacks,
+  type XaiRealtimeClientConfig,
+} from './realtime/index.js';

--- a/runtime/src/voice/realtime/client.ts
+++ b/runtime/src/voice/realtime/client.ts
@@ -1,0 +1,337 @@
+/**
+ * xAI Realtime Voice WebSocket client.
+ *
+ * Connects to wss://api.x.ai/v1/realtime and manages bidirectional
+ * audio streaming, tool calling, and automatic reconnection.
+ *
+ * The `ws` package is lazy-loaded (same pattern as Gateway).
+ *
+ * @module
+ */
+
+import type {
+  ClientEvent,
+  ServerEvent,
+  VoiceSessionConfig,
+  VoiceSessionCallbacks,
+  XaiRealtimeClientConfig,
+} from './types.js';
+import { VoiceRealtimeError } from './errors.js';
+import { uint8ToBase64, base64ToUint8 } from '../../utils/encoding.js';
+
+const DEFAULT_BASE_URL = 'wss://api.x.ai/v1/realtime';
+const MAX_RECONNECT_ATTEMPTS = 5;
+const BASE_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 16_000;
+
+type ConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
+
+/**
+ * WebSocket client for xAI's real-time voice API.
+ *
+ * Usage:
+ * ```ts
+ * const client = new XaiRealtimeClient({
+ *   apiKey: 'xai-...',
+ *   sessionConfig: { voice: 'Ara', model: 'grok-4-1-fast-reasoning' },
+ *   callbacks: {
+ *     onAudioDelta: (pcm) => playback.enqueue(pcm),
+ *     onTranscriptDone: (text) => console.log('Agent:', text),
+ *     onFunctionCall: async (name, args) => toolHandler(name, JSON.parse(args)),
+ *   },
+ * });
+ * await client.connect();
+ * client.sendAudio(pcmChunk);
+ * ```
+ */
+export class XaiRealtimeClient {
+  private ws: unknown | null = null;
+  private _state: ConnectionState = 'disconnected';
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private intentionalClose = false;
+
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly sessionConfig: VoiceSessionConfig | undefined;
+  private readonly callbacks: VoiceSessionCallbacks;
+  private readonly maxReconnectAttempts: number;
+  private readonly logger: XaiRealtimeClientConfig['logger'];
+
+  constructor(config: XaiRealtimeClientConfig) {
+    this.apiKey = config.apiKey;
+    this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    this.sessionConfig = config.sessionConfig;
+    this.callbacks = config.callbacks ?? {};
+    this.maxReconnectAttempts = config.maxReconnectAttempts ?? MAX_RECONNECT_ATTEMPTS;
+    this.logger = config.logger;
+  }
+
+  /** Current connection state. */
+  get state(): ConnectionState {
+    return this._state;
+  }
+
+  /**
+   * Open a WebSocket connection to the xAI Realtime API.
+   * Sends session.update with the initial config after connect.
+   */
+  async connect(): Promise<void> {
+    if (this._state === 'connected' || this._state === 'connecting') return;
+
+    this.intentionalClose = false;
+    this.setState(this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting');
+
+    const WebSocket = await this.loadWebSocket();
+    const ws = new WebSocket(this.baseUrl, {
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      ws.onopen = () => {
+        this.ws = ws;
+        this.reconnectAttempts = 0;
+        this.setState('connected');
+        this.logger?.info?.('xAI Realtime connected');
+
+        // Send initial session config
+        if (this.sessionConfig) {
+          this.sendEvent({ type: 'session.update', session: this.sessionConfig });
+        }
+
+        resolve();
+      };
+
+      ws.onmessage = (event: { data: string }) => {
+        this.handleServerEvent(event.data);
+      };
+
+      ws.onerror = (event: { message?: string }) => {
+        const msg = event.message ?? 'WebSocket error';
+        if (this._state === 'connecting') {
+          reject(new VoiceRealtimeError(`Connection failed: ${msg}`));
+        }
+      };
+
+      ws.onclose = () => {
+        this.ws = null;
+        if (!this.intentionalClose) {
+          this.logger?.debug?.('xAI Realtime disconnected unexpectedly, scheduling reconnect');
+          this.setState('disconnected');
+          this.scheduleReconnect();
+        } else {
+          this.setState('disconnected');
+        }
+      };
+    });
+  }
+
+  /** Update the voice session configuration (voice, tools, instructions, etc). */
+  updateSession(config: VoiceSessionConfig): void {
+    this.sendEvent({ type: 'session.update', session: config });
+  }
+
+  /** Stream raw PCM audio to the server. */
+  sendAudio(pcm: Uint8Array): void {
+    const base64 = uint8ToBase64(pcm);
+    this.sendEvent({ type: 'input_audio_buffer.append', audio: base64 });
+  }
+
+  /** Stream pre-encoded base64 PCM audio to the server (avoids re-encoding). */
+  sendAudioBase64(base64: string): void {
+    this.sendEvent({ type: 'input_audio_buffer.append', audio: base64 });
+  }
+
+  /** Commit the audio buffer (for push-to-talk mode). */
+  commitAudio(): void {
+    this.sendEvent({ type: 'input_audio_buffer.commit' });
+  }
+
+  /** Clear the pending audio buffer. */
+  clearAudio(): void {
+    this.sendEvent({ type: 'input_audio_buffer.clear' });
+  }
+
+  /** Explicitly request the model to generate a response. */
+  requestResponse(): void {
+    this.sendEvent({ type: 'response.create' });
+  }
+
+  /** Cancel an in-progress response. */
+  cancelResponse(): void {
+    this.sendEvent({ type: 'response.cancel' });
+  }
+
+  /** Gracefully close the WebSocket connection. */
+  close(): void {
+    this.intentionalClose = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      (this.ws as { close(): void }).close();
+      this.ws = null;
+    }
+    this.setState('disconnected');
+  }
+
+  // --------------------------------------------------------------------------
+  // Internal
+  // --------------------------------------------------------------------------
+
+  private sendEvent(event: ClientEvent): boolean {
+    if (!this.ws) {
+      return false;
+    }
+    (this.ws as { send(data: string): void }).send(JSON.stringify(event));
+    return true;
+  }
+
+  private handleServerEvent(raw: string): void {
+    let event: ServerEvent;
+    try {
+      event = JSON.parse(raw) as ServerEvent;
+    } catch {
+      this.logger?.warn?.('Failed to parse xAI Realtime event');
+      return;
+    }
+
+    this.logger?.debug?.('xAI event:', event.type);
+
+    switch (event.type) {
+      case 'session.created':
+        this.callbacks.onSessionCreated?.();
+        break;
+
+      case 'response.output_audio.delta': {
+        // Prefer base64 callback to avoid unnecessary decode/re-encode
+        if (this.callbacks.onAudioDeltaBase64) {
+          this.callbacks.onAudioDeltaBase64(event.delta);
+        } else if (this.callbacks.onAudioDelta) {
+          this.callbacks.onAudioDelta(base64ToUint8(event.delta));
+        }
+        break;
+      }
+
+      case 'response.output_audio_transcript.delta':
+        this.callbacks.onTranscriptDelta?.(event.delta);
+        break;
+
+      case 'response.output_audio_transcript.done':
+        this.callbacks.onTranscriptDone?.(event.transcript);
+        break;
+
+      case 'response.function_call_arguments.done':
+        if (this.callbacks.onFunctionCall) {
+          this.logger?.debug?.('Tool call:', event.name);
+          void this.handleFunctionCall(event.name, event.arguments, event.call_id);
+        }
+        break;
+
+      case 'input_audio_buffer.speech_started':
+        this.callbacks.onSpeechStarted?.();
+        break;
+
+      case 'input_audio_buffer.speech_stopped':
+        this.callbacks.onSpeechStopped?.();
+        break;
+
+      case 'response.done':
+        this.callbacks.onResponseDone?.();
+        break;
+
+      case 'error':
+        this.logger?.warn?.('xAI Realtime error:', event.error.type, event.error.message);
+        this.callbacks.onError?.(event.error);
+        break;
+
+      // Ignore other event types (session.updated, rate_limits.updated, etc.)
+      default:
+        break;
+    }
+  }
+
+  private async handleFunctionCall(name: string, args: string, callId: string): Promise<void> {
+    if (!this.callbacks.onFunctionCall) return;
+
+    try {
+      const result = await this.callbacks.onFunctionCall(name, args, callId);
+
+      // Send tool result back
+      this.sendEvent({
+        type: 'conversation.item.create',
+        item: {
+          type: 'function_call_output',
+          call_id: callId,
+          output: result,
+        },
+      });
+
+      // Request the model to continue with the tool result
+      this.sendEvent({ type: 'response.create' });
+    } catch (err) {
+      // Send error as tool output so the model can recover
+      this.sendEvent({
+        type: 'conversation.item.create',
+        item: {
+          type: 'function_call_output',
+          call_id: callId,
+          output: JSON.stringify({ error: (err as Error).message }),
+        },
+      });
+      this.sendEvent({ type: 'response.create' });
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.intentionalClose) return;
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      this.callbacks.onError?.({
+        type: 'reconnect_failed',
+        message: `Max reconnect attempts (${this.maxReconnectAttempts}) reached`,
+      });
+      return;
+    }
+
+    const delay = Math.min(
+      BASE_RECONNECT_DELAY_MS * Math.pow(2, this.reconnectAttempts),
+      MAX_RECONNECT_DELAY_MS,
+    );
+    this.reconnectAttempts++;
+    this.logger?.debug?.(`Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.connect().catch(() => {
+        // connect() rejects on failure; scheduleReconnect will be called via onclose
+      });
+    }, delay);
+  }
+
+  private setState(state: ConnectionState): void {
+    if (this._state === state) return;
+    this._state = state;
+    this.callbacks.onConnectionStateChange?.(state);
+  }
+
+  private async loadWebSocket(): Promise<new (url: string, opts?: Record<string, unknown>) => {
+    onopen: (() => void) | null;
+    onmessage: ((event: { data: string }) => void) | null;
+    onerror: ((event: { message?: string }) => void) | null;
+    onclose: (() => void) | null;
+    send(data: string): void;
+    close(): void;
+  }> {
+    try {
+      const mod = await import('ws');
+      return (mod.default ?? mod.WebSocket ?? mod) as any;
+    } catch {
+      throw new VoiceRealtimeError(
+        'The "ws" package is required for XaiRealtimeClient. Install it: npm install ws',
+      );
+    }
+  }
+}

--- a/runtime/src/voice/realtime/errors.ts
+++ b/runtime/src/voice/realtime/errors.ts
@@ -1,0 +1,24 @@
+/**
+ * Error types for the xAI Realtime Voice client.
+ *
+ * @module
+ */
+
+import { RuntimeError, RuntimeErrorCodes } from '../../types/errors.js';
+
+/**
+ * Error thrown when a realtime voice session operation fails.
+ */
+export class VoiceRealtimeError extends RuntimeError {
+  /** Optional xAI error type (e.g. 'invalid_request_error', 'server_error'). */
+  public readonly xaiType?: string;
+  /** Optional xAI error code from the server. */
+  public readonly xaiCode?: string;
+
+  constructor(message: string, xaiType?: string, xaiCode?: string) {
+    super(message, RuntimeErrorCodes.VOICE_REALTIME_ERROR);
+    this.name = 'VoiceRealtimeError';
+    this.xaiType = xaiType;
+    this.xaiCode = xaiCode;
+  }
+}

--- a/runtime/src/voice/realtime/index.ts
+++ b/runtime/src/voice/realtime/index.ts
@@ -1,0 +1,24 @@
+/**
+ * xAI Realtime Voice API client module.
+ *
+ * @module
+ */
+
+// Types
+export type {
+  XaiVoice,
+  XaiAudioFormat,
+  VadConfig,
+  VoiceTool,
+  VoiceSessionConfig,
+  ClientEvent,
+  ServerEvent,
+  VoiceSessionCallbacks,
+  XaiRealtimeClientConfig,
+} from './types.js';
+
+// Error classes
+export { VoiceRealtimeError } from './errors.js';
+
+// Client
+export { XaiRealtimeClient } from './client.js';

--- a/runtime/src/voice/realtime/types.ts
+++ b/runtime/src/voice/realtime/types.ts
@@ -1,0 +1,298 @@
+/**
+ * xAI Realtime Voice API protocol types.
+ *
+ * Follows the xAI/OpenAI Realtime API WebSocket protocol for
+ * bidirectional voice streaming at wss://api.x.ai/v1/realtime.
+ *
+ * @module
+ */
+
+// ============================================================================
+// Voice & Audio Configuration
+// ============================================================================
+
+/** Available xAI voice personas. */
+export type XaiVoice = 'Ara' | 'Rex' | 'Sal' | 'Eve' | 'Leo';
+
+/** Supported audio wire formats. */
+export type XaiAudioFormat = 'pcm16' | 'g711_ulaw' | 'g711_alaw';
+
+/** Voice Activity Detection (VAD) configuration. */
+export interface VadConfig {
+  /** VAD type: 'server_vad' for automatic turn detection. */
+  readonly type: 'server_vad';
+  /** Silence threshold (0.0–1.0). Default: 0.5 */
+  readonly threshold?: number;
+  /** Silence duration (ms) before speech end. Default: 500 */
+  readonly silence_duration_ms?: number;
+  /** Audio prefix duration (ms) to include before speech start. Default: 300 */
+  readonly prefix_padding_ms?: number;
+}
+
+/** Tool definition for voice session (same as chat tools). */
+export interface VoiceTool {
+  readonly type: 'function';
+  readonly function: {
+    readonly name: string;
+    readonly description: string;
+    readonly parameters: Record<string, unknown>;
+  };
+}
+
+// ============================================================================
+// Session Configuration
+// ============================================================================
+
+/** Configuration sent via session.update event. */
+export interface VoiceSessionConfig {
+  readonly model?: string;
+  readonly voice?: XaiVoice;
+  readonly modalities?: ReadonlyArray<'text' | 'audio'>;
+  readonly instructions?: string;
+  readonly input_audio_format?: XaiAudioFormat;
+  readonly output_audio_format?: XaiAudioFormat;
+  readonly turn_detection?: VadConfig | null;
+  readonly tools?: readonly VoiceTool[];
+  readonly temperature?: number;
+}
+
+// ============================================================================
+// Client → Server Events
+// ============================================================================
+
+export interface SessionUpdateEvent {
+  readonly type: 'session.update';
+  readonly session: VoiceSessionConfig;
+}
+
+export interface InputAudioBufferAppendEvent {
+  readonly type: 'input_audio_buffer.append';
+  readonly audio: string; // base64-encoded PCM
+}
+
+export interface InputAudioBufferCommitEvent {
+  readonly type: 'input_audio_buffer.commit';
+}
+
+export interface InputAudioBufferClearEvent {
+  readonly type: 'input_audio_buffer.clear';
+}
+
+export interface ResponseCreateEvent {
+  readonly type: 'response.create';
+  readonly response?: {
+    readonly modalities?: ReadonlyArray<'text' | 'audio'>;
+  };
+}
+
+export interface ResponseCancelEvent {
+  readonly type: 'response.cancel';
+}
+
+export interface ConversationItemCreateEvent {
+  readonly type: 'conversation.item.create';
+  readonly item: {
+    readonly type: 'function_call_output';
+    readonly call_id: string;
+    readonly output: string;
+  };
+}
+
+export type ClientEvent =
+  | SessionUpdateEvent
+  | InputAudioBufferAppendEvent
+  | InputAudioBufferCommitEvent
+  | InputAudioBufferClearEvent
+  | ResponseCreateEvent
+  | ResponseCancelEvent
+  | ConversationItemCreateEvent;
+
+// ============================================================================
+// Server → Client Events
+// ============================================================================
+
+export interface SessionCreatedServerEvent {
+  readonly type: 'session.created';
+  readonly session: Record<string, unknown>;
+}
+
+export interface SessionUpdatedServerEvent {
+  readonly type: 'session.updated';
+  readonly session: Record<string, unknown>;
+}
+
+export interface ResponseAudioDeltaEvent {
+  readonly type: 'response.output_audio.delta';
+  readonly delta: string; // base64-encoded PCM
+  readonly response_id: string;
+  readonly item_id: string;
+  readonly output_index: number;
+  readonly content_index: number;
+}
+
+export interface ResponseAudioDoneEvent {
+  readonly type: 'response.output_audio.done';
+  readonly response_id: string;
+  readonly item_id: string;
+}
+
+export interface ResponseAudioTranscriptDeltaEvent {
+  readonly type: 'response.output_audio_transcript.delta';
+  readonly delta: string;
+  readonly response_id: string;
+  readonly item_id: string;
+}
+
+export interface ResponseAudioTranscriptDoneEvent {
+  readonly type: 'response.output_audio_transcript.done';
+  readonly transcript: string;
+  readonly response_id: string;
+  readonly item_id: string;
+}
+
+export interface ResponseTextDeltaEvent {
+  readonly type: 'response.text.delta';
+  readonly delta: string;
+  readonly response_id: string;
+}
+
+export interface ResponseTextDoneEvent {
+  readonly type: 'response.text.done';
+  readonly text: string;
+  readonly response_id: string;
+}
+
+export interface ResponseFunctionCallArgumentsDeltaEvent {
+  readonly type: 'response.function_call_arguments.delta';
+  readonly delta: string;
+  readonly call_id: string;
+  readonly name: string;
+  readonly item_id: string;
+}
+
+export interface ResponseFunctionCallArgumentsDoneEvent {
+  readonly type: 'response.function_call_arguments.done';
+  readonly arguments: string;
+  readonly call_id: string;
+  readonly name: string;
+  readonly item_id: string;
+}
+
+export interface ResponseDoneEvent {
+  readonly type: 'response.done';
+  readonly response: Record<string, unknown>;
+}
+
+export interface InputAudioBufferSpeechStartedEvent {
+  readonly type: 'input_audio_buffer.speech_started';
+  readonly audio_start_ms: number;
+  readonly item_id: string;
+}
+
+export interface InputAudioBufferSpeechStoppedEvent {
+  readonly type: 'input_audio_buffer.speech_stopped';
+  readonly audio_end_ms: number;
+  readonly item_id: string;
+}
+
+export interface InputAudioBufferCommittedEvent {
+  readonly type: 'input_audio_buffer.committed';
+  readonly item_id: string;
+}
+
+export interface ConversationItemCreatedEvent {
+  readonly type: 'conversation.item.created';
+  readonly item: Record<string, unknown>;
+}
+
+export interface ErrorServerEvent {
+  readonly type: 'error';
+  readonly error: {
+    readonly type: string;
+    readonly code?: string;
+    readonly message: string;
+  };
+}
+
+export interface RateLimitsUpdatedEvent {
+  readonly type: 'rate_limits.updated';
+  readonly rate_limits: ReadonlyArray<{
+    readonly name: string;
+    readonly limit: number;
+    readonly remaining: number;
+    readonly reset_seconds: number;
+  }>;
+}
+
+export type ServerEvent =
+  | SessionCreatedServerEvent
+  | SessionUpdatedServerEvent
+  | ResponseAudioDeltaEvent
+  | ResponseAudioDoneEvent
+  | ResponseAudioTranscriptDeltaEvent
+  | ResponseAudioTranscriptDoneEvent
+  | ResponseTextDeltaEvent
+  | ResponseTextDoneEvent
+  | ResponseFunctionCallArgumentsDeltaEvent
+  | ResponseFunctionCallArgumentsDoneEvent
+  | ResponseDoneEvent
+  | InputAudioBufferSpeechStartedEvent
+  | InputAudioBufferSpeechStoppedEvent
+  | InputAudioBufferCommittedEvent
+  | ConversationItemCreatedEvent
+  | ErrorServerEvent
+  | RateLimitsUpdatedEvent;
+
+// ============================================================================
+// Client Callbacks
+// ============================================================================
+
+/** Consumer callbacks for voice session events. */
+export interface VoiceSessionCallbacks {
+  /** Raw PCM audio chunk from the agent's voice response (decoded from base64). */
+  onAudioDelta?: (audio: Uint8Array) => void;
+  /** Base64-encoded PCM audio chunk — use instead of onAudioDelta to avoid decode/re-encode overhead. */
+  onAudioDeltaBase64?: (base64: string) => void;
+  /** Incremental transcript of the agent's voice. */
+  onTranscriptDelta?: (text: string) => void;
+  /** Full transcript when agent finishes speaking. */
+  onTranscriptDone?: (text: string) => void;
+  /** Agent wants to call a tool. Return the tool result string. */
+  onFunctionCall?: (name: string, args: string, callId: string) => Promise<string>;
+  /** VAD detected speech start. */
+  onSpeechStarted?: () => void;
+  /** VAD detected speech stop. */
+  onSpeechStopped?: () => void;
+  /** Session established. */
+  onSessionCreated?: () => void;
+  /** Response generation finished. */
+  onResponseDone?: () => void;
+  /** Protocol error from xAI. */
+  onError?: (error: { type: string; code?: string; message: string }) => void;
+  /** WebSocket connection state change. */
+  onConnectionStateChange?: (state: 'connecting' | 'connected' | 'disconnected' | 'reconnecting') => void;
+}
+
+// ============================================================================
+// Client Configuration
+// ============================================================================
+
+/** Configuration for XaiRealtimeClient. */
+export interface XaiRealtimeClientConfig {
+  /** xAI API key. */
+  readonly apiKey: string;
+  /** WebSocket endpoint. Default: wss://api.x.ai/v1/realtime */
+  readonly baseUrl?: string;
+  /** Initial session configuration. */
+  readonly sessionConfig?: VoiceSessionConfig;
+  /** Event callbacks. */
+  readonly callbacks?: VoiceSessionCallbacks;
+  /** Max reconnect attempts. Default: 5 */
+  readonly maxReconnectAttempts?: number;
+  /** Optional logger for debug/info output. */
+  readonly logger?: {
+    debug?(...args: unknown[]): void;
+    info?(...args: unknown[]): void;
+    warn?(...args: unknown[]): void;
+  };
+}

--- a/runtime/src/voice/types.ts
+++ b/runtime/src/voice/types.ts
@@ -106,9 +106,18 @@ export interface TTSConfig {
   readonly model?: string;
 }
 
+/** xAI Realtime voice provider configuration. */
+export interface RealtimeVoiceConfig {
+  readonly provider: 'xai-realtime';
+  readonly apiKey: string;
+  readonly voice?: 'Ara' | 'Rex' | 'Sal' | 'Eve' | 'Leo';
+  readonly model?: string;
+}
+
 /** Combined voice configuration. */
 export interface VoiceConfig {
   readonly stt?: STTConfig;
   readonly tts?: TTSConfig;
   readonly autoTts?: boolean;
+  readonly realtime?: RealtimeVoiceConfig;
 }

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -1,11 +1,26 @@
 import { useCallback, useRef, useState } from 'react';
+import type { VoiceState, VoiceMode } from '../../types';
+import { VoiceButton } from './VoiceButton';
 
 interface ChatInputProps {
   onSend: (content: string) => void;
   disabled?: boolean;
+  voiceState?: VoiceState;
+  voiceMode?: VoiceMode;
+  onVoiceToggle?: () => void;
+  onPushToTalkStart?: () => void;
+  onPushToTalkStop?: () => void;
 }
 
-export function ChatInput({ onSend, disabled }: ChatInputProps) {
+export function ChatInput({
+  onSend,
+  disabled,
+  voiceState = 'inactive',
+  voiceMode = 'vad',
+  onVoiceToggle,
+  onPushToTalkStart,
+  onPushToTalkStop,
+}: ChatInputProps) {
   const [value, setValue] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -52,6 +67,16 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
         rows={1}
         className="flex-1 bg-tetsuo-800 text-tetsuo-100 border border-tetsuo-600 rounded-lg px-4 py-2.5 text-sm resize-none focus:outline-none focus:border-accent placeholder:text-tetsuo-500 disabled:opacity-50"
       />
+      {onVoiceToggle && (
+        <VoiceButton
+          voiceState={voiceState}
+          mode={voiceMode}
+          onToggle={onVoiceToggle}
+          onPushToTalkStart={onPushToTalkStart}
+          onPushToTalkStop={onPushToTalkStop}
+          disabled={disabled}
+        />
+      )}
       <button
         onClick={handleSubmit}
         disabled={disabled || !value.trim()}

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -1,23 +1,60 @@
-import type { ChatMessage } from '../../types';
+import type { ChatMessage, VoiceState, VoiceMode } from '../../types';
 import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
+import { VoiceIndicator } from './VoiceIndicator';
 
 interface ChatViewProps {
   messages: ChatMessage[];
   isTyping: boolean;
   onSend: (content: string) => void;
   connected: boolean;
+  voiceState?: VoiceState;
+  voiceTranscript?: string;
+  voiceMode?: VoiceMode;
+  onVoiceToggle?: () => void;
+  onVoiceModeChange?: (mode: VoiceMode) => void;
+  onPushToTalkStart?: () => void;
+  onPushToTalkStop?: () => void;
 }
 
-export function ChatView({ messages, isTyping, onSend, connected }: ChatViewProps) {
+export function ChatView({
+  messages,
+  isTyping,
+  onSend,
+  connected,
+  voiceState = 'inactive',
+  voiceTranscript = '',
+  voiceMode = 'vad',
+  onVoiceToggle,
+  onVoiceModeChange,
+  onPushToTalkStart,
+  onPushToTalkStop,
+}: ChatViewProps) {
   return (
     <div className="flex flex-col h-full">
       <div className="px-4 py-3 border-b border-tetsuo-700">
         <h2 className="text-sm font-semibold text-tetsuo-200">Chat</h2>
       </div>
 
+      {onVoiceModeChange && (
+        <VoiceIndicator
+          voiceState={voiceState}
+          transcript={voiceTranscript}
+          mode={voiceMode}
+          onModeChange={onVoiceModeChange}
+        />
+      )}
+
       <MessageList messages={messages} isTyping={isTyping} />
-      <ChatInput onSend={onSend} disabled={!connected} />
+      <ChatInput
+        onSend={onSend}
+        disabled={!connected}
+        voiceState={voiceState}
+        voiceMode={voiceMode}
+        onVoiceToggle={onVoiceToggle}
+        onPushToTalkStart={onPushToTalkStart}
+        onPushToTalkStop={onPushToTalkStop}
+      />
     </div>
   );
 }

--- a/web/src/components/chat/VoiceButton.tsx
+++ b/web/src/components/chat/VoiceButton.tsx
@@ -1,0 +1,101 @@
+import type { VoiceState, VoiceMode } from '../../types';
+
+interface VoiceButtonProps {
+  voiceState: VoiceState;
+  mode: VoiceMode;
+  onToggle: () => void;
+  onPushToTalkStart?: () => void;
+  onPushToTalkStop?: () => void;
+  disabled?: boolean;
+}
+
+/**
+ * Mic toggle button with visual state indicators.
+ *
+ * - Inactive: grey mic icon
+ * - Listening: pulsing green ring
+ * - Speaking: animated blue ring
+ * - Processing: amber pulse
+ */
+export function VoiceButton({
+  voiceState,
+  mode,
+  onToggle,
+  onPushToTalkStart,
+  onPushToTalkStop,
+  disabled,
+}: VoiceButtonProps) {
+  const isActive = voiceState !== 'inactive';
+  const isListening = voiceState === 'listening';
+  const isSpeaking = voiceState === 'speaking';
+  const isProcessing = voiceState === 'processing';
+  const isConnecting = voiceState === 'connecting';
+
+  const ringColor = isSpeaking
+    ? 'ring-blue-400'
+    : isListening
+    ? 'ring-green-400'
+    : isProcessing
+    ? 'ring-amber-400'
+    : isConnecting
+    ? 'ring-tetsuo-400'
+    : '';
+
+  const pulseClass = (isListening || isSpeaking || isProcessing)
+    ? 'animate-pulse'
+    : '';
+
+  const bgColor = isActive
+    ? 'bg-red-600 hover:bg-red-700'
+    : 'bg-tetsuo-700 hover:bg-tetsuo-600';
+
+  // In PTT mode, use mouse/touch events for press-and-hold
+  const isPTT = mode === 'push-to-talk' && isActive;
+
+  return (
+    <button
+      onClick={isPTT ? undefined : onToggle}
+      onMouseDown={isPTT ? onPushToTalkStart : undefined}
+      onMouseUp={isPTT ? onPushToTalkStop : undefined}
+      onMouseLeave={isPTT ? onPushToTalkStop : undefined}
+      onTouchStart={isPTT ? onPushToTalkStart : undefined}
+      onTouchEnd={isPTT ? onPushToTalkStop : undefined}
+      disabled={disabled}
+      title={
+        isPTT
+          ? 'Hold to talk'
+          : isActive
+          ? 'Stop voice'
+          : 'Start voice'
+      }
+      className={`
+        relative flex items-center justify-center
+        w-10 h-10 rounded-lg text-sm transition-colors
+        ${bgColor}
+        ${isActive ? `ring-2 ${ringColor} ${pulseClass}` : ''}
+        disabled:opacity-50 disabled:cursor-not-allowed
+      `}
+    >
+      <MicIcon active={isActive} />
+    </button>
+  );
+}
+
+function MicIcon({ active }: { active: boolean }) {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={active ? 'white' : '#9ca3af'}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" x2="12" y1="19" y2="22" />
+    </svg>
+  );
+}

--- a/web/src/components/chat/VoiceIndicator.tsx
+++ b/web/src/components/chat/VoiceIndicator.tsx
@@ -1,0 +1,66 @@
+import type { VoiceState, VoiceMode } from '../../types';
+
+interface VoiceIndicatorProps {
+  voiceState: VoiceState;
+  transcript: string;
+  mode: VoiceMode;
+  onModeChange: (mode: VoiceMode) => void;
+}
+
+const STATE_LABELS: Record<VoiceState, string> = {
+  inactive: '',
+  connecting: 'Connecting...',
+  listening: 'Listening...',
+  speaking: 'Speaking...',
+  processing: 'Processing...',
+};
+
+/**
+ * Status bar shown when voice is active.
+ *
+ * Displays voice state, running transcript, and mode toggle.
+ */
+export function VoiceIndicator({
+  voiceState,
+  transcript,
+  mode,
+  onModeChange,
+}: VoiceIndicatorProps) {
+  if (voiceState === 'inactive') return null;
+
+  const stateColor =
+    voiceState === 'listening'
+      ? 'bg-green-500'
+      : voiceState === 'speaking'
+      ? 'bg-blue-500'
+      : voiceState === 'processing'
+      ? 'bg-amber-500'
+      : 'bg-tetsuo-500';
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 bg-tetsuo-800 border-b border-tetsuo-700 text-xs">
+      {/* Status dot + label */}
+      <div className="flex items-center gap-2 shrink-0">
+        <span className={`inline-block w-2 h-2 rounded-full ${stateColor} animate-pulse`} />
+        <span className="text-tetsuo-300 font-medium">
+          {STATE_LABELS[voiceState]}
+        </span>
+      </div>
+
+      {/* Transcript */}
+      {transcript && (
+        <span className="text-tetsuo-400 truncate flex-1 min-w-0">
+          {transcript}
+        </span>
+      )}
+
+      {/* Mode toggle */}
+      <button
+        onClick={() => onModeChange(mode === 'vad' ? 'push-to-talk' : 'vad')}
+        className="shrink-0 px-2 py-0.5 rounded border border-tetsuo-600 text-tetsuo-400 hover:text-tetsuo-200 hover:border-tetsuo-500 transition-colors"
+      >
+        {mode === 'vad' ? 'VAD' : 'PTT'}
+      </button>
+    </div>
+  );
+}

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -1,0 +1,5 @@
+/** PCM 24kHz, 16-bit signed, mono, little-endian — matching xAI Realtime API format. */
+export const VOICE_SAMPLE_RATE = 24_000;
+
+/** Interval (ms) between mic audio chunk flushes. */
+export const VOICE_CHUNK_INTERVAL_MS = 100;

--- a/web/src/hooks/useAudioPlayer.ts
+++ b/web/src/hooks/useAudioPlayer.ts
@@ -1,0 +1,87 @@
+import { useCallback, useRef, useState } from 'react';
+import { VOICE_SAMPLE_RATE } from '../constants';
+
+/**
+ * Streaming audio playback hook.
+ *
+ * Receives base64-encoded PCM16 chunks, decodes them, and queues
+ * them for gapless playback via the Web Audio API.
+ */
+export function useAudioPlayer() {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const contextRef = useRef<AudioContext | null>(null);
+  const nextStartTimeRef = useRef(0);
+  const activeSourcesRef = useRef(0);
+
+  const ensureContext = useCallback(() => {
+    if (!contextRef.current || contextRef.current.state === 'closed') {
+      contextRef.current = new AudioContext({ sampleRate: VOICE_SAMPLE_RATE });
+      nextStartTimeRef.current = 0;
+    }
+    if (contextRef.current.state === 'suspended') {
+      void contextRef.current.resume();
+    }
+    return contextRef.current;
+  }, []);
+
+  const enqueue = useCallback((base64: string) => {
+    const ctx = ensureContext();
+    if (ctx.state === 'closed') return;
+    const pcm = base64ToInt16(base64);
+
+    // Create AudioBuffer from Int16 PCM
+    const audioBuffer = ctx.createBuffer(1, pcm.length, VOICE_SAMPLE_RATE);
+    const channel = audioBuffer.getChannelData(0);
+    for (let i = 0; i < pcm.length; i++) {
+      channel[i] = pcm[i] / (pcm[i] < 0 ? 0x8000 : 0x7FFF);
+    }
+
+    const source = ctx.createBufferSource();
+    source.buffer = audioBuffer;
+    source.connect(ctx.destination);
+
+    // Schedule for gapless playback
+    const now = ctx.currentTime;
+    const startTime = Math.max(now, nextStartTimeRef.current);
+    source.start(startTime);
+    nextStartTimeRef.current = startTime + audioBuffer.duration;
+
+    activeSourcesRef.current++;
+    setIsPlaying(true);
+
+    source.onended = () => {
+      activeSourcesRef.current--;
+      if (activeSourcesRef.current <= 0) {
+        activeSourcesRef.current = 0;
+        setIsPlaying(false);
+      }
+    };
+  }, [ensureContext]);
+
+  const stop = useCallback(() => {
+    if (contextRef.current) {
+      void contextRef.current.close();
+      contextRef.current = null;
+    }
+    nextStartTimeRef.current = 0;
+    activeSourcesRef.current = 0;
+    setIsPlaying(false);
+  }, []);
+
+  return { isPlaying, enqueue, stop };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Decode base64 string to Int16Array (browser). */
+function base64ToInt16(base64: string): Int16Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  // Interpret as Int16 LE
+  return new Int16Array(bytes.buffer);
+}

--- a/web/src/hooks/useAudioRecorder.ts
+++ b/web/src/hooks/useAudioRecorder.ts
@@ -1,0 +1,131 @@
+import { useCallback, useRef, useState } from 'react';
+import { VOICE_SAMPLE_RATE, VOICE_CHUNK_INTERVAL_MS } from '../constants';
+
+/**
+ * Low-level mic capture hook.
+ *
+ * Captures audio from the user's microphone via getUserMedia + AudioWorklet/ScriptProcessor,
+ * converts Float32 → Int16 LE, base64-encodes, and delivers chunks every ~100ms.
+ */
+export function useAudioRecorder() {
+  const [isRecording, setIsRecording] = useState(false);
+  const streamRef = useRef<MediaStream | null>(null);
+  const contextRef = useRef<AudioContext | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const callbackRef = useRef<((base64: string) => void) | null>(null);
+  const bufferRef = useRef<Int16Array[]>([]);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const flush = useCallback(() => {
+    const chunks = bufferRef.current;
+    if (chunks.length === 0) return;
+    bufferRef.current = [];
+
+    // Concatenate all chunks
+    const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+    const merged = new Int16Array(totalLen);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    // Convert Int16Array to base64
+    const bytes = new Uint8Array(merged.buffer, merged.byteOffset, merged.byteLength);
+    const base64 = uint8ToBase64(bytes);
+    callbackRef.current?.(base64);
+  }, []);
+
+  const start = useCallback(async (onAudioData: (base64: string) => void) => {
+    if (isRecording) return;
+
+    callbackRef.current = onAudioData;
+
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        sampleRate: VOICE_SAMPLE_RATE,
+        channelCount: 1,
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+    });
+
+    const ctx = new AudioContext({ sampleRate: VOICE_SAMPLE_RATE });
+    const source = ctx.createMediaStreamSource(stream);
+
+    // ScriptProcessorNode for wide browser support (AudioWorklet is better but
+    // requires a separate worker file which complicates the build)
+    const processor = ctx.createScriptProcessor(4096, 1, 1);
+    processor.onaudioprocess = (e) => {
+      const float32 = e.inputBuffer.getChannelData(0);
+      const int16 = float32ToInt16(float32);
+      bufferRef.current.push(int16);
+    };
+
+    source.connect(processor);
+    processor.connect(ctx.destination);
+
+    streamRef.current = stream;
+    contextRef.current = ctx;
+    processorRef.current = processor;
+
+    // Flush accumulated audio at regular intervals
+    timerRef.current = setInterval(flush, VOICE_CHUNK_INTERVAL_MS);
+
+    setIsRecording(true);
+  }, [isRecording, flush]);
+
+  const stop = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
+
+    // Flush remaining audio
+    flush();
+
+    if (processorRef.current) {
+      processorRef.current.disconnect();
+      processorRef.current = null;
+    }
+    if (contextRef.current) {
+      void contextRef.current.close();
+      contextRef.current = null;
+    }
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        track.stop();
+      }
+      streamRef.current = null;
+    }
+
+    callbackRef.current = null;
+    bufferRef.current = [];
+    setIsRecording(false);
+  }, [flush]);
+
+  return { isRecording, start, stop };
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Convert Float32 audio samples (-1..1) to Int16 LE. */
+function float32ToInt16(float32: Float32Array): Int16Array {
+  const int16 = new Int16Array(float32.length);
+  for (let i = 0; i < float32.length; i++) {
+    const s = Math.max(-1, Math.min(1, float32[i]));
+    int16[i] = s < 0 ? s * 0x8000 : s * 0x7FFF;
+  }
+  return int16;
+}
+
+/** Uint8Array to base64 string (browser). */
+function uint8ToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}

--- a/web/src/hooks/useVoice.ts
+++ b/web/src/hooks/useVoice.ts
@@ -1,0 +1,167 @@
+import { useCallback, useRef, useState } from 'react';
+import type { WSMessage, VoiceState, VoiceMode } from '../types';
+import { useAudioRecorder } from './useAudioRecorder';
+import { useAudioPlayer } from './useAudioPlayer';
+
+interface UseVoiceOptions {
+  send: (msg: Record<string, unknown>) => void;
+}
+
+/**
+ * Voice orchestration hook.
+ *
+ * Ties together mic capture, audio playback, and the WebSocket voice protocol
+ * to provide a complete bidirectional voice experience.
+ */
+export function useVoice({ send }: UseVoiceOptions) {
+  const [voiceState, setVoiceState] = useState<VoiceState>('inactive');
+  const [transcript, setTranscript] = useState('');
+  const [mode, setMode] = useState<VoiceMode>('vad');
+  const transcriptRef = useRef('');
+
+  const recorder = useAudioRecorder();
+  const player = useAudioPlayer();
+
+  const isVoiceActive = voiceState !== 'inactive';
+
+  const startVoice = useCallback(async () => {
+    if (isVoiceActive) return;
+
+    setVoiceState('connecting');
+    setTranscript('');
+    transcriptRef.current = '';
+
+    try {
+      // Tell the server to start a voice session
+      send({ type: 'voice.start' });
+
+      // Start recording and stream audio chunks to the server
+      await recorder.start((base64: string) => {
+        send({ type: 'voice.audio', payload: { audio: base64 } });
+      });
+    } catch {
+      // getUserMedia permission denied or no mic available
+      setVoiceState('inactive');
+      setTranscript('Microphone access denied');
+      send({ type: 'voice.stop' });
+    }
+  }, [isVoiceActive, send, recorder]);
+
+  const stopVoice = useCallback(() => {
+    recorder.stop();
+    player.stop();
+    send({ type: 'voice.stop' });
+    setVoiceState('inactive');
+    setTranscript('');
+    transcriptRef.current = '';
+  }, [recorder, player, send]);
+
+  /** For push-to-talk: user presses and holds. */
+  const pushToTalkStart = useCallback(() => {
+    if (mode !== 'push-to-talk' || !isVoiceActive) return;
+    setVoiceState('listening');
+  }, [mode, isVoiceActive]);
+
+  /** For push-to-talk: user releases. */
+  const pushToTalkStop = useCallback(() => {
+    if (mode !== 'push-to-talk' || !isVoiceActive) return;
+    send({ type: 'voice.commit' });
+    setVoiceState('processing');
+  }, [mode, isVoiceActive, send]);
+
+  /** Handle incoming voice-related WebSocket messages. */
+  const handleMessage = useCallback((msg: WSMessage) => {
+    const type = msg.type;
+    const payload = (msg.payload ?? {}) as Record<string, unknown>;
+
+    switch (type) {
+      case 'voice.started':
+        setVoiceState('listening');
+        break;
+
+      case 'voice.stopped':
+        recorder.stop();
+        player.stop();
+        setVoiceState('inactive');
+        break;
+
+      case 'voice.audio': {
+        const audio = payload.audio;
+        if (typeof audio === 'string') {
+          player.enqueue(audio);
+          if (voiceState !== 'speaking') {
+            setVoiceState('speaking');
+          }
+        }
+        break;
+      }
+
+      case 'voice.transcript': {
+        if (payload.done) {
+          transcriptRef.current = '';
+          setTranscript(payload.text as string);
+        } else {
+          transcriptRef.current += payload.delta as string;
+          setTranscript(transcriptRef.current);
+        }
+        break;
+      }
+
+      case 'voice.speech_started':
+        setVoiceState('listening');
+        break;
+
+      case 'voice.speech_stopped':
+        setVoiceState('processing');
+        break;
+
+      case 'voice.response_done':
+        // Agent finished speaking, go back to listening
+        if (voiceState !== 'inactive') {
+          setVoiceState('listening');
+        }
+        break;
+
+      case 'voice.state': {
+        const connectionState = payload.connectionState;
+        if (connectionState === 'reconnecting') {
+          setVoiceState('connecting');
+        } else if (connectionState === 'disconnected') {
+          setVoiceState('inactive');
+        }
+        break;
+      }
+
+      case 'voice.error': {
+        const errMsg = (payload.message as string) ?? 'Voice error';
+        setTranscript(errMsg);
+        // If we were connecting, the session failed to start — go inactive
+        if (voiceState === 'connecting') {
+          recorder.stop();
+          player.stop();
+          setVoiceState('inactive');
+        }
+        break;
+      }
+
+      default:
+        // Not a voice message — ignore
+        break;
+    }
+  }, [recorder, player, voiceState]);
+
+  return {
+    isVoiceActive,
+    isRecording: recorder.isRecording,
+    isSpeaking: player.isPlaying,
+    voiceState,
+    transcript,
+    startVoice,
+    stopVoice,
+    mode,
+    setMode,
+    pushToTalkStart,
+    pushToTalkStop,
+    handleMessage,
+  };
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -137,6 +137,15 @@ export interface WSMessage {
 }
 
 // ============================================================================
+// Voice
+// Keep in sync with runtime/src/channels/webchat/types.ts voice protocol types
+// ============================================================================
+
+export type VoiceState = 'inactive' | 'connecting' | 'listening' | 'speaking' | 'processing';
+
+export type VoiceMode = 'vad' | 'push-to-talk';
+
+// ============================================================================
 // Navigation
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Upgrade default LLM from `grok-3` to `grok-4-1-fast-reasoning` (2M context, agentic reasoning)
- Integrate xAI Realtime Voice API (`wss://api.x.ai/v1/realtime`) for bidirectional voice conversations
- End-to-end voice pipeline: browser mic → Gateway WS → xAI realtime → audio playback + transcript

## Changes

### Runtime (backend)
- **`voice/realtime/`** — New `XaiRealtimeClient` WebSocket client with auto-reconnect, VAD/push-to-talk, tool calling
- **`gateway/voice-bridge.ts`** — Per-client voice session manager bridging Gateway WS to xAI realtime
- **`gateway/daemon.ts`** — Wires VoiceBridge when Grok provider configured; model fallback updated
- **`channels/webchat/plugin.ts`** — Routes `voice.*` messages to VoiceBridge
- **`llm/grok/adapter.ts`** — Default model → `grok-4-1-fast-reasoning`
- **`utils/encoding.ts`** — Shared `uint8ToBase64`/`base64ToUint8` helpers
- **`types/errors.ts`** — New `VOICE_REALTIME_ERROR` error code

### Web Portal (frontend)
- **`hooks/useAudioRecorder.ts`** — Mic capture via Web Audio API (PCM 24kHz mono)
- **`hooks/useAudioPlayer.ts`** — Gapless streaming playback via AudioBufferSourceNode
- **`hooks/useVoice.ts`** — Voice orchestration (recorder + player + WS protocol)
- **`components/chat/VoiceButton.tsx`** — Mic toggle with state-driven visual indicators
- **`components/chat/VoiceIndicator.tsx`** — Transcript display + VAD/PTT mode toggle
- **`constants.ts`** — Shared `VOICE_SAMPLE_RATE` (24kHz), `VOICE_CHUNK_INTERVAL_MS` (100ms)

## Audio Format (end-to-end)

PCM 24kHz, 16-bit signed, mono, little-endian — no transcoding:
```
Browser (Web Audio → Int16 LE) → base64 → WS → Gateway → base64 → xAI
xAI → base64 PCM → Gateway → WS → base64 → Browser (AudioContext playback)
```

## Test plan

- [x] `npm run build` passes (SDK + Runtime + MCP + Docs-MCP)
- [x] Runtime tests pass (4673 pass, 6 pre-existing failures)
- [x] xAI realtime WebSocket connects successfully
- [x] Voice session lifecycle (start → speech detected → response audio → stop)
- [x] Daemon survives audio arriving before xAI connection ready (no crash)
- [ ] Manual: mic capture → voice response → audio playback in browser
- [ ] Manual: push-to-talk mode toggle
- [ ] Manual: tool calling during voice session