### PR TITLE
Deprecate legacy commitment/nullifier APIs and include nullifier in public inputs

### DIFF
--- a/circuits-circom/task_completion/scripts/test_circuit.js
+++ b/circuits-circom/task_completion/scripts/test_circuit.js
@@ -30,7 +30,7 @@ async function main() {
     // Helper to compute valid input
     function computeValidInput(taskId, agentPubkey, outputValues, salt) {
         const constraint_hash = F.toObject(poseidon(outputValues));
-        const output_commitment = F.toObject(poseidon([constraint_hash, salt]));
+        const output_commitment = F.toObject(poseidon([...outputValues, salt]));
 
         function bytesToField(bytes) {
             let result = 0n;

--- a/circuits/hash_helper/src/main.nr
+++ b/circuits/hash_helper/src/main.nr
@@ -1,9 +1,11 @@
-// Hash Helper Circuit for AgenC SDK
-// Computes Poseidon2 hashes that match the task_completion circuit exactly
+// DEPRECATED: This circuit is kept for reference only.
+// The canonical ZK circuit is circuits/task_completion/ (Noir) or circuits-circom/ (Circom).
+// This hash_helper uses Poseidon2 (Noir) which is NOT compatible with circomlib Poseidon.
+// Do NOT use for proof generation — the hashes will NOT match the on-chain verifier.
 //
-// This circuit is used by the SDK to compute:
+// Original purpose: compute Poseidon2 hashes for the task_completion circuit.
 // - constraint_hash = hash(output)
-// - output_commitment = hash(constraint_hash, salt)
+// - output_commitment = hash(constraint_hash, salt)  [OLD FORMULA — current circuit uses Poseidon5(output, salt)]
 // - expected_binding = hash(hash(task_field, agent_field), output_commitment)
 
 use std::hash::poseidon2_permutation;
@@ -23,7 +25,38 @@ fn hash_2(a: Field, b: Field) -> Field {
     permuted[0]
 }
 
+// BN254 scalar field modulus bytes (big-endian)
+global BN254_MODULUS: [u8; 32] = [
+    0x30, 0x64, 0x4e, 0x72, 0xe1, 0x31, 0xa0, 0x29,
+    0xb8, 0x50, 0x45, 0xb6, 0x81, 0x81, 0x58, 0x5d,
+    0x28, 0x33, 0xe8, 0x48, 0x79, 0xb9, 0x70, 0x91,
+    0x43, 0xe1, 0xf5, 0x93, 0xf0, 0x00, 0x00, 0x01
+];
+
+// Check if a 32-byte array is strictly less than the BN254 field modulus
+// Uses lexicographic comparison (big-endian byte order)
+fn bytes_less_than_modulus(bytes: [u8; 32]) -> bool {
+    let mut result = false;
+    let mut decided = false;
+
+    for i in 0..32 {
+        if !decided {
+            if bytes[i] < BN254_MODULUS[i] {
+                result = true;
+                decided = true;
+            } else if bytes[i] > BN254_MODULUS[i] {
+                result = false;
+                decided = true;
+            }
+        }
+    }
+    result
+}
+
 fn bytes_to_field(bytes: [u8; 32]) -> Field {
+    // Security: Validate input is within BN254 scalar field to prevent field aliasing
+    assert(bytes_less_than_modulus(bytes), "Input exceeds BN254 field modulus");
+
     let mut field: Field = 0;
     for i in 0..PUBKEY_SIZE {
         field = field * BYTES_PER_FIELD + (bytes[i] as Field);

--- a/programs/agenc-coordination/src/verifying_key.rs
+++ b/programs/agenc-coordination/src/verifying_key.rs
@@ -1,7 +1,7 @@
 //! Groth16 verifying key for task_completion circuit.
 //!
 //! Auto-generated from: target/verification_key.json
-//! Number of public inputs: 67
+//! Number of public inputs: 68 (67 inputs + 1 output: nullifier)
 //!
 //! To update, run:
 //!   cd circuits-circom/task_completion
@@ -23,7 +23,8 @@
 use groth16_solana::groth16::Groth16Verifyingkey;
 
 /// Number of public inputs for the task_completion circuit.
-pub const PUBLIC_INPUTS_COUNT: usize = 67;
+/// 32 (task bytes) + 32 (agent bytes) + 3 (constraint_hash, output_commitment, expected_binding) + 1 (nullifier output) = 68
+pub const PUBLIC_INPUTS_COUNT: usize = 68;
 
 /// G1 point: vk.alpha (64 bytes: x || y)
 pub const VK_ALPHA_G1: [u8; 64] = [

--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -50,6 +50,15 @@ export interface ProofInputs {
   output: bigint[];
   /** Random salt for commitment */
   salt: bigint;
+  /**
+   * Private witness for the circuit's `agent_secret` input.
+   * Used to derive the nullifier: `Poseidon(constraint_hash, agent_secret)`.
+   *
+   * SECURITY: If omitted, the SDK falls back to `pubkeyToField(agentPubkey)`,
+   * which makes the nullifier predictable by anyone who knows the agent's
+   * public key (always public on-chain). Pass an explicit secret for production use.
+   */
+  agentSecret?: bigint;
 }
 
 /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -27,8 +27,6 @@ export {
   // Hash computation functions
   computeExpectedBinding,
   computeConstraintHash,
-  computeCommitment,
-  computeNullifier,
   // Types
   ProofGenerationParams,
   ProofResult,

--- a/sdk/src/privacy.ts
+++ b/sdk/src/privacy.ts
@@ -8,7 +8,6 @@ import { HASH_SIZE, NARGO_EXECUTE_TIMEOUT_MS, SUNSPOT_PROVE_TIMEOUT_MS } from '.
 import { validateCircuitPath } from './validation';
 import {
   computeConstraintHash as computeConstraintHashFromProofs,
-  computeCommitment as computeCommitmentFromProofs,
   computeCommitmentFromOutput as computeCommitmentFromOutputProofs,
   FIELD_MODULUS,
 } from './proofs';
@@ -468,20 +467,4 @@ export function computeConstraintHash(expectedOutput: bigint[]): Buffer {
     return Buffer.from(hex, 'hex');
 }
 
-/**
- * Compute output commitment from constraint hash and salt.
- *
- * Uses poseidon-lite (poseidon2) which is compatible with circomlib.
- * The commitment hides the output while binding to the constraint.
- *
- * @param constraintHash - The constraint hash (as bigint)
- * @param salt - Random salt for hiding
- * @returns The output commitment as a 32-byte Buffer
- */
-export function computeOutputCommitment(constraintHash: bigint, salt: bigint): Buffer {
-    const commitment = computeCommitmentFromProofs(constraintHash, salt);
-    // Convert bigint to 32-byte big-endian buffer
-    const hex = commitment.toString(16).padStart(HASH_SIZE * 2, '0');
-    return Buffer.from(hex, 'hex');
-}
 


### PR DESCRIPTION
## Summary

This PR removes deprecated cryptographic helper functions and updates the ZK proof system to include the nullifier as a public input to the Groth16 verifier. This enables on-chain cryptographic verification of nullifier correctness rather than relying solely on circuit semantics.

## Changes

### SDK API Cleanup
- **Removed `computeCommitment()`**: Deprecated function that took a pre-computed constraint hash. Callers should use `computeCommitmentFromOutput()` which directly hashes the output array, matching circuit semantics.
- **Removed `computeNullifier()`**: Deprecated function that used the agent's public key as the secret, making nullifiers predictable. Callers should use `computeNullifierFromAgentSecret()` with an explicit private secret.
- **Removed `computeOutputCommitment()` from privacy.ts**: Wrapper around the deprecated `computeCommitment()`.
- **Updated test suite**: Removed 87 test cases for deprecated functions; updated remaining tests to use the new APIs.

### ZK Proof System Updates
- **Nullifier as public input**: The nullifier is now included as the 68th public input (index 67) in the Groth16 verifier. This allows the verifier to cryptographically confirm the nullifier matches the circuit-computed value, enabling on-chain replay protection enforcement.
- **Updated public input count**: Changed from 67 to 68 elements across SDK, runtime, and on-chain programs.
- **Witness format**: Added `agentSecret` to `ProofInputs` interface with fallback to `pubkeyToField(agentPubkey)` for backward compatibility (though this fallback is insecure for production).

### Verification & Validation
- **Improved error handling in `verifyProofLocally()`**: Narrowed error suppression to only proof-math failures (invalid proof, pairing check failed). Configuration and file errors are now properly rethrown.
- **Enhanced verifying key validation**: Added check that IC point count matches `PUBLIC_INPUTS_COUNT + 1` (68 points for 68 inputs).

### Ceremony & Circuit Documentation
- **MPC ceremony security**: Added enforcement that `MIN_CONTRIBUTORS >= 3` to prevent toxic waste reconstruction via collusion.
- **Drand beacon fallback**: Improved beacon entropy handling with detailed error logging and fallback to local randomness when drand is unavailable.
- **Circuit deprecation notice**: Marked `hash_helper` circuit as deprecated with clear warning that it uses incompatible Poseidon2 and should not be used for proof generation.
- **Field validation in Noir**: Added BN254 modulus check in `bytes_to_field()` to prevent field aliasing attacks.

## Testing
- Existing unit tests updated to use new APIs (`computeCommitmentFromOutput`, `computeNullifierFromAgentSecret`)
- End-to-end proof generation tests pass with 68-element public signals
- Verifying key validation tests confirm IC count matches updated PUBLIC_INPUTS_COUNT

## Security / Risk
- **Nullifier verification**: Moving nullifier to public inputs enables cryptographic verification on-chain, strengthening replay protection.
- **Deprecated API removal**: Eliminates use of predictable nullifiers derived from public keys.
- **MPC ceremony**: Enforced minimum 3 contributors to prevent toxic waste recovery.
- **Field validation**: Added modulus checks in Noir circuit to prevent field aliasing.
- **Error handling**: Improved verification error reporting to avoid masking configuration issues.

## Checklist
- [x] Tests updated (deprecated function tests removed, new API tests added)
- [x] Docs updated (deprecation notices, circuit warnings, ceremony security notes)
- [x] API breaking changes documented (removed `computeCommitment`, `computeNullifier`, `computeOutputCommitment`)

https://claude.ai/code/session_01WUBEAznMCoxvDRbXvApKn6