### PR TITLE
fix(program,sdk): add binding/nullifier seed entropy validation (CRIT-7)

### DIFF
--- a/audit/security-audit-2026-02-19.md
+++ b/audit/security-audit-2026-02-19.md
@@ -193,6 +193,7 @@ RISC Zero integration must be completed before mainnet.
 - [x] CRIT-4: Fix VERIFIER_PROGRAM_ID mismatch in SDK (**FIXED**)
 - [x] CRIT-5: Add ownership validation for worker_token_account (**FIXED** — strengthened with SPL token account authority check)
 - [x] CRIT-6: Handle zero-vote dispute slash case (**NOT A BUG** — MIN_VOTERS_FOR_RESOLUTION=3 prevents zero-vote resolution)
+- [x] CRIT-7: Validate binding/nullifier seed entropy (**FIXED** — byte diversity check requiring min 8 distinct values, on-chain + SDK preflight + salt zero guard)
 - [x] CRIT-8: Fix PrivacyClient.completeTaskPrivate() NPE (**FIXED** — rewired to use real SDK proof generation + task submission)
 - [x] CRIT-9: Add devnet/mainnet deployment configs (**FIXED** — PR #1222 added devnet/mainnet-beta to TRUSTED_DEPLOYMENTS)
 - [x] HIGH-3: Enforce minimum stake for disputes > 0 (**FIXED** in update_rate_limits.rs + execute_proposal.rs)

--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -613,4 +613,7 @@ pub enum CoordinationError {
 
     #[msg("Token account owner does not match expected authority")]
     InvalidTokenAccountOwner,
+
+    #[msg("Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)")]
+    InsufficientSeedEntropy,
 }

--- a/sdk/src/proofs.ts
+++ b/sdk/src/proofs.ts
@@ -336,6 +336,11 @@ function simulateSealProofBytes(journal: Buffer, imageId: Buffer): Buffer {
 export async function generateProof(params: ProofGenerationParams): Promise<ProofResult> {
   const startTime = Date.now();
 
+  // Validate salt is non-zero (zero salt makes commitments deterministic, defeating privacy)
+  if (params.salt === 0n) {
+    throw new Error('Invalid salt: must be non-zero for privacy preservation');
+  }
+
   if (params.agentSecret === undefined) {
     console.warn(
       'SECURITY WARNING: agentSecret not provided to generateProof(). Falling back to ' +


### PR DESCRIPTION
## Summary

- **On-chain**: Add `has_sufficient_byte_diversity()` check in `parse_and_validate_journal()` requiring binding and nullifier seeds to contain at least 8 distinct byte values. SHA-256 outputs average ~28; this rejects constant-fill, short-period, and arithmetic patterns. New error: `InsufficientSeedEntropy` (6193).
- **SDK proofs**: Add zero-salt guard in `generateProof()` — rejects `salt === 0n` before proof generation.
- **SDK preflight**: Add `binding_entropy` and `nullifier_entropy` checks in `runProofSubmissionPreflight()` using the same 8-distinct-byte threshold.

## Test plan

- [x] 108 Rust program unit tests pass (8 new entropy tests)
- [x] 14 zkVM host tests pass
- [x] 258 SDK vitest tests pass (5 new: 2 salt validation, 3 entropy preflight)
- [x] 225 LiteSVM integration tests pass