### PR TITLE
fix(sdk): prepend ComputeBudget to completeTaskPrivate, deprecate Noir artifacts

### DIFF
--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -91,7 +91,7 @@ export interface ProofInputs {
   /** Random salt for commitment */
   salt: bigint;
   /**
-   * Private witness for the circuit's `agent_secret` input.
+   * Private witness for the zkVM guest's `agent_secret` input.
    * Used to derive nullifier seed bytes in SDK proof generation.
    *
    * SECURITY: If omitted, the SDK falls back to `pubkeyToField(agentPubkey)`,

--- a/sdk/src/__tests__/contract.test.ts
+++ b/sdk/src/__tests__/contract.test.ts
@@ -26,6 +26,7 @@ function makeKeypair(seed: number): Keypair {
 function makeProgram(methodNames: string[], rpcValue: string): unknown {
   const builder = {
     accountsPartial: vi.fn().mockReturnThis(),
+    preInstructions: vi.fn().mockReturnThis(),
     signers: vi.fn().mockReturnThis(),
     rpc: vi.fn().mockResolvedValue(rpcValue),
   };

--- a/sdk/src/__tests__/proof-validation.test.ts
+++ b/sdk/src/__tests__/proof-validation.test.ts
@@ -176,8 +176,10 @@ function makeValidationHarness(options?: {
     methods: {
       completeTaskPrivate: vi.fn().mockReturnValue({
         accountsPartial: vi.fn().mockReturnValue({
-          signers: vi.fn().mockReturnValue({
-            rpc: vi.fn().mockResolvedValue('tx-sig'),
+          preInstructions: vi.fn().mockReturnValue({
+            signers: vi.fn().mockReturnValue({
+              rpc: vi.fn().mockResolvedValue('tx-sig'),
+            }),
           }),
         }),
       }),

--- a/sdk/src/__tests__/proofs.test.ts
+++ b/sdk/src/__tests__/proofs.test.ts
@@ -336,8 +336,8 @@ describe('proofs', () => {
       expect(binding2).toBe(binding);
     });
 
-    it('matches circuit computation for known values', () => {
-      // These test values should match the circuit test fixtures
+    it('matches RISC Zero computation for known values', () => {
+      // These test values should match the RISC Zero guest test fixtures
       // Task ID: 42 (0x2a) as 32-byte big-endian
       const taskIdBytes = Buffer.alloc(32, 0);
       taskIdBytes[31] = 0x2a;

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -43,7 +43,7 @@ export const U64_SIZE = 8;
 /** Anchor account discriminator size in bytes */
 export const DISCRIMINATOR_SIZE = 8;
 
-/** Number of field elements in output array (circuit constraint) */
+/** Number of field elements in task output array */
 export const OUTPUT_FIELD_COUNT = 4;
 
 // ============================================================================
@@ -89,7 +89,10 @@ export const TRUSTED_RISC0_IMAGE_ID = Uint8Array.from([
  */
 export const VERIFICATION_COMPUTE_UNITS = 50_000;
 
-/** Number of public inputs in the circuit (32 task_id bytes + 32 agent bytes + constraint_hash + output_commitment + expected_binding) */
+/**
+ * @deprecated Since v1.3.0. Noir circuit artifact — not used by RISC Zero proof path.
+ * Will be removed in v2.0.0.
+ */
 export const PUBLIC_INPUTS_COUNT = 67;
 
 // ============================================================================

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -10,6 +10,7 @@ import {
   PublicKey,
   Keypair,
   SystemProgram,
+  ComputeBudgetProgram,
 } from '@solana/web3.js';
 import anchor, { type Program } from '@coral-xyz/anchor';
 import {
@@ -29,6 +30,8 @@ import {
   RISC0_JOURNAL_LEN,
   RISC0_IMAGE_ID_LEN,
   TRUSTED_RISC0_SELECTOR,
+  RECOMMENDED_CU_COMPLETE_TASK_PRIVATE,
+  RECOMMENDED_CU_COMPLETE_TASK_PRIVATE_TOKEN,
 } from './constants';
 import { getAccount } from './anchor-utils';
 import { getSdkLogger } from './logger';
@@ -704,6 +707,10 @@ export async function completeTaskPrivate(
     };
   }
 
+  const cuLimit = mint
+    ? RECOMMENDED_CU_COMPLETE_TASK_PRIVATE_TOKEN
+    : RECOMMENDED_CU_COMPLETE_TASK_PRIVATE;
+
   const tx = await program.methods
     .completeTaskPrivate(taskIdU64, {
       sealBytes: Array.from(sealBytes),
@@ -730,6 +737,9 @@ export async function completeTaskPrivate(
       systemProgram: SystemProgram.programId,
       ...tokenAccounts,
     })
+    .preInstructions([
+      ComputeBudgetProgram.setComputeUnitLimit({ units: cuLimit }),
+    ])
     .signers([worker])
     .rpc();
 


### PR DESCRIPTION
## Summary

- **ComputeBudgetProgram prepended to `completeTaskPrivate()`** — uses `RECOMMENDED_CU_COMPLETE_TASK_PRIVATE` (200k) for SOL tasks and `RECOMMENDED_CU_COMPLETE_TASK_PRIVATE_TOKEN` (250k) for SPL token tasks via Anchor `.preInstructions()`
- **Deprecated `PUBLIC_INPUTS_COUNT`** — Noir circuit artifact (67 public signals), not used by RISC Zero proof path
- **Replaced stale "circuit" references** with "RISC Zero" in SDK constants, tests, and runtime proof types

## Test plan

- [x] SDK tests pass (258/258)
- [x] Runtime tests pass (4698/4698)
- [x] LiteSVM integration tests pass (225/225)
- [x] SDK + runtime builds succeed