### PR TITLE
fix(runtime): remove bash from desktop auto-screenshot triggers

### DIFF
--- a/runtime/src/desktop/manager.ts
+++ b/runtime/src/desktop/manager.ts
@@ -157,6 +157,7 @@ export class DesktopSandboxManager {
         config.healthCheckIntervalMs ?? defaults.healthCheckIntervalMs!,
       networkMode: config.networkMode ?? defaults.networkMode!,
       securityProfile: config.securityProfile ?? defaults.securityProfile!,
+      autoScreenshot: config.autoScreenshot ?? false,
       labels: config.labels,
       playwright: config.playwright ?? {},
     };

--- a/runtime/src/desktop/session-router.test.ts
+++ b/runtime/src/desktop/session-router.test.ts
@@ -26,6 +26,14 @@ vi.mock("./rest-bridge.js", () => {
         content: '{"clicked":true}',
       }),
     },
+    {
+      name: "desktop.bash",
+      description: "Run bash command",
+      inputSchema: {},
+      execute: vi.fn().mockResolvedValue({
+        content: '{"stdout":"hello","exitCode":0}',
+      }),
+    },
   ];
 
   return {
@@ -216,6 +224,20 @@ describe("createDesktopAwareToolHandler", () => {
       const parsed = JSON.parse(result);
       expect(parsed.clicked).toBe(true);
       // No _screenshot since it failed
+      expect(parsed._screenshot).toBeUndefined();
+    });
+
+    it("skips for bash commands (not a GUI action)", async () => {
+      const manager = mockManager();
+      const handler = createDesktopAwareToolHandler(baseHandler, "sess1", {
+        desktopManager: manager,
+        bridges,
+        autoScreenshot: true,
+      });
+
+      const result = await handler("desktop.bash", { command: "ls" });
+      const parsed = JSON.parse(result);
+      expect(parsed.stdout).toBe("hello");
       expect(parsed._screenshot).toBeUndefined();
     });
 

--- a/runtime/src/desktop/session-router.ts
+++ b/runtime/src/desktop/session-router.ts
@@ -29,7 +29,6 @@ const DESKTOP_ACTION_TOOLS = new Set([
   "mouse_scroll",
   "keyboard_type",
   "keyboard_key",
-  "bash",
   "window_focus",
 ]);
 

--- a/runtime/src/desktop/types.ts
+++ b/runtime/src/desktop/types.ts
@@ -67,6 +67,8 @@ export interface DesktopSandboxConfig {
   readonly securityProfile?: "strict" | "permissive";
   /** Extra Docker labels. */
   readonly labels?: Record<string, string>;
+  /** Auto-capture screenshot after GUI action tools (mouse, keyboard). Default: false */
+  readonly autoScreenshot?: boolean;
   /** Playwright MCP browser automation options. */
   readonly playwright?: {
     /** Enable Playwright MCP bridge for structured browser automation. Default: true */

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -459,7 +459,7 @@ export class DaemonManager {
           containerMCPConfigs: containerMCPConfigs.length > 0 ? containerMCPConfigs : undefined,
           containerMCPBridges: containerMCPConfigs.length > 0 ? containerMCPBridges : undefined,
           logger: desktopLogger,
-          autoScreenshot: true,
+          autoScreenshot: config.desktop?.autoScreenshot ?? false,
         });
     }
 


### PR DESCRIPTION
## Summary

- Remove `bash` from `DESKTOP_ACTION_TOOLS` — shell commands don't change the desktop GUI, so auto-screenshotting after them was wasteful
- Add `autoScreenshot` to `DesktopSandboxConfig` for user configurability
- Default `autoScreenshot` to `false` in daemon wiring — the agent calls `desktop.screenshot` explicitly when needed

## Test plan

- [x] New test: bash commands don't trigger auto-screenshot even when enabled
- [x] All 14 session-router tests pass
- [x] `tsc --noEmit` clean