### PR TITLE
feat: ZK hardening cleanup — export PrivacyClient, remove Noir legacy, named constants

### DIFF
--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -23,6 +23,14 @@ const RISC0_SELECTOR_LEN: usize = 4;
 const RISC0_IMAGE_ID_LEN: usize = 32;
 const RISC0_GROTH16_SEAL_LEN: usize = 256;
 const RISC0_SEAL_BORSH_LEN: usize = RISC0_SELECTOR_LEN + RISC0_GROTH16_SEAL_LEN;
+
+// Journal field offsets (each field is HASH_SIZE=32 bytes)
+const JOURNAL_TASK_PDA_OFFSET: usize = 0;
+const JOURNAL_AUTHORITY_OFFSET: usize = HASH_SIZE;       // 32
+const JOURNAL_CONSTRAINT_OFFSET: usize = 2 * HASH_SIZE;  // 64
+const JOURNAL_COMMITMENT_OFFSET: usize = 3 * HASH_SIZE;  // 96
+const JOURNAL_BINDING_OFFSET: usize = 4 * HASH_SIZE;     // 128
+const JOURNAL_NULLIFIER_OFFSET: usize = 5 * HASH_SIZE;   // 160
 const ROUTER_VERIFY_IX_DISCRIMINATOR: [u8; 8] = [133, 161, 141, 48, 120, 198, 88, 150];
 const VERIFIER_ENTRY_DISCRIMINATOR: [u8; 8] = [102, 247, 148, 158, 33, 153, 100, 93];
 const VERIFIER_ENTRY_ACCOUNT_LEN: usize = 8 + RISC0_SELECTOR_LEN + 32 + 1;
@@ -387,12 +395,12 @@ fn parse_and_validate_journal(journal: &[u8]) -> Result<ParsedJournal> {
         CoordinationError::InvalidJournalLength
     );
 
-    let task_pda = read_journal_field(journal, 0)?;
-    let agent_authority = read_journal_field(journal, 32)?;
-    let constraint_hash = read_journal_field(journal, 64)?;
-    let output_commitment = read_journal_field(journal, 96)?;
-    let binding = read_journal_field(journal, 128)?;
-    let nullifier = read_journal_field(journal, 160)?;
+    let task_pda = read_journal_field(journal, JOURNAL_TASK_PDA_OFFSET)?;
+    let agent_authority = read_journal_field(journal, JOURNAL_AUTHORITY_OFFSET)?;
+    let constraint_hash = read_journal_field(journal, JOURNAL_CONSTRAINT_OFFSET)?;
+    let output_commitment = read_journal_field(journal, JOURNAL_COMMITMENT_OFFSET)?;
+    let binding = read_journal_field(journal, JOURNAL_BINDING_OFFSET)?;
+    let nullifier = read_journal_field(journal, JOURNAL_NULLIFIER_OFFSET)?;
 
     require!(
         output_commitment != [0u8; HASH_SIZE],

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -7440,6 +7440,11 @@
       "code": 6192,
       "name": "InvalidTokenAccountOwner",
       "msg": "Token account owner does not match expected authority"
+    },
+    {
+      "code": 6193,
+      "name": "InsufficientSeedEntropy",
+      "msg": "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
     }
   ],
   "types": [

--- a/runtime/src/proof/engine.test.ts
+++ b/runtime/src/proof/engine.test.ts
@@ -324,7 +324,7 @@ describe('ProofEngine', () => {
       vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(true);
       const engine = new ProofEngine();
 
-      const valid = await engine.verify(new Uint8Array(256), [1n, 2n]);
+      const valid = await engine.verify(new Uint8Array(256), new Uint8Array(192));
       expect(valid).toBe(true);
       expect(mockVerifyProofLocally).toHaveBeenCalledOnce();
     });
@@ -333,7 +333,7 @@ describe('ProofEngine', () => {
       vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(true);
       const engine = new ProofEngine();
 
-      await engine.verify(new Uint8Array(256), []);
+      await engine.verify(new Uint8Array(256), new Uint8Array(192));
       const stats = engine.getStats();
       expect(stats.verificationsPerformed).toBe(1);
       expect(stats.verificationsFailed).toBe(0);
@@ -343,7 +343,7 @@ describe('ProofEngine', () => {
       vi.mocked(mockVerifyProofLocally).mockResolvedValueOnce(false);
       const engine = new ProofEngine();
 
-      await engine.verify(new Uint8Array(256), []);
+      await engine.verify(new Uint8Array(256), new Uint8Array(192));
       const stats = engine.getStats();
       expect(stats.verificationsPerformed).toBe(1);
       expect(stats.verificationsFailed).toBe(1);
@@ -353,7 +353,7 @@ describe('ProofEngine', () => {
       vi.mocked(mockVerifyProofLocally).mockRejectedValueOnce(new Error('boom'));
       const engine = new ProofEngine();
 
-      await expect(engine.verify(new Uint8Array(256), [])).rejects.toThrow(
+      await expect(engine.verify(new Uint8Array(256), new Uint8Array(192))).rejects.toThrow(
         ProofVerificationError,
       );
     });

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -7452,6 +7452,11 @@ export type AgencCoordination = {
       "code": 6192,
       "name": "invalidTokenAccountOwner",
       "msg": "Token account owner does not match expected authority"
+    },
+    {
+      "code": 6193,
+      "name": "insufficientSeedEntropy",
+      "msg": "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
     }
   ],
   "types": [

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -216,7 +216,7 @@ export const RuntimeErrorCodes = {
 export type RuntimeErrorCode = (typeof RuntimeErrorCodes)[keyof typeof RuntimeErrorCodes];
 
 // ============================================================================
-// Anchor Error Codes (192 codes: 6000-6191)
+// Anchor Error Codes (194 codes: 6000-6193)
 // ============================================================================
 
 /**
@@ -416,6 +416,8 @@ export const AnchorErrorCodes = {
   ReputationAgentNotActive: 6189,
   ReputationDisputesPending: 6190,
   PrivateTaskRequiresZkProof: 6191,
+  InvalidTokenAccountOwner: 6192,
+  InsufficientSeedEntropy: 6193,
 } as const;
 
 /** Union type of all Anchor error code values */
@@ -622,10 +624,12 @@ const AnchorErrorMessages: Record<AnchorErrorCode, string> = {
   6189: "Agent must be Active to participate in reputation economy",
   6190: "Agent has pending disputes as defendant: cannot withdraw stake",
   6191: "Private tasks (non-zero constraint_hash) must use complete_task_private",
+  6192: "Token account owner does not match expected authority",
+  6193: "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)",
 };
 
 const ANCHOR_ERROR_MIN_CODE = 6000;
-const ANCHOR_ERROR_MAX_CODE = 6191;
+const ANCHOR_ERROR_MAX_CODE = 6193;
 
 // ============================================================================
 // Validation Helpers

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -209,8 +209,15 @@ export {
 } from './errors';
 
 export {
-  validateProofPreconditions,
+  // Current API
+  runProofSubmissionPreflight,
   DEFAULT_MAX_PROOF_AGE_MS,
+  type ProofSubmissionPreflightResult,
+  type ProofSubmissionPreflightFailure,
+  type ProofSubmissionPreflightWarning,
+  type ProofSubmissionPreflightParams,
+  // Deprecated aliases (v1.6.0)
+  validateProofPreconditions,
   type ProofPreconditionResult,
   type ProofPreconditionFailure,
   type ProofPreconditionWarning,
@@ -304,6 +311,17 @@ export {
   type SkillRatingState,
   type PurchaseRecordState,
 } from './skills';
+
+export {
+  PrivacyClient,
+  type PrivacyClientConfig,
+} from './client';
+
+export {
+  validateProverEndpoint,
+  validateRisc0PayloadShape,
+  type Risc0PayloadLike,
+} from './validation';
 
 // Version info
 export const VERSION = '1.3.0';

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -35,6 +35,7 @@ import { getSdkLogger } from './logger';
 import { getDependentTaskCount } from './queries';
 import { runProofSubmissionPreflight, type ProofSubmissionPreflightResult, type ProofPreconditionResult } from './proof-validation';
 import { NullifierCache } from './nullifier-cache';
+import { validateRisc0PayloadShape } from './validation';
 
 export { TaskState };
 
@@ -644,6 +645,9 @@ export async function completeTaskPrivate(
   const imageId = toFixedBytes(proof.imageId, RISC0_IMAGE_ID_LEN, 'imageId');
   const bindingSeed = toFixedBytes(proof.bindingSeed, HASH_SIZE, 'bindingSeed');
   const nullifierSeed = toFixedBytes(proof.nullifierSeed, HASH_SIZE, 'nullifierSeed');
+
+  // Defense-in-depth: validate payload shape (sizes + trusted selector)
+  validateRisc0PayloadShape({ sealBytes, journal, imageId, bindingSeed, nullifierSeed });
 
   const [bindingSpend] = PublicKey.findProgramAddressSync(
     [BINDING_SPEND_SEED, bindingSeed],


### PR DESCRIPTION
## Summary

- Export `PrivacyClient`, `PrivacyClientConfig`, `validateRisc0PayloadShape`, and new proof-validation API names from SDK barrel
- Remove legacy Noir-era code from `proofs.ts`: `byteFromSignal()`, `signalToFieldBytes()`, `buildJournalFromPublicSignals()` — these used a 68-element signal array format from the old Noir circuit system
- Change `verifyProofLocally()` to accept `journal: Buffer` instead of `publicSignals: bigint[]`, eliminating the signal→journal round-trip reconstruction
- Add `validateRisc0PayloadShape()` call in `completeTaskPrivate()` for defense-in-depth payload validation before on-chain submission
- Add zero-checks for computed `constraintHash` and `outputCommitment` in `generateProof()` to catch misconfigured tasks early
- Replace magic number journal offsets (0, 32, 64, 96, 128, 160) with named constants (`JOURNAL_TASK_PDA_OFFSET`, etc.) in `complete_task_private.rs`
- Update runtime `ProofEngine`: remove `buildPublicSignals()`, pass journal directly to `verifyProofLocally()`
- Sync IDL and runtime error mapping for `InsufficientSeedEntropy` (6193) and `InvalidTokenAccountOwner` (6192)

Net: -55 lines (78 added, 133 removed)

## Test plan

- [x] 108 Rust program tests pass
- [x] 14 zkVM host tests pass
- [x] 258 SDK tests pass
- [x] 4698 runtime tests pass (including 65 error mapping tests)
- [x] 225 LiteSVM integration tests pass
- [x] Full build + typecheck succeeds