### PR TITLE
docs: update CLAUDE.md and README.md to match current codebase

### DIFF
--- a/.claude/notes/gotchas.md
+++ b/.claude/notes/gotchas.md
@@ -16,3 +16,12 @@ MCP replay tests can fail from environment/runtime import mismatches (for exampl
 
 ## 2026-02-18
 - For anti-spam controls, prefer shared validation helpers instead of duplicating reputation/account-age gates across instructions.
+
+## 2026-02-21
+
+### Desktop Sandbox Module Patterns
+- `execFileAsync()` exists in both `gateway/sandbox.ts` and `desktop/manager.ts` — next time extract to `utils/exec.ts` before duplicating
+- Container port numbers (9990, 6080) should always be constants, not inline strings in Docker args and port parsing
+- When splitting array initializers into `const arr = [...]; arr.push(...)`, watch for `];` vs `);` — the push call needs parenthesis, not bracket
+- `err instanceof Error ? err.message : err` pattern repeated 10+ times across desktop module — always extract to a shared `getErrorMessage()` helper early
+- Void fire-and-forget promises (e.g. `void this.destroy(id)` in timer callbacks) should always have `.catch()` logging to prevent silent container leaks

--- a/README.md
+++ b/README.md
@@ -64,13 +64,16 @@ AgenC is a decentralized protocol for coordinating AI agents on Solana. Agents r
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`programs/agenc-coordination`](programs/agenc-coordination/) | — | Solana smart contract (Rust/Anchor) — 42 instructions, 47 event types |
+| [`programs/agenc-coordination`](programs/agenc-coordination/) | — | Solana smart contract (Rust/Anchor) — 42 instructions, 57 event types |
 | [`@agenc/sdk`](sdk/) | 1.3.0 | TypeScript SDK — task operations, ZK proofs, SPL token support |
 | [`@agenc/runtime`](runtime/) | 0.1.0 | Agent runtime (~90k lines) — LLM adapters, memory, workflows, marketplace |
 | [`@agenc/mcp`](mcp/) | 0.1.0 | MCP server — protocol operations as AI-consumable tools |
 | [`docs-mcp`](docs-mcp/) | — | Docs MCP server — AI-assisted architecture doc lookups per roadmap issue |
 | [`demo-app`](demo-app/) | — | React web interface for privacy workflow demonstration |
 | [`zkvm`](zkvm/) | — | RISC Zero guest/host programs for private task completion proofs |
+| [`containers/desktop`](containers/desktop/) | — | Docker desktop sandbox — headless Ubuntu/XFCE + VNC + REST API for autonomous desktop automation |
+| [`web`](web/) | — | Web application frontend |
+| [`mobile`](mobile/) | — | Mobile application |
 
 ## Quick Start
 
@@ -105,7 +108,7 @@ anchor build
 # Fast integration tests via LiteSVM (~5s)
 npm run test:fast
 
-# SDK + Runtime unit tests (~1800+ tests)
+# SDK + Runtime unit tests (~4800+ tests)
 npm run test
 
 # Full Anchor integration tests (requires solana-test-validator)
@@ -194,7 +197,7 @@ npm run test:fixtures
 │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
 │  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
 │  │ Gateway  │ │ Channels │ │  Voice   │ │  Social  │ │ Bridges  │  │
-│  │Lifecycle │ │ 7 plugins│ │STT + TTS │ │Discovery │ │LangChain │  │
+│  │Lifecycle │ │ 8 plugins│ │STT + TTS │ │Discovery │ │LangChain │  │
 │  │Sessions  │ │Telegram, │ │Whisper,  │ │Messaging │ │X402, Far-│  │
 │  │Scheduler │ │Discord...│ │ElevenLabs│ │Feed, Rep │ │caster    │  │
 │  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
@@ -242,18 +245,23 @@ AgenC/
 │   ├── src/
 │   │   ├── lib.rs                   # Program entrypoint (42 instructions)
 │   │   ├── state.rs                 # 23 account structures + 9 enums
-│   │   ├── errors.rs                # 192 error codes (6000-6191)
-│   │   ├── events.rs                # 47 event types
+│   │   ├── errors.rs                # 176 error codes (6000-6175)
+│   │   ├── events.rs                # 57 event types
 │   │   └── instructions/            # Instruction handlers + helper modules
 │   └── fuzz/                        # 8 fuzz testing targets
 ├── sdk/                             # TypeScript SDK (v1.3.0)
 │   └── src/                         # Client, proofs, tasks, tokens, bids, validation
 ├── runtime/                         # Agent Runtime (v0.1.0, ~90k lines)
-│   └── src/                         # 29 modules, see Runtime section
+│   └── src/                         # 31 modules, see Runtime section
 ├── mcp/                             # MCP Server (v0.1.0)
 │   └── src/                         # Tools: connection, agents, tasks, protocol, disputes, replay
 ├── docs-mcp/                        # Docs MCP Server (architecture doc lookups)
 ├── demo-app/                        # React + Vite web interface
+├── containers/                      # Docker services (desktop sandbox)
+├── web/                             # Web application frontend
+├── mobile/                          # Mobile application
+├── demo/                            # Demo scripts and tools
+├── security/                        # Security audit tools and reports
 ├── zkvm/                            # RISC Zero guest + host proving workspace
 ├── examples/                        # 10 example projects
 ├── tests/                           # LiteSVM integration tests
@@ -435,9 +443,9 @@ const agent = new AgentBuilder()
 | `autonomous/` | Self-operating agents with task scanning, speculative execution, risk scoring |
 | `task/` | Task CRUD, discovery, proof pipeline, dead letter queue, rollback |
 | `gateway/` | Persistent agent gateway with sessions, config watcher, scheduler, WebSocket control |
-| `channels/` | Channel plugins (Telegram, Discord, WebChat, Slack, WhatsApp, Signal, Matrix) |
+| `channels/` | Channel plugins (Telegram, Discord, WebChat, Slack, WhatsApp, Signal, Matrix, iMessage) |
 | `llm/` | LLM adapters (Grok, Anthropic, Ollama) with tool calling loop |
-| `tools/` | MCP-compatible tool registry, built-in protocol tools, system tools (HTTP, filesystem, browser, bash) |
+| `tools/` | MCP-compatible tool registry, built-in protocol tools, system tools (HTTP, filesystem, browser, bash, macOS) |
 | `memory/` | Pluggable backends (InMemory, SQLite, Redis) + structured memory, embeddings, graph, encryption |
 | `voice/` | Speech-to-text (Whisper), text-to-speech (ElevenLabs, OpenAI, Edge), realtime voice |
 | `social/` | Agent discovery, messaging, feed integration, reputation scoring, collaboration |
@@ -455,7 +463,9 @@ const agent = new AgentBuilder()
 | `telemetry/` | Unified metrics collection with pluggable sinks |
 | `eval/` | Deterministic benchmarks, mutation testing, trajectory recording + replay |
 | `replay/` | On-chain event timeline store, backfill service, alerting |
-| `events/` | Event subscriptions + parsing for 47 on-chain event types |
+| `desktop/` | Desktop automation executor (see-think-act loop), awareness heartbeat, container bridge |
+| `mcp-client/` | MCP client bridge — connects external MCP servers (Peekaboo, macos-automator) to ToolRegistry |
+| `events/` | Event subscriptions + parsing for 57 on-chain event types |
 
 ### LLM Providers
 


### PR DESCRIPTION
## Summary

- Add Desktop Sandbox Container and macOS Native Agent documentation to CLAUDE.md
- Fix all stale counts across CLAUDE.md and README.md (event types 47→57, error codes 192→176, tests ~1800→~4800, modules 29→31, channels 7→8)
- Add missing packages, directories, modules, test files, and build scripts to both docs

## Changes

**CLAUDE.md** (305 lines added):
- Desktop Sandbox Container section: Docker architecture, REST API, 13 tools, security, env vars
- macOS Native Agent section: AppleScript/JXA tools, iMessage channel, DesktopExecutor, Desktop Awareness, MCP Client Bridge
- Fixed all stale counts from comprehensive codebase audit
- Added missing modules (desktop/, mcp-client/), packages (web/, mobile/, containers/), error codes, test files, PDA helpers, scripts

**README.md** (28 lines changed):
- Fixed event types (47→57), error codes (192→176, 6000-6191→6000-6175), test count (~1800→~4800)
- Fixed module count (29→31), channel count (7→8)
- Added Desktop Sandbox, Web App, Mobile App to packages table
- Added containers/, web/, mobile/, demo/, security/ to directory structure
- Added desktop/ and mcp-client/ to module overview
- Added iMessage to channels list, macOS to tools list

## Test plan

- [x] Documentation-only changes, no code modified
- [x] All counts verified against actual codebase via grep/ls