### PR TITLE
fix(web): match desktop viewer to active chat session

### DIFF
--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -356,6 +356,9 @@ export class WebChatChannel
     // Ensure session mapping
     const sessionId = this.ensureSession(clientId);
 
+    // Notify the client of its session ID (needed for desktop viewer matching)
+    send({ type: 'chat.session', payload: { sessionId } });
+
     // Store user message in history
     this.appendHistory(sessionId, {
       content: content as string,

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -183,6 +183,13 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
         break;
       }
 
+      case 'chat.session': {
+        const payload = (msg.payload ?? msg) as Record<string, unknown>;
+        const id = (payload.sessionId as string) ?? null;
+        if (id) setSessionId(id);
+        break;
+      }
+
       case 'chat.resumed': {
         const payload = (msg.payload ?? msg) as Record<string, unknown>;
         const resumedId = (payload.sessionId as string) ?? null;

--- a/web/src/hooks/useDesktop.ts
+++ b/web/src/hooks/useDesktop.ts
@@ -21,6 +21,7 @@ export interface UseDesktopReturn {
   loading: boolean;
   error: string | null;
   activeVncUrl: string | null;
+  vncUrlForSession: (sessionId: string | null | undefined) => string | null;
   refresh: () => void;
   create: (sessionId?: string) => void;
   destroy: (containerId: string) => void;
@@ -79,5 +80,18 @@ export function useDesktop({ send, connected }: UseDesktopOptions): UseDesktopRe
     [sandboxes],
   );
 
-  return { sandboxes, loading, error, activeVncUrl, refresh, create, destroy, handleMessage } as UseDesktopReturn & { handleMessage: (msg: WSMessage) => void };
+  // Find VNC URL for a specific chat session (the agent's desktop tools
+  // create containers keyed by the chat sessionId, so we match on that).
+  const vncUrlForSession = useCallback(
+    (sessionId: string | null | undefined): string | null => {
+      if (!sessionId) return activeVncUrl;
+      const match = sandboxes.find(
+        (s) => s.status === 'ready' && s.sessionId === sessionId,
+      );
+      return match?.vncUrl ?? activeVncUrl;
+    },
+    [sandboxes, activeVncUrl],
+  );
+
+  return { sandboxes, loading, error, activeVncUrl, vncUrlForSession, refresh, create, destroy, handleMessage } as UseDesktopReturn & { handleMessage: (msg: WSMessage) => void };
 }


### PR DESCRIPTION
## Summary

- Fixes desktop viewer showing the wrong container when multiple sandboxes exist
- Server now sends `chat.session` with the session ID on each message so the frontend knows which sandbox to display
- `vncUrlForSession()` matches sandbox by session ID instead of blindly picking the first ready one
- Periodic 5s sandbox list refresh catches lazily-created containers

## Changes

- **runtime/src/channels/webchat/plugin.ts** — send `chat.session` with sessionId after ensureSession
- **web/src/hooks/useChat.ts** — handle `chat.session` message to track session ID
- **web/src/hooks/useDesktop.ts** — add `vncUrlForSession()` method
- **web/src/App.tsx** — use session-matched URL, add periodic refresh, hide RightPanel correctly

## Test plan

- [ ] Fresh chat session → agent uses desktop tools → VNC viewer shows the correct container
- [ ] Multiple sandboxes → viewer follows the active chat session's container
- [ ] Session resume → viewer updates to match the resumed session