### PR TITLE
fix(sdk,program,zkvm): pin real RISC Zero image ID and fix PrivacyClient (CRIT-3, CRIT-8)

### DIFF
--- a/audit/security-audit-2026-02-19.md
+++ b/audit/security-audit-2026-02-19.md
@@ -189,11 +189,11 @@ RISC Zero integration must be completed before mainnet.
 
 - [x] CRIT-1: Replace simulated proofs with real RISC Zero prover (**FIXED** — PR #1220 real Groth16 prover, PR #1222 runtime wiring)
 - [x] CRIT-2: Implement actual zkVM guest program (**FIXED** — PR #1220 real guest at zkvm/methods/guest/src/main.rs)
-- [ ] CRIT-3: Generate and pin real image ID from guest ELF (tooling ready: `cargo run -p agenc-zkvm-host --features production-prover -- image-id`; needs rzup installed)
+- [x] CRIT-3: Generate and pin real image ID from guest ELF (**FIXED** — real SHA-256 digest `caafc273...` pinned in both complete_task_private.rs and sdk/src/constants.ts)
 - [x] CRIT-4: Fix VERIFIER_PROGRAM_ID mismatch in SDK (**FIXED**)
 - [x] CRIT-5: Add ownership validation for worker_token_account (**FIXED** — strengthened with SPL token account authority check)
 - [x] CRIT-6: Handle zero-vote dispute slash case (**NOT A BUG** — MIN_VOTERS_FOR_RESOLUTION=3 prevents zero-vote resolution)
-- [ ] CRIT-8: Fix PrivacyClient.completeTaskPrivate() NPE
+- [x] CRIT-8: Fix PrivacyClient.completeTaskPrivate() NPE (**FIXED** — rewired to use real SDK proof generation + task submission)
 - [x] CRIT-9: Add devnet/mainnet deployment configs (**FIXED** — PR #1222 added devnet/mainnet-beta to TRUSTED_DEPLOYMENTS)
 - [x] HIGH-3: Enforce minimum stake for disputes > 0 (**FIXED** in update_rate_limits.rs + execute_proposal.rs)
 - [x] HIGH-5: Validate treasury spend recipient (**FIXED** — zero-pubkey check added)

--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -32,16 +32,12 @@ const TRUSTED_RISC0_ROUTER_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7");
 const TRUSTED_RISC0_VERIFIER_PROGRAM_ID: Pubkey =
     Pubkey::from_str_const("THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge");
-// TODO(CRIT-3): Arithmetic placeholder — not a real SHA-256 digest of the guest ELF.
-// To compute the real value:
-//   1. Install rzup: curl -L https://risczero.com/install | bash && rzup install
-//   2. Run: cargo run -p agenc-zkvm-host --features production-prover -- image-id
-//   3. Copy the Rust constant output here
-//   4. Copy the TypeScript constant to sdk/src/constants.ts
-// Both values MUST match exactly or complete_task_private will reject all proofs.
+// SHA-256 digest of the RISC Zero guest ELF (agenc-zkvm-methods AGENC_GUEST_ID).
+// Regenerate with: cargo run -p agenc-zkvm-host --features production-prover -- image-id
+// This value MUST match TRUSTED_RISC0_IMAGE_ID in sdk/src/constants.ts exactly.
 const TRUSTED_RISC0_IMAGE_ID: [u8; RISC0_IMAGE_ID_LEN] = [
-    6, 15, 16, 25, 34, 43, 44, 53, 62, 71, 72, 81, 90, 99, 100, 109, 118, 127, 128, 137, 146, 155,
-    156, 165, 174, 183, 184, 193, 202, 211, 212, 221,
+    202, 175, 194, 115, 244, 76, 8, 9, 197, 55, 54, 103, 21, 34, 178, 245,
+    211, 97, 58, 48, 7, 14, 121, 214, 109, 60, 64, 137, 170, 156, 79, 219,
 ];
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]

--- a/sdk/src/__tests__/client.test.ts
+++ b/sdk/src/__tests__/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { PublicKey, Keypair } from '@solana/web3.js';
 import { PrivacyClient } from '../client';
 
 describe('PrivacyClient input validation (#963)', () => {
@@ -38,17 +39,90 @@ describe('PrivacyClient input validation (#963)', () => {
   });
 
   describe('completeTaskPrivate validation', () => {
-    it('rejects when not initialized', async () => {
+    it('rejects when wallet not initialized', async () => {
       const client = new PrivacyClient({ rpcUrl: 'http://localhost:8899' });
       await expect(
         client.completeTaskPrivate({
-          taskId: 1,
+          taskPda: PublicKey.default,
           output: [1n, 2n, 3n, 4n],
-          salt: 123n,
-          recipientWallet: {} as any,
-          escrowLamports: 1000,
         })
       ).rejects.toThrow('not initialized');
+    });
+
+    it('rejects when program not initialized', async () => {
+      const wallet = Keypair.generate();
+      const client = new PrivacyClient({ rpcUrl: 'http://localhost:8899', wallet });
+      // init without IDL — program stays null
+      await client.init(wallet);
+      await expect(
+        client.completeTaskPrivate({
+          taskPda: PublicKey.default,
+          output: [1n, 2n, 3n, 4n],
+        })
+      ).rejects.toThrow('Program not initialized');
+    });
+
+    it('rejects when agentId not provided', async () => {
+      const wallet = Keypair.generate();
+      // No agentId in config, set program via internal access
+      const client = new PrivacyClient({ rpcUrl: 'http://localhost:8899', wallet });
+      // Bypass init to set wallet + program without needing a real IDL
+      (client as any).program = {};
+      await expect(
+        client.completeTaskPrivate({
+          taskPda: PublicKey.default,
+          output: [1n, 2n, 3n, 4n],
+        })
+      ).rejects.toThrow('Agent ID not provided');
+    });
+
+    it('rejects invalid output array length', async () => {
+      const wallet = Keypair.generate();
+      const client = new PrivacyClient({
+        rpcUrl: 'http://localhost:8899',
+        wallet,
+        agentId: new Uint8Array(32).fill(1),
+      });
+      (client as any).program = {};
+      await expect(
+        client.completeTaskPrivate({
+          taskPda: PublicKey.default,
+          output: [1n, 2n, 3n],
+        })
+      ).rejects.toThrow('exactly 4');
+    });
+
+    it('rejects zero salt', async () => {
+      const wallet = Keypair.generate();
+      const client = new PrivacyClient({
+        rpcUrl: 'http://localhost:8899',
+        wallet,
+        agentId: new Uint8Array(32).fill(1),
+      });
+      (client as any).program = {};
+      await expect(
+        client.completeTaskPrivate({
+          taskPda: PublicKey.default,
+          output: [1n, 2n, 3n, 4n],
+          salt: 0n,
+        })
+      ).rejects.toThrow('non-zero');
+    });
+
+    it('rejects negative bigint in output', async () => {
+      const wallet = Keypair.generate();
+      const client = new PrivacyClient({
+        rpcUrl: 'http://localhost:8899',
+        wallet,
+        agentId: new Uint8Array(32).fill(1),
+      });
+      (client as any).program = {};
+      await expect(
+        client.completeTaskPrivate({
+          taskPda: PublicKey.default,
+          output: [1n, 2n, -1n, 4n],
+        })
+      ).rejects.toThrow('output[2]');
     });
   });
 });

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -72,19 +72,14 @@ export const RISC0_IMAGE_ID_LEN = 32;
 export const TRUSTED_RISC0_SELECTOR = Uint8Array.from([0x52, 0x5a, 0x56, 0x4d]);
 
 /**
- * Trusted RISC0 image ID pinned by protocol policy.
+ * Trusted RISC0 image ID — SHA-256 digest of the RISC Zero guest ELF.
  *
- * TODO(CRIT-3): This is an arithmetic placeholder, not a real SHA-256 digest of
- * the guest ELF. To compute the real image ID:
- *   1. Install rzup: curl -L https://risczero.com/install | bash && rzup install
- *   2. Run: cargo run -p agenc-zkvm-host --features production-prover -- image-id
- *   3. Copy the TypeScript constant output here
- *   4. Copy the Rust constant to complete_task_private.rs
- *   Both values MUST match exactly or complete_task_private will reject all proofs.
+ * Regenerate with: cargo run -p agenc-zkvm-host --features production-prover -- image-id
+ * This value MUST match TRUSTED_RISC0_IMAGE_ID in complete_task_private.rs exactly.
  */
 export const TRUSTED_RISC0_IMAGE_ID = Uint8Array.from([
-  6, 15, 16, 25, 34, 43, 44, 53, 62, 71, 72, 81, 90, 99, 100, 109, 118, 127, 128, 137, 146, 155,
-  156, 165, 174, 183, 184, 193, 202, 211, 212, 221,
+  202, 175, 194, 115, 244, 76, 8, 9, 197, 55, 54, 103, 21, 34, 178, 245,
+  211, 97, 58, 48, 7, 14, 121, 214, 109, 60, 64, 137, 170, 156, 79, 219,
 ]);
 
 /**


### PR DESCRIPTION
## Summary

- **CRIT-3**: Extract and pin real RISC Zero image ID (`caafc273f44c0809...`) from guest ELF via `production-prover` build. Updates both `complete_task_private.rs` and `sdk/src/constants.ts`. Fixes 3 risc0-zkvm 3.0.5 API compatibility issues in `zkvm/host/src/lib.rs` (`write()` return type, `groth16()` Result vs Option, `Digestible` trait import).
- **CRIT-8**: Rewrites `PrivacyClient.completeTaskPrivate()` to use real SDK proof generation (`generateProof`) and task submission (`submitCompleteTaskPrivate`). Removes dead `PrivacyOperationsClient` interface that always threw NPE. Adds input validation (wallet, program, agentId, output array, salt).

## Test plan

- [x] 100 Rust program unit tests pass
- [x] 14 zkVM host tests pass
- [x] 253 SDK vitest tests pass (including 14 client tests)
- [x] 55 runtime proof engine tests pass
- [x] 225 LiteSVM integration tests pass
- [x] `cargo build --features production-prover` succeeds
- [x] `cargo run -p agenc-zkvm-host --features production-prover -- image-id` outputs correct hex