### PR TITLE
feat(skills): add PumpTracks music token skill

### DIFF
--- a/runtime/src/skills/index.ts
+++ b/runtime/src/skills/index.ts
@@ -79,6 +79,29 @@ export {
   WELL_KNOWN_TOKENS,
 } from './jupiter/index.js';
 
+// PumpTracks skill
+export {
+  PumpTracksSkill,
+  PumpTracksClient,
+  PumpTracksApiError,
+  type PumpTracksClientConfig,
+  type PumpTracksSkillConfig,
+  type ListTracksParams,
+  type SearchTracksParams,
+  type MintTrackParams,
+  type Track,
+  type Artist,
+  type MintResult,
+  type PrepareResult,
+  PUMPTRACKS_API_BASE_URL,
+  DEFAULT_TIMEOUT_MS,
+  SUPPORTED_AUDIO_TYPES,
+  SUPPORTED_IMAGE_TYPES,
+  MAX_AUDIO_SIZE,
+  MAX_ARTWORK_SIZE,
+  MIN_MINT_SOL,
+} from './pumptracks/index.js';
+
 // Markdown SKILL.md parser
 export {
   type MarkdownSkill,

--- a/runtime/src/skills/pumptracks/constants.ts
+++ b/runtime/src/skills/pumptracks/constants.ts
@@ -1,0 +1,26 @@
+/**
+ * PumpTracks skill constants.
+ *
+ * @module
+ */
+
+/** Default PumpTracks API base URL */
+export const PUMPTRACKS_API_BASE_URL = 'https://pumptracks.fun/api/v1';
+
+/** Default request timeout (60s — minting involves file uploads + IPFS) */
+export const DEFAULT_TIMEOUT_MS = 60_000;
+
+/** Supported audio formats */
+export const SUPPORTED_AUDIO_TYPES = ['audio/mpeg', 'audio/wav', 'audio/ogg', 'audio/flac', 'audio/mp4'];
+
+/** Supported image formats */
+export const SUPPORTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+/** Max audio file size (50MB) */
+export const MAX_AUDIO_SIZE = 50 * 1024 * 1024;
+
+/** Max artwork file size (10MB) */
+export const MAX_ARTWORK_SIZE = 10 * 1024 * 1024;
+
+/** Minimum SOL required for minting (0.05 SOL initial buy + fees) */
+export const MIN_MINT_SOL = 0.07;

--- a/runtime/src/skills/pumptracks/index.ts
+++ b/runtime/src/skills/pumptracks/index.ts
@@ -1,0 +1,33 @@
+/**
+ * PumpTracks skill module for @agenc/runtime
+ *
+ * Launch, browse, and search music tokens on Solana via PumpTracks.
+ *
+ * @module
+ */
+
+export { PumpTracksSkill } from './pumptracks-skill.js';
+export { PumpTracksClient, PumpTracksApiError } from './pumptracks-client.js';
+export type { PumpTracksClientConfig } from './pumptracks-client.js';
+
+export type {
+  PumpTracksSkillConfig,
+  ListTracksParams,
+  SearchTracksParams,
+  MintTrackParams,
+  Track,
+  Artist,
+  MintResult,
+  PrepareResult,
+  ApiResponse,
+} from './types.js';
+
+export {
+  PUMPTRACKS_API_BASE_URL,
+  DEFAULT_TIMEOUT_MS,
+  SUPPORTED_AUDIO_TYPES,
+  SUPPORTED_IMAGE_TYPES,
+  MAX_AUDIO_SIZE,
+  MAX_ARTWORK_SIZE,
+  MIN_MINT_SOL,
+} from './constants.js';

--- a/runtime/src/skills/pumptracks/pumptracks-client.ts
+++ b/runtime/src/skills/pumptracks/pumptracks-client.ts
@@ -1,0 +1,254 @@
+/**
+ * Low-level HTTP client for PumpTracks API v1.
+ *
+ * Handles authentication, request serialization, and error handling
+ * for all PumpTracks endpoints (tracks, artists, minting).
+ *
+ * @module
+ */
+
+import type { Logger } from '../../utils/logger.js';
+import type {
+  ListTracksParams,
+  SearchTracksParams,
+  Track,
+  Artist,
+  PrepareResult,
+  MintResult,
+  ApiResponse,
+} from './types.js';
+import { PUMPTRACKS_API_BASE_URL } from './constants.js';
+
+/**
+ * Configuration for PumpTracksClient.
+ */
+export interface PumpTracksClientConfig {
+  /** PumpTracks API base URL */
+  apiBaseUrl: string;
+  /** API key for authentication */
+  apiKey: string;
+  /** Request timeout in milliseconds */
+  timeoutMs: number;
+  /** Logger */
+  logger: Logger;
+}
+
+/**
+ * Error thrown when a PumpTracks API request fails.
+ */
+export class PumpTracksApiError extends Error {
+  public readonly statusCode: number | undefined;
+  public readonly endpoint: string;
+
+  constructor(message: string, endpoint: string, statusCode?: number) {
+    super(message);
+    this.name = 'PumpTracksApiError';
+    this.endpoint = endpoint;
+    this.statusCode = statusCode;
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, PumpTracksApiError);
+    }
+  }
+}
+
+/**
+ * Low-level HTTP client for PumpTracks API v1.
+ *
+ * @example
+ * ```typescript
+ * const client = new PumpTracksClient({
+ *   apiBaseUrl: 'https://pumptracks.fun/api/v1',
+ *   apiKey: 'pt_live_xxxxx',
+ *   timeoutMs: 60000,
+ *   logger,
+ * });
+ *
+ * const tracks = await client.listTracks({ genre: 'Electronic', limit: 10 });
+ * ```
+ */
+export class PumpTracksClient {
+  private readonly apiBaseUrl: string;
+  private readonly apiKey: string;
+  private readonly timeoutMs: number;
+  private readonly logger: Logger;
+
+  constructor(config: PumpTracksClientConfig) {
+    this.apiBaseUrl = config.apiBaseUrl;
+    this.apiKey = config.apiKey;
+    this.timeoutMs = config.timeoutMs;
+    this.logger = config.logger;
+  }
+
+  /**
+   * List tracks with optional filters.
+   */
+  async listTracks(params?: ListTracksParams): Promise<Track[]> {
+    const url = new URL('/tracks', this.apiBaseUrl);
+    if (params?.limit) url.searchParams.set('limit', params.limit.toString());
+    if (params?.offset) url.searchParams.set('offset', params.offset.toString());
+    if (params?.genre) url.searchParams.set('genre', params.genre);
+    if (params?.artist) url.searchParams.set('artist', params.artist);
+    if (params?.sort) url.searchParams.set('sort', params.sort);
+    if (params?.order) url.searchParams.set('order', params.order);
+
+    const data = await this.get<{ tracks: Track[] }>(url.toString(), '/tracks');
+    return data.tracks;
+  }
+
+  /**
+   * Get a single track by mint address.
+   */
+  async getTrack(mint: string): Promise<Track> {
+    const url = `${this.apiBaseUrl}/tracks/${mint}`;
+    return this.get<Track>(url, `/tracks/${mint}`);
+  }
+
+  /**
+   * Search tracks by title, artist, or symbol.
+   */
+  async searchTracks(params: SearchTracksParams): Promise<Track[]> {
+    const url = new URL('/tracks/search', this.apiBaseUrl);
+    url.searchParams.set('q', params.q);
+    if (params.limit) url.searchParams.set('limit', params.limit.toString());
+
+    const data = await this.get<{ tracks: Track[] }>(url.toString(), '/tracks/search');
+    return data.tracks;
+  }
+
+  /**
+   * Get artist profile by wallet address.
+   */
+  async getArtist(wallet: string): Promise<Artist> {
+    const url = `${this.apiBaseUrl}/artists/${wallet}`;
+    return this.get<Artist>(url, `/artists/${wallet}`);
+  }
+
+  /**
+   * Prepare a mint: upload files, build unsigned transaction.
+   *
+   * @param formData - FormData with audio, artwork, title, artist, genre, wallet
+   * @returns Unsigned transactions + mint address + track info
+   */
+  async prepareMint(formData: FormData): Promise<PrepareResult> {
+    this.logger.debug('PumpTracks: preparing mint...');
+
+    const response = await this.fetchWithTimeout(`${this.apiBaseUrl}/tracks/mint`, {
+      method: 'POST',
+      headers: { 'X-API-Key': this.apiKey },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => 'unknown');
+      throw new PumpTracksApiError(
+        `Prepare mint failed (${response.status}): ${body}`,
+        '/tracks/mint',
+        response.status,
+      );
+    }
+
+    const result = await response.json() as ApiResponse<PrepareResult>;
+    if (!result.success || !result.data) {
+      throw new PumpTracksApiError(
+        result.error || 'Prepare mint returned no data',
+        '/tracks/mint',
+      );
+    }
+
+    return result.data;
+  }
+
+  /**
+   * Submit signed transactions to finalize the mint.
+   *
+   * @param transactions - Base64-encoded signed VersionedTransaction(s)
+   * @param mint - Token mint address
+   * @param trackInfo - Track info from prepare step
+   * @returns Confirmed tx IDs + play URL
+   */
+  async submitMint(
+    transactions: string[],
+    mint: string,
+    trackInfo: PrepareResult['trackInfo'],
+  ): Promise<MintResult> {
+    this.logger.debug('PumpTracks: submitting signed transactions...');
+
+    const response = await this.fetchWithTimeout(`${this.apiBaseUrl}/tracks/submit`, {
+      method: 'POST',
+      headers: {
+        'X-API-Key': this.apiKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ transactions, mint, trackInfo }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => 'unknown');
+      throw new PumpTracksApiError(
+        `Submit mint failed (${response.status}): ${body}`,
+        '/tracks/submit',
+        response.status,
+      );
+    }
+
+    const result = await response.json() as ApiResponse<MintResult>;
+    if (!result.success || !result.data) {
+      throw new PumpTracksApiError(
+        result.error || 'Submit mint returned no data',
+        '/tracks/submit',
+      );
+    }
+
+    return result.data;
+  }
+
+  // ─── Private helpers ──────────────────────────────────
+
+  private async get<T>(url: string, endpoint: string): Promise<T> {
+    const response = await this.fetchWithTimeout(url, {
+      method: 'GET',
+      headers: {
+        'X-API-Key': this.apiKey,
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => 'unknown');
+      throw new PumpTracksApiError(
+        `Request failed (${response.status}): ${body}`,
+        endpoint,
+        response.status,
+      );
+    }
+
+    const result = await response.json() as ApiResponse<T>;
+    if (!result.success || !result.data) {
+      throw new PumpTracksApiError(
+        result.error || 'Request returned no data',
+        endpoint,
+      );
+    }
+
+    return result.data;
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new PumpTracksApiError(
+          `Request timed out after ${this.timeoutMs}ms`,
+          url,
+        );
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/runtime/src/skills/pumptracks/pumptracks-skill.ts
+++ b/runtime/src/skills/pumptracks/pumptracks-skill.ts
@@ -1,0 +1,287 @@
+/**
+ * PumpTracks music token skill implementation.
+ *
+ * Provides track browsing, searching, artist lookup, and full
+ * music token minting via the PumpTracks API + Raydium LaunchLab.
+ *
+ * @module
+ */
+
+import { VersionedTransaction } from '@solana/web3.js';
+import type { Skill, SkillMetadata, SkillAction, SkillContext, SemanticVersion } from '../types.js';
+import { SkillState } from '../types.js';
+import { SkillNotReadyError } from '../errors.js';
+import { PumpTracksClient } from './pumptracks-client.js';
+import { PUMPTRACKS_API_BASE_URL, DEFAULT_TIMEOUT_MS } from './constants.js';
+import type {
+  PumpTracksSkillConfig,
+  ListTracksParams,
+  SearchTracksParams,
+  MintTrackParams,
+  Track,
+  Artist,
+  MintResult,
+} from './types.js';
+import type { Logger } from '../../utils/logger.js';
+import type { Wallet } from '../../types/wallet.js';
+import { Capability } from '../../agent/capabilities.js';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const VERSION: SemanticVersion = '0.1.0';
+
+/**
+ * PumpTracks skill for launching music tokens on Solana.
+ *
+ * Actions:
+ * - `getTracks`    — List tracks with optional filters (genre, artist, sort)
+ * - `getTrack`     — Get a single track by mint address
+ * - `searchTracks` — Search tracks by title, artist, or symbol
+ * - `getArtist`    — Get artist profile and their tracks
+ * - `mintTrack`    — Full end-to-end mint: upload files, sign transaction, submit
+ *
+ * @example
+ * ```typescript
+ * const pumptracks = new PumpTracksSkill({
+ *   apiKey: 'pt_live_xxxxxxxxxxxxx',
+ * });
+ * const registry = new SkillRegistry();
+ * registry.register(pumptracks);
+ * await registry.initializeAll({ connection, wallet, logger });
+ *
+ * // Browse tracks
+ * const tracks = await pumptracks.getTracks({ genre: 'Electronic', limit: 10 });
+ *
+ * // Mint a new music token
+ * const result = await pumptracks.mintTrack({
+ *   audio: './song.mp3',
+ *   artwork: './cover.jpg',
+ *   title: 'My Song',
+ *   artist: 'Artist Name',
+ *   genre: 'Electronic',
+ * });
+ * console.log(`Track live at: ${result.playUrl}`);
+ * ```
+ */
+export class PumpTracksSkill implements Skill {
+  readonly metadata: SkillMetadata = {
+    name: 'pumptracks',
+    description: 'PumpTracks music token launchpad — mint, browse, and search music tokens on Solana',
+    version: VERSION,
+    requiredCapabilities: Capability.COMPUTE | Capability.NETWORK,
+    tags: ['music', 'nft', 'token', 'mint', 'solana', 'pumptracks'],
+  };
+
+  private _state: SkillState = SkillState.Created;
+  private wallet: Wallet | null = null;
+  private logger: Logger | null = null;
+  private client: PumpTracksClient | null = null;
+
+  private readonly apiKey: string;
+  private readonly apiBaseUrl: string;
+  private readonly timeoutMs: number;
+
+  private readonly actions: ReadonlyArray<SkillAction>;
+
+  constructor(config: PumpTracksSkillConfig) {
+    this.apiKey = config.apiKey;
+    this.apiBaseUrl = config.apiBaseUrl ?? PUMPTRACKS_API_BASE_URL;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+    this.actions = [
+      {
+        name: 'getTracks',
+        description: 'List music tracks on PumpTracks with optional filters (genre, artist, sort)',
+        execute: (params: unknown) => this.getTracks(params as ListTracksParams),
+      },
+      {
+        name: 'getTrack',
+        description: 'Get a single track by its Solana mint address',
+        execute: (params: unknown) => {
+          const p = params as { mint: string };
+          return this.getTrack(p.mint);
+        },
+      },
+      {
+        name: 'searchTracks',
+        description: 'Search for tracks by title, artist name, or token symbol',
+        execute: (params: unknown) => this.searchTracks(params as SearchTracksParams),
+      },
+      {
+        name: 'getArtist',
+        description: 'Get an artist profile and their tracks by wallet address',
+        execute: (params: unknown) => {
+          const p = params as { wallet: string };
+          return this.getArtist(p.wallet);
+        },
+      },
+      {
+        name: 'mintTrack',
+        description: 'Mint a new music token on PumpTracks. Uploads audio + artwork, builds the Raydium LaunchLab transaction, signs it, and submits. The wallet used by this agent becomes the on-chain creator. Requires ~0.07 SOL.',
+        execute: (params: unknown) => this.mintTrack(params as MintTrackParams),
+      },
+    ];
+  }
+
+  get state(): SkillState {
+    return this._state;
+  }
+
+  async initialize(context: SkillContext): Promise<void> {
+    this._state = SkillState.Initializing;
+    try {
+      this.wallet = context.wallet;
+      this.logger = context.logger;
+      this.client = new PumpTracksClient({
+        apiBaseUrl: this.apiBaseUrl,
+        apiKey: this.apiKey,
+        timeoutMs: this.timeoutMs,
+        logger: context.logger,
+      });
+      this._state = SkillState.Ready;
+    } catch (err) {
+      this._state = SkillState.Error;
+      throw err;
+    }
+  }
+
+  async shutdown(): Promise<void> {
+    this._state = SkillState.ShuttingDown;
+    this.client = null;
+    this.wallet = null;
+    this.logger = null;
+    this._state = SkillState.Stopped;
+  }
+
+  getActions(): ReadonlyArray<SkillAction> {
+    return this.actions;
+  }
+
+  getAction(name: string): SkillAction | undefined {
+    return this.actions.find((a) => a.name === name);
+  }
+
+  // ============================================================================
+  // Typed action methods
+  // ============================================================================
+
+  /**
+   * List tracks with optional filters.
+   */
+  async getTracks(params?: ListTracksParams): Promise<Track[]> {
+    this.ensureReady();
+    return this.client!.listTracks(params);
+  }
+
+  /**
+   * Get a single track by mint address.
+   */
+  async getTrack(mint: string): Promise<Track> {
+    this.ensureReady();
+    return this.client!.getTrack(mint);
+  }
+
+  /**
+   * Search tracks by title, artist, or symbol.
+   */
+  async searchTracks(params: SearchTracksParams): Promise<Track[]> {
+    this.ensureReady();
+    return this.client!.searchTracks(params);
+  }
+
+  /**
+   * Get artist profile by wallet address.
+   */
+  async getArtist(wallet: string): Promise<Artist> {
+    this.ensureReady();
+    return this.client!.getArtist(wallet);
+  }
+
+  /**
+   * Full end-to-end mint flow:
+   * 1. Upload audio + artwork to PumpTracks (which handles Firebase + IPFS)
+   * 2. Receive unsigned Raydium LaunchLab transaction
+   * 3. Sign with the agent's wallet
+   * 4. Submit signed transaction back to PumpTracks
+   * 5. PumpTracks verifies on-chain and registers the track
+   *
+   * @returns Mint address, tx IDs, and play URL
+   */
+  async mintTrack(params: MintTrackParams): Promise<MintResult> {
+    this.ensureReady();
+
+    const walletAddress = this.wallet!.publicKey.toBase58();
+    this.logger!.info(`PumpTracks: minting "${params.title}" by ${params.artist}...`);
+
+    // ── Step 1: Build form data ──
+    const formData = new FormData();
+
+    // Handle audio — file path or Buffer
+    if (typeof params.audio === 'string') {
+      const audioBuffer = fs.readFileSync(params.audio);
+      const audioFilename = path.basename(params.audio);
+      formData.append('audio', new Blob([audioBuffer]), audioFilename);
+    } else {
+      formData.append('audio', new Blob([params.audio]), params.audioFilename || 'track.mp3');
+    }
+
+    // Handle artwork — file path or Buffer
+    if (typeof params.artwork === 'string') {
+      const artBuffer = fs.readFileSync(params.artwork);
+      const artFilename = path.basename(params.artwork);
+      formData.append('artwork', new Blob([artBuffer]), artFilename);
+    } else {
+      formData.append('artwork', new Blob([params.artwork]), params.artworkFilename || 'cover.jpg');
+    }
+
+    formData.append('title', params.title);
+    formData.append('artist', params.artist);
+    formData.append('genre', params.genre);
+    formData.append('wallet', walletAddress);
+    if (params.twitter) formData.append('twitter', params.twitter);
+    if (params.tiktok) formData.append('tiktok', params.tiktok);
+    if (params.instagram) formData.append('instagram', params.instagram);
+
+    // ── Step 2: Prepare mint (upload files + build unsigned tx) ──
+    this.logger!.info('PumpTracks: uploading files and preparing transaction...');
+    const prepared = await this.client!.prepareMint(formData);
+
+    this.logger!.info(`PumpTracks: mint address = ${prepared.mint}`);
+    this.logger!.info(`PumpTracks: ${prepared.transactions.length} transaction(s) to sign`);
+
+    // ── Step 3: Sign each transaction with agent wallet ──
+    this.logger!.info('PumpTracks: signing transactions...');
+    const signedTransactions: string[] = [];
+
+    for (let i = 0; i < prepared.transactions.length; i++) {
+      const txBytes = Buffer.from(prepared.transactions[i], 'base64');
+      const tx = VersionedTransaction.deserialize(txBytes);
+      const signedTx = await this.wallet!.signTransaction(tx);
+      signedTransactions.push(Buffer.from(signedTx.serialize()).toString('base64'));
+      this.logger!.debug(`PumpTracks: signed transaction ${i + 1}/${prepared.transactions.length}`);
+    }
+
+    // ── Step 4: Submit signed transactions ──
+    this.logger!.info('PumpTracks: submitting to Solana...');
+    const result = await this.client!.submitMint(
+      signedTransactions,
+      prepared.mint,
+      prepared.trackInfo,
+    );
+
+    this.logger!.info(`PumpTracks: track live at ${result.playUrl}`);
+    this.logger!.info(`PumpTracks: tx(s): ${result.txIds.join(', ')}`);
+
+    return result;
+  }
+
+  // ============================================================================
+  // Private helpers
+  // ============================================================================
+
+  private ensureReady(): void {
+    if (this._state !== SkillState.Ready) {
+      throw new SkillNotReadyError('pumptracks');
+    }
+  }
+}

--- a/runtime/src/skills/pumptracks/types.ts
+++ b/runtime/src/skills/pumptracks/types.ts
@@ -1,0 +1,168 @@
+/**
+ * PumpTracks skill type definitions.
+ *
+ * @module
+ */
+
+/**
+ * Configuration for PumpTracksSkill.
+ */
+export interface PumpTracksSkillConfig {
+  /** PumpTracks API base URL (default: https://pumptracks.fun/api/v1) */
+  apiBaseUrl?: string;
+  /** API key for authentication (pt_live_xxxxx) */
+  apiKey: string;
+  /** Request timeout in milliseconds (default: 60000) */
+  timeoutMs?: number;
+}
+
+/**
+ * Parameters for listing tracks.
+ */
+export interface ListTracksParams {
+  /** Max results, 1-100 (default: 50) */
+  limit?: number;
+  /** Skip N results (default: 0) */
+  offset?: number;
+  /** Filter by genre */
+  genre?: string;
+  /** Filter by artist wallet */
+  artist?: string;
+  /** Sort field: "createdAt" or "playCount" */
+  sort?: 'createdAt' | 'playCount';
+  /** Sort order */
+  order?: 'asc' | 'desc';
+}
+
+/**
+ * Parameters for searching tracks.
+ */
+export interface SearchTracksParams {
+  /** Search query (searches title, artist, symbol) */
+  q: string;
+  /** Max results (default: 20) */
+  limit?: number;
+}
+
+/**
+ * Parameters for minting a new music token.
+ */
+export interface MintTrackParams {
+  /** Path to audio file or Buffer */
+  audio: string | Buffer;
+  /** Path to artwork file or Buffer */
+  artwork: string | Buffer;
+  /** Song title (max 32 chars) */
+  title: string;
+  /** Artist name (max 32 chars) */
+  artist: string;
+  /** Genre (max 20 chars) */
+  genre: string;
+  /** Optional audio filename (used when audio is a Buffer) */
+  audioFilename?: string;
+  /** Optional artwork filename (used when artwork is a Buffer) */
+  artworkFilename?: string;
+  /** Optional X/Twitter URL */
+  twitter?: string;
+  /** Optional TikTok URL */
+  tiktok?: string;
+  /** Optional Instagram URL */
+  instagram?: string;
+}
+
+/**
+ * Track data returned from the API.
+ */
+export interface Track {
+  /** Token mint address */
+  mint: string;
+  /** Song title */
+  title: string;
+  /** Artist name */
+  artist: string;
+  /** Genre */
+  genre: string;
+  /** Token symbol */
+  symbol: string;
+  /** Artwork URL */
+  artUri?: string;
+  /** Audio stream URL */
+  trackUri?: string;
+  /** IPFS metadata URI */
+  metadataUri?: string;
+  /** Creator wallet */
+  mintedBy: string;
+  /** Play count */
+  playCount?: number;
+  /** Creation timestamp */
+  createdAt: string;
+  /** PumpTracks play page URL */
+  playUrl?: string;
+  /** Trading links */
+  links?: {
+    solscan?: string;
+    jupiter?: string;
+    raydium?: string;
+  };
+}
+
+/**
+ * Artist profile data.
+ */
+export interface Artist {
+  /** Wallet address */
+  wallet: string;
+  /** Display name */
+  name?: string;
+  /** Number of tracks */
+  trackCount: number;
+  /** Total plays across all tracks */
+  totalPlays: number;
+  /** Artist's tracks */
+  tracks: Track[];
+}
+
+/**
+ * Result of a successful mint operation.
+ */
+export interface MintResult {
+  /** Token mint address */
+  mint: string;
+  /** Confirmed Solana transaction signatures */
+  txIds: string[];
+  /** PumpTracks play page URL */
+  playUrl: string;
+}
+
+/**
+ * Intermediate result from the prepare (mint) step.
+ */
+export interface PrepareResult {
+  /** Base64-encoded unsigned VersionedTransaction(s) */
+  transactions: string[];
+  /** Token mint address */
+  mint: string;
+  /** Track info to pass back in submit step */
+  trackInfo: {
+    title: string;
+    artist: string;
+    genre: string;
+    symbol: string;
+    metadataUri: string;
+    artUri: string;
+    trackUri: string;
+    wallet: string;
+    twitter?: string;
+    tiktok?: string;
+    instagram?: string;
+  };
+}
+
+/**
+ * API response wrapper.
+ */
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}

--- a/runtime/src/tools/skill-adapter.ts
+++ b/runtime/src/tools/skill-adapter.ts
@@ -171,3 +171,59 @@ export const JUPITER_ACTION_SCHEMAS: ActionSchemaMap = {
     required: ['mints'],
   },
 };
+
+/**
+ * JSON Schema definitions for all 5 PumpTracks skill actions.
+ *
+ * PumpTracks is a music token launchpad on Solana. Agents can browse,
+ * search, and mint music tokens via these actions.
+ */
+export const PUMPTRACKS_ACTION_SCHEMAS: ActionSchemaMap = {
+  getTracks: {
+    type: 'object',
+    properties: {
+      limit: { type: 'number', description: 'Max results, 1-100 (default 50)' },
+      offset: { type: 'number', description: 'Skip N results (default 0)' },
+      genre: { type: 'string', description: 'Filter by genre (e.g. "Electronic", "Hip-Hop")' },
+      artist: { type: 'string', description: 'Filter by artist wallet address' },
+      sort: { type: 'string', description: 'Sort by "createdAt" or "playCount"' },
+      order: { type: 'string', description: 'Sort order: "asc" or "desc"' },
+    },
+  },
+  getTrack: {
+    type: 'object',
+    properties: {
+      mint: { type: 'string', description: 'Solana token mint address (base58)' },
+    },
+    required: ['mint'],
+  },
+  searchTracks: {
+    type: 'object',
+    properties: {
+      q: { type: 'string', description: 'Search query (searches title, artist, symbol)' },
+      limit: { type: 'number', description: 'Max results (default 20)' },
+    },
+    required: ['q'],
+  },
+  getArtist: {
+    type: 'object',
+    properties: {
+      wallet: { type: 'string', description: 'Artist Solana wallet address (base58)' },
+    },
+    required: ['wallet'],
+  },
+  mintTrack: {
+    type: 'object',
+    properties: {
+      audio: { type: 'string', description: 'Path to audio file (MP3, WAV, OGG, FLAC, M4A — max 50MB)' },
+      artwork: { type: 'string', description: 'Path to artwork image (JPEG, PNG, GIF, WebP — max 10MB)' },
+      title: { type: 'string', description: 'Song title (max 32 chars)' },
+      artist: { type: 'string', description: 'Artist name (max 32 chars)' },
+      genre: { type: 'string', description: 'Genre (max 20 chars)' },
+      twitter: { type: 'string', description: 'Optional X/Twitter URL' },
+      tiktok: { type: 'string', description: 'Optional TikTok URL' },
+      instagram: { type: 'string', description: 'Optional Instagram URL' },
+    },
+    required: ['audio', 'artwork', 'title', 'artist', 'genre'],
+  },
+};


### PR DESCRIPTION
## Summary

Adds a new AgenC skill for [PumpTracks](https://pumptracks.fun) — a music token launchpad on Solana built on Raydium LaunchLab.

- **`getTracks`** — Browse the catalog with genre/artist/sort filters
- **`getTrack`** — Get track details by mint address
- **`searchTracks`** — Search by title, artist, or token symbol
- **`getArtist`** — Get artist profile and their tracks
- **`mintTrack`** — Full end-to-end mint: upload audio + artwork → sign Raydium tx → submit to Solana

The `mintTrack` action handles the complete flow automatically:
1. Uploads audio + artwork to PumpTracks API (stored on Firebase + IPFS)
2. Receives an unsigned Raydium LaunchLab transaction
3. Signs it with the agent's wallet
4. Submits the signed tx back — PumpTracks confirms on-chain and registers the track
5. Track is immediately live and streamable at `pumptracks.fun/play/<mint>`

### Setup

```typescript
import { PumpTracksSkill } from './skills/pumptracks/index.js';

const pumptracks = new PumpTracksSkill({
  apiKey: process.env.PUMPTRACKS_API_KEY!, // pt_live_xxxxx
});

registry.register(pumptracks);
await registry.initializeAll({ connection, wallet, logger });
```

### Usage

```typescript
// Browse tracks
const tracks = await pumptracks.getTracks({ genre: 'Electronic', limit: 10 });

// Mint a music token (~0.07 SOL)
const result = await pumptracks.mintTrack({
  audio: './song.mp3',
  artwork: './cover.jpg',
  title: 'My Song',
  artist: 'Artist Name',
  genre: 'Electronic',
});
console.log(result.playUrl); // https://pumptracks.fun/play/MINT_ADDRESS
```

### Files

```
runtime/src/skills/pumptracks/
├── pumptracks-skill.ts      # Skill class (5 actions, follows Jupiter pattern)
├── pumptracks-client.ts     # HTTP client for PumpTracks API v1
├── types.ts                 # TypeScript interfaces
├── constants.ts             # API URLs, file limits
└── index.ts                 # Barrel exports
runtime/src/tools/skill-adapter.ts  # Added PUMPTRACKS_ACTION_SCHEMAS
runtime/src/skills/index.ts         # Added PumpTracks exports
```

Follows the same architecture as the Jupiter skill — same `Skill` interface, lifecycle management, action registry, and JSON schema definitions for the tool adapter.

### API Key

Each agent needs a PumpTracks API key. Get one by signing a message with your wallet:

```bash
curl -X POST https://pumptracks.fun/api/v1/auth \
  -H "Content-Type: application/json" \
  -d '{"wallet":"...","signature":"...","message":"PumpTracks API Key Request\n\nTimestamp:..."}'
```

Default keys have read-only access. Write access (`tracks:prepare` + `tracks:submit`) available on request.

### Dependencies

Uses `@solana/web3.js` (already in AgenC). No additional dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)