### PR TITLE
fix(program,sdk): medium-severity audit findings

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -618,4 +618,17 @@ pub enum CoordinationError {
         "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
     )]
     InsufficientSeedEntropy,
+
+    // Audit hardening errors (sequential from enum position)
+    #[msg("Proposal cannot be cancelled after votes have been cast")]
+    ProposalHasVotes,
+
+    #[msg("Token-denominated skill must have a non-zero price")]
+    SkillTokenPriceRequired,
+
+    #[msg("Voting period too short: must be at least 1 hour")]
+    VotingPeriodTooShort,
+
+    #[msg("Treasury spend amount must be greater than zero")]
+    TreasurySpendAmountZero,
 }

--- a/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
@@ -157,6 +157,12 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
 
     require!(slash_amount > 0, CoordinationError::InvalidSlashAmount);
 
+    // Pre-validate lamports before state mutation (DISPUTE-015)
+    require!(
+        worker_agent.to_account_info().lamports() >= slash_amount,
+        CoordinationError::InsufficientFunds
+    );
+
     // Apply reputation penalty for losing the dispute (before lamport transfer to satisfy borrow checker)
     apply_reputation_penalty(worker_agent, &clock)?;
 

--- a/programs/agenc-coordination/src/instructions/cancel_proposal.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_proposal.rs
@@ -31,7 +31,7 @@ pub fn handler(ctx: Context<CancelProposal>) -> Result<()> {
     // Can only cancel if no votes have been cast
     require!(
         proposal.total_voters == 0,
-        CoordinationError::ProposalVotingEnded
+        CoordinationError::ProposalHasVotes
     );
 
     proposal.status = ProposalStatus::Cancelled;

--- a/programs/agenc-coordination/src/instructions/delegate_reputation.rs
+++ b/programs/agenc-coordination/src/instructions/delegate_reputation.rs
@@ -17,6 +17,10 @@ pub struct DelegateReputation<'info> {
     )]
     pub delegator_agent: Account<'info, AgentRegistration>,
 
+    #[account(
+        seeds = [b"agent", delegatee_agent.agent_id.as_ref()],
+        bump = delegatee_agent.bump,
+    )]
     pub delegatee_agent: Account<'info, AgentRegistration>,
 
     #[account(

--- a/programs/agenc-coordination/src/instructions/execute_proposal.rs
+++ b/programs/agenc-coordination/src/instructions/execute_proposal.rs
@@ -189,6 +189,9 @@ fn execute_treasury_spend<'info>(
             .map_err(|_| error!(CoordinationError::InvalidProposalPayload))?,
     );
 
+    // Reject zero-amount treasury spends (EXECPROP-005)
+    require!(amount > 0, CoordinationError::TreasurySpendAmountZero);
+
     let treasury = treasury_opt.ok_or(error!(CoordinationError::InvalidProposalPayload))?;
     let recipient = recipient_opt.ok_or(error!(CoordinationError::InvalidProposalPayload))?;
 

--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -186,7 +186,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
         .accounts
         .worker_claim
         .as_ref()
-        .expect("worker claim validated above")
+        .ok_or(CoordinationError::WorkerClaimRequired)?
         .is_completed;
     let no_votes = dispute.total_voters == 0;
 

--- a/programs/agenc-coordination/src/instructions/migrate.rs
+++ b/programs/agenc-coordination/src/instructions/migrate.rs
@@ -46,6 +46,15 @@ pub fn handler(ctx: Context<MigrateProtocol>, target_version: u8) -> Result<()> 
         CoordinationError::CorruptedData
     );
 
+    // Verify unused multisig_owners slots are zeroed (MIG-003)
+    let owners_len = config.multisig_owners_len as usize;
+    for i in owners_len..ProtocolConfig::MAX_MULTISIG_OWNERS {
+        require!(
+            config.multisig_owners[i] == Pubkey::default(),
+            CoordinationError::CorruptedData
+        );
+    }
+
     let current_version = config.protocol_version;
 
     // Validate migration path

--- a/programs/agenc-coordination/src/instructions/register_skill.rs
+++ b/programs/agenc-coordination/src/instructions/register_skill.rs
@@ -62,6 +62,11 @@ pub fn handler(
         CoordinationError::SkillInvalidContentHash
     );
 
+    // Token-denominated skills must have a non-zero price (REGSKILL-001)
+    if price_mint.is_some() {
+        require!(price > 0, CoordinationError::SkillTokenPriceRequired);
+    }
+
     let clock = Clock::get()?;
     let skill = &mut ctx.accounts.skill;
 

--- a/programs/agenc-coordination/src/instructions/revoke_delegation.rs
+++ b/programs/agenc-coordination/src/instructions/revoke_delegation.rs
@@ -20,6 +20,7 @@ pub struct RevokeDelegation<'info> {
         close = authority,
         seeds = [b"reputation_delegation", delegator_agent.key().as_ref(), delegation.delegatee.as_ref()],
         bump = delegation.bump,
+        constraint = delegation.delegator == delegator_agent.key() @ CoordinationError::UnauthorizedAgent,
     )]
     pub delegation: Account<'info, ReputationDelegation>,
 }

--- a/programs/agenc-coordination/src/instructions/update_skill.rs
+++ b/programs/agenc-coordination/src/instructions/update_skill.rs
@@ -56,6 +56,11 @@ pub fn handler(
     let clock = Clock::get()?;
     let skill = &mut ctx.accounts.skill;
 
+    // Token-denominated skills must maintain a non-zero price (UPDSKILL-001)
+    if skill.price_mint.is_some() {
+        require!(price > 0, CoordinationError::SkillTokenPriceRequired);
+    }
+
     skill.content_hash = content_hash;
     skill.price = price;
     if let Some(new_tags) = tags {

--- a/programs/agenc-coordination/src/instructions/update_treasury.rs
+++ b/programs/agenc-coordination/src/instructions/update_treasury.rs
@@ -35,7 +35,10 @@ pub fn handler(ctx: Context<UpdateTreasury>) -> Result<()> {
         CoordinationError::InvalidTreasury
     );
 
-    let is_program_owned = new_treasury.owner == &crate::ID;
+    // For program-owned accounts, verify initialized and rent-exempt (TREAS-001)
+    let is_program_owned = new_treasury.owner == &crate::ID
+        && new_treasury.data_len() > 0
+        && new_treasury.lamports() >= Rent::get()?.minimum_balance(new_treasury.data_len());
     let is_system_owned_signer =
         new_treasury.owner == &system_program::ID && new_treasury.is_signer;
     require!(

--- a/sdk/src/agents.ts
+++ b/sdk/src/agents.ts
@@ -64,7 +64,7 @@ function parseAgentStatus(raw: unknown): AgentStatus {
     if ("suspended" in enumObj) return AgentStatus.Suspended;
   }
 
-  return AgentStatus.Inactive;
+  throw new Error(`Unknown agent status: ${JSON.stringify(raw)}`);
 }
 
 export function deriveAgentPda(

--- a/sdk/src/disputes.ts
+++ b/sdk/src/disputes.ts
@@ -130,7 +130,7 @@ function parseResolutionType(raw: unknown): ResolutionType {
     if ("complete" in enumObj) return ResolutionType.Complete;
     if ("split" in enumObj) return ResolutionType.Split;
   }
-  return ResolutionType.Refund;
+  throw new Error(`Unknown resolution type: ${JSON.stringify(raw)}`);
 }
 
 function parseDisputeStatus(raw: unknown): DisputeStatus {
@@ -142,7 +142,7 @@ function parseDisputeStatus(raw: unknown): DisputeStatus {
     if ("expired" in enumObj) return DisputeStatus.Expired;
     if ("cancelled" in enumObj) return DisputeStatus.Cancelled;
   }
-  return DisputeStatus.Active;
+  throw new Error(`Unknown dispute status: ${JSON.stringify(raw)}`);
 }
 
 function deriveAgentPda(

--- a/sdk/src/governance.ts
+++ b/sdk/src/governance.ts
@@ -64,7 +64,7 @@ function parseProposalType(raw: unknown): ProposalType {
     if ("rateLimitChange" in obj || "rate_limit_change" in obj)
       return ProposalType.RateLimitChange;
   }
-  return ProposalType.ProtocolUpgrade;
+  throw new Error(`Unknown proposal type: ${JSON.stringify(raw)}`);
 }
 
 function parseProposalStatus(raw: unknown): ProposalStatus {
@@ -76,7 +76,7 @@ function parseProposalStatus(raw: unknown): ProposalStatus {
     if ("defeated" in obj) return ProposalStatus.Defeated;
     if ("cancelled" in obj) return ProposalStatus.Cancelled;
   }
-  return ProposalStatus.Active;
+  throw new Error(`Unknown proposal status: ${JSON.stringify(raw)}`);
 }
 
 // ============================================================================

--- a/sdk/src/prover.ts
+++ b/sdk/src/prover.ts
@@ -15,6 +15,7 @@ import {
   RISC0_IMAGE_ID_LEN,
   HASH_SIZE,
 } from "./constants.js";
+import { validateProverEndpoint } from "./validation.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -230,6 +231,9 @@ async function proveRemote(
   const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  // Validate endpoint URL (MED-6)
+  validateProverEndpoint(config.endpoint);
 
   const url = config.endpoint.endsWith("/prove")
     ? config.endpoint

--- a/sdk/src/queries.ts
+++ b/sdk/src/queries.ts
@@ -620,10 +620,19 @@ export async function getReplayHealthCheck(
 /**
  * Deserialize raw Task account data into a DependentTask object.
  */
+/** Minimum buffer size for a Task account (through reward_mint field) */
+const MIN_TASK_BUFFER_SIZE = TASK_FIELD_OFFSETS.REWARD_MINT + 33; // 1 Option discriminator + 32 pubkey
+
 function deserializeTaskAccount(
   publicKey: PublicKey,
   data: Buffer,
 ): DependentTask {
+  if (data.length < MIN_TASK_BUFFER_SIZE) {
+    throw new Error(
+      `Task account buffer too small: expected >= ${MIN_TASK_BUFFER_SIZE} bytes, got ${data.length}`,
+    );
+  }
+
   const taskId = data.subarray(
     TASK_FIELD_OFFSETS.TASK_ID,
     TASK_FIELD_OFFSETS.TASK_ID + 32,
@@ -740,6 +749,12 @@ function deserializeDispute(
   data: Buffer,
   role: ActorDisputeSummary["actorRole"],
 ): ActorDisputeSummary {
+  if (data.length < DISPUTE_ACCOUNT_SIZE) {
+    throw new Error(
+      `Dispute account buffer too small: expected >= ${DISPUTE_ACCOUNT_SIZE} bytes, got ${data.length}`,
+    );
+  }
+
   const disputeId = new Uint8Array(
     data.subarray(
       DISPUTE_FIELD_OFFSETS.DISPUTE_ID,

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -45,7 +45,7 @@ import {
 import { getAccount } from "./anchor-utils";
 import { getSdkLogger } from "./logger";
 import { deriveProtocolPda } from "./protocol";
-import { getDependentTaskCount } from "./queries";
+import { getDependentTaskCount, TASK_FIELD_OFFSETS } from "./queries";
 import {
   runProofSubmissionPreflight,
   type ProofSubmissionPreflightResult,
@@ -1099,7 +1099,7 @@ export async function getTasksByCreator(
   const tasks = await getAccount(program, "task").all([
     {
       memcmp: {
-        offset: DISCRIMINATOR_SIZE + 32, // After discriminator + task_id
+        offset: TASK_FIELD_OFFSETS.CREATOR,
         bytes: creator.toBase58(),
       },
     },
@@ -1389,7 +1389,11 @@ function parseTaskState(
     cancelled: TaskState.Cancelled,
     disputed: TaskState.Disputed,
   };
-  return stateMap[key] ?? TaskState.Open;
+  const mapped = stateMap[key];
+  if (mapped === undefined) {
+    throw new Error(`Unknown task state: "${key}"`);
+  }
+  return mapped;
 }
 
 /**


### PR DESCRIPTION
## Summary

  - **expire_dispute**: replace `.expect()` with proper error propagation (`WorkerClaimRequired`)
  - **apply_dispute_slash**: pre-check worker lamports before state mutation to prevent inconsistent state
  - **cancel_proposal**: use semantically correct `ProposalHasVotes` error instead of `ProposalVotingEnded`
  - **delegate_reputation**: add seeds+bump PDA verification on `delegatee_agent`
  - **revoke_delegation**: add `delegation.delegator == delegator_agent` ownership constraint
  - **register_skill / update_skill**: require non-zero price for token-denominated skills
  - **update_treasury**: validate treasury account is initialized and rent-exempt
  - **execute_proposal**: reject zero-amount treasury spends
  - **create_proposal**: validate TreasurySpend payload at creation time; enforce 1-hour minimum voting period
  - **migrate**: validate unused multisig_owners slots are zeroed
  - **SDK parsers** (agents, tasks, disputes, governance): throw on unknown enum values instead of silent defaults
  - **SDK queries**: add buffer minimum length checks in raw account deserialization
  - **SDK prover**: validate remote endpoint URL before fetch

  ## Test plan

  - [x] `cargo check` clean
  - [x] `cargo test` — 100/100 pass
  - [x] `npm run build` (SDK) clean
  - [x] SDK vitest — 255/257 pass (2 pre-existing)