### PR TITLE
feat(runtime): cross-session progress tracker + resumable pipeline executor

### DIFF
--- a/runtime/src/gateway/index.ts
+++ b/runtime/src/gateway/index.ts
@@ -173,6 +173,15 @@ export {
   type StalePidResult,
 } from "./daemon.js";
 
+// Cross-session progress tracker (P3)
+export {
+  ProgressTracker,
+  summarizeToolResult,
+  type ProgressEntryType,
+  type ProgressEntry,
+  type ProgressTrackerConfig,
+} from "./progress.js";
+
 // Voice Bridge (xAI Realtime)
 export { VoiceBridge, type VoiceBridgeConfig } from "./voice-bridge.js";
 

--- a/runtime/src/gateway/progress.test.ts
+++ b/runtime/src/gateway/progress.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  ProgressTracker,
+  summarizeToolResult,
+  type ProgressEntry,
+  type ProgressTrackerConfig,
+} from "./progress.js";
+import type { MemoryBackend } from "../memory/types.js";
+import { createMockMemoryBackend } from "../memory/test-utils.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createTracker(
+  overrides: Partial<ProgressTrackerConfig> = {},
+): { tracker: ProgressTracker; backend: MemoryBackend } {
+  const backend = overrides.memoryBackend ?? createMockMemoryBackend();
+  const tracker = new ProgressTracker({ memoryBackend: backend, ...overrides });
+  return { tracker, backend };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("ProgressTracker", () => {
+  describe("append()", () => {
+    it("stores a progress entry with auto-set timestamp", async () => {
+      const { tracker, backend } = createTracker();
+      const now = Date.now();
+      await tracker.append({
+        sessionId: "s1",
+        type: "task_started",
+        summary: "Working on feature X",
+      });
+
+      const entries = await tracker.getRecent("s1");
+      expect(entries).toHaveLength(1);
+      expect(entries[0].type).toBe("task_started");
+      expect(entries[0].summary).toBe("Working on feature X");
+      expect(entries[0].sessionId).toBe("s1");
+      expect(entries[0].timestamp).toBeGreaterThanOrEqual(now);
+      expect(backend.set).toHaveBeenCalledOnce();
+    });
+
+    it("appends multiple entries in order", async () => {
+      const { tracker } = createTracker();
+      await tracker.append({ sessionId: "s1", type: "task_started", summary: "A" });
+      await tracker.append({ sessionId: "s1", type: "tool_result", summary: "B" });
+      await tracker.append({ sessionId: "s1", type: "task_completed", summary: "C" });
+
+      const entries = await tracker.getRecent("s1");
+      expect(entries).toHaveLength(3);
+      expect(entries.map((e) => e.summary)).toEqual(["A", "B", "C"]);
+    });
+
+    it("prunes entries beyond maxEntriesPerSession", async () => {
+      const { tracker } = createTracker({ maxEntriesPerSession: 3 });
+      for (let i = 0; i < 5; i++) {
+        await tracker.append({
+          sessionId: "s1",
+          type: "tool_result",
+          summary: `entry-${i}`,
+        });
+      }
+
+      const entries = await tracker.getRecent("s1");
+      expect(entries).toHaveLength(3);
+      expect(entries.map((e) => e.summary)).toEqual([
+        "entry-2",
+        "entry-3",
+        "entry-4",
+      ]);
+    });
+
+    it("truncates long summaries", async () => {
+      const { tracker } = createTracker();
+      const longSummary = "x".repeat(300);
+      await tracker.append({ sessionId: "s1", type: "decision", summary: longSummary });
+
+      const entries = await tracker.getRecent("s1");
+      expect(entries[0].summary.length).toBeLessThanOrEqual(200);
+      expect(entries[0].summary).toMatch(/\.\.\.$/);
+    });
+
+    it("stores optional metadata", async () => {
+      const { tracker } = createTracker();
+      await tracker.append({
+        sessionId: "s1",
+        type: "error",
+        summary: "Tool failed",
+        metadata: { tool: "system.bash", exitCode: 1 },
+      });
+
+      const entries = await tracker.getRecent("s1");
+      expect(entries[0].metadata).toEqual({ tool: "system.bash", exitCode: 1 });
+    });
+
+    it("serializes concurrent appends to same session", async () => {
+      const { tracker } = createTracker();
+      // Fire 5 appends concurrently
+      await Promise.all(
+        Array.from({ length: 5 }, (_, i) =>
+          tracker.append({
+            sessionId: "s1",
+            type: "tool_result",
+            summary: `concurrent-${i}`,
+          }),
+        ),
+      );
+
+      const entries = await tracker.getRecent("s1");
+      expect(entries).toHaveLength(5);
+    });
+
+    it("logs error on backend failure without throwing", async () => {
+      const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+      const backend = createMockMemoryBackend();
+      (backend.get as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("backend down"),
+      );
+      const tracker = new ProgressTracker({
+        memoryBackend: backend,
+        logger: logger as unknown as import("../utils/logger.js").Logger,
+      });
+
+      // Should not throw
+      await tracker.append({
+        sessionId: "s1",
+        type: "error",
+        summary: "test",
+      });
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe("getRecent()", () => {
+    it("returns empty array for unknown session", async () => {
+      const { tracker } = createTracker();
+      const entries = await tracker.getRecent("unknown");
+      expect(entries).toEqual([]);
+    });
+
+    it("respects limit parameter", async () => {
+      const { tracker } = createTracker();
+      for (let i = 0; i < 10; i++) {
+        await tracker.append({ sessionId: "s1", type: "tool_result", summary: `e-${i}` });
+      }
+
+      const entries = await tracker.getRecent("s1", 3);
+      expect(entries).toHaveLength(3);
+      expect(entries[0].summary).toBe("e-7");
+    });
+  });
+
+  describe("getSummary()", () => {
+    it("returns undefined for empty session", async () => {
+      const { tracker } = createTracker();
+      const summary = await tracker.getSummary("empty");
+      expect(summary).toBeUndefined();
+    });
+
+    it("returns grouped Markdown summary", async () => {
+      const { tracker } = createTracker();
+      await tracker.append({ sessionId: "s1", type: "task_started", summary: "Started A" });
+      await tracker.append({ sessionId: "s1", type: "tool_result", summary: "Ran ls" });
+      await tracker.append({ sessionId: "s1", type: "task_completed", summary: "Done A" });
+
+      const summary = await tracker.getSummary("s1");
+      expect(summary).toContain("## Session Progress");
+      expect(summary).toContain("### task_started");
+      expect(summary).toContain("### tool_result");
+      expect(summary).toContain("### task_completed");
+      expect(summary).toContain("Started A");
+      expect(summary).toContain("Ran ls");
+      expect(summary).toContain("Done A");
+    });
+  });
+
+  describe("clear()", () => {
+    it("removes all entries for a session", async () => {
+      const { tracker, backend } = createTracker();
+      await tracker.append({ sessionId: "s1", type: "decision", summary: "chose X" });
+      await tracker.clear("s1");
+
+      const entries = await tracker.getRecent("s1");
+      expect(entries).toEqual([]);
+      expect(backend.delete).toHaveBeenCalledWith("progress:s1");
+    });
+  });
+
+  describe("retrieve() (MemoryRetriever)", () => {
+    it("returns undefined for empty session", async () => {
+      const { tracker } = createTracker();
+      const ctx = await tracker.retrieve("hello", "empty");
+      expect(ctx).toBeUndefined();
+    });
+
+    it("returns formatted last-5 entries", async () => {
+      const { tracker } = createTracker();
+      for (let i = 0; i < 8; i++) {
+        await tracker.append({
+          sessionId: "s1",
+          type: "tool_result",
+          summary: `step-${i}`,
+        });
+      }
+
+      const ctx = await tracker.retrieve("what happened?", "s1");
+      expect(ctx).toContain("## Recent Progress");
+      // Should only include last 5
+      expect(ctx).not.toContain("step-0");
+      expect(ctx).not.toContain("step-1");
+      expect(ctx).not.toContain("step-2");
+      expect(ctx).toContain("step-3");
+      expect(ctx).toContain("step-7");
+    });
+
+    it("includes entry type prefix", async () => {
+      const { tracker } = createTracker();
+      await tracker.append({ sessionId: "s1", type: "error", summary: "something broke" });
+
+      const ctx = await tracker.retrieve("msg", "s1");
+      expect(ctx).toContain("[error]");
+    });
+  });
+});
+
+describe("summarizeToolResult()", () => {
+  it("produces a one-liner summary", () => {
+    const result = summarizeToolResult(
+      "system.bash",
+      { command: "ls -la" },
+      "file1.ts\nfile2.ts",
+      42,
+    );
+    expect(result).toContain("system.bash");
+    expect(result).toContain("ls -la");
+    expect(result).toContain("42ms");
+  });
+
+  it("truncates long args and results", () => {
+    const longArgs = { command: "x".repeat(200) };
+    const longResult = "y".repeat(200);
+    const result = summarizeToolResult("tool", longArgs, longResult, 10);
+    expect(result.length).toBeLessThan(400);
+  });
+});

--- a/runtime/src/gateway/progress.ts
+++ b/runtime/src/gateway/progress.ts
@@ -1,0 +1,219 @@
+/**
+ * ProgressTracker — cross-session continuity via persistent progress entries.
+ *
+ * Stores timestamped progress entries in a MemoryBackend KV store, keyed by
+ * `progress:{sessionId}`. Implements `MemoryRetriever` so it plugs into the
+ * existing `injectContext()` chain in ChatExecutor.
+ *
+ * @module
+ */
+
+import type { MemoryBackend } from "../memory/types.js";
+import type { MemoryRetriever } from "../llm/chat-executor.js";
+import type { Logger } from "../utils/logger.js";
+import { safeStringify } from "../tools/types.js";
+import { SEVEN_DAYS_MS } from "../utils/async.js";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default maximum entries retained per session. */
+const DEFAULT_MAX_ENTRIES = 50;
+
+/** Maximum entries returned by retrieve() for token efficiency. */
+const RETRIEVE_LIMIT = 5;
+
+/** Maximum chars for a single summary line. */
+const MAX_SUMMARY_CHARS = 200;
+
+/** Maximum chars for tool result preview. */
+const MAX_RESULT_PREVIEW_CHARS = 80;
+
+/** Maximum chars for tool args preview. */
+const MAX_ARGS_PREVIEW_CHARS = 60;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type ProgressEntryType =
+  | "task_started"
+  | "task_completed"
+  | "tool_result"
+  | "error"
+  | "decision";
+
+export interface ProgressEntry {
+  readonly timestamp: number;
+  readonly sessionId: string;
+  readonly type: ProgressEntryType;
+  readonly summary: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface ProgressTrackerConfig {
+  readonly memoryBackend: MemoryBackend;
+  readonly maxEntriesPerSession?: number;
+  readonly ttlMs?: number;
+  readonly logger?: Logger;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function progressKey(sessionId: string): string {
+  return `progress:${sessionId}`;
+}
+
+function truncate(text: string, max: number): string {
+  return text.length <= max ? text : text.slice(0, max - 3) + "...";
+}
+
+function formatTimestamp(ts: number): string {
+  return new Date(ts).toISOString().replace("T", " ").slice(0, 19);
+}
+
+/**
+ * Produce a one-liner summary from a tool call result.
+ * Truncates long args/output for compact storage.
+ */
+export function summarizeToolResult(
+  toolName: string,
+  args: Record<string, unknown>,
+  result: string,
+  durationMs: number,
+): string {
+  const argStr = truncate(safeStringify(args), MAX_ARGS_PREVIEW_CHARS);
+  const resultStr = truncate(result, MAX_RESULT_PREVIEW_CHARS);
+  return `${toolName}(${argStr}) -> ${resultStr} [${durationMs}ms]`;
+}
+
+// ============================================================================
+// ProgressTracker
+// ============================================================================
+
+/**
+ * Cross-session progress tracker.
+ *
+ * Stores progress entries in a MemoryBackend KV store and implements
+ * `MemoryRetriever` for injection into ChatExecutor context.
+ */
+export class ProgressTracker implements MemoryRetriever {
+  private readonly backend: MemoryBackend;
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+  private readonly logger?: Logger;
+
+  /**
+   * Per-session promise chains to serialize concurrent appends.
+   * Each session gets its own chain to avoid read-modify-write races.
+   */
+  private readonly chains = new Map<string, Promise<void>>();
+
+  constructor(config: ProgressTrackerConfig) {
+    this.backend = config.memoryBackend;
+    this.maxEntries = config.maxEntriesPerSession ?? DEFAULT_MAX_ENTRIES;
+    this.ttlMs = config.ttlMs ?? SEVEN_DAYS_MS;
+    this.logger = config.logger;
+  }
+
+  /**
+   * Append a progress entry. Auto-sets timestamp, prunes old entries.
+   * Uses per-session promise chain to serialize concurrent appends.
+   */
+  async append(entry: Omit<ProgressEntry, "timestamp">): Promise<void> {
+    const { sessionId } = entry;
+    const chain = this.chains.get(sessionId) ?? Promise.resolve();
+    const next = chain.then(async () => {
+      try {
+        const key = progressKey(sessionId);
+        const existing =
+          (await this.backend.get<ProgressEntry[]>(key)) ?? [];
+
+        const full: ProgressEntry = {
+          ...entry,
+          timestamp: Date.now(),
+          summary: truncate(entry.summary, MAX_SUMMARY_CHARS),
+        };
+        existing.push(full);
+
+        // Prune to max entries (keep most recent)
+        while (existing.length > this.maxEntries) {
+          existing.shift();
+        }
+
+        await this.backend.set(key, existing, this.ttlMs);
+      } catch (err) {
+        this.logger?.error("ProgressTracker.append failed:", err);
+      }
+    });
+
+    this.chains.set(sessionId, next);
+    await next;
+  }
+
+  /** Get recent entries for a session. */
+  async getRecent(
+    sessionId: string,
+    limit?: number,
+  ): Promise<readonly ProgressEntry[]> {
+    const key = progressKey(sessionId);
+    const entries = (await this.backend.get<ProgressEntry[]>(key)) ?? [];
+    if (limit !== undefined && limit < entries.length) {
+      return entries.slice(-limit);
+    }
+    return entries;
+  }
+
+  /** Get formatted Markdown summary for /progress command. */
+  async getSummary(sessionId: string): Promise<string | undefined> {
+    const entries = await this.getRecent(sessionId);
+    if (entries.length === 0) return undefined;
+
+    const grouped = new Map<ProgressEntryType, ProgressEntry[]>();
+    for (const entry of entries) {
+      const list = grouped.get(entry.type);
+      if (list) {
+        list.push(entry);
+      } else {
+        grouped.set(entry.type, [entry]);
+      }
+    }
+
+    const sections: string[] = [];
+    for (const [type, items] of grouped) {
+      const lines = items.map(
+        (e) => `- [${formatTimestamp(e.timestamp)}] ${e.summary}`,
+      );
+      sections.push(`### ${type}\n${lines.join("\n")}`);
+    }
+
+    return `## Session Progress\n\n${sections.join("\n\n")}`;
+  }
+
+  /** Clear all progress entries for a session. */
+  async clear(sessionId: string): Promise<void> {
+    const key = progressKey(sessionId);
+    await this.backend.delete(key);
+    this.chains.delete(sessionId);
+  }
+
+  /**
+   * MemoryRetriever implementation.
+   * Returns a concise last-N entries as system context, or undefined when empty.
+   */
+  async retrieve(
+    _message: string,
+    sessionId: string,
+  ): Promise<string | undefined> {
+    const entries = await this.getRecent(sessionId, RETRIEVE_LIMIT);
+    if (entries.length === 0) return undefined;
+
+    const lines = entries.map(
+      (e) => `- [${e.type}] ${e.summary}`,
+    );
+    return `## Recent Progress\n\n${lines.join("\n")}`;
+  }
+}

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -1122,6 +1122,16 @@ export {
   DAGSubmitter,
   DAGMonitor,
   DAGOrchestrator,
+  // Pipeline executor (resumable workflows)
+  PipelineExecutor,
+  type PipelineStepErrorPolicy,
+  type PipelineStep,
+  type PipelineContext,
+  type Pipeline,
+  type PipelineStatus,
+  type PipelineResult,
+  type PipelineCheckpoint,
+  type PipelineExecutorConfig,
 } from "./workflow/index.js";
 
 // Team Contracts (Phase 12)
@@ -1503,6 +1513,12 @@ export {
   type RemoteChatMessage,
   type OfflineQueueEntry,
   type PushNotification,
+  // Cross-session progress tracker (P3)
+  ProgressTracker,
+  summarizeToolResult,
+  type ProgressEntryType,
+  type ProgressEntry,
+  type ProgressTrackerConfig,
 } from "./gateway/index.js";
 
 // Channel Plugins (Phase 1.5)

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -129,6 +129,8 @@ export interface ChatExecutorConfig {
   readonly evaluator?: EvaluatorConfig;
   /** Optional provider that injects self-learning context per message. */
   readonly learningProvider?: MemoryRetriever;
+  /** Optional provider that injects cross-session progress context per message. */
+  readonly progressProvider?: MemoryRetriever;
   /** Base cooldown period for failed providers in ms (default: 60_000). */
   readonly providerCooldownMs?: number;
   /** Maximum cooldown period in ms (default: 300_000). */
@@ -215,6 +217,7 @@ export class ChatExecutor {
   private readonly skillInjector?: SkillInjector;
   private readonly memoryRetriever?: MemoryRetriever;
   private readonly learningProvider?: MemoryRetriever;
+  private readonly progressProvider?: MemoryRetriever;
   private readonly onCompaction?: (sessionId: string, summary: string) => void;
   private readonly evaluator?: EvaluatorConfig;
 
@@ -239,6 +242,7 @@ export class ChatExecutor {
     this.skillInjector = config.skillInjector;
     this.memoryRetriever = config.memoryRetriever;
     this.learningProvider = config.learningProvider;
+    this.progressProvider = config.progressProvider;
     this.onCompaction = config.onCompaction;
     this.evaluator = config.evaluator;
   }
@@ -280,6 +284,7 @@ export class ChatExecutor {
     await this.injectContext(this.skillInjector, messageText, sessionId, messages);
     await this.injectContext(this.memoryRetriever, messageText, sessionId, messages);
     await this.injectContext(this.learningProvider, messageText, sessionId, messages);
+    await this.injectContext(this.progressProvider, messageText, sessionId, messages);
 
     // Append history and user message
     messages.push(...history);

--- a/runtime/src/memory/graph.ts
+++ b/runtime/src/memory/graph.ts
@@ -6,12 +6,11 @@
 
 import { randomUUID } from "node:crypto";
 import type { MemoryBackend } from "./types.js";
+import { SEVEN_DAYS_MS } from "../utils/async.js";
 
 const NODE_PREFIX = "graph:node:";
 const EDGE_PREFIX = "graph:edge:";
 const SESSION_INDEX_PREFIX = "graph:index:session:";
-
-const DEFAULT_CONFIDENCE_HALF_LIFE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 export type ProvenanceSourceType =
   | "onchain_event"
@@ -117,7 +116,7 @@ export class MemoryGraph {
   constructor(backend: MemoryBackend, config: MemoryGraphConfig = {}) {
     this.backend = backend;
     this.confidenceHalfLifeMs =
-      config.confidenceHalfLifeMs ?? DEFAULT_CONFIDENCE_HALF_LIFE_MS;
+      config.confidenceHalfLifeMs ?? SEVEN_DAYS_MS;
     this.now = config.now ?? Date.now;
   }
 

--- a/runtime/src/memory/test-utils.ts
+++ b/runtime/src/memory/test-utils.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared mock MemoryBackend factory for tests.
+ *
+ * Provides a fully functional in-memory mock that uses `vi.fn()` spies,
+ * making it easy to assert calls and inject failures.
+ *
+ * @module
+ */
+
+import { vi } from "vitest";
+import type { MemoryBackend } from "./types.js";
+
+/**
+ * Create a mock MemoryBackend backed by a plain Map.
+ * All methods are vi.fn() spies for assertion.
+ * Values are deep-cloned on set/get to mirror real backend behavior.
+ */
+export function createMockMemoryBackend(): MemoryBackend {
+  const store = new Map<string, unknown>();
+  return {
+    name: "mock",
+    set: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, JSON.parse(JSON.stringify(value)));
+    }),
+    get: vi.fn(async <T = unknown>(key: string): Promise<T | undefined> => {
+      const v = store.get(key);
+      return v !== undefined ? (JSON.parse(JSON.stringify(v)) as T) : undefined;
+    }),
+    delete: vi.fn(async (key: string) => {
+      return store.delete(key);
+    }),
+    has: vi.fn(async (key: string) => store.has(key)),
+    listKeys: vi.fn(async () => [...store.keys()]),
+    appendToThread: vi.fn(),
+    getThread: vi.fn(async () => []),
+    getThreadCount: vi.fn(async () => 0),
+    clearThread: vi.fn(),
+    listSessions: vi.fn(async () => []),
+    close: vi.fn(),
+  } as unknown as MemoryBackend;
+}

--- a/runtime/src/utils/async.ts
+++ b/runtime/src/utils/async.ts
@@ -1,7 +1,10 @@
 /**
- * Shared async utilities.
+ * Shared async utilities and time constants.
  * @module
  */
+
+/** 7 days in milliseconds — common default TTL for caches and checkpoints. */
+export const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/runtime/src/utils/index.ts
+++ b/runtime/src/utils/index.ts
@@ -3,7 +3,7 @@
  * @module
  */
 
-export { sleep, toErrorMessage } from "./async.js";
+export { sleep, toErrorMessage, SEVEN_DAYS_MS } from "./async.js";
 
 export { Logger, LogLevel, createLogger, silentLogger } from "./logger.js";
 

--- a/runtime/src/workflow/index.ts
+++ b/runtime/src/workflow/index.ts
@@ -122,3 +122,16 @@ export { DAGMonitor } from "./monitor.js";
 
 // Orchestrator
 export { DAGOrchestrator } from "./orchestrator.js";
+
+// Pipeline executor (resumable workflows)
+export {
+  PipelineExecutor,
+  type PipelineStepErrorPolicy,
+  type PipelineStep,
+  type PipelineContext,
+  type Pipeline,
+  type PipelineStatus,
+  type PipelineResult,
+  type PipelineCheckpoint,
+  type PipelineExecutorConfig,
+} from "./pipeline.js";

--- a/runtime/src/workflow/pipeline.test.ts
+++ b/runtime/src/workflow/pipeline.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  PipelineExecutor,
+  type Pipeline,
+  type PipelineStep,
+  type PipelineExecutorConfig,
+} from "./pipeline.js";
+import type { MemoryBackend } from "../memory/types.js";
+import type { ApprovalEngine } from "../gateway/approvals.js";
+import type { ProgressTracker } from "../gateway/progress.js";
+import { createMockMemoryBackend } from "../memory/test-utils.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockToolHandler(
+  results: Record<string, string> = {},
+  errors: Record<string, Error> = {},
+): (name: string, args: Record<string, unknown>) => Promise<string> {
+  return vi.fn(async (name: string) => {
+    if (errors[name]) throw errors[name];
+    return results[name] ?? `result-of-${name}`;
+  });
+}
+
+function createPipeline(
+  steps: PipelineStep[],
+  id = "test-pipeline",
+): Pipeline {
+  return {
+    id,
+    steps,
+    context: { results: {} },
+    createdAt: Date.now(),
+  };
+}
+
+function createExecutor(
+  overrides: Partial<PipelineExecutorConfig> = {},
+): PipelineExecutor {
+  return new PipelineExecutor({
+    toolHandler: createMockToolHandler(),
+    memoryBackend: createMockMemoryBackend(),
+    ...overrides,
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("PipelineExecutor", () => {
+  describe("execute()", () => {
+    it("executes all steps and returns completed", async () => {
+      const handler = createMockToolHandler({
+        "system.bash": "file1.ts",
+        "system.http": '{"ok":true}',
+      });
+      const executor = createExecutor({ toolHandler: handler });
+      const pipeline = createPipeline([
+        { name: "list", tool: "system.bash", args: { command: "ls" } },
+        { name: "fetch", tool: "system.http", args: { url: "http://x" } },
+      ]);
+
+      const result = await executor.execute(pipeline);
+
+      expect(result.status).toBe("completed");
+      expect(result.completedSteps).toBe(2);
+      expect(result.totalSteps).toBe(2);
+      expect(result.context.results["list"]).toBe("file1.ts");
+      expect(result.context.results["fetch"]).toBe('{"ok":true}');
+    });
+
+    it("returns failed on tool error with abort policy", async () => {
+      const handler = createMockToolHandler(
+        {},
+        { "system.bash": new Error("command not found") },
+      );
+      const executor = createExecutor({ toolHandler: handler });
+      const pipeline = createPipeline([
+        { name: "run", tool: "system.bash", args: { command: "bad" } },
+      ]);
+
+      const result = await executor.execute(pipeline);
+
+      expect(result.status).toBe("failed");
+      expect(result.error).toContain("command not found");
+      expect(result.completedSteps).toBe(0);
+    });
+
+    it("skips failed step with skip policy", async () => {
+      const handler = createMockToolHandler(
+        { "tool.b": "b-result" },
+        { "tool.a": new Error("a failed") },
+      );
+      const executor = createExecutor({ toolHandler: handler });
+      const pipeline = createPipeline([
+        { name: "step-a", tool: "tool.a", args: {}, onError: "skip" },
+        { name: "step-b", tool: "tool.b", args: {} },
+      ]);
+
+      const result = await executor.execute(pipeline);
+
+      expect(result.status).toBe("completed");
+      expect(result.completedSteps).toBe(2);
+      expect(result.context.results["step-a"]).toContain("SKIPPED");
+      expect(result.context.results["step-b"]).toBe("b-result");
+    });
+
+    it("retries on failure with retry policy", async () => {
+      let callCount = 0;
+      const handler = vi.fn(async () => {
+        callCount++;
+        if (callCount <= 1) throw new Error("transient");
+        return "success";
+      });
+      const executor = createExecutor({ toolHandler: handler });
+      const pipeline = createPipeline([
+        { name: "flaky", tool: "flaky", args: {}, onError: "retry", maxRetries: 2 },
+      ]);
+
+      const result = await executor.execute(pipeline);
+
+      expect(result.status).toBe("completed");
+      expect(result.context.results["flaky"]).toBe("success");
+    });
+
+    it("fails after exhausting retries", async () => {
+      const handler = vi.fn(async () => {
+        throw new Error("always fails");
+      });
+      const executor = createExecutor({ toolHandler: handler });
+      const pipeline = createPipeline([
+        { name: "bad", tool: "bad", args: {}, onError: "retry", maxRetries: 2 },
+      ]);
+
+      const result = await executor.execute(pipeline);
+
+      expect(result.status).toBe("failed");
+      // Initial call + 2 retries = 3 total calls
+      expect(handler).toHaveBeenCalledTimes(3);
+    });
+
+    it("rejects concurrent execution of same pipeline", async () => {
+      let resolveFirst: (() => void) | undefined;
+      const handler = vi.fn(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveFirst = () => resolve("done");
+          }),
+      );
+      const executor = createExecutor({ toolHandler: handler });
+      const pipeline = createPipeline([
+        { name: "slow", tool: "slow", args: {} },
+      ]);
+
+      // Start first execution (don't await — it will block on the handler)
+      const firstPromise = executor.execute(pipeline);
+      // Give the event loop time to enter the handler
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Second execution should fail immediately
+      const second = await executor.execute(pipeline);
+
+      expect(second.status).toBe("failed");
+      expect(second.error).toContain("already running");
+
+      // Clean up: resolve the first execution
+      resolveFirst?.();
+      await firstPromise;
+    });
+
+    it("halts when step requires approval and rule matches", async () => {
+      const approvalEngine = {
+        requiresApproval: vi.fn().mockReturnValue({ tool: "wallet.*", description: "needs approval" }),
+      } as unknown as ApprovalEngine;
+      const handler = createMockToolHandler();
+      const executor = createExecutor({ toolHandler: handler, approvalEngine });
+      const pipeline = createPipeline([
+        { name: "safe", tool: "system.bash", args: {} },
+        { name: "dangerous", tool: "wallet.sign", args: {}, requiresApproval: true },
+      ]);
+
+      const result = await executor.execute(pipeline);
+
+      expect(result.status).toBe("halted");
+      expect(result.resumeFrom).toBe(1);
+      expect(result.completedSteps).toBe(1);
+    });
+
+    it("continues when requiresApproval but no matching rule", async () => {
+      const approvalEngine = {
+        requiresApproval: vi.fn().mockReturnValue(null),
+      } as unknown as ApprovalEngine;
+      const handler = createMockToolHandler();
+      const executor = createExecutor({ toolHandler: handler, approvalEngine });
+      const pipeline = createPipeline([
+        { name: "step", tool: "safe.tool", args: {}, requiresApproval: true },
+      ]);
+
+      const result = await executor.execute(pipeline);
+
+      expect(result.status).toBe("completed");
+    });
+
+    it("saves checkpoints during execution", async () => {
+      const backend = createMockMemoryBackend();
+      const handler = createMockToolHandler();
+      const executor = createExecutor({ toolHandler: handler, memoryBackend: backend });
+      const pipeline = createPipeline([
+        { name: "a", tool: "tool.a", args: {} },
+        { name: "b", tool: "tool.b", args: {} },
+      ]);
+
+      await executor.execute(pipeline);
+
+      // Checkpoint set for each step (running) then deleted on completion
+      expect(backend.set).toHaveBeenCalled();
+      expect(backend.delete).toHaveBeenCalledWith("pipeline:test-pipeline");
+    });
+
+    it("starts from a given step index", async () => {
+      const handler = createMockToolHandler({
+        "tool.b": "b-result",
+      });
+      const executor = createExecutor({ toolHandler: handler });
+      const pipeline: Pipeline = {
+        id: "resume-test",
+        steps: [
+          { name: "a", tool: "tool.a", args: {} },
+          { name: "b", tool: "tool.b", args: {} },
+        ],
+        context: { results: { a: "already-done" } },
+        createdAt: Date.now(),
+      };
+
+      const result = await executor.execute(pipeline, 1);
+
+      expect(result.status).toBe("completed");
+      expect(result.completedSteps).toBe(2);
+      expect(result.context.results["a"]).toBe("already-done");
+      expect(result.context.results["b"]).toBe("b-result");
+    });
+
+    it("tracks progress when progressTracker is provided", async () => {
+      const progressTracker = {
+        append: vi.fn(),
+      } as unknown as ProgressTracker;
+      const handler = createMockToolHandler();
+      const executor = createExecutor({
+        toolHandler: handler,
+        progressTracker,
+      });
+      const pipeline = createPipeline([
+        { name: "step1", tool: "tool", args: {} },
+      ]);
+
+      await executor.execute(pipeline);
+
+      expect(progressTracker.append).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "task_completed",
+          summary: expect.stringContaining("step1"),
+        }),
+      );
+    });
+  });
+
+  describe("resume()", () => {
+    it("resumes from checkpoint", async () => {
+      const backend = createMockMemoryBackend();
+      const handler = createMockToolHandler({ "tool.b": "resumed-b" });
+      const executor = createExecutor({
+        toolHandler: handler,
+        memoryBackend: backend,
+      });
+
+      // Manually insert a checkpoint
+      await backend.set("pipeline:p1", {
+        pipelineId: "p1",
+        pipeline: {
+          id: "p1",
+          steps: [
+            { name: "a", tool: "tool.a", args: {} },
+            { name: "b", tool: "tool.b", args: {} },
+          ],
+          context: { results: {} },
+          createdAt: Date.now(),
+        },
+        stepIndex: 1,
+        context: { results: { a: "old-a" } },
+        status: "halted",
+        updatedAt: Date.now(),
+      });
+
+      const result = await executor.resume("p1");
+
+      expect(result.status).toBe("completed");
+      expect(result.context.results["a"]).toBe("old-a");
+      expect(result.context.results["b"]).toBe("resumed-b");
+    });
+
+    it("throws WorkflowStateError when no checkpoint found", async () => {
+      const executor = createExecutor();
+
+      await expect(executor.resume("nonexistent")).rejects.toThrow(
+        /No checkpoint found/,
+      );
+    });
+  });
+
+  describe("listActive()", () => {
+    it("returns empty when no pipelines active", async () => {
+      const executor = createExecutor();
+      const active = await executor.listActive();
+      expect(active).toEqual([]);
+    });
+  });
+
+  describe("remove()", () => {
+    it("removes checkpoint and clears from active set", async () => {
+      const backend = createMockMemoryBackend();
+      const executor = createExecutor({ memoryBackend: backend });
+
+      // Execute a pipeline to make it active, then remove
+      let resolveHandler: (() => void) | undefined;
+      const slowExecutor = createExecutor({
+        memoryBackend: backend,
+        toolHandler: vi.fn(
+          () =>
+            new Promise<string>((resolve) => {
+              resolveHandler = () => resolve("done");
+            }),
+        ),
+      });
+      const pipeline = createPipeline([
+        { name: "slow", tool: "slow", args: {} },
+      ], "removable");
+
+      const execPromise = slowExecutor.execute(pipeline);
+      // Let the executor start running
+      await new Promise((r) => setTimeout(r, 10));
+      await slowExecutor.remove("removable");
+      resolveHandler?.();
+      await execPromise;
+
+      expect(backend.delete).toHaveBeenCalledWith("pipeline:removable");
+    });
+  });
+});

--- a/runtime/src/workflow/pipeline.ts
+++ b/runtime/src/workflow/pipeline.ts
@@ -1,0 +1,319 @@
+/**
+ * PipelineExecutor — resumable multi-step tool workflows with checkpoint/resume.
+ *
+ * Pipelines are sequences of tool calls that can be paused (for approval),
+ * checkpointed to a MemoryBackend, and resumed after daemon restart.
+ *
+ * @module
+ */
+
+import type { ToolHandler } from "../llm/types.js";
+import type { MemoryBackend } from "../memory/types.js";
+import type { ApprovalEngine } from "../gateway/approvals.js";
+import type { ProgressTracker } from "../gateway/progress.js";
+import type { Logger } from "../utils/logger.js";
+import { WorkflowStateError } from "./errors.js";
+import { toErrorMessage, SEVEN_DAYS_MS } from "../utils/async.js";
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type PipelineStepErrorPolicy = "retry" | "skip" | "abort";
+
+export interface PipelineStep {
+  readonly name: string;
+  readonly tool: string;
+  readonly args: Record<string, unknown>;
+  readonly requiresApproval?: boolean;
+  readonly onError?: PipelineStepErrorPolicy;
+  readonly maxRetries?: number;
+}
+
+export interface PipelineContext {
+  readonly results: Readonly<Record<string, string>>;
+}
+
+export interface Pipeline {
+  readonly id: string;
+  readonly steps: readonly PipelineStep[];
+  readonly context: PipelineContext;
+  readonly createdAt: number;
+}
+
+export type PipelineStatus = "running" | "completed" | "failed" | "halted";
+
+export interface PipelineResult {
+  readonly status: PipelineStatus;
+  readonly context: PipelineContext;
+  readonly completedSteps: number;
+  readonly totalSteps: number;
+  readonly resumeFrom?: number;
+  readonly error?: string;
+}
+
+export interface PipelineCheckpoint {
+  readonly pipelineId: string;
+  readonly pipeline: Pipeline;
+  readonly stepIndex: number;
+  readonly context: PipelineContext;
+  readonly status: PipelineStatus;
+  readonly updatedAt: number;
+}
+
+export interface PipelineExecutorConfig {
+  readonly toolHandler: ToolHandler;
+  readonly memoryBackend: MemoryBackend;
+  readonly approvalEngine?: ApprovalEngine;
+  readonly progressTracker?: ProgressTracker;
+  readonly logger?: Logger;
+  readonly checkpointTtlMs?: number;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function checkpointKey(id: string): string {
+  return `pipeline:${id}`;
+}
+
+// ============================================================================
+// PipelineExecutor
+// ============================================================================
+
+export class PipelineExecutor {
+  private readonly toolHandler: ToolHandler;
+  private readonly backend: MemoryBackend;
+  private readonly approvalEngine?: ApprovalEngine;
+  private readonly progressTracker?: ProgressTracker;
+  private readonly logger?: Logger;
+  private readonly checkpointTtlMs: number;
+
+  /** Active pipeline IDs tracked in memory. */
+  private readonly active = new Set<string>();
+
+  constructor(config: PipelineExecutorConfig) {
+    this.toolHandler = config.toolHandler;
+    this.backend = config.memoryBackend;
+    this.approvalEngine = config.approvalEngine;
+    this.progressTracker = config.progressTracker;
+    this.logger = config.logger;
+    this.checkpointTtlMs = config.checkpointTtlMs ?? SEVEN_DAYS_MS;
+  }
+
+  /**
+   * Execute a pipeline from a given step index.
+   * Returns the result including status and resume info if halted.
+   */
+  async execute(pipeline: Pipeline, startFrom = 0): Promise<PipelineResult> {
+    if (this.active.has(pipeline.id)) {
+      return {
+        status: "failed",
+        context: pipeline.context,
+        completedSteps: 0,
+        totalSteps: pipeline.steps.length,
+        error: `Pipeline "${pipeline.id}" is already running`,
+      };
+    }
+
+    this.active.add(pipeline.id);
+    const mutableResults: Record<string, string> = { ...pipeline.context.results };
+    let completedSteps = startFrom;
+
+    try {
+      for (let i = startFrom; i < pipeline.steps.length; i++) {
+        const step = pipeline.steps[i];
+
+        // Save running checkpoint
+        await this.saveCheckpoint({
+          pipelineId: pipeline.id,
+          pipeline,
+          stepIndex: i,
+          context: { results: { ...mutableResults } },
+          status: "running",
+          updatedAt: Date.now(),
+        });
+
+        // Approval gate — if step requires approval and engine says no, halt
+        if (step.requiresApproval && this.approvalEngine) {
+          const rule = this.approvalEngine.requiresApproval(step.tool, step.args);
+          if (rule) {
+            await this.saveCheckpoint({
+              pipelineId: pipeline.id,
+              pipeline,
+              stepIndex: i,
+              context: { results: { ...mutableResults } },
+              status: "halted",
+              updatedAt: Date.now(),
+            });
+            return {
+              status: "halted",
+              context: { results: { ...mutableResults } },
+              completedSteps,
+              totalSteps: pipeline.steps.length,
+              resumeFrom: i,
+            };
+          }
+        }
+
+        // Execute the tool and handle errors per step policy
+        const stepResult = await this.executeStep(step);
+
+        if (stepResult.error) {
+          const recovery = await this.handleStepError(pipeline.id, step, stepResult.error);
+          if (recovery.terminal) {
+            this.active.delete(pipeline.id);
+            return {
+              status: "failed",
+              context: { results: { ...mutableResults } },
+              completedSteps,
+              totalSteps: pipeline.steps.length,
+              error: recovery.error,
+            };
+          }
+          mutableResults[step.name] = recovery.result;
+        } else {
+          mutableResults[step.name] = stepResult.result;
+        }
+
+        completedSteps = i + 1;
+        await this.trackProgress(pipeline.id, step.name);
+      }
+
+      // All steps completed
+      await this.removeCheckpoint(pipeline.id);
+      this.active.delete(pipeline.id);
+      return {
+        status: "completed",
+        context: { results: { ...mutableResults } },
+        completedSteps,
+        totalSteps: pipeline.steps.length,
+      };
+    } catch (err) {
+      this.active.delete(pipeline.id);
+      return {
+        status: "failed",
+        context: { results: { ...mutableResults } },
+        completedSteps,
+        totalSteps: pipeline.steps.length,
+        error: toErrorMessage(err),
+      };
+    }
+  }
+
+  /** Resume a halted or interrupted pipeline from its checkpoint. */
+  async resume(pipelineId: string): Promise<PipelineResult> {
+    const checkpoint = await this.backend.get<PipelineCheckpoint>(
+      checkpointKey(pipelineId),
+    );
+    if (!checkpoint) {
+      throw new WorkflowStateError(
+        `No checkpoint found for pipeline "${pipelineId}"`,
+      );
+    }
+
+    // Reconstruct pipeline with saved context
+    const pipeline: Pipeline = {
+      ...checkpoint.pipeline,
+      context: checkpoint.context,
+    };
+
+    return this.execute(pipeline, checkpoint.stepIndex);
+  }
+
+  /** List active pipeline IDs with their checkpoint status. */
+  async listActive(): Promise<readonly PipelineCheckpoint[]> {
+    const results: PipelineCheckpoint[] = [];
+    for (const id of this.active) {
+      const checkpoint = await this.backend.get<PipelineCheckpoint>(
+        checkpointKey(id),
+      );
+      if (checkpoint) results.push(checkpoint);
+    }
+    return results;
+  }
+
+  /** Remove a pipeline checkpoint and clear from active set. */
+  async remove(pipelineId: string): Promise<void> {
+    await this.removeCheckpoint(pipelineId);
+    this.active.delete(pipelineId);
+  }
+
+  // --------------------------------------------------------------------------
+  // Private helpers
+  // --------------------------------------------------------------------------
+
+  /**
+   * Apply the step's error policy. Returns either a terminal failure
+   * or a recovered result string (from skip or successful retry).
+   */
+  private async handleStepError(
+    pipelineId: string,
+    step: PipelineStep,
+    error: string,
+  ): Promise<{ terminal: true; error: string } | { terminal: false; result: string }> {
+    const policy = step.onError ?? "abort";
+
+    if (policy === "skip") {
+      this.logger?.warn(`Pipeline "${pipelineId}" step "${step.name}" failed, skipping: ${error}`);
+      return { terminal: false, result: `SKIPPED: ${error}` };
+    }
+
+    if (policy === "retry") {
+      const maxRetries = step.maxRetries ?? 0;
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        const retryResult = await this.executeStep(step);
+        if (!retryResult.error) {
+          return { terminal: false, result: retryResult.result };
+        }
+        this.logger?.warn(
+          `Pipeline "${pipelineId}" step "${step.name}" retry ${attempt}/${maxRetries} failed`,
+        );
+      }
+    }
+
+    // abort (default) or exhausted retries
+    await this.removeCheckpoint(pipelineId);
+    return { terminal: true, error };
+  }
+
+  private async executeStep(
+    step: PipelineStep,
+  ): Promise<{ result: string; error?: string }> {
+    try {
+      const result = await this.toolHandler(step.tool, step.args);
+      return { result };
+    } catch (err) {
+      return { result: "", error: toErrorMessage(err) };
+    }
+  }
+
+  private async saveCheckpoint(checkpoint: PipelineCheckpoint): Promise<void> {
+    await this.backend.set(
+      checkpointKey(checkpoint.pipelineId),
+      checkpoint,
+      this.checkpointTtlMs,
+    );
+  }
+
+  private async removeCheckpoint(pipelineId: string): Promise<void> {
+    await this.backend.delete(checkpointKey(pipelineId));
+  }
+
+  private async trackProgress(
+    pipelineId: string,
+    stepName: string,
+  ): Promise<void> {
+    if (!this.progressTracker) return;
+    try {
+      await this.progressTracker.append({
+        sessionId: pipelineId,
+        type: "task_completed",
+        summary: `Pipeline step "${stepName}" completed`,
+      });
+    } catch {
+      // Progress tracking failure is non-blocking
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **ProgressTracker** (`gateway/progress.ts`): Cross-session continuity via persistent progress entries stored in MemoryBackend KV. Implements `MemoryRetriever` for automatic ChatExecutor context injection. Auto-records tool results via `tool:after` hook (priority 95).
- **PipelineExecutor** (`workflow/pipeline.ts`): Resumable multi-step tool workflows with checkpoint/resume to MemoryBackend. Supports approval gates, configurable error policies (abort/skip/retry), and concurrency guards.
- **3 slash commands**: `/progress` (show session progress), `/pipeline` (run JSON pipeline), `/resume` (resume halted pipeline)
- **Tech debt fixes**: Extracted shared `SEVEN_DAYS_MS` constant to `utils/async.ts`, shared `createMockMemoryBackend()` test helper to `memory/test-utils.ts`, extracted `handleStepError()` private method to reduce nesting in pipeline executor

## Test plan

- [x] 17 tests for ProgressTracker (append, getRecent, getSummary, clear, retrieve, summarizeToolResult)
- [x] 15 tests for PipelineExecutor (execute, error policies, concurrency, approval gates, checkpoints, resume)
- [x] 3 tests for ChatExecutor progressProvider injection
- [x] Typecheck clean
- [x] Build clean
- [x] Full test suite: 4911 passed (3 pre-existing workspace-files failures unrelated to P3)