### PR TITLE
fix(coordination): harden treasury + multisig governance paths

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -512,6 +512,9 @@ pub enum CoordinationError {
     #[msg("Treasury must be a program-owned PDA")]
     TreasuryNotProgramOwned,
 
+    #[msg("Treasury must be program-owned, or a signer system account for governance spends")]
+    TreasuryNotSpendable,
+
     // Skill registry errors (sequential from enum position)
     #[msg("Skill ID cannot be all zeros")]
     SkillInvalidId,
@@ -560,7 +563,9 @@ pub enum CoordinationError {
     #[msg("Reputation stake has insufficient balance for withdrawal")]
     ReputationStakeInsufficientBalance,
 
-    #[msg("Reputation delegation amount invalid: must be > 0, <= 10000, and >= MIN_DELEGATION_AMOUNT")]
+    #[msg(
+        "Reputation delegation amount invalid: must be > 0, <= 10000, and >= MIN_DELEGATION_AMOUNT"
+    )]
     ReputationDelegationAmountInvalid,
 
     #[msg("Cannot delegate reputation to self")]

--- a/programs/agenc-coordination/src/events.rs
+++ b/programs/agenc-coordination/src/events.rs
@@ -209,6 +209,26 @@ pub struct ProtocolInitialized {
     pub timestamp: i64,
 }
 
+/// Emitted when protocol treasury is updated via multisig governance.
+#[event]
+pub struct TreasuryUpdated {
+    pub old_treasury: Pubkey,
+    pub new_treasury: Pubkey,
+    pub updated_by: Pubkey,
+    pub timestamp: i64,
+}
+
+/// Emitted when multisig signer set or threshold is updated.
+#[event]
+pub struct MultisigUpdated {
+    pub old_threshold: u8,
+    pub new_threshold: u8,
+    pub old_owner_count: u8,
+    pub new_owner_count: u8,
+    pub updated_by: Pubkey,
+    pub timestamp: i64,
+}
+
 /// Emitted for reward distribution
 #[event]
 pub struct RewardDistributed {

--- a/programs/agenc-coordination/src/instructions/mod.rs
+++ b/programs/agenc-coordination/src/instructions/mod.rs
@@ -32,41 +32,43 @@ pub mod validation;
 pub mod apply_dispute_slash;
 pub mod apply_initiator_slash;
 pub mod cancel_dispute;
+pub mod cancel_proposal;
 pub mod cancel_task;
 pub mod claim_task;
 pub mod complete_task;
 pub mod complete_task_private;
 pub mod create_dependent_task;
+pub mod create_proposal;
 pub mod create_task;
+pub mod delegate_reputation;
 pub mod deregister_agent;
+pub mod execute_proposal;
 pub mod expire_claim;
 pub mod expire_dispute;
+pub mod initialize_governance;
 pub mod initialize_protocol;
 pub mod initiate_dispute;
 pub mod migrate;
-pub mod register_agent;
-pub mod resolve_dispute;
-pub mod suspend_agent;
-pub mod unsuspend_agent;
-pub mod update_agent;
-pub mod update_protocol_fee;
-pub mod update_rate_limits;
-pub mod update_state;
-pub mod vote_dispute;
-pub mod cancel_proposal;
-pub mod create_proposal;
-pub mod execute_proposal;
-pub mod initialize_governance;
-pub mod vote_proposal;
 pub mod post_to_feed;
 pub mod purchase_skill;
 pub mod rate_skill;
+pub mod register_agent;
 pub mod register_skill;
-pub mod update_skill;
-pub mod upvote_post;
-pub mod delegate_reputation;
+pub mod resolve_dispute;
 pub mod revoke_delegation;
 pub mod stake_reputation;
+pub mod suspend_agent;
+pub mod unsuspend_agent;
+pub mod update_agent;
+pub mod update_multisig;
+pub mod update_protocol_fee;
+pub mod update_rate_limits;
+pub mod update_skill;
+pub mod update_state;
+pub mod update_treasury;
+pub mod upvote_post;
+pub mod vote_dispute;
+pub mod vote_proposal;
 pub mod withdraw_reputation_stake;
 
 // Glob re-exports are required for Anchor's #[program] macro to access generated
@@ -78,6 +80,8 @@ pub use apply_initiator_slash::*;
 #[allow(ambiguous_glob_reexports)]
 pub use cancel_dispute::*;
 #[allow(ambiguous_glob_reexports)]
+pub use cancel_proposal::*;
+#[allow(ambiguous_glob_reexports)]
 pub use cancel_task::*;
 #[allow(ambiguous_glob_reexports)]
 pub use claim_task::*;
@@ -87,12 +91,20 @@ pub use complete_task::*;
 pub use complete_task_private::*;
 #[allow(ambiguous_glob_reexports)]
 pub use create_dependent_task::*;
+#[allow(ambiguous_glob_reexports)]
+pub use create_proposal::*;
 pub use create_task::*;
+#[allow(ambiguous_glob_reexports)]
+pub use delegate_reputation::*;
 #[allow(ambiguous_glob_reexports)]
 pub use deregister_agent::*;
 #[allow(ambiguous_glob_reexports)]
+pub use execute_proposal::*;
+#[allow(ambiguous_glob_reexports)]
 pub use expire_claim::*;
 pub use expire_dispute::*;
+#[allow(ambiguous_glob_reexports)]
+pub use initialize_governance::*;
 #[allow(ambiguous_glob_reexports)]
 pub use initialize_protocol::*;
 #[allow(ambiguous_glob_reexports)]
@@ -100,9 +112,21 @@ pub use initiate_dispute::*;
 #[allow(ambiguous_glob_reexports)]
 pub use migrate::*;
 #[allow(ambiguous_glob_reexports)]
+pub use post_to_feed::*;
+#[allow(ambiguous_glob_reexports)]
+pub use purchase_skill::*;
+#[allow(ambiguous_glob_reexports)]
+pub use rate_skill::*;
+#[allow(ambiguous_glob_reexports)]
 pub use register_agent::*;
 #[allow(ambiguous_glob_reexports)]
+pub use register_skill::*;
+#[allow(ambiguous_glob_reexports)]
 pub use resolve_dispute::*;
+#[allow(ambiguous_glob_reexports)]
+pub use revoke_delegation::*;
+#[allow(ambiguous_glob_reexports)]
+pub use stake_reputation::*;
 #[allow(ambiguous_glob_reexports)]
 pub use suspend_agent::*;
 #[allow(ambiguous_glob_reexports)]
@@ -110,40 +134,22 @@ pub use unsuspend_agent::*;
 #[allow(ambiguous_glob_reexports)]
 pub use update_agent::*;
 #[allow(ambiguous_glob_reexports)]
+pub use update_multisig::*;
+#[allow(ambiguous_glob_reexports)]
 pub use update_protocol_fee::*;
 #[allow(ambiguous_glob_reexports)]
 pub use update_rate_limits::*;
 #[allow(ambiguous_glob_reexports)]
+pub use update_skill::*;
+#[allow(ambiguous_glob_reexports)]
 pub use update_state::*;
 #[allow(ambiguous_glob_reexports)]
-pub use vote_dispute::*;
-#[allow(ambiguous_glob_reexports)]
-pub use cancel_proposal::*;
-#[allow(ambiguous_glob_reexports)]
-pub use create_proposal::*;
-#[allow(ambiguous_glob_reexports)]
-pub use execute_proposal::*;
-#[allow(ambiguous_glob_reexports)]
-pub use initialize_governance::*;
-#[allow(ambiguous_glob_reexports)]
-pub use vote_proposal::*;
-#[allow(ambiguous_glob_reexports)]
-pub use post_to_feed::*;
-#[allow(ambiguous_glob_reexports)]
-pub use purchase_skill::*;
-#[allow(ambiguous_glob_reexports)]
-pub use rate_skill::*;
-#[allow(ambiguous_glob_reexports)]
-pub use register_skill::*;
-#[allow(ambiguous_glob_reexports)]
-pub use update_skill::*;
+pub use update_treasury::*;
 #[allow(ambiguous_glob_reexports)]
 pub use upvote_post::*;
 #[allow(ambiguous_glob_reexports)]
-pub use delegate_reputation::*;
+pub use vote_dispute::*;
 #[allow(ambiguous_glob_reexports)]
-pub use revoke_delegation::*;
-#[allow(ambiguous_glob_reexports)]
-pub use stake_reputation::*;
+pub use vote_proposal::*;
 #[allow(ambiguous_glob_reexports)]
 pub use withdraw_reputation_stake::*;

--- a/programs/agenc-coordination/src/instructions/update_multisig.rs
+++ b/programs/agenc-coordination/src/instructions/update_multisig.rs
@@ -1,0 +1,97 @@
+//! Update multisig owners and threshold (multisig gated).
+//!
+//! Hardening goals:
+//! - Allow signer rotation to recover from key loss/compromise.
+//! - Prevent accidental lockouts by validating new signer set thoroughly.
+
+use crate::errors::CoordinationError;
+use crate::events::MultisigUpdated;
+use crate::state::ProtocolConfig;
+use crate::utils::multisig::{require_multisig, validate_multisig_owners};
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+use std::collections::BTreeSet;
+
+#[derive(Accounts)]
+pub struct UpdateMultisig<'info> {
+    #[account(
+        mut,
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+}
+
+pub fn handler(
+    ctx: Context<UpdateMultisig>,
+    new_threshold: u8,
+    new_owners: Vec<Pubkey>,
+) -> Result<()> {
+    let config = &mut ctx.accounts.protocol_config;
+    require_multisig(config, ctx.remaining_accounts)?;
+
+    require!(
+        !new_owners.is_empty(),
+        CoordinationError::MultisigInvalidSigners
+    );
+    require!(
+        new_owners.len() <= ProtocolConfig::MAX_MULTISIG_OWNERS,
+        CoordinationError::MultisigInvalidSigners
+    );
+    // Keep the same safety invariant used during protocol initialization:
+    // threshold must be strictly less than owner count to preserve recovery
+    // capacity if one key is lost.
+    require!(
+        new_threshold > 0 && (new_threshold as usize) < new_owners.len(),
+        CoordinationError::MultisigInvalidThreshold
+    );
+    validate_multisig_owners(&new_owners)?;
+
+    // Additional hardening: require that enough signers from the *new* set are
+    // present in this update transaction. This prevents rotating to an
+    // unreachable signer set due to typo/misconfiguration.
+    let mut counted = BTreeSet::new();
+    let mut new_set_approvals = 0usize;
+    for account in ctx.remaining_accounts {
+        if account.is_signer
+            && account.owner == &system_program::ID
+            && new_owners.contains(account.key)
+            && !counted.contains(account.key)
+        {
+            counted.insert(*account.key);
+            new_set_approvals += 1;
+        }
+    }
+    require!(
+        new_set_approvals >= new_threshold as usize,
+        CoordinationError::MultisigNotEnoughSigners
+    );
+
+    let old_threshold = config.multisig_threshold;
+    let old_owner_count = config.multisig_owners_len;
+
+    config.multisig_threshold = new_threshold;
+    config.multisig_owners_len = new_owners.len() as u8;
+    config.multisig_owners = [Pubkey::default(); ProtocolConfig::MAX_MULTISIG_OWNERS];
+    for (index, owner) in new_owners.iter().enumerate() {
+        config.multisig_owners[index] = *owner;
+    }
+
+    let updated_by = ctx
+        .remaining_accounts
+        .iter()
+        .find(|account| account.is_signer)
+        .map(|account| account.key())
+        .unwrap_or_default();
+
+    emit!(MultisigUpdated {
+        old_threshold,
+        new_threshold,
+        old_owner_count,
+        new_owner_count: config.multisig_owners_len,
+        updated_by,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/instructions/update_treasury.rs
+++ b/programs/agenc-coordination/src/instructions/update_treasury.rs
@@ -1,0 +1,70 @@
+//! Update protocol treasury (multisig gated).
+//!
+//! This provides a safe recovery path if the original treasury configuration
+//! becomes unusable, and allows rotating treasury custody over time.
+
+use crate::errors::CoordinationError;
+use crate::events::TreasuryUpdated;
+use crate::state::ProtocolConfig;
+use crate::utils::multisig::require_multisig;
+use anchor_lang::prelude::*;
+use anchor_lang::system_program;
+
+#[derive(Accounts)]
+pub struct UpdateTreasury<'info> {
+    #[account(
+        mut,
+        seeds = [b"protocol"],
+        bump = protocol_config.bump
+    )]
+    pub protocol_config: Account<'info, ProtocolConfig>,
+
+    /// CHECK: Validated in handler.
+    /// Must be either:
+    /// - program-owned (preferred), or
+    /// - a system-owned signer account (legacy compatibility).
+    pub new_treasury: UncheckedAccount<'info>,
+}
+
+pub fn handler(ctx: Context<UpdateTreasury>) -> Result<()> {
+    require_multisig(&ctx.accounts.protocol_config, ctx.remaining_accounts)?;
+
+    let new_treasury = &ctx.accounts.new_treasury;
+    require!(
+        new_treasury.key() != Pubkey::default(),
+        CoordinationError::InvalidTreasury
+    );
+
+    let is_program_owned = new_treasury.owner == &crate::ID;
+    let is_system_owned_signer =
+        new_treasury.owner == &system_program::ID && new_treasury.is_signer;
+    require!(
+        is_program_owned || is_system_owned_signer,
+        CoordinationError::TreasuryNotSpendable
+    );
+
+    let config = &mut ctx.accounts.protocol_config;
+    require!(
+        new_treasury.key() != config.treasury,
+        CoordinationError::InvalidInput
+    );
+
+    let old_treasury = config.treasury;
+    config.treasury = new_treasury.key();
+
+    let updated_by = ctx
+        .remaining_accounts
+        .iter()
+        .find(|account| account.is_signer)
+        .map(|account| account.key())
+        .unwrap_or_default();
+
+    emit!(TreasuryUpdated {
+        old_treasury,
+        new_treasury: config.treasury,
+        updated_by,
+        timestamp: Clock::get()?.unix_timestamp,
+    });
+
+    Ok(())
+}

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -322,6 +322,28 @@ pub mod agenc_coordination {
         instructions::update_protocol_fee::handler(ctx, protocol_fee_bps)
     }
 
+    /// Update protocol treasury destination (multisig gated).
+    ///
+    /// Hardening:
+    /// - Allows treasury rotation/recovery.
+    /// - New treasury must be program-owned, or a signer system account.
+    pub fn update_treasury(ctx: Context<UpdateTreasury>) -> Result<()> {
+        instructions::update_treasury::handler(ctx)
+    }
+
+    /// Rotate multisig owners/threshold (multisig gated).
+    ///
+    /// Hardening:
+    /// - Allows signer rotation for key loss/compromise recovery.
+    /// - Requires threshold of new-set signers in the same update transaction.
+    pub fn update_multisig(
+        ctx: Context<UpdateMultisig>,
+        new_threshold: u8,
+        new_owners: Vec<Pubkey>,
+    ) -> Result<()> {
+        instructions::update_multisig::handler(ctx, new_threshold, new_owners)
+    }
+
     /// Update rate limiting configuration (multisig gated).
     /// Parameters can be tuned post-deployment without program upgrade.
     ///

--- a/programs/agenc-coordination/src/utils/validation.rs
+++ b/programs/agenc-coordination/src/utils/validation.rs
@@ -16,6 +16,8 @@
 ///
 /// # Examples
 /// ```
+/// use agenc_coordination::utils::validation::validate_string_input;
+///
 /// assert!(validate_string_input("https://example.com/api"));
 /// assert!(validate_string_input("hello world"));
 /// assert!(!validate_string_input("hello\x00world")); // null byte
@@ -33,7 +35,9 @@ mod tests {
     fn test_valid_url() {
         assert!(validate_string_input("https://example.com/api/v1"));
         assert!(validate_string_input("http://localhost:8080"));
-        assert!(validate_string_input("https://api.example.com/agents?id=123"));
+        assert!(validate_string_input(
+            "https://api.example.com/agents?id=123"
+        ));
     }
 
     #[test]
@@ -44,7 +48,9 @@ mod tests {
 
     #[test]
     fn test_valid_special_chars() {
-        assert!(validate_string_input("https://example.com/path?key=value&other=123"));
+        assert!(validate_string_input(
+            "https://example.com/path?key=value&other=123"
+        ));
         assert!(validate_string_input("ipfs://QmHash123"));
         assert!(validate_string_input("ar://arweave-hash"));
     }
@@ -57,9 +63,9 @@ mod tests {
     #[test]
     fn test_invalid_control_chars() {
         assert!(!validate_string_input("hello\x00world")); // null byte
-        assert!(!validate_string_input("hello\nworld"));   // newline
-        assert!(!validate_string_input("hello\rworld"));   // carriage return
-        assert!(!validate_string_input("hello\tworld"));   // tab
+        assert!(!validate_string_input("hello\nworld")); // newline
+        assert!(!validate_string_input("hello\rworld")); // carriage return
+        assert!(!validate_string_input("hello\tworld")); // tab
         assert!(!validate_string_input("\x1b[31mred\x1b[0m")); // ANSI escape
     }
 


### PR DESCRIPTION
## Summary
- harden protocol treasury validation at initialization to require spendable treasury configuration
- harden governance treasury spend execution to support program-owned treasury and signer-gated system treasury fallback
- add multisig-gated `update_treasury` and `update_multisig` instructions with strict validation and audit events
- wire new instructions into module exports and program entrypoints
- update protocol docs/comments and fix validation doctest import

## Validation
- cargo check --manifest-path programs/agenc-coordination/Cargo.toml
- cargo test --manifest-path programs/agenc-coordination/Cargo.toml