### PR TITLE
feat(runtime): wire PolicyEngine, Marketplace, and Social Module into daemon

### DIFF
--- a/.claude/notes/gotchas.md
+++ b/.claude/notes/gotchas.md
@@ -39,3 +39,12 @@ MCP replay tests can fail from environment/runtime import mismatches (for exampl
 
 ### safeStringify vs JSON.stringify
 - Always use `safeStringify()` (from `tools/types.ts`) when serializing objects that could contain `bigint`, `PublicKey`, or other non-JSON types. `JSON.stringify` will throw at runtime. Fixed in `chat-executor.ts` error paths (P2 tech debt cleanup).
+
+## 2026-02-25
+
+### Daemon Subsystem Wiring Patterns
+- **Wallet loading is duplicated** in `wireSocial()` and `createToolRegistry()`. Next time extract to `private async loadWallet(config)` before adding a third copy.
+- **SDK `MatchingPolicy` type** is `"best_price" | "best_eta" | "weighted_score"` — NOT `"best_quality"` or `"weighted"`. Always check SDK source-of-truth types before defining gateway config enums.
+- **`AgentDiscovery` does NOT implement `PeerResolver`** — you can't pass it directly to `AgentMessaging.discovery`. The `discovery` param accepts `PeerResolver` interface, not `AgentDiscovery`. Currently we omit it.
+- **`spendBudget.limitLamports` is a string** in gateway config (for JSON round-trip), converted via `BigInt()` at use-site. Always validate decimal format before `BigInt()` to avoid startup crashes.
+- **UNSAFE_KEYS in config-watcher.ts** must be updated when adding subsystem enable/disable toggles — otherwise hot-reload treats subsystem enablement as a safe change.

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -115,6 +115,46 @@ export interface GatewayMCPServerConfig {
   timeout?: number;
 }
 
+export interface GatewayPolicyConfig {
+  enabled?: boolean;
+  toolAllowList?: string[];
+  toolDenyList?: string[];
+  actionBudgets?: Record<string, { limit: number; windowMs: number }>;
+  /** Spend budget. `limitLamports` is a decimal string for JSON round-trip safety. */
+  spendBudget?: { limitLamports: string; windowMs: number };
+  /** Max risk score in [0, 1]. */
+  maxRiskScore?: number;
+  circuitBreaker?: {
+    enabled?: boolean;
+    threshold: number;
+    windowMs: number;
+    mode: "pause_discovery" | "halt_submissions" | "safe_mode";
+  };
+}
+
+export interface GatewayMarketplaceConfig {
+  enabled?: boolean;
+  defaultMatchingPolicy?: "best_price" | "best_eta" | "weighted_score";
+  antiSpam?: {
+    maxActiveBidsPerBidderPerTask?: number;
+    maxBidsPerTask?: number;
+  };
+  authorizedSelectorIds?: string[];
+}
+
+export interface GatewaySocialConfig {
+  enabled?: boolean;
+  discoveryEnabled?: boolean;
+  discoveryCacheTtlMs?: number;
+  discoveryCacheMaxEntries?: number;
+  messagingEnabled?: boolean;
+  messagingMode?: "on-chain" | "off-chain" | "auto";
+  messagingPort?: number;
+  feedEnabled?: boolean;
+  collaborationEnabled?: boolean;
+  reputationEnabled?: boolean;
+}
+
 export interface GatewayConfig {
   gateway: GatewayBindConfig;
   agent: GatewayAgentConfig;
@@ -129,6 +169,12 @@ export interface GatewayConfig {
   desktop?: DesktopSandboxConfig;
   /** External MCP server connections */
   mcp?: GatewayMCPConfig;
+  /** Policy engine: budget enforcement + circuit breakers on tool calls */
+  policy?: GatewayPolicyConfig;
+  /** Marketplace: task bidding between agents */
+  marketplace?: GatewayMarketplaceConfig;
+  /** Social module: discovery, messaging, feed, reputation, collaboration */
+  social?: GatewaySocialConfig;
 }
 
 // ============================================================================

--- a/runtime/src/gateway/workspace-files.test.ts
+++ b/runtime/src/gateway/workspace-files.test.ts
@@ -23,9 +23,9 @@ afterEach(async () => {
 });
 
 describe("WORKSPACE_FILES", () => {
-  it("contains all 11 file names", () => {
+  it("contains all 12 file names", () => {
     const values = Object.values(WORKSPACE_FILES);
-    expect(values).toHaveLength(11);
+    expect(values).toHaveLength(12);
     expect(values).toContain("AGENT.md");
     expect(values).toContain("SOUL.md");
     expect(values).toContain("USER.md");
@@ -37,6 +37,7 @@ describe("WORKSPACE_FILES", () => {
     expect(values).toContain("CAPABILITIES.md");
     expect(values).toContain("POLICY.md");
     expect(values).toContain("REPUTATION.md");
+    expect(values).toContain("X.md");
   });
 });
 
@@ -233,7 +234,7 @@ describe("scaffoldWorkspace", () => {
     const wsDir = join(tmpDir, "workspace");
     const created = await scaffoldWorkspace(wsDir);
 
-    expect(created).toHaveLength(11);
+    expect(created).toHaveLength(12);
     for (const fileName of Object.values(WORKSPACE_FILES)) {
       expect(created).toContain(fileName);
     }
@@ -252,7 +253,7 @@ describe("scaffoldWorkspace", () => {
     const created = await scaffoldWorkspace(wsDir);
 
     expect(created).not.toContain("AGENT.md");
-    expect(created).toHaveLength(10);
+    expect(created).toHaveLength(11);
 
     const loader = new WorkspaceLoader(wsDir);
     const agentContent = await loader.loadFile("AGENT");


### PR DESCRIPTION
## Summary

- Wire 3 fully-implemented-but-unwired subsystems into the daemon lifecycle: **PolicyEngine** (budget enforcement + circuit breakers as `tool:before` hook), **Marketplace** (TaskBidMarketplace + ServiceMarketplace for agent-to-agent task bidding), and **Social Module** (5 composable components: AgentDiscovery, AgentMessaging, AgentFeed, ReputationScorer, CollaborationProtocol)
- Add `GatewayPolicyConfig`, `GatewayMarketplaceConfig`, `GatewaySocialConfig` config interfaces with deep validation for all nested fields
- Fix 11 tech debt items: extract `loadWallet()` helper, named constants for all magic values, deduplicate channel wiring into loop, standardize `logger.warn?.()`, fix stale workspace test assertions

## Changes

| File | Change |
|------|--------|
| `runtime/src/gateway/types.ts` | Add 3 new config interfaces, extend `GatewayConfig` |
| `runtime/src/gateway/config-watcher.ts` | Deep validation for policy/marketplace/social sections, UNSAFE_KEYS update |
| `runtime/src/gateway/daemon.ts` | 7 private fields, `wireMarketplace()`, `wireSocial()`, policy hook + hot-reload, `loadWallet()` helper, constants extraction, channel wiring loop |
| `runtime/src/gateway/workspace-files.test.ts` | Fix stale file counts (11→12 for X.md) |
| `.claude/notes/gotchas.md` | Document 5 new daemon wiring gotchas |

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npx vitest run` — 4914 tests pass, 0 failures
- [x] Stale workspace-files.test.ts failures fixed (was 3 failing, now 0)