### PR TITLE
fix(security): hardening phase 3 — resolve 12 audit findings

### DIFF
--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -1,578 +1,54 @@
 {
-  "accounts": [
-    {
-      "discriminator": [
-        130,
-        53,
-        100,
-        103,
-        121,
-        77,
-        148,
-        19
-      ],
-      "name": "AgentRegistration"
-    },
-    {
-      "discriminator": [
-        11,
-        232,
-        15,
-        241,
-        234,
-        143,
-        35,
-        252
-      ],
-      "name": "CoordinationState"
-    },
-    {
-      "discriminator": [
-        36,
-        49,
-        241,
-        67,
-        40,
-        36,
-        241,
-        74
-      ],
-      "name": "Dispute"
-    },
-    {
-      "discriminator": [
-        166,
-        202,
-        140,
-        76,
-        65,
-        35,
-        254,
-        149
-      ],
-      "name": "DisputeVote"
-    },
-    {
-      "discriminator": [
-        207,
-        91,
-        250,
-        28,
-        152,
-        179,
-        215,
-        209
-      ],
-      "name": "ProtocolConfig"
-    },
-    {
-      "discriminator": [
-        79,
-        34,
-        229,
-        55,
-        88,
-        90,
-        55,
-        84
-      ],
-      "name": "Task"
-    },
-    {
-      "discriminator": [
-        115,
-        77,
-        242,
-        98,
-        7,
-        81,
-        209,
-        137
-      ],
-      "name": "TaskClaim"
-    },
-    {
-      "discriminator": [
-        209,
-        72,
-        197,
-        54,
-        17,
-        55,
-        3,
-        187
-      ],
-      "name": "TaskEscrow"
-    }
-  ],
-  "address": "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ",
-  "errors": [
-    {
-      "code": 6000,
-      "msg": "Agent is already registered",
-      "name": "AgentAlreadyRegistered"
-    },
-    {
-      "code": 6001,
-      "msg": "Agent not found",
-      "name": "AgentNotFound"
-    },
-    {
-      "code": 6002,
-      "msg": "Agent is not active",
-      "name": "AgentNotActive"
-    },
-    {
-      "code": 6003,
-      "msg": "Agent has insufficient capabilities",
-      "name": "InsufficientCapabilities"
-    },
-    {
-      "code": 6004,
-      "msg": "Agent has reached maximum active tasks",
-      "name": "MaxActiveTasksReached"
-    },
-    {
-      "code": 6005,
-      "msg": "Agent has active tasks and cannot be deregistered",
-      "name": "AgentHasActiveTasks"
-    },
-    {
-      "code": 6006,
-      "msg": "Only the agent authority can perform this action",
-      "name": "UnauthorizedAgent"
-    },
-    {
-      "code": 6007,
-      "msg": "Task not found",
-      "name": "TaskNotFound"
-    },
-    {
-      "code": 6008,
-      "msg": "Task is not open for claims",
-      "name": "TaskNotOpen"
-    },
-    {
-      "code": 6009,
-      "msg": "Task has reached maximum workers",
-      "name": "TaskFullyClaimed"
-    },
-    {
-      "code": 6010,
-      "msg": "Task has expired",
-      "name": "TaskExpired"
-    },
-    {
-      "code": 6011,
-      "msg": "Task deadline has not passed",
-      "name": "TaskNotExpired"
-    },
-    {
-      "code": 6012,
-      "msg": "Task is not in progress",
-      "name": "TaskNotInProgress"
-    },
-    {
-      "code": 6013,
-      "msg": "Task is already completed",
-      "name": "TaskAlreadyCompleted"
-    },
-    {
-      "code": 6014,
-      "msg": "Task cannot be cancelled",
-      "name": "TaskCannotBeCancelled"
-    },
-    {
-      "code": 6015,
-      "msg": "Only the task creator can perform this action",
-      "name": "UnauthorizedTaskAction"
-    },
-    {
-      "code": 6016,
-      "msg": "Invalid task type",
-      "name": "InvalidTaskType"
-    },
-    {
-      "code": 6017,
-      "msg": "Task has no workers",
-      "name": "NoWorkers"
-    },
-    {
-      "code": 6018,
-      "msg": "Worker has already claimed this task",
-      "name": "AlreadyClaimed"
-    },
-    {
-      "code": 6019,
-      "msg": "Worker has not claimed this task",
-      "name": "NotClaimed"
-    },
-    {
-      "code": 6020,
-      "msg": "Claim has already been completed",
-      "name": "ClaimAlreadyCompleted"
-    },
-    {
-      "code": 6021,
-      "msg": "Invalid proof of work",
-      "name": "InvalidProof"
-    },
-    {
-      "code": 6022,
-      "msg": "Dispute is not active",
-      "name": "DisputeNotActive"
-    },
-    {
-      "code": 6023,
-      "msg": "Voting period has ended",
-      "name": "VotingEnded"
-    },
-    {
-      "code": 6024,
-      "msg": "Voting period has not ended",
-      "name": "VotingNotEnded"
-    },
-    {
-      "code": 6025,
-      "msg": "Already voted on this dispute",
-      "name": "AlreadyVoted"
-    },
-    {
-      "code": 6026,
-      "msg": "Not authorized to vote (not an arbiter)",
-      "name": "NotArbiter"
-    },
-    {
-      "code": 6027,
-      "msg": "Insufficient votes to resolve",
-      "name": "InsufficientVotes"
-    },
-    {
-      "code": 6028,
-      "msg": "Dispute has already been resolved",
-      "name": "DisputeAlreadyResolved"
-    },
-    {
-      "code": 6029,
-      "msg": "State version mismatch (concurrent modification)",
-      "name": "VersionMismatch"
-    },
-    {
-      "code": 6030,
-      "msg": "State key already exists",
-      "name": "StateKeyExists"
-    },
-    {
-      "code": 6031,
-      "msg": "State not found",
-      "name": "StateNotFound"
-    },
-    {
-      "code": 6032,
-      "msg": "Protocol is already initialized",
-      "name": "ProtocolAlreadyInitialized"
-    },
-    {
-      "code": 6033,
-      "msg": "Protocol is not initialized",
-      "name": "ProtocolNotInitialized"
-    },
-    {
-      "code": 6034,
-      "msg": "Invalid protocol fee (must be <= 1000 bps)",
-      "name": "InvalidProtocolFee"
-    },
-    {
-      "code": 6035,
-      "msg": "Invalid dispute threshold",
-      "name": "InvalidDisputeThreshold"
-    },
-    {
-      "code": 6036,
-      "msg": "Insufficient stake for arbiter registration",
-      "name": "InsufficientStake"
-    },
-    {
-      "code": 6037,
-      "msg": "Invalid input parameter",
-      "name": "InvalidInput"
-    },
-    {
-      "code": 6038,
-      "msg": "Arithmetic overflow",
-      "name": "ArithmeticOverflow"
-    },
-    {
-      "code": 6039,
-      "msg": "Insufficient funds",
-      "name": "InsufficientFunds"
-    },
-    {
-      "code": 6040,
-      "msg": "Account data is corrupted",
-      "name": "CorruptedData"
-    },
-    {
-      "code": 6041,
-      "msg": "String too long",
-      "name": "StringTooLong"
-    }
-  ],
-  "events": [
-    {
-      "discriminator": [
-        132,
-        69,
-        246,
-        19,
-        135,
-        65,
-        28,
-        134
-      ],
-      "name": "AgentDeregistered"
-    },
-    {
-      "discriminator": [
-        191,
-        78,
-        217,
-        54,
-        232,
-        100,
-        189,
-        85
-      ],
-      "name": "AgentRegistered"
-    },
-    {
-      "discriminator": [
-        210,
-        179,
-        162,
-        250,
-        123,
-        250,
-        210,
-        166
-      ],
-      "name": "AgentUpdated"
-    },
-    {
-      "discriminator": [
-        150,
-        109,
-        93,
-        252,
-        198,
-        4,
-        183,
-        153
-      ],
-      "name": "DisputeInitiated"
-    },
-    {
-      "discriminator": [
-        121,
-        64,
-        249,
-        153,
-        139,
-        128,
-        236,
-        187
-      ],
-      "name": "DisputeResolved"
-    },
-    {
-      "discriminator": [
-        193,
-        34,
-        94,
-        69,
-        4,
-        179,
-        143,
-        87
-      ],
-      "name": "DisputeVoteCast"
-    },
-    {
-      "discriminator": [
-        173,
-        122,
-        168,
-        254,
-        9,
-        118,
-        76,
-        132
-      ],
-      "name": "ProtocolInitialized"
-    },
-    {
-      "discriminator": [
-        36,
-        65,
-        223,
-        38,
-        136,
-        162,
-        10,
-        30
-      ],
-      "name": "RewardDistributed"
-    },
-    {
-      "discriminator": [
-        187,
-        220,
-        147,
-        37,
-        52,
-        210,
-        78,
-        173
-      ],
-      "name": "StateUpdated"
-    },
-    {
-      "discriminator": [
-        158,
-        101,
-        220,
-        187,
-        16,
-        141,
-        141,
-        64
-      ],
-      "name": "TaskCancelled"
-    },
-    {
-      "discriminator": [
-        208,
-        90,
-        243,
-        116,
-        80,
-        15,
-        228,
-        202
-      ],
-      "name": "TaskClaimed"
-    },
-    {
-      "discriminator": [
-        132,
-        223,
-        98,
-        152,
-        2,
-        9,
-        57,
-        128
-      ],
-      "name": "TaskCompleted"
-    },
-    {
-      "discriminator": [
-        49,
-        174,
-        6,
-        7,
-        71,
-        159,
-        69,
-        175
-      ],
-      "name": "TaskCreated"
-    }
-  ],
+  "address": "5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7",
+  "metadata": {
+    "name": "agenc_coordination",
+    "version": "0.1.0",
+    "spec": "0.1.0",
+    "description": "AgenC Decentralized Agent Coordination Protocol for Solana",
+    "repository": "https://github.com/tetsuo-ai/AgenC"
+  },
   "instructions": [
     {
-      "accounts": [
-        {
-          "name": "task",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  116,
-                  97,
-                  115,
-                  107
-                ]
-              },
-              {
-                "account": "Task",
-                "kind": "account",
-                "path": "task.creator"
-              },
-              {
-                "account": "Task",
-                "kind": "account",
-                "path": "task.task_id"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "escrow",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  101,
-                  115,
-                  99,
-                  114,
-                  111,
-                  119
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "task"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "creator",
-          "relations": [
-            "task"
-          ],
-          "signer": true,
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [],
-      "discriminator": [
-        69,
-        228,
-        134,
-        187,
-        134,
-        105,
-        238,
-        48
-      ],
+      "name": "apply_dispute_slash",
       "docs": [
-        "Cancel an unclaimed or expired task and reclaim funds."
+        "Apply slashing to a worker after losing a dispute."
       ],
-      "name": "cancel_task"
-    },
-    {
+      "discriminator": [
+        195,
+        168,
+        20,
+        83,
+        250,
+        122,
+        11,
+        187
+      ],
       "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
         {
           "name": "task",
           "pda": {
@@ -587,21 +63,20 @@
                 ]
               },
               {
-                "account": "Task",
                 "kind": "account",
-                "path": "task.creator"
+                "path": "task.creator",
+                "account": "Task"
               },
               {
-                "account": "Task",
                 "kind": "account",
-                "path": "task.task_id"
+                "path": "task.task_id",
+                "account": "Task"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
-          "name": "claim",
+          "name": "worker_claim",
           "pda": {
             "seeds": [
               {
@@ -620,14 +95,15 @@
               },
               {
                 "kind": "account",
-                "path": "worker"
+                "path": "worker_claim.worker",
+                "account": "TaskClaim"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
-          "name": "worker",
+          "name": "worker_agent",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -641,144 +117,12 @@
                 ]
               },
               {
-                "account": "AgentRegistration",
                 "kind": "account",
-                "path": "worker.agent_id"
+                "path": "worker_agent.agent_id",
+                "account": "AgentRegistration"
               }
             ]
-          },
-          "writable": true
-        },
-        {
-          "name": "authority",
-          "relations": [
-            "worker"
-          ],
-          "signer": true,
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
-        }
-      ],
-      "args": [],
-      "discriminator": [
-        49,
-        222,
-        219,
-        238,
-        155,
-        68,
-        221,
-        136
-      ],
-      "docs": [
-        "Claim a task to signal intent to work on it.",
-        "Agent must have required capabilities and task must be claimable."
-      ],
-      "name": "claim_task"
-    },
-    {
-      "accounts": [
-        {
-          "name": "task",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  116,
-                  97,
-                  115,
-                  107
-                ]
-              },
-              {
-                "account": "Task",
-                "kind": "account",
-                "path": "task.creator"
-              },
-              {
-                "account": "Task",
-                "kind": "account",
-                "path": "task.task_id"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "claim",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  99,
-                  108,
-                  97,
-                  105,
-                  109
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "task"
-              },
-              {
-                "kind": "account",
-                "path": "worker"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "escrow",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  101,
-                  115,
-                  99,
-                  114,
-                  111,
-                  119
-                ]
-              },
-              {
-                "kind": "account",
-                "path": "task"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "worker",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  97,
-                  103,
-                  101,
-                  110,
-                  116
-                ]
-              },
-              {
-                "account": "AgentRegistration",
-                "kind": "account",
-                "path": "worker.agent_id"
-              }
-            ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "protocol_config",
@@ -798,8 +142,724 @@
                 ]
               }
             ]
-          },
+          }
+        },
+        {
+          "name": "treasury",
           "writable": true
+        },
+        {
+          "name": "escrow",
+          "docs": [
+            "Escrow PDA for the disputed task (kept open until slash for token disputes)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding deferred slash amount"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury token ATA receiving slashed tokens"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL mint for task rewards (must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "apply_initiator_slash",
+      "docs": [
+        "Apply slashing to a dispute initiator when their dispute is rejected.",
+        "This provides symmetric slashing: workers are slashed for bad work,",
+        "initiators are slashed for frivolous disputes."
+      ],
+      "discriminator": [
+        63,
+        59,
+        40,
+        189,
+        124,
+        61,
+        159,
+        168
+      ],
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task being disputed - validates initiator was a participant"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "initiator_agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "initiator_agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "treasury",
+          "writable": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "cancel_dispute",
+      "docs": [
+        "Cancel a dispute before any votes are cast.",
+        "Only the dispute initiator can cancel, and only if no arbiter has voted yet."
+      ],
+      "discriminator": [
+        23,
+        155,
+        220,
+        94,
+        76,
+        141,
+        231,
+        124
+      ],
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "Only the initiator's authority can cancel"
+          ],
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "cancel_proposal",
+      "docs": [
+        "Cancel a governance proposal before any votes are cast.",
+        "Only the proposer's authority can cancel."
+      ],
+      "discriminator": [
+        106,
+        74,
+        128,
+        146,
+        19,
+        65,
+        39,
+        23
+      ],
+      "accounts": [
+        {
+          "name": "proposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal.proposer",
+                "account": "Proposal"
+              },
+              {
+                "kind": "account",
+                "path": "proposal.nonce",
+                "account": "Proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "cancel_task",
+      "docs": [
+        "Cancel an unclaimed or expired task and reclaim funds."
+      ],
+      "discriminator": [
+        69,
+        228,
+        134,
+        187,
+        134,
+        105,
+        238,
+        48
+      ],
+      "accounts": [
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "task"
+          ]
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account to receive refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "claim_task",
+      "docs": [
+        "Claim a task to signal intent to work on it.",
+        "Agent must have required capabilities and task must be claimable."
+      ],
+      "discriminator": [
+        49,
+        222,
+        219,
+        238,
+        155,
+        68,
+        221,
+        136
+      ],
+      "accounts": [
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "claim",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "worker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "worker.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "worker"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "complete_task",
+      "docs": [
+        "Submit proof of work and mark task portion as complete.",
+        "For collaborative tasks, multiple completions may be needed.",
+        "",
+        "# Arguments",
+        "* `ctx` - Context with task, worker claim, and reward accounts",
+        "* `proof_hash` - 32-byte hash of the proof of work",
+        "* `result_data` - Optional result data or pointer"
+      ],
+      "discriminator": [
+        109,
+        167,
+        192,
+        41,
+        129,
+        108,
+        220,
+        196
+      ],
+      "accounts": [
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "claim",
+          "docs": [
+            "Note: Claim account is closed after completion.",
+            "If proof-of-completion is needed later, store result_hash",
+            "in an event or separate completion record."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "docs": [
+            "Note: Escrow account is closed conditionally after the final completion.",
+            "For collaborative tasks with multiple workers, it stays open until all complete."
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "worker.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "treasury",
@@ -807,15 +867,54 @@
         },
         {
           "name": "authority",
+          "writable": true,
+          "signer": true,
           "relations": [
             "worker"
-          ],
-          "signer": true,
-          "writable": true
+          ]
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account",
+          "docs": [
+            "Worker's token account to receive reward (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury's token account for protocol fees (optional, must pre-exist)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
       "args": [
@@ -839,32 +938,425 @@
             }
           }
         }
-      ],
-      "discriminator": [
-        109,
-        167,
-        192,
-        41,
-        129,
-        108,
-        220,
-        196
-      ],
-      "docs": [
-        "Submit proof of work and mark task portion as complete.",
-        "For collaborative tasks, multiple completions may be needed.",
-        "",
-        "# Arguments",
-        "* `ctx` - Context with task, worker claim, and reward accounts",
-        "* `proof_hash` - 32-byte hash of the proof of work",
-        "* `result_data` - Optional result data or pointer"
-      ],
-      "name": "complete_task"
+      ]
     },
     {
+      "name": "complete_task_private",
+      "docs": [
+        "Complete a task with private proof verification."
+      ],
+      "discriminator": [
+        117,
+        181,
+        96,
+        96,
+        194,
+        254,
+        58,
+        35
+      ],
       "accounts": [
         {
           "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "claim",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "writable": true
+        },
+        {
+          "name": "worker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "worker.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "binding_spend",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  98,
+                  105,
+                  110,
+                  100,
+                  105,
+                  110,
+                  103,
+                  95,
+                  115,
+                  112,
+                  101,
+                  110,
+                  100
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "proof.binding_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "nullifier_spend",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  110,
+                  117,
+                  108,
+                  108,
+                  105,
+                  102,
+                  105,
+                  101,
+                  114,
+                  95,
+                  115,
+                  112,
+                  101,
+                  110,
+                  100
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "proof.nullifier_seed"
+              }
+            ]
+          }
+        },
+        {
+          "name": "treasury",
+          "writable": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "worker"
+          ]
+        },
+        {
+          "name": "router_program"
+        },
+        {
+          "name": "router",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  111,
+                  117,
+                  116,
+                  101,
+                  114
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                78,
+                225,
+                133,
+                125,
+                40,
+                66,
+                77,
+                214,
+                9,
+                252,
+                64,
+                53,
+                108,
+                230,
+                117,
+                158,
+                173,
+                73,
+                175,
+                167,
+                6,
+                101,
+                14,
+                54,
+                1,
+                226,
+                70,
+                97,
+                85,
+                205,
+                10,
+                148
+              ]
+            }
+          }
+        },
+        {
+          "name": "verifier_entry",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  101,
+                  114,
+                  105,
+                  102,
+                  105,
+                  101,
+                  114
+                ]
+              },
+              {
+                "kind": "const",
+                "value": [
+                  82,
+                  90,
+                  86,
+                  77
+                ]
+              }
+            ],
+            "program": {
+              "kind": "const",
+              "value": [
+                78,
+                225,
+                133,
+                125,
+                40,
+                66,
+                77,
+                214,
+                9,
+                252,
+                64,
+                53,
+                108,
+                230,
+                117,
+                158,
+                173,
+                73,
+                175,
+                167,
+                6,
+                101,
+                14,
+                54,
+                1,
+                226,
+                70,
+                97,
+                85,
+                205,
+                10,
+                148
+              ]
+            }
+          }
+        },
+        {
+          "name": "verifier_program"
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": [
+        {
+          "name": "task_id",
+          "type": "u64"
+        },
+        {
+          "name": "proof",
+          "type": {
+            "defined": {
+              "name": "PrivateCompletionPayload"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "create_dependent_task",
+      "docs": [
+        "Create a new task that depends on an existing parent task.",
+        "The parent task must not be cancelled or disputed.",
+        "",
+        "# Arguments",
+        "* `ctx` - Context with task, escrow, parent_task, and creator accounts",
+        "* `task_id` - Unique identifier for the task",
+        "* `required_capabilities` - Bitmask of required agent capabilities",
+        "* `description` - Task description or instruction hash",
+        "* `reward_amount` - SOL or token reward for completion",
+        "* `max_workers` - Maximum number of agents that can work on this task",
+        "* `deadline` - Unix timestamp deadline (0 = no deadline)",
+        "* `task_type` - 0=exclusive (single worker), 1=collaborative (multi-worker)",
+        "* `constraint_hash` - For private tasks: hash of expected output (None for non-private)",
+        "* `dependency_type` - 1=Data, 2=Ordering, 3=Proof"
+      ],
+      "discriminator": [
+        113,
+        118,
+        102,
+        157,
+        66,
+        214,
+        158,
+        146
+      ],
+      "accounts": [
+        {
+          "name": "task",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -885,11 +1377,11 @@
                 "path": "task_id"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "escrow",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -908,11 +1400,21 @@
                 "path": "task"
               }
             ]
-          },
-          "writable": true
+          }
+        },
+        {
+          "name": "parent_task",
+          "docs": [
+            "The parent task this new task depends on",
+            "Note: Uses Box to reduce stack usage for this large account"
+          ]
         },
         {
           "name": "protocol_config",
+          "docs": [
+            "Note: Uses Box to reduce stack usage for this large account"
+          ],
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -929,17 +1431,95 @@
                 ]
               }
             ]
-          },
-          "writable": true
+          }
+        },
+        {
+          "name": "creator_agent",
+          "docs": [
+            "Creator's agent registration for rate limiting (required)"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "creator_agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The authority that owns the creator_agent"
+          ],
+          "signer": true,
+          "relations": [
+            "creator_agent"
+          ]
         },
         {
           "name": "creator",
-          "signer": true,
-          "writable": true
+          "docs": [
+            "The creator who pays for and owns the task",
+            "Must match authority to prevent social engineering attacks (#375)"
+          ],
+          "writable": true,
+          "signer": true
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint for reward denomination (optional)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Escrow's associated token account for holding reward tokens (optional)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Account program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
         }
       ],
       "args": [
@@ -980,38 +1560,82 @@
         {
           "name": "task_type",
           "type": "u8"
+        },
+        {
+          "name": "constraint_hash",
+          "type": {
+            "option": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        },
+        {
+          "name": "dependency_type",
+          "type": "u8"
+        },
+        {
+          "name": "min_reputation",
+          "type": "u16"
+        },
+        {
+          "name": "reward_mint",
+          "type": {
+            "option": "pubkey"
+          }
         }
-      ],
-      "discriminator": [
-        194,
-        80,
-        6,
-        180,
-        232,
-        127,
-        48,
-        171
-      ],
-      "docs": [
-        "Create a new task with requirements and optional reward.",
-        "Tasks are stored in a PDA derived from the creator and task ID.",
-        "",
-        "# Arguments",
-        "* `ctx` - Context with task account and creator",
-        "* `task_id` - Unique identifier for the task",
-        "* `required_capabilities` - Bitmask of required agent capabilities",
-        "* `description` - Task description or instruction hash",
-        "* `reward_amount` - SOL or token reward for completion",
-        "* `max_workers` - Maximum number of agents that can work on this task",
-        "* `deadline` - Unix timestamp deadline (0 = no deadline)",
-        "* `task_type` - 0=exclusive (single worker), 1=collaborative (multi-worker)"
-      ],
-      "name": "create_task"
+      ]
     },
     {
+      "name": "create_proposal",
+      "docs": [
+        "Create a governance proposal.",
+        "Proposer must be an active agent with sufficient stake."
+      ],
+      "discriminator": [
+        132,
+        116,
+        68,
+        174,
+        216,
+        160,
+        198,
+        22
+      ],
       "accounts": [
         {
-          "name": "agent",
+          "name": "proposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposer"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "proposer",
           "pda": {
             "seeds": [
               {
@@ -1025,13 +1649,12 @@
                 ]
               },
               {
-                "account": "AgentRegistration",
                 "kind": "account",
-                "path": "agent.agent_id"
+                "path": "proposer.agent_id",
+                "account": "AgentRegistration"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "protocol_config",
@@ -1051,19 +1674,431 @@
                 ]
               }
             ]
-          },
-          "writable": true
+          }
+        },
+        {
+          "name": "governance_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "authority",
-          "relations": [
-            "agent"
-          ],
+          "writable": true,
           "signer": true,
-          "writable": true
+          "relations": [
+            "proposer"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [],
+      "args": [
+        {
+          "name": "nonce",
+          "type": "u64"
+        },
+        {
+          "name": "proposal_type",
+          "type": "u8"
+        },
+        {
+          "name": "title_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "description_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "payload",
+          "type": {
+            "array": [
+              "u8",
+              64
+            ]
+          }
+        },
+        {
+          "name": "voting_period",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "create_task",
+      "docs": [
+        "Create a new task with requirements and optional reward.",
+        "Tasks are stored in a PDA derived from the creator and task ID.",
+        "",
+        "# Arguments",
+        "* `ctx` - Context with task account and creator",
+        "* `task_id` - Unique identifier for the task",
+        "* `required_capabilities` - Bitmask of required agent capabilities",
+        "* `description` - Task description or instruction hash",
+        "* `reward_amount` - SOL or token reward for completion",
+        "* `max_workers` - Maximum number of agents that can work on this task",
+        "* `deadline` - Unix timestamp deadline (0 = no deadline)",
+        "* `task_type` - 0=exclusive (single worker), 1=collaborative (multi-worker)",
+        "* `constraint_hash` - For private tasks: hash of expected output (None for non-private)"
+      ],
+      "discriminator": [
+        194,
+        80,
+        6,
+        180,
+        232,
+        127,
+        48,
+        171
+      ],
+      "accounts": [
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "creator"
+              },
+              {
+                "kind": "arg",
+                "path": "task_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator_agent",
+          "docs": [
+            "Creator's agent registration for rate limiting (required)"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "creator_agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "docs": [
+            "The authority that owns the creator_agent"
+          ],
+          "signer": true,
+          "relations": [
+            "creator_agent"
+          ]
+        },
+        {
+          "name": "creator",
+          "docs": [
+            "The creator who pays for and owns the task",
+            "Must match authority to prevent social engineering attacks (#375)"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint for reward denomination (optional)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Escrow's associated token account for holding reward tokens (optional).",
+            "Created via ATA CPI during handler if token task."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        },
+        {
+          "name": "associated_token_program",
+          "docs": [
+            "Associated Token Account program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+        }
+      ],
+      "args": [
+        {
+          "name": "task_id",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "required_capabilities",
+          "type": "u64"
+        },
+        {
+          "name": "description",
+          "type": {
+            "array": [
+              "u8",
+              64
+            ]
+          }
+        },
+        {
+          "name": "reward_amount",
+          "type": "u64"
+        },
+        {
+          "name": "max_workers",
+          "type": "u8"
+        },
+        {
+          "name": "deadline",
+          "type": "i64"
+        },
+        {
+          "name": "task_type",
+          "type": "u8"
+        },
+        {
+          "name": "constraint_hash",
+          "type": {
+            "option": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        },
+        {
+          "name": "min_reputation",
+          "type": "u16"
+        },
+        {
+          "name": "reward_mint",
+          "type": {
+            "option": "pubkey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "delegate_reputation",
+      "docs": [
+        "Delegate reputation points to a trusted peer.",
+        "One delegation per (delegator, delegatee) pair."
+      ],
+      "discriminator": [
+        195,
+        86,
+        46,
+        27,
+        29,
+        166,
+        147,
+        66
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "delegator_agent"
+          ]
+        },
+        {
+          "name": "delegator_agent",
+          "writable": true
+        },
+        {
+          "name": "delegatee_agent"
+        },
+        {
+          "name": "delegation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  112,
+                  117,
+                  116,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "delegator_agent"
+              },
+              {
+                "kind": "account",
+                "path": "delegatee_agent"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u16"
+        },
+        {
+          "name": "expires_at",
+          "type": "i64"
+        }
+      ]
+    },
+    {
+      "name": "deregister_agent",
+      "docs": [
+        "Deregister an agent and reclaim rent.",
+        "Agent must have no active tasks."
+      ],
       "discriminator": [
         227,
         208,
@@ -1074,14 +2109,309 @@
         111,
         1
       ],
-      "docs": [
-        "Deregister an agent and reclaim rent.",
-        "Agent must have no active tasks."
+      "accounts": [
+        {
+          "name": "agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "agent"
+          ]
+        }
       ],
-      "name": "deregister_agent"
+      "args": []
     },
     {
+      "name": "execute_proposal",
+      "docs": [
+        "Execute an approved governance proposal after voting period ends.",
+        "Permissionless — anyone can call after quorum + majority is met."
+      ],
+      "discriminator": [
+        186,
+        60,
+        116,
+        133,
+        108,
+        128,
+        111,
+        28
+      ],
       "accounts": [
+        {
+          "name": "proposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal.proposer",
+                "account": "Proposal"
+              },
+              {
+                "kind": "account",
+                "path": "proposal.nonce",
+                "account": "Proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "governance_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "executor",
+          "docs": [
+            "Executor can be anyone (permissionless after voting ends)"
+          ],
+          "signer": true
+        },
+        {
+          "name": "treasury",
+          "docs": [
+            "Must match protocol_config.treasury. Spend path supports:",
+            "- program-owned treasury (direct lamport mutation), or",
+            "- system-owned treasury when this account signs."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "recipient",
+          "docs": [
+            "Validated from proposal payload in handler."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "expire_claim",
+      "docs": [
+        "Expire a stale claim to free up task slot.",
+        "Can only be called after claim.expires_at has passed."
+      ],
+      "discriminator": [
+        176,
+        78,
+        241,
+        29,
+        159,
+        81,
+        26,
+        6
+      ],
+      "accounts": [
+        {
+          "name": "caller",
+          "docs": [
+            "Caller who triggers the expiration - receives cleanup reward"
+          ],
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "claim",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker"
+              }
+            ]
+          }
+        },
+        {
+          "name": "worker",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "worker.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
         {
           "name": "protocol_config",
           "pda": {
@@ -1100,20 +2430,376 @@
                 ]
               }
             ]
-          },
+          }
+        },
+        {
+          "name": "rent_recipient",
           "writable": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "expire_dispute",
+      "docs": [
+        "Expire a dispute after the maximum duration has passed."
+      ],
+      "discriminator": [
+        241,
+        116,
+        178,
+        182,
+        234,
+        173,
+        61,
+        120
+      ],
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "creator",
+          "writable": true
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Worker's claim on the disputed task (fix #137)",
+            "Optional - when provided, allows decrementing worker's active_tasks",
+            "and enables fair refund distribution (fix #418)"
+          ],
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker_claim.worker",
+                "account": "TaskClaim"
+              }
+            ]
+          }
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Worker's AgentRegistration PDA (must be dispute defendant)."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_authority",
+          "docs": [
+            "Required when worker should receive funds on expiration"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account for refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account_ata",
+          "docs": [
+            "Worker's token account for payment (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "initialize_governance",
+      "docs": [
+        "Initialize governance configuration.",
+        "Must be called by the protocol authority."
+      ],
+      "discriminator": [
+        171,
+        87,
+        101,
+        237,
+        27,
+        107,
+        201,
+        57
+      ],
+      "accounts": [
+        {
+          "name": "governance_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "voting_period",
+          "type": "i64"
+        },
+        {
+          "name": "execution_delay",
+          "type": "i64"
+        },
+        {
+          "name": "quorum_bps",
+          "type": "u16"
+        },
+        {
+          "name": "approval_threshold_bps",
+          "type": "u16"
+        },
+        {
+          "name": "min_proposal_stake",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "initialize_protocol",
+      "docs": [
+        "Initialize the protocol configuration.",
+        "Called once to set up global parameters."
+      ],
+      "discriminator": [
+        188,
+        233,
+        252,
+        106,
+        134,
+        146,
+        202,
+        91
+      ],
+      "accounts": [
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "treasury"
         },
         {
           "name": "authority",
-          "signer": true,
-          "writable": true
+          "writable": true,
+          "signer": true
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "second_signer",
+          "docs": [
+            "Second multisig signer required at initialization to prevent single-party setup.",
+            "Must be different from authority and must be in multisig_owners.",
+            "This ensures at least two parties are involved in protocol initialization (fix #556)."
+          ],
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -1128,28 +2814,50 @@
         {
           "name": "min_stake",
           "type": "u64"
+        },
+        {
+          "name": "min_stake_for_dispute",
+          "type": "u64"
+        },
+        {
+          "name": "multisig_threshold",
+          "type": "u8"
+        },
+        {
+          "name": "multisig_owners",
+          "type": {
+            "vec": "pubkey"
+          }
         }
-      ],
-      "discriminator": [
-        188,
-        233,
-        252,
-        106,
-        134,
-        146,
-        202,
-        91
-      ],
-      "docs": [
-        "Initialize the protocol configuration.",
-        "Called once to set up global parameters."
-      ],
-      "name": "initialize_protocol"
+      ]
     },
     {
+      "name": "initiate_dispute",
+      "docs": [
+        "Initiate a conflict resolution process.",
+        "Creates a dispute that requires multi-sig consensus to resolve.",
+        "",
+        "# Arguments",
+        "* `ctx` - Context with dispute account",
+        "* `dispute_id` - Unique identifier for the dispute",
+        "* `task_id` - Related task ID",
+        "* `evidence_hash` - Hash of evidence supporting the dispute",
+        "* `resolution_type` - 0=refund, 1=complete, 2=split"
+      ],
+      "discriminator": [
+        128,
+        242,
+        160,
+        23,
+        44,
+        61,
+        171,
+        37
+      ],
       "accounts": [
         {
           "name": "dispute",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -1169,11 +2877,11 @@
                 "path": "dispute_id"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "task",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -1186,21 +2894,21 @@
                 ]
               },
               {
-                "account": "Task",
                 "kind": "account",
-                "path": "task.creator"
+                "path": "task.creator",
+                "account": "Task"
               },
               {
-                "account": "Task",
                 "kind": "account",
-                "path": "task.task_id"
+                "path": "task.task_id",
+                "account": "Task"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "agent",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -1214,24 +2922,88 @@
                 ]
               },
               {
-                "account": "AgentRegistration",
                 "kind": "account",
-                "path": "agent.agent_id"
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
               }
             ]
           }
         },
         {
-          "name": "authority",
-          "relations": [
-            "agent"
-          ],
-          "signer": true,
-          "writable": true
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "initiator_claim",
+          "docs": [
+            "Optional: Initiator's claim if they are a worker (not the creator)"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "agent"
+              }
+            ]
+          }
+        },
+        {
+          "name": "worker_agent",
+          "docs": [
+            "Optional: Worker agent to be disputed (required when initiator is task creator)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Optional: Worker's claim (required when worker_agent is provided)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "agent"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -1265,35 +3037,106 @@
         {
           "name": "resolution_type",
           "type": "u8"
+        },
+        {
+          "name": "evidence",
+          "type": "string"
         }
-      ],
-      "discriminator": [
-        128,
-        242,
-        160,
-        23,
-        44,
-        61,
-        171,
-        37
-      ],
-      "docs": [
-        "Initiate a conflict resolution process.",
-        "Creates a dispute that requires multi-sig consensus to resolve.",
-        "",
-        "# Arguments",
-        "* `ctx` - Context with dispute account",
-        "* `dispute_id` - Unique identifier for the dispute",
-        "* `task_id` - Related task ID",
-        "* `evidence_hash` - Hash of evidence supporting the dispute",
-        "* `resolution_type` - 0=refund, 1=complete, 2=split"
-      ],
-      "name": "initiate_dispute"
+      ]
     },
     {
+      "name": "migrate_protocol",
+      "docs": [
+        "Migrate protocol to a new version (multisig gated).",
+        "Handles state migration when upgrading the program.",
+        "",
+        "# Arguments",
+        "* `target_version` - The version to migrate to"
+      ],
+      "discriminator": [
+        182,
+        254,
+        253,
+        220,
+        0,
+        144,
+        234,
+        250
+      ],
       "accounts": [
         {
-          "name": "agent",
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "target_version",
+          "type": "u8"
+        }
+      ]
+    },
+    {
+      "name": "post_to_feed",
+      "docs": [
+        "Post to the agent feed.",
+        "Author must be an active agent. Content is stored on IPFS, hash on-chain."
+      ],
+      "discriminator": [
+        140,
+        84,
+        238,
+        165,
+        168,
+        159,
+        119,
+        128
+      ],
+      "accounts": [
+        {
+          "name": "post",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "author"
+              },
+              {
+                "kind": "arg",
+                "path": "nonce"
+              }
+            ]
+          }
+        },
+        {
+          "name": "author",
           "pda": {
             "seeds": [
               {
@@ -1307,11 +3150,211 @@
                 ]
               },
               {
-                "kind": "arg",
-                "path": "agent_id"
+                "kind": "account",
+                "path": "author.agent_id",
+                "account": "AgentRegistration"
               }
             ]
-          },
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "author"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "content_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "nonce",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "topic",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "parent_post",
+          "type": {
+            "option": "pubkey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "purchase_skill",
+      "docs": [
+        "Purchase a skill (SOL or SPL token).",
+        "Protocol fee is deducted and sent to treasury."
+      ],
+      "discriminator": [
+        70,
+        41,
+        105,
+        156,
+        159,
+        169,
+        215,
+        188
+      ],
+      "accounts": [
+        {
+          "name": "skill",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  107,
+                  105,
+                  108,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "skill.author",
+                "account": "SkillRegistration"
+              },
+              {
+                "kind": "account",
+                "path": "skill.skill_id",
+                "account": "SkillRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "purchase_record",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  107,
+                  105,
+                  108,
+                  108,
+                  95,
+                  112,
+                  117,
+                  114,
+                  99,
+                  104,
+                  97,
+                  115,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "skill"
+              },
+              {
+                "kind": "account",
+                "path": "buyer"
+              }
+            ]
+          }
+        },
+        {
+          "name": "buyer",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "buyer.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "author_agent",
+          "docs": [
+            "Skill author's agent registration"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "author_agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "author_wallet",
           "writable": true
         },
         {
@@ -1332,17 +3375,326 @@
                 ]
               }
             ]
-          },
+          }
+        },
+        {
+          "name": "treasury",
           "writable": true
         },
         {
           "name": "authority",
+          "writable": true,
           "signer": true,
-          "writable": true
+          "relations": [
+            "buyer"
+          ]
         },
         {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "price_mint",
+          "docs": [
+            "SPL token mint for price denomination (optional)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "buyer_token_account",
+          "docs": [
+            "Buyer's token account (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "author_token_account",
+          "docs": [
+            "Author's token account (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury's token account (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "rate_skill",
+      "docs": [
+        "Rate a skill (1-5, reputation-weighted).",
+        "One rating per agent per skill, enforced by PDA uniqueness."
+      ],
+      "discriminator": [
+        44,
+        124,
+        30,
+        253,
+        90,
+        244,
+        174,
+        75
+      ],
+      "accounts": [
+        {
+          "name": "skill",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  107,
+                  105,
+                  108,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "skill.author",
+                "account": "SkillRegistration"
+              },
+              {
+                "kind": "account",
+                "path": "skill.skill_id",
+                "account": "SkillRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "rating_account",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  107,
+                  105,
+                  108,
+                  108,
+                  95,
+                  114,
+                  97,
+                  116,
+                  105,
+                  110,
+                  103
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "skill"
+              },
+              {
+                "kind": "account",
+                "path": "rater"
+              }
+            ]
+          }
+        },
+        {
+          "name": "rater",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "rater.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "purchase_record",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  107,
+                  105,
+                  108,
+                  108,
+                  95,
+                  112,
+                  117,
+                  114,
+                  99,
+                  104,
+                  97,
+                  115,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "skill"
+              },
+              {
+                "kind": "account",
+                "path": "rater"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "rater"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "rating",
+          "type": "u8"
+        },
+        {
+          "name": "review_hash",
+          "type": {
+            "option": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "register_agent",
+      "docs": [
+        "Register a new agent on-chain with its capabilities and metadata.",
+        "Creates a unique PDA for the agent that serves as its on-chain identity.",
+        "",
+        "# Arguments",
+        "* `ctx` - Context containing agent account and signer",
+        "* `agent_id` - Unique 32-byte identifier for the agent",
+        "* `capabilities` - Bitmask of agent capabilities (see AgentCapability)",
+        "* `endpoint` - Network endpoint for off-chain communication",
+        "* `metadata_uri` - Optional URI to extended metadata (IPFS/Arweave)"
+      ],
+      "discriminator": [
+        135,
+        157,
+        66,
+        195,
+        2,
+        113,
+        175,
+        30
+      ],
+      "accounts": [
+        {
+          "name": "agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "arg",
+                "path": "agent_id"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
       "args": [
@@ -1368,107 +3720,77 @@
           "type": {
             "option": "string"
           }
+        },
+        {
+          "name": "stake_amount",
+          "type": "u64"
         }
-      ],
-      "discriminator": [
-        135,
-        157,
-        66,
-        195,
-        2,
-        113,
-        175,
-        30
-      ],
-      "docs": [
-        "Register a new agent on-chain with its capabilities and metadata.",
-        "Creates a unique PDA for the agent that serves as its on-chain identity.",
-        "",
-        "# Arguments",
-        "* `ctx` - Context containing agent account and signer",
-        "* `agent_id` - Unique 32-byte identifier for the agent",
-        "* `capabilities` - Bitmask of agent capabilities (see AgentCapability)",
-        "* `endpoint` - Network endpoint for off-chain communication",
-        "* `metadata_uri` - Optional URI to extended metadata (IPFS/Arweave)"
-      ],
-      "name": "register_agent"
+      ]
     },
     {
+      "name": "register_skill",
+      "docs": [
+        "Register a new skill on-chain.",
+        "Author must be an active agent."
+      ],
+      "discriminator": [
+        166,
+        249,
+        255,
+        189,
+        192,
+        197,
+        102,
+        2
+      ],
       "accounts": [
         {
-          "name": "dispute",
+          "name": "skill",
+          "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  100,
+                  115,
+                  107,
                   105,
-                  115,
-                  112,
-                  117,
-                  116,
-                  101
+                  108,
+                  108
                 ]
               },
               {
-                "account": "Dispute",
                 "kind": "account",
-                "path": "dispute.dispute_id"
+                "path": "author"
+              },
+              {
+                "kind": "arg",
+                "path": "skill_id"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
-          "name": "task",
+          "name": "author",
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  116,
                   97,
-                  115,
-                  107
-                ]
-              },
-              {
-                "account": "Task",
-                "kind": "account",
-                "path": "task.creator"
-              },
-              {
-                "account": "Task",
-                "kind": "account",
-                "path": "task.task_id"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "escrow",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
+                  103,
                   101,
-                  115,
-                  99,
-                  114,
-                  111,
-                  119
+                  110,
+                  116
                 ]
               },
               {
                 "kind": "account",
-                "path": "task"
+                "path": "author.agent_id",
+                "account": "AgentRegistration"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
           "name": "protocol_config",
@@ -1491,20 +3813,73 @@
           }
         },
         {
-          "name": "creator",
-          "writable": true
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "author"
+          ]
         },
         {
-          "name": "worker",
-          "optional": true,
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
         }
       ],
-      "args": [],
+      "args": [
+        {
+          "name": "skill_id",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "name",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "content_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "price",
+          "type": "u64"
+        },
+        {
+          "name": "price_mint",
+          "type": {
+            "option": "pubkey"
+          }
+        },
+        {
+          "name": "tags",
+          "type": {
+            "array": [
+              "u8",
+              64
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "resolve_dispute",
+      "docs": [
+        "Execute the resolved dispute outcome.",
+        "Requires sufficient votes to meet threshold."
+      ],
       "discriminator": [
         231,
         6,
@@ -1515,16 +3890,379 @@
         12,
         230
       ],
-      "docs": [
-        "Execute the resolved dispute outcome.",
-        "Requires sufficient votes to meet threshold."
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "escrow",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  101,
+                  115,
+                  99,
+                  114,
+                  111,
+                  119
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "resolver",
+          "signer": true
+        },
+        {
+          "name": "creator",
+          "writable": true
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Worker's claim proving they worked on task (fix #59)",
+            "Required for Complete/Split resolutions that pay a worker",
+            "Made mutable to allow closing after dispute resolution (fix #439)"
+          ],
+          "writable": true,
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker_claim.worker",
+                "account": "TaskClaim"
+              }
+            ]
+          }
+        },
+        {
+          "name": "worker",
+          "docs": [
+            "Worker agent account for the dispute defendant."
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_authority",
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        },
+        {
+          "name": "token_escrow_ata",
+          "docs": [
+            "Token escrow ATA holding reward tokens (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "creator_token_account",
+          "docs": [
+            "Creator's token account for refund (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "worker_token_account_ata",
+          "docs": [
+            "Worker's token account for payment (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "treasury_token_account",
+          "docs": [
+            "Treasury's token account for protocol fees (optional)"
+          ],
+          "writable": true,
+          "optional": true
+        },
+        {
+          "name": "reward_mint",
+          "docs": [
+            "SPL token mint (optional, must match task.reward_mint)"
+          ],
+          "optional": true
+        },
+        {
+          "name": "token_program",
+          "docs": [
+            "SPL Token program (optional, required for token tasks)"
+          ],
+          "optional": true,
+          "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+        }
       ],
-      "name": "resolve_dispute"
+      "args": []
     },
     {
+      "name": "revoke_delegation",
+      "docs": [
+        "Revoke a reputation delegation and close the account.",
+        "Rent is returned to the delegator's authority."
+      ],
+      "discriminator": [
+        188,
+        92,
+        135,
+        67,
+        160,
+        181,
+        54,
+        62
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "delegator_agent"
+          ]
+        },
+        {
+          "name": "delegator_agent",
+          "writable": true
+        },
+        {
+          "name": "delegation",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  112,
+                  117,
+                  116,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  100,
+                  101,
+                  108,
+                  101,
+                  103,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "delegator_agent"
+              },
+              {
+                "kind": "account",
+                "path": "delegation.delegatee",
+                "account": "ReputationDelegation"
+              }
+            ]
+          }
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "stake_reputation",
+      "docs": [
+        "Stake SOL on agent reputation.",
+        "Creates or adds to an existing reputation stake account."
+      ],
+      "discriminator": [
+        104,
+        250,
+        157,
+        87,
+        16,
+        190,
+        180,
+        238
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "agent"
+          ]
+        },
+        {
+          "name": "agent"
+        },
+        {
+          "name": "reputation_stake",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  112,
+                  117,
+                  116,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  115,
+                  116,
+                  97,
+                  107,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent"
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "suspend_agent",
+      "docs": [
+        "Suspend an agent (protocol authority only, fix #819).",
+        "Prevents the agent from claiming tasks or participating in disputes."
+      ],
+      "discriminator": [
+        242,
+        28,
+        54,
+        59,
+        247,
+        20,
+        59,
+        110
+      ],
       "accounts": [
         {
           "name": "agent",
+          "writable": true,
           "pda": {
             "seeds": [
               {
@@ -1538,20 +4276,159 @@
                 ]
               },
               {
-                "account": "AgentRegistration",
                 "kind": "account",
-                "path": "agent.agent_id"
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
               }
             ]
-          },
-          "writable": true
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
         },
         {
           "name": "authority",
+          "signer": true,
+          "relations": [
+            "protocol_config"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "unsuspend_agent",
+      "docs": [
+        "Unsuspend an agent (protocol authority only, fix #819).",
+        "Restores the agent to Inactive status."
+      ],
+      "discriminator": [
+        79,
+        75,
+        53,
+        57,
+        177,
+        142,
+        131,
+        149
+      ],
+      "accounts": [
+        {
+          "name": "agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
+          "relations": [
+            "protocol_config"
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "update_agent",
+      "docs": [
+        "Update an existing agent's registration data.",
+        "Only the agent's authority can modify its registration."
+      ],
+      "discriminator": [
+        85,
+        2,
+        178,
+        9,
+        119,
+        139,
+        102,
+        164
+      ],
+      "accounts": [
+        {
+          "name": "agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "signer": true,
           "relations": [
             "agent"
-          ],
-          "signer": true
+          ]
         }
       ],
       "args": [
@@ -1579,183 +4456,272 @@
             "option": "u8"
           }
         }
-      ],
-      "discriminator": [
-        85,
-        2,
-        178,
-        9,
-        119,
-        139,
-        102,
-        164
-      ],
-      "docs": [
-        "Update an existing agent's registration data.",
-        "Only the agent's authority can modify its registration."
-      ],
-      "name": "update_agent"
+      ]
     },
     {
+      "name": "update_min_version",
+      "docs": [
+        "Update minimum supported protocol version (multisig gated).",
+        "Used to deprecate old versions after migration grace period.",
+        "",
+        "# Arguments",
+        "* `new_min_version` - The new minimum supported version"
+      ],
+      "discriminator": [
+        149,
+        215,
+        23,
+        120,
+        114,
+        69,
+        110,
+        37
+      ],
       "accounts": [
         {
-          "name": "state",
+          "name": "protocol_config",
+          "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  115,
+                  112,
+                  114,
+                  111,
                   116,
-                  97,
-                  116,
-                  101
+                  111,
+                  99,
+                  111,
+                  108
                 ]
-              },
-              {
-                "kind": "arg",
-                "path": "state_key"
               }
             ]
-          },
-          "writable": true
-        },
-        {
-          "name": "agent",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  97,
-                  103,
-                  101,
-                  110,
-                  116
-                ]
-              },
-              {
-                "account": "AgentRegistration",
-                "kind": "account",
-                "path": "agent.agent_id"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "authority",
-          "relations": [
-            "agent"
-          ],
-          "signer": true,
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          }
         }
       ],
       "args": [
         {
-          "name": "state_key",
-          "type": {
-            "array": [
-              "u8",
-              32
-            ]
-          }
-        },
-        {
-          "name": "state_value",
-          "type": {
-            "array": [
-              "u8",
-              64
-            ]
-          }
-        },
-        {
-          "name": "version",
-          "type": "u64"
+          "name": "new_min_version",
+          "type": "u8"
         }
-      ],
-      "discriminator": [
-        135,
-        112,
-        215,
-        75,
-        247,
-        185,
-        53,
-        176
-      ],
-      "docs": [
-        "Update shared coordination state.",
-        "Used for broadcasting state changes to other agents.",
-        "",
-        "# Arguments",
-        "* `ctx` - Context with coordination PDA",
-        "* `state_key` - Key identifying the state variable",
-        "* `state_value` - New value for the state",
-        "* `version` - Expected current version (for optimistic locking)"
-      ],
-      "name": "update_state"
+      ]
     },
     {
+      "name": "update_multisig",
+      "docs": [
+        "Rotate multisig owners/threshold (multisig gated).",
+        "",
+        "Hardening:",
+        "- Allows signer rotation for key loss/compromise recovery.",
+        "- Requires threshold of new-set signers in the same update transaction."
+      ],
+      "discriminator": [
+        152,
+        192,
+        112,
+        152,
+        120,
+        184,
+        150,
+        59
+      ],
       "accounts": [
         {
-          "name": "dispute",
+          "name": "protocol_config",
+          "writable": true,
           "pda": {
             "seeds": [
               {
                 "kind": "const",
                 "value": [
-                  100,
-                  105,
-                  115,
                   112,
-                  117,
-                  116,
-                  101
-                ]
-              },
-              {
-                "account": "Dispute",
-                "kind": "account",
-                "path": "dispute.dispute_id"
-              }
-            ]
-          },
-          "writable": true
-        },
-        {
-          "name": "vote",
-          "pda": {
-            "seeds": [
-              {
-                "kind": "const",
-                "value": [
-                  118,
+                  114,
                   111,
                   116,
-                  101
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "new_threshold",
+          "type": "u8"
+        },
+        {
+          "name": "new_owners",
+          "type": {
+            "vec": "pubkey"
+          }
+        }
+      ]
+    },
+    {
+      "name": "update_protocol_fee",
+      "docs": [
+        "Update the protocol fee (multisig gated)."
+      ],
+      "discriminator": [
+        170,
+        136,
+        6,
+        60,
+        43,
+        130,
+        81,
+        96
+      ],
+      "accounts": [
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "protocol_fee_bps",
+          "type": "u16"
+        }
+      ]
+    },
+    {
+      "name": "update_rate_limits",
+      "docs": [
+        "Update rate limiting configuration (multisig gated).",
+        "Parameters can be tuned post-deployment without program upgrade.",
+        "",
+        "# Arguments",
+        "* `task_creation_cooldown` - Seconds between task creations (0 = disabled)",
+        "* `max_tasks_per_24h` - Maximum tasks per agent per 24h (0 = unlimited)",
+        "* `dispute_initiation_cooldown` - Seconds between disputes (0 = disabled)",
+        "* `max_disputes_per_24h` - Maximum disputes per agent per 24h (0 = unlimited)",
+        "* `min_stake_for_dispute` - Minimum stake required to initiate dispute"
+      ],
+      "discriminator": [
+        247,
+        36,
+        121,
+        254,
+        22,
+        16,
+        226,
+        1
+      ],
+      "accounts": [
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "task_creation_cooldown",
+          "type": "i64"
+        },
+        {
+          "name": "max_tasks_per_24h",
+          "type": "u8"
+        },
+        {
+          "name": "dispute_initiation_cooldown",
+          "type": "i64"
+        },
+        {
+          "name": "max_disputes_per_24h",
+          "type": "u8"
+        },
+        {
+          "name": "min_stake_for_dispute",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_skill",
+      "docs": [
+        "Update a skill's content, price, tags, or active status.",
+        "Only the skill author can update."
+      ],
+      "discriminator": [
+        116,
+        142,
+        164,
+        86,
+        9,
+        27,
+        112,
+        227
+      ],
+      "accounts": [
+        {
+          "name": "skill",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  107,
+                  105,
+                  108,
+                  108
                 ]
               },
               {
                 "kind": "account",
-                "path": "dispute"
+                "path": "author"
               },
               {
                 "kind": "account",
-                "path": "arbiter"
+                "path": "skill.skill_id",
+                "account": "SkillRegistration"
               }
             ]
-          },
-          "writable": true
+          }
         },
         {
-          "name": "arbiter",
+          "name": "author",
           "pda": {
             "seeds": [
               {
@@ -1769,9 +4735,9 @@
                 ]
               },
               {
-                "account": "AgentRegistration",
                 "kind": "account",
-                "path": "arbiter.agent_id"
+                "path": "author.agent_id",
+                "account": "AgentRegistration"
               }
             ]
           }
@@ -1798,22 +4764,360 @@
         },
         {
           "name": "authority",
-          "relations": [
-            "arbiter"
-          ],
           "signer": true,
-          "writable": true
-        },
-        {
-          "address": "11111111111111111111111111111111",
-          "name": "system_program"
+          "relations": [
+            "author"
+          ]
         }
       ],
       "args": [
         {
-          "name": "approve",
-          "type": "bool"
+          "name": "content_hash",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "price",
+          "type": "u64"
+        },
+        {
+          "name": "tags",
+          "type": {
+            "option": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          }
+        },
+        {
+          "name": "is_active",
+          "type": {
+            "option": "bool"
+          }
         }
+      ]
+    },
+    {
+      "name": "update_state",
+      "docs": [
+        "Update shared coordination state.",
+        "Used for broadcasting state changes to other agents.",
+        "",
+        "# Arguments",
+        "* `ctx` - Context with coordination PDA",
+        "* `state_key` - Key identifying the state variable",
+        "* `state_value` - New value for the state",
+        "* `version` - Expected current version (for optimistic locking)"
+      ],
+      "discriminator": [
+        135,
+        112,
+        215,
+        75,
+        247,
+        185,
+        53,
+        176
+      ],
+      "accounts": [
+        {
+          "name": "state",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  115,
+                  116,
+                  97,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              },
+              {
+                "kind": "arg",
+                "path": "state_key"
+              }
+            ]
+          }
+        },
+        {
+          "name": "agent",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "agent"
+          ]
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "state_key",
+          "type": {
+            "array": [
+              "u8",
+              32
+            ]
+          }
+        },
+        {
+          "name": "state_value",
+          "type": {
+            "array": [
+              "u8",
+              64
+            ]
+          }
+        },
+        {
+          "name": "version",
+          "type": "u64"
+        }
+      ]
+    },
+    {
+      "name": "update_treasury",
+      "docs": [
+        "Update protocol treasury destination (multisig gated).",
+        "",
+        "Hardening:",
+        "- Allows treasury rotation/recovery.",
+        "- New treasury must be program-owned, or a signer system account."
+      ],
+      "discriminator": [
+        60,
+        16,
+        243,
+        66,
+        96,
+        59,
+        254,
+        131
+      ],
+      "accounts": [
+        {
+          "name": "protocol_config",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "new_treasury",
+          "docs": [
+            "Must be either:",
+            "- program-owned (preferred), or",
+            "- a system-owned signer account (legacy compatibility)."
+          ]
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "upvote_post",
+      "docs": [
+        "Upvote a feed post.",
+        "One vote per agent per post, enforced by PDA uniqueness."
+      ],
+      "discriminator": [
+        198,
+        186,
+        192,
+        175,
+        171,
+        226,
+        72,
+        252
+      ],
+      "accounts": [
+        {
+          "name": "post",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  111,
+                  115,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "post.author",
+                "account": "FeedPost"
+              },
+              {
+                "kind": "account",
+                "path": "post.nonce",
+                "account": "FeedPost"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vote",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  117,
+                  112,
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "post"
+              },
+              {
+                "kind": "account",
+                "path": "voter"
+              }
+            ]
+          }
+        },
+        {
+          "name": "voter",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "voter.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "voter"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": []
+    },
+    {
+      "name": "vote_dispute",
+      "docs": [
+        "Vote on a dispute resolution.",
+        "Arbiters must be registered agents with arbitration capability."
       ],
       "discriminator": [
         23,
@@ -1825,27 +5129,2334 @@
         4,
         243
       ],
-      "docs": [
-        "Vote on a dispute resolution.",
-        "Arbiters must be registered agents with arbitration capability."
+      "accounts": [
+        {
+          "name": "dispute",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  100,
+                  105,
+                  115,
+                  112,
+                  117,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute.dispute_id",
+                "account": "Dispute"
+              }
+            ]
+          }
+        },
+        {
+          "name": "task",
+          "docs": [
+            "Task account for arbiter party validation (fix #461)"
+          ],
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  116,
+                  97,
+                  115,
+                  107
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task.creator",
+                "account": "Task"
+              },
+              {
+                "kind": "account",
+                "path": "task.task_id",
+                "account": "Task"
+              }
+            ]
+          },
+          "relations": [
+            "dispute"
+          ]
+        },
+        {
+          "name": "worker_claim",
+          "docs": [
+            "Optional: Worker's claim on the task (for arbiter party validation, fix #461)",
+            "If provided, validates arbiter is not the worker"
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  99,
+                  108,
+                  97,
+                  105,
+                  109
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "task"
+              },
+              {
+                "kind": "account",
+                "path": "worker_claim.worker",
+                "account": "TaskClaim"
+              }
+            ]
+          }
+        },
+        {
+          "name": "defendant_agent",
+          "docs": [
+            "Optional: Defendant's agent registration (for authority-level participant check, fix #824)",
+            "If provided, validates arbiter's authority is not the defendant worker's authority.",
+            "Must match the dispute's defendant field."
+          ],
+          "optional": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "defendant_agent.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vote",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute"
+              },
+              {
+                "kind": "account",
+                "path": "arbiter"
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority_vote",
+          "docs": [
+            "Authority-level vote tracking to prevent Sybil attacks (fix #101)",
+            "One authority can only vote once per dispute, regardless of how many agents they control"
+          ],
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  117,
+                  116,
+                  104,
+                  111,
+                  114,
+                  105,
+                  116,
+                  121,
+                  95,
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "dispute"
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "arbiter",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "arbiter.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "arbiter"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
       ],
-      "name": "vote_dispute"
+      "args": [
+        {
+          "name": "approve",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "vote_proposal",
+      "docs": [
+        "Vote on a governance proposal.",
+        "Voter must be an active agent. Double voting prevented by PDA uniqueness."
+      ],
+      "discriminator": [
+        247,
+        104,
+        114,
+        240,
+        237,
+        41,
+        200,
+        36
+      ],
+      "accounts": [
+        {
+          "name": "proposal",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  112,
+                  111,
+                  115,
+                  97,
+                  108
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal.proposer",
+                "account": "Proposal"
+              },
+              {
+                "kind": "account",
+                "path": "proposal.nonce",
+                "account": "Proposal"
+              }
+            ]
+          }
+        },
+        {
+          "name": "vote",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  103,
+                  111,
+                  118,
+                  101,
+                  114,
+                  110,
+                  97,
+                  110,
+                  99,
+                  101,
+                  95,
+                  118,
+                  111,
+                  116,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "proposal"
+              },
+              {
+                "kind": "account",
+                "path": "authority"
+              }
+            ]
+          }
+        },
+        {
+          "name": "voter",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  97,
+                  103,
+                  101,
+                  110,
+                  116
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "voter.agent_id",
+                "account": "AgentRegistration"
+              }
+            ]
+          }
+        },
+        {
+          "name": "protocol_config",
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  112,
+                  114,
+                  111,
+                  116,
+                  111,
+                  99,
+                  111,
+                  108
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "voter"
+          ]
+        },
+        {
+          "name": "system_program",
+          "address": "11111111111111111111111111111111"
+        }
+      ],
+      "args": [
+        {
+          "name": "approve",
+          "type": "bool"
+        }
+      ]
+    },
+    {
+      "name": "withdraw_reputation_stake",
+      "docs": [
+        "Withdraw SOL from reputation stake after cooldown period.",
+        "Agent must have no pending disputes as defendant."
+      ],
+      "discriminator": [
+        234,
+        37,
+        157,
+        236,
+        80,
+        222,
+        40,
+        233
+      ],
+      "accounts": [
+        {
+          "name": "authority",
+          "writable": true,
+          "signer": true,
+          "relations": [
+            "agent"
+          ]
+        },
+        {
+          "name": "agent"
+        },
+        {
+          "name": "reputation_stake",
+          "writable": true,
+          "pda": {
+            "seeds": [
+              {
+                "kind": "const",
+                "value": [
+                  114,
+                  101,
+                  112,
+                  117,
+                  116,
+                  97,
+                  116,
+                  105,
+                  111,
+                  110,
+                  95,
+                  115,
+                  116,
+                  97,
+                  107,
+                  101
+                ]
+              },
+              {
+                "kind": "account",
+                "path": "agent"
+              }
+            ]
+          }
+        }
+      ],
+      "args": [
+        {
+          "name": "amount",
+          "type": "u64"
+        }
+      ]
     }
   ],
-  "metadata": {
-    "description": "AgenC Decentralized Agent Coordination Protocol for Solana",
-    "name": "agenc_coordination",
-    "repository": "https://github.com/tetsuo-ai/AgenC",
-    "spec": "0.1.0",
-    "version": "0.1.0"
-  },
+  "accounts": [
+    {
+      "name": "AgentRegistration",
+      "discriminator": [
+        130,
+        53,
+        100,
+        103,
+        121,
+        77,
+        148,
+        19
+      ]
+    },
+    {
+      "name": "AuthorityDisputeVote",
+      "discriminator": [
+        194,
+        81,
+        47,
+        196,
+        187,
+        81,
+        110,
+        137
+      ]
+    },
+    {
+      "name": "BindingSpend",
+      "discriminator": [
+        196,
+        241,
+        81,
+        0,
+        238,
+        99,
+        30,
+        100
+      ]
+    },
+    {
+      "name": "CoordinationState",
+      "discriminator": [
+        11,
+        232,
+        15,
+        241,
+        234,
+        143,
+        35,
+        252
+      ]
+    },
+    {
+      "name": "Dispute",
+      "discriminator": [
+        36,
+        49,
+        241,
+        67,
+        40,
+        36,
+        241,
+        74
+      ]
+    },
+    {
+      "name": "DisputeVote",
+      "discriminator": [
+        166,
+        202,
+        140,
+        76,
+        65,
+        35,
+        254,
+        149
+      ]
+    },
+    {
+      "name": "FeedPost",
+      "discriminator": [
+        228,
+        215,
+        236,
+        73,
+        246,
+        181,
+        191,
+        228
+      ]
+    },
+    {
+      "name": "FeedVote",
+      "discriminator": [
+        228,
+        56,
+        120,
+        128,
+        135,
+        128,
+        195,
+        19
+      ]
+    },
+    {
+      "name": "GovernanceConfig",
+      "discriminator": [
+        81,
+        63,
+        124,
+        107,
+        210,
+        100,
+        145,
+        70
+      ]
+    },
+    {
+      "name": "GovernanceVote",
+      "discriminator": [
+        157,
+        104,
+        16,
+        111,
+        208,
+        31,
+        53,
+        132
+      ]
+    },
+    {
+      "name": "NullifierSpend",
+      "discriminator": [
+        254,
+        192,
+        216,
+        27,
+        119,
+        64,
+        151,
+        144
+      ]
+    },
+    {
+      "name": "Proposal",
+      "discriminator": [
+        26,
+        94,
+        189,
+        187,
+        116,
+        136,
+        53,
+        33
+      ]
+    },
+    {
+      "name": "ProtocolConfig",
+      "discriminator": [
+        207,
+        91,
+        250,
+        28,
+        152,
+        179,
+        215,
+        209
+      ]
+    },
+    {
+      "name": "PurchaseRecord",
+      "discriminator": [
+        239,
+        38,
+        40,
+        199,
+        4,
+        96,
+        209,
+        2
+      ]
+    },
+    {
+      "name": "ReputationDelegation",
+      "discriminator": [
+        247,
+        166,
+        224,
+        123,
+        62,
+        95,
+        198,
+        71
+      ]
+    },
+    {
+      "name": "ReputationStake",
+      "discriminator": [
+        226,
+        12,
+        248,
+        110,
+        109,
+        108,
+        99,
+        212
+      ]
+    },
+    {
+      "name": "SkillRating",
+      "discriminator": [
+        107,
+        74,
+        49,
+        243,
+        139,
+        30,
+        9,
+        244
+      ]
+    },
+    {
+      "name": "SkillRegistration",
+      "discriminator": [
+        195,
+        23,
+        19,
+        205,
+        215,
+        225,
+        192,
+        254
+      ]
+    },
+    {
+      "name": "Task",
+      "discriminator": [
+        79,
+        34,
+        229,
+        55,
+        88,
+        90,
+        55,
+        84
+      ]
+    },
+    {
+      "name": "TaskClaim",
+      "discriminator": [
+        115,
+        77,
+        242,
+        98,
+        7,
+        81,
+        209,
+        137
+      ]
+    },
+    {
+      "name": "TaskEscrow",
+      "discriminator": [
+        209,
+        72,
+        197,
+        54,
+        17,
+        55,
+        3,
+        187
+      ]
+    }
+  ],
+  "events": [
+    {
+      "name": "AgentDeregistered",
+      "discriminator": [
+        132,
+        69,
+        246,
+        19,
+        135,
+        65,
+        28,
+        134
+      ]
+    },
+    {
+      "name": "AgentRegistered",
+      "discriminator": [
+        191,
+        78,
+        217,
+        54,
+        232,
+        100,
+        189,
+        85
+      ]
+    },
+    {
+      "name": "AgentSuspended",
+      "discriminator": [
+        219,
+        202,
+        177,
+        3,
+        116,
+        220,
+        164,
+        148
+      ]
+    },
+    {
+      "name": "AgentUnsuspended",
+      "discriminator": [
+        26,
+        114,
+        30,
+        199,
+        235,
+        91,
+        134,
+        255
+      ]
+    },
+    {
+      "name": "AgentUpdated",
+      "discriminator": [
+        210,
+        179,
+        162,
+        250,
+        123,
+        250,
+        210,
+        166
+      ]
+    },
+    {
+      "name": "ArbiterVotesCleanedUp",
+      "discriminator": [
+        50,
+        95,
+        231,
+        24,
+        238,
+        79,
+        179,
+        220
+      ]
+    },
+    {
+      "name": "BondDeposited",
+      "discriminator": [
+        210,
+        149,
+        47,
+        232,
+        72,
+        128,
+        248,
+        153
+      ]
+    },
+    {
+      "name": "BondLocked",
+      "discriminator": [
+        89,
+        45,
+        139,
+        7,
+        22,
+        105,
+        232,
+        59
+      ]
+    },
+    {
+      "name": "BondReleased",
+      "discriminator": [
+        191,
+        161,
+        250,
+        29,
+        188,
+        146,
+        120,
+        251
+      ]
+    },
+    {
+      "name": "BondSlashed",
+      "discriminator": [
+        59,
+        7,
+        252,
+        195,
+        234,
+        156,
+        42,
+        54
+      ]
+    },
+    {
+      "name": "DependentTaskCreated",
+      "discriminator": [
+        82,
+        63,
+        46,
+        148,
+        85,
+        191,
+        122,
+        114
+      ]
+    },
+    {
+      "name": "DisputeCancelled",
+      "discriminator": [
+        38,
+        80,
+        189,
+        225,
+        112,
+        190,
+        156,
+        178
+      ]
+    },
+    {
+      "name": "DisputeExpired",
+      "discriminator": [
+        28,
+        47,
+        191,
+        124,
+        204,
+        113,
+        101,
+        116
+      ]
+    },
+    {
+      "name": "DisputeInitiated",
+      "discriminator": [
+        150,
+        109,
+        93,
+        252,
+        198,
+        4,
+        183,
+        153
+      ]
+    },
+    {
+      "name": "DisputeResolved",
+      "discriminator": [
+        121,
+        64,
+        249,
+        153,
+        139,
+        128,
+        236,
+        187
+      ]
+    },
+    {
+      "name": "DisputeVoteCast",
+      "discriminator": [
+        193,
+        34,
+        94,
+        69,
+        4,
+        179,
+        143,
+        87
+      ]
+    },
+    {
+      "name": "GovernanceInitialized",
+      "discriminator": [
+        41,
+        187,
+        103,
+        26,
+        42,
+        44,
+        30,
+        15
+      ]
+    },
+    {
+      "name": "GovernanceVoteCast",
+      "discriminator": [
+        223,
+        253,
+        198,
+        94,
+        141,
+        151,
+        78,
+        57
+      ]
+    },
+    {
+      "name": "MigrationCompleted",
+      "discriminator": [
+        223,
+        45,
+        123,
+        192,
+        106,
+        249,
+        6,
+        241
+      ]
+    },
+    {
+      "name": "MultisigUpdated",
+      "discriminator": [
+        242,
+        206,
+        37,
+        59,
+        122,
+        197,
+        210,
+        72
+      ]
+    },
+    {
+      "name": "PostCreated",
+      "discriminator": [
+        209,
+        178,
+        232,
+        24,
+        158,
+        92,
+        77,
+        227
+      ]
+    },
+    {
+      "name": "PostUpvoted",
+      "discriminator": [
+        85,
+        112,
+        248,
+        67,
+        90,
+        20,
+        117,
+        210
+      ]
+    },
+    {
+      "name": "ProposalCancelled",
+      "discriminator": [
+        253,
+        59,
+        104,
+        46,
+        129,
+        78,
+        9,
+        14
+      ]
+    },
+    {
+      "name": "ProposalCreated",
+      "discriminator": [
+        186,
+        8,
+        160,
+        108,
+        81,
+        13,
+        51,
+        206
+      ]
+    },
+    {
+      "name": "ProposalExecuted",
+      "discriminator": [
+        92,
+        213,
+        189,
+        201,
+        101,
+        83,
+        111,
+        83
+      ]
+    },
+    {
+      "name": "ProtocolFeeUpdated",
+      "discriminator": [
+        172,
+        56,
+        83,
+        113,
+        219,
+        69,
+        69,
+        105
+      ]
+    },
+    {
+      "name": "ProtocolInitialized",
+      "discriminator": [
+        173,
+        122,
+        168,
+        254,
+        9,
+        118,
+        76,
+        132
+      ]
+    },
+    {
+      "name": "ProtocolVersionUpdated",
+      "discriminator": [
+        233,
+        202,
+        182,
+        241,
+        6,
+        134,
+        81,
+        48
+      ]
+    },
+    {
+      "name": "RateLimitHit",
+      "discriminator": [
+        157,
+        150,
+        77,
+        158,
+        30,
+        167,
+        242,
+        145
+      ]
+    },
+    {
+      "name": "RateLimitsUpdated",
+      "discriminator": [
+        32,
+        232,
+        72,
+        132,
+        73,
+        25,
+        219,
+        10
+      ]
+    },
+    {
+      "name": "ReputationChanged",
+      "discriminator": [
+        190,
+        190,
+        93,
+        65,
+        6,
+        39,
+        92,
+        250
+      ]
+    },
+    {
+      "name": "ReputationDelegated",
+      "discriminator": [
+        143,
+        11,
+        134,
+        202,
+        135,
+        97,
+        121,
+        223
+      ]
+    },
+    {
+      "name": "ReputationDelegationRevoked",
+      "discriminator": [
+        130,
+        130,
+        191,
+        20,
+        81,
+        88,
+        109,
+        152
+      ]
+    },
+    {
+      "name": "ReputationStakeWithdrawn",
+      "discriminator": [
+        189,
+        97,
+        237,
+        131,
+        201,
+        190,
+        121,
+        43
+      ]
+    },
+    {
+      "name": "ReputationStaked",
+      "discriminator": [
+        12,
+        70,
+        73,
+        125,
+        30,
+        125,
+        6,
+        10
+      ]
+    },
+    {
+      "name": "RewardDistributed",
+      "discriminator": [
+        36,
+        65,
+        223,
+        38,
+        136,
+        162,
+        10,
+        30
+      ]
+    },
+    {
+      "name": "SkillPurchased",
+      "discriminator": [
+        90,
+        255,
+        155,
+        123,
+        29,
+        16,
+        39,
+        75
+      ]
+    },
+    {
+      "name": "SkillRated",
+      "discriminator": [
+        90,
+        85,
+        214,
+        124,
+        228,
+        179,
+        112,
+        13
+      ]
+    },
+    {
+      "name": "SkillRegistered",
+      "discriminator": [
+        222,
+        131,
+        204,
+        34,
+        182,
+        68,
+        239,
+        64
+      ]
+    },
+    {
+      "name": "SkillUpdated",
+      "discriminator": [
+        168,
+        10,
+        44,
+        211,
+        219,
+        5,
+        98,
+        98
+      ]
+    },
+    {
+      "name": "SpeculativeCommitmentCreated",
+      "discriminator": [
+        72,
+        69,
+        96,
+        30,
+        161,
+        244,
+        6,
+        183
+      ]
+    },
+    {
+      "name": "StateUpdated",
+      "discriminator": [
+        187,
+        220,
+        147,
+        37,
+        52,
+        210,
+        78,
+        173
+      ]
+    },
+    {
+      "name": "TaskCancelled",
+      "discriminator": [
+        158,
+        101,
+        220,
+        187,
+        16,
+        141,
+        141,
+        64
+      ]
+    },
+    {
+      "name": "TaskClaimed",
+      "discriminator": [
+        208,
+        90,
+        243,
+        116,
+        80,
+        15,
+        228,
+        202
+      ]
+    },
+    {
+      "name": "TaskCompleted",
+      "discriminator": [
+        132,
+        223,
+        98,
+        152,
+        2,
+        9,
+        57,
+        128
+      ]
+    },
+    {
+      "name": "TaskCreated",
+      "discriminator": [
+        49,
+        174,
+        6,
+        7,
+        71,
+        159,
+        69,
+        175
+      ]
+    },
+    {
+      "name": "TreasuryUpdated",
+      "discriminator": [
+        80,
+        239,
+        54,
+        168,
+        43,
+        38,
+        85,
+        145
+      ]
+    }
+  ],
+  "errors": [
+    {
+      "code": 6000,
+      "name": "AgentAlreadyRegistered",
+      "msg": "Agent is already registered"
+    },
+    {
+      "code": 6001,
+      "name": "AgentNotFound",
+      "msg": "Agent not found"
+    },
+    {
+      "code": 6002,
+      "name": "AgentNotActive",
+      "msg": "Agent is not active"
+    },
+    {
+      "code": 6003,
+      "name": "InsufficientCapabilities",
+      "msg": "Agent has insufficient capabilities"
+    },
+    {
+      "code": 6004,
+      "name": "InvalidCapabilities",
+      "msg": "Agent capabilities bitmask cannot be zero"
+    },
+    {
+      "code": 6005,
+      "name": "MaxActiveTasksReached",
+      "msg": "Agent has reached maximum active tasks"
+    },
+    {
+      "code": 6006,
+      "name": "AgentHasActiveTasks",
+      "msg": "Agent has active tasks and cannot be deregistered"
+    },
+    {
+      "code": 6007,
+      "name": "UnauthorizedAgent",
+      "msg": "Only the agent authority can perform this action"
+    },
+    {
+      "code": 6008,
+      "name": "CreatorAuthorityMismatch",
+      "msg": "Creator must match authority to prevent social engineering"
+    },
+    {
+      "code": 6009,
+      "name": "InvalidAgentId",
+      "msg": "Invalid agent ID: agent_id cannot be all zeros"
+    },
+    {
+      "code": 6010,
+      "name": "AgentRegistrationRequired",
+      "msg": "Agent registration required to create tasks"
+    },
+    {
+      "code": 6011,
+      "name": "AgentSuspended",
+      "msg": "Agent is suspended and cannot change status"
+    },
+    {
+      "code": 6012,
+      "name": "AgentBusyWithTasks",
+      "msg": "Agent cannot set status to Active while having active tasks"
+    },
+    {
+      "code": 6013,
+      "name": "TaskNotFound",
+      "msg": "Task not found"
+    },
+    {
+      "code": 6014,
+      "name": "TaskNotOpen",
+      "msg": "Task is not open for claims"
+    },
+    {
+      "code": 6015,
+      "name": "TaskFullyClaimed",
+      "msg": "Task has reached maximum workers"
+    },
+    {
+      "code": 6016,
+      "name": "TaskExpired",
+      "msg": "Task has expired"
+    },
+    {
+      "code": 6017,
+      "name": "TaskNotExpired",
+      "msg": "Task deadline has not passed"
+    },
+    {
+      "code": 6018,
+      "name": "DeadlinePassed",
+      "msg": "Task deadline has passed"
+    },
+    {
+      "code": 6019,
+      "name": "TaskNotInProgress",
+      "msg": "Task is not in progress"
+    },
+    {
+      "code": 6020,
+      "name": "TaskAlreadyCompleted",
+      "msg": "Task is already completed"
+    },
+    {
+      "code": 6021,
+      "name": "TaskCannotBeCancelled",
+      "msg": "Task cannot be cancelled"
+    },
+    {
+      "code": 6022,
+      "name": "UnauthorizedTaskAction",
+      "msg": "Only the task creator can perform this action"
+    },
+    {
+      "code": 6023,
+      "name": "InvalidCreator",
+      "msg": "Invalid creator"
+    },
+    {
+      "code": 6024,
+      "name": "InvalidTaskId",
+      "msg": "Invalid task ID: cannot be zero"
+    },
+    {
+      "code": 6025,
+      "name": "InvalidDescription",
+      "msg": "Invalid description: cannot be empty"
+    },
+    {
+      "code": 6026,
+      "name": "InvalidMaxWorkers",
+      "msg": "Invalid max workers: must be between 1 and 100"
+    },
+    {
+      "code": 6027,
+      "name": "InvalidTaskType",
+      "msg": "Invalid task type"
+    },
+    {
+      "code": 6028,
+      "name": "InvalidDeadline",
+      "msg": "Invalid deadline: deadline must be greater than zero"
+    },
+    {
+      "code": 6029,
+      "name": "InvalidReward",
+      "msg": "Invalid reward: reward must be greater than zero"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidRequiredCapabilities",
+      "msg": "Invalid required capabilities: required_capabilities cannot be zero"
+    },
+    {
+      "code": 6031,
+      "name": "CompetitiveTaskAlreadyWon",
+      "msg": "Competitive task already completed by another worker"
+    },
+    {
+      "code": 6032,
+      "name": "NoWorkers",
+      "msg": "Task has no workers"
+    },
+    {
+      "code": 6033,
+      "name": "ConstraintHashMismatch",
+      "msg": "Proof constraint hash does not match task's stored constraint hash"
+    },
+    {
+      "code": 6034,
+      "name": "NotPrivateTask",
+      "msg": "Task is not a private task (no constraint hash set)"
+    },
+    {
+      "code": 6035,
+      "name": "AlreadyClaimed",
+      "msg": "Worker has already claimed this task"
+    },
+    {
+      "code": 6036,
+      "name": "NotClaimed",
+      "msg": "Worker has not claimed this task"
+    },
+    {
+      "code": 6037,
+      "name": "ClaimAlreadyCompleted",
+      "msg": "Claim has already been completed"
+    },
+    {
+      "code": 6038,
+      "name": "ClaimNotExpired",
+      "msg": "Claim has not expired yet"
+    },
+    {
+      "code": 6039,
+      "name": "ClaimExpired",
+      "msg": "Claim has expired"
+    },
+    {
+      "code": 6040,
+      "name": "InvalidExpiration",
+      "msg": "Invalid expiration: expires_at cannot be zero"
+    },
+    {
+      "code": 6041,
+      "name": "InvalidProof",
+      "msg": "Invalid proof of work"
+    },
+    {
+      "code": 6042,
+      "name": "ZkVerificationFailed",
+      "msg": "ZK proof verification failed"
+    },
+    {
+      "code": 6043,
+      "name": "InvalidSealEncoding",
+      "msg": "Invalid RISC0 seal encoding"
+    },
+    {
+      "code": 6044,
+      "name": "InvalidJournalLength",
+      "msg": "Invalid RISC0 journal length"
+    },
+    {
+      "code": 6045,
+      "name": "InvalidJournalBinding",
+      "msg": "Invalid RISC0 journal binding"
+    },
+    {
+      "code": 6046,
+      "name": "InvalidJournalTask",
+      "msg": "RISC0 journal task binding mismatch"
+    },
+    {
+      "code": 6047,
+      "name": "InvalidJournalAuthority",
+      "msg": "RISC0 journal authority binding mismatch"
+    },
+    {
+      "code": 6048,
+      "name": "InvalidImageId",
+      "msg": "Invalid RISC0 image ID"
+    },
+    {
+      "code": 6049,
+      "name": "TrustedSelectorMismatch",
+      "msg": "RISC0 seal selector does not match trusted selector"
+    },
+    {
+      "code": 6050,
+      "name": "TrustedVerifierProgramMismatch",
+      "msg": "RISC0 verifier program does not match trusted verifier"
+    },
+    {
+      "code": 6051,
+      "name": "RouterAccountMismatch",
+      "msg": "RISC0 router account constraints failed"
+    },
+    {
+      "code": 6052,
+      "name": "InvalidProofSize",
+      "msg": "Invalid proof size - expected 256 bytes for RISC Zero seal body"
+    },
+    {
+      "code": 6053,
+      "name": "InvalidProofBinding",
+      "msg": "Invalid proof binding: expected_binding cannot be all zeros"
+    },
+    {
+      "code": 6054,
+      "name": "InvalidOutputCommitment",
+      "msg": "Invalid output commitment: output_commitment cannot be all zeros"
+    },
+    {
+      "code": 6055,
+      "name": "InvalidRentRecipient",
+      "msg": "Invalid rent recipient: must be worker authority"
+    },
+    {
+      "code": 6056,
+      "name": "GracePeriodNotPassed",
+      "msg": "Grace period not passed: only worker authority can expire claim within 60 seconds of expiry"
+    },
+    {
+      "code": 6057,
+      "name": "InvalidProofHash",
+      "msg": "Invalid proof hash: proof_hash cannot be all zeros"
+    },
+    {
+      "code": 6058,
+      "name": "InvalidResultData",
+      "msg": "Invalid result data: result_data cannot be all zeros when provided"
+    },
+    {
+      "code": 6059,
+      "name": "DisputeNotActive",
+      "msg": "Dispute is not active"
+    },
+    {
+      "code": 6060,
+      "name": "VotingEnded",
+      "msg": "Voting period has ended"
+    },
+    {
+      "code": 6061,
+      "name": "VotingNotEnded",
+      "msg": "Voting period has not ended"
+    },
+    {
+      "code": 6062,
+      "name": "AlreadyVoted",
+      "msg": "Already voted on this dispute"
+    },
+    {
+      "code": 6063,
+      "name": "NotArbiter",
+      "msg": "Not authorized to vote (not an arbiter)"
+    },
+    {
+      "code": 6064,
+      "name": "InsufficientVotes",
+      "msg": "Insufficient votes to resolve"
+    },
+    {
+      "code": 6065,
+      "name": "DisputeAlreadyResolved",
+      "msg": "Dispute has already been resolved"
+    },
+    {
+      "code": 6066,
+      "name": "UnauthorizedResolver",
+      "msg": "Only protocol authority or dispute initiator can resolve disputes"
+    },
+    {
+      "code": 6067,
+      "name": "ActiveDisputeVotes",
+      "msg": "Agent has active dispute votes pending resolution"
+    },
+    {
+      "code": 6068,
+      "name": "RecentVoteActivity",
+      "msg": "Agent must wait 24 hours after voting before deregistering"
+    },
+    {
+      "code": 6069,
+      "name": "AuthorityAlreadyVoted",
+      "msg": "Authority has already voted on this dispute"
+    },
+    {
+      "code": 6070,
+      "name": "InsufficientEvidence",
+      "msg": "Insufficient dispute evidence provided"
+    },
+    {
+      "code": 6071,
+      "name": "EvidenceTooLong",
+      "msg": "Dispute evidence exceeds maximum allowed length"
+    },
+    {
+      "code": 6072,
+      "name": "DisputeNotExpired",
+      "msg": "Dispute has not expired"
+    },
+    {
+      "code": 6073,
+      "name": "SlashAlreadyApplied",
+      "msg": "Dispute slashing already applied"
+    },
+    {
+      "code": 6074,
+      "name": "SlashWindowExpired",
+      "msg": "Slash window expired: must apply slashing within 7 days of resolution"
+    },
+    {
+      "code": 6075,
+      "name": "DisputeNotResolved",
+      "msg": "Dispute has not been resolved"
+    },
+    {
+      "code": 6076,
+      "name": "NotTaskParticipant",
+      "msg": "Only task creator or workers can initiate disputes"
+    },
+    {
+      "code": 6077,
+      "name": "InvalidEvidenceHash",
+      "msg": "Invalid evidence hash: cannot be all zeros"
+    },
+    {
+      "code": 6078,
+      "name": "ArbiterIsDisputeParticipant",
+      "msg": "Arbiter cannot vote on disputes they are a participant in"
+    },
+    {
+      "code": 6079,
+      "name": "InsufficientQuorum",
+      "msg": "Insufficient quorum: minimum number of voters not reached"
+    },
+    {
+      "code": 6080,
+      "name": "ActiveDisputesExist",
+      "msg": "Agent has active disputes as defendant and cannot deregister"
+    },
+    {
+      "code": 6081,
+      "name": "WorkerAgentRequired",
+      "msg": "Worker agent account required when creator initiates dispute"
+    },
+    {
+      "code": 6082,
+      "name": "WorkerClaimRequired",
+      "msg": "Worker claim account required when creator initiates dispute"
+    },
+    {
+      "code": 6083,
+      "name": "WorkerNotInDispute",
+      "msg": "Worker was not involved in this dispute"
+    },
+    {
+      "code": 6084,
+      "name": "InitiatorCannotResolve",
+      "msg": "Dispute initiator cannot resolve their own dispute"
+    },
+    {
+      "code": 6085,
+      "name": "VersionMismatch",
+      "msg": "State version mismatch (concurrent modification)"
+    },
+    {
+      "code": 6086,
+      "name": "StateKeyExists",
+      "msg": "State key already exists"
+    },
+    {
+      "code": 6087,
+      "name": "StateNotFound",
+      "msg": "State not found"
+    },
+    {
+      "code": 6088,
+      "name": "InvalidStateValue",
+      "msg": "Invalid state value: state_value cannot be all zeros"
+    },
+    {
+      "code": 6089,
+      "name": "StateOwnershipViolation",
+      "msg": "State ownership violation: only the creator agent can update this state"
+    },
+    {
+      "code": 6090,
+      "name": "InvalidStateKey",
+      "msg": "Invalid state key: state_key cannot be all zeros"
+    },
+    {
+      "code": 6091,
+      "name": "ProtocolAlreadyInitialized",
+      "msg": "Protocol is already initialized"
+    },
+    {
+      "code": 6092,
+      "name": "ProtocolNotInitialized",
+      "msg": "Protocol is not initialized"
+    },
+    {
+      "code": 6093,
+      "name": "InvalidProtocolFee",
+      "msg": "Invalid protocol fee (must be <= 1000 bps)"
+    },
+    {
+      "code": 6094,
+      "name": "InvalidTreasury",
+      "msg": "Invalid treasury: treasury account cannot be default pubkey"
+    },
+    {
+      "code": 6095,
+      "name": "InvalidDisputeThreshold",
+      "msg": "Invalid dispute threshold: must be 1-100 (percentage of votes required)"
+    },
+    {
+      "code": 6096,
+      "name": "InsufficientStake",
+      "msg": "Insufficient stake for arbiter registration"
+    },
+    {
+      "code": 6097,
+      "name": "MultisigInvalidThreshold",
+      "msg": "Invalid multisig threshold"
+    },
+    {
+      "code": 6098,
+      "name": "MultisigInvalidSigners",
+      "msg": "Invalid multisig signer configuration"
+    },
+    {
+      "code": 6099,
+      "name": "MultisigNotEnoughSigners",
+      "msg": "Not enough multisig signers"
+    },
+    {
+      "code": 6100,
+      "name": "MultisigDuplicateSigner",
+      "msg": "Duplicate multisig signer provided"
+    },
+    {
+      "code": 6101,
+      "name": "MultisigDefaultSigner",
+      "msg": "Multisig signer cannot be default pubkey"
+    },
+    {
+      "code": 6102,
+      "name": "MultisigSignerNotSystemOwned",
+      "msg": "Multisig signer account not owned by System Program"
+    },
+    {
+      "code": 6103,
+      "name": "InvalidInput",
+      "msg": "Invalid input parameter"
+    },
+    {
+      "code": 6104,
+      "name": "ArithmeticOverflow",
+      "msg": "Arithmetic overflow"
+    },
+    {
+      "code": 6105,
+      "name": "VoteOverflow",
+      "msg": "Vote count overflow"
+    },
+    {
+      "code": 6106,
+      "name": "InsufficientFunds",
+      "msg": "Insufficient funds"
+    },
+    {
+      "code": 6107,
+      "name": "RewardTooSmall",
+      "msg": "Reward too small: worker must receive at least 1 lamport"
+    },
+    {
+      "code": 6108,
+      "name": "CorruptedData",
+      "msg": "Account data is corrupted"
+    },
+    {
+      "code": 6109,
+      "name": "StringTooLong",
+      "msg": "String too long"
+    },
+    {
+      "code": 6110,
+      "name": "InvalidAccountOwner",
+      "msg": "Account owner validation failed: account not owned by this program"
+    },
+    {
+      "code": 6111,
+      "name": "RateLimitExceeded",
+      "msg": "Rate limit exceeded: maximum actions per 24h window reached"
+    },
+    {
+      "code": 6112,
+      "name": "CooldownNotElapsed",
+      "msg": "Cooldown period has not elapsed since last action"
+    },
+    {
+      "code": 6113,
+      "name": "UpdateTooFrequent",
+      "msg": "Agent update too frequent: must wait cooldown period"
+    },
+    {
+      "code": 6114,
+      "name": "InvalidCooldown",
+      "msg": "Cooldown value cannot be negative"
+    },
+    {
+      "code": 6115,
+      "name": "CooldownTooLarge",
+      "msg": "Cooldown value exceeds maximum (24 hours)"
+    },
+    {
+      "code": 6116,
+      "name": "RateLimitTooHigh",
+      "msg": "Rate limit value exceeds maximum allowed (1000)"
+    },
+    {
+      "code": 6117,
+      "name": "CooldownTooLong",
+      "msg": "Cooldown value exceeds maximum allowed (1 week)"
+    },
+    {
+      "code": 6118,
+      "name": "InsufficientStakeForDispute",
+      "msg": "Insufficient stake to initiate dispute"
+    },
+    {
+      "code": 6119,
+      "name": "InsufficientStakeForCreatorDispute",
+      "msg": "Creator-initiated disputes require 2x the minimum stake"
+    },
+    {
+      "code": 6120,
+      "name": "VersionMismatchProtocol",
+      "msg": "Protocol version mismatch: account version incompatible with current program"
+    },
+    {
+      "code": 6121,
+      "name": "AccountVersionTooOld",
+      "msg": "Account version too old: migration required"
+    },
+    {
+      "code": 6122,
+      "name": "AccountVersionTooNew",
+      "msg": "Account version too new: program upgrade required"
+    },
+    {
+      "code": 6123,
+      "name": "InvalidMigrationSource",
+      "msg": "Migration not allowed: invalid source version"
+    },
+    {
+      "code": 6124,
+      "name": "InvalidMigrationTarget",
+      "msg": "Migration not allowed: invalid target version"
+    },
+    {
+      "code": 6125,
+      "name": "UnauthorizedUpgrade",
+      "msg": "Only upgrade authority can perform this action"
+    },
+    {
+      "code": 6126,
+      "name": "InvalidMinVersion",
+      "msg": "Minimum version cannot exceed current protocol version"
+    },
+    {
+      "code": 6127,
+      "name": "ProtocolConfigRequired",
+      "msg": "Protocol config account required: suspending an agent requires the protocol config PDA in remaining_accounts"
+    },
+    {
+      "code": 6128,
+      "name": "ParentTaskCancelled",
+      "msg": "Parent task has been cancelled"
+    },
+    {
+      "code": 6129,
+      "name": "ParentTaskDisputed",
+      "msg": "Parent task is in disputed state"
+    },
+    {
+      "code": 6130,
+      "name": "InvalidDependencyType",
+      "msg": "Invalid dependency type"
+    },
+    {
+      "code": 6131,
+      "name": "ParentTaskNotCompleted",
+      "msg": "Parent task must be completed before completing a proof-dependent task"
+    },
+    {
+      "code": 6132,
+      "name": "ParentTaskAccountRequired",
+      "msg": "Parent task account required for proof-dependent task completion"
+    },
+    {
+      "code": 6133,
+      "name": "UnauthorizedCreator",
+      "msg": "Parent task does not belong to the same creator"
+    },
+    {
+      "code": 6134,
+      "name": "NullifierAlreadySpent",
+      "msg": "Nullifier has already been spent - proof/knowledge reuse detected"
+    },
+    {
+      "code": 6135,
+      "name": "InvalidNullifier",
+      "msg": "Invalid nullifier: nullifier value cannot be all zeros"
+    },
+    {
+      "code": 6136,
+      "name": "IncompleteWorkerAccounts",
+      "msg": "All worker accounts must be provided when cancelling a task with active claims"
+    },
+    {
+      "code": 6137,
+      "name": "WorkerAccountsRequired",
+      "msg": "Worker accounts required when task has active workers"
+    },
+    {
+      "code": 6138,
+      "name": "DuplicateArbiter",
+      "msg": "Duplicate arbiter provided in remaining_accounts"
+    },
+    {
+      "code": 6139,
+      "name": "InsufficientEscrowBalance",
+      "msg": "Escrow has insufficient balance for reward transfer"
+    },
+    {
+      "code": 6140,
+      "name": "InvalidStatusTransition",
+      "msg": "Invalid task status transition"
+    },
+    {
+      "code": 6141,
+      "name": "StakeTooLow",
+      "msg": "Stake value is below minimum required (0.001 SOL)"
+    },
+    {
+      "code": 6142,
+      "name": "InvalidMinStake",
+      "msg": "min_stake_for_dispute must be greater than zero"
+    },
+    {
+      "code": 6143,
+      "name": "InvalidSlashAmount",
+      "msg": "Slash amount must be greater than zero"
+    },
+    {
+      "code": 6144,
+      "name": "BondAmountTooLow",
+      "msg": "Bond amount too low"
+    },
+    {
+      "code": 6145,
+      "name": "BondAlreadyExists",
+      "msg": "Bond already exists"
+    },
+    {
+      "code": 6146,
+      "name": "BondNotFound",
+      "msg": "Bond not found"
+    },
+    {
+      "code": 6147,
+      "name": "BondNotMatured",
+      "msg": "Bond not yet matured"
+    },
+    {
+      "code": 6148,
+      "name": "InsufficientReputation",
+      "msg": "Agent reputation below task minimum requirement"
+    },
+    {
+      "code": 6149,
+      "name": "InvalidMinReputation",
+      "msg": "Invalid minimum reputation: must be <= 10000"
+    },
+    {
+      "code": 6150,
+      "name": "DevelopmentKeyNotAllowed",
+      "msg": "Development verifying key detected (gamma == delta). ZK proofs are forgeable. Run MPC ceremony before use."
+    },
+    {
+      "code": 6151,
+      "name": "SelfTaskNotAllowed",
+      "msg": "Cannot claim own task: worker authority matches task creator"
+    },
+    {
+      "code": 6152,
+      "name": "MissingTokenAccounts",
+      "msg": "Token accounts not provided for token-denominated task"
+    },
+    {
+      "code": 6153,
+      "name": "InvalidTokenEscrow",
+      "msg": "Token escrow ATA does not match expected derivation"
+    },
+    {
+      "code": 6154,
+      "name": "InvalidTokenMint",
+      "msg": "Provided mint does not match task's reward_mint"
+    },
+    {
+      "code": 6155,
+      "name": "TokenTransferFailed",
+      "msg": "SPL token transfer CPI failed"
+    },
+    {
+      "code": 6156,
+      "name": "ProposalNotActive",
+      "msg": "Proposal is not active"
+    },
+    {
+      "code": 6157,
+      "name": "ProposalVotingNotEnded",
+      "msg": "Voting period has not ended"
+    },
+    {
+      "code": 6158,
+      "name": "ProposalVotingEnded",
+      "msg": "Voting period has ended"
+    },
+    {
+      "code": 6159,
+      "name": "ProposalAlreadyExecuted",
+      "msg": "Proposal has already been executed"
+    },
+    {
+      "code": 6160,
+      "name": "ProposalInsufficientQuorum",
+      "msg": "Insufficient quorum for proposal execution"
+    },
+    {
+      "code": 6161,
+      "name": "ProposalNotApproved",
+      "msg": "Proposal did not achieve majority"
+    },
+    {
+      "code": 6162,
+      "name": "ProposalUnauthorizedCancel",
+      "msg": "Only the proposer can cancel this proposal"
+    },
+    {
+      "code": 6163,
+      "name": "ProposalInsufficientStake",
+      "msg": "Insufficient stake to create a proposal"
+    },
+    {
+      "code": 6164,
+      "name": "InvalidProposalPayload",
+      "msg": "Invalid proposal payload"
+    },
+    {
+      "code": 6165,
+      "name": "InvalidProposalType",
+      "msg": "Invalid proposal type"
+    },
+    {
+      "code": 6166,
+      "name": "TreasuryInsufficientBalance",
+      "msg": "Treasury spend amount exceeds available balance"
+    },
+    {
+      "code": 6167,
+      "name": "TimelockNotElapsed",
+      "msg": "Execution timelock has not elapsed"
+    },
+    {
+      "code": 6168,
+      "name": "InvalidGovernanceParam",
+      "msg": "Invalid governance configuration parameter"
+    },
+    {
+      "code": 6169,
+      "name": "TreasuryNotProgramOwned",
+      "msg": "Treasury must be a program-owned PDA"
+    },
+    {
+      "code": 6170,
+      "name": "TreasuryNotSpendable",
+      "msg": "Treasury must be program-owned, or a signer system account for governance spends"
+    },
+    {
+      "code": 6171,
+      "name": "SkillInvalidId",
+      "msg": "Skill ID cannot be all zeros"
+    },
+    {
+      "code": 6172,
+      "name": "SkillInvalidName",
+      "msg": "Skill name cannot be all zeros"
+    },
+    {
+      "code": 6173,
+      "name": "SkillInvalidContentHash",
+      "msg": "Skill content hash cannot be all zeros"
+    },
+    {
+      "code": 6174,
+      "name": "SkillNotActive",
+      "msg": "Skill is not active"
+    },
+    {
+      "code": 6175,
+      "name": "SkillInvalidRating",
+      "msg": "Rating must be between 1 and 5"
+    },
+    {
+      "code": 6176,
+      "name": "SkillSelfRating",
+      "msg": "Cannot rate own skill"
+    },
+    {
+      "code": 6177,
+      "name": "SkillUnauthorizedUpdate",
+      "msg": "Only the skill author can update this skill"
+    },
+    {
+      "code": 6178,
+      "name": "SkillSelfPurchase",
+      "msg": "Cannot purchase own skill"
+    },
+    {
+      "code": 6179,
+      "name": "FeedInvalidContentHash",
+      "msg": "Feed content hash cannot be all zeros"
+    },
+    {
+      "code": 6180,
+      "name": "FeedInvalidTopic",
+      "msg": "Feed topic cannot be all zeros"
+    },
+    {
+      "code": 6181,
+      "name": "FeedPostNotFound",
+      "msg": "Feed post not found"
+    },
+    {
+      "code": 6182,
+      "name": "FeedSelfUpvote",
+      "msg": "Cannot upvote own post"
+    },
+    {
+      "code": 6183,
+      "name": "ReputationStakeAmountTooLow",
+      "msg": "Reputation stake amount must be greater than zero"
+    },
+    {
+      "code": 6184,
+      "name": "ReputationStakeLocked",
+      "msg": "Reputation stake is locked: withdrawal before cooldown"
+    },
+    {
+      "code": 6185,
+      "name": "ReputationStakeInsufficientBalance",
+      "msg": "Reputation stake has insufficient balance for withdrawal"
+    },
+    {
+      "code": 6186,
+      "name": "ReputationDelegationAmountInvalid",
+      "msg": "Reputation delegation amount invalid: must be > 0, <= 10000, and >= MIN_DELEGATION_AMOUNT"
+    },
+    {
+      "code": 6187,
+      "name": "ReputationCannotDelegateSelf",
+      "msg": "Cannot delegate reputation to self"
+    },
+    {
+      "code": 6188,
+      "name": "ReputationDelegationExpired",
+      "msg": "Reputation delegation has expired"
+    },
+    {
+      "code": 6189,
+      "name": "ReputationAgentNotActive",
+      "msg": "Agent must be Active to participate in reputation economy"
+    },
+    {
+      "code": 6190,
+      "name": "ReputationDisputesPending",
+      "msg": "Agent has pending disputes as defendant: cannot withdraw stake"
+    },
+    {
+      "code": 6191,
+      "name": "PrivateTaskRequiresZkProof",
+      "msg": "Private tasks (non-zero constraint_hash) must use complete_task_private"
+    },
+    {
+      "code": 6192,
+      "name": "InvalidTokenAccountOwner",
+      "msg": "Token account owner does not match expected authority"
+    },
+    {
+      "code": 6193,
+      "name": "InsufficientSeedEntropy",
+      "msg": "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
+    }
+  ],
   "types": [
     {
+      "name": "AgentDeregistered",
       "docs": [
         "Emitted when an agent deregisters"
       ],
-      "name": "AgentDeregistered",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "agent_id",
@@ -1864,16 +7475,16 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "AgentRegistered",
       "docs": [
         "Emitted when a new agent registers"
       ],
-      "name": "AgentRegistered",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "agent_id",
@@ -1897,26 +7508,30 @@
             "type": "string"
           },
           {
+            "name": "stake_amount",
+            "type": "u64"
+          },
+          {
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "AgentRegistration",
       "docs": [
         "Agent registration account",
         "PDA seeds: [\"agent\", agent_id]"
       ],
-      "name": "AgentRegistration",
       "type": {
+        "kind": "struct",
         "fields": [
           {
+            "name": "agent_id",
             "docs": [
               "Unique agent identifier"
             ],
-            "name": "agent_id",
             "type": {
               "array": [
                 "u8",
@@ -1925,24 +7540,32 @@
             }
           },
           {
+            "name": "authority",
             "docs": [
               "Agent's signing authority"
             ],
-            "name": "authority",
             "type": "pubkey"
           },
           {
-            "docs": [
-              "Capability bitmask"
-            ],
             "name": "capabilities",
+            "docs": [
+              "Agent capabilities as a bitmask (u64).",
+              "",
+              "Each bit represents a specific capability the agent possesses.",
+              "See [`capability`] module for defined bits:",
+              "- Bits 0-9: Currently defined capabilities (COMPUTE, INFERENCE, etc.)",
+              "- Bits 10-63: Reserved for future protocol extensions",
+              "",
+              "Agents can only claim tasks where they have all required capabilities:",
+              "`(agent.capabilities & task.required_capabilities) == task.required_capabilities`"
+            ],
             "type": "u64"
           },
           {
+            "name": "status",
             "docs": [
               "Agent status"
             ],
-            "name": "status",
             "type": {
               "defined": {
                 "name": "AgentStatus"
@@ -1950,96 +7573,162 @@
             }
           },
           {
-            "docs": [
-              "Network endpoint (max 128 chars)"
-            ],
             "name": "endpoint",
+            "docs": [
+              "Network endpoint (max 256 chars)"
+            ],
             "type": "string"
           },
           {
+            "name": "metadata_uri",
             "docs": [
               "Extended metadata URI (max 128 chars)"
             ],
-            "name": "metadata_uri",
             "type": "string"
           },
           {
+            "name": "registered_at",
             "docs": [
               "Registration timestamp"
             ],
-            "name": "registered_at",
             "type": "i64"
           },
           {
+            "name": "last_active",
             "docs": [
               "Last activity timestamp"
             ],
-            "name": "last_active",
             "type": "i64"
           },
           {
+            "name": "tasks_completed",
             "docs": [
               "Total tasks completed"
             ],
-            "name": "tasks_completed",
             "type": "u64"
           },
           {
+            "name": "total_earned",
             "docs": [
               "Total rewards earned"
             ],
-            "name": "total_earned",
             "type": "u64"
           },
           {
-            "docs": [
-              "Reputation score (0-10000)"
-            ],
             "name": "reputation",
+            "docs": [
+              "Agent reputation score (0-10000)",
+              "Initial value: 5000 (neutral starting point)",
+              "Can be adjusted via protocol config in future versions"
+            ],
             "type": "u16"
           },
           {
+            "name": "active_tasks",
             "docs": [
               "Active task count"
             ],
-            "name": "active_tasks",
-            "type": "u8"
+            "type": "u16"
           },
           {
+            "name": "stake",
             "docs": [
               "Stake amount (for arbiters)"
             ],
-            "name": "stake",
             "type": "u64"
           },
           {
+            "name": "bump",
             "docs": [
               "Bump seed"
             ],
-            "name": "bump",
             "type": "u8"
           },
           {
+            "name": "last_task_created",
             "docs": [
-              "Reserved"
+              "Timestamp of last task creation"
             ],
+            "type": "i64"
+          },
+          {
+            "name": "last_dispute_initiated",
+            "docs": [
+              "Timestamp of last dispute initiated"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "task_count_24h",
+            "docs": [
+              "Number of tasks created in current 24h window"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "dispute_count_24h",
+            "docs": [
+              "Number of disputes initiated in current 24h window"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "rate_limit_window_start",
+            "docs": [
+              "Start of current rate limit window (unix timestamp)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "active_dispute_votes",
+            "docs": [
+              "Active dispute votes pending resolution"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "last_vote_timestamp",
+            "docs": [
+              "Timestamp of last dispute vote"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "last_state_update",
+            "docs": [
+              "Timestamp of last state update"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "disputes_as_defendant",
+            "docs": [
+              "Active disputes where this agent is a defendant (can be slashed)"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "_reserved",
+            "docs": [
+              "Reserved bytes for future use.",
+              "Note: Not validated on deserialization - may contain arbitrary data",
+              "from previous versions. New fields should handle this gracefully."
+            ],
             "type": {
               "array": [
                 "u8",
-                32
+                4
               ]
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "AgentStatus",
       "docs": [
         "Agent status"
       ],
-      "name": "AgentStatus",
       "repr": {
         "kind": "rust"
       },
@@ -2062,11 +7751,68 @@
       }
     },
     {
+      "name": "AgentSuspended",
+      "docs": [
+        "Emitted when an agent is suspended by the protocol authority (fix #819)"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AgentUnsuspended",
+      "docs": [
+        "Emitted when an agent is unsuspended by the protocol authority (fix #819)"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AgentUpdated",
       "docs": [
         "Emitted when an agent updates its registration"
       ],
-      "name": "AgentUpdated",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "agent_id",
@@ -2089,86 +7835,18 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "ArbiterVotesCleanedUp",
       "docs": [
-        "Shared coordination state",
-        "PDA seeds: [\"state\", state_key]"
+        "Emitted when arbiter votes are cleaned up during dispute expiration"
       ],
-      "name": "CoordinationState",
       "type": {
+        "kind": "struct",
         "fields": [
           {
-            "docs": [
-              "State key"
-            ],
-            "name": "state_key",
-            "type": {
-              "array": [
-                "u8",
-                32
-              ]
-            }
-          },
-          {
-            "docs": [
-              "State value"
-            ],
-            "name": "state_value",
-            "type": {
-              "array": [
-                "u8",
-                64
-              ]
-            }
-          },
-          {
-            "docs": [
-              "Last updater"
-            ],
-            "name": "last_updater",
-            "type": "pubkey"
-          },
-          {
-            "docs": [
-              "Version for optimistic locking"
-            ],
-            "name": "version",
-            "type": "u64"
-          },
-          {
-            "docs": [
-              "Last update timestamp"
-            ],
-            "name": "updated_at",
-            "type": "i64"
-          },
-          {
-            "docs": [
-              "Bump seed"
-            ],
-            "name": "bump",
-            "type": "u8"
-          }
-        ],
-        "kind": "struct"
-      }
-    },
-    {
-      "docs": [
-        "Dispute account for conflict resolution",
-        "PDA seeds: [\"dispute\", dispute_id]"
-      ],
-      "name": "Dispute",
-      "type": {
-        "fields": [
-          {
-            "docs": [
-              "Dispute identifier"
-            ],
             "name": "dispute_id",
             "type": {
               "array": [
@@ -2178,24 +7856,75 @@
             }
           },
           {
+            "name": "arbiter_count",
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "AuthorityDisputeVote",
+      "docs": [
+        "Authority-level vote record to prevent Sybil attacks",
+        "One authority can only vote once per dispute, regardless of how many agents they control",
+        "PDA seeds: [\"authority_vote\", dispute, authority]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dispute",
             "docs": [
-              "Related task"
+              "Dispute being voted on"
             ],
-            "name": "task",
             "type": "pubkey"
           },
           {
+            "name": "authority",
             "docs": [
-              "Initiator"
+              "Authority (wallet) that voted"
             ],
-            "name": "initiator",
             "type": "pubkey"
           },
           {
+            "name": "voting_agent",
             "docs": [
-              "Evidence hash"
+              "The agent used to cast this vote"
             ],
-            "name": "evidence_hash",
+            "type": "pubkey"
+          },
+          {
+            "name": "voted_at",
+            "docs": [
+              "Vote timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BindingSpend",
+      "docs": [
+        "Binding spend account to prevent statement replay for the same",
+        "task/authority/commitment context.",
+        "PDA seeds: [\"binding_spend\", binding]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "binding",
+            "docs": [
+              "Binding value committed in the private journal."
+            ],
             "type": {
               "array": [
                 "u8",
@@ -2204,10 +7933,349 @@
             }
           },
           {
+            "name": "task",
+            "docs": [
+              "The task where this binding was first used"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "agent",
+            "docs": [
+              "The agent who spent this binding"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "spent_at",
+            "docs": [
+              "Timestamp when binding was spent"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondDeposited",
+      "docs": [
+        "Emitted when bond is deposited to speculation bond account"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "new_total",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondLocked",
+      "docs": [
+        "Emitted when bond is locked for a commitment"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondReleased",
+      "docs": [
+        "Emitted when bond is released back to agent after successful proof"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "BondSlashed",
+      "docs": [
+        "Emitted when an agent's bond is slashed due to failed speculation"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "commitment",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "reason",
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "CoordinationState",
+      "docs": [
+        "Shared coordination state",
+        "PDA seeds: [\"state\", owner, state_key]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "owner",
+            "docs": [
+              "Owner authority - namespaces state to prevent cross-user collisions"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "state_key",
+            "docs": [
+              "State key"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "state_value",
+            "docs": [
+              "State value"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "last_updater",
+            "docs": [
+              "Last updater"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "version",
+            "docs": [
+              "Version for optimistic locking"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "updated_at",
+            "docs": [
+              "Last update timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DependencyType",
+      "docs": [
+        "Task dependency type for speculative execution decisions"
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "None"
+          },
+          {
+            "name": "Data"
+          },
+          {
+            "name": "Ordering"
+          },
+          {
+            "name": "Proof"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DependentTaskCreated",
+      "docs": [
+        "Emitted when a task with dependencies is created"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "task_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "creator",
+            "type": "pubkey"
+          },
+          {
+            "name": "depends_on",
+            "type": "pubkey"
+          },
+          {
+            "name": "dependency_type",
+            "type": "u8"
+          },
+          {
+            "name": "reward_mint",
+            "docs": [
+              "SPL token mint for reward denomination (None = SOL)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Dispute",
+      "docs": [
+        "Dispute account for conflict resolution",
+        "PDA seeds: [\"dispute\", dispute_id]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dispute_id",
+            "docs": [
+              "Dispute identifier"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "task",
+            "docs": [
+              "Related task"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "initiator",
+            "docs": [
+              "Initiator (agent PDA)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "initiator_authority",
+            "docs": [
+              "Initiator's authority wallet (for resolver constraint)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "evidence_hash",
+            "docs": [
+              "Evidence hash"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "resolution_type",
             "docs": [
               "Proposed resolution type"
             ],
-            "name": "resolution_type",
             "type": {
               "defined": {
                 "name": "ResolutionType"
@@ -2215,10 +8283,10 @@
             }
           },
           {
+            "name": "status",
             "docs": [
               "Dispute status"
             ],
-            "name": "status",
             "type": {
               "defined": {
                 "name": "DisputeStatus"
@@ -2226,64 +8294,197 @@
             }
           },
           {
+            "name": "created_at",
             "docs": [
               "Creation timestamp"
             ],
-            "name": "created_at",
             "type": "i64"
           },
           {
+            "name": "resolved_at",
             "docs": [
               "Resolution timestamp"
             ],
-            "name": "resolved_at",
             "type": "i64"
           },
           {
+            "name": "votes_for",
             "docs": [
               "Votes for approval"
             ],
-            "name": "votes_for",
-            "type": "u8"
+            "type": "u64"
           },
           {
+            "name": "votes_against",
             "docs": [
               "Votes against"
             ],
-            "name": "votes_against",
-            "type": "u8"
+            "type": "u64"
           },
           {
-            "docs": [
-              "Total eligible voters"
-            ],
             "name": "total_voters",
+            "docs": [
+              "Total arbiters who voted (max 255 due to u8)",
+              "Note: Increase to u16 if more arbiters needed"
+            ],
             "type": "u8"
           },
           {
-            "docs": [
-              "Voting deadline"
-            ],
             "name": "voting_deadline",
+            "docs": [
+              "Voting deadline - after this, no new votes accepted",
+              "voting_deadline = created_at + voting_period"
+            ],
             "type": "i64"
           },
           {
+            "name": "expires_at",
+            "docs": [
+              "Dispute expiration - after this, can call expire_dispute",
+              "expires_at = created_at + max_dispute_duration",
+              "Note: expires_at >= voting_deadline, allowing resolution after voting ends"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slash_applied",
+            "docs": [
+              "Whether worker slashing has been applied"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "initiator_slash_applied",
+            "docs": [
+              "Whether initiator slashing has been applied (for rejected disputes)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "worker_stake_at_dispute",
+            "docs": [
+              "Snapshot of worker's stake at dispute initiation (prevents stake withdrawal attacks)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "initiated_by_creator",
+            "docs": [
+              "Whether the dispute was initiated by the task creator (fix #407)",
+              "Used to apply stricter requirements and different expiration behavior for creator disputes"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "bump",
             "docs": [
               "Bump seed"
             ],
-            "name": "bump",
             "type": "u8"
+          },
+          {
+            "name": "defendant",
+            "docs": [
+              "The defendant worker's agent PDA (fix #827)",
+              "Binds slashing target at dispute initiation to prevent slashing wrong worker",
+              "on collaborative tasks with multiple claimants."
+            ],
+            "type": "pubkey"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "DisputeCancelled",
+      "docs": [
+        "Emitted when a dispute is cancelled by its initiator (fix #587)"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dispute_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "task",
+            "type": "pubkey"
+          },
+          {
+            "name": "initiator",
+            "type": "pubkey"
+          },
+          {
+            "name": "cancelled_at",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DisputeExpired",
+      "docs": [
+        "Emitted when a dispute expires without resolution",
+        "Updated in fix #418 to include fair distribution details"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "dispute_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "task_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "refund_amount",
+            "type": "u64"
+          },
+          {
+            "name": "creator_amount",
+            "docs": [
+              "Amount refunded to creator (fix #418)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "worker_amount",
+            "docs": [
+              "Amount paid to worker (fix #418)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "DisputeInitiated",
       "docs": [
         "Emitted when a dispute is initiated"
       ],
-      "name": "DisputeInitiated",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "dispute_id",
@@ -2308,6 +8509,13 @@
             "type": "pubkey"
           },
           {
+            "name": "defendant",
+            "docs": [
+              "The defendant worker's agent PDA (fix #827)"
+            ],
+            "type": "pubkey"
+          },
+          {
             "name": "resolution_type",
             "type": "u8"
           },
@@ -2319,16 +8527,25 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
-      "docs": [
-        "Emitted when a dispute is resolved"
-      ],
       "name": "DisputeResolved",
+      "docs": [
+        "Emitted when a dispute is resolved",
+        "",
+        "The `outcome` field distinguishes between different resolution paths:",
+        "- 0 = Rejected (approved=false with actual votes cast)",
+        "- 1 = Approved (approved=true with votes meeting threshold)",
+        "- 2 = NoVoteDefault (no votes cast, defaulted to rejection - fix #425)",
+        "",
+        "The NoVoteDefault outcome indicates arbiter apathy rather than active rejection.",
+        "This allows consumers to distinguish between \"arbiters rejected this\" vs",
+        "\"no arbiters participated, so it defaulted to rejection\"."
+      ],
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "dispute_id",
@@ -2344,26 +8561,32 @@
             "type": "u8"
           },
           {
-            "name": "votes_for",
+            "name": "outcome",
+            "docs": [
+              "Resolution outcome: 0=Rejected, 1=Approved, 2=NoVoteDefault"
+            ],
             "type": "u8"
           },
           {
+            "name": "votes_for",
+            "type": "u64"
+          },
+          {
             "name": "votes_against",
-            "type": "u8"
+            "type": "u64"
           },
           {
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "DisputeStatus",
       "docs": [
         "Dispute status"
       ],
-      "name": "DisputeStatus",
       "repr": {
         "kind": "rust"
       },
@@ -2378,63 +8601,74 @@
           },
           {
             "name": "Expired"
+          },
+          {
+            "name": "Cancelled"
           }
         ]
       }
     },
     {
+      "name": "DisputeVote",
       "docs": [
         "Vote record for dispute",
         "PDA seeds: [\"vote\", dispute, voter]"
       ],
-      "name": "DisputeVote",
       "type": {
+        "kind": "struct",
         "fields": [
           {
+            "name": "dispute",
             "docs": [
               "Dispute being voted on"
             ],
-            "name": "dispute",
             "type": "pubkey"
           },
           {
+            "name": "voter",
             "docs": [
               "Voter (arbiter)"
             ],
-            "name": "voter",
             "type": "pubkey"
           },
           {
+            "name": "approved",
             "docs": [
               "Vote (true = approve, false = reject)"
             ],
-            "name": "approved",
             "type": "bool"
           },
           {
+            "name": "voted_at",
             "docs": [
               "Vote timestamp"
             ],
-            "name": "voted_at",
             "type": "i64"
           },
           {
+            "name": "stake_at_vote",
+            "docs": [
+              "Arbiter's stake at the time of voting (for weighted resolution)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
             "docs": [
               "Bump seed"
             ],
-            "name": "bump",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "DisputeVoteCast",
       "docs": [
         "Emitted when a vote is cast on a dispute"
       ],
-      "name": "DisputeVoteCast",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "dispute_id",
@@ -2455,103 +8689,238 @@
           },
           {
             "name": "votes_for",
-            "type": "u8"
+            "type": "u64"
           },
           {
             "name": "votes_against",
-            "type": "u8"
+            "type": "u64"
           },
           {
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "FeedPost",
       "docs": [
-        "Protocol configuration account",
-        "PDA seeds: [\"protocol\"]"
+        "Agent feed post (content hash stored on-chain, content on IPFS)",
+        "PDA seeds: [\"post\", author_agent_pda, nonce]"
       ],
-      "name": "ProtocolConfig",
       "type": {
+        "kind": "struct",
         "fields": [
           {
+            "name": "author",
             "docs": [
-              "Protocol authority"
+              "Author agent PDA"
             ],
-            "name": "authority",
             "type": "pubkey"
           },
           {
+            "name": "content_hash",
             "docs": [
-              "Treasury for protocol fees"
+              "IPFS content hash (CIDv1 or SHA-256 of content)"
             ],
-            "name": "treasury",
-            "type": "pubkey"
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
+            "name": "topic",
             "docs": [
-              "Minimum votes needed to resolve dispute (percentage, 1-100)"
+              "Topic identifier (application-level grouping)"
             ],
-            "name": "dispute_threshold",
-            "type": "u8"
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
+            "name": "parent_post",
             "docs": [
-              "Protocol fee in basis points (1/100th of a percent)"
+              "Optional parent post PDA (for replies/threads)"
             ],
-            "name": "protocol_fee_bps",
-            "type": "u16"
+            "type": {
+              "option": "pubkey"
+            }
           },
           {
+            "name": "nonce",
             "docs": [
-              "Minimum stake required to register as arbiter"
+              "Unique nonce (client-generated UUID)"
             ],
-            "name": "min_arbiter_stake",
-            "type": "u64"
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
           },
           {
+            "name": "upvote_count",
             "docs": [
-              "Total registered agents"
+              "Number of upvotes"
             ],
-            "name": "total_agents",
-            "type": "u64"
+            "type": "u32"
           },
           {
+            "name": "created_at",
             "docs": [
-              "Total tasks created"
+              "Creation timestamp"
             ],
-            "name": "total_tasks",
-            "type": "u64"
+            "type": "i64"
           },
           {
-            "docs": [
-              "Total tasks completed"
-            ],
-            "name": "completed_tasks",
-            "type": "u64"
-          },
-          {
-            "docs": [
-              "Total value distributed"
-            ],
-            "name": "total_value_distributed",
-            "type": "u64"
-          },
-          {
-            "docs": [
-              "Bump seed for PDA"
-            ],
             "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
             "type": "u8"
           },
           {
+            "name": "_reserved",
             "docs": [
               "Reserved for future use"
             ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "FeedVote",
+      "docs": [
+        "Feed upvote record (one per voter per post, prevents double voting)",
+        "PDA seeds: [\"upvote\", post_pda, voter_agent_pda]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "post",
+            "docs": [
+              "Post PDA that was upvoted"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "docs": [
+              "Voter agent PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Vote timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          },
+          {
             "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "GovernanceConfig",
+      "docs": [
+        "Governance configuration account",
+        "PDA seeds: [\"governance\"]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "Protocol authority (must match ProtocolConfig.authority at init time)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "min_proposal_stake",
+            "docs": [
+              "Minimum stake required to create a proposal"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "voting_period",
+            "docs": [
+              "Voting period in seconds for new proposals"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "execution_delay",
+            "docs": [
+              "Execution delay after voting ends (timelock) in seconds"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "quorum_bps",
+            "docs": [
+              "Quorum in basis points of total agents' stake"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "approval_threshold_bps",
+            "docs": [
+              "Approval threshold in basis points (e.g., 5000 = simple majority)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "total_proposals",
+            "docs": [
+              "Total proposals created (monotonic counter)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
             "type": {
               "array": [
                 "u8",
@@ -2559,16 +8928,955 @@
               ]
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "GovernanceInitialized",
+      "docs": [
+        "Emitted when governance configuration is initialized"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "voting_period",
+            "type": "i64"
+          },
+          {
+            "name": "execution_delay",
+            "type": "i64"
+          },
+          {
+            "name": "quorum_bps",
+            "type": "u16"
+          },
+          {
+            "name": "approval_threshold_bps",
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "GovernanceVote",
+      "docs": [
+        "Governance vote record",
+        "PDA seeds: [\"governance_vote\", proposal, voter]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal",
+            "docs": [
+              "Proposal being voted on"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "docs": [
+              "Voter (agent PDA)"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "approved",
+            "docs": [
+              "Vote (true = approve, false = reject)"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "voted_at",
+            "docs": [
+              "Vote timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "vote_weight",
+            "docs": [
+              "Voter's effective vote weight (reputation * stake, capped)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "GovernanceVoteCast",
+      "docs": [
+        "Emitted when a vote is cast on a governance proposal"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "type": "pubkey"
+          },
+          {
+            "name": "approved",
+            "type": "bool"
+          },
+          {
+            "name": "vote_weight",
+            "type": "u64"
+          },
+          {
+            "name": "votes_for",
+            "type": "u64"
+          },
+          {
+            "name": "votes_against",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MigrationCompleted",
+      "docs": [
+        "Emitted when protocol migration is completed"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "from_version",
+            "type": "u8"
+          },
+          {
+            "name": "to_version",
+            "type": "u8"
+          },
+          {
+            "name": "authority",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "MultisigUpdated",
+      "docs": [
+        "Emitted when multisig signer set or threshold is updated."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_threshold",
+            "type": "u8"
+          },
+          {
+            "name": "new_threshold",
+            "type": "u8"
+          },
+          {
+            "name": "old_owner_count",
+            "type": "u8"
+          },
+          {
+            "name": "new_owner_count",
+            "type": "u8"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "NullifierSpend",
+      "docs": [
+        "Nullifier spend account to prevent global proof/knowledge replay.",
+        "PDA seeds: [\"nullifier_spend\", nullifier]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "nullifier",
+            "docs": [
+              "Nullifier value committed in the private journal."
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "task",
+            "docs": [
+              "The task where this nullifier was first used"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "agent",
+            "docs": [
+              "The agent who spent this nullifier"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "spent_at",
+            "docs": [
+              "Timestamp when nullifier was spent"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PostCreated",
+      "docs": [
+        "Emitted when an agent creates a feed post"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "post",
+            "type": "pubkey"
+          },
+          {
+            "name": "author",
+            "type": "pubkey"
+          },
+          {
+            "name": "content_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "topic",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "parent_post",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PostUpvoted",
+      "docs": [
+        "Emitted when a feed post is upvoted"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "post",
+            "type": "pubkey"
+          },
+          {
+            "name": "voter",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_upvote_count",
+            "type": "u32"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PrivateCompletionPayload",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "seal_bytes",
+            "type": "bytes"
+          },
+          {
+            "name": "journal",
+            "type": "bytes"
+          },
+          {
+            "name": "image_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "binding_seed",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "nullifier_seed",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Proposal",
+      "docs": [
+        "Governance proposal account",
+        "PDA seeds: [\"proposal\", proposer, nonce]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposer",
+            "docs": [
+              "Proposer's agent PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "proposer_authority",
+            "docs": [
+              "Proposer's authority wallet"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "nonce",
+            "docs": [
+              "Monotonic nonce per proposer (allows multiple proposals)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "proposal_type",
+            "docs": [
+              "Proposal type"
+            ],
+            "type": {
+              "defined": {
+                "name": "ProposalType"
+              }
+            }
+          },
+          {
+            "name": "title_hash",
+            "docs": [
+              "Title hash (SHA256 of title string)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "description_hash",
+            "docs": [
+              "Description hash (SHA256 of description/URI)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "payload",
+            "docs": [
+              "Type-specific payload (64 bytes)",
+              "FeeChange: new fee bps as u16 LE in bytes [0..2], rest zero",
+              "TreasurySpend: recipient Pubkey [0..32] + amount u64 LE [32..40], rest zero",
+              "ProtocolUpgrade: reserved for future parameter batch changes"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "status",
+            "docs": [
+              "Current status"
+            ],
+            "type": {
+              "defined": {
+                "name": "ProposalStatus"
+              }
+            }
+          },
+          {
+            "name": "created_at",
+            "docs": [
+              "Creation timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "voting_deadline",
+            "docs": [
+              "Voting deadline (no new votes accepted after this)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "execution_after",
+            "docs": [
+              "Earliest timestamp at which the proposal can be executed (timelock)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "executed_at",
+            "docs": [
+              "Execution timestamp (0 if not executed)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "votes_for",
+            "docs": [
+              "Total stake-weighted votes for approval"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "votes_against",
+            "docs": [
+              "Total stake-weighted votes against"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_voters",
+            "docs": [
+              "Number of individual voters"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "quorum",
+            "docs": [
+              "Required quorum (minimum total stake-weighted votes)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalCancelled",
+      "docs": [
+        "Emitted when a governance proposal is cancelled"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposer",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalCreated",
+      "docs": [
+        "Emitted when a governance proposal is created"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposer",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal_type",
+            "type": "u8"
+          },
+          {
+            "name": "title_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "voting_deadline",
+            "type": "i64"
+          },
+          {
+            "name": "quorum",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalExecuted",
+      "docs": [
+        "Emitted when a governance proposal is executed"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "proposal",
+            "type": "pubkey"
+          },
+          {
+            "name": "proposal_type",
+            "type": "u8"
+          },
+          {
+            "name": "votes_for",
+            "type": "u64"
+          },
+          {
+            "name": "votes_against",
+            "type": "u64"
+          },
+          {
+            "name": "total_voters",
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalStatus",
+      "docs": [
+        "Governance proposal status"
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Active"
+          },
+          {
+            "name": "Executed"
+          },
+          {
+            "name": "Defeated"
+          },
+          {
+            "name": "Cancelled"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProposalType",
+      "docs": [
+        "Governance proposal type"
+      ],
+      "repr": {
+        "kind": "rust"
+      },
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "ProtocolUpgrade"
+          },
+          {
+            "name": "FeeChange"
+          },
+          {
+            "name": "TreasurySpend"
+          },
+          {
+            "name": "RateLimitChange"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolConfig",
+      "docs": [
+        "Protocol configuration account",
+        "PDA seeds: [\"protocol\"]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "authority",
+            "docs": [
+              "Protocol authority",
+              "Note: Cannot be updated after initialization."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "treasury",
+            "docs": [
+              "Treasury address for protocol fees",
+              "Can be updated via multisig-gated `update_treasury`."
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "dispute_threshold",
+            "docs": [
+              "Minimum votes needed to resolve dispute (percentage, 1-100)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "protocol_fee_bps",
+            "docs": [
+              "Protocol fee in basis points (1/100th of a percent)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "min_arbiter_stake",
+            "docs": [
+              "Minimum stake required to register as arbiter"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "min_agent_stake",
+            "docs": [
+              "Minimum stake required to register as agent"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "max_claim_duration",
+            "docs": [
+              "Max duration (seconds) a claim can stay active without completion"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "max_dispute_duration",
+            "docs": [
+              "Max duration (seconds) a dispute can remain active"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "total_agents",
+            "docs": [
+              "Total registered agents"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_tasks",
+            "docs": [
+              "Total tasks created"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "completed_tasks",
+            "docs": [
+              "Total tasks completed"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "total_value_distributed",
+            "docs": [
+              "Total value distributed"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "multisig_threshold",
+            "docs": [
+              "Multisig threshold"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "multisig_owners_len",
+            "docs": [
+              "Length of configured multisig owners"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "task_creation_cooldown",
+            "docs": [
+              "Minimum cooldown between task creations (seconds, 0 = disabled)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "max_tasks_per_24h",
+            "docs": [
+              "Maximum tasks an agent can create per 24h window (0 = unlimited)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "dispute_initiation_cooldown",
+            "docs": [
+              "Minimum cooldown between dispute initiations (seconds, 0 = disabled)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "max_disputes_per_24h",
+            "docs": [
+              "Maximum disputes an agent can initiate per 24h window (0 = unlimited)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "min_stake_for_dispute",
+            "docs": [
+              "Minimum stake required to initiate a dispute (griefing resistance)"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "slash_percentage",
+            "docs": [
+              "Percentage of stake slashed on losing dispute (0-100)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "state_update_cooldown",
+            "docs": [
+              "Cooldown between state updates per agent (seconds, 0 = disabled) (fix #415)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "voting_period",
+            "docs": [
+              "Voting period for disputes in seconds (default: 24 hours)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "protocol_version",
+            "docs": [
+              "Current protocol version (for upgrades)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "min_supported_version",
+            "docs": [
+              "Minimum supported version for backward compatibility"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_padding",
+            "docs": [
+              "Padding for future use and alignment",
+              "Currently unused but reserved for backwards-compatible additions"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                2
+              ]
+            }
+          },
+          {
+            "name": "multisig_owners",
+            "docs": [
+              "Multisig owners for admin-gated protocol changes.",
+              "",
+              "Updated via multisig-gated `update_multisig` with strict validation:",
+              "- owner keys must be unique and non-default",
+              "- threshold must satisfy 0 < threshold < owners_len",
+              "- update tx must include threshold signers from the new owner set",
+              "",
+              "Only the first `multisig_owners_len` entries are valid; remaining slots",
+              "are always `Pubkey::default()`."
+            ],
+            "type": {
+              "array": [
+                "pubkey",
+                5
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolFeeUpdated",
+      "docs": [
+        "Emitted when protocol fee is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "new_fee_bps",
+            "type": "u16"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ProtocolInitialized",
       "docs": [
         "Emitted when protocol is initialized"
       ],
-      "name": "ProtocolInitialized",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "authority",
@@ -2590,15 +9898,473 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "ProtocolVersionUpdated",
+      "docs": [
+        "Emitted when protocol version is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_version",
+            "type": "u8"
+          },
+          {
+            "name": "new_version",
+            "type": "u8"
+          },
+          {
+            "name": "min_supported_version",
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "PurchaseRecord",
+      "docs": [
+        "Purchase record (one per buyer per skill, prevents double purchase)",
+        "PDA seeds: [\"skill_purchase\", skill_pda, buyer_agent_pda]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "skill",
+            "docs": [
+              "Skill purchased"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "buyer",
+            "docs": [
+              "Buyer's agent PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "price_paid",
+            "docs": [
+              "Price paid at time of purchase"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Purchase timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "RateLimitHit",
+      "docs": [
+        "Emitted when a rate limit is hit"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "action_type",
+            "type": "u8"
+          },
+          {
+            "name": "limit_type",
+            "type": "u8"
+          },
+          {
+            "name": "current_count",
+            "type": "u8"
+          },
+          {
+            "name": "max_count",
+            "type": "u8"
+          },
+          {
+            "name": "cooldown_remaining",
+            "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RateLimitsUpdated",
+      "docs": [
+        "Emitted when rate limit configuration is updated"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "task_creation_cooldown",
+            "type": "i64"
+          },
+          {
+            "name": "max_tasks_per_24h",
+            "type": "u8"
+          },
+          {
+            "name": "dispute_initiation_cooldown",
+            "type": "i64"
+          },
+          {
+            "name": "max_disputes_per_24h",
+            "type": "u8"
+          },
+          {
+            "name": "min_stake_for_dispute",
+            "type": "u64"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReputationChanged",
+      "docs": [
+        "Emitted when an agent's reputation changes"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "old_reputation",
+            "type": "u16"
+          },
+          {
+            "name": "new_reputation",
+            "type": "u16"
+          },
+          {
+            "name": "reason",
+            "docs": [
+              "Reason: 0=completion, 1=dispute_slash, 2=decay"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReputationDelegated",
+      "docs": [
+        "Emitted when an agent delegates reputation to a peer"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "delegator",
+            "type": "pubkey"
+          },
+          {
+            "name": "delegatee",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u16"
+          },
+          {
+            "name": "expires_at",
+            "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReputationDelegation",
+      "docs": [
+        "Reputation delegation — agent delegates reputation points to a trusted peer.",
+        "One delegation per (delegator, delegatee) pair. Revoke-and-redelegate pattern.",
+        "PDA seeds: [\"reputation_delegation\", delegator_pda, delegatee_pda]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "delegator",
+            "docs": [
+              "Delegator agent PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "delegatee",
+            "docs": [
+              "Delegatee agent PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "docs": [
+              "Reputation points delegated (0-10000 scale)"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "expires_at",
+            "docs": [
+              "Expiration timestamp (0 = no expiry)"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "created_at",
+            "docs": [
+              "Delegation creation timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReputationDelegationRevoked",
+      "docs": [
+        "Emitted when a reputation delegation is revoked"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "delegator",
+            "type": "pubkey"
+          },
+          {
+            "name": "delegatee",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReputationStake",
+      "docs": [
+        "Reputation stake account — agent stakes SOL on their reputation.",
+        "SOL is stored as excess lamports on the PDA (same pattern as agent registration stake).",
+        "Account is never closed to preserve slash_count history (prevents reset exploit).",
+        "PDA seeds: [\"reputation_stake\", agent_pda]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "docs": [
+              "Agent PDA this stake belongs to"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "staked_amount",
+            "docs": [
+              "SOL lamports currently staked"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "locked_until",
+            "docs": [
+              "Timestamp before which withdrawals are blocked"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "slash_count",
+            "docs": [
+              "Historical count of slashes applied"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "created_at",
+            "docs": [
+              "Account creation timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed for PDA"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReputationStakeWithdrawn",
+      "docs": [
+        "Emitted when an agent withdraws staked SOL"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "remaining_staked",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ReputationStaked",
+      "docs": [
+        "Emitted when an agent stakes SOL on their reputation"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "agent",
+            "type": "pubkey"
+          },
+          {
+            "name": "amount",
+            "type": "u64"
+          },
+          {
+            "name": "total_staked",
+            "type": "u64"
+          },
+          {
+            "name": "locked_until",
+            "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "ResolutionType",
       "docs": [
         "Dispute resolution type"
       ],
-      "name": "ResolutionType",
       "repr": {
         "kind": "rust"
       },
@@ -2618,11 +10384,12 @@
       }
     },
     {
+      "name": "RewardDistributed",
       "docs": [
         "Emitted for reward distribution"
       ],
-      "name": "RewardDistributed",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "task_id",
@@ -2649,16 +10416,458 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "SkillPurchased",
+      "docs": [
+        "Emitted when a skill is purchased"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "skill",
+            "type": "pubkey"
+          },
+          {
+            "name": "buyer",
+            "type": "pubkey"
+          },
+          {
+            "name": "author",
+            "type": "pubkey"
+          },
+          {
+            "name": "price_paid",
+            "type": "u64"
+          },
+          {
+            "name": "protocol_fee",
+            "type": "u64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SkillRated",
+      "docs": [
+        "Emitted when a skill is rated by another agent"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "skill",
+            "type": "pubkey"
+          },
+          {
+            "name": "rater",
+            "type": "pubkey"
+          },
+          {
+            "name": "rating",
+            "type": "u8"
+          },
+          {
+            "name": "rater_reputation",
+            "type": "u16"
+          },
+          {
+            "name": "new_total_rating",
+            "type": "u64"
+          },
+          {
+            "name": "new_rating_count",
+            "type": "u32"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SkillRating",
+      "docs": [
+        "Skill rating record (one per rater per skill)",
+        "PDA seeds: [\"skill_rating\", skill_pda, rater_agent_pda]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "skill",
+            "docs": [
+              "Skill being rated"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "rater",
+            "docs": [
+              "Rater's agent PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "rating",
+            "docs": [
+              "Rating value (1-5)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "review_hash",
+            "docs": [
+              "Optional review content hash"
+            ],
+            "type": {
+              "option": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          },
+          {
+            "name": "rater_reputation",
+            "docs": [
+              "Rater's reputation at time of rating"
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "timestamp",
+            "docs": [
+              "Rating timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                4
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SkillRegistered",
+      "docs": [
+        "Emitted when a new skill is registered"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "skill",
+            "type": "pubkey"
+          },
+          {
+            "name": "author",
+            "type": "pubkey"
+          },
+          {
+            "name": "skill_id",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "content_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "price",
+            "type": "u64"
+          },
+          {
+            "name": "price_mint",
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SkillRegistration",
+      "docs": [
+        "Skill registration account",
+        "PDA seeds: [\"skill\", author_agent_pda, skill_id]"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "author",
+            "docs": [
+              "Author's agent PDA"
+            ],
+            "type": "pubkey"
+          },
+          {
+            "name": "skill_id",
+            "docs": [
+              "Unique skill identifier"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "docs": [
+              "Skill display name"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "content_hash",
+            "docs": [
+              "Content hash (IPFS CID, Arweave tx, etc.)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "price",
+            "docs": [
+              "Price in lamports (SOL) or token smallest units"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "price_mint",
+            "docs": [
+              "Optional SPL token mint for price denomination (None = SOL)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "tags",
+            "docs": [
+              "Tags for discovery (encoded by client)"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
+            "name": "total_rating",
+            "docs": [
+              "Sum of reputation-weighted ratings"
+            ],
+            "type": "u64"
+          },
+          {
+            "name": "rating_count",
+            "docs": [
+              "Number of ratings received"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "download_count",
+            "docs": [
+              "Number of purchases"
+            ],
+            "type": "u32"
+          },
+          {
+            "name": "version",
+            "docs": [
+              "Content version (monotonically increasing)"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "is_active",
+            "docs": [
+              "Whether the skill is currently active"
+            ],
+            "type": "bool"
+          },
+          {
+            "name": "created_at",
+            "docs": [
+              "Creation timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "updated_at",
+            "docs": [
+              "Last update timestamp"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "bump",
+            "docs": [
+              "Bump seed"
+            ],
+            "type": "u8"
+          },
+          {
+            "name": "_reserved",
+            "docs": [
+              "Reserved for future use"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                8
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "SkillUpdated",
+      "docs": [
+        "Emitted when a skill is updated by its author"
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "skill",
+            "type": "pubkey"
+          },
+          {
+            "name": "author",
+            "type": "pubkey"
+          },
+          {
+            "name": "content_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "price",
+            "type": "u64"
+          },
+          {
+            "name": "version",
+            "type": "u8"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "SpeculativeCommitmentCreated",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "task",
+            "type": "pubkey"
+          },
+          {
+            "name": "producer",
+            "type": "pubkey"
+          },
+          {
+            "name": "result_hash",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "bonded_stake",
+            "type": "u64"
+          },
+          {
+            "name": "expires_at",
+            "type": "i64"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
+          }
+        ]
+      }
+    },
+    {
+      "name": "StateUpdated",
       "docs": [
         "Emitted when coordination state is updated"
       ],
-      "name": "StateUpdated",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "state_key",
@@ -2666,6 +10875,15 @@
               "array": [
                 "u8",
                 32
+              ]
+            }
+          },
+          {
+            "name": "state_value",
+            "type": {
+              "array": [
+                "u8",
+                64
               ]
             }
           },
@@ -2681,23 +10899,23 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "Task",
       "docs": [
         "Task account",
         "PDA seeds: [\"task\", creator, task_id]"
       ],
-      "name": "Task",
       "type": {
+        "kind": "struct",
         "fields": [
           {
+            "name": "task_id",
             "docs": [
               "Unique task identifier"
             ],
-            "name": "task_id",
             "type": {
               "array": [
                 "u8",
@@ -2706,24 +10924,28 @@
             }
           },
           {
+            "name": "creator",
             "docs": [
               "Task creator (paying party)"
             ],
-            "name": "creator",
             "type": "pubkey"
           },
           {
-            "docs": [
-              "Required capability bitmask"
-            ],
             "name": "required_capabilities",
+            "docs": [
+              "Required capability bitmask (u64).",
+              "",
+              "Specifies which capabilities an agent must have to claim this task.",
+              "See [`capability`] module for defined bits. An agent can claim this",
+              "task only if: `(agent.capabilities & required_capabilities) == required_capabilities`"
+            ],
             "type": "u64"
           },
           {
+            "name": "description",
             "docs": [
               "Task description or instruction hash"
             ],
-            "name": "description",
             "type": {
               "array": [
                 "u8",
@@ -2732,31 +10954,44 @@
             }
           },
           {
+            "name": "constraint_hash",
+            "docs": [
+              "Constraint hash for private task verification (hash of expected output)",
+              "For private tasks, workers must prove they know output that hashes to this value"
+            ],
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "reward_amount",
             "docs": [
               "Reward amount in lamports"
             ],
-            "name": "reward_amount",
             "type": "u64"
           },
           {
+            "name": "max_workers",
             "docs": [
               "Maximum workers allowed"
             ],
-            "name": "max_workers",
             "type": "u8"
           },
           {
+            "name": "current_workers",
             "docs": [
               "Current worker count"
             ],
-            "name": "current_workers",
             "type": "u8"
           },
           {
+            "name": "status",
             "docs": [
               "Task status"
             ],
-            "name": "status",
             "type": {
               "defined": {
                 "name": "TaskStatus"
@@ -2764,10 +10999,10 @@
             }
           },
           {
+            "name": "task_type",
             "docs": [
               "Task type"
             ],
-            "name": "task_type",
             "type": {
               "defined": {
                 "name": "TaskType"
@@ -2775,38 +11010,38 @@
             }
           },
           {
+            "name": "created_at",
             "docs": [
               "Creation timestamp"
             ],
-            "name": "created_at",
             "type": "i64"
           },
           {
+            "name": "deadline",
             "docs": [
               "Deadline timestamp (0 = no deadline)"
             ],
-            "name": "deadline",
             "type": "i64"
           },
           {
+            "name": "completed_at",
             "docs": [
               "Completion timestamp"
             ],
-            "name": "completed_at",
             "type": "i64"
           },
           {
+            "name": "escrow",
             "docs": [
               "Escrow account for reward"
             ],
-            "name": "escrow",
             "type": "pubkey"
           },
           {
+            "name": "result",
             "docs": [
               "Result data or pointer"
             ],
-            "name": "result",
             "type": {
               "array": [
                 "u8",
@@ -2815,48 +11050,82 @@
             }
           },
           {
+            "name": "completions",
             "docs": [
               "Number of completions (for collaborative tasks)"
             ],
-            "name": "completions",
             "type": "u8"
           },
           {
+            "name": "required_completions",
             "docs": [
               "Required completions"
             ],
-            "name": "required_completions",
             "type": "u8"
           },
           {
+            "name": "bump",
             "docs": [
               "Bump seed"
             ],
-            "name": "bump",
             "type": "u8"
           },
           {
+            "name": "protocol_fee_bps",
             "docs": [
-              "Reserved"
+              "Protocol fee in basis points, locked at task creation (#479)"
             ],
-            "name": "_reserved",
+            "type": "u16"
+          },
+          {
+            "name": "depends_on",
+            "docs": [
+              "Optional parent task this task depends on (None for independent tasks)"
+            ],
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "option": "pubkey"
+            }
+          },
+          {
+            "name": "dependency_type",
+            "docs": [
+              "Type of dependency relationship"
+            ],
+            "type": {
+              "defined": {
+                "name": "DependencyType"
+              }
+            }
+          },
+          {
+            "name": "min_reputation",
+            "docs": [
+              "Minimum reputation score (0-10000) required for workers to claim this task.",
+              "0 means no reputation gate (default for backward compatibility)."
+            ],
+            "type": "u16"
+          },
+          {
+            "name": "reward_mint",
+            "docs": [
+              "Optional SPL token mint for reward denomination.",
+              "None = SOL rewards (default, backward compatible).",
+              "Some(mint) = SPL token rewards using the specified mint."
+            ],
+            "type": {
+              "option": "pubkey"
             }
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "TaskCancelled",
       "docs": [
         "Emitted when a task is cancelled"
       ],
-      "name": "TaskCancelled",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "task_id",
@@ -2879,51 +11148,58 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "TaskClaim",
       "docs": [
         "Worker's claim on a task",
         "PDA seeds: [\"claim\", task, worker_agent]"
       ],
-      "name": "TaskClaim",
       "type": {
+        "kind": "struct",
         "fields": [
           {
+            "name": "task",
             "docs": [
               "Task being claimed"
             ],
-            "name": "task",
             "type": "pubkey"
           },
           {
+            "name": "worker",
             "docs": [
               "Worker agent"
             ],
-            "name": "worker",
             "type": "pubkey"
           },
           {
+            "name": "claimed_at",
             "docs": [
               "Claim timestamp"
             ],
-            "name": "claimed_at",
             "type": "i64"
           },
           {
+            "name": "expires_at",
+            "docs": [
+              "Expiration timestamp for claim"
+            ],
+            "type": "i64"
+          },
+          {
+            "name": "completed_at",
             "docs": [
               "Completion timestamp"
             ],
-            "name": "completed_at",
             "type": "i64"
           },
           {
+            "name": "proof_hash",
             "docs": [
               "Proof of work hash"
             ],
-            "name": "proof_hash",
             "type": {
               "array": [
                 "u8",
@@ -2932,10 +11208,10 @@
             }
           },
           {
+            "name": "result_data",
             "docs": [
               "Result data"
             ],
-            "name": "result_data",
             "type": {
               "array": [
                 "u8",
@@ -2944,43 +11220,43 @@
             }
           },
           {
+            "name": "is_completed",
             "docs": [
               "Is completed"
             ],
-            "name": "is_completed",
             "type": "bool"
           },
           {
+            "name": "is_validated",
             "docs": [
               "Is validated"
             ],
-            "name": "is_validated",
             "type": "bool"
           },
           {
+            "name": "reward_paid",
             "docs": [
               "Reward paid"
             ],
-            "name": "reward_paid",
             "type": "u64"
           },
           {
+            "name": "bump",
             "docs": [
               "Bump seed"
             ],
-            "name": "bump",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "TaskClaimed",
       "docs": [
         "Emitted when an agent claims a task"
       ],
-      "name": "TaskClaimed",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "task_id",
@@ -3007,16 +11283,16 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "TaskCompleted",
       "docs": [
         "Emitted when a task is completed"
       ],
-      "name": "TaskCompleted",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "task_id",
@@ -3041,6 +11317,15 @@
             }
           },
           {
+            "name": "result_data",
+            "type": {
+              "array": [
+                "u8",
+                64
+              ]
+            }
+          },
+          {
             "name": "reward_paid",
             "type": "u64"
           },
@@ -3048,16 +11333,16 @@
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "TaskCreated",
       "docs": [
         "Emitted when a new task is created"
       ],
-      "name": "TaskCreated",
       "type": {
+        "kind": "struct",
         "fields": [
           {
             "name": "task_id",
@@ -3089,65 +11374,77 @@
             "type": "i64"
           },
           {
+            "name": "min_reputation",
+            "type": "u16"
+          },
+          {
+            "name": "reward_mint",
+            "docs": [
+              "SPL token mint for reward denomination (None = SOL)"
+            ],
+            "type": {
+              "option": "pubkey"
+            }
+          },
+          {
             "name": "timestamp",
             "type": "i64"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "TaskEscrow",
       "docs": [
         "Task escrow account",
         "PDA seeds: [\"escrow\", task]"
       ],
-      "name": "TaskEscrow",
       "type": {
+        "kind": "struct",
         "fields": [
           {
+            "name": "task",
             "docs": [
               "Task this escrow belongs to"
             ],
-            "name": "task",
             "type": "pubkey"
           },
           {
+            "name": "amount",
             "docs": [
               "Total amount deposited"
             ],
-            "name": "amount",
             "type": "u64"
           },
           {
+            "name": "distributed",
             "docs": [
               "Amount already distributed"
             ],
-            "name": "distributed",
             "type": "u64"
           },
           {
+            "name": "is_closed",
             "docs": [
               "Is closed"
             ],
-            "name": "is_closed",
             "type": "bool"
           },
           {
+            "name": "bump",
             "docs": [
               "Bump seed"
             ],
-            "name": "bump",
             "type": "u8"
           }
-        ],
-        "kind": "struct"
+        ]
       }
     },
     {
+      "name": "TaskStatus",
       "docs": [
         "Task status"
       ],
-      "name": "TaskStatus",
       "repr": {
         "kind": "rust"
       },
@@ -3176,10 +11473,10 @@
       }
     },
     {
-      "docs": [
-        "Task type"
-      ],
       "name": "TaskType",
+      "docs": [
+        "Task type enumeration"
+      ],
       "repr": {
         "kind": "rust"
       },
@@ -3194,6 +11491,33 @@
           },
           {
             "name": "Competitive"
+          }
+        ]
+      }
+    },
+    {
+      "name": "TreasuryUpdated",
+      "docs": [
+        "Emitted when protocol treasury is updated via multisig governance."
+      ],
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "old_treasury",
+            "type": "pubkey"
+          },
+          {
+            "name": "new_treasury",
+            "type": "pubkey"
+          },
+          {
+            "name": "updated_by",
+            "type": "pubkey"
+          },
+          {
+            "name": "timestamp",
+            "type": "i64"
           }
         ]
       }

--- a/runtime/src/cli/index.ts
+++ b/runtime/src/cli/index.ts
@@ -3027,7 +3027,7 @@ function buildIncidentEventAnomalyId(entry: {
   timestampMs: number;
 }): string {
   const seed = `${entry.seq}|${entry.slot}|${entry.signature}|${entry.sourceEventName}|${entry.sourceEventType}|${entry.taskPda ?? ""}|${entry.disputePda ?? ""}|${entry.timestampMs}`;
-  return createHash("sha1").update(seed).digest("hex").slice(0, 16);
+  return createHash("sha256").update(seed).digest("hex").slice(0, 16);
 }
 
 async function queryIncidentRecords(
@@ -3081,13 +3081,13 @@ function buildReplayCompareResult(comparison: ReplayComparisonResult): {
     anomalyIds: comparison.anomalies.map((anomaly, index) => {
       const sourceContext = anomaly.context;
       const seed = `${anomaly.code}|${sourceContext.sourceEventName ?? ""}|${sourceContext.seq ?? index}|${sourceContext.sourceEventSequence ?? ""}`;
-      return createHash("sha1").update(seed).digest("hex").slice(0, 16);
+      return createHash("sha256").update(seed).digest("hex").slice(0, 16);
     }),
     topAnomalies: comparison.anomalies.slice(0, 50).map((anomaly, index) => {
       const sourceContext = anomaly.context;
       const anomalySeed = `${anomaly.code}|${sourceContext.taskPda ?? ""}|${sourceContext.seq ?? index}`;
       return {
-        anomalyId: createHash("sha1")
+        anomalyId: createHash("sha256")
           .update(anomalySeed)
           .digest("hex")
           .slice(0, 16),
@@ -3174,7 +3174,7 @@ function summarizeIncidentValidation(
 
   const anomalyIds = [...replayResult.errors, ...replayResult.warnings].map(
     (entry, index) =>
-      createHash("sha1")
+      createHash("sha256")
         .update(entry)
         .update(String(index))
         .digest("hex")

--- a/runtime/src/connection/retry.ts
+++ b/runtime/src/connection/retry.ts
@@ -145,7 +145,9 @@ export function isWriteMethod(methodName: string): boolean {
  */
 export function computeBackoff(attempt: number, config: RetryConfig): number {
   const base = Math.min(config.baseDelayMs * 2 ** attempt, config.maxDelayMs);
-  const jitter = 1 + Math.random() * config.jitterFactor;
+  const buf = new Uint32Array(1);
+  globalThis.crypto.getRandomValues(buf);
+  const jitter = 1 + (buf[0] / 0x100000000) * config.jitterFactor;
   return Math.round(base * jitter);
 }
 

--- a/runtime/src/eval/incident-case.ts
+++ b/runtime/src/eval/incident-case.ts
@@ -503,5 +503,5 @@ function computeAnomalyId(
     traceSampled: context.traceSampled,
   } as unknown as JsonValue);
 
-  return createHash("sha1").update(seed).digest("hex").slice(0, 16);
+  return createHash("sha256").update(seed).digest("hex").slice(0, 16);
 }

--- a/runtime/src/task/executor.ts
+++ b/runtime/src/task/executor.ts
@@ -1376,7 +1376,9 @@ function computeBackoffDelay(attempt: number, policy: RetryPolicy): number {
     policy.maxDelayMs,
   );
   if (policy.jitter) {
-    return Math.floor(Math.random() * exponentialDelay);
+    const buf = new Uint32Array(1);
+    globalThis.crypto.getRandomValues(buf);
+    return Math.floor((buf[0] / 0x100000000) * exponentialDelay);
   }
   return exponentialDelay;
 }

--- a/runtime/src/task/proof-deferral.ts
+++ b/runtime/src/task/proof-deferral.ts
@@ -941,8 +941,10 @@ export class ProofDeferralManager {
     );
 
     if (jitter) {
-      // Full jitter: random value between 0 and exponentialDelay
-      return Math.floor(Math.random() * exponentialDelay);
+      // Full jitter: cryptographically random value between 0 and exponentialDelay
+      const buf = new Uint32Array(1);
+      globalThis.crypto.getRandomValues(buf);
+      return Math.floor((buf[0] / 0x100000000) * exponentialDelay);
     }
 
     return exponentialDelay;

--- a/runtime/src/task/proof-pipeline.ts
+++ b/runtime/src/task/proof-pipeline.ts
@@ -747,8 +747,11 @@ export class ProofPipeline {
     );
 
     if (jitter) {
-      // Full jitter: random value between 0 and exponentialDelay
-      return Math.floor(Math.random() * exponentialDelay);
+      // Full jitter: cryptographically random value between 0 and exponentialDelay.
+      // Uses crypto.getRandomValues to prevent predictable retry timing in proof submission.
+      const buf = new Uint32Array(1);
+      globalThis.crypto.getRandomValues(buf);
+      return Math.floor((buf[0] / 0x100000000) * exponentialDelay);
     }
 
     return exponentialDelay;

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -11,7 +11,7 @@
  * IDL can be found at `target/idl/agenc_coordination.json`.
  */
 export type AgencCoordination = {
-  "address": "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ",
+  "address": "5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7",
   "metadata": {
     "name": "agencCoordination",
     "version": "0.1.0",
@@ -2041,7 +2041,8 @@ export type AgencCoordination = {
           ]
         },
         {
-          "name": "delegatorAgent"
+          "name": "delegatorAgent",
+          "writable": true
         },
         {
           "name": "delegateeAgent"
@@ -4132,7 +4133,8 @@ export type AgencCoordination = {
           ]
         },
         {
-          "name": "delegatorAgent"
+          "name": "delegatorAgent",
+          "writable": true
         },
         {
           "name": "delegation",
@@ -7638,7 +7640,7 @@ export type AgencCoordination = {
             "docs": [
               "Active task count"
             ],
-            "type": "u8"
+            "type": "u16"
           },
           {
             "name": "stake",
@@ -7727,7 +7729,7 @@ export type AgencCoordination = {
             "type": {
               "array": [
                 "u8",
-                5
+                4
               ]
             }
           }

--- a/sdk/src/__tests__/prover.test.ts
+++ b/sdk/src/__tests__/prover.test.ts
@@ -482,7 +482,7 @@ describe("prove — local-binary backend", () => {
     const { prove: proveMocked } = await import("../prover");
     const config: LocalBinaryProverConfig = {
       kind: "local-binary",
-      binaryPath: "/test/bin",
+      binaryPath: "/test/agenc-zkvm-host",
     };
 
     const result = await proveMocked(validInput(), config);
@@ -514,7 +514,7 @@ describe("prove — local-binary backend", () => {
     const { prove: proveMocked } = await import("../prover");
     await proveMocked(validInput(), {
       kind: "local-binary",
-      binaryPath: "/test/bin",
+      binaryPath: "/test/agenc-zkvm-host",
     });
 
     expect(child.stdin.write).toHaveBeenCalled();
@@ -530,7 +530,7 @@ describe("prove — local-binary backend", () => {
     const { prove: proveMocked } = await import("../prover");
     const config: LocalBinaryProverConfig = {
       kind: "local-binary",
-      binaryPath: "/test/bin",
+      binaryPath: "/test/agenc-zkvm-host",
     };
 
     try {
@@ -550,7 +550,7 @@ describe("prove — local-binary backend", () => {
     const { prove: proveMocked } = await import("../prover");
     const config: LocalBinaryProverConfig = {
       kind: "local-binary",
-      binaryPath: "/nonexistent/bin",
+      binaryPath: "/nonexistent/agenc-zkvm-host",
     };
 
     try {
@@ -569,7 +569,7 @@ describe("prove — local-binary backend", () => {
     const { prove: proveMocked } = await import("../prover");
     const config: LocalBinaryProverConfig = {
       kind: "local-binary",
-      binaryPath: "/test/bin",
+      binaryPath: "/test/agenc-zkvm-host",
     };
 
     try {
@@ -581,6 +581,42 @@ describe("prove — local-binary backend", () => {
         "failed to parse prover output",
       );
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Local binary path validation
+// ---------------------------------------------------------------------------
+
+describe("prove — local-binary path validation", () => {
+  it("rejects relative binary path", async () => {
+    const config: LocalBinaryProverConfig = {
+      kind: "local-binary",
+      binaryPath: "relative/agenc-zkvm-host",
+    };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      "binaryPath must be an absolute path",
+    );
+  });
+
+  it("rejects path with .. segments", async () => {
+    const config: LocalBinaryProverConfig = {
+      kind: "local-binary",
+      binaryPath: "/test/../etc/agenc-zkvm-host",
+    };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      "must not contain '..'",
+    );
+  });
+
+  it("rejects binary not named agenc-zkvm-host", async () => {
+    const config: LocalBinaryProverConfig = {
+      kind: "local-binary",
+      binaryPath: "/test/some-other-binary",
+    };
+    await expect(prove(validInput(), config)).rejects.toThrow(
+      "must point to an agenc-zkvm-host binary",
+    );
   });
 });
 

--- a/sdk/src/nullifier-cache.ts
+++ b/sdk/src/nullifier-cache.ts
@@ -57,6 +57,21 @@ export class NullifierCache {
     return true;
   }
 
+  /**
+   * Atomically check if a nullifier is already used and mark it if not.
+   * Returns `true` if the nullifier was successfully marked (was NOT previously used).
+   * Returns `false` if the nullifier is already in use.
+   *
+   * This eliminates the TOCTOU gap between separate `isUsed()` and `markUsed()` calls.
+   */
+  tryMarkUsed(nullifier: Uint8Array | Buffer): boolean {
+    if (this.isUsed(nullifier)) {
+      return false;
+    }
+    this.markUsed(nullifier);
+    return true;
+  }
+
   markUsed(nullifier: Uint8Array | Buffer): void {
     const key = this.toKey(nullifier);
 


### PR DESCRIPTION
## Summary

Comprehensive security audit and hardening pass resolving 12 findings across all packages (5 CRITICAL, 7 HIGH).

### CRITICAL Fixes
- **Reputation delegation inflation** — `delegate_reputation.rs` was not deducting reputation from the delegator, allowing unbounded inflation. Now uses `checked_sub(amount)` on delegation and `saturating_add().min(MAX_REPUTATION)` on revocation
- **Daemon bash tool unrestricted** — Was passing full `process.env` with `unrestricted: true`, exposing API keys and secrets to LLM tool-calling. Changed to safe env allowlist (`PATH`, `HOME`, `USER`, `SHELL`, `LANG`, `TERM`, `SOLANA_RPC_URL`)
- **Daemon filesystem tool overbroad** — Was allowing `homedir()` with delete. Restricted to `~/.agenc/workspace` + `/tmp`, `allowDelete: false`
- **SDK prover path injection** — `proveLocal()` accepted arbitrary binary paths. Added: absolute path check, path traversal rejection, `agenc-zkvm-host` name prefix validation. `proveRemote()` now calls `validateProverEndpoint()` before sending proof material

### HIGH Fixes
- **Gateway localhost auto-auth bypass** — `localBypass` defaulted to `true` and undefined `remoteAddress` was treated as local. Changed to opt-in (`localBypass: true` required) and reject missing remoteAddress. Added explicit auth guards for privileged operations (`reload`, `config.set`, `sessions.kill`, `wallet.airdrop`)
- **WebChat session hijacking** — No ownership tracking on sessions, allowing cross-client resume. Added `sessionOwners` map with ownership verification on resume and filtered session listing
- **Commitment ledger unsafe deserialization** — `JSON.parse(data)` with no validation on disk-persisted ledger. Added per-field type/range validation, enum validation, and graceful skip of corrupted entries
- **MCP path traversal** — Replay and testing tools accepted `..` in file paths. Added Zod refinement rejecting traversal and project root containment check
- **MCP testing env leak** — Test child processes received full `process.env`. Changed to safe allowlist
- **Sandbox env injection** — No validation on env var key names. Added `^[A-Za-z_][A-Za-z0-9_]*$` regex check
- **Nullifier cache TOCTOU** — Separate `isUsed()`/`markUsed()` calls had race window. Added atomic `tryMarkUsed()` method
- **Weak cryptography** — `Math.random()` replaced with `crypto.getRandomValues` for retry jitter and proof nonces; `SHA-1` replaced with `SHA-256` for incident/anomaly IDs

### False Positives Investigated and Dismissed
- `create_dependent_task` parent PDA validation — Anchor's `Account<'info, Task>` constraint handles this
- Governance vote Sybil — GovernanceVote PDA already uses `authority.key()` (wallet) as seed
- Reputation stake to non-matching agent — PDA seeds bind agent to stake 1:1

## Test plan
- [x] `npm run build` — all packages build cleanly
- [x] `npm run test:fast` — 229 passing, 5 failing (all pre-existing BN.js precision bugs)
- [x] SDK vitest — 260/260 passing (including 33 prover tests with new validation tests)
- [x] Gateway tests — 32/32 passing (updated for localBypass default change)
- [x] WebChat tests — 25/25 passing (new session hijacking prevention test added)
- [x] Commitment ledger tests — 55/55 passing
- [x] `anchor build` — Rust program compiles cleanly