### PR TITLE
fix(desktop): remove no-new-privileges that blocks sudo

### DIFF
--- a/runtime/src/desktop/manager.ts
+++ b/runtime/src/desktop/manager.ts
@@ -391,7 +391,6 @@ export class DesktopSandboxManager {
         "--cap-add", "DAC_OVERRIDE",
         "--cap-add", "KILL",
         "--cap-add", "NET_BIND_SERVICE",
-        "--security-opt", "no-new-privileges",
       );
     }
 


### PR DESCRIPTION
Removes --security-opt no-new-privileges from strict security profile. This flag prevents sudo from working inside desktop containers.