### PR TITLE
fix(security): hardening phase 4 — close 8 exploit chains

### DIFF
--- a/programs/agenc-coordination/src/errors.rs
+++ b/programs/agenc-coordination/src/errors.rs
@@ -618,4 +618,16 @@ pub enum CoordinationError {
         "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
     )]
     InsufficientSeedEntropy,
+
+    #[msg("Skill price below minimum required")]
+    SkillPriceBelowMinimum,
+
+    #[msg("Skill price changed since transaction was prepared")]
+    SkillPriceChanged,
+
+    #[msg("Delegation must be active for minimum duration before revocation")]
+    DelegationCooldownNotElapsed,
+
+    #[msg("Rate limit value below protocol minimum")]
+    RateLimitBelowMinimum,
 }

--- a/programs/agenc-coordination/src/instructions/constants.rs
+++ b/programs/agenc-coordination/src/instructions/constants.rs
@@ -57,6 +57,12 @@ pub const REPUTATION_STAKING_COOLDOWN: i64 = 7 * 24 * 60 * 60;
 /// Minimum delegation amount in reputation points (1% of max reputation)
 pub const MIN_DELEGATION_AMOUNT: u16 = 100;
 
+/// Minimum skill price in lamports to prevent free sybil rating attacks (~$0.0002)
+pub const MIN_SKILL_PRICE: u64 = 1_000;
+
+/// Minimum duration a delegation must be active before revocation (7 days in seconds)
+pub const MIN_DELEGATION_DURATION: i64 = 7 * 24 * 60 * 60;
+
 // ============================================================================
 // Default Rate Limit Constants
 // ============================================================================

--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -285,6 +285,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
             &ctx.remaining_accounts[i],
             &ctx.remaining_accounts[i + 1],
             &dispute.key(),
+            &crate::ID,
         )?;
     }
 
@@ -318,6 +319,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
             &ctx.remaining_accounts[i],
             &ctx.remaining_accounts[i + 1],
             &task.key(),
+            &crate::ID,
         )?;
     }
 

--- a/programs/agenc-coordination/src/instructions/purchase_skill.rs
+++ b/programs/agenc-coordination/src/instructions/purchase_skill.rs
@@ -89,7 +89,7 @@ pub struct PurchaseSkill<'info> {
     pub token_program: Option<Program<'info, Token>>,
 }
 
-pub fn handler(ctx: Context<PurchaseSkill>) -> Result<()> {
+pub fn handler(ctx: Context<PurchaseSkill>, expected_price: u64) -> Result<()> {
     let config = &ctx.accounts.protocol_config;
     check_version_compatible(config)?;
 
@@ -109,6 +109,10 @@ pub fn handler(ctx: Context<PurchaseSkill>) -> Result<()> {
 
     let clock = Clock::get()?;
     let price = skill.price;
+    require!(
+        price <= expected_price,
+        CoordinationError::SkillPriceChanged
+    );
     let mut protocol_fee = 0u64;
 
     if price > 0 || skill.price_mint.is_some() {

--- a/programs/agenc-coordination/src/instructions/rate_skill.rs
+++ b/programs/agenc-coordination/src/instructions/rate_skill.rs
@@ -76,6 +76,12 @@ pub fn handler(ctx: Context<RateSkill>, rating: u8, review_hash: Option<[u8; 32]
         CoordinationError::SkillSelfRating
     );
 
+    // Defense-in-depth: block ratings on pre-existing free-purchase records (sybil vector)
+    require!(
+        ctx.accounts.purchase_record.price_paid > 0,
+        CoordinationError::SkillPriceBelowMinimum
+    );
+
     let clock = Clock::get()?;
 
     // Reputation-weighted rating: rating * rater_reputation

--- a/programs/agenc-coordination/src/instructions/register_skill.rs
+++ b/programs/agenc-coordination/src/instructions/register_skill.rs
@@ -2,6 +2,7 @@
 
 use crate::errors::CoordinationError;
 use crate::events::SkillRegistered;
+use crate::instructions::constants::MIN_SKILL_PRICE;
 use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig, SkillRegistration};
 use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
@@ -60,6 +61,10 @@ pub fn handler(
     require!(
         content_hash != [0u8; 32],
         CoordinationError::SkillInvalidContentHash
+    );
+    require!(
+        price >= MIN_SKILL_PRICE,
+        CoordinationError::SkillPriceBelowMinimum
     );
 
     let clock = Clock::get()?;

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -438,6 +438,7 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
             &ctx.remaining_accounts[i],
             &ctx.remaining_accounts[i + 1],
             &dispute.key(),
+            &crate::ID,
         )?;
     }
 
@@ -464,6 +465,7 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
             &ctx.remaining_accounts[i],
             &ctx.remaining_accounts[i + 1],
             &task.key(),
+            &crate::ID,
         )?;
     }
 

--- a/programs/agenc-coordination/src/instructions/update_rate_limits.rs
+++ b/programs/agenc-coordination/src/instructions/update_rate_limits.rs
@@ -73,6 +73,26 @@ pub fn handler(
         CoordinationError::InvalidInput
     );
 
+    // Enforce minimum rate limits to prevent spam even with compromised multisig.
+    // Cooldowns must be >= 1 second (prevents 0 = "disabled" attack vector).
+    // Per-24h limits must be >= 1 (prevents 0 = "unlimited" attack vector).
+    require!(
+        task_creation_cooldown >= 1,
+        CoordinationError::RateLimitBelowMinimum
+    );
+    require!(
+        max_tasks_per_24h >= 1,
+        CoordinationError::RateLimitBelowMinimum
+    );
+    require!(
+        dispute_initiation_cooldown >= 1,
+        CoordinationError::RateLimitBelowMinimum
+    );
+    require!(
+        max_disputes_per_24h >= 1,
+        CoordinationError::RateLimitBelowMinimum
+    );
+
     let config = &mut ctx.accounts.protocol_config;
     config.task_creation_cooldown = task_creation_cooldown;
     config.max_tasks_per_24h = max_tasks_per_24h;

--- a/programs/agenc-coordination/src/instructions/update_skill.rs
+++ b/programs/agenc-coordination/src/instructions/update_skill.rs
@@ -2,6 +2,7 @@
 
 use crate::errors::CoordinationError;
 use crate::events::SkillUpdated;
+use crate::instructions::constants::MIN_SKILL_PRICE;
 use crate::state::{AgentRegistration, AgentStatus, ProtocolConfig, SkillRegistration};
 use crate::utils::version::check_version_compatible;
 use anchor_lang::prelude::*;
@@ -51,6 +52,10 @@ pub fn handler(
     require!(
         content_hash != [0u8; 32],
         CoordinationError::SkillInvalidContentHash
+    );
+    require!(
+        price >= MIN_SKILL_PRICE,
+        CoordinationError::SkillPriceBelowMinimum
     );
 
     let clock = Clock::get()?;

--- a/programs/agenc-coordination/src/lib.rs
+++ b/programs/agenc-coordination/src/lib.rs
@@ -496,8 +496,9 @@ pub mod agenc_coordination {
 
     /// Purchase a skill (SOL or SPL token).
     /// Protocol fee is deducted and sent to treasury.
-    pub fn purchase_skill(ctx: Context<PurchaseSkill>) -> Result<()> {
-        instructions::purchase_skill::handler(ctx)
+    /// expected_price provides slippage protection against front-running.
+    pub fn purchase_skill(ctx: Context<PurchaseSkill>, expected_price: u64) -> Result<()> {
+        instructions::purchase_skill::handler(ctx, expected_price)
     }
 
     /// Post to the agent feed.

--- a/runtime/idl/agenc_coordination.json
+++ b/runtime/idl/agenc_coordination.json
@@ -3230,7 +3230,8 @@
       "name": "purchase_skill",
       "docs": [
         "Purchase a skill (SOL or SPL token).",
-        "Protocol fee is deducted and sent to treasury."
+        "Protocol fee is deducted and sent to treasury.",
+        "expected_price provides slippage protection against front-running."
       ],
       "discriminator": [
         70,
@@ -3433,7 +3434,12 @@
           "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "expected_price",
+          "type": "u64"
+        }
+      ]
     },
     {
       "name": "rate_skill",
@@ -7447,6 +7453,26 @@
       "code": 6193,
       "name": "InsufficientSeedEntropy",
       "msg": "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
+    },
+    {
+      "code": 6194,
+      "name": "SkillPriceBelowMinimum",
+      "msg": "Skill price below minimum required"
+    },
+    {
+      "code": 6195,
+      "name": "SkillPriceChanged",
+      "msg": "Skill price changed since transaction was prepared"
+    },
+    {
+      "code": 6196,
+      "name": "DelegationCooldownNotElapsed",
+      "msg": "Delegation must be active for minimum duration before revocation"
+    },
+    {
+      "code": 6197,
+      "name": "RateLimitBelowMinimum",
+      "msg": "Rate limit value below protocol minimum"
     }
   ],
   "types": [

--- a/runtime/src/skills/registry/payment.test.ts
+++ b/runtime/src/skills/registry/payment.test.ts
@@ -7,6 +7,7 @@ import { RuntimeErrorCodes, AnchorErrorCodes } from "../../types/errors.js";
 import { PROGRAM_ID } from "@agenc/sdk";
 import { silentLogger } from "../../utils/logger.js";
 import { generateAgentId } from "../../utils/encoding.js";
+import BN from "bn.js";
 
 // ============================================================================
 // Test Helpers
@@ -195,8 +196,12 @@ describe("SkillPurchaseManager", () => {
       expect(result.transactionSignature).toBe("mock-tx-signature");
       expect(result.contentPath).toBe("/tmp/skill.md");
 
-      // Verify tx was submitted
-      expect(program.methods.purchaseSkill).toHaveBeenCalled();
+      // Verify tx was submitted with expected_price slippage protection
+      expect(program.methods.purchaseSkill).toHaveBeenCalledWith(
+        expect.objectContaining({ toString: expect.any(Function) }),
+      );
+      const purchaseArg = program.methods.purchaseSkill.mock.calls[0][0];
+      expect(purchaseArg.toString()).toBe("1000000");
       expect(program._methodBuilder.accountsPartial).toHaveBeenCalled();
       expect(registryClient.install).toHaveBeenCalledWith(
         "test-skill",

--- a/runtime/src/skills/registry/payment.ts
+++ b/runtime/src/skills/registry/payment.ts
@@ -12,7 +12,7 @@ import {
   getAssociatedTokenAddressSync,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import type { Program } from "@coral-xyz/anchor";
+import { type Program, BN } from "@coral-xyz/anchor";
 import type { AgencCoordination } from "../../types/agenc_coordination.js";
 import type { Logger } from "../../utils/logger.js";
 import { silentLogger } from "../../utils/logger.js";
@@ -146,7 +146,7 @@ export class SkillPurchaseManager {
 
     try {
       const sig = await this.program.methods
-        .purchaseSkill()
+        .purchaseSkill(new BN(price.toString()))
         .accountsPartial({
           skill: skillPda,
           buyer: this.buyerAgentPda,

--- a/runtime/src/types/agenc_coordination.ts
+++ b/runtime/src/types/agenc_coordination.ts
@@ -3242,7 +3242,8 @@ export type AgencCoordination = {
       "name": "purchaseSkill",
       "docs": [
         "Purchase a skill (SOL or SPL token).",
-        "Protocol fee is deducted and sent to treasury."
+        "Protocol fee is deducted and sent to treasury.",
+        "expected_price provides slippage protection against front-running."
       ],
       "discriminator": [
         70,
@@ -3445,7 +3446,12 @@ export type AgencCoordination = {
           "address": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
         }
       ],
-      "args": []
+      "args": [
+        {
+          "name": "expectedPrice",
+          "type": "u64"
+        }
+      ]
     },
     {
       "name": "rateSkill",
@@ -7459,6 +7465,26 @@ export type AgencCoordination = {
       "code": 6193,
       "name": "insufficientSeedEntropy",
       "msg": "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)"
+    },
+    {
+      "code": 6194,
+      "name": "skillPriceBelowMinimum",
+      "msg": "Skill price below minimum required"
+    },
+    {
+      "code": 6195,
+      "name": "skillPriceChanged",
+      "msg": "Skill price changed since transaction was prepared"
+    },
+    {
+      "code": 6196,
+      "name": "delegationCooldownNotElapsed",
+      "msg": "Delegation must be active for minimum duration before revocation"
+    },
+    {
+      "code": 6197,
+      "name": "rateLimitBelowMinimum",
+      "msg": "Rate limit value below protocol minimum"
     }
   ],
   "types": [

--- a/runtime/src/types/errors.ts
+++ b/runtime/src/types/errors.ts
@@ -217,7 +217,7 @@ export type RuntimeErrorCode =
   (typeof RuntimeErrorCodes)[keyof typeof RuntimeErrorCodes];
 
 // ============================================================================
-// Anchor Error Codes (194 codes: 6000-6193)
+// Anchor Error Codes (198 codes: 6000-6197)
 // ============================================================================
 
 /**
@@ -419,6 +419,10 @@ export const AnchorErrorCodes = {
   PrivateTaskRequiresZkProof: 6191,
   InvalidTokenAccountOwner: 6192,
   InsufficientSeedEntropy: 6193,
+  SkillPriceBelowMinimum: 6194,
+  SkillPriceChanged: 6195,
+  DelegationCooldownNotElapsed: 6196,
+  RateLimitBelowMinimum: 6197,
 } as const;
 
 /** Union type of all Anchor error code values */
@@ -628,10 +632,14 @@ const AnchorErrorMessages: Record<AnchorErrorCode, string> = {
   6191: "Private tasks (non-zero constraint_hash) must use complete_task_private",
   6192: "Token account owner does not match expected authority",
   6193: "Binding or nullifier seed has insufficient byte diversity (min 8 distinct bytes required)",
+  6194: "Skill price below minimum required",
+  6195: "Skill price changed since transaction was prepared",
+  6196: "Delegation must be active for minimum duration before revocation",
+  6197: "Rate limit value below protocol minimum",
 };
 
 const ANCHOR_ERROR_MIN_CODE = 6000;
-const ANCHOR_ERROR_MAX_CODE = 6193;
+const ANCHOR_ERROR_MAX_CODE = 6197;
 
 // ============================================================================
 // Validation Helpers

--- a/tests/agent-feed.ts
+++ b/tests/agent-feed.ts
@@ -98,6 +98,7 @@ describe("agent-feed (issue #1103)", () => {
     workerAgentPda: PublicKey,
     label: string,
   ): Promise<void> => {
+    advanceClock(svm, 2); // satisfy rate limit cooldown
     const taskId = nextRepTaskId(label);
     const taskPda = deriveTaskPda(
       repCreator.publicKey,
@@ -297,6 +298,11 @@ describe("agent-feed (issue #1103)", () => {
     await boostReputation(poster2, poster2AgentPda, 5, "feed-rep-p2");
     await boostReputation(poster3, poster3AgentPda, 2, "feed-rep-p3");
     advanceClock(svm, 60 * 60 + 1);
+  });
+
+  // Advance clock to satisfy rate limit cooldowns between tests
+  beforeEach(() => {
+    advanceClock(svm, 2);
   });
 
   // ==========================================================================

--- a/tests/complete_task_private.ts
+++ b/tests/complete_task_private.ts
@@ -22,6 +22,7 @@ import {
   createLiteSVMContext,
   fundAccount,
   getClockTimestamp,
+  advanceClock,
   injectMockVerifierRouter,
   type LiteSVMContext,
 } from "./litesvm-helpers";
@@ -320,6 +321,11 @@ describe("complete_task_private (LiteSVM + mock router)", () => {
     });
   });
 
+  // Advance clock to satisfy rate limit cooldowns between tests
+  beforeEach(() => {
+    advanceClock(ctx.svm, 2);
+  });
+
   it("completes private task end-to-end with real hashes", async () => {
     const output = [11n, 22n, 33n, 44n];
     const salt = generateSalt();
@@ -407,6 +413,7 @@ describe("complete_task_private (LiteSVM + mock router)", () => {
     });
 
     // Second task reusing the same binding/nullifier seeds should fail
+    advanceClock(ctx.svm, 2); // satisfy rate limit cooldown
     const taskIdBuf2 = makeTaskId("zkp2b", runId);
     const { taskPda: task2Pda, escrowPda: escrow2Pda, claimPda: claim2Pda } =
       await createTaskAndClaim(constraintHashBuf, taskIdBuf2);

--- a/tests/dispute-slash-logic.ts
+++ b/tests/dispute-slash-logic.ts
@@ -222,10 +222,10 @@ describe("dispute-slash-logic (issue #136)", () => {
     try {
       await program.methods
         .updateRateLimits(
-          new BN(0), // task_creation_cooldown = 0 (disabled)
-          0, // max_tasks_per_24h = 0 (unlimited)
-          new BN(0), // dispute_initiation_cooldown = 0 (disabled)
-          0, // max_disputes_per_24h = 0 (unlimited)
+          new BN(1), // task_creation_cooldown = 1s (minimum allowed)
+          255, // max_tasks_per_24h = 255 (effectively unlimited)
+          new BN(1), // dispute_initiation_cooldown = 1s (minimum allowed)
+          255, // max_disputes_per_24h = 255 (effectively unlimited)
           new BN(LAMPORTS_PER_SOL / 100), // min_stake_for_dispute = 0.01 SOL (must be > 0)
         )
         .accountsPartial({
@@ -341,6 +341,11 @@ describe("dispute-slash-logic (issue #136)", () => {
       CAPABILITY_ARBITER,
       minArbiterStake,
     );
+  });
+
+  // Advance clock to satisfy rate limit cooldowns between tests
+  beforeEach(() => {
+    advanceClock(svm, 2);
   });
 
   describe("applyDisputeSlash preconditions", () => {

--- a/tests/governance.ts
+++ b/tests/governance.ts
@@ -311,6 +311,11 @@ describe("governance (issue #1106)", () => {
     });
   });
 
+  // Advance clock to satisfy rate limit cooldowns between tests
+  beforeEach(() => {
+    advanceClock(svm, 2);
+  });
+
   // ==========================================================================
   // initialize_governance
   // ==========================================================================
@@ -728,10 +733,10 @@ describe("governance (issue #1106)", () => {
       try {
         await program.methods
           .updateRateLimits(
-            new BN(0),
-            0,
-            new BN(0),
-            0,
+            new BN(1), // task_creation_cooldown = 1s (minimum allowed)
+            255, // max_tasks_per_24h = 255 (effectively unlimited)
+            new BN(1), // dispute_initiation_cooldown = 1s (minimum allowed)
+            255, // max_disputes_per_24h = 255 (effectively unlimited)
             new BN(LAMPORTS_PER_SOL / 100),
           )
           .accountsPartial({ protocolConfig: protocolPda })

--- a/tests/lifecycle-guards.ts
+++ b/tests/lifecycle-guards.ts
@@ -335,6 +335,11 @@ describe("Task lifecycle guards (#959)", () => {
     }
   });
 
+  // Advance clock to satisfy rate limit cooldowns between tests
+  beforeEach(() => {
+    advanceClock(svm, 2);
+  });
+
   it("rejects double completion on competitive task (CompetitiveTaskAlreadyWon)", async () => {
     const taskId = nextTaskId();
     const { taskPda, escrowPda } = await createCompetitiveTask(

--- a/tests/litesvm-helpers.ts
+++ b/tests/litesvm-helpers.ts
@@ -360,6 +360,11 @@ export function advanceClock(svm: LiteSVM, seconds: number): void {
   clock.unixTimestamp = newTimestamp;
   clock.slot = newSlot;
   svm.setClock(clock);
+  // Expire the current blockhash so subsequent transactions get a fresh one.
+  // Without this, two identical transactions (same accounts, instruction, signers)
+  // sent before and after a clock advance would share the same blockhash,
+  // producing identical bytes and triggering AlreadyProcessed (error 6).
+  svm.expireBlockhash();
 }
 
 // ============================================================================

--- a/tests/litesvm-poc.ts
+++ b/tests/litesvm-poc.ts
@@ -122,13 +122,13 @@ describe("litesvm-poc", () => {
       expect(config.protocolFeeBps).to.equal(100);
     });
 
-    it("should disable rate limits", async () => {
+    it("should set rate limits to minimums", async () => {
       await program.methods
         .updateRateLimits(
-          new BN(0),
-          0,
-          new BN(0),
-          0,
+          new BN(1), // task_creation_cooldown = 1s (minimum allowed)
+          255, // max_tasks_per_24h = 255 (effectively unlimited)
+          new BN(1), // dispute_initiation_cooldown = 1s (minimum allowed)
+          255, // max_disputes_per_24h = 255 (effectively unlimited)
           new BN(MIN_DISPUTE_STAKE_LAMPORTS),
         )
         .accountsPartial({ protocolConfig: protocolPda })

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -386,10 +386,10 @@ export async function disableRateLimitsForTests(params: {
 
   const builder = program.methods
     .updateRateLimits(
-      new BN(0), // task_creation_cooldown = 0 (disabled)
-      0, // max_tasks_per_24h = 0 (unlimited)
-      new BN(0), // dispute_initiation_cooldown = 0 (disabled)
-      0, // max_disputes_per_24h = 0 (unlimited)
+      new BN(1), // task_creation_cooldown = 1s (minimum allowed)
+      255, // max_tasks_per_24h = 255 (effectively unlimited)
+      new BN(1), // dispute_initiation_cooldown = 1s (minimum allowed)
+      255, // max_disputes_per_24h = 255 (effectively unlimited)
       new BN(minStakeForDisputeLamports), // min_stake_for_dispute (>= 1000)
     )
     .accountsPartial({ protocolConfig: protocolPda })

--- a/tests/test_1.ts
+++ b/tests/test_1.ts
@@ -350,6 +350,9 @@ describe("test_1", () => {
   // This prevents cascading failures when a test deactivates an agent
   // and ensures agents are registered even if before() had issues
   beforeEach(async () => {
+    // Advance clock to satisfy rate limit cooldowns between tests
+    advanceClock(svm, 2);
+
     const agentsToCheck = [
       {
         id: agentId1,
@@ -10035,6 +10038,7 @@ describe("test_1", () => {
         expect(agent.activeTasks).to.equal(1);
 
         // Claim task 2
+        advanceClock(svm, 2); // satisfy rate limit cooldown
         const taskId2 = Buffer.from("track-task-002".padEnd(32, "\0"));
         const taskPda2 = deriveTaskPda(creator.publicKey, taskId2);
         const escrowPda2 = deriveEscrowPda(taskPda2);
@@ -10870,6 +10874,7 @@ describe("test_1", () => {
 
         // Create and claim 10 tasks
         for (let i = 0; i < 10; i++) {
+          advanceClock(svm, 2); // satisfy rate limit cooldown
           const taskId = Buffer.from(
             `busy-task-${i.toString().padStart(3, "0")}`.padEnd(32, "\0"),
           );
@@ -10923,6 +10928,7 @@ describe("test_1", () => {
         expect(agent.activeTasks).to.equal(10);
 
         // 11th claim should fail
+        advanceClock(svm, 2); // satisfy rate limit cooldown
         const taskId11 = Buffer.from("busy-task-010".padEnd(32, "\0"));
         const taskPda11 = deriveTaskPda(creator.publicKey, taskId11);
         const escrowPda11 = deriveEscrowPda(taskPda11);

--- a/tests/zk-proof-lifecycle.ts
+++ b/tests/zk-proof-lifecycle.ts
@@ -22,6 +22,7 @@ import {
   createLiteSVMContext,
   fundAccount,
   getClockTimestamp,
+  advanceClock,
   injectMockVerifierRouter,
   type LiteSVMContext,
 } from "./litesvm-helpers";
@@ -320,6 +321,11 @@ describe("ZK Proof Verification Lifecycle (LiteSVM)", () => {
       capabilities: CAPABILITY_COMPUTE,
       stakeLamports: LAMPORTS_PER_SOL / 10,
     });
+  });
+
+  // Advance clock to satisfy rate limit cooldowns between tests
+  beforeEach(() => {
+    advanceClock(ctx.svm, 2);
   });
 
   it("submits complete_task_private with dual-spend + router accounts", async () => {


### PR DESCRIPTION
## Summary

- Close 8 exploit chains identified in security audit (4 CRITICAL, 2 HIGH, 2 MEDIUM)
- Allow initiator slash on cancelled disputes, enforce minimum skill price, add purchase slippage protection, validate PDAs in remaining_accounts, add delegation revocation cooldown, deduplicate vote keys, reorder token escrow close in cancel_task, enforce minimum rate limits
- Add 4 new error codes (6194–6197), update runtime error mapping, IDL, and all LiteSVM tests for rate limit cooldown compliance
- Fix `advanceClock()` to expire blockhash after clock manipulation, preventing AlreadyProcessed errors

## Test plan

- [x] `anchor build` — compiles cleanly
- [x] `cargo test` — Rust unit tests pass (100/100)
- [x] `npm run test:fast` — 234 LiteSVM integration tests pass
- [x] `npm run build` — all packages build (sdk + runtime + mcp + docs-mcp)
- [x] Runtime errors test — 65/65 pass with new error codes
- [x] Runtime payment.test.ts — 22/22 pass with expected_price param
- [x] reputation-economy.ts — 15/15 pass including delegation cooldown
- [x] litesvm-poc — 13/13 pass