### PR TITLE
feat(runtime,web): wire activity feed, agents list, and UI improvements

### DIFF
--- a/runtime/src/channels/webchat/types.ts
+++ b/runtime/src/channels/webchat/types.ts
@@ -21,7 +21,7 @@ export interface WebChatDeps {
   /** Gateway instance for status queries. */
   gateway: {
     getStatus(): { state: string; uptimeMs: number; channels: string[]; activeSessions: number; controlPlanePort: number };
-    config: { agent?: { name?: string } };
+    config: { agent?: { name?: string }; connection?: { rpcUrl?: string; keypairPath?: string } };
   };
   /** Optional skill listing for skills.list handler. */
   skills?: ReadonlyArray<{ name: string; description: string; enabled: boolean }>;
@@ -33,6 +33,10 @@ export interface WebChatDeps {
   approvalEngine?: import('../../gateway/approvals.js').ApprovalEngine;
   /** Optional callback to toggle a skill's enabled state. */
   skillToggle?: (name: string, enabled: boolean) => void;
+  /** Optional Solana connection for on-chain task operations. */
+  connection?: import('@solana/web3.js').Connection;
+  /** Optional callback to broadcast events to all subscribed WS clients. */
+  broadcastEvent?: (eventType: string, data: Record<string, unknown>) => void;
 }
 
 // ============================================================================

--- a/runtime/src/gateway/approvals.ts
+++ b/runtime/src/gateway/approvals.ts
@@ -147,7 +147,7 @@ export const DEFAULT_APPROVAL_RULES: readonly ApprovalRule[] = [
   },
   {
     tool: 'agenc.createTask',
-    conditions: { minAmount: 1 },
+    conditions: { minAmount: 1_000_000_000 },
     description: 'Task creation with reward exceeding 1 SOL',
   },
 ];

--- a/runtime/src/tools/agenc/tools.ts
+++ b/runtime/src/tools/agenc/tools.ts
@@ -177,10 +177,15 @@ async function resolveCreatorAgentPda(
     return [pda, err];
   }
 
-  const accounts = await program.account.agentRegistration.all();
-  const matches = accounts.filter((acc) => {
-    const account = acc.account as unknown as { authority?: PublicKey };
-    return account.authority?.equals(creator) ?? false;
+  // Use raw getProgramAccounts to bypass Anchor deserialization bug with enum repr
+  const bs58 = await import('bs58');
+  const AGENT_DISCRIMINATOR = Buffer.from([130, 53, 100, 103, 121, 77, 148, 19]);
+  const AGENT_AUTHORITY_OFFSET = 40; // 8 (disc) + 32 (agent_id)
+  const matches = await program.provider.connection.getProgramAccounts(program.programId, {
+    filters: [
+      { memcmp: { offset: 0, bytes: bs58.default.encode(AGENT_DISCRIMINATOR) } },
+      { memcmp: { offset: AGENT_AUTHORITY_OFFSET, bytes: creator.toBase58() } },
+    ],
   });
 
   if (matches.length === 0) {
@@ -190,7 +195,7 @@ async function resolveCreatorAgentPda(
     return [null, errorResult('Multiple agent registrations found. Provide creatorAgentPda.')];
   }
 
-  return [matches[0].publicKey, null];
+  return [matches[0].pubkey, null];
 }
 
 function isMissingAccountError(err: unknown): boolean {
@@ -521,7 +526,7 @@ export function createCreateTaskTool(
         },
         reward: {
           type: 'string',
-          description: 'Reward amount in lamports or token base units (integer string)',
+          description: 'Reward in lamports (1 SOL = 1000000000 lamports). E.g. for 0.05 SOL pass "50000000".',
         },
         requiredCapabilities: {
           type: 'string',
@@ -642,7 +647,22 @@ export function createCreateTaskTool(
         const taskPda = findTaskPda(creator, taskId, program.programId);
         const escrowPda = findEscrowPda(taskPda, program.programId);
         const protocolPda = findProtocolPda(program.programId);
-        const tokenAccounts = buildCreateTaskTokenAccounts(rewardMint, escrowPda, creator);
+
+        const accounts: Record<string, PublicKey | null> = {
+          task: taskPda,
+          escrow: escrowPda,
+          protocolConfig: protocolPda,
+          creatorAgent: creatorAgentPda,
+          authority: creator,
+          creator,
+          systemProgram: SystemProgram.programId,
+        };
+
+        // Only include token accounts when a reward mint is specified
+        if (rewardMint) {
+          const tokenAccounts = buildCreateTaskTokenAccounts(rewardMint, escrowPda, creator);
+          Object.assign(accounts, tokenAccounts);
+        }
 
         const txSignature = await program.methods
           .createTask(
@@ -654,19 +674,8 @@ export function createCreateTaskTool(
             new anchor.BN(deadline),
             taskType,
             constraintHash ? toAnchorBytes(constraintHash) : null,
-            minReputation,
-            rewardMint,
           )
-          .accountsPartial({
-            task: taskPda,
-            escrow: escrowPda,
-            protocolConfig: protocolPda,
-            creatorAgent: creatorAgentPda,
-            authority: creator,
-            creator,
-            systemProgram: SystemProgram.programId,
-            ...tokenAccounts,
-          })
+          .accountsPartial(accounts)
           .rpc();
 
         return {
@@ -683,6 +692,16 @@ export function createCreateTaskTool(
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error);
         logger.error(`agenc.createTask failed: ${msg}`);
+
+        // Detect on-chain rate-limit cooldown — non-retriable, tell the LLM to wait
+        if (msg.includes('CooldownNotElapsed') || msg.includes('6072')) {
+          return errorResult(
+            'RATE LIMITED: The on-chain 60-second cooldown between task creations has not elapsed. ' +
+            'Do NOT retry — wait at least 60 seconds before creating the next task. ' +
+            'Tell the user to try again in about a minute.',
+          );
+        }
+
         return errorResult(msg);
       }
     },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { useApprovals } from './hooks/useApprovals';
 import { useSettings } from './hooks/useSettings';
 import { useWallet } from './hooks/useWallet';
 import { useActivityFeed } from './hooks/useActivityFeed';
+import { useAgents } from './hooks/useAgents';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Sidebar } from './components/Sidebar';
 import { RightPanel } from './components/RightPanel';
@@ -54,6 +55,7 @@ export default function App() {
   const gatewaySettings = useSettings({ send, connected });
   const walletInfo = useWallet({ send, connected });
   const activityFeed = useActivityFeed({ send, connected }) as WithHandler<ReturnType<typeof useActivityFeed>>;
+  const agentsData = useAgents({ send, connected }) as WithHandler<ReturnType<typeof useAgents>>;
 
   // Voice toggle — start or stop voice session
   const handleVoiceToggle = useCallback(() => {
@@ -76,6 +78,7 @@ export default function App() {
     gatewaySettings.handleMessage(msg);
     walletInfo.handleMessage(msg);
     activityFeed.handleMessage(msg);
+    agentsData.handleMessage(msg);
   }
 
   const handleApprove = useCallback(
@@ -105,6 +108,8 @@ export default function App() {
             connectionState={connectionState}
             workspace="default"
             pendingApprovals={approvals.pending.length}
+            theme={theme}
+            onToggleTheme={toggleTheme}
           />
         </div>
 
@@ -119,6 +124,8 @@ export default function App() {
                 connectionState={connectionState}
                 workspace="default"
                 pendingApprovals={approvals.pending.length}
+                theme={theme}
+                onToggleTheme={toggleTheme}
                 mobile
               />
             </div>
@@ -192,7 +199,11 @@ export default function App() {
               />
             )}
             {currentView === 'settings' && (
-              <SettingsView settings={gatewaySettings} />
+              <SettingsView
+                settings={gatewaySettings}
+                autoApprove={approvals.autoApprove}
+                onAutoApproveChange={approvals.setAutoApprove}
+              />
             )}
             {currentView === 'payment' && (
               <PaymentView wallet={walletInfo} />
@@ -209,6 +220,9 @@ export default function App() {
             activeSessionId={chat.sessionId}
             onSelectSession={chat.resumeSession}
             onNewChat={chat.startNewChat}
+            autoApprove={approvals.autoApprove}
+            onAutoApproveChange={approvals.setAutoApprove}
+            agents={agentsData.agents}
           />
         </div>
 

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -8,6 +8,8 @@ interface SidebarProps {
   workspace: string;
   pendingApprovals: number;
   mobile?: boolean;
+  theme?: 'light' | 'dark';
+  onToggleTheme?: () => void;
 }
 
 interface NavItem {
@@ -36,6 +38,8 @@ export function Sidebar({
   connectionState,
   pendingApprovals,
   mobile,
+  theme,
+  onToggleTheme,
 }: SidebarProps) {
   return (
     <div className="w-20 h-full bg-tetsuo-50 border-r border-tetsuo-200 flex flex-col items-center py-4">
@@ -98,8 +102,25 @@ export function Sidebar({
         })}
       </div>}
 
-      {/* Connection */}
+      {/* Theme toggle + Connection */}
       <div className="flex flex-col items-center gap-2">
+        {onToggleTheme && (
+          <button
+            onClick={onToggleTheme}
+            title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            className="w-12 h-12 rounded-xl flex items-center justify-center text-tetsuo-400 hover:text-tetsuo-600 hover:bg-tetsuo-100 transition-all duration-200 active:scale-90"
+          >
+            {theme === 'dark' ? (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+              </svg>
+            )}
+          </button>
+        )}
         <ConnectionStatus state={connectionState} compact />
       </div>
     </div>

--- a/web/src/components/payment/PaymentView.tsx
+++ b/web/src/components/payment/PaymentView.tsx
@@ -76,8 +76,8 @@ export function PaymentView({ wallet: w }: PaymentViewProps) {
             <div className="h-8 w-32 rounded bg-tetsuo-100 animate-pulse" />
           ) : wallet ? (
             <div className="relative">
-              <div className={`text-2xl font-bold text-tetsuo-800 transition-all duration-300 ${airdropSuccess ? 'text-emerald-500' : ''}`}>
-                {wallet.sol.toFixed(4)} SOL
+              <div className={`font-bold text-tetsuo-800 transition-all duration-300 whitespace-nowrap ${airdropSuccess ? 'text-emerald-500' : ''} ${wallet.sol >= 1_000_000 ? 'text-base' : wallet.sol >= 1_000 ? 'text-xl' : 'text-2xl'}`}>
+                {wallet.sol.toLocaleString('en-US', { minimumFractionDigits: 4, maximumFractionDigits: 4 })} SOL
               </div>
               <div className="text-xs text-tetsuo-400 mt-1 capitalize">
                 {wallet.network === 'mainnet-beta' ? 'Mainnet' : wallet.network}

--- a/web/src/components/settings/SettingsView.tsx
+++ b/web/src/components/settings/SettingsView.tsx
@@ -28,9 +28,11 @@ const LLM_PROVIDERS: LLMProviderDef[] = [
 
 interface SettingsViewProps {
   settings: UseSettingsReturn;
+  autoApprove?: boolean;
+  onAutoApproveChange?: (v: boolean) => void;
 }
 
-export function SettingsView({ settings }: SettingsViewProps) {
+export function SettingsView({ settings, autoApprove = false, onAutoApproveChange }: SettingsViewProps) {
   const { settings: config, loaded, saving, lastError, save, ollamaModels, ollamaError, fetchOllamaModels } = settings;
 
   const [provider, setProvider] = useState(config.llm.provider);
@@ -246,6 +248,18 @@ export function SettingsView({ settings }: SettingsViewProps) {
                   title="Select Mode"
                 />
               </div>
+            </div>
+          </section>
+
+          {/* Tool Approvals */}
+          <section className="space-y-3">
+            <h2 className="text-sm font-semibold text-tetsuo-800">Tool Approvals</h2>
+            <div className="flex items-center justify-between">
+              <div>
+                <span className="text-sm text-tetsuo-600">Auto-approve all tool calls</span>
+                <p className="text-xs text-tetsuo-400 mt-0.5">Skip confirmation dialogs for bash, HTTP, filesystem, etc.</p>
+              </div>
+              <ToggleSwitch on={autoApprove} onChange={(v) => onAutoApproveChange?.(v)} />
             </div>
           </section>
 

--- a/web/src/components/tasks/CreateTaskForm.tsx
+++ b/web/src/components/tasks/CreateTaskForm.tsx
@@ -50,7 +50,7 @@ export function CreateTaskForm({ onCreate }: CreateTaskFormProps) {
         />
       </div>
       <div>
-        <label className="text-[10px] text-tetsuo-400 uppercase tracking-[0.15em] font-medium block mb-1.5">Reward (lamports)</label>
+        <label className="text-[10px] text-tetsuo-400 uppercase tracking-[0.15em] font-medium block mb-1.5">Reward (SOL)</label>
         <input
           type="number"
           value={reward}

--- a/web/src/components/tasks/TaskCard.tsx
+++ b/web/src/components/tasks/TaskCard.tsx
@@ -19,7 +19,14 @@ export function TaskCard({ task, onCancel }: TaskCardProps) {
   return (
     <div className="px-4 py-3.5 rounded-xl border border-tetsuo-200 bg-tetsuo-50 hover:border-tetsuo-300 transition-all duration-200 hover:shadow-sm">
       <div className="flex items-center justify-between gap-3">
-        <div className="text-sm font-medium text-tetsuo-800 truncate font-mono">{task.id.slice(0, 16)}...</div>
+        <div className="min-w-0 flex-1">
+          {task.description ? (
+            <div className="text-sm font-medium text-tetsuo-800 truncate">{task.description}</div>
+          ) : (
+            <div className="text-sm font-medium text-tetsuo-800 truncate font-mono">{task.id.slice(0, 16)}...</div>
+          )}
+          <div className="text-[10px] text-tetsuo-400 font-mono mt-0.5">{task.id.slice(0, 16)}...</div>
+        </div>
         <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[10px] font-semibold uppercase tracking-wider shrink-0 ${style.bg} ${style.text}`}>
           <span className={`w-1.5 h-1.5 rounded-full ${style.dot}`} />
           {task.status}

--- a/web/src/hooks/useAgents.ts
+++ b/web/src/hooks/useAgents.ts
@@ -1,0 +1,34 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { AgentInfo, WSMessage } from '../types';
+
+interface UseAgentsOptions {
+  send: (msg: Record<string, unknown>) => void;
+  connected: boolean;
+}
+
+export interface UseAgentsReturn {
+  agents: AgentInfo[];
+  refresh: () => void;
+}
+
+export function useAgents({ send, connected }: UseAgentsOptions): UseAgentsReturn & { handleMessage: (msg: WSMessage) => void } {
+  const [agents, setAgents] = useState<AgentInfo[]>([]);
+
+  const refresh = useCallback(() => {
+    send({ type: 'agents.list' });
+  }, [send]);
+
+  const handleMessage = useCallback((msg: WSMessage) => {
+    if (msg.type === 'agents.list') {
+      const payload = (msg.payload ?? []) as AgentInfo[];
+      setAgents(Array.isArray(payload) ? payload : []);
+    }
+  }, []);
+
+  // Auto-fetch on connect
+  useEffect(() => {
+    if (connected) refresh();
+  }, [connected, refresh]);
+
+  return { agents, refresh, handleMessage };
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -75,6 +75,7 @@ export interface TaskInfo {
   reward?: string;
   creator?: string;
   worker?: string;
+  description?: string;
 }
 
 // ============================================================================
@@ -101,6 +102,21 @@ export interface ApprovalRequest {
   requestId: string;
   action: string;
   details: Record<string, unknown>;
+}
+
+// ============================================================================
+// Agents
+// ============================================================================
+
+export interface AgentInfo {
+  pda: string;
+  agentId: string;
+  authority: string;
+  capabilities: string[];
+  status: string;
+  reputation: number;
+  tasksCompleted: number;
+  stake: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Activity Feed**: Emit `broadcastEvent()` at key points in the daemon message pipeline (`chat.inbound`, `tool.executed`, `chat.response`, `task.created`, `task.cancelled`) so the Activity Feed tab shows real-time events
- **Agents List**: Add `handleAgentsList` handler querying on-chain `AgentRegistration` accounts via `getProgramAccounts` with sequential Borsh parsing for variable-length fields; replace hardcoded static agents in RightPanel with live on-chain data (static fallback when no agents found)
- **On-chain Tasks**: Wire task list/create/cancel through raw `getProgramAccounts` to bypass Anchor enum deserialization issues; fix `createTask` tool token account handling and approval threshold (1 lamport → 1 SOL)
- **Web UI**: Auto-approve toggle in settings + approvals hook with localStorage persistence, collapsible tool call groups in chat, theme toggle in sidebar, large-number SOL formatting, task card descriptions

## Files Changed (16)

### Runtime (5)
- `runtime/src/channels/webchat/handlers.ts` — On-chain task handlers + `handleAgentsList` + broadcast calls
- `runtime/src/channels/webchat/types.ts` — Add `connection` and `broadcastEvent` to `WebChatDeps`
- `runtime/src/gateway/daemon.ts` — Pass `broadcastEvent` to deps, emit events in message pipeline
- `runtime/src/gateway/approvals.ts` — Fix approval threshold to 1 SOL
- `runtime/src/tools/agenc/tools.ts` — Fix Anchor deserialization bypass, token account handling

### Web (11)
- `web/src/hooks/useAgents.ts` — **New** hook for on-chain agents list
- `web/src/hooks/useApprovals.ts` — Auto-approve with localStorage
- `web/src/types.ts` — Add `AgentInfo` + task types
- `web/src/App.tsx` — Wire `useAgents` hook + pass agents to RightPanel
- `web/src/components/RightPanel.tsx` — Live on-chain agents with static fallback
- `web/src/components/Sidebar.tsx` — Theme toggle button
- `web/src/components/chat/ChatMessage.tsx` — Collapsible tool call groups
- `web/src/components/payment/PaymentView.tsx` — Large number formatting
- `web/src/components/settings/SettingsView.tsx` — Auto-approve toggle section
- `web/src/components/tasks/CreateTaskForm.tsx` — Label fix (lamports → SOL)
- `web/src/components/tasks/TaskCard.tsx` — Show description + PDA

## Test plan

- [x] Runtime builds with `npx tsup` (verified)
- [x] Web frontend typechecks with `tsc --noEmit` (verified)
- [x] Activity Feed shows `chat.inbound` and `chat.response` events on message send
- [x] Agents panel shows on-chain registered agent with capabilities and status
- [x] Task list/create/cancel work via on-chain operations
- [ ] Auto-approve toggle persists across page reloads
- [ ] Theme toggle works in sidebar on desktop