### PR TITLE
fix(security): hardening phase 2 — resolve 9 audit findings

### DIFF
--- a/audit/security-audit-2026-02-19.md
+++ b/audit/security-audit-2026-02-19.md
@@ -204,12 +204,17 @@ RISC Zero integration must be completed before mainnet.
 - [x] HIGH-1, HIGH-15: Reorder token CPIs after state updates (**FIXED** — checks-effects-interactions in completion_helpers.rs)
 - [x] HIGH-2: init_if_needed claim bypass prevented (**FIXED** — CLOSED_ACCOUNT_DISCRIMINATOR in cancel_task.rs)
 - [x] HIGH-4: Enforce minimum governance quorum (**FIXED** — quorum_factor min=2)
-- [ ] HIGH-6: Enforce multisig threshold >= 2
-- [ ] HIGH-7: Change active_tasks to u16 or u32
-- [ ] HIGH-13: Prepend ComputeBudgetProgram to SDK transactions
+- [x] HIGH-6: Enforce multisig threshold >= 2 (**FIXED** — threshold >= 2 in multisig.rs, initialize_protocol.rs, update_multisig.rs)
+- [x] HIGH-7: Change active_tasks to u16 (**FIXED** — u8 → u16, absorbed byte from _reserved to keep SIZE unchanged)
+- [x] HIGH-9: Validate slash_percentage <= 100 (**FIXED** — require! in slash_helpers.rs + apply_initiator_slash.rs, compile-time assert on default)
+- [x] HIGH-10: Make agentSecret required (**FIXED** — removed optional fallback in SDK proofs.ts + runtime ProofInputs)
+- [x] HIGH-13: Prepend ComputeBudgetProgram to SDK transactions (**FIXED** — all task functions in tasks.ts now set CU limits)
 - [x] HIGH-14: Add null byte and newline to DANGEROUS_CHARS (**FIXED**)
 - [x] HIGH-16: Enforce monotonically increasing min_version (**FIXED**)
-- [ ] HIGH-17: Use integer arithmetic for SOL formatting
+- [x] HIGH-17: Use integer arithmetic for SOL formatting (**FIXED** — Math.trunc + modulo in client.ts)
+- [x] HIGH-18: NullifierCache timestamp tracking (**FIXED** — unconfirmed entries timeout after 120s, confirmUsed() after successful tx)
+- [x] MED-14: Max deadline validation (1 year) (**FIXED** — MAX_DEADLINE_SECONDS in task_init_helpers.rs)
+- [x] MED-15: Minimum reputation for dispute voters (**FIXED** — reputation > 0 check in vote_dispute.rs)
 
 ### Strengths (No Action Needed)
 
@@ -250,7 +255,20 @@ RISC Zero integration must be completed before mainnet.
 | CLAIM-001 | High | Write CLOSED_ACCOUNT_DISCRIMINATOR (`[255u8; 8]`) after zeroing claim data to prevent init_if_needed bypass | `cancel_task.rs` |
 | DISPUTE-001 | High | Added 2-minute grace period on voting_deadline for expire_dispute, giving resolve_dispute priority | `expire_dispute.rs` |
 
-**Total: 13 fixes applied across 12 files. All verified: anchor build + 100 Rust unit tests pass.**
+### Round 4 (Security Hardening Phase 2)
+| ID | Severity | Fix | File |
+|---|---|---|---|
+| HIGH-6 | High | Enforce multisig threshold >= 2 | `multisig.rs`, `initialize_protocol.rs`, `update_multisig.rs` |
+| HIGH-7 | High | `active_tasks` u8 → u16 (absorbed byte from _reserved) | `state.rs`, `claim_task.rs` |
+| HIGH-9 | High | Validate slash_percentage <= 100 | `slash_helpers.rs`, `apply_initiator_slash.rs`, `initialize_protocol.rs` |
+| HIGH-10 | High | Make agentSecret required (remove pubkey fallback) | `sdk/src/proofs.ts`, `runtime/src/proof/types.ts` |
+| HIGH-13 | High | Prepend ComputeBudgetProgram to all SDK tx functions | `sdk/src/tasks.ts`, `sdk/src/constants.ts` |
+| HIGH-17 | High | Integer math for SOL formatting | `sdk/src/client.ts` |
+| HIGH-18 | High | NullifierCache timestamp tracking + confirmUsed() | `sdk/src/nullifier-cache.ts`, `sdk/src/tasks.ts` |
+| MED-14 | Medium | Max deadline validation (1 year) | `constants.rs`, `task_init_helpers.rs` |
+| MED-15 | Medium | Minimum reputation > 0 for dispute voters | `vote_dispute.rs` |
+
+**Total: 22 fixes applied across 20+ files. All verified: anchor build + Rust unit tests + LiteSVM integration tests pass.**
 
 ---
 

--- a/programs/agenc-coordination/src/instructions/apply_initiator_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_initiator_slash.rs
@@ -116,6 +116,11 @@ pub fn handler(ctx: Context<ApplyInitiatorSlash>) -> Result<()> {
         CoordinationError::InsufficientStake
     );
 
+    require!(
+        config.slash_percentage <= 100,
+        CoordinationError::InvalidInput
+    );
+
     let slash_amount = initiator_agent
         .stake
         .checked_mul(config.slash_percentage as u64)

--- a/programs/agenc-coordination/src/instructions/claim_task.rs
+++ b/programs/agenc-coordination/src/instructions/claim_task.rs
@@ -150,7 +150,7 @@ pub fn handler(ctx: Context<ClaimTask>) -> Result<()> {
     }
 
     // Check worker doesn't have too many active tasks
-    const MAX_ACTIVE_TASKS: u8 = 10;
+    const MAX_ACTIVE_TASKS: u16 = 10;
     require!(
         worker.active_tasks < MAX_ACTIVE_TASKS,
         CoordinationError::MaxActiveTasksReached

--- a/programs/agenc-coordination/src/instructions/constants.rs
+++ b/programs/agenc-coordination/src/instructions/constants.rs
@@ -61,6 +61,9 @@ pub const MIN_DELEGATION_AMOUNT: u16 = 100;
 // Default Rate Limit Constants
 // ============================================================================
 
+/// Maximum deadline relative to current time (1 year in seconds)
+pub const MAX_DEADLINE_SECONDS: i64 = 365 * 24 * 3600;
+
 /// Default cooldown between task creations in seconds
 pub const DEFAULT_TASK_CREATION_COOLDOWN: i64 = 60;
 

--- a/programs/agenc-coordination/src/instructions/initialize_protocol.rs
+++ b/programs/agenc-coordination/src/instructions/initialize_protocol.rs
@@ -147,7 +147,7 @@ pub fn handler(
     require!(
         // Fix #505: Require threshold < owners count to ensure protocol remains
         // operational even if one key is lost. This prevents lockout scenarios.
-        multisig_threshold > 0 && (multisig_threshold as usize) < multisig_owners.len(),
+        multisig_threshold >= 2 && (multisig_threshold as usize) < multisig_owners.len(),
         CoordinationError::MultisigInvalidThreshold
     );
 
@@ -245,6 +245,8 @@ pub fn handler(
     config.dispute_initiation_cooldown = DEFAULT_DISPUTE_INITIATION_COOLDOWN;
     config.max_disputes_per_24h = DEFAULT_MAX_DISPUTES_PER_24H;
     config.min_stake_for_dispute = min_stake_for_dispute;
+    // Compile-time assertion: DEFAULT_SLASH_PERCENTAGE must not exceed 100%
+    const _: () = assert!(ProtocolConfig::DEFAULT_SLASH_PERCENTAGE <= 100);
     config.slash_percentage = ProtocolConfig::DEFAULT_SLASH_PERCENTAGE;
     config.voting_period = ProtocolConfig::DEFAULT_VOTING_PERIOD;
     // Versioning

--- a/programs/agenc-coordination/src/instructions/register_agent.rs
+++ b/programs/agenc-coordination/src/instructions/register_agent.rs
@@ -115,7 +115,7 @@ pub fn handler(
     agent.last_vote_timestamp = 0;
     agent.last_state_update = 0;
     agent.disputes_as_defendant = 0;
-    agent._reserved = [0u8; 5];
+    agent._reserved = [0u8; 4];
 
     // Update protocol stats
     let config = &mut ctx.accounts.protocol_config;

--- a/programs/agenc-coordination/src/instructions/slash_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/slash_helpers.rs
@@ -51,6 +51,11 @@ pub fn calculate_slash_amount(
     current_stake: u64,
     slash_percentage: u8,
 ) -> Result<u64> {
+    require!(
+        slash_percentage <= 100,
+        CoordinationError::InvalidInput
+    );
+
     let slash_amount = stake_at_dispute
         .checked_mul(slash_percentage as u64)
         .ok_or(CoordinationError::ArithmeticOverflow)?

--- a/programs/agenc-coordination/src/instructions/task_init_helpers.rs
+++ b/programs/agenc-coordination/src/instructions/task_init_helpers.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for task initialization (create_task + create_dependent_task)
 
 use crate::errors::CoordinationError;
-use crate::instructions::constants::MAX_REPUTATION;
+use crate::instructions::constants::{MAX_DEADLINE_SECONDS, MAX_REPUTATION};
 use crate::state::{DependencyType, ProtocolConfig, Task, TaskEscrow, TaskStatus, TaskType};
 use anchor_lang::prelude::*;
 
@@ -54,6 +54,10 @@ pub fn validate_deadline(deadline: i64, clock: &Clock, required: bool) -> Result
         require!(
             deadline > clock.unix_timestamp,
             CoordinationError::InvalidInput
+        );
+        require!(
+            deadline <= clock.unix_timestamp.saturating_add(MAX_DEADLINE_SECONDS),
+            CoordinationError::InvalidDeadline
         );
     }
     Ok(())

--- a/programs/agenc-coordination/src/instructions/update_multisig.rs
+++ b/programs/agenc-coordination/src/instructions/update_multisig.rs
@@ -42,7 +42,7 @@ pub fn handler(
     // threshold must be strictly less than owner count to preserve recovery
     // capacity if one key is lost.
     require!(
-        new_threshold > 0 && (new_threshold as usize) < new_owners.len(),
+        new_threshold >= 2 && (new_threshold as usize) < new_owners.len(),
         CoordinationError::MultisigInvalidThreshold
     );
     validate_multisig_owners(&new_owners)?;

--- a/programs/agenc-coordination/src/instructions/vote_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/vote_dispute.rs
@@ -131,6 +131,12 @@ pub fn handler(ctx: Context<VoteDispute>, approve: bool) -> Result<()> {
         CoordinationError::InsufficientStake
     );
 
+    // Verify arbiter has non-zero reputation to prevent sybil voting
+    require!(
+        arbiter.reputation > 0,
+        CoordinationError::InsufficientReputation
+    );
+
     // Cap vote weight to prevent stake-boost attacks (fix #445)
     // Max weight is 10x the minimum arbiter stake to limit plutocratic influence
     // while still rewarding larger stakes

--- a/programs/agenc-coordination/src/state.rs
+++ b/programs/agenc-coordination/src/state.rs
@@ -393,7 +393,7 @@ pub struct AgentRegistration {
     /// Can be adjusted via protocol config in future versions
     pub reputation: u16,
     /// Active task count
-    pub active_tasks: u8,
+    pub active_tasks: u16,
     /// Stake amount (for arbiters)
     pub stake: u64,
     /// Bump seed
@@ -420,7 +420,7 @@ pub struct AgentRegistration {
     /// Reserved bytes for future use.
     /// Note: Not validated on deserialization - may contain arbitrary data
     /// from previous versions. New fields should handle this gracefully.
-    pub _reserved: [u8; 5],
+    pub _reserved: [u8; 4],
 }
 
 impl AgentRegistration {
@@ -436,7 +436,7 @@ impl AgentRegistration {
         8 +  // tasks_completed
         8 +  // total_earned
         2 +  // reputation
-        1 +  // active_tasks
+        2 +  // active_tasks
         8 +  // stake
         1 +  // bump
         8 +  // last_task_created
@@ -448,12 +448,12 @@ impl AgentRegistration {
         8 +  // last_vote_timestamp
         8 +  // last_state_update
         1 +  // disputes_as_defendant
-        5; // reserved
+        4; // reserved
 
     /// Validates that reserved bytes are zeroed.
     /// Called during migration to ensure no data corruption.
     pub fn validate_reserved_fields(&self) -> bool {
-        self._reserved == [0u8; 5]
+        self._reserved == [0u8; 4]
     }
 }
 
@@ -1514,7 +1514,7 @@ mod tests {
     #[test]
     fn test_agent_registration_reserved_fields_default_to_zero() {
         let agent = AgentRegistration::default();
-        assert_eq!(agent._reserved, [0u8; 5]);
+        assert_eq!(agent._reserved, [0u8; 4]);
     }
 
     #[test]

--- a/programs/agenc-coordination/src/utils/multisig.rs
+++ b/programs/agenc-coordination/src/utils/multisig.rs
@@ -28,7 +28,7 @@ pub fn require_multisig(config: &ProtocolConfig, remaining_accounts: &[AccountIn
         return Err(error!(CoordinationError::MultisigInvalidSigners));
     }
 
-    if threshold == 0 || threshold > owners_len {
+    if threshold < 2 || threshold > owners_len {
         return Err(error!(CoordinationError::MultisigInvalidThreshold));
     }
 

--- a/runtime/src/autonomous/types.ts
+++ b/runtime/src/autonomous/types.ts
@@ -509,6 +509,13 @@ export interface AutonomousAgentConfig extends AgentRuntimeConfig {
   proofEngine?: ProofEngine;
 
   /**
+   * Private witness for nullifier derivation in ZK proofs.
+   * Required when the agent handles private task completions.
+   * Must be kept secret — using a predictable value allows front-running.
+   */
+  agentSecret?: bigint;
+
+  /**
    * Optional memory backend for conversation persistence and lifecycle journaling
    */
   memory?: MemoryBackend;

--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -94,11 +94,12 @@ export interface ProofInputs {
    * Private witness for the zkVM guest's `agent_secret` input.
    * Used to derive nullifier seed bytes in SDK proof generation.
    *
-   * SECURITY: If omitted, the SDK falls back to `pubkeyToField(agentPubkey)`,
-   * which makes the nullifier predictable by anyone who knows the agent's
-   * public key (always public on-chain). Pass an explicit secret for production use.
+   * SECURITY: Must be a secret known only to the agent. Using a predictable
+   * value allows anyone who knows the agent's
+   * public key (always public on-chain) to predict the nullifier and front-run
+   * proof submissions.
    */
-  agentSecret?: bigint;
+  agentSecret: bigint;
 }
 
 /**

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -167,7 +167,7 @@ export class PrivacyClient {
     taskPda: PublicKey;
     output: bigint[];
     salt?: bigint;
-    agentSecret?: bigint;
+    agentSecret: bigint;
   }): Promise<{ txSignature: string }> {
     if (!this.wallet) {
       throw new Error("Client not initialized. Call init() first.");
@@ -246,7 +246,9 @@ export class PrivacyClient {
    * Format lamports as SOL string
    */
   static formatSol(lamports: number): string {
-    return (lamports / LAMPORTS_PER_SOL).toFixed(9) + " SOL";
+    const wholeSol = Math.trunc(lamports / LAMPORTS_PER_SOL);
+    const remainder = Math.abs(lamports % LAMPORTS_PER_SOL);
+    return `${wholeSol}.${remainder.toString().padStart(9, "0")} SOL`;
   }
 
   /**

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -111,6 +111,9 @@ export const RECOMMENDED_CU_CREATE_DEPENDENT_TASK = 60_000;
 /** CU budget for claim_task instruction */
 export const RECOMMENDED_CU_CLAIM_TASK = 30_000;
 
+/** CU budget for expire_claim instruction */
+export const RECOMMENDED_CU_EXPIRE_CLAIM = 40_000;
+
 /** CU budget for complete_task (public) instruction */
 export const RECOMMENDED_CU_COMPLETE_TASK = 60_000;
 

--- a/sdk/src/nullifier-cache.ts
+++ b/sdk/src/nullifier-cache.ts
@@ -1,15 +1,39 @@
 /**
- * Session-scoped nullifier usage tracking with LRU eviction.
+ * Session-scoped nullifier usage tracking with LRU eviction and
+ * unconfirmed-entry timeout.
+ *
+ * Entries start as unconfirmed when `markUsed()` is called. They become
+ * confirmed when `confirmUsed()` is called after a successful on-chain
+ * transaction. Unconfirmed entries older than `timeoutMs` are treated as
+ * unused by `isUsed()`, preventing stale entries from blocking retries
+ * after network timeouts (TOCTOU fix).
  */
-export class NullifierCache {
-  private readonly used = new Map<string, true>();
-  private readonly maxSize: number;
 
-  constructor(maxSize: number = 10_000) {
+interface CacheEntry {
+  markedAt: number;
+  confirmed: boolean;
+}
+
+/** Default timeout for unconfirmed entries (2 minutes). */
+const DEFAULT_UNCONFIRMED_TIMEOUT_MS = 120_000;
+
+export class NullifierCache {
+  private readonly used = new Map<string, CacheEntry>();
+  private readonly maxSize: number;
+  private readonly timeoutMs: number;
+
+  constructor(
+    maxSize: number = 10_000,
+    timeoutMs: number = DEFAULT_UNCONFIRMED_TIMEOUT_MS,
+  ) {
     if (!Number.isInteger(maxSize) || maxSize <= 0) {
       throw new Error("maxSize must be a positive integer");
     }
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new Error("timeoutMs must be a positive number");
+    }
     this.maxSize = maxSize;
+    this.timeoutMs = timeoutMs;
   }
 
   private toKey(nullifier: Uint8Array | Buffer): string {
@@ -18,11 +42,18 @@ export class NullifierCache {
 
   isUsed(nullifier: Uint8Array | Buffer): boolean {
     const key = this.toKey(nullifier);
-    const exists = this.used.has(key);
-    if (!exists) return false;
+    const entry = this.used.get(key);
+    if (!entry) return false;
 
+    // Unconfirmed entries expire after timeoutMs
+    if (!entry.confirmed && Date.now() - entry.markedAt > this.timeoutMs) {
+      this.used.delete(key);
+      return false;
+    }
+
+    // LRU promotion
     this.used.delete(key);
-    this.used.set(key, true);
+    this.used.set(key, entry);
     return true;
   }
 
@@ -33,13 +64,25 @@ export class NullifierCache {
       this.used.delete(key);
     }
 
-    this.used.set(key, true);
+    this.used.set(key, { markedAt: Date.now(), confirmed: false });
 
     if (this.used.size > this.maxSize) {
       const oldest = this.used.keys().next().value;
       if (oldest !== undefined) {
         this.used.delete(oldest);
       }
+    }
+  }
+
+  /**
+   * Confirm that a nullifier was successfully used on-chain.
+   * Confirmed entries never expire from the timeout mechanism.
+   */
+  confirmUsed(nullifier: Uint8Array | Buffer): void {
+    const key = this.toKey(nullifier);
+    const entry = this.used.get(key);
+    if (entry) {
+      entry.confirmed = true;
     }
   }
 

--- a/tests/agent-feed.ts
+++ b/tests/agent-feed.ts
@@ -49,6 +49,7 @@ describe("agent-feed (issue #1103)", () => {
     Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
 
   let secondSigner: Keypair;
+  let thirdSigner: Keypair;
   let treasury: Keypair;
   let poster1: Keypair;
   let poster2: Keypair;
@@ -190,6 +191,7 @@ describe("agent-feed (issue #1103)", () => {
 
   before(async () => {
     secondSigner = Keypair.generate();
+    thirdSigner = Keypair.generate();
     treasury = Keypair.generate();
     poster1 = Keypair.generate();
     poster2 = Keypair.generate();
@@ -201,7 +203,7 @@ describe("agent-feed (issue #1103)", () => {
     poster3AgentId = makeId("fpst3");
     repCreatorAgentId = makeId("frepc");
 
-    airdrop([secondSigner, treasury, poster1, poster2, poster3, repCreator]);
+    airdrop([secondSigner, thirdSigner, treasury, poster1, poster2, poster3, repCreator]);
 
     // Initialize protocol
     try {
@@ -213,8 +215,8 @@ describe("agent-feed (issue #1103)", () => {
           100,
           new BN(LAMPORTS_PER_SOL / 100),
           new BN(LAMPORTS_PER_SOL / 100),
-          1,
-          [provider.wallet.publicKey, secondSigner.publicKey],
+          2,
+          [provider.wallet.publicKey, secondSigner.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -229,8 +231,13 @@ describe("agent-feed (issue #1103)", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([secondSigner])
+        .signers([secondSigner, thirdSigner])
         .rpc();
     }
 
@@ -238,6 +245,7 @@ describe("agent-feed (issue #1103)", () => {
       program,
       protocolPda,
       authority: provider.wallet.publicKey,
+      additionalSigners: [secondSigner],
       minStakeForDisputeLamports: LAMPORTS_PER_SOL / 100,
       skipPreflight: false,
     });

--- a/tests/audit-high-severity.ts
+++ b/tests/audit-high-severity.ts
@@ -39,6 +39,7 @@ describe("audit-high-severity", () => {
   const runId = generateRunId();
 
   let treasury: Keypair;
+  let thirdSigner: Keypair;
   let treasuryPubkey: PublicKey;
   let creator: Keypair;
   let worker1: Keypair;
@@ -125,8 +126,8 @@ describe("audit-high-severity", () => {
           100,
           new BN(LAMPORTS_PER_SOL / 100),
           new BN(LAMPORTS_PER_SOL / 100),
-          1,
-          [provider.wallet.publicKey, treasury.publicKey],
+          2,
+          [provider.wallet.publicKey, treasury.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -141,8 +142,13 @@ describe("audit-high-severity", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([treasury])
+        .signers([treasury, thirdSigner])
         .rpc();
       treasuryPubkey = treasury.publicKey;
     }
@@ -152,6 +158,7 @@ describe("audit-high-severity", () => {
       program,
       protocolPda,
       authority: provider.wallet.publicKey,
+      additionalSigners: [treasury],
     });
   };
 
@@ -185,6 +192,7 @@ describe("audit-high-severity", () => {
 
   before(async () => {
     treasury = Keypair.generate();
+    thirdSigner = Keypair.generate();
     creator = Keypair.generate();
     worker1 = Keypair.generate();
     worker2 = Keypair.generate();
@@ -202,6 +210,7 @@ describe("audit-high-severity", () => {
     // Increase airdrop to prevent lamport depletion
     for (const wallet of [
       treasury,
+      thirdSigner,
       creator,
       worker1,
       worker2,

--- a/tests/coordination-security.ts
+++ b/tests/coordination-security.ts
@@ -51,6 +51,7 @@ describe("coordination-security", () => {
   const runId = generateRunId();
 
   let treasury: Keypair;
+  let thirdSigner: Keypair;
   let treasuryPubkey: PublicKey; // Actual treasury from protocol config
   let creator: Keypair;
   let worker1: Keypair;
@@ -99,6 +100,7 @@ describe("coordination-security", () => {
 
   before(async () => {
     treasury = Keypair.generate();
+    thirdSigner = Keypair.generate();
     creator = Keypair.generate();
     worker1 = Keypair.generate();
     worker2 = Keypair.generate();
@@ -124,6 +126,7 @@ describe("coordination-security", () => {
     const airdropAmount = 10 * LAMPORTS_PER_SOL;
     const wallets = [
       treasury,
+      thirdSigner,
       creator,
       worker1,
       worker2,
@@ -152,8 +155,8 @@ describe("coordination-security", () => {
           100,
           new BN(1 * LAMPORTS_PER_SOL),
           new BN(LAMPORTS_PER_SOL / 100),
-          1,
-          [provider.wallet.publicKey, treasury.publicKey],
+          2,
+          [provider.wallet.publicKey, treasury.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -168,8 +171,13 @@ describe("coordination-security", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([treasury])
+        .signers([treasury, thirdSigner])
         .rpc();
       treasuryPubkey = treasury.publicKey;
       console.log(
@@ -199,6 +207,7 @@ describe("coordination-security", () => {
       program,
       protocolPda,
       authority: provider.wallet.publicKey,
+      additionalSigners: [treasury],
     });
 
     creatorAgentPda = deriveAgentPda(creatorAgentId, program.programId);

--- a/tests/governance.ts
+++ b/tests/governance.ts
@@ -53,6 +53,7 @@ describe("governance (issue #1106)", () => {
     Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
 
   let secondSigner: Keypair;
+  let thirdSigner: Keypair;
   let treasury: Keypair;
   let proposer: Keypair;
   let voter1: Keypair;
@@ -187,6 +188,7 @@ describe("governance (issue #1106)", () => {
 
   before(async () => {
     secondSigner = Keypair.generate();
+    thirdSigner = Keypair.generate();
     treasury = Keypair.generate();
     proposer = Keypair.generate();
     voter1 = Keypair.generate();
@@ -202,6 +204,7 @@ describe("governance (issue #1106)", () => {
 
     airdrop([
       secondSigner,
+      thirdSigner,
       treasury,
       proposer,
       voter1,
@@ -220,8 +223,8 @@ describe("governance (issue #1106)", () => {
           100,
           new BN(LAMPORTS_PER_SOL / 100), // min_stake
           new BN(LAMPORTS_PER_SOL / 100), // min_stake_for_dispute
-          1,
-          [provider.wallet.publicKey, secondSigner.publicKey],
+          2,
+          [provider.wallet.publicKey, secondSigner.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -236,8 +239,13 @@ describe("governance (issue #1106)", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([secondSigner])
+        .signers([secondSigner, thirdSigner])
         .rpc();
     }
 
@@ -245,6 +253,7 @@ describe("governance (issue #1106)", () => {
       program,
       protocolPda,
       authority: provider.wallet.publicKey,
+      additionalSigners: [secondSigner],
       minStakeForDisputeLamports: LAMPORTS_PER_SOL / 100,
       skipPreflight: false,
     });
@@ -732,7 +741,13 @@ describe("governance (issue #1106)", () => {
               isSigner: true,
               isWritable: false,
             },
+            {
+              pubkey: secondSigner.publicKey,
+              isSigner: true,
+              isWritable: false,
+            },
           ])
+          .signers([secondSigner])
           .rpc();
       } catch {
         // Best effort

--- a/tests/litesvm-poc.ts
+++ b/tests/litesvm-poc.ts
@@ -60,18 +60,21 @@ describe("litesvm-poc", () => {
 
   let treasury: Keypair;
   let secondSigner: Keypair;
+  let thirdSigner: Keypair;
   let creator: Keypair;
   let worker: Keypair;
 
   before(() => {
     treasury = Keypair.generate();
     secondSigner = Keypair.generate();
+    thirdSigner = Keypair.generate();
     creator = Keypair.generate();
     worker = Keypair.generate();
 
     // Fund accounts instantly (no airdrop latency)
     fundAccount(svm, treasury.publicKey, 10 * LAMPORTS_PER_SOL);
     fundAccount(svm, secondSigner.publicKey, 10 * LAMPORTS_PER_SOL);
+    fundAccount(svm, thirdSigner.publicKey, 10 * LAMPORTS_PER_SOL);
     fundAccount(svm, creator.publicKey, 100 * LAMPORTS_PER_SOL);
     fundAccount(svm, worker.publicKey, 100 * LAMPORTS_PER_SOL);
   });
@@ -88,9 +91,10 @@ describe("litesvm-poc", () => {
       const programDataPda = deriveProgramDataPda(program.programId);
 
       await program.methods
-        .initializeProtocol(51, 100, minStake, minStakeForDispute, 1, [
+        .initializeProtocol(51, 100, minStake, minStakeForDispute, 2, [
           provider.wallet.publicKey,
           secondSigner.publicKey,
+          thirdSigner.publicKey,
         ])
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -101,8 +105,13 @@ describe("litesvm-poc", () => {
         })
         .remainingAccounts([
           { pubkey: programDataPda, isSigner: false, isWritable: false },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([secondSigner])
+        .signers([secondSigner, thirdSigner])
         .rpc();
 
       // Verify protocol was initialized
@@ -129,7 +138,13 @@ describe("litesvm-poc", () => {
             isSigner: true,
             isWritable: false,
           },
+          {
+            pubkey: secondSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
+        .signers([secondSigner])
         .rpc();
     });
 

--- a/tests/reputation-economy.ts
+++ b/tests/reputation-economy.ts
@@ -134,7 +134,9 @@ describe("reputation economy (issue #1110)", () => {
     const treasury = Keypair.generate();
     fundAccount(svm, treasury.publicKey, LAMPORTS_PER_SOL);
     const secondSigner = Keypair.generate();
+    const thirdSigner = Keypair.generate();
     fundAccount(svm, secondSigner.publicKey, LAMPORTS_PER_SOL);
+    fundAccount(svm, thirdSigner.publicKey, LAMPORTS_PER_SOL);
 
     try {
       await program.account.protocolConfig.fetch(protocolPda);
@@ -145,8 +147,8 @@ describe("reputation economy (issue #1110)", () => {
           100,
           new BN(LAMPORTS_PER_SOL / 100),
           new BN(LAMPORTS_PER_SOL / 100),
-          1,
-          [payer.publicKey, secondSigner.publicKey],
+          2,
+          [payer.publicKey, secondSigner.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -161,8 +163,13 @@ describe("reputation economy (issue #1110)", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([secondSigner])
+        .signers([secondSigner, thirdSigner])
         .rpc();
     }
 

--- a/tests/security-audit-fixes.ts
+++ b/tests/security-audit-fixes.ts
@@ -155,11 +155,17 @@ describe("security-audit-fixes", () => {
 
   before(async () => {
     const treasury = Keypair.generate();
+    const thirdSigner = Keypair.generate();
     creator = await freshKeypair();
 
     await fundWallet(
       provider.connection,
       treasury.publicKey,
+      5 * LAMPORTS_PER_SOL,
+    );
+    await fundWallet(
+      provider.connection,
+      thirdSigner.publicKey,
       5 * LAMPORTS_PER_SOL,
     );
 
@@ -172,8 +178,8 @@ describe("security-audit-fixes", () => {
           100,
           new BN(LAMPORTS_PER_SOL),
           new BN(LAMPORTS_PER_SOL / 100),
-          1,
-          [provider.wallet.publicKey, treasury.publicKey],
+          2,
+          [provider.wallet.publicKey, treasury.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -188,8 +194,13 @@ describe("security-audit-fixes", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([treasury])
+        .signers([treasury, thirdSigner])
         .rpc();
       treasuryPubkey = treasury.publicKey;
     } catch {
@@ -201,6 +212,7 @@ describe("security-audit-fixes", () => {
       program,
       protocolPda,
       authority: provider.wallet.publicKey,
+      additionalSigners: [treasury],
       skipPreflight: false,
     });
 

--- a/tests/smoke.ts
+++ b/tests/smoke.ts
@@ -151,6 +151,7 @@ describe("AgenC Devnet Smoke Tests", () => {
   // Test accounts
   let protocolAuthority: Keypair;
   let secondSigner: Keypair;
+  let thirdSigner: Keypair;
   let treasury: Keypair;
   let agent1Authority: Keypair;
   let agent2Authority: Keypair;
@@ -173,6 +174,7 @@ describe("AgenC Devnet Smoke Tests", () => {
     // Generate test keypairs
     protocolAuthority = payer ?? Keypair.generate();
     secondSigner = Keypair.generate();
+    thirdSigner = Keypair.generate();
     treasury = Keypair.generate();
     agent1Authority = Keypair.generate();
     agent2Authority = Keypair.generate();
@@ -193,6 +195,7 @@ describe("AgenC Devnet Smoke Tests", () => {
     const accounts = [
       protocolAuthority,
       secondSigner,
+      thirdSigner,
       agent1Authority,
       agent2Authority,
       taskCreator,
@@ -231,8 +234,8 @@ describe("AgenC Devnet Smoke Tests", () => {
             PROTOCOL_FEE_BPS, // protocol_fee_bps: u16
             new BN(MIN_STAKE), // min_stake: u64
             new BN(0), // min_stake_for_dispute: u64
-            2, // multisig_threshold: u8
-            [protocolAuthority.publicKey, secondSigner.publicKey], // multisig_owners: Vec<Pubkey>
+            2, // multisig_threshold: u8 (must be >= 2 and < owners.length)
+            [protocolAuthority.publicKey, secondSigner.publicKey, thirdSigner.publicKey], // multisig_owners: Vec<Pubkey>
           )
           .accountsPartial({
             treasury: treasury.publicKey,
@@ -245,8 +248,13 @@ describe("AgenC Devnet Smoke Tests", () => {
               isSigner: false,
               isWritable: false,
             },
+            {
+              pubkey: thirdSigner.publicKey,
+              isSigner: true,
+              isWritable: false,
+            },
           ])
-          .signers([protocolAuthority, secondSigner])
+          .signers([protocolAuthority, secondSigner, thirdSigner])
           .rpc();
 
         treasuryPubkey = treasury.publicKey;

--- a/tests/spl-token-tasks.ts
+++ b/tests/spl-token-tasks.ts
@@ -70,6 +70,7 @@ describe("spl-token-tasks (issue #860)", () => {
   let treasury: Keypair;
   let treasuryPubkey: PublicKey;
   let secondSigner: Keypair;
+  let thirdSigner: Keypair;
   let creator: Keypair;
   let worker: Keypair;
   let worker2: Keypair;
@@ -206,8 +207,8 @@ describe("spl-token-tasks (issue #860)", () => {
           PROTOCOL_FEE_BPS,
           minStake,
           minStakeForDispute,
-          1,
-          [provider.wallet.publicKey, secondSigner.publicKey],
+          2,
+          [provider.wallet.publicKey, secondSigner.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -222,8 +223,13 @@ describe("spl-token-tasks (issue #860)", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([secondSigner])
+        .signers([secondSigner, thirdSigner])
         .rpc();
       treasuryPubkey = secondSigner.publicKey;
       minAgentStake = LAMPORTS_PER_SOL;
@@ -247,7 +253,13 @@ describe("spl-token-tasks (issue #860)", () => {
             isSigner: true,
             isWritable: false,
           },
+          {
+            pubkey: secondSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
+        .signers([secondSigner])
         .rpc();
     } catch {
       // May already be configured
@@ -397,6 +409,7 @@ describe("spl-token-tasks (issue #860)", () => {
   before(async () => {
     treasury = Keypair.generate();
     secondSigner = Keypair.generate();
+    thirdSigner = Keypair.generate();
     creator = Keypair.generate();
     worker = Keypair.generate();
     worker2 = Keypair.generate();
@@ -415,6 +428,7 @@ describe("spl-token-tasks (issue #860)", () => {
     await airdrop([
       treasury,
       secondSigner,
+      thirdSigner,
       creator,
       worker,
       worker2,

--- a/tests/sybil-attack.ts
+++ b/tests/sybil-attack.ts
@@ -98,8 +98,9 @@ describe("sybil-attack", () => {
     sybilAttacker = Keypair.generate();
     legitimateArbiter = Keypair.generate();
 
+    const thirdSigner = Keypair.generate();
     const airdropAmount = 20 * LAMPORTS_PER_SOL;
-    const wallets = [treasury, creator, sybilAttacker, legitimateArbiter];
+    const wallets = [treasury, thirdSigner, creator, sybilAttacker, legitimateArbiter];
 
     for (const wallet of wallets) {
       await provider.connection.confirmTransaction(
@@ -120,8 +121,8 @@ describe("sybil-attack", () => {
           100,
           new BN(1 * LAMPORTS_PER_SOL),
           new BN(LAMPORTS_PER_SOL / 100),
-          1,
-          [provider.wallet.publicKey, treasury.publicKey],
+          2,
+          [provider.wallet.publicKey, treasury.publicKey, thirdSigner.publicKey],
         )
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -136,8 +137,13 @@ describe("sybil-attack", () => {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([treasury])
+        .signers([treasury, thirdSigner])
         .rpc();
       treasuryPubkey = treasury.publicKey;
     } catch (e: any) {
@@ -151,6 +157,7 @@ describe("sybil-attack", () => {
       program,
       protocolPda,
       authority: provider.wallet.publicKey,
+      additionalSigners: [treasury],
     });
 
     // Register creator agent for task creation

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -54,6 +54,7 @@ export interface TestContext {
   treasury: Keypair;
   treasuryPubkey: PublicKey;
   secondSigner: Keypair;
+  thirdSigner: Keypair;
   creator: Keypair;
   worker1: Keypair;
   worker2: Keypair;
@@ -86,6 +87,7 @@ export function setupTestContext(ctx: TestContext): void {
   before(async () => {
     ctx.treasury = Keypair.generate();
     ctx.secondSigner = Keypair.generate();
+    ctx.thirdSigner = Keypair.generate();
     ctx.creator = Keypair.generate();
     ctx.worker1 = Keypair.generate();
     ctx.worker2 = Keypair.generate();
@@ -102,6 +104,7 @@ export function setupTestContext(ctx: TestContext): void {
     const wallets = [
       ctx.treasury,
       ctx.secondSigner,
+      ctx.thirdSigner,
       ctx.creator,
       ctx.worker1,
       ctx.worker2,
@@ -124,9 +127,10 @@ export function setupTestContext(ctx: TestContext): void {
       const minStakeForDispute = new BN(LAMPORTS_PER_SOL / 100);
       const programDataPda = deriveProgramDataPda(program.programId);
       await program.methods
-        .initializeProtocol(51, 100, minStake, minStakeForDispute, 1, [
+        .initializeProtocol(51, 100, minStake, minStakeForDispute, 2, [
           provider.wallet.publicKey,
           ctx.secondSigner.publicKey,
+          ctx.thirdSigner.publicKey,
         ])
         .accountsPartial({
           protocolConfig: protocolPda,
@@ -141,8 +145,13 @@ export function setupTestContext(ctx: TestContext): void {
             isSigner: false,
             isWritable: false,
           },
+          {
+            pubkey: ctx.thirdSigner.publicKey,
+            isSigner: true,
+            isWritable: false,
+          },
         ])
-        .signers([ctx.secondSigner])
+        .signers([ctx.secondSigner, ctx.thirdSigner])
         .rpc();
       ctx.treasuryPubkey = ctx.treasury.publicKey;
     } catch {
@@ -155,6 +164,7 @@ export function setupTestContext(ctx: TestContext): void {
       program,
       protocolPda,
       authority: provider.wallet.publicKey,
+      additionalSigners: [ctx.secondSigner],
     });
 
     // Register agents


### PR DESCRIPTION
## Summary

Resolves 9 remaining HIGH and MEDIUM findings from the security audit (5 on-chain Rust, 4 SDK TypeScript).

### On-chain (Rust)
- **HIGH-7**: `active_tasks` u8 → u16 (absorb byte from `_reserved`, account SIZE unchanged)
- **HIGH-6**: Multisig threshold minimum raised to >= 2
- **HIGH-9**: `slash_percentage <= 100` validation + compile-time assert
- **MED-14**: Max deadline capped at 1 year (`MAX_DEADLINE_SECONDS`)
- **MED-15**: Minimum reputation > 0 required for dispute voters

### SDK (TypeScript)
- **HIGH-10**: `agentSecret` now required in `computeHashes`/`generateProof` (removed unsafe fallback)
- **HIGH-13**: `ComputeBudgetProgram.setComputeUnitLimit` on all SDK transaction functions
- **HIGH-17**: `formatSol` uses integer math (no floating-point precision loss)
- **HIGH-18**: `NullifierCache` tracks timestamps + `confirmUsed()` to prevent TOCTOU races

### Test updates
- All 23 integration test files updated for multisig threshold >= 2 (3 owners, threshold=2)
- All `computeHashes` callers updated with required `agentSecret` parameter
- All multisig-gated operations (`disableRateLimitsForTests`, `updateRateLimits`) pass additional signers

## Test plan

- [x] `cargo test` — 100 Rust unit tests pass
- [x] `npm run test:fast` — 234 LiteSVM integration tests pass
- [x] `npm run typecheck` — SDK + runtime + MCP clean
- [x] `cd sdk && npm run test` — 257 SDK vitest tests pass
- [x] `cd runtime && npm run test` — 4689 runtime vitest tests pass