### PR TITLE
fix(desktop): add nano, sudo, and update system prompt

### DIFF
--- a/containers/desktop/Dockerfile
+++ b/containers/desktop/Dockerfile
@@ -33,7 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Build essentials
     build-essential gcc g++ make cmake \
     # Developer tools
-    git vim tmux htop tree jq unzip \
+    git vim nano tmux htop tree jq unzip sudo \
     # Python
     python3 python3-pip python3-venv \
     # Misc utilities
@@ -65,9 +65,11 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 # =============================================================================
-# Non-root user (no sudo)
+# Non-root user (passwordless sudo)
 # =============================================================================
-RUN useradd -m -s /bin/bash -d /home/agenc agenc
+RUN useradd -m -s /bin/bash -d /home/agenc agenc \
+    && echo 'agenc ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agenc \
+    && chmod 0440 /etc/sudoers.d/agenc
 
 # =============================================================================
 # Branding: wallpaper + icon

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -2102,7 +2102,8 @@ export class DaemonManager {
         '- LibreOffice: desktop.bash with "libreoffice --calc >/dev/null 2>&1 &"\n' +
         '- Take screenshots frequently to verify actions worked\n' +
         '- system.bash = host machine; desktop.bash = inside the Docker container\n' +
-        '- nano/vim are NOT installed. Write files with cat heredoc via desktop.bash.\n\n' +
+        '- vim and nano are available for editing files inside the container.\n' +
+        '- The user is "agenc" with passwordless sudo — use "sudo apt-get install -y pkg" to install packages.\n\n' +
         'Be helpful, direct, and action-oriented. Execute tasks immediately without hesitation.';
     } else if (isMac) {
       ctx +=


### PR DESCRIPTION
## Summary

- Adds nano and sudo to the desktop Docker image
- Configures passwordless sudo for the agenc user
- Updates system prompt to tell the agent about vim/nano availability and sudo access