### PR TITLE
feat(runtime,zkvm,sdk): wire ProofEngine to real RISC Zero prover backends

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -32,6 +32,9 @@ const TRUSTED_RISC0_ROUTER_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7");
 const TRUSTED_RISC0_VERIFIER_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge");
+// TODO(CRIT-3): Arithmetic placeholder — not a real SHA-256 digest of the guest ELF.
+// To compute the real value: build with `production-prover`, extract AGENC_GUEST_ID,
+// convert via guest_id_to_image_id(). Must match sdk/src/constants.ts exactly.
 const TRUSTED_RISC0_IMAGE_ID: [u8; RISC0_IMAGE_ID_LEN] = [
     6, 15, 16, 25, 34, 43, 44, 53, 62, 71, 72, 81, 90, 99, 100, 109, 118, 127, 128, 137, 146, 155,
     156, 165, 174, 183, 184, 193, 202, 211, 212, 221,

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -917,6 +917,9 @@ export {
   // Core types
   type ProofEngineConfig,
   type ProofCacheConfig,
+  type ProverBackend,
+  type ProverBackendConfig,
+  type RouterConfig,
   type ProofInputs,
   type EngineProofResult,
   type ProofEngineStats,
@@ -931,6 +934,7 @@ export {
   deriveCacheKey,
   // Engine
   ProofEngine,
+  buildSdkProverConfig,
 } from './proof/index.js';
 
 // Memory Backends (Phase 6)

--- a/runtime/src/proof/index.ts
+++ b/runtime/src/proof/index.ts
@@ -32,4 +32,4 @@ export {
 export { ProofCache, deriveCacheKey } from './cache.js';
 
 // Engine
-export { ProofEngine } from './engine.js';
+export { ProofEngine, buildSdkProverConfig } from './engine.js';

--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -11,7 +11,7 @@ import type { MetricsProvider } from '../task/types.js';
 // Re-export HashResult from SDK for convenience
 export type { HashResult } from '@agenc/sdk';
 
-export type ProverBackend = 'deterministic-local' | 'remote';
+export type ProverBackend = 'deterministic-local' | 'local-binary' | 'remote';
 
 export interface RouterConfig {
   /** Trusted verifier-router program id */
@@ -27,10 +27,14 @@ export interface RouterConfig {
 export interface ProverBackendConfig {
   /** Prover backend kind */
   kind?: ProverBackend;
-  /** Optional prover endpoint for remote backends */
+  /** Absolute path to the agenc-zkvm-host binary (required when kind is 'local-binary') */
+  binaryPath?: string;
+  /** Prover endpoint URL (required when kind is 'remote') */
   endpoint?: string;
-  /** Optional prover timeout */
+  /** Prover timeout in milliseconds */
   timeoutMs?: number;
+  /** Optional headers for remote prover (e.g. auth tokens) */
+  headers?: Record<string, string>;
 }
 
 export interface ToolsStatus {

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -71,7 +71,20 @@ export const RISC0_IMAGE_ID_LEN = 32;
 /** Trusted RISC0 selector for router verification */
 export const TRUSTED_RISC0_SELECTOR = Uint8Array.from([0x52, 0x5a, 0x56, 0x4d]);
 
-/** Trusted RISC0 image ID pinned by protocol policy */
+/**
+ * Trusted RISC0 image ID pinned by protocol policy.
+ *
+ * TODO(CRIT-3): This is an arithmetic placeholder, not a real SHA-256 digest of
+ * the guest ELF. To compute the real image ID:
+ *   1. Install rzup (RISC Zero toolchain manager)
+ *   2. Build zkvm workspace with `production-prover` feature:
+ *      cargo build -p agenc-zkvm-host --features production-prover
+ *   3. Extract AGENC_GUEST_ID from agenc-zkvm-methods crate
+ *   4. Convert via guest_id_to_image_id() (LE u32x8 → [u8; 32])
+ *   5. Update this constant AND the on-chain TRUSTED_RISC0_IMAGE_ID in
+ *      programs/agenc-coordination/src/instructions/complete_task_private.rs
+ *   Both values MUST match exactly or complete_task_private will reject all proofs.
+ */
 export const TRUSTED_RISC0_IMAGE_ID = Uint8Array.from([
   6, 15, 16, 25, 34, 43, 44, 53, 62, 71, 72, 81, 90, 99, 100, 109, 118, 127, 128, 137, 146, 155,
   156, 165, 174, 183, 184, 193, 202, 211, 212, 221,

--- a/zkvm/host/src/config.rs
+++ b/zkvm/host/src/config.rs
@@ -23,13 +23,30 @@ pub enum ConfigError {
     ClusterNotAllowlisted,
 }
 
-pub const TRUSTED_DEPLOYMENTS: [TrustedDeployment; 1] = [TrustedDeployment {
-    cluster: DEFAULT_CLUSTER,
-    router_program_id: TRUSTED_ROUTER_PROGRAM_ID,
-    verifier_program_id: TRUSTED_VERIFIER_PROGRAM_ID,
-    provenance: DEPLOYMENT_PROVENANCE,
-    provenance_path: DEPLOYMENT_PROVENANCE_PATH,
-}];
+// Program IDs are the same across clusters (deployed from boundless-xyz/risc0-solana tag v3.0.0)
+pub const TRUSTED_DEPLOYMENTS: [TrustedDeployment; 3] = [
+    TrustedDeployment {
+        cluster: DEFAULT_CLUSTER,
+        router_program_id: TRUSTED_ROUTER_PROGRAM_ID,
+        verifier_program_id: TRUSTED_VERIFIER_PROGRAM_ID,
+        provenance: DEPLOYMENT_PROVENANCE,
+        provenance_path: DEPLOYMENT_PROVENANCE_PATH,
+    },
+    TrustedDeployment {
+        cluster: "devnet",
+        router_program_id: TRUSTED_ROUTER_PROGRAM_ID,
+        verifier_program_id: TRUSTED_VERIFIER_PROGRAM_ID,
+        provenance: DEPLOYMENT_PROVENANCE,
+        provenance_path: DEPLOYMENT_PROVENANCE_PATH,
+    },
+    TrustedDeployment {
+        cluster: "mainnet-beta",
+        router_program_id: TRUSTED_ROUTER_PROGRAM_ID,
+        verifier_program_id: TRUSTED_VERIFIER_PROGRAM_ID,
+        provenance: DEPLOYMENT_PROVENANCE,
+        provenance_path: DEPLOYMENT_PROVENANCE_PATH,
+    },
+];
 
 pub fn require_allowlisted_deployment(cluster: &str) -> Result<&'static TrustedDeployment, ConfigError> {
     TRUSTED_DEPLOYMENTS

--- a/zkvm/host/src/lib.rs
+++ b/zkvm/host/src/lib.rs
@@ -456,16 +456,34 @@ mod tests {
     }
 
     #[test]
-    fn deployment_allowlist_rejects_unknown_cluster() {
-        let err = ensure_allowlisted_deployment("devnet")
+    fn deployment_allowlist_rejects_non_allowlisted_cluster() {
+        let err = ensure_allowlisted_deployment("testnet")
             .expect_err("non-allowlisted cluster must be rejected");
 
         assert_eq!(
             err,
             ProveError::ClusterNotAllowlisted {
-                cluster: "devnet".to_string(),
+                cluster: "testnet".to_string(),
             }
         );
+    }
+
+    #[test]
+    fn deployment_allowlist_accepts_devnet() {
+        let deployment = config::require_allowlisted_deployment("devnet")
+            .expect("devnet must be allowlisted");
+
+        assert_eq!(deployment.router_program_id, config::TRUSTED_ROUTER_PROGRAM_ID);
+        assert_eq!(deployment.verifier_program_id, config::TRUSTED_VERIFIER_PROGRAM_ID);
+    }
+
+    #[test]
+    fn deployment_allowlist_accepts_mainnet_beta() {
+        let deployment = config::require_allowlisted_deployment("mainnet-beta")
+            .expect("mainnet-beta must be allowlisted");
+
+        assert_eq!(deployment.router_program_id, config::TRUSTED_ROUTER_PROGRAM_ID);
+        assert_eq!(deployment.verifier_program_id, config::TRUSTED_VERIFIER_PROGRAM_ID);
     }
 
     // -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **runtime/proof**: Added `local-binary` to `ProverBackend` union and wired `generate()` to call `generateProofWithProver()` for real backends; `buildSdkProverConfig()` translates runtime config to SDK prover config; local verification is skipped for real backends with a warning
- **runtime/proof tests**: Expanded from 37 to 55 tests covering `buildSdkProverConfig` mapping, `local-binary`/`remote` dispatch, verification-skip behaviour, and `checkTools` pass-through
- **zkvm/host**: Expanded `TRUSTED_DEPLOYMENTS` from 1 to 3 entries (localnet + devnet + mainnet-beta); updated deployment tests accordingly
- **sdk/constants**: Documented `TRUSTED_RISC0_IMAGE_ID` as a placeholder with `TODO(CRIT-3)` — must be replaced with the audited production image ID before mainnet launch
- **program**: Added matching `TODO(CRIT-3)` comment on the on-chain `TRUSTED_RISC0_IMAGE_ID` constant in `complete_task_private.rs`

## Test plan

- [ ] `cd runtime && npm run test` — all ~1800+ vitest tests pass, including the 18 new proof engine tests
- [ ] `cargo test --manifest-path zkvm/host/Cargo.toml` — deployment allowlist tests pass for all three trusted deployments
- [ ] `npm run typecheck` — no TypeScript errors across sdk, runtime, mcp
- [ ] `npm run build` — clean build of all packages