### PR TITLE
fix(program): strengthen CRIT-5 worker token validation + CRIT-3 image-id tooling

### DIFF
--- a/audit/security-audit-2026-02-19.md
+++ b/audit/security-audit-2026-02-19.md
@@ -187,14 +187,14 @@ RISC Zero integration must be completed before mainnet.
 
 ### Must Fix (Blocks Deployment)
 
-- [ ] CRIT-1: Replace simulated proofs with real RISC Zero prover
-- [ ] CRIT-2: Implement actual zkVM guest program
-- [ ] CRIT-3: Generate and pin real image ID from guest ELF
+- [x] CRIT-1: Replace simulated proofs with real RISC Zero prover (**FIXED** — PR #1220 real Groth16 prover, PR #1222 runtime wiring)
+- [x] CRIT-2: Implement actual zkVM guest program (**FIXED** — PR #1220 real guest at zkvm/methods/guest/src/main.rs)
+- [ ] CRIT-3: Generate and pin real image ID from guest ELF (tooling ready: `cargo run -p agenc-zkvm-host --features production-prover -- image-id`; needs rzup installed)
 - [x] CRIT-4: Fix VERIFIER_PROGRAM_ID mismatch in SDK (**FIXED**)
-- [x] CRIT-5: Add ownership validation for worker_token_account (**FIXED**)
+- [x] CRIT-5: Add ownership validation for worker_token_account (**FIXED** — strengthened with SPL token account authority check)
 - [x] CRIT-6: Handle zero-vote dispute slash case (**NOT A BUG** — MIN_VOTERS_FOR_RESOLUTION=3 prevents zero-vote resolution)
 - [ ] CRIT-8: Fix PrivacyClient.completeTaskPrivate() NPE
-- [ ] CRIT-9: Add devnet/mainnet deployment configs
+- [x] CRIT-9: Add devnet/mainnet deployment configs (**FIXED** — PR #1222 added devnet/mainnet-beta to TRUSTED_DEPLOYMENTS)
 - [x] HIGH-3: Enforce minimum stake for disputes > 0 (**FIXED** in update_rate_limits.rs + execute_proposal.rs)
 - [x] HIGH-5: Validate treasury spend recipient (**FIXED** — zero-pubkey check added)
 

--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -610,4 +610,7 @@ pub enum CoordinationError {
     // ZK security errors (sequential from enum position)
     #[msg("Private tasks (non-zero constraint_hash) must use complete_task_private")]
     PrivateTaskRequiresZkProof,
+
+    #[msg("Token account owner does not match expected authority")]
+    InvalidTokenAccountOwner,
 }

--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -178,7 +178,7 @@ pub fn handler(
             .as_ref()
             .unwrap()
             .to_account_info();
-        validate_unchecked_token_mint(&worker_ta_info, &mint.key())?;
+        validate_unchecked_token_mint(&worker_ta_info, &mint.key(), &ctx.accounts.authority.key())?;
 
         Some(TokenPaymentAccounts {
             token_escrow_ata: token_escrow.to_account_info(),

--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -33,8 +33,12 @@ const TRUSTED_RISC0_ROUTER_PROGRAM_ID: Pubkey =
 const TRUSTED_RISC0_VERIFIER_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge");
 // TODO(CRIT-3): Arithmetic placeholder — not a real SHA-256 digest of the guest ELF.
-// To compute the real value: build with `production-prover`, extract AGENC_GUEST_ID,
-// convert via guest_id_to_image_id(). Must match sdk/src/constants.ts exactly.
+// To compute the real value:
+//   1. Install rzup: curl -L https://risczero.com/install | bash && rzup install
+//   2. Run: cargo run -p agenc-zkvm-host --features production-prover -- image-id
+//   3. Copy the Rust constant output here
+//   4. Copy the TypeScript constant to sdk/src/constants.ts
+// Both values MUST match exactly or complete_task_private will reject all proofs.
 const TRUSTED_RISC0_IMAGE_ID: [u8; RISC0_IMAGE_ID_LEN] = [
     6, 15, 16, 25, 34, 43, 44, 53, 62, 71, 72, 81, 90, 99, 100, 109, 118, 127, 128, 137, 146, 155,
     156, 165, 174, 183, 184, 193, 202, 211, 212, 221,
@@ -290,7 +294,11 @@ pub fn complete_task_private(
             &mint.key(),
             &ctx.accounts.protocol_config.treasury,
         )?;
-        validate_unchecked_token_mint(&worker_token_account.to_account_info(), &mint.key())?;
+        validate_unchecked_token_mint(
+            &worker_token_account.to_account_info(),
+            &mint.key(),
+            &ctx.accounts.authority.key(),
+        )?;
 
         Some(TokenPaymentAccounts {
             token_escrow_ata: token_escrow.to_account_info(),

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -6739,7 +6739,7 @@
     {
       "code": 6052,
       "name": "InvalidProofSize",
-      "msg": "Invalid proof size - expected 256 bytes for Groth16"
+      "msg": "Invalid proof size - expected 256 bytes for RISC Zero seal body"
     },
     {
       "code": 6053,
@@ -7435,6 +7435,11 @@
       "code": 6191,
       "name": "PrivateTaskRequiresZkProof",
       "msg": "Private tasks (non-zero constraint_hash) must use complete_task_private"
+    },
+    {
+      "code": 6192,
+      "name": "InvalidTokenAccountOwner",
+      "msg": "Token account owner does not match expected authority"
     }
   ],
   "types": [

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -6751,7 +6751,7 @@ export type AgencCoordination = {
     {
       "code": 6052,
       "name": "invalidProofSize",
-      "msg": "Invalid proof size - expected 256 bytes for Groth16"
+      "msg": "Invalid proof size - expected 256 bytes for RISC Zero seal body"
     },
     {
       "code": 6053,
@@ -7447,6 +7447,11 @@ export type AgencCoordination = {
       "code": 6191,
       "name": "privateTaskRequiresZkProof",
       "msg": "Private tasks (non-zero constraint_hash) must use complete_task_private"
+    },
+    {
+      "code": 6192,
+      "name": "invalidTokenAccountOwner",
+      "msg": "Token account owner does not match expected authority"
     }
   ],
   "types": [

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -76,13 +76,10 @@ export const TRUSTED_RISC0_SELECTOR = Uint8Array.from([0x52, 0x5a, 0x56, 0x4d]);
  *
  * TODO(CRIT-3): This is an arithmetic placeholder, not a real SHA-256 digest of
  * the guest ELF. To compute the real image ID:
- *   1. Install rzup (RISC Zero toolchain manager)
- *   2. Build zkvm workspace with `production-prover` feature:
- *      cargo build -p agenc-zkvm-host --features production-prover
- *   3. Extract AGENC_GUEST_ID from agenc-zkvm-methods crate
- *   4. Convert via guest_id_to_image_id() (LE u32x8 → [u8; 32])
- *   5. Update this constant AND the on-chain TRUSTED_RISC0_IMAGE_ID in
- *      programs/agenc-coordination/src/instructions/complete_task_private.rs
+ *   1. Install rzup: curl -L https://risczero.com/install | bash && rzup install
+ *   2. Run: cargo run -p agenc-zkvm-host --features production-prover -- image-id
+ *   3. Copy the TypeScript constant output here
+ *   4. Copy the Rust constant to complete_task_private.rs
  *   Both values MUST match exactly or complete_task_private will reject all proofs.
  */
 export const TRUSTED_RISC0_IMAGE_ID = Uint8Array.from([

--- a/zkvm/host/src/main.rs
+++ b/zkvm/host/src/main.rs
@@ -71,18 +71,50 @@ fn print_image_id() -> Result<(), String> {
         let image_id = agenc_zkvm_host::guest_id_to_image_id(
             &agenc_zkvm_methods::AGENC_GUEST_ID,
         );
-        print!("[");
+
+        println!("=== RISC Zero Image ID (from guest ELF) ===\n");
+
+        // Rust constant format (for complete_task_private.rs)
+        println!("// Rust (programs/.../complete_task_private.rs)");
+        print!("const TRUSTED_RISC0_IMAGE_ID: [u8; RISC0_IMAGE_ID_LEN] = [\n    ");
         for (i, byte) in image_id.iter().enumerate() {
-            if i > 0 {
+            if i > 0 && i % 11 == 0 {
+                print!("\n    ");
+            } else if i > 0 {
                 print!(", ");
             }
-            print!("0x{byte:02x}");
+            print!("{byte}");
         }
-        println!("]");
+        println!(",\n];\n");
+
+        // TypeScript constant format (for sdk/src/constants.ts)
+        println!("// TypeScript (sdk/src/constants.ts)");
+        print!("export const TRUSTED_RISC0_IMAGE_ID = Uint8Array.from([\n  ");
+        for (i, byte) in image_id.iter().enumerate() {
+            if i > 0 && i % 11 == 0 {
+                print!("\n  ");
+            } else if i > 0 {
+                print!(", ");
+            }
+            print!("{byte}");
+        }
+        println!(",\n]);\n");
+
+        // Raw hex for verification
+        print!("// Hex: ");
+        for byte in &image_id {
+            print!("{byte:02x}");
+        }
+        println!();
+
         Ok(())
     }
     #[cfg(not(feature = "production-prover"))]
     {
-        Err("image-id requires --features production-prover (needs rzup toolchain)".into())
+        Err(concat!(
+            "image-id requires --features production-prover (needs rzup toolchain).\n",
+            "Install: curl -L https://risczero.com/install | bash && rzup install\n",
+            "Then: cargo run -p agenc-zkvm-host --features production-prover -- image-id"
+        ).into())
     }
 }


### PR DESCRIPTION
## Summary

- **CRIT-5 (strengthened):** `validate_unchecked_token_mint()` now validates SPL token account owner (bytes 32..64) matches worker authority. New `InvalidTokenAccountOwner` error code (6192). Prevents reward redirection to attacker-controlled accounts.
- **CRIT-3 (tooling):** Enhanced `image-id` CLI command to output copy-paste-ready constants in both Rust and TypeScript formats. Unified TODO comments with actionable 4-step instructions.
- **Audit status:** Marked CRIT-1, CRIT-2, CRIT-9 as fixed based on PRs #1220-#1222.

## Files changed

| File | Change |
|------|--------|
| `errors.rs` | +`InvalidTokenAccountOwner` (6192) |
| `token_helpers.rs` | +`expected_owner` param, SPL owner check at bytes 32..64 |
| `complete_task.rs` | Pass `authority.key()` to validation |
| `complete_task_private.rs` | Pass `authority.key()` to validation, updated TODO |
| `sdk/src/constants.ts` | Simplified TODO instructions |
| `zkvm/host/src/main.rs` | Enhanced `image-id` output (Rust + TS formats) |
| `audit/security-audit-2026-02-19.md` | Updated CRIT-1/2/9 status |

## Test plan

- [x] 100 Rust program unit tests pass
- [x] 14 zkVM host tests pass  
- [x] 225 LiteSVM integration tests pass
- [x] 17 SPL token task tests pass
- [x] 248 SDK tests pass
- [x] 55 runtime proof engine tests pass