### PR TITLE
feat(sdk,zkvm): add real RISC Zero prover backends to SDK

### DIFF
--- a/sdk/src/__tests__/prover.test.ts
+++ b/sdk/src/__tests__/prover.test.ts
@@ -1,0 +1,565 @@
+/**
+ * Unit tests for the prover backends.
+ *
+ * Local binary tests mock child_process.spawn with EventEmitter-based stubs.
+ * Remote tests mock globalThis.fetch.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  prove,
+  ProverError,
+  type ProverInput,
+  type LocalBinaryProverConfig,
+  type RemoteProverConfig,
+} from '../prover';
+import {
+  RISC0_SEAL_BORSH_LEN,
+  RISC0_JOURNAL_LEN,
+  RISC0_IMAGE_ID_LEN,
+} from '../constants';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function validInput(): ProverInput {
+  return {
+    taskPda: new Uint8Array(32).fill(1),
+    agentAuthority: new Uint8Array(32).fill(2),
+    constraintHash: new Uint8Array(32).fill(3),
+    outputCommitment: new Uint8Array(32).fill(4),
+    binding: new Uint8Array(32).fill(5),
+    nullifier: new Uint8Array(32).fill(6),
+  };
+}
+
+function validOutputPayload() {
+  return {
+    seal_bytes: Array.from({ length: RISC0_SEAL_BORSH_LEN }, (_, i) => i & 0xff),
+    journal: Array.from({ length: RISC0_JOURNAL_LEN }, (_, i) => (i * 3) & 0xff),
+    image_id: Array.from({ length: RISC0_IMAGE_ID_LEN }, (_, i) => (i * 7) & 0xff),
+  };
+}
+
+function validOutputJson(): string {
+  return JSON.stringify(validOutputPayload());
+}
+
+// ---------------------------------------------------------------------------
+// Input validation (tested via remote backend to avoid child_process mocking)
+// ---------------------------------------------------------------------------
+
+describe('prove — input validation', () => {
+  const remoteConfig: RemoteProverConfig = {
+    kind: 'remote',
+    endpoint: 'https://prover.example.com',
+  };
+
+  it('rejects taskPda that is not 32 bytes', async () => {
+    const input = validInput();
+    input.taskPda = new Uint8Array(16);
+    await expect(prove(input, remoteConfig)).rejects.toThrow('taskPda must be exactly 32 bytes');
+  });
+
+  it('rejects agentAuthority that is not 32 bytes', async () => {
+    const input = validInput();
+    input.agentAuthority = new Uint8Array(0);
+    await expect(prove(input, remoteConfig)).rejects.toThrow('agentAuthority must be exactly 32 bytes');
+  });
+
+  it('rejects constraintHash that is not 32 bytes', async () => {
+    const input = validInput();
+    input.constraintHash = new Uint8Array(64);
+    await expect(prove(input, remoteConfig)).rejects.toThrow('constraintHash must be exactly 32 bytes');
+  });
+
+  it('rejects outputCommitment that is not 32 bytes', async () => {
+    const input = validInput();
+    input.outputCommitment = new Uint8Array(31);
+    await expect(prove(input, remoteConfig)).rejects.toThrow('outputCommitment must be exactly 32 bytes');
+  });
+
+  it('rejects binding that is not 32 bytes', async () => {
+    const input = validInput();
+    input.binding = new Uint8Array(33);
+    await expect(prove(input, remoteConfig)).rejects.toThrow('binding must be exactly 32 bytes');
+  });
+
+  it('rejects nullifier that is not 32 bytes', async () => {
+    const input = validInput();
+    input.nullifier = new Uint8Array(1);
+    await expect(prove(input, remoteConfig)).rejects.toThrow('nullifier must be exactly 32 bytes');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Remote backend (uses fetch mock — reliable and straightforward)
+// ---------------------------------------------------------------------------
+
+describe('prove — remote backend', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns valid buffers on HTTP 200', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validOutputPayload()),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = {
+      kind: 'remote',
+      endpoint: 'https://prover.example.com',
+    };
+
+    const result = await prove(validInput(), config);
+    expect(result.sealBytes.length).toBe(RISC0_SEAL_BORSH_LEN);
+    expect(result.journal.length).toBe(RISC0_JOURNAL_LEN);
+    expect(result.imageId.length).toBe(RISC0_IMAGE_ID_LEN);
+    expect(Buffer.isBuffer(result.sealBytes)).toBe(true);
+    expect(Buffer.isBuffer(result.journal)).toBe(true);
+    expect(Buffer.isBuffer(result.imageId)).toBe(true);
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0]).toBe('https://prover.example.com/prove');
+    expect(calls[0][1].method).toBe('POST');
+  });
+
+  it('appends /prove to endpoint without trailing slash', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validOutputPayload()),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = {
+      kind: 'remote',
+      endpoint: 'https://prover.example.com/api',
+    };
+
+    await prove(validInput(), config);
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0]).toBe('https://prover.example.com/api/prove');
+  });
+
+  it('does not double-append /prove if already present', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validOutputPayload()),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = {
+      kind: 'remote',
+      endpoint: 'https://prover.example.com/prove',
+    };
+
+    await prove(validInput(), config);
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0]).toBe('https://prover.example.com/prove');
+  });
+
+  it('strips trailing slashes from endpoint', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validOutputPayload()),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = {
+      kind: 'remote',
+      endpoint: 'https://prover.example.com/api/',
+    };
+
+    await prove(validInput(), config);
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0]).toBe('https://prover.example.com/api/prove');
+  });
+
+  it('wraps HTTP error in ProverError', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('Internal Server Error'),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = {
+      kind: 'remote',
+      endpoint: 'https://prover.example.com',
+    };
+
+    await expect(prove(validInput(), config)).rejects.toThrow(ProverError);
+    try {
+      await prove(validInput(), config);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProverError);
+      expect((err as ProverError).backend).toBe('remote');
+      expect((err as ProverError).message).toContain('HTTP 500');
+    }
+  });
+
+  it('wraps network failure in ProverError', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(
+      new TypeError('Failed to fetch'),
+    ) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = {
+      kind: 'remote',
+      endpoint: 'https://prover.example.com',
+    };
+
+    await expect(prove(validInput(), config)).rejects.toThrow(ProverError);
+    try {
+      await prove(validInput(), config);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProverError);
+      expect((err as ProverError).message).toContain('request failed');
+    }
+  });
+
+  it('passes custom headers', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validOutputPayload()),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = {
+      kind: 'remote',
+      endpoint: 'https://prover.example.com',
+      headers: { Authorization: 'Bearer token123' },
+    };
+
+    await prove(validInput(), config);
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][1].headers).toMatchObject({
+      Authorization: 'Bearer token123',
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('sends correct JSON body with all 6 fields', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(validOutputPayload()),
+    }) as unknown as typeof fetch;
+
+    const input = validInput();
+    await prove(input, { kind: 'remote', endpoint: 'https://test.com' });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    const body = JSON.parse(calls[0][1].body);
+    expect(body.task_pda).toHaveLength(32);
+    expect(body.agent_authority).toHaveLength(32);
+    expect(body.constraint_hash).toHaveLength(32);
+    expect(body.output_commitment).toHaveLength(32);
+    expect(body.binding).toHaveLength(32);
+    expect(body.nullifier).toHaveLength(32);
+    // Verify values match input
+    expect(body.task_pda).toEqual(Array.from(input.taskPda));
+    expect(body.nullifier).toEqual(Array.from(input.nullifier));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output validation (tested via remote backend)
+// ---------------------------------------------------------------------------
+
+describe('prove — output validation', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('rejects seal_bytes with wrong length', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        seal_bytes: [1, 2, 3],
+        journal: Array.from({ length: RISC0_JOURNAL_LEN }, () => 0),
+        image_id: Array.from({ length: RISC0_IMAGE_ID_LEN }, () => 0),
+      }),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = { kind: 'remote', endpoint: 'https://test.com' };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      `seal_bytes must be ${RISC0_SEAL_BORSH_LEN} bytes`,
+    );
+  });
+
+  it('rejects journal with wrong length', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        seal_bytes: Array.from({ length: RISC0_SEAL_BORSH_LEN }, () => 0),
+        journal: [1, 2],
+        image_id: Array.from({ length: RISC0_IMAGE_ID_LEN }, () => 0),
+      }),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = { kind: 'remote', endpoint: 'https://test.com' };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      `journal must be ${RISC0_JOURNAL_LEN} bytes`,
+    );
+  });
+
+  it('rejects image_id with wrong length', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        seal_bytes: Array.from({ length: RISC0_SEAL_BORSH_LEN }, () => 0),
+        journal: Array.from({ length: RISC0_JOURNAL_LEN }, () => 0),
+        image_id: [1],
+      }),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = { kind: 'remote', endpoint: 'https://test.com' };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      `image_id must be ${RISC0_IMAGE_ID_LEN} bytes`,
+    );
+  });
+
+  it('rejects missing seal_bytes array', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        journal: Array.from({ length: RISC0_JOURNAL_LEN }, () => 0),
+        image_id: Array.from({ length: RISC0_IMAGE_ID_LEN }, () => 0),
+      }),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = { kind: 'remote', endpoint: 'https://test.com' };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      'prover output missing seal_bytes array',
+    );
+  });
+
+  it('rejects missing journal array', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        seal_bytes: Array.from({ length: RISC0_SEAL_BORSH_LEN }, () => 0),
+        image_id: Array.from({ length: RISC0_IMAGE_ID_LEN }, () => 0),
+      }),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = { kind: 'remote', endpoint: 'https://test.com' };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      'prover output missing journal array',
+    );
+  });
+
+  it('rejects missing image_id array', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        seal_bytes: Array.from({ length: RISC0_SEAL_BORSH_LEN }, () => 0),
+        journal: Array.from({ length: RISC0_JOURNAL_LEN }, () => 0),
+      }),
+    }) as unknown as typeof fetch;
+
+    const config: RemoteProverConfig = { kind: 'remote', endpoint: 'https://test.com' };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      'prover output missing image_id array',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local binary backend
+// ---------------------------------------------------------------------------
+
+describe('prove — local-binary backend', () => {
+  // We test local-binary by mocking child_process.spawn at the module level
+  let spawnMock: ReturnType<typeof vi.fn>;
+
+  function mockSpawnWith(stdout: string, stderr: string, exitCode: number) {
+    const { EventEmitter } = require('node:events');
+
+    const child = new EventEmitter();
+    const stdoutEmitter = new EventEmitter();
+    const stderrEmitter = new EventEmitter();
+    child.stdout = stdoutEmitter;
+    child.stderr = stderrEmitter;
+    child.stdin = {
+      write: vi.fn(),
+      end: vi.fn(),
+    };
+
+    // Schedule data + close events after listeners have been attached
+    setImmediate(() => {
+      if (stdout) stdoutEmitter.emit('data', Buffer.from(stdout));
+      if (stderr) stderrEmitter.emit('data', Buffer.from(stderr));
+      setImmediate(() => child.emit('close', exitCode));
+    });
+
+    spawnMock.mockReturnValue(child);
+    return child;
+  }
+
+  function mockSpawnError(errorMessage: string) {
+    const { EventEmitter } = require('node:events');
+
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.stdin = {
+      write: vi.fn(),
+      end: vi.fn(),
+    };
+
+    setImmediate(() => {
+      const err = new Error(errorMessage) as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      child.emit('error', err);
+    });
+
+    spawnMock.mockReturnValue(child);
+    return child;
+  }
+
+  beforeEach(() => {
+    spawnMock = vi.fn();
+    vi.doMock('node:child_process', () => ({
+      spawn: spawnMock,
+    }));
+  });
+
+  afterEach(() => {
+    vi.doUnmock('node:child_process');
+    vi.restoreAllMocks();
+  });
+
+  it('returns valid buffers on successful spawn', async () => {
+    mockSpawnWith(validOutputJson(), '', 0);
+
+    const { prove: proveMocked } = await import('../prover');
+    const config: LocalBinaryProverConfig = {
+      kind: 'local-binary',
+      binaryPath: '/test/bin',
+    };
+
+    const result = await proveMocked(validInput(), config);
+    expect(result.sealBytes.length).toBe(RISC0_SEAL_BORSH_LEN);
+    expect(result.journal.length).toBe(RISC0_JOURNAL_LEN);
+    expect(result.imageId.length).toBe(RISC0_IMAGE_ID_LEN);
+    expect(Buffer.isBuffer(result.sealBytes)).toBe(true);
+  });
+
+  it('passes correct args to spawn', async () => {
+    mockSpawnWith(validOutputJson(), '', 0);
+
+    const { prove: proveMocked } = await import('../prover');
+    await proveMocked(validInput(), {
+      kind: 'local-binary',
+      binaryPath: '/usr/local/bin/agenc-zkvm-host',
+    });
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      '/usr/local/bin/agenc-zkvm-host',
+      ['prove', '--stdin'],
+      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
+    );
+  });
+
+  it('writes JSON to stdin', async () => {
+    const child = mockSpawnWith(validOutputJson(), '', 0);
+
+    const { prove: proveMocked } = await import('../prover');
+    await proveMocked(validInput(), {
+      kind: 'local-binary',
+      binaryPath: '/test/bin',
+    });
+
+    expect(child.stdin.write).toHaveBeenCalled();
+    const writtenJson = JSON.parse(child.stdin.write.mock.calls[0][0]);
+    expect(writtenJson.task_pda).toHaveLength(32);
+    expect(writtenJson.nullifier).toHaveLength(32);
+    expect(child.stdin.end).toHaveBeenCalled();
+  });
+
+  it('wraps non-zero exit code in ProverError', async () => {
+    mockSpawnWith('', 'something went wrong', 1);
+
+    const { prove: proveMocked } = await import('../prover');
+    const config: LocalBinaryProverConfig = {
+      kind: 'local-binary',
+      binaryPath: '/test/bin',
+    };
+
+    try {
+      await proveMocked(validInput(), config);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProverError);
+      expect((err as ProverError).backend).toBe('local-binary');
+      expect((err as ProverError).message).toContain('exited with code 1');
+      expect((err as ProverError).message).toContain('something went wrong');
+    }
+  });
+
+  it('wraps spawn ENOENT in ProverError', async () => {
+    mockSpawnError('spawn ENOENT');
+
+    const { prove: proveMocked } = await import('../prover');
+    const config: LocalBinaryProverConfig = {
+      kind: 'local-binary',
+      binaryPath: '/nonexistent/bin',
+    };
+
+    try {
+      await proveMocked(validInput(), config);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProverError);
+      expect((err as ProverError).backend).toBe('local-binary');
+      expect((err as ProverError).message).toContain('failed to spawn');
+    }
+  });
+
+  it('wraps invalid JSON output in ProverError', async () => {
+    mockSpawnWith('not valid json!', '', 0);
+
+    const { prove: proveMocked } = await import('../prover');
+    const config: LocalBinaryProverConfig = {
+      kind: 'local-binary',
+      binaryPath: '/test/bin',
+    };
+
+    try {
+      await proveMocked(validInput(), config);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProverError);
+      expect((err as ProverError).message).toContain('failed to parse prover output');
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ProverError
+// ---------------------------------------------------------------------------
+
+describe('ProverError', () => {
+  it('has correct name property', () => {
+    const err = new ProverError('test', 'local-binary');
+    expect(err.name).toBe('ProverError');
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it('preserves backend type', () => {
+    const local = new ProverError('msg', 'local-binary');
+    expect(local.backend).toBe('local-binary');
+
+    const remote = new ProverError('msg', 'remote');
+    expect(remote.backend).toBe('remote');
+  });
+
+  it('preserves cause', () => {
+    const originalError = new Error('original');
+    const err = new ProverError('wrapped', 'remote', originalError);
+    expect(err.cause).toBe(originalError);
+  });
+
+  it('message is accessible', () => {
+    const err = new ProverError('test message', 'local-binary');
+    expect(err.message).toBe('test message');
+  });
+});

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -9,6 +9,7 @@
 
 export {
   generateProof,
+  generateProofWithProver,
   verifyProofLocally,
   computeHashes,
   generateSalt,
@@ -22,6 +23,14 @@ export {
   ProofResult,
   HashResult,
 } from './proofs';
+
+export {
+  type ProverConfig,
+  type LocalBinaryProverConfig,
+  type RemoteProverConfig,
+  type ProverInput,
+  ProverError,
+} from './prover';
 
 export {
   createTask,

--- a/sdk/src/prover.ts
+++ b/sdk/src/prover.ts
@@ -1,0 +1,288 @@
+/**
+ * Real RISC Zero prover backends for AgenC SDK.
+ *
+ * Two backends are supported:
+ * - `local-binary`: spawns the agenc-zkvm-host binary as a subprocess
+ * - `remote`: HTTP POST to a prover endpoint
+ *
+ * The `prove()` function is an internal implementation detail — only types
+ * and `ProverError` are re-exported from the SDK barrel.
+ */
+
+import {
+  RISC0_SEAL_BORSH_LEN,
+  RISC0_JOURNAL_LEN,
+  RISC0_IMAGE_ID_LEN,
+  HASH_SIZE,
+} from './constants.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LocalBinaryProverConfig {
+  kind: 'local-binary';
+  /** Absolute path to the agenc-zkvm-host binary. */
+  binaryPath: string;
+  /** Timeout in milliseconds (default 300 000 = 5 min). */
+  timeoutMs?: number;
+}
+
+export interface RemoteProverConfig {
+  kind: 'remote';
+  /** HTTP(S) URL of the prover service. */
+  endpoint: string;
+  /** Timeout in milliseconds (default 300 000 = 5 min). */
+  timeoutMs?: number;
+  /** Optional headers (e.g. auth tokens). */
+  headers?: Record<string, string>;
+}
+
+export type ProverConfig = LocalBinaryProverConfig | RemoteProverConfig;
+
+export interface ProverInput {
+  taskPda: Uint8Array;
+  agentAuthority: Uint8Array;
+  constraintHash: Uint8Array;
+  outputCommitment: Uint8Array;
+  binding: Uint8Array;
+  nullifier: Uint8Array;
+}
+
+export class ProverError extends Error {
+  override name = 'ProverError' as const;
+  constructor(
+    message: string,
+    public readonly backend: 'local-binary' | 'remote',
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 300_000;
+const FIELD_BYTE_LEN = HASH_SIZE; // 32
+
+// ---------------------------------------------------------------------------
+// Input / output helpers
+// ---------------------------------------------------------------------------
+
+function validateInputField(name: string, field: Uint8Array): void {
+  if (field.length !== FIELD_BYTE_LEN) {
+    throw new Error(`${name} must be exactly ${FIELD_BYTE_LEN} bytes, got ${field.length}`);
+  }
+}
+
+function validateProverInput(input: ProverInput): void {
+  validateInputField('taskPda', input.taskPda);
+  validateInputField('agentAuthority', input.agentAuthority);
+  validateInputField('constraintHash', input.constraintHash);
+  validateInputField('outputCommitment', input.outputCommitment);
+  validateInputField('binding', input.binding);
+  validateInputField('nullifier', input.nullifier);
+}
+
+interface RawProverOutput {
+  seal_bytes?: unknown;
+  journal?: unknown;
+  image_id?: unknown;
+}
+
+function validateProverOutput(
+  raw: RawProverOutput,
+  backend: 'local-binary' | 'remote',
+): { sealBytes: Buffer; journal: Buffer; imageId: Buffer } {
+  if (!Array.isArray(raw.seal_bytes)) {
+    throw new ProverError('prover output missing seal_bytes array', backend);
+  }
+  if (!Array.isArray(raw.journal)) {
+    throw new ProverError('prover output missing journal array', backend);
+  }
+  if (!Array.isArray(raw.image_id)) {
+    throw new ProverError('prover output missing image_id array', backend);
+  }
+
+  const sealBytes = Buffer.from(raw.seal_bytes as number[]);
+  const journal = Buffer.from(raw.journal as number[]);
+  const imageId = Buffer.from(raw.image_id as number[]);
+
+  if (sealBytes.length !== RISC0_SEAL_BORSH_LEN) {
+    throw new ProverError(
+      `seal_bytes must be ${RISC0_SEAL_BORSH_LEN} bytes, got ${sealBytes.length}`,
+      backend,
+    );
+  }
+  if (journal.length !== RISC0_JOURNAL_LEN) {
+    throw new ProverError(
+      `journal must be ${RISC0_JOURNAL_LEN} bytes, got ${journal.length}`,
+      backend,
+    );
+  }
+  if (imageId.length !== RISC0_IMAGE_ID_LEN) {
+    throw new ProverError(
+      `image_id must be ${RISC0_IMAGE_ID_LEN} bytes, got ${imageId.length}`,
+      backend,
+    );
+  }
+
+  return { sealBytes, journal, imageId };
+}
+
+function buildInputJson(input: ProverInput): string {
+  return JSON.stringify({
+    task_pda: Array.from(input.taskPda),
+    agent_authority: Array.from(input.agentAuthority),
+    constraint_hash: Array.from(input.constraintHash),
+    output_commitment: Array.from(input.outputCommitment),
+    binding: Array.from(input.binding),
+    nullifier: Array.from(input.nullifier),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Local binary backend
+// ---------------------------------------------------------------------------
+
+async function proveLocal(
+  input: ProverInput,
+  config: LocalBinaryProverConfig,
+): Promise<{ sealBytes: Buffer; journal: Buffer; imageId: Buffer }> {
+  const { spawn } = await import('node:child_process');
+
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const inputJson = buildInputJson(input);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(config.binaryPath, ['prove', '--stdin'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      timeout: timeoutMs,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (err: Error) => {
+      reject(new ProverError(
+        `failed to spawn prover binary: ${err.message}`,
+        'local-binary',
+        err,
+      ));
+    });
+
+    child.on('close', (code: number | null) => {
+      if (code !== 0) {
+        reject(new ProverError(
+          `prover exited with code ${code}: ${stderr.trim() || '(no stderr)'}`,
+          'local-binary',
+        ));
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(stdout) as RawProverOutput;
+        resolve(validateProverOutput(parsed, 'local-binary'));
+      } catch (err) {
+        if (err instanceof ProverError) {
+          reject(err);
+        } else {
+          reject(new ProverError(
+            `failed to parse prover output: ${(err as Error).message}`,
+            'local-binary',
+            err,
+          ));
+        }
+      }
+    });
+
+    child.stdin.write(inputJson);
+    child.stdin.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Remote backend
+// ---------------------------------------------------------------------------
+
+async function proveRemote(
+  input: ProverInput,
+  config: RemoteProverConfig,
+): Promise<{ sealBytes: Buffer; journal: Buffer; imageId: Buffer }> {
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  const url = config.endpoint.endsWith('/prove')
+    ? config.endpoint
+    : `${config.endpoint.replace(/\/+$/, '')}/prove`;
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...config.headers,
+      },
+      body: buildInputJson(input),
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => '(unreadable body)');
+      throw new ProverError(
+        `prover returned HTTP ${response.status}: ${body}`,
+        'remote',
+      );
+    }
+
+    const parsed = (await response.json()) as RawProverOutput;
+    return validateProverOutput(parsed, 'remote');
+  } catch (err) {
+    if (err instanceof ProverError) throw err;
+    if ((err as Error).name === 'AbortError') {
+      throw new ProverError(
+        `prover request timed out after ${timeoutMs}ms`,
+        'remote',
+        err,
+      );
+    }
+    throw new ProverError(
+      `prover request failed: ${(err as Error).message}`,
+      'remote',
+      err,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export async function prove(
+  input: ProverInput,
+  config: ProverConfig,
+): Promise<{ sealBytes: Buffer; journal: Buffer; imageId: Buffer }> {
+  validateProverInput(input);
+
+  switch (config.kind) {
+    case 'local-binary':
+      return proveLocal(input, config);
+    case 'remote':
+      return proveRemote(input, config);
+    default:
+      throw new Error(`unknown prover backend: ${(config as { kind: string }).kind}`);
+  }
+}

--- a/zkvm/Cargo.lock
+++ b/zkvm/Cargo.lock
@@ -56,6 +56,8 @@ dependencies = [
  "agenc-zkvm-methods",
  "borsh 0.10.4",
  "risc0-zkvm",
+ "serde",
+ "serde_json",
  "verifier_router",
 ]
 

--- a/zkvm/host/Cargo.toml
+++ b/zkvm/host/Cargo.toml
@@ -26,4 +26,6 @@ agenc-zkvm-guest = { path = "../guest" }
 agenc-zkvm-methods = { path = "../methods", optional = true }
 borsh = "0.10.4"
 risc0-zkvm = { version = "~3.0", optional = true, default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 verifier_router = { git = "https://github.com/boundless-xyz/risc0-solana", tag = "v3.0.0", package = "verifier_router", default-features = false, features = ["client", "cpi"] }


### PR DESCRIPTION
## Summary

- Add `generateProofWithProver()` to SDK with two prover backends: `local-binary` (subprocess spawning `agenc-zkvm-host prove --stdin`) and `remote` (HTTP POST)
- Add `--stdin` JSON input mode to the zkvm host binary for programmatic use
- Replace hand-rolled JSON serialization in zkvm host with `serde_json`
- Existing `generateProof()` simulated path is fully unchanged (backward compatible)

## Test plan

- [x] All 12 Rust zkvm host tests pass (`cargo test`)
- [x] Stdin JSON mode produces identical output to default mode
- [x] Default `prove` mode unchanged (no `--stdin` = uses test defaults)
- [x] All 248 SDK tests pass (17 test files, including 35 new tests)
- [x] SDK typecheck clean (`tsc --noEmit`)
- [x] SDK build clean (`tsup` ESM + CJS + DTS)