### PR TITLE
docs: update AGENTS.md, CLAUDE.md, and README.md to current codebase state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- `programs/agenc-coordination/`: Anchor Solana program (Rust). Instruction handlers live in `src/instructions/`; fuzz targets live in `fuzz/`.
+- `programs/agenc-coordination/`: Anchor Solana program (Rust). 42 instruction handlers in `src/instructions/`; 9 helper modules; 8 fuzz targets in `fuzz/`.
 - `sdk/`, `runtime/`, `mcp/`, and `docs-mcp/`: core TypeScript packages built and tested independently.
 - `tests/`: root integration suite (LiteSVM + Anchor flows).
-- `zkvm/`: RISC Zero guest/host programs for ZK proof generation and verification.
+- `zkvm/`: RISC Zero guest (journal schema) + host (prover, seal encoding) crates for ZK proof generation.
 - App surfaces: `web/`, `mobile/`, `demo-app/`, and `examples/`.
 - Operational docs/scripts: `docs/` and `scripts/`.
 
@@ -14,7 +14,7 @@
 - `anchor build`: compile the on-chain program.
 - `npm run typecheck`: run TypeScript checks across core packages.
 - `npm run test`: run SDK + Runtime unit tests.
-- `npm run test:fast`: run fast LiteSVM integration coverage.
+- `npm run test:fast`: run fast LiteSVM integration coverage (~5s, includes agent-feed tests).
 - `npm run test:anchor`: run full Anchor tests (requires local validator tooling).
 - `./scripts/setup-dev.sh`: full bootstrap (env checks, builds, tests).
 
@@ -24,11 +24,14 @@
 - Use `bigint` for on-chain u64 values; use `BN` only at Anchor instruction boundaries.
 - Runtime module layout should follow: `types.ts`, `errors.ts`, `<module>.ts`, `<module>.test.ts`, `index.ts`.
 - Rust changes should pass `cargo fmt --check` and `cargo clippy`.
+- Use `safeStringify()` for any data containing bigint (JSON.stringify throws).
 
 ## Testing Guidelines
 - Unit tests are co-located as `*.test.ts` (primarily under `runtime/src/**` and `sdk/src/**`, run via Vitest).
 - Root `tests/*.ts` covers protocol/integration behavior with LiteSVM and Anchor test utilities.
 - Add or update regression tests with behavior changes; run `npm run test:fast && npm run typecheck` before opening a PR.
+- LiteSVM clock doesn't auto-advance — use `advanceClock(svm, 61)` before `updateAgent` (60s cooldown).
+- Use `getClockTimestamp(svm)` not `Date.now()` for deadline calculations.
 
 ## Commit & Pull Request Guidelines
 - Use Conventional Commits (examples: `feat(runtime): add replay gate`, `fix(program): validate deadline`).


### PR DESCRIPTION
## Summary

- Correct all stale counts across AGENTS.md, CLAUDE.md, and README.md
- Program: 42 instructions (was 25), 192 error codes (was 147), 47 events (was 30)
- Add missing instruction categories: skill registry (4), agent feed (2), reputation economy (4), protocol admin (update_treasury, update_multisig)
- Runtime: 29 module directories — add voice, social, bridges, reputation modules
- All 8 fuzz targets documented (was 4)
- Fix example rename: zk-proof-demo → risc0-proof-demo
- Remove stale file references (router_policy.rs, risc0_config.rs)
- Add docs-mcp to packages table
- Expand PDA listing and documentation table

## Test plan

- [x] No code changes — documentation only
- [x] All counts verified against source files