### PR TITLE
fix(runtime): resolve all 12 TypeScript compilation errors

### DIFF
--- a/runtime/src/autonomous/curiosity.ts
+++ b/runtime/src/autonomous/curiosity.ts
@@ -19,6 +19,7 @@ import type { ToolHandler } from "../llm/types.js";
 import type { MemoryBackend } from "../memory/types.js";
 import type { ProactiveCommunicator } from "../gateway/proactive.js";
 import type { GoalManager } from "./goal-manager.js";
+import { createGatewayMessage } from "../gateway/message.js";
 
 // ============================================================================
 // Types
@@ -99,14 +100,14 @@ export function createCuriosityAction(config: CuriosityConfig): HeartbeatAction 
 
           // Research the topic using ChatExecutor with tools
           const result = await chatExecutor.execute({
-            message: {
+            message: createGatewayMessage({
               sessionId,
               senderId: "curiosity-module",
+              senderName: "Curiosity",
               content: RESEARCH_PROMPT + topic,
               channel: "internal",
-              scope: "system",
-              timestamp: Date.now(),
-            },
+              scope: "dm",
+            }),
             history: [],
             systemPrompt,
             sessionId,
@@ -136,14 +137,14 @@ export function createCuriosityAction(config: CuriosityConfig): HeartbeatAction 
           let isNoteworthy = false;
           try {
             const evalResult = await chatExecutor.execute({
-              message: {
+              message: createGatewayMessage({
                 sessionId: `curiosity-eval:${Date.now()}`,
                 senderId: "curiosity-module",
+                senderName: "Curiosity",
                 content: EVALUATE_PROMPT + result.content,
                 channel: "internal",
-                scope: "system",
-                timestamp: Date.now(),
-              },
+                scope: "dm",
+              }),
               history: [],
               systemPrompt: "You are a concise evaluator. Return only valid JSON.",
               sessionId: `curiosity-eval:${Date.now()}`,

--- a/runtime/src/channels/imessage/plugin.ts
+++ b/runtime/src/channels/imessage/plugin.ts
@@ -12,6 +12,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { BaseChannelPlugin } from "../../gateway/channel.js";
+import { createGatewayMessage } from "../../gateway/message.js";
 import type { OutboundMessage } from "../../gateway/message.js";
 import type { IMessageChannelConfig } from "./types.js";
 
@@ -166,14 +167,14 @@ export class IMessageChannel extends BaseChannelPlugin {
         const sessionId = `imessage:${msg.sender}`;
         this.sessionMap.set(sessionId, msg.sender);
 
-        await this.context.onMessage({
+        await this.context.onMessage(createGatewayMessage({
           sessionId,
           senderId: msg.sender,
+          senderName: msg.sender,
           content: msg.text,
           channel: "imessage",
           scope: "dm",
-          timestamp: Date.now(),
-        });
+        }));
       }
 
       if (!this.healthy) {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -523,7 +523,12 @@ export class DaemonManager {
       `<i>Send any message to get started.</i>`;
 
     const telegram = new TelegramChannel();
-    const sessionMgr = new SessionManager({ maxSessions: 100 });
+    const sessionMgr = new SessionManager({
+      scope: "per-channel-peer",
+      reset: { mode: "idle", idleMinutes: 30 },
+      compaction: "truncate",
+      maxHistoryLength: 100,
+    });
     const systemPrompt = await this.buildSystemPrompt(config);
 
     const onMessage = async (msg: GatewayMessage): Promise<void> => {
@@ -625,7 +630,12 @@ export class DaemonManager {
     config: GatewayConfig,
     channelConfig: Record<string, unknown>,
   ): Promise<void> {
-    const sessionMgr = new SessionManager({ maxSessions: 100 });
+    const sessionMgr = new SessionManager({
+      scope: "per-channel-peer",
+      reset: { mode: "idle", idleMinutes: 30 },
+      compaction: "truncate",
+      maxHistoryLength: 100,
+    });
     const systemPrompt = await this.buildSystemPrompt(config);
 
     const onMessage = async (msg: GatewayMessage): Promise<void> => {
@@ -700,7 +710,7 @@ export class DaemonManager {
 
     if (channels.discord) {
       try {
-        const discord = new DiscordChannel();
+        const discord = new DiscordChannel(channels.discord as unknown as ConstructorParameters<typeof DiscordChannel>[0]);
         await this.wireExternalChannel(discord, "discord", config, channels.discord as unknown as Record<string, unknown>);
         this._discordChannel = discord;
       } catch (err) { this.logger.error("Failed to wire Discord channel:", err); }
@@ -708,7 +718,7 @@ export class DaemonManager {
 
     if (channels.slack) {
       try {
-        const slack = new SlackChannel();
+        const slack = new SlackChannel(channels.slack as unknown as ConstructorParameters<typeof SlackChannel>[0]);
         await this.wireExternalChannel(slack, "slack", config, channels.slack as unknown as Record<string, unknown>);
         this._slackChannel = slack;
       } catch (err) { this.logger.error("Failed to wire Slack channel:", err); }
@@ -716,7 +726,7 @@ export class DaemonManager {
 
     if (channels.whatsapp) {
       try {
-        const whatsapp = new WhatsAppChannel();
+        const whatsapp = new WhatsAppChannel(channels.whatsapp as unknown as ConstructorParameters<typeof WhatsAppChannel>[0]);
         await this.wireExternalChannel(whatsapp, "whatsapp", config, channels.whatsapp as unknown as Record<string, unknown>);
         this._whatsAppChannel = whatsapp;
       } catch (err) { this.logger.error("Failed to wire WhatsApp channel:", err); }
@@ -724,7 +734,7 @@ export class DaemonManager {
 
     if (channels.signal) {
       try {
-        const signal = new SignalChannel();
+        const signal = new SignalChannel(channels.signal as unknown as ConstructorParameters<typeof SignalChannel>[0]);
         await this.wireExternalChannel(signal, "signal", config, channels.signal as unknown as Record<string, unknown>);
         this._signalChannel = signal;
       } catch (err) { this.logger.error("Failed to wire Signal channel:", err); }
@@ -732,7 +742,7 @@ export class DaemonManager {
 
     if (channels.matrix) {
       try {
-        const matrix = new MatrixChannel();
+        const matrix = new MatrixChannel(channels.matrix as unknown as ConstructorParameters<typeof MatrixChannel>[0]);
         await this.wireExternalChannel(matrix, "matrix", config, channels.matrix as unknown as Record<string, unknown>);
         this._matrixChannel = matrix;
       } catch (err) { this.logger.error("Failed to wire Matrix channel:", err); }
@@ -756,7 +766,7 @@ export class DaemonManager {
    * and CronScheduler for long-running research tasks (curiosity every 2h, self-learning every 6h).
    */
   private async wireAutonomousFeatures(config: GatewayConfig): Promise<void> {
-    const heartbeatConfig = (config as Record<string, unknown>).heartbeat as
+    const heartbeatConfig = (config as unknown as Record<string, unknown>).heartbeat as
       | { enabled?: boolean; intervalMs?: number }
       | undefined;
     if (heartbeatConfig?.enabled === false) return;
@@ -2025,6 +2035,10 @@ export class DaemonManager {
 
   get goalManager(): import('../autonomous/goal-manager.js').GoalManager | null {
     return this._goalManager;
+  }
+
+  get proactiveCommunicator(): ProactiveCommunicator | null {
+    return this._proactiveCommunicator;
   }
 
   getStatus(): DaemonStatus {

--- a/runtime/src/types/errors.test.ts
+++ b/runtime/src/types/errors.test.ts
@@ -67,8 +67,8 @@ describe('RuntimeErrorCodes', () => {
     expect(RuntimeErrorCodes.MARKETPLACE_MATCHING_ERROR).toBe('MARKETPLACE_MATCHING_ERROR');
   });
 
-  it('has exactly 97 error codes', () => {
-    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(97);
+  it('has exactly 101 error codes', () => {
+    expect(Object.keys(RuntimeErrorCodes)).toHaveLength(101);
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix `curiosity.ts` and `imessage/plugin.ts` to use `createGatewayMessage()` with valid `MessageScope` and required `id`/`senderName` fields
- Fix `SessionManager` constructor calls to use proper `SessionConfig` instead of invalid `maxSessions`
- Pass channel configs to Discord/Slack/WhatsApp/Signal/Matrix constructors (they require typed config, not zero args)
- Fix `GatewayConfig` to `Record<string, unknown>` cast through `unknown` intermediate
- Add `proactiveCommunicator` getter to resolve TS6133 unused field
- Update error code count test from 97 to 101 (4 desktop sandbox codes)

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [x] All 502 tests across affected modules pass (desktop, channels, autonomous, types)
- [x] 4 pre-existing LiteSVM/CLI contract failures unchanged