### PR TITLE
fix(containers): fix desktop sandbox startup for non-root user

### DIFF
--- a/containers/desktop/Dockerfile
+++ b/containers/desktop/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     x11vnc novnc websockify \
     # Input automation
     xdotool xclip xsel \
-    # Screenshot
-    scrot imagemagick \
+    # Screenshot + display info
+    scrot imagemagick xdpyinfo \
     # Process management
     supervisor \
     # Fonts
@@ -37,8 +37,9 @@ RUN useradd -m -s /bin/bash -d /home/agenc agenc
 # XFCE configuration (disable screensaver, power management, first-run wizard)
 COPY xfce-config/ /home/agenc/.config/xfce4/xfconf/xfce-perchannel-xml/
 
-# Supervisor configuration
+# Supervisor configuration (must be readable by non-root agenc user)
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+RUN chmod 644 /etc/supervisor/conf.d/supervisord.conf
 
 # REST server
 COPY server/package.json server/package-lock.json* /opt/server/

--- a/containers/desktop/supervisord.conf
+++ b/containers/desktop/supervisord.conf
@@ -1,8 +1,18 @@
+[unix_http_server]
+file=/tmp/supervisor.sock
+chmod=0700
+
 [supervisord]
 nodaemon=true
-user=agenc
 logfile=/tmp/supervisord.log
 pidfile=/tmp/supervisord.pid
+childlogdir=/tmp
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
 
 [program:xvfb]
 command=/usr/bin/Xvfb :1 -screen 0 %(ENV_DISPLAY_WIDTH)sx%(ENV_DISPLAY_HEIGHT)sx%(ENV_DISPLAY_DEPTH)s -ac +extension GLX +render -noreset


### PR DESCRIPTION
## Summary
- Fix supervisord.conf permissions (chmod 644) so non-root `agenc` user can read it
- Rewrite supervisord.conf to be fully self-contained with all socket/log/pid paths under `/tmp/`, removing the `user=agenc` directive (container already runs as agenc via `USER`)
- Add missing `xdpyinfo` package to Dockerfile for the `screen_size` REST tool

## Test plan
- [x] Built image: `docker build -t agenc/desktop:latest containers/desktop/`
- [x] Container starts and stays running (no immediate exit)
- [x] Health check passes: `curl http://localhost:9990/health`
- [x] All 13 REST tools verified working (bash, screenshot, mouse_click, keyboard_type, clipboard, window_list, screen_size)
- [x] noVNC accessible at http://localhost:6080