### PR TITLE
fix(runtime): decode HTML entities at LLM adapter level

### DIFF
--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -1942,19 +1942,12 @@ export class DaemonManager {
           }
         }
 
-        // Decode HTML entities in string args (some LLMs emit &amp; &lt; &gt; etc.)
-        const cleanArgs = Object.fromEntries(
-          Object.entries(args).map(([k, v]) =>
-            [k, typeof v === 'string' ? v.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&quot;/g, '"').replace(/&#39;/g, "'") : v],
-          ),
-        );
-
         const start = Date.now();
         // Use desktop-aware handler if available, otherwise base handler
         const activeHandler = this._desktopRouterFactory
           ? this._desktopRouterFactory(msg.sessionId)
           : baseToolHandler;
-        const result = await activeHandler(name, cleanArgs);
+        const result = await activeHandler(name, args);
         const durationMs = Date.now() - start;
 
         webChat.pushToSession(msg.sessionId, {

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -160,8 +160,16 @@ export function validateToolCall(raw: unknown): LLMToolCall | null {
     return null;
   }
 
+  // Decode HTML entities that some LLMs (e.g. Grok) emit in tool call arguments
+  const decoded = argumentsRaw
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+
   try {
-    JSON.parse(argumentsRaw);
+    JSON.parse(decoded);
   } catch {
     return null;
   }
@@ -169,6 +177,6 @@ export function validateToolCall(raw: unknown): LLMToolCall | null {
   return {
     id,
     name,
-    arguments: argumentsRaw,
+    arguments: decoded,
   };
 }


### PR DESCRIPTION
## Summary
- Move HTML entity decoding from daemon tool handler to `validateToolCall()` in `llm/types.ts`
- Fixes `&amp;&amp;` showing in UI tool call display — previous fix only decoded for execution but the `tools.executing` WebSocket event still sent raw encoded args
- Decoding at the source means all consumers (UI, tool execution, logging) get clean args

## Test plan
- [ ] Send agent a task that generates `&&` in bash commands
- [ ] Verify both UI display and actual execution show `&&` not `&amp;&amp;`