### PR TITLE
fix(runtime): resolve 4 pre-existing test failures

### DIFF
--- a/runtime/src/events/idl-drift-check.ts
+++ b/runtime/src/events/idl-drift-check.ts
@@ -144,8 +144,8 @@ function getLineForContractContractField(
   sourceText: string,
 ): number | undefined {
   const lines = sourceText.split("\n");
-  const eventMarker = `eventName: '${eventName}',`;
-  const fieldMarker = `name: '${fieldName}',`;
+  const eventMarker = `eventName: "${eventName}",`;
+  const fieldMarker = `name: "${fieldName}",`;
   const eventLine = lines.findIndex((line) => line.includes(eventMarker));
   if (eventLine < 0) return undefined;
 

--- a/runtime/src/gateway/approvals.test.ts
+++ b/runtime/src/gateway/approvals.test.ts
@@ -165,12 +165,16 @@ describe("ApprovalEngine", () => {
       expect(engine.requiresApproval("wallet.transfer", {})).toBeNull();
     });
 
-    it("matches agenc.createTask with reward > 1", () => {
+    it("matches agenc.createTask with reward > 1 SOL (in lamports)", () => {
       expect(
-        engine.requiresApproval("agenc.createTask", { reward: 2 }),
+        engine.requiresApproval("agenc.createTask", {
+          reward: 2_000_000_000,
+        }),
       ).not.toBeNull();
       expect(
-        engine.requiresApproval("agenc.createTask", { reward: 0.5 }),
+        engine.requiresApproval("agenc.createTask", {
+          reward: 500_000_000,
+        }),
       ).toBeNull();
     });
 
@@ -631,11 +635,11 @@ describe("ApprovalEngine", () => {
       expect(rule!.conditions!.minAmount).toBe(0.1);
     });
 
-    it("agenc.createTask has minAmount 1", () => {
+    it("agenc.createTask has minAmount 1 SOL in lamports", () => {
       const rule = DEFAULT_APPROVAL_RULES.find(
         (r) => r.tool === "agenc.createTask",
       );
-      expect(rule!.conditions!.minAmount).toBe(1);
+      expect(rule!.conditions!.minAmount).toBe(1_000_000_000);
     });
   });
 });

--- a/runtime/src/tools/agenc/agenc-tools.test.ts
+++ b/runtime/src/tools/agenc/agenc-tools.test.ts
@@ -169,6 +169,9 @@ function createMockProgram() {
             uiAmountString: "2.5",
           },
         })),
+        getProgramAccounts: vi.fn(async () => [
+          { pubkey: AGENT_PDA, account: { data: Buffer.alloc(0) } },
+        ]),
       },
     },
     account: {


### PR DESCRIPTION
## Summary

Fixes 4 test failures that have been present since the prettier formatting pass.

- **idl-drift-check.test.ts**: `getLineForContractContractField()` searched for single-quoted strings (`eventName: 'taskCreated'`) but prettier reformatted `idl-contract.ts` to double quotes. Updated the marker strings to match.
- **approvals.test.ts** (2 failures): `DEFAULT_APPROVAL_RULES` sets `agenc.createTask` minAmount to `1_000_000_000` (lamports), but tests expected `1` (SOL) and passed `reward: 2` (lamports). Updated tests to use lamport values.
- **agenc-tools.test.ts**: `createCreateTaskTool` calls `resolveCreatorAgentPda()` which uses `getProgramAccounts()` — missing from the mock. Added the mock method.

## Test plan

- [x] All 4698 runtime tests pass (0 failures)
- [x] Previously-failing tests verified individually