### PR TITLE
fix: purge remaining Noir references from source and docs

### DIFF
--- a/.claude/agents/doc-issue-writer.md
+++ b/.claude/agents/doc-issue-writer.md
@@ -227,7 +227,7 @@ Based on complexity and target, apply appropriate labels:
 |-----------|-------|
 | target == "anchor" | `anchor` |
 | target == "sdk" | `sdk` |
-| target == "circuits" | `circuits` |
+| target == "zkvm" | `zkvm` |
 | target == "tests" | `tests` |
 | complexity == "trivial" or "low" | `good first issue` |
 | complexity == "high" or "very_high" | `complex` |

--- a/.claude/rules/noir-circuits.md
+++ b/.claude/rules/noir-circuits.md
@@ -1,4 +1,0 @@
-# DELETED - Noir circuits have been replaced by RISC Zero zkVM
-
-See `zk-overview.md` for the current ZK architecture.
-See `zkvm/` for the guest and host crate source.

--- a/docs/design/speculative-execution/API-SPECIFICATION.md
+++ b/docs/design/speculative-execution/API-SPECIFICATION.md
@@ -397,7 +397,7 @@ export interface ProofInputs {
   /** Execution trace (compressed) */
   executionTrace: Uint8Array;
   
-  /** Public inputs for the circuit */
+  /** Public inputs (journal fields) */
   publicInputs: bigint[];
   
   /** Private witness data */
@@ -499,7 +499,7 @@ export enum ProofErrorCode {
   /** Out of memory during proof generation */
   OUT_OF_MEMORY = 'OUT_OF_MEMORY',
   
-  /** Circuit constraint violation */
+  /** Proof constraint violation */
   CONSTRAINT_VIOLATION = 'CONSTRAINT_VIOLATION',
   
   /** Worker crashed during generation */

--- a/docs/design/speculative-execution/DESIGN-DOCUMENT.md
+++ b/docs/design/speculative-execution/DESIGN-DOCUMENT.md
@@ -1417,7 +1417,7 @@ export interface DeferredProof {
   commitmentId: string;
   /** 388-byte Groth16 proof */
   proof: Uint8Array;
-  /** Circuit public inputs */
+  /** Proof public inputs (journal fields) */
   publicInputs: bigint[];
   /** Ancestor task IDs that must confirm first */
   ancestors: Uint8Array[];

--- a/runtime/src/proof/engine.test.ts
+++ b/runtime/src/proof/engine.test.ts
@@ -788,11 +788,11 @@ describe('deriveCacheKey', () => {
 
 describe('Proof error classes', () => {
   it('ProofGenerationError has correct properties', () => {
-    const err = new ProofGenerationError('circuit not found');
+    const err = new ProofGenerationError('prover not found');
     expect(err.name).toBe('ProofGenerationError');
     expect(err.code).toBe(RuntimeErrorCodes.PROOF_GENERATION_ERROR);
-    expect(err.cause).toBe('circuit not found');
-    expect(err.message).toContain('circuit not found');
+    expect(err.cause).toBe('prover not found');
+    expect(err.message).toContain('prover not found');
     expect(err instanceof RuntimeError).toBe(true);
   });
 

--- a/runtime/src/skills/markdown/parser.test.ts
+++ b/runtime/src/skills/markdown/parser.test.ts
@@ -48,7 +48,7 @@ This skill provides ZK proof generation.
 
 ## Usage
 
-Call \`risc0-prover prove\` with the circuit path.
+Call \`risc0-prover prove\` with the guest ELF path.
 `;
 
 const MINIMAL_SKILL_MD = `---

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -931,7 +931,7 @@ export class TaskNotClaimableError extends RuntimeError {
  *
  * @example
  * ```typescript
- * throw new TaskExecutionError(taskPda, 'Circuit generation failed');
+ * throw new TaskExecutionError(taskPda, 'Proof generation failed');
  * ```
  */
 export class TaskExecutionError extends RuntimeError {


### PR DESCRIPTION
## Summary

- Delete `.claude/rules/noir-circuits.md` placeholder file
- Replace "circuit not found" / "Circuit generation failed" / "circuit path" with RISC Zero terminology in runtime source
- Update speculative execution API spec + design doc: "Circuit public inputs" -> "Proof public inputs (journal fields)", "Circuit constraint violation" -> "Proof constraint violation"

Also updated local-only files (CODEX.md, codex.md, doc-issue-writer agent) to replace `circuits/` -> `zkvm/`.

## Test plan

- [x] SDK: 258/258 pass
- [x] Runtime: 4698/4698 pass