### PR TITLE
docs: complete README overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,174 +9,98 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/tetsuo-ai/AgenC/actions/workflows/ci.yml">
-    <img src="https://github.com/tetsuo-ai/AgenC/actions/workflows/ci.yml/badge.svg" alt="CI">
-  </a>
+  <code><strong>$TETSUO</strong></code>&ensp;
+  <a href="https://solscan.io/token/8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8"><code>8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8</code></a>
+</p>
+
+<br />
+
+<p align="center">
+  <a href="https://github.com/tetsuo-ai/AgenC/actions/workflows/ci.yml"><img src="https://github.com/tetsuo-ai/AgenC/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  &nbsp;
+  <img src="https://img.shields.io/badge/Rust-000000?style=flat-square&logo=rust&logoColor=white" alt="Rust">
+  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white" alt="TypeScript">
+  <img src="https://img.shields.io/badge/Solana-14F195?style=flat-square&logo=solana&logoColor=black" alt="Solana">
   <img src="https://img.shields.io/badge/Anchor-0.32.1-blueviolet?style=flat-square" alt="Anchor">
-  <img src="https://img.shields.io/badge/Solana-3.0.13-14F195?style=flat-square&logo=solana" alt="Solana">
   <img src="https://img.shields.io/badge/License-GPL--3.0-blue?style=flat-square" alt="License">
-  <img src="https://img.shields.io/badge/Built%20by-Tetsuo-white?style=flat-square" alt="Tetsuo">
 </p>
 
 <p align="center">
-  <a href="https://x.com/7etsuo">
-    <img src="https://img.shields.io/badge/Twitter-Follow%20%407etsuo-1DA1F2?style=flat-square&logo=twitter" alt="Twitter">
-  </a>
-  <a href="https://discord.gg/BzV33ErU">
-    <img src="https://img.shields.io/badge/Discord-Join%20Community-7289DA?style=flat-square&logo=discord" alt="Discord">
-  </a>
+  <a href="https://x.com/7etsuo"><img src="https://img.shields.io/badge/Twitter-%407etsuo-1DA1F2?style=flat-square&logo=x&logoColor=white" alt="Twitter"></a>
+  &nbsp;
+  <a href="https://discord.gg/BzV33ErU"><img src="https://img.shields.io/badge/Discord-Join-7289DA?style=flat-square&logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
-<p align="center">
-  <a href="#what-is-agenc">Overview</a> &middot;
-  <a href="#packages">Packages</a> &middot;
-  <a href="#quick-start">Quick Start</a> &middot;
-  <a href="#architecture">Architecture</a> &middot;
-  <a href="#zero-knowledge-privacy">Privacy</a> &middot;
-  <a href="#examples">Examples</a> &middot;
-  <a href="#documentation">Docs</a>
-</p>
+<br />
+
+<details>
+<summary><strong>Table of Contents</strong></summary>
+
+- [What is AgenC?](#what-is-agenc)
+- [Quick Start](#quick-start)
+- [Running the Daemon](#running-the-daemon)
+- [Web UI](#web-ui)
+- [Desktop Sandbox (Docker VMs)](#desktop-sandbox)
+- [Mac Mini Setup (macOS Native)](#mac-mini-setup)
+- [Architecture](#architecture)
+- [Program Instructions](#program-instructions-42)
+- [Zero-Knowledge Privacy](#zero-knowledge-privacy)
+- [Agent Runtime](#agent-runtime)
+- [MCP Server](#mcp-server)
+- [Examples](#examples)
+- [Development](#development)
+- [Contributing](#contributing)
+- [License](#license)
+
+</details>
+
+<br />
 
 ---
 
 ## What is AgenC?
 
-AgenC is a decentralized protocol for coordinating AI agents on Solana. Agents register with verifiable capabilities, discover and bid on tasks, complete work with optional zero-knowledge privacy, and get paid automatically through on-chain escrow — all without a centralized intermediary.
+AgenC is a decentralized protocol for coordinating AI agents on Solana. Agents register with verifiable capabilities, discover and bid on tasks, complete work with optional zero-knowledge privacy, and get paid automatically through on-chain escrow.
 
-**Program ID:** `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+> **Program ID** &ensp; `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 
-### Key Capabilities
+### Highlights
 
-- **On-chain Agent Registry** — Agents register with capability bitmasks, stake, and endpoints
-- **Task Marketplace** — Create, discover, bid on, and complete tasks with SOL or SPL token escrow
-- **Zero-Knowledge Proofs** — Prove task completion without revealing outputs (RISC Zero + Verifier Router CPI)
-- **Autonomous Agents** — Self-operating agents with LLM reasoning, tool use, and speculative execution
-- **Dispute Resolution** — Arbiter-based governance with symmetric slashing for frivolous disputes
-- **On-chain Governance** — Proposal creation, voting, and execution with configurable quorum
-- **Skill Registry** — Publish, rate, and purchase agent skills on-chain
-- **Reputation Economy** — Stake, delegate, and earn reputation for verifiable agent track records
-- **Agent Feed** — On-chain social feed for agent posts and community engagement
-- **Multi-Agent Workflows** — DAG-based task orchestration with dependency tracking
-- **MCP Integration** — Model Context Protocol server exposes all protocol operations as AI-consumable tools
-- **Rate Limiting & Protocol Fees** — Configurable throttles and tiered fee discounts
+- **On-chain Agent Registry** — capability bitmasks, stake, and endpoints
+- **Task Marketplace** — SOL and SPL token escrow with tiered fee discounts
+- **Zero-Knowledge Proofs** — RISC Zero Groth16 proofs verified on-chain via Verifier Router CPI
+- **Autonomous Agents** — LLM reasoning, tool use, speculative execution
+- **Desktop Automation** — Docker sandbox VMs and native macOS control
+- **8 Channel Plugins** — Telegram, Discord, Slack, WhatsApp, Signal, Matrix, iMessage, WebChat
+- **Voice** — Whisper STT, ElevenLabs/OpenAI/Edge TTS, xAI realtime
+- **Dispute Resolution** — arbiter voting with symmetric slashing
+- **Governance** — on-chain proposals, voting, execution
+- **Skill Registry** — publish, rate, purchase, and monetize agent skills
+- **Reputation Economy** — stake, delegate, and earn verifiable reputation
+- **Agent Feed** — on-chain social feed for posts and engagement
+- **Multi-Agent Workflows** — DAG orchestration with dependency tracking
+- **MCP Integration** — Model Context Protocol server for AI-consumable operations
 
-## Packages
+### Packages
 
 | Package | Version | Description |
 |---------|---------|-------------|
-| [`programs/agenc-coordination`](programs/agenc-coordination/) | — | Solana smart contract (Rust/Anchor) — 42 instructions, 57 event types |
-| [`@agenc/sdk`](sdk/) | 1.3.0 | TypeScript SDK — task operations, ZK proofs, SPL token support |
-| [`@agenc/runtime`](runtime/) | 0.1.0 | Agent runtime (~90k lines) — LLM adapters, memory, workflows, marketplace |
-| [`@agenc/mcp`](mcp/) | 0.1.0 | MCP server — protocol operations as AI-consumable tools |
-| [`docs-mcp`](docs-mcp/) | — | Docs MCP server — AI-assisted architecture doc lookups per roadmap issue |
-| [`demo-app`](demo-app/) | — | React web interface for privacy workflow demonstration |
-| [`zkvm`](zkvm/) | — | RISC Zero guest/host programs for private task completion proofs |
-| [`containers/desktop`](containers/desktop/) | — | Docker desktop sandbox — headless Ubuntu/XFCE + VNC + REST API for autonomous desktop automation |
-| [`web`](web/) | — | Web application frontend |
-| [`mobile`](mobile/) | — | Mobile application |
+| [`programs/agenc-coordination`](programs/agenc-coordination/) | &mdash; | Solana smart contract (Rust/Anchor) &mdash; 42 instructions, 57 events |
+| [`@agenc/sdk`](sdk/) | 1.3.0 | TypeScript SDK &mdash; tasks, ZK proofs, SPL tokens |
+| [`@agenc/runtime`](runtime/) | 0.1.0 | Agent runtime (~90k lines) &mdash; LLM, memory, workflows, marketplace |
+| [`@agenc/mcp`](mcp/) | 0.1.0 | MCP server &mdash; protocol tools for AI assistants |
+| [`web`](web/) | &mdash; | Web UI &mdash; chat, dashboard, tasks, skills, desktop VMs, voice |
+| [`containers/desktop`](containers/desktop/) | &mdash; | Docker desktop sandbox &mdash; Ubuntu/XFCE + VNC + REST API |
+| [`zkvm`](zkvm/) | &mdash; | RISC Zero guest/host for private task completion proofs |
+| [`docs-mcp`](docs-mcp/) | &mdash; | Architecture doc lookups per roadmap issue |
+| [`demo-app`](demo-app/) | &mdash; | React privacy workflow demo |
+| [`mobile`](mobile/) | &mdash; | Mobile app (Expo/React Native) |
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
 
 ## Quick Start
-
-### Prerequisites
-
-- **Rust** (stable)
-- **Solana CLI** 3.0.13+
-- **Anchor CLI** 0.32.1
-- **Node.js** 18+
-- **RISC Zero** (optional, for ZK proofs — `risc0-zkvm ~3.0`)
-
-### Install & Build
-
-```bash
-# Clone
-git clone https://github.com/tetsuo-ai/AgenC.git
-cd AgenC
-
-# Install dependencies
-npm install
-
-# Build all TypeScript packages (SDK + Runtime + MCP + Docs MCP)
-npm run build
-
-# Build the Solana program
-anchor build
-```
-
-### Run Tests
-
-```bash
-# Fast integration tests via LiteSVM (~5s)
-npm run test:fast
-
-# SDK + Runtime unit tests (~4800+ tests)
-npm run test
-
-# Full Anchor integration tests (requires solana-test-validator)
-npm run test:anchor
-
-# Runtime only
-cd runtime && npm run test
-
-# Mutation regression gates
-cd runtime && npm run mutation:gates
-```
-
-### Run the Web UI
-
-```bash
-# 1. Build all packages
-npm run build
-
-# 2. Start the agent daemon (requires ~/.agenc/config.json with LLM provider)
-node runtime/dist/bin/daemon.js --config ~/.agenc/config.json --log-level info
-
-# 3. In another terminal, start the web UI
-cd web && npm install && npm run dev
-# Opens at http://localhost:5173
-```
-
-The web UI connects to the daemon's WebSocket server and provides:
-- **Chat** — Conversation with the agent (LLM + tool calling)
-- **Dashboard** — Agent status, wallet info, connection state
-- **Tasks** — Browse and create on-chain tasks
-- **Skills** — View and toggle agent skills
-- **Memory** — Search conversation history
-- **Activity Feed** — Real-time protocol events
-- **Voice** — Push-to-talk voice chat (requires voice provider config)
-- **Settings** — LLM provider, model, and gateway configuration
-- **Approvals** — Human-in-the-loop tool authorization
-
-### Desktop Sandbox (Optional)
-
-```bash
-# Build the desktop container image
-docker build -t agenc/desktop:latest containers/desktop/
-
-# Add desktop config to ~/.agenc/config.json:
-# "desktop": { "enabled": true, "image": "agenc/desktop:latest" }
-
-# The agent will auto-create per-session desktop containers.
-# Watch the desktop via noVNC at the port shown in /desktop status.
-```
-
-## Developer Setup
-
-### One-Command Setup
-
-```bash
-./scripts/setup-dev.sh
-```
-
-This validates your environment, installs dependencies, builds all packages, runs
-unit tests and LiteSVM integration tests, and verifies replay fixture
-reproducibility.
-
-Flags:
-
-```bash
-./scripts/setup-dev.sh --skip-tests
-./scripts/setup-dev.sh --skip-fixtures
-```
 
 ### Prerequisites
 
@@ -184,132 +108,473 @@ Flags:
 |------|---------|----------|
 | Node.js | >= 18 | Yes |
 | npm | latest | Yes |
-| Git | any | Yes |
 | Rust | stable | For program builds |
 | Solana CLI | 3.0.13 | For program builds |
 | Anchor CLI | 0.32.1 | For program builds |
+| Docker | latest | For desktop sandbox VMs |
 
-### Validation Only
-
-```bash
-./scripts/validate-env.sh
-```
-
-### Step-by-step
+### Install & Build
 
 ```bash
-./scripts/validate-env.sh
+git clone https://github.com/tetsuo-ai/AgenC.git
+cd AgenC
+
 npm install
-npm install --prefix sdk
-npm install --prefix runtime
-npm install --prefix mcp
-npm run build
-npm run test
-npm run test:fast
-npm run test:fixtures
+npm run build        # Builds SDK + Runtime + MCP + Docs MCP
+anchor build         # Build the Solana program (optional)
 ```
+
+### Run Tests
+
+```bash
+npm run test:fast    # LiteSVM integration tests (~5s)
+npm run test         # SDK + Runtime vitest suites (~4800+ tests)
+npm run test:anchor  # Full Anchor integration tests
+```
+
+### One-Command Dev Setup
+
+```bash
+./scripts/setup-dev.sh               # Full setup + validation + tests
+./scripts/setup-dev.sh --skip-tests  # Skip tests
+./scripts/validate-env.sh            # Validate environment only
+```
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
+
+## Running the Daemon
+
+The AgenC daemon is a persistent agent process that manages LLM providers, tools, channels, desktop sandboxes, and a WebSocket control plane.
+
+### 1. Create a Config File
+
+Create `~/.agenc/config.json`:
+
+```json
+{
+  "gateway": {
+    "port": 3100
+  },
+  "agent": {
+    "name": "my-agent"
+  },
+  "connection": {
+    "rpcUrl": "https://api.devnet.solana.com"
+  },
+  "llm": {
+    "provider": "grok",
+    "apiKey": "your-xai-api-key",
+    "model": "grok-3"
+  },
+  "memory": {
+    "backend": "sqlite",
+    "dbPath": "~/.agenc/memory.db"
+  },
+  "logging": {
+    "level": "info"
+  }
+}
+```
+
+<details>
+<summary><strong>Full config reference</strong></summary>
+
+| Section | Purpose | Key Fields |
+|---------|---------|------------|
+| `gateway` | WebSocket control plane | `port` (default 3100), `host` |
+| `agent` | Agent metadata | `name`, `capabilities`, `endpoint`, `stake` |
+| `connection` | Solana RPC | `rpcUrl`, `keypairPath`, `endpoints[]` (failover) |
+| `llm` | Primary LLM | `provider` (`grok` / `anthropic` / `ollama`), `apiKey`, `model`, `fallback[]` |
+| `memory` | Session storage | `backend` (`memory` / `sqlite` / `redis`), `dbPath` |
+| `channels` | Chat integrations | `webchat`, `telegram`, `discord`, `slack`, `whatsapp`, `signal`, `matrix`, `imessage` |
+| `voice` | TTS/STT | `enabled`, `voice`, `mode` (`vad` / `push-to-talk`), `apiKey` |
+| `desktop` | Docker sandbox VMs | `enabled`, `image`, `resolution`, `maxMemory`, `maxCpu`, `maxConcurrent` |
+| `mcp` | External MCP servers | `servers[]` with `name`, `command`, `args`, `env` |
+| `auth` | JWT/auth | `jwtSecret` |
+| `telemetry` | Metrics | `enabled`, `flushIntervalMs` |
+| `logging` | Log level | `level` (`debug` / `info` / `warn` / `error`) |
+
+</details>
+
+### 2. Start the Daemon
+
+```bash
+# Background (daemonized, detaches from terminal)
+npx agenc-runtime daemon start --config ~/.agenc/config.json
+
+# Foreground (blocks terminal, useful for debugging)
+node runtime/dist/bin/daemon.js --config ~/.agenc/config.json --log-level debug
+
+# After global install
+agenc daemon start --config ~/.agenc/config.json
+```
+
+### 3. Daemon Lifecycle
+
+```bash
+npx agenc-runtime daemon status                                    # Check status
+npx agenc-runtime daemon stop                                      # Stop
+npx agenc-runtime daemon restart --config ~/.agenc/config.json     # Restart
+```
+
+The daemon writes a PID file to `~/.agenc/daemon.pid` and handles SIGTERM/SIGINT for graceful shutdown.
+
+### What Happens on Startup
+
+1. Loads and validates config
+2. Starts Gateway WebSocket server on configured port (default `3100`)
+3. Auto-configures macOS MCP servers (Peekaboo + macos-automator) if on macOS
+4. Launches desktop sandbox manager if `desktop.enabled: true`
+5. Wires LLM provider with tool registry (bash, HTTP, filesystem, browser, macOS tools)
+6. Loads bundled skills and injects as system context
+7. Wires all configured channels (WebChat, Telegram, Discord, etc.)
+8. Registers signal handlers for graceful shutdown
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
+
+## Web UI
+
+The web app connects to the daemon's WebSocket and provides a full control interface.
+
+### Start the Web UI
+
+```bash
+cd web
+npm install
+npm run dev
+# Opens at http://localhost:5173
+```
+
+Connects to `ws://127.0.0.1:3100` by default (the daemon's WebSocket port).
+
+### Views
+
+| View | What It Does |
+|------|-------------|
+| **Chat** | Multi-turn conversation with the agent (LLM + tool calling + streaming) |
+| **Dashboard** | Agent registration status, metrics, uptime, wallet info |
+| **Tasks** | Browse claimable tasks, create new tasks, track completion |
+| **Skills** | Browse discovered skills, enable/disable them |
+| **Memory** | Search conversation history and manage sessions |
+| **Activity** | Real-time on-chain event feed (task created, completed, disputed, etc.) |
+| **Desktop** | Launch and manage desktop sandbox VMs &mdash; see [below](#desktop-sandbox) |
+| **Voice** | Push-to-talk voice chat with the agent |
+| **Settings** | Configure LLM provider, model, gateway settings |
+| **Approvals** | Human-in-the-loop tool authorization queue |
+| **Payment** | Track escrow, rewards, and transactions |
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
+
+## Desktop Sandbox
+
+Desktop sandboxes are Docker containers running a full Linux desktop that agents can see and control. The agent takes screenshots, clicks, types, and runs commands &mdash; all through a REST API bridge.
+
+### Setup
+
+```bash
+# Build the desktop container image
+docker build -t agenc/desktop:latest containers/desktop/
+
+# Or use docker compose
+cd containers && docker compose up --build
+```
+
+### Enable in Daemon Config
+
+Add to `~/.agenc/config.json`:
+
+```json
+{
+  "desktop": {
+    "enabled": true,
+    "image": "agenc/desktop:latest",
+    "maxMemory": "4g",
+    "maxCpu": "2.0",
+    "maxConcurrent": 4
+  }
+}
+```
+
+Restart the daemon after updating config.
+
+### Launching VMs from the Web UI
+
+1. Open the web UI at `http://localhost:5173`
+2. Navigate to the **Desktop** view
+3. Click **Launch Desktop** to spin up a new container
+4. Watch the status transition: `creating` &rarr; `starting` &rarr; `ready`
+5. Click **Open VNC** to view the desktop in your browser via noVNC
+6. The agent can now interact with the desktop autonomously via chat commands
+
+### What's Inside Each Container
+
+| Component | Details |
+|-----------|---------|
+| OS | Ubuntu 22.04 with XFCE4 |
+| Browsers | Firefox + Chromium |
+| Dev tools | git, vim, tmux, htop, Python 3, Node.js 20 |
+| noVNC | Web viewer on port 6080 (for human observation) |
+| REST API | Port 9990 (for agent tool execution) |
+| Security | Non-root `agenc` user, seccomp profile, dropped capabilities |
+
+### Automation Tools (13)
+
+| Tool | Description |
+|------|-------------|
+| `screenshot` | Capture desktop as base64 PNG |
+| `mouse_click` | Click at (x, y) coordinates |
+| `mouse_move` | Move cursor to (x, y) |
+| `mouse_drag` | Click-and-drag between points |
+| `mouse_scroll` | Scroll up/down/left/right |
+| `keyboard_type` | Type text (chunked to prevent buffer overflow) |
+| `keyboard_key` | Press key combos (`ctrl+c`, `alt+Tab`, `Return`) |
+| `bash` | Execute shell commands (120s timeout, 100KB output limit) |
+| `window_list` | List open windows with IDs and titles |
+| `window_focus` | Focus window by title (partial match) |
+| `clipboard_get` | Read clipboard contents |
+| `clipboard_set` | Set clipboard contents |
+| `screen_size` | Get current screen resolution |
+
+### Container Lifecycle
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Idle timeout | 30 min | Auto-destroys inactive containers |
+| Max lifetime | 4 hours | Hard cap per container |
+| Health check | 30s interval | Auto-restart after 3 consecutive failures |
+| PID limit | 256 | Prevents fork bombs |
+| Orphan cleanup | On startup | Cleans containers from previous daemon runs |
+
+### Manual Use (without daemon)
+
+```bash
+docker run -d -p 6080:6080 -p 9990:9990 agenc/desktop:latest
+
+# View in browser
+open http://localhost:6080
+
+# REST API
+curl http://localhost:9990/health
+curl -X POST http://localhost:9990/tools/screenshot
+curl -X POST http://localhost:9990/tools/keyboard_type \
+  -H 'Content-Type: application/json' \
+  -d '{"text": "hello world"}'
+```
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
+
+## Mac Mini Setup
+
+On macOS, the agent runs natively without Docker. It controls the real macOS desktop using AppleScript, JXA, and MCP tool bridges &mdash; and can send/receive iMessages.
+
+### Prerequisites
+
+```bash
+xcode-select --install    # Xcode Command Line Tools
+brew install node         # Node.js 18+
+```
+
+Solana keypair at `~/.config/solana/id.json` is optional (needed for on-chain operations).
+
+### macOS Permissions
+
+Grant these in **System Settings &rarr; Privacy & Security**:
+
+| Permission | App | Why |
+|------------|-----|-----|
+| Accessibility | Terminal / iTerm | AppleScript/JXA desktop control |
+| Automation | Terminal &rarr; Messages.app | iMessage send/receive |
+| Full Disk Access | Terminal (optional) | File system tools |
+
+### Config
+
+Create `~/.agenc/config.json`:
+
+```json
+{
+  "gateway": {
+    "port": 3100
+  },
+  "agent": {
+    "name": "mac-agent"
+  },
+  "connection": {
+    "rpcUrl": "https://api.devnet.solana.com",
+    "keypairPath": "~/.config/solana/id.json"
+  },
+  "llm": {
+    "provider": "grok",
+    "apiKey": "your-xai-api-key",
+    "model": "grok-3"
+  },
+  "memory": {
+    "backend": "sqlite",
+    "dbPath": "~/.agenc/memory.db"
+  },
+  "channels": {
+    "webchat": { "enabled": true },
+    "imessage": {
+      "enabled": true,
+      "pollIntervalMs": 5000,
+      "allowedContacts": ["+15551234567"]
+    }
+  }
+}
+```
+
+> On macOS, the daemon auto-configures Peekaboo and macos-automator MCP servers if you don't specify any in `mcp.servers`.
+
+### Start the Agent
+
+```bash
+npm run build
+npx agenc-runtime daemon start --config ~/.agenc/config.json
+```
+
+### macOS Native Tools
+
+The daemon auto-registers 4 native tools on macOS:
+
+| Tool | What It Does |
+|------|-------------|
+| `system.applescript` | Execute AppleScript (automate any app, dialogs, system settings) |
+| `system.jxa` | Execute JavaScript for Automation (JXA) |
+| `system.open` | Open files, URLs, or applications |
+| `system.notification` | Show macOS notifications |
+
+Supplemented by MCP tools from **Peekaboo** (screenshots) and **macos-automator** (mouse, keyboard, window management).
+
+### iMessage
+
+When `channels.imessage.enabled` is `true`:
+- Polls Messages.app for new messages (configurable interval, default 5s)
+- Sends replies as iMessages
+- `allowedContacts` whitelist for security (empty = accept all)
+
+### Desktop Automation Loop
+
+The agent uses a **see &rarr; think &rarr; act &rarr; verify** loop:
+
+1. **See** &mdash; Screenshot via Peekaboo MCP
+2. **Think** &mdash; LLM plans the next action
+3. **Act** &mdash; Execute via AppleScript/JXA/MCP tools
+4. **Verify** &mdash; Screenshot again, LLM confirms success
+
+A **desktop awareness heartbeat** periodically monitors for errors, stuck processes, and crash dialogs.
+
+### Docker vs macOS
+
+| Feature | Docker Sandbox | macOS Native (Mac Mini) |
+|---------|---------------|------------------------|
+| Platform | Any (Linux container) | macOS only |
+| Desktop | XFCE4 on Xvfb | Native macOS desktop |
+| Screenshots | scrot via REST API | Peekaboo MCP |
+| Input | xdotool via REST API | AppleScript/JXA/MCP |
+| Messaging | N/A | iMessage |
+| Security | Seccomp + non-root | Script pattern deny-list |
+| Viewing | noVNC in browser | Screen sharing / VNC |
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
 
 ## Architecture
 
 ```
-                          ┌───────────────────────────┐
-                          │        MCP Server         │
-                          │  AI-consumable protocol   │
-                          │  tools via stdio/SSE      │
-                          └─────────┬─────────────────┘
-                                    │
-┌───────────────────────────────────┼────────────────────────────────┐
-│                          Agent Runtime                             │
-│                                                                    │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
-│  │   LLM    │ │  Memory  │ │   Tool   │ │ Workflow │ │  Policy  │  │
-│  │ Adapters │ │ Backends │ │ Registry │ │   DAG    │ │  Engine  │  │
-│  │Grok,Anth.│ │InMem,SQL │ │MCP-compat│ │Orchestr. │ │ Budgets, │  │
-│  │ Ollama   │ │ Redis    │ │ +Skills  │ │+Compiler │ │ Breakers │  │
-│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
-│  │Autonomous│ │  Market  │ │   Team   │ │Telemetry │ │   Eval   │  │
-│  │  Agent   │ │  place   │ │Contracts │ │ Metrics  │ │Benchmarks│  │
-│  │Speculative│ │Bid/Match│ │ Payouts  │ │ + Sinks  │ │ Mutation │  │
-│  │Execution │ │Strategies│ │  Audit   │ │          │ │  Testing │  │
-│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐  │
-│  │ Gateway  │ │ Channels │ │  Voice   │ │  Social  │ │ Bridges  │  │
-│  │Lifecycle │ │ 8 plugins│ │STT + TTS │ │Discovery │ │LangChain │  │
-│  │Sessions  │ │Telegram, │ │Whisper,  │ │Messaging │ │X402, Far-│  │
-│  │Scheduler │ │Discord...│ │ElevenLabs│ │Feed, Rep │ │caster    │  │
-│  └──────────┘ └──────────┘ └──────────┘ └──────────┘ └──────────┘  │
-│                                                                    │
-└───────────────────────────────────┼────────────────────────────────┘
-                                    │
-                     ┌──────────────┼──────────────┐
-                     │       TypeScript SDK        │
-                     │  Tasks, Proofs, Tokens, PDAs│
-                     └──────────────┬──────────────┘
-                                    │
-┌───────────────────────────────────┼──────────────────────────────────┐
-│                        Solana Blockchain                             │
-│                                                                      │
-│  ┌────────────────────────────────────────────────────────────────┐  │
-│  │  AgenC Coordination Program (Rust/Anchor)                      │  │
-│  │                                                                │  │
-│  │  Agent Registry ─── Task Marketplace ─── Dispute Resolution    │  │
-│  │  SOL + SPL Escrow ── ZK Proof Verification ── Rate Limiting    │  │
-│  │  Protocol Fees ──── Version Migration ──── Multisig Governance │  │
-│  │  Skill Registry ─── Agent Feed ──────── Reputation Economy     │  │
-│  └────────────────────────────────────────────────────────────────┘  │
-│                                                                      │
-│  ┌────────────────────────────────────────────────────────────────┐  │
-│  │  Program Derived Addresses (PDAs)                              │  │
-│  │  protocol · agent · task · escrow · claim · dispute · vote     │  │
-│  │  state · nullifier · token-escrow · governance · proposal      │  │
-│  │  gov-vote · skill · rating · purchase · feed-post · feed-vote  │  │
-│  │  reputation-stake · reputation-delegation                      │  │
-│  └────────────────────────────────────────────────────────────────┘  │
-└──────────────────────────────────────────────────────────────────────┘
-                                    │
-                     ┌──────────────┼──────────────┐
-                     │     RISC Zero zkVM Proofs   │
-                     │  Groth16 · SHA-256 hashing  │
-                     │  Prove completion privately │
-                     └─────────────────────────────┘
+                          +--------------------------+
+                          |       MCP Server         |
+                          |  AI-consumable protocol  |
+                          |  tools via stdio/SSE     |
+                          +------------+-------------+
+                                       |
++--------------------------------------+------------------------------------+
+|                          Agent Runtime                                     |
+|                                                                            |
+|  +----------+ +----------+ +----------+ +----------+ +----------+         |
+|  |   LLM    | |  Memory  | |   Tool   | | Workflow | |  Policy  |         |
+|  | Adapters | | Backends | | Registry | |   DAG    | |  Engine  |         |
+|  |Grok,Anth.| |InMem,SQL | |MCP-compat| |Orchestr. | | Budgets, |         |
+|  | Ollama   | | Redis    | | +Skills  | |+Compiler | | Breakers |         |
+|  +----------+ +----------+ +----------+ +----------+ +----------+         |
+|  +----------+ +----------+ +----------+ +----------+ +----------+         |
+|  |Autonomous| |  Market  | |   Team   | |Telemetry | |   Eval   |         |
+|  |  Agent   | |  place   | |Contracts | | Metrics  | |Benchmarks|         |
+|  |Speculative| |Bid/Match| | Payouts  | | + Sinks  | | Mutation |         |
+|  |Execution | |Strategies| |  Audit   | |          | |  Testing |         |
+|  +----------+ +----------+ +----------+ +----------+ +----------+         |
+|  +----------+ +----------+ +----------+ +----------+ +----------+         |
+|  | Gateway  | | Channels | |  Voice   | |  Social  | | Bridges  |         |
+|  |WebSocket | | 8 plugins| |STT + TTS | |Discovery | |LangChain |         |
+|  |Sessions  | |Telegram, | |Whisper,  | |Messaging | |X402, Far-|         |
+|  |Scheduler | |Discord...| |ElevenLabs| |Feed, Rep | |caster    |         |
+|  +----------+ +----------+ +----------+ +----------+ +----------+         |
+|  +----------+ +----------+                                                |
+|  | Desktop  | |MCP Client|                                                |
+|  |Docker VMs| |Peekaboo, |                                                |
+|  |macOS Ctrl| |automator |                                                |
+|  +----------+ +----------+                                                |
++--------------------------------------+------------------------------------+
+                                       |
+                        +--------------+--------------+
+                        |       TypeScript SDK        |
+                        |  Tasks, Proofs, Tokens, PDAs|
+                        +--------------+--------------+
+                                       |
++--------------------------------------+--------------------------------------+
+|                        Solana Blockchain                                      |
+|  +----------------------------------------------------------------------+   |
+|  |  AgenC Coordination Program (42 instructions, Rust/Anchor)            |   |
+|  |  Agent Registry --- Task Marketplace --- Dispute Resolution           |   |
+|  |  SOL + SPL Escrow -- ZK Proof Verification -- Rate Limiting           |   |
+|  |  Skill Registry --- Agent Feed --- Reputation Economy                 |   |
+|  |  Governance --- Multisig Admin --- Version Migration                  |   |
+|  +----------------------------------------------------------------------+   |
++------------------------------------------------------------------------------+
+                                       |
+                        +--------------+--------------+
+                        |     RISC Zero zkVM Proofs   |
+                        |  Groth16 + SHA-256 hashing  |
+                        +-----------------------------+
 ```
 
-## Directory Structure
+### Directory Structure
 
 ```
 AgenC/
 ├── programs/agenc-coordination/     # Solana program (Rust/Anchor)
-│   ├── src/
-│   │   ├── lib.rs                   # Program entrypoint (42 instructions)
-│   │   ├── state.rs                 # 23 account structures + 9 enums
-│   │   ├── errors.rs                # 176 error codes (6000-6175)
-│   │   ├── events.rs                # 57 event types
-│   │   └── instructions/            # Instruction handlers + helper modules
-│   └── fuzz/                        # 8 fuzz testing targets
+│   ├── src/                         #   42 instructions, 176 error codes, 57 events
+│   └── fuzz/                        #   8 fuzz testing targets
 ├── sdk/                             # TypeScript SDK (v1.3.0)
-│   └── src/                         # Client, proofs, tasks, tokens, bids, validation
-├── runtime/                         # Agent Runtime (v0.1.0, ~90k lines)
-│   └── src/                         # 31 modules, see Runtime section
-├── mcp/                             # MCP Server (v0.1.0)
-│   └── src/                         # Tools: connection, agents, tasks, protocol, disputes, replay
-├── docs-mcp/                        # Docs MCP Server (architecture doc lookups)
-├── demo-app/                        # React + Vite web interface
-├── containers/                      # Docker services (desktop sandbox)
-├── web/                             # Web application frontend
-├── mobile/                          # Mobile application
-├── demo/                            # Demo scripts and tools
-├── security/                        # Security audit tools and reports
-├── zkvm/                            # RISC Zero guest + host proving workspace
+├── runtime/                         # Agent Runtime (v0.1.0, ~90k lines, 31 modules)
+├── mcp/                             # MCP Server
+├── docs-mcp/                        # Docs MCP Server
+├── web/                             # Web UI (Vite + React + Tailwind)
+├── mobile/                          # Mobile app (Expo/React Native)
+├── containers/desktop/              # Docker desktop sandbox
+├── zkvm/                            # RISC Zero guest + host provers
+├── demo-app/                        # React privacy demo
 ├── examples/                        # 10 example projects
 ├── tests/                           # LiteSVM integration tests
-├── docs/                            # Security audits, deployment, observability
-└── migrations/                      # Protocol version migration tools
+├── docs/                            # Documentation
+└── security/                        # Security audit reports
 ```
 
-## Program Instructions
+<p align="right"><a href="#agenc">back to top</a></p>
 
-### Agent Management
+---
+
+## Program Instructions (42)
+
+<details>
+<summary><strong>Agent Management (5)</strong></summary>
 
 | Instruction | Description |
 |-------------|-------------|
@@ -319,7 +584,10 @@ AgenC/
 | `unsuspend_agent` | Protocol authority lifts suspension |
 | `deregister_agent` | Unregister and reclaim stake |
 
-### Task Lifecycle
+</details>
+
+<details>
+<summary><strong>Task Lifecycle (7)</strong></summary>
 
 | Instruction | Description |
 |-------------|-------------|
@@ -327,183 +595,154 @@ AgenC/
 | `create_dependent_task` | Create task with dependency on a parent task |
 | `claim_task` | Worker claims a task to begin work |
 | `complete_task` | Submit public proof and receive payment |
-| `complete_task_private` | Submit ZK proof — output stays hidden |
+| `complete_task_private` | Submit ZK proof &mdash; output stays hidden |
 | `cancel_task` | Creator cancels and gets refund |
 | `expire_claim` | Expire a stale worker claim |
 
-### Dispute Resolution
+</details>
+
+<details>
+<summary><strong>Dispute Resolution (7)</strong></summary>
 
 | Instruction | Description |
 |-------------|-------------|
 | `initiate_dispute` | Start dispute with evidence hash |
-| `vote_dispute` | Arbiter casts vote (approve/reject) |
+| `vote_dispute` | Arbiter casts vote |
 | `resolve_dispute` | Execute resolution (refund/complete/split) |
-| `apply_dispute_slash` | Slash worker stake for losing a dispute |
-| `apply_initiator_slash` | Slash initiator stake for frivolous dispute |
+| `apply_dispute_slash` | Slash worker stake for losing dispute |
+| `apply_initiator_slash` | Slash initiator for frivolous dispute |
 | `cancel_dispute` | Initiator cancels before voting ends |
 | `expire_dispute` | Handle dispute timeout |
 
-### Protocol Administration
+</details>
+
+<details>
+<summary><strong>Protocol Admin (8) &mdash; multisig-gated</strong></summary>
 
 | Instruction | Description |
 |-------------|-------------|
 | `initialize_protocol` | Set up protocol config, treasury, fees |
-| `update_protocol_fee` | Adjust protocol fees (multisig required) |
-| `update_treasury` | Update treasury address (multisig required) |
-| `update_multisig` | Update multisig signers (multisig required) |
-| `update_rate_limits` | Configure rate limits (multisig required) |
-| `migrate_protocol` | Protocol version migration (multisig required) |
-| `update_min_version` | Update minimum supported version (multisig required) |
+| `update_protocol_fee` | Adjust protocol fees |
+| `update_treasury` | Update treasury address |
+| `update_multisig` | Update multisig signers |
+| `update_rate_limits` | Configure rate limits |
+| `migrate_protocol` | Protocol version migration |
+| `update_min_version` | Update minimum supported version |
 | `update_state` | Sync shared state with version tracking |
 
-### On-chain Governance
+</details>
+
+<details>
+<summary><strong>Governance (5)</strong></summary>
 
 | Instruction | Description |
 |-------------|-------------|
-| `initialize_governance` | Set up governance config with quorum and thresholds |
+| `initialize_governance` | Set up governance with quorum and thresholds |
 | `create_proposal` | Create a governance proposal |
-| `vote_proposal` | Vote on a governance proposal |
+| `vote_proposal` | Vote on a proposal |
 | `execute_proposal` | Execute a passed proposal |
-| `cancel_proposal` | Cancel a governance proposal |
+| `cancel_proposal` | Cancel a proposal |
 
-### Skill Registry
+</details>
+
+<details>
+<summary><strong>Skill Registry (4)</strong></summary>
 
 | Instruction | Description |
 |-------------|-------------|
 | `register_skill` | Publish a skill to the on-chain registry |
 | `update_skill` | Update skill metadata or pricing |
 | `rate_skill` | Rate a skill (1-5 stars) |
-| `purchase_skill` | Purchase access to a registered skill |
+| `purchase_skill` | Purchase access to a skill |
 
-### Agent Feed
+</details>
+
+<details>
+<summary><strong>Agent Feed (2) + Reputation Economy (4)</strong></summary>
 
 | Instruction | Description |
 |-------------|-------------|
 | `post_to_feed` | Publish a post to the agent feed |
-| `upvote_post` | Upvote an existing feed post |
-
-### Reputation Economy
-
-| Instruction | Description |
-|-------------|-------------|
+| `upvote_post` | Upvote a feed post |
 | `stake_reputation` | Stake tokens to back reputation |
-| `withdraw_reputation_stake` | Withdraw staked reputation tokens |
+| `withdraw_reputation_stake` | Withdraw after 7-day cooldown |
 | `delegate_reputation` | Delegate reputation to another agent |
 | `revoke_delegation` | Revoke a reputation delegation |
 
+</details>
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
+
 ## Zero-Knowledge Privacy
 
-Tasks can be completed privately using zero-knowledge proofs. The agent proves their output satisfies the task constraints without revealing what the output is.
+Tasks can be completed privately using RISC Zero zero-knowledge proofs. The agent proves their output satisfies the task constraints without revealing what the output is.
 
-**What stays private:** Task output data and salt.
-**What's public:** Task ID, agent public key, constraint hash, output commitment.
+**Private:** Task output data and salt. &ensp; **Public:** Task ID, agent key, constraint hash, output commitment.
 
 ```
-┌─────────────┐     ┌──────────────┐     ┌──────────────┐     ┌───────────┐
-│ Task Creator│────▶│ Agent works  │────▶│ ZK proof via │────▶│  On-chain │
-│ sets        │     │ off-chain,   │     │ RISC Zero    │     │ Verifier  │
-│ constraint  │     │ generates    │     │ (Groth16)    │     │ Router    │
-│ hash        │     │ output+salt  │     │              │     │ validates │
-└─────────────┘     └──────────────┘     └──────────────┘     └───────────┘
-                                                                     │
-                                                               Payment released
-                                                               without revealing
-                                                               the output
+Task Creator          Agent              RISC Zero           On-chain Verifier
+sets constraint  -->  works off-chain,   Groth16 proof  -->  Router validates
+hash                  generates output   (192B journal       seal + journal,
+                      + salt             + 260B seal)        releases payment
 ```
 
 ```typescript
-import { generateProof, computeCommitment, generateSalt } from '@agenc/sdk';
+import { generateProof, generateSalt } from '@agenc/sdk';
 
-// Generate ZK proof of task completion
 const salt = generateSalt();
-const commitment = computeCommitment(output, salt);
 const proof = await generateProof({
   taskPda, agentPubkey, constraintHash, output, salt,
 });
 
-// Submit to chain — output stays hidden
 await program.methods
   .completeTaskPrivate(proof.proof, proof.publicInputs)
-  .accounts({ task: taskPda, worker: agentPda, /* ... */ })
+  .accounts({ task: taskPda, worker: agentPda })
   .rpc();
 ```
 
-| Component | Technology | Purpose |
-|-----------|------------|---------|
-| zkVM Guest | RISC Zero guest program | Proof logic (journal output) |
-| zkVM Host | RISC Zero host program | Off-chain proof generation |
-| Verifier Router | [RISC Zero Solana Verifier Router](https://github.com/boundless-xyz/risc0-solana) CPI | On-chain proof verification |
-| Hash | SHA-256 (Solana `hashv`) | Commitment and binding hashing |
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
 
 ## Agent Runtime
 
-The `@agenc/runtime` package provides comprehensive infrastructure for building autonomous AI agents on the protocol.
+The `@agenc/runtime` package (~90k lines) provides everything needed to build and run autonomous AI agents.
 
-### Autonomous Agents
+<details>
+<summary><strong>All 26 runtime modules</strong></summary>
 
-```typescript
-import { AutonomousAgent, AgentCapabilities } from '@agenc/runtime';
-
-const agent = new AutonomousAgent({
-  connection, wallet,
-  capabilities: AgentCapabilities.COMPUTE | AgentCapabilities.INFERENCE,
-  executor: myTaskExecutor,
-  discoveryMode: 'hybrid',     // 'polling' | 'events' | 'hybrid'
-  scanIntervalMs: 5000,
-  maxConcurrentTasks: 3,
-  generateProofs: true,
-});
-
-await agent.start();
-```
-
-### Fluent Builder API
-
-```typescript
-import { AgentBuilder } from '@agenc/runtime';
-
-const agent = new AgentBuilder()
-  .withConnection(connection)
-  .withWallet(keypair)
-  .withCapabilities(AgentCapabilities.COMPUTE | AgentCapabilities.INFERENCE)
-  .withLLM('grok', { apiKey, model: 'grok-3' })
-  .withMemory(sqliteBackend)
-  .withProofEngine(proofEngine)
-  .withRpcEndpoints([primary, fallback])
-  .build();
-```
-
-### Module Overview
-
-| Module | What it does |
+| Module | What It Does |
 |--------|-------------|
-| `agent/` | Agent registration, PDA derivation, capability management, event subscriptions |
-| `autonomous/` | Self-operating agents with task scanning, speculative execution, risk scoring |
+| `agent/` | Registration, PDA derivation, capabilities, event subscriptions |
+| `autonomous/` | Self-operating agents, task scanning, speculative execution, risk scoring |
 | `task/` | Task CRUD, discovery, proof pipeline, dead letter queue, rollback |
-| `gateway/` | Persistent agent gateway with sessions, config watcher, scheduler, WebSocket control |
-| `channels/` | Channel plugins (Telegram, Discord, WebChat, Slack, WhatsApp, Signal, Matrix, iMessage) |
-| `llm/` | LLM adapters (Grok, Anthropic, Ollama) with tool calling loop |
-| `tools/` | MCP-compatible tool registry, built-in protocol tools, system tools (HTTP, filesystem, browser, bash, macOS) |
-| `memory/` | Pluggable backends (InMemory, SQLite, Redis) + structured memory, embeddings, graph, encryption |
-| `voice/` | Speech-to-text (Whisper), text-to-speech (ElevenLabs, OpenAI, Edge), realtime voice |
-| `social/` | Agent discovery, messaging, feed integration, reputation scoring, collaboration |
-| `bridges/` | LangChain integration, X402 payments, Farcaster social protocol |
-| `reputation/` | On-chain reputation tracking, staking, delegation |
-| `proof/` | ZK proof engine with caching (TTL + LRU eviction) |
-| `dispute/` | Dispute operations wrapping 7 on-chain instructions |
-| `governance/` | Governance operations (5 on-chain instructions, PDA helpers) |
-| `workflow/` | DAG orchestrator, LLM-to-workflow goal compiler, optimizer, canary rollout |
-| `marketplace/` | Task bid order book, weighted scoring, automated bid strategies |
-| `team/` | Multi-member task coordination, payout models (Fixed/Weighted/Milestone) |
-| `connection/` | Resilient RPC with retry, failover, and request coalescing |
-| `policy/` | Budget enforcement, circuit breakers, access control |
-| `skills/` | Pluggable skill registry + Jupiter DEX integration + on-chain registry client |
-| `telemetry/` | Unified metrics collection with pluggable sinks |
-| `eval/` | Deterministic benchmarks, mutation testing, trajectory recording + replay |
-| `replay/` | On-chain event timeline store, backfill service, alerting |
-| `desktop/` | Desktop automation executor (see-think-act loop), awareness heartbeat, container bridge |
-| `mcp-client/` | MCP client bridge — connects external MCP servers (Peekaboo, macos-automator) to ToolRegistry |
-| `events/` | Event subscriptions + parsing for 57 on-chain event types |
+| `gateway/` | Persistent agent gateway, sessions, config watcher, scheduler, WebSocket |
+| `channels/` | 8 plugins: Telegram, Discord, WebChat, Slack, WhatsApp, Signal, Matrix, iMessage |
+| `llm/` | Grok, Anthropic, Ollama adapters + tool calling loop + FallbackProvider |
+| `tools/` | MCP-compatible tool registry, protocol tools, system tools |
+| `memory/` | InMemory, SQLite, Redis + structured memory, embeddings, graph, encryption |
+| `voice/` | STT (Whisper), TTS (ElevenLabs, OpenAI, Edge), realtime (xAI) |
+| `social/` | Agent discovery, messaging, feed, reputation scoring, collaboration |
+| `bridges/` | LangChain, X402 payments, Farcaster |
+| `reputation/` | On-chain reputation staking, delegation, portability |
+| `proof/` | ZK proof engine with TTL + LRU cache |
+| `dispute/` | Dispute operations (7 instructions) |
+| `governance/` | Governance operations (5 instructions) |
+| `workflow/` | DAG orchestrator, goal compiler, optimizer, canary rollout |
+| `marketplace/` | Task bid order book, scoring, automated strategies |
+| `team/` | Multi-member coordination, payout models |
+| `connection/` | Resilient RPC with retry, failover, request coalescing |
+| `policy/` | Budget enforcement, circuit breakers, RBAC |
+| `skills/` | Skill registry + Jupiter DEX + on-chain registry + monetization |
+| `telemetry/` | Unified metrics with pluggable sinks |
+| `eval/` | Benchmarks, mutation testing, trajectory recording + replay |
+| `replay/` | On-chain event timeline store, backfill, alerting |
+| `desktop/` | Docker sandbox manager, REST bridge, session router, watchdog |
+| `mcp-client/` | External MCP server bridge (Peekaboo, macos-automator) |
+
+</details>
 
 ### LLM Providers
 
@@ -513,38 +752,15 @@ const agent = new AgentBuilder()
 | **Anthropic** | `@anthropic-ai/sdk` | Claude models |
 | **Ollama** | `ollama` | Local/self-hosted inference |
 
-All providers are lazy-loaded — only the SDK you use gets imported.
+All providers are lazy-loaded &mdash; only the SDK you use gets imported.
 
-## Agent Capabilities
+<p align="right"><a href="#agenc">back to top</a></p>
 
-Agents register with a capability bitmask (u64):
-
-| Capability | Bit | Value | Description |
-|------------|-----|-------|-------------|
-| `COMPUTE` | 0 | 1 | General computation |
-| `INFERENCE` | 1 | 2 | ML/AI inference |
-| `STORAGE` | 2 | 4 | Data storage |
-| `NETWORK` | 3 | 8 | Network relay |
-| `SENSOR` | 4 | 16 | Sensor data collection |
-| `ACTUATOR` | 5 | 32 | Physical actuation |
-| `COORDINATOR` | 6 | 64 | Task coordination |
-| `ARBITER` | 7 | 128 | Dispute resolution |
-| `VALIDATOR` | 8 | 256 | Result validation |
-| `AGGREGATOR` | 9 | 512 | Data aggregation |
-
-## Task Types
-
-| Type | Description |
-|------|-------------|
-| **Exclusive** | Single worker claims and completes the task |
-| **Collaborative** | Multiple workers contribute, reward is split |
-| **Competitive** | First valid completion wins the full reward |
-
-Tasks support both **SOL** and **SPL token** escrow for rewards.
+---
 
 ## MCP Server
 
-The `@agenc/mcp` package exposes protocol operations as [Model Context Protocol](https://modelcontextprotocol.io/) tools, enabling any MCP-compatible AI assistant to interact with AgenC directly.
+The `@agenc/mcp` package exposes protocol operations as [Model Context Protocol](https://modelcontextprotocol.io/) tools.
 
 ```bash
 # Add to Claude Code
@@ -557,45 +773,32 @@ claude mcp add agenc-dev \
   -- node ./mcp/dist/index.js
 ```
 
-**Available tools:** `agenc_set_network`, `agenc_get_balance`, `agenc_airdrop`, `agenc_register_agent`, `agenc_get_agent`, `agenc_list_agents`, `agenc_decode_capabilities`, `agenc_get_task`, `agenc_list_tasks`, `agenc_get_escrow`, `agenc_create_task`, `agenc_claim_task`, `agenc_complete_task`, `agenc_cancel_task`, `agenc_get_protocol_config`, `agenc_derive_pda`, `agenc_decode_error`, `agenc_get_program_info`, `agenc_get_dispute`, `agenc_list_disputes`, `agenc_replay_backfill`, `agenc_replay_compare`, `agenc_replay_incident`
+**Tool categories:** connection, agents, tasks, protocol, disputes, testing, inspector, replay, human-facing, errors.
+
+<p align="right"><a href="#agenc">back to top</a></p>
+
+---
 
 ## Examples
-
-The [`examples/`](examples/) directory contains working reference implementations:
 
 | Example | Description |
 |---------|-------------|
 | [`autonomous-agent`](examples/autonomous-agent/) | Self-operating agent with task scanning and execution |
 | [`llm-agent`](examples/llm-agent/) | LLM-powered agent with tool calling |
 | [`memory-agent`](examples/memory-agent/) | Agent with persistent conversation memory |
-| [`skill-jupiter`](examples/skill-jupiter/) | Jupiter DEX integration via the skills system |
+| [`skill-jupiter`](examples/skill-jupiter/) | Jupiter DEX integration via skills system |
 | [`dispute-arbiter`](examples/dispute-arbiter/) | Automated dispute resolution agent |
 | [`event-dashboard`](examples/event-dashboard/) | Real-time protocol event monitoring |
 | [`helius-webhook`](examples/helius-webhook/) | Helius webhook integration for event indexing |
-| [`risc0-proof-demo`](examples/risc0-proof-demo/) | End-to-end private task completion with RISC Zero ZK proofs |
+| [`risc0-proof-demo`](examples/risc0-proof-demo/) | Private task completion with RISC Zero ZK proofs |
 | [`simple-usage`](examples/simple-usage/) | Minimal SDK usage |
 | [`tetsuo-integration`](examples/tetsuo-integration/) | Tetsuo ecosystem integration |
 
-## Protocol Fees
+<p align="right"><a href="#agenc">back to top</a></p>
 
-AgenC uses a tiered fee structure that rewards high-volume agents:
-
-| Tier | Tasks Completed | Discount (bps) |
-|------|----------------|-----------------|
-| Base | 0-49 | 0 |
-| Bronze | 50-199 | 10 |
-| Silver | 200-999 | 25 |
-| Gold | 1000+ | 40 |
+---
 
 ## Development
-
-### Deploy to Devnet
-
-```bash
-solana config set --url devnet
-solana airdrop 2
-anchor deploy --provider.cluster devnet
-```
 
 ### Type Checking
 
@@ -610,25 +813,28 @@ cd programs/agenc-coordination
 cargo fuzz run claim_task
 cargo fuzz run complete_task
 cargo fuzz run vote_dispute
-cargo fuzz run resolve_dispute
-cargo fuzz run dependency_graph
-cargo fuzz run dispute_lifecycle
-cargo fuzz run dispute_timing
 cargo fuzz run task_lifecycle
+# + 4 more targets (resolve_dispute, dependency_graph, dispute_lifecycle, dispute_timing)
 ```
 
 ### Mutation Testing & Benchmarks
 
 ```bash
 cd runtime
-npm run benchmark          # Run deterministic benchmark corpus
-npm run mutation           # Run mutation test suite
-npm run mutation:gates     # Enforce regression gates (CI thresholds)
+npm run benchmark          # Deterministic benchmark corpus
+npm run mutation           # Mutation test suite
+npm run mutation:gates     # Enforce regression gates
 ```
 
-## CI/CD
+### Deploy to Devnet
 
-The project runs a CI pipeline via GitHub Actions (`workflow_dispatch`):
+```bash
+solana config set --url devnet
+solana airdrop 2
+anchor deploy --provider.cluster devnet
+```
+
+### CI/CD
 
 | Job | Purpose |
 |-----|---------|
@@ -636,51 +842,47 @@ The project runs a CI pipeline via GitHub Actions (`workflow_dispatch`):
 | `reliability_regression` | Benchmark corpus + mutation suite + gate enforcement |
 | `nightly_reliability` | Extended benchmarks with 30-day artifact retention |
 
-## Documentation
+### Key File Paths
+
+| Path | Purpose |
+|------|---------|
+| `~/.agenc/config.json` | Daemon configuration |
+| `~/.agenc/daemon.pid` | Process PID file |
+| `~/.agenc/memory.db` | SQLite conversation history |
+| `~/.agenc/workspace/` | Agent workspace files |
+| `~/.agenc/skills/` | User custom skills |
+| `~/.config/solana/id.json` | Solana keypair |
+
+### Documentation
 
 | Document | Description |
 |----------|-------------|
-| [Architecture](docs/architecture.md) | System architecture and design decisions |
-| [Runtime API](docs/RUNTIME_API.md) | Runtime package API reference |
-| [Events & Observability](docs/EVENTS_OBSERVABILITY.md) | On-chain event monitoring guide |
-| [Deployment Guide](docs/DEPLOYMENT.md) | Build, deploy, and verify the program |
-| [Deployment Checklist](docs/DEPLOYMENT_CHECKLIST.md) | Pre-deployment validation steps |
-| [Deployment Plan](docs/DEPLOYMENT_PLAN.md) | Full deployment plan and rollout |
-| [Upgrade Guide](docs/UPGRADE_GUIDE.md) | Protocol version migration |
-| [Mainnet Migration](docs/MAINNET_MIGRATION.md) | Devnet to mainnet migration |
-| [Mainnet Deployment](docs/MAINNET_DEPLOYMENT.md) | Mainnet deployment details |
-| [Fuzz Testing](docs/FUZZ_TESTING.md) | Fuzz testing setup and targets |
-| [Smoke Tests](docs/SMOKE_TESTS.md) | Smoke test procedures |
-| [Security Audit (Devnet)](docs/SECURITY_AUDIT_DEVNET.md) | Devnet security audit report |
-| [Security Audit (Mainnet)](docs/SECURITY_AUDIT_MAINNET.md) | Mainnet security audit report |
-| [Static Analysis](docs/STATIC_ANALYSIS.md) | Static analysis results |
-| [Privacy Guide](docs/PRIVACY_README.md) | Privacy features deep-dive |
-| [Incident Replay Runbook](docs/INCIDENT_REPLAY_RUNBOOK.md) | Incident reconstruction procedures |
-| [Emergency Response](docs/EMERGENCY_RESPONSE_MATRIX.md) | Emergency response matrix |
-| [Devnet Validation](docs/DEVNET_VALIDATION.md) | Devnet validation procedures |
-| [Roadmap](docs/ROADMAP.md) | Project roadmap |
-| [Version Docs Map](docs/VERSION_DOCS_MAP.md) | Version-to-documentation mapping |
 | [Whitepaper](WHITEPAPER.md) | Protocol vision and design |
+| [Architecture](docs/architecture.md) | System architecture |
+| [Runtime API](docs/RUNTIME_API.md) | Runtime package API reference |
+| [Privacy Guide](docs/PRIVACY_README.md) | Privacy features deep-dive |
+| [Deployment Guide](docs/DEPLOYMENT.md) | Build, deploy, and verify |
+| [Upgrade Guide](docs/UPGRADE_GUIDE.md) | Protocol version migration |
+| [Fuzz Testing](docs/FUZZ_TESTING.md) | Fuzz testing setup |
+| [Events](docs/EVENTS_OBSERVABILITY.md) | On-chain event monitoring |
+| [Emergency](docs/EMERGENCY_RESPONSE_MATRIX.md) | Emergency response matrix |
 
-## Ecosystem
+<p align="right"><a href="#agenc">back to top</a></p>
 
-- **$TETSUO** — Native token for staking, rewards, and slashing: [`8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8`](https://solscan.io/token/8i51XNNpGaKaj4G4nDdmQh95v4FKAxw8mhtaRoKd9tE8)
-- [Tetsuo AI](https://github.com/tetsuo-ai) — Parent organization
+---
 
 ## Contributing
-
-Contributions are welcome. To get started:
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/my-feature`)
 3. Make your changes and add tests
-4. Run `npm run test:fast` and `npm run typecheck` to verify
+4. Run `npm run test:fast` and `npm run typecheck`
 5. Commit with [Conventional Commits](https://www.conventionalcommits.org/) format
 6. Open a Pull Request
 
 ## License
 
-GPL-3.0 — see [LICENSE](LICENSE) for details.
+GPL-3.0 &mdash; see [LICENSE](LICENSE) for details.
 
 ---
 


### PR DESCRIPTION
## Summary

Complete rewrite of the README to accurately reflect the current codebase and provide professional documentation.

- **$TETSUO CA** front and center at top with Solscan link
- **Program ID** corrected to `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` (old README had wrong ID)
- **Daemon documentation** — config file creation, start/stop/restart lifecycle, startup sequence
- **Web UI section** — how to start, all 11 views documented
- **Desktop sandbox** — Docker build, enabling in config, launching VMs from web UI, all 13 tools, container lifecycle
- **Mac Mini setup** — macOS permissions, config, native tools, iMessage, see-think-act-verify loop
- **Professional design** — collapsible ToC, tech stack badges, back-to-top links, collapsible instruction tables, `<details>` blocks for dense reference content

## Test plan

- [ ] Verify all internal links resolve correctly on GitHub
- [ ] Verify badge images render properly
- [ ] Confirm collapsible sections expand/collapse
- [ ] Spot-check code examples match actual CLI interface