### PR TITLE
feat(gateway): wire semantic memory pipeline into daemon

### DIFF
--- a/runtime/src/gateway/hooks.test.ts
+++ b/runtime/src/gateway/hooks.test.ts
@@ -478,19 +478,10 @@ describe("HookDispatcher", () => {
   });
 
   describe("createBuiltinHooks", () => {
-    it("returns 4 built-in hook handlers", () => {
+    it("returns 3 built-in hook handlers", () => {
       const hooks = createBuiltinHooks();
 
-      expect(hooks).toHaveLength(4);
-    });
-
-    it("includes session-memory-recorder on message:inbound", () => {
-      const hooks = createBuiltinHooks();
-      const recorder = hooks.find((h) => h.name === "session-memory-recorder");
-
-      expect(recorder).toBeDefined();
-      expect(recorder!.event).toBe("message:inbound");
-      expect(recorder!.priority).toBe(50);
+      expect(hooks).toHaveLength(3);
     });
 
     it("includes tool-audit-logger on tool:after", () => {
@@ -540,8 +531,7 @@ describe("HookDispatcher", () => {
         dispatcher.on(hook);
       }
 
-      expect(dispatcher.getHandlerCount()).toBe(4);
-      expect(dispatcher.hasHandlers("message:inbound")).toBe(true);
+      expect(dispatcher.getHandlerCount()).toBe(3);
       expect(dispatcher.hasHandlers("tool:after")).toBe(true);
       expect(dispatcher.hasHandlers("gateway:startup")).toBe(true);
       expect(dispatcher.hasHandlers("tool:before")).toBe(true);

--- a/runtime/src/gateway/hooks.ts
+++ b/runtime/src/gateway/hooks.ts
@@ -318,12 +318,6 @@ export class HookDispatcher {
 export function createBuiltinHooks(): HookHandler[] {
   return [
     {
-      event: "message:inbound",
-      name: "session-memory-recorder",
-      priority: 50,
-      handler: async () => ({ continue: true }),
-    },
-    {
       event: "tool:after",
       name: "tool-audit-logger",
       priority: 90,

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -41,6 +41,14 @@ export interface GatewayMemoryConfig {
   password?: string;
   /** AES-256-GCM encryption key for content at rest (hex-encoded, 64 hex chars = 32 bytes). */
   encryptionKey?: string;
+  /** Embedding provider for semantic memory. Auto-selects if omitted. */
+  embeddingProvider?: "ollama" | "openai" | "noop";
+  /** API key for embedding provider. Falls back to llm.apiKey. */
+  embeddingApiKey?: string;
+  /** Base URL for embedding provider (e.g. Ollama host). */
+  embeddingBaseUrl?: string;
+  /** Embedding model name (e.g. 'nomic-embed-text'). */
+  embeddingModel?: string;
 }
 
 export interface GatewayChannelConfig {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -151,6 +151,7 @@ export default function App() {
                 messages={chat.messages}
                 isTyping={chat.isTyping}
                 onSend={chat.sendMessage}
+                onStop={chat.stopGeneration}
                 connected={connected}
                 voiceState={voice.voiceState}
                 voiceTranscript={voice.transcript}

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -4,6 +4,8 @@ import { VoiceButton } from './VoiceButton';
 
 interface ChatInputProps {
   onSend: (content: string, attachments?: File[]) => void;
+  onStop?: () => void;
+  isGenerating?: boolean;
   disabled?: boolean;
   voiceState?: VoiceState;
   voiceMode?: VoiceMode;
@@ -14,6 +16,8 @@ interface ChatInputProps {
 
 export function ChatInput({
   onSend,
+  onStop,
+  isGenerating = false,
   disabled,
   voiceState = 'inactive',
   voiceMode = 'vad',
@@ -191,18 +195,31 @@ export function ChatInput({
             />
           )}
 
-          {/* Send button — pill with text + arrow */}
-          <button
-            onClick={handleSubmit}
-            disabled={disabled || (!value.trim() && attachments.length === 0)}
-            className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-accent text-white text-sm font-medium hover:bg-accent-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-            title="Send message"
-          >
-            Send
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none">
-              <path d="M3.478 2.405a.75.75 0 0 0-.926.94l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.405z" />
-            </svg>
-          </button>
+          {/* Send / Stop button */}
+          {isGenerating ? (
+            <button
+              onClick={onStop}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-red-500 text-white text-sm font-medium hover:bg-red-600 transition-colors"
+              title="Stop generation"
+            >
+              Stop
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                <rect x="6" y="6" width="12" height="12" rx="2" />
+              </svg>
+            </button>
+          ) : (
+            <button
+              onClick={handleSubmit}
+              disabled={disabled || (!value.trim() && attachments.length === 0)}
+              className="flex items-center gap-1.5 px-4 py-2 rounded-xl bg-accent text-white text-sm font-medium hover:bg-accent-dark transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              title="Send message"
+            >
+              Send
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" stroke="none">
+                <path d="M3.478 2.405a.75.75 0 0 0-.926.94l2.432 7.905H13.5a.75.75 0 0 1 0 1.5H4.984l-2.432 7.905a.75.75 0 0 0 .926.94 60.519 60.519 0 0 0 18.445-8.986.75.75 0 0 0 0-1.218A60.517 60.517 0 0 0 3.478 2.405z" />
+              </svg>
+            </button>
+          )}
         </div>
       </div>
 

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -9,6 +9,7 @@ interface ChatViewProps {
   messages: ChatMessage[];
   isTyping: boolean;
   onSend: (content: string, attachments?: File[]) => void;
+  onStop?: () => void;
   connected: boolean;
   voiceState?: VoiceState;
   voiceTranscript?: string;
@@ -29,6 +30,7 @@ export function ChatView({
   messages,
   isTyping,
   onSend,
+  onStop,
   connected,
   voiceState = 'inactive',
   voiceTranscript = '',
@@ -102,6 +104,8 @@ export function ChatView({
           <div className="animate-input-glow rounded-2xl">
             <ChatInput
               onSend={onSend}
+              onStop={onStop}
+              isGenerating={isTyping}
               disabled={!connected}
               voiceState={voiceState}
               voiceMode={voiceMode}
@@ -224,6 +228,8 @@ export function ChatView({
       <MessageList messages={messages} isTyping={isTyping} theme={theme} searchQuery={searchQuery} />
       <ChatInput
         onSend={onSend}
+        onStop={onStop}
+        isGenerating={isTyping}
         disabled={!connected}
         voiceState={voiceState}
         voiceMode={voiceMode}


### PR DESCRIPTION
## Summary

- Wire the existing semantic memory components (embeddings, vector store, ingestion engine, retriever) into the daemon's WebChat pipeline
- Every conversation turn is now embedded and stored; new messages trigger hybrid semantic search (cosine + BM25) for relevant past context
- Falls back gracefully to naive last-10-messages retriever when no embedding provider is available (Ollama not running, no API key)

## Changes

- **`runtime/src/gateway/types.ts`** — Add `embeddingProvider`, `embeddingApiKey`, `embeddingBaseUrl`, `embeddingModel` to `GatewayMemoryConfig`
- **`runtime/src/gateway/daemon.ts`** — Wire full semantic memory stack in `wireWebChat()`: auto-select embedding provider, create vector store + ingestion engine, register ingestion hooks, create `SemanticMemoryRetriever`; fix `message:outbound` and `session:compact` hook payloads
- **`runtime/src/gateway/hooks.ts`** — Remove no-op `session-memory-recorder` stub (replaced by real `memory-ingestion-turn` hook)
- **`runtime/src/gateway/hooks.test.ts`** — Update tests for stub removal

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npm run test` — 4860 tests pass (3 pre-existing failures in workspace-files unrelated)
- [x] Affected module tests all pass (hooks, ingestion, retriever, vector-store: 131/131)
- [ ] Manual: with Ollama running, verify log shows "Semantic memory enabled"
- [ ] Manual: without Ollama, verify fallback log and normal chat behavior