### PR TITLE
feat(runtime): wire Telegram channel to gateway daemon

### DIFF
--- a/runtime/src/channels/telegram/plugin.test.ts
+++ b/runtime/src/channels/telegram/plugin.test.ts
@@ -340,7 +340,7 @@ describe("TelegramChannel", () => {
 
     await plugin.send({ sessionId, content: "reply text" });
 
-    expect(mockApi.sendMessage).toHaveBeenCalledWith(789, "reply text");
+    expect(mockApi.sendMessage).toHaveBeenCalledWith(789, "reply text", { parse_mode: "HTML" });
 
     await plugin.stop();
   });
@@ -616,7 +616,7 @@ describe("TelegramChannel", () => {
       ],
     });
 
-    expect(mockApi.sendMessage).toHaveBeenCalledWith(789, "check this out");
+    expect(mockApi.sendMessage).toHaveBeenCalledWith(789, "check this out", { parse_mode: "HTML" });
     expect(mockApi.sendPhoto).toHaveBeenCalledWith(
       789,
       "https://example.com/img.png",

--- a/runtime/src/channels/telegram/plugin.ts
+++ b/runtime/src/channels/telegram/plugin.ts
@@ -200,7 +200,11 @@ export class TelegramChannel extends BaseChannelPlugin {
     const calls: Array<() => Promise<unknown>> = [];
 
     if (message.content.length > 0) {
-      calls.push(() => this.api.sendMessage(chatId, message.content));
+      calls.push(() =>
+        this.api.sendMessage(chatId, message.content, {
+          parse_mode: "HTML",
+        }),
+      );
     }
 
     if (message.attachments) {


### PR DESCRIPTION
## Summary

- Install `grammy` and wire the Telegram channel plugin into the gateway daemon's message pipeline
- Telegram bot now routes messages through ChatExecutor (same LLM pipeline as WebChat)
- Adds `/start` command with a formatted HTML welcome message
- Sends LLM responses with `parse_mode: "HTML"` and escapes output to prevent injection
- Includes session management, memory persistence, and graceful shutdown

## Changes

- **`runtime/src/gateway/daemon.ts`** — Import `TelegramChannel`, add `wireTelegram()` method that initializes the channel from `config.channels.telegram`, routes inbound messages through `ChatExecutor`, handles `/start` welcome, and cleans up on `stop()`
- **`runtime/src/channels/telegram/plugin.ts`** — Add `parse_mode: "HTML"` to `sendMessage` calls
- **`runtime/src/channels/telegram/plugin.test.ts`** — Update test assertions for HTML parse mode

## Config

Requires `channels.telegram.botToken` in gateway config:

```json
{
  "channels": {
    "telegram": {
      "botToken": "<BOT_TOKEN>"
    }
  }
}
```

## Test plan

- [x] All 57 runtime tests pass (`npm run test`)
- [ ] Send message to Telegram bot — verify LLM response
- [ ] Send `/start` — verify formatted welcome message
- [ ] Verify activity feed events fire on Telegram messages