### PR TITLE
refactor: extract magic numbers to named constants

### DIFF
--- a/programs/agenc-coordination/src/instructions/update_agent.rs
+++ b/programs/agenc-coordination/src/instructions/update_agent.rs
@@ -27,6 +27,9 @@ pub struct UpdateAgent<'info> {
 /// Cooldown period between agent updates (1 minute)
 const UPDATE_COOLDOWN: i64 = 60;
 
+/// Maximum length for agent metadata URI
+const MAX_METADATA_URI_LEN: usize = 128;
+
 pub fn handler(
     ctx: Context<UpdateAgent>,
     capabilities: Option<u64>,
@@ -55,20 +58,20 @@ pub fn handler(
     }
 
     if let Some(uri) = metadata_uri {
-        require!(uri.len() <= 128, CoordinationError::StringTooLong);
+        require!(uri.len() <= MAX_METADATA_URI_LEN, CoordinationError::StringTooLong);
         require!(validate_string_input(&uri), CoordinationError::InvalidInput);
         agent.metadata_uri = uri;
     }
 
     if let Some(s) = status {
         // Prevent suspended agents from changing their own status (only protocol authority can unsuspend)
-        if s != 3 && agent.status == AgentStatus::Suspended {
+        if s != AgentStatus::Suspended as u8 && agent.status == AgentStatus::Suspended {
             return Err(CoordinationError::AgentSuspended.into());
         }
 
         // Prevent setting status to Active while agent has active tasks
         // Agents with pending work should remain Busy, not advertise as available
-        if s == 1 && agent.active_tasks > 0 {
+        if s == AgentStatus::Active as u8 && agent.active_tasks > 0 {
             return Err(CoordinationError::AgentBusyWithTasks.into());
         }
 

--- a/runtime/src/connection/manager.ts
+++ b/runtime/src/connection/manager.ts
@@ -52,6 +52,7 @@ const DEFAULT_HEALTH: HealthCheckConfig = {
   unhealthyCooldownMs: 30_000,
 };
 
+/** Exponential moving average weight — 10% new sample, 90% history. */
 const EMA_FACTOR = 0.1;
 
 // ============================================================================

--- a/runtime/src/memory/in-memory/backend.ts
+++ b/runtime/src/memory/in-memory/backend.ts
@@ -36,6 +36,9 @@ interface KVEntry {
   expiresAt?: number;
 }
 
+const DEFAULT_MAX_ENTRIES_PER_SESSION = 1000;
+const DEFAULT_MAX_TOTAL_ENTRIES = 100_000;
+
 export class InMemoryBackend implements MemoryBackend {
   readonly name = 'in-memory';
 
@@ -52,8 +55,8 @@ export class InMemoryBackend implements MemoryBackend {
   constructor(config: InMemoryBackendConfig = {}) {
     this.logger = config.logger ?? silentLogger;
     this.defaultTtlMs = config.defaultTtlMs ?? 0;
-    this.maxEntriesPerSession = config.maxEntriesPerSession ?? 1000;
-    this.maxTotalEntries = config.maxTotalEntries ?? 100_000;
+    this.maxEntriesPerSession = config.maxEntriesPerSession ?? DEFAULT_MAX_ENTRIES_PER_SESSION;
+    this.maxTotalEntries = config.maxTotalEntries ?? DEFAULT_MAX_TOTAL_ENTRIES;
     this.metrics = config.metrics;
   }
 

--- a/runtime/src/task/filters.ts
+++ b/runtime/src/task/filters.ts
@@ -11,6 +11,9 @@
 import type { DiscoveredTask, TaskFilterConfig, TaskScorer, OnChainTask } from './types.js';
 import { OnChainTaskStatus, isPrivateTask } from './types.js';
 
+/** Default time remaining (1 day in seconds) for tasks with no deadline. */
+const DEFAULT_NO_DEADLINE_SECONDS = 86_400;
+
 /**
  * Checks if an agent has all required capabilities using bitwise AND.
  *
@@ -148,7 +151,7 @@ export function matchesFilter(
  *
  * Score = reward / max(1, timeRemaining).
  * Tasks with higher reward and shorter deadlines score higher.
- * Tasks with no deadline use 86400 (1 day) as the default time remaining.
+ * Tasks with no deadline use DEFAULT_NO_DEADLINE_SECONDS (1 day) as the default time remaining.
  *
  * @param task - The discovered task to score
  * @returns Numeric score (higher = higher priority)
@@ -161,7 +164,7 @@ export function matchesFilter(
 export const defaultTaskScorer: TaskScorer = (task: DiscoveredTask): number => {
   const now = Math.floor(Date.now() / 1000);
   const timeRemaining =
-    task.task.deadline > 0 ? task.task.deadline - now : 86400;
+    task.task.deadline > 0 ? task.task.deadline - now : DEFAULT_NO_DEADLINE_SECONDS;
 
   const denominator = Math.max(1, timeRemaining);
   return Number(task.task.rewardAmount) / denominator;

--- a/runtime/src/task/rollback-controller.ts
+++ b/runtime/src/task/rollback-controller.ts
@@ -182,6 +182,9 @@ export interface RollbackStats {
 // Default Configuration
 // ============================================================================
 
+/** Maximum number of rollback history entries to retain. */
+const DEFAULT_MAX_HISTORY_SIZE = 1000;
+
 const DEFAULT_CONFIG: RollbackConfig = {
   allowRetry: false,
   maxRetries: 0,
@@ -242,7 +245,7 @@ export class RollbackController {
   private rollbackHistory: RollbackResult[] = [];
 
   /** Maximum history entries to keep */
-  private readonly maxHistorySize: number = 1000;
+  private readonly maxHistorySize: number = DEFAULT_MAX_HISTORY_SIZE;
 
   /** Cumulative statistics */
   private stats: RollbackStats = {

--- a/runtime/src/workflow/optimizer.ts
+++ b/runtime/src/workflow/optimizer.ts
@@ -108,10 +108,10 @@ function nonNegative(value: number): number {
 }
 
 function hashString(input: string): number {
-  let hash = 2166136261;
+  let hash = 2166136261; // FNV-1a 32-bit offset basis
   for (let i = 0; i < input.length; i++) {
     hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
+    hash = Math.imul(hash, 16777619); // FNV-1a 32-bit prime
   }
   return hash >>> 0;
 }

--- a/runtime/src/workflow/rollout.ts
+++ b/runtime/src/workflow/rollout.ts
@@ -92,10 +92,10 @@ function nonNegative(value: number): number {
 }
 
 function hashString(input: string): number {
-  let hash = 2166136261;
+  let hash = 2166136261; // FNV-1a 32-bit offset basis
   for (let i = 0; i < input.length; i++) {
     hash ^= input.charCodeAt(i);
-    hash = Math.imul(hash, 16777619);
+    hash = Math.imul(hash, 16777619); // FNV-1a 32-bit prime
   }
   return hash >>> 0;
 }


### PR DESCRIPTION
## Summary

- Extract bare numeric literals to named constants across 7 files in runtime and program
- Replace raw agent status integers with `AgentStatus` enum expressions in `update_agent.rs`
- Annotate FNV-1a hash algorithm constants in workflow modules
- All changes are behavior-preserving (no logic changes)

### Files changed

| File | Change |
|------|--------|
| `runtime/src/task/filters.ts` | `86400` → `DEFAULT_NO_DEADLINE_SECONDS` |
| `runtime/src/task/rollback-controller.ts` | `1000` → `DEFAULT_MAX_HISTORY_SIZE` |
| `runtime/src/memory/in-memory/backend.ts` | `1000`/`100_000` → named constants |
| `runtime/src/connection/manager.ts` | Document `EMA_FACTOR` |
| `runtime/src/workflow/optimizer.ts` | Annotate FNV-1a constants |
| `runtime/src/workflow/rollout.ts` | Annotate FNV-1a constants |
| `programs/.../update_agent.rs` | `128` → `MAX_METADATA_URI_LEN`, raw `3`/`1` → enum expressions |

## Test plan

- [x] `npm run build` passes (TypeScript + Rust)
- [x] `npm run test:fast` passes (225/225 LiteSVM integration tests)
- [x] `cd runtime && npm run test` passes (4695/4698 — 3 pre-existing failures unrelated)
- [x] `anchor build` compiles successfully