### PR TITLE
feat(web): embedded desktop viewer in chat view

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ViewId, WSMessage, ApprovalRequest } from './types';
 import { useWebSocket } from './hooks/useWebSocket';
 import { useTheme } from './hooks/useTheme';
@@ -59,6 +59,20 @@ export default function App() {
   const activityFeed = useActivityFeed({ send, connected }) as WithHandler<ReturnType<typeof useActivityFeed>>;
   const agentsData = useAgents({ send, connected }) as WithHandler<ReturnType<typeof useAgents>>;
   const desktop = useDesktop({ send, connected }) as WithHandler<ReturnType<typeof useDesktop>>;
+  const [desktopPanelOpen, setDesktopPanelOpen] = useState(false);
+  const prevVncUrl = useRef<string | null>(null);
+
+  const toggleDesktopPanel = useCallback(() => {
+    setDesktopPanelOpen((prev) => !prev);
+  }, []);
+
+  // Auto-open desktop panel when a sandbox becomes ready
+  useEffect(() => {
+    if (desktop.activeVncUrl && !prevVncUrl.current) {
+      setDesktopPanelOpen(true);
+    }
+    prevVncUrl.current = desktop.activeVncUrl;
+  }, [desktop.activeVncUrl]);
 
   // Voice toggle — start or stop voice session
   const handleVoiceToggle = useCallback(() => {
@@ -166,6 +180,9 @@ export default function App() {
                 activeSessionId={chat.sessionId}
                 onSelectSession={chat.resumeSession}
                 onNewChat={chat.startNewChat}
+                desktopUrl={desktop.activeVncUrl}
+                desktopOpen={desktopPanelOpen}
+                onToggleDesktop={toggleDesktopPanel}
               />
             )}
             {currentView === 'status' && (

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -4,6 +4,7 @@ import type { ChatSessionInfo } from '../../hooks/useChat';
 import { MessageList } from './MessageList';
 import { ChatInput } from './ChatInput';
 import { VoiceOverlay } from './VoiceOverlay';
+import { DesktopPanel } from './DesktopPanel';
 
 interface ChatViewProps {
   messages: ChatMessage[];
@@ -24,6 +25,9 @@ interface ChatViewProps {
   activeSessionId?: string | null;
   onSelectSession?: (sessionId: string) => void;
   onNewChat?: () => void;
+  desktopUrl?: string | null;
+  desktopOpen?: boolean;
+  onToggleDesktop?: () => void;
 }
 
 export function ChatView({
@@ -45,6 +49,9 @@ export function ChatView({
   activeSessionId,
   onSelectSession,
   onNewChat,
+  desktopUrl,
+  desktopOpen = false,
+  onToggleDesktop,
 }: ChatViewProps) {
   const isDark = theme === 'dark';
   const [searchOpen, setSearchOpen] = useState(false);
@@ -159,6 +166,17 @@ export function ChatView({
               </svg>
             )}
           </button>
+          {desktopUrl && onToggleDesktop && (
+            <button
+              onClick={onToggleDesktop}
+              className={`w-9 h-9 rounded-lg flex items-center justify-center transition-colors ${desktopOpen ? 'text-accent bg-accent-bg' : 'text-tetsuo-400 hover:text-tetsuo-600 hover:bg-tetsuo-100'}`}
+              title={desktopOpen ? 'Hide desktop viewer' : 'Show desktop viewer'}
+            >
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <rect x="2" y="3" width="20" height="14" rx="2" ry="2" /><line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
+              </svg>
+            </button>
+          )}
           <button
             onClick={toggleSearch}
             className={`w-9 h-9 rounded-lg flex items-center justify-center transition-colors ${searchOpen ? 'text-accent bg-accent-bg' : 'text-tetsuo-400 hover:text-tetsuo-600 hover:bg-tetsuo-100'}`}
@@ -225,7 +243,15 @@ export function ChatView({
         )}
       </div>
 
-      <MessageList messages={messages} isTyping={isTyping} theme={theme} searchQuery={searchQuery} />
+      {/* Message list + optional desktop panel */}
+      <div className="flex-1 min-h-0 flex">
+        <MessageList messages={messages} isTyping={isTyping} theme={theme} searchQuery={searchQuery} />
+        {desktopOpen && desktopUrl && (
+          <div className="hidden md:flex w-[50%] min-w-[400px]">
+            <DesktopPanel vncUrl={desktopUrl} onClose={onToggleDesktop!} />
+          </div>
+        )}
+      </div>
       <ChatInput
         onSend={onSend}
         onStop={onStop}

--- a/web/src/components/chat/DesktopPanel.tsx
+++ b/web/src/components/chat/DesktopPanel.tsx
@@ -1,0 +1,72 @@
+import { useCallback, useState } from 'react';
+
+interface DesktopPanelProps {
+  vncUrl: string;
+  onClose: () => void;
+}
+
+export function DesktopPanel({ vncUrl, onClose }: DesktopPanelProps) {
+  const [loading, setLoading] = useState(true);
+
+  const iframeSrc = `${vncUrl}?autoconnect=true&resize=scale&view_only=true`;
+
+  const openFullscreen = useCallback(() => {
+    window.open(vncUrl, '_blank', 'noopener');
+  }, [vncUrl]);
+
+  return (
+    <div className="flex flex-col h-full border-l border-tetsuo-200 bg-surface">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-tetsuo-200 bg-tetsuo-50/50">
+        <div className="flex items-center gap-2 text-sm font-medium text-tetsuo-700">
+          <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
+          Desktop
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={openFullscreen}
+            className="w-7 h-7 rounded flex items-center justify-center text-tetsuo-400 hover:text-tetsuo-600 hover:bg-tetsuo-100 transition-colors"
+            title="Open in new tab"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <polyline points="15 3 21 3 21 9" />
+              <line x1="10" y1="14" x2="21" y2="3" />
+              <path d="M21 14v5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5" />
+            </svg>
+          </button>
+          <button
+            onClick={onClose}
+            className="w-7 h-7 rounded flex items-center justify-center text-tetsuo-400 hover:text-tetsuo-600 hover:bg-tetsuo-100 transition-colors"
+            title="Close desktop viewer"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* iframe container */}
+      <div className="relative flex-1 min-h-0">
+        {loading && (
+          <div className="absolute inset-0 flex items-center justify-center bg-tetsuo-50">
+            <div className="flex flex-col items-center gap-2 text-tetsuo-400">
+              <svg className="animate-spin w-6 h-6" viewBox="0 0 24 24" fill="none">
+                <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="2" opacity="0.25" />
+                <path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+              </svg>
+              <span className="text-xs">Connecting to desktop...</span>
+            </div>
+          </div>
+        )}
+        <iframe
+          src={iframeSrc}
+          className="w-full h-full border-0"
+          onLoad={() => setLoading(false)}
+          allow="clipboard-read; clipboard-write"
+          title="Desktop Viewer"
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/useDesktop.ts
+++ b/web/src/hooks/useDesktop.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { WSMessage } from '../types';
 
 export interface DesktopSandbox {
@@ -20,6 +20,7 @@ export interface UseDesktopReturn {
   sandboxes: DesktopSandbox[];
   loading: boolean;
   error: string | null;
+  activeVncUrl: string | null;
   refresh: () => void;
   create: (sessionId?: string) => void;
   destroy: (containerId: string) => void;
@@ -73,5 +74,10 @@ export function useDesktop({ send, connected }: UseDesktopOptions): UseDesktopRe
     }
   }, [send]);
 
-  return { sandboxes, loading, error, refresh, create, destroy, handleMessage } as UseDesktopReturn & { handleMessage: (msg: WSMessage) => void };
+  const activeVncUrl = useMemo(
+    () => sandboxes.find((s) => s.status === 'ready')?.vncUrl ?? null,
+    [sandboxes],
+  );
+
+  return { sandboxes, loading, error, activeVncUrl, refresh, create, destroy, handleMessage } as UseDesktopReturn & { handleMessage: (msg: WSMessage) => void };
 }


### PR DESCRIPTION
## Summary

- Adds a toggleable noVNC iframe panel to `ChatView` so you can watch agent desktop automation live inline with chat
- Monitor icon appears in the chat header when a desktop sandbox is active; clicking it toggles a 50/50 split layout
- Panel auto-opens when a sandbox becomes ready, hidden on mobile

## Changes

- **New:** `web/src/components/chat/DesktopPanel.tsx` — iframe wrapper with loading spinner, open-in-new-tab, and close buttons
- **Modified:** `web/src/components/chat/ChatView.tsx` — monitor toggle button in header + flex split layout
- **Modified:** `web/src/hooks/useDesktop.ts` — `activeVncUrl` derived from first ready sandbox
- **Modified:** `web/src/App.tsx` — `desktopPanelOpen` state, auto-open effect, props wired to ChatView

## Test plan

- [ ] `cd web && npm run build` passes
- [ ] No desktop button visible when no sandbox running
- [ ] Launch desktop from Desktop page → chat header shows monitor icon
- [ ] Toggle opens split view with live noVNC feed
- [ ] Close button hides panel, chat returns to full width
- [ ] Open-in-new-tab button works
- [ ] Panel hidden on mobile viewports