### PR TITLE
chore: replace stale program ID across all docs and examples

### DIFF
--- a/audit/BOUNTY_PROGRAM.md
+++ b/audit/BOUNTY_PROGRAM.md
@@ -11,7 +11,7 @@ The AgenC Coordination Protocol is a decentralized multi-agent coordination laye
 - Dispute resolution via arbiter voting
 - Multisig-gated protocol governance
 
-**Program ID:** `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+**Program ID:** `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 
 **Source Repository:** [Insert repository URL]
 

--- a/demo/e2e_devnet_test.ts
+++ b/demo/e2e_devnet_test.ts
@@ -11,7 +11,7 @@ import { Connection, Keypair, PublicKey, LAMPORTS_PER_SOL } from '@solana/web3.j
 import { createHash } from 'crypto';
 
 const RPC_URL = process.env.HELIUS_RPC || 'https://api.devnet.solana.com';
-const AGENC_PROGRAM_ID = new PublicKey('EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ');
+const AGENC_PROGRAM_ID = new PublicKey('5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7');
 const ROUTER_PROGRAM_ID = new PublicKey('6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7');
 const VERIFIER_PROGRAM_ID = new PublicKey('THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge');
 const TRUSTED_SELECTOR = Buffer.from('525a5631', 'hex');

--- a/docs/DEPLOYMENT_PLAN.md
+++ b/docs/DEPLOYMENT_PLAN.md
@@ -4,7 +4,7 @@
 
 \## Program ID
 
-EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ
+5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
 
 text## Upgrade Authority Strategy
 
@@ -34,7 +34,7 @@ text## Upgrade Authority Strategy
 
 1\. `anchor build`
 
-2\. `anchor deploy --provider.cluster devnet --program-id EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+2\. `anchor deploy --provider.cluster devnet --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 
 3\. Set upgrade authority if needed: `solana program set-upgrade-authority ...`
 
@@ -54,17 +54,17 @@ text## Upgrade Authority Strategy
 
 6\. Set multisig upgrade authority:
 
-solana program set-upgrade-authority EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ --new-upgrade-authority <multisig-pubkey>
+solana program set-upgrade-authority 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 --new-upgrade-authority <multisig-pubkey>
 
 text7. (Optional) Revoke authority for immutability:
 
-solana program set-upgrade-authority EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ --final
+solana program set-upgrade-authority 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 --final
 
 
 
 \## Verification Steps
 
-1\. `solana program show EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` → confirm owner and upgrade authority
+1\. `solana program show 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` → confirm owner and upgrade authority
 
 2\. Run integration tests on cluster: `anchor test --skip-local-validator`
 

--- a/docs/DEVNET_VALIDATION.md
+++ b/docs/DEVNET_VALIDATION.md
@@ -3,8 +3,7 @@
 ## Deployment Details
 
 - Cluster: Solana Devnet
-- Program ID: `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
-- IDL Account: `EuDy3ct4M8Mge5s3TLSvH6jtKhGpxZAh6iyJ2xyrJJjb`
+- Program ID: `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 - Anchor Version: `0.32.1`
 - Commit: `c53771ddbb4097f45c08fe339a924bb348c33aab`
 

--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -3,7 +3,7 @@
 **Protocol:** AgenC Coordination Protocol
 **Anchor Version:** 0.32.1
 **Solana Version:** 3.0.13
-**Current Program ID:** `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+**Current Program ID:** `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 
 This document provides step-by-step instructions for deploying the AgenC Coordination Protocol to Solana mainnet-beta.
 
@@ -155,7 +155,7 @@ seeds = true
 skip-lint = false
 
 [programs.localnet]
-agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"
+agenc_coordination = "5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7"
 
 [provider]
 cluster = "localnet"
@@ -165,7 +165,7 @@ wallet = "~/.config/solana/id.json"
 Add mainnet configuration:
 ```toml
 [programs.mainnet]
-agenc_coordination = "EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"
+agenc_coordination = "5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7"
 
 [provider]
 cluster = "mainnet"
@@ -690,7 +690,7 @@ Before proceeding to mainnet, obtain sign-off from:
 
 | Account | Address |
 |---------|---------|
-| Program ID | `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` |
+| Program ID | `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` |
 | Protocol PDA | |
 | Treasury | |
 | Upgrade Authority (Multisig) | |

--- a/docs/PRIVACY_README.md
+++ b/docs/PRIVACY_README.md
@@ -53,7 +53,7 @@ Replay is blocked with dual spend records:
 
 ## Contracts
 
-- AgenC Program: `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+- AgenC Program: `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 - Router Program: `6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7`
 - Verifier Program: `THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge`
 - Privacy Cash: `9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD`

--- a/docs/SECURITY_AUDIT_DEVNET.md
+++ b/docs/SECURITY_AUDIT_DEVNET.md
@@ -9,8 +9,7 @@ This document provides an audit-ready security package for the AgenC Solana coor
 - Program: `programs/agenc-coordination`
 - Cluster: Solana Devnet
 - Commit: `c53771ddbb4097f45c08fe339a924bb348c33aab`
-- Program ID: `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
-- IDL Account: `EuDy3ct4M8Mge5s3TLSvH6jtKhGpxZAh6iyJ2xyrJJjb`
+- Program ID: `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 - Anchor Version: `0.32.1`
 
 ## Threat Model

--- a/docs/SECURITY_AUDIT_MAINNET.md
+++ b/docs/SECURITY_AUDIT_MAINNET.md
@@ -2,7 +2,7 @@
 
 **Document Version:** 1.0
 **Protocol:** AgenC Coordination Protocol
-**Program ID:** `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ`
+**Program ID:** `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 **Framework:** Anchor (Solana)
 
 ## 1. Audit Scope

--- a/docs/UPGRADE_GUIDE.md
+++ b/docs/UPGRADE_GUIDE.md
@@ -83,7 +83,7 @@ solana config set --url devnet
 
 # Deploy (upgrade existing program)
 anchor upgrade target/deploy/agenc_coordination.so \
-  --program-id EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ \
+  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 \
   --provider.cluster devnet
 ```
 
@@ -123,11 +123,11 @@ yarn run smoke-test --cluster devnet
 
 ```bash
 # IMPORTANT: Ensure upgrade authority is multisig
-solana program show EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ
+solana program show 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
 
 # Deploy with multisig approval
 anchor upgrade target/deploy/agenc_coordination.so \
-  --program-id EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ \
+  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 \
   --provider.cluster mainnet
 ```
 
@@ -214,12 +214,12 @@ If bugs are discovered after migration:
 ```bash
 # Option A: Deploy hotfix
 anchor upgrade target/deploy/agenc_coordination_hotfix.so \
-  --program-id EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ
+  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
 
 # Option B: Roll back program binary
 # Deploy the previous version binary
 anchor upgrade target/deploy/agenc_coordination_v1.so \
-  --program-id EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ
+  --program-id 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
 ```
 
 **Important**: Rolling back the binary does NOT roll back account state. The old program must handle the new account format.
@@ -267,7 +267,7 @@ The upgrade authority should be a multisig. Example using Squads Protocol:
 
 ```bash
 # Transfer upgrade authority to multisig
-solana program set-upgrade-authority EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ \
+solana program set-upgrade-authority 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7 \
   --new-upgrade-authority <SQUADS_MULTISIG_ADDRESS>
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,7 +74,7 @@ Required verification accounts:
 
 | Component | Program ID |
 |-----------|------------|
-| AgenC Coordination | `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` |
+| AgenC Coordination | `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` |
 | Router Program | `6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7` |
 | Verifier Program | `THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge` |
 | Privacy Cash | `9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD` |

--- a/examples/helius-webhook/README.md
+++ b/examples/helius-webhook/README.md
@@ -73,7 +73,7 @@ npm run subscribe
 
 | Program | Address |
 |---------|---------|
-| AgenC Coordination | `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` |
+| AgenC Coordination | `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` |
 
 Note: private completion verification now routes through router/verifier-entry accounts and the trusted verifier program.
 

--- a/examples/helius-webhook/index.ts
+++ b/examples/helius-webhook/index.ts
@@ -34,7 +34,7 @@ if (!HELIUS_WEBHOOK_SECRET) {
 }
 const ROUTER_PROGRAM_ID = '6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7';
 const VERIFIER_PROGRAM_ID = 'THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge';
-const AGENC_PROGRAM_ID = 'EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ';
+const AGENC_PROGRAM_ID = '5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7';
 const WEBHOOK_PORT = process.env.PORT || 3000;
 
 // Helius API endpoints

--- a/examples/tetsuo-integration/README.md
+++ b/examples/tetsuo-integration/README.md
@@ -44,7 +44,7 @@ npm run demo
 
 | Contract | Address |
 |----------|---------|
-| AgenC Program | `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` |
+| AgenC Program | `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` |
 | Router Program | `6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7` |
 | Verifier Program | `THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge` |
 | Privacy Cash | `9fhQBbumKEFuXtMBDw8AaQyAjCorLGJQiS3skWZdQyQD` |

--- a/examples/tetsuo-integration/index.ts
+++ b/examples/tetsuo-integration/index.ts
@@ -64,7 +64,7 @@ if (!IS_DEMO_MODE) {
 // import { PrivacyClient, generateProof, generateSalt } from '@agenc/sdk';
 
 // Simulated imports for demo
-const AGENC_PROGRAM_ID = new PublicKey('EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ');
+const AGENC_PROGRAM_ID = new PublicKey('5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7');
 const ROUTER_PROGRAM_ID = new PublicKey('6JvFfBrvCcWgANKh1Eae9xDq4RC6cfJuBcf71rp2k9Y7');
 const VERIFIER_PROGRAM_ID = new PublicKey('THq1qFYQoh7zgcjXoMXduDBqiZRCPeg3PvvMbrVQUge');
 const TRUSTED_SELECTOR = Buffer.from('525a5631', 'hex');

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -352,7 +352,7 @@ ALL required capabilities set to claim a task.
 
 const PDA_SEEDS_REFERENCE = `# AgenC PDA Seeds
 
-All PDAs are derived from the program ID: EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ
+All PDAs are derived from the program ID: 5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7
 
 | Account          | Seeds                              | Notes                       |
 |------------------|------------------------------------|-----------------------------|

--- a/scripts/simulate_upgrade.sh
+++ b/scripts/simulate_upgrade.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 
 CLUSTER="${1:-devnet}"
-PROGRAM_ID="EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ"
+PROGRAM_ID="5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7"
 
 echo "=== AgenC Protocol Upgrade Simulation (Manual) ==="
 echo "Cluster: $CLUSTER"


### PR DESCRIPTION
## Summary

Replace old program ID `EopUaCV2svxj9j4hd7KjbrWfdjkspmm2BCBe7jGpKzKZ` with the actual deployed program ID `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7` across 16 files:

- `docs/` — architecture, deployment plan, mainnet deployment, upgrade guide, security audits, devnet validation, privacy readme
- `examples/` — helius-webhook, tetsuo-integration (both README and source)
- `mcp/src/server.ts` — PDA seed reference  
- `scripts/simulate_upgrade.sh`
- `audit/BOUNTY_PROGRAM.md`
- `demo/e2e_devnet_test.ts`

Also removed stale IDL account references (`EuDy3ct4M8Mge5s3TLSvH6jtKhGpxZAh6iyJ2xyrJJjb`) that pointed to an old deployment.

## Test plan

- [x] `rg EopUaCV2 .` returns zero matches
- [x] `rg EuDy3ct4 .` returns zero matches