### PR TITLE
fix(web): make desktop VNC viewer interactive

### DIFF
--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -247,7 +247,7 @@ export function ChatView({
       <div className="flex-1 min-h-0 flex">
         <MessageList messages={messages} isTyping={isTyping} theme={theme} searchQuery={searchQuery} />
         {desktopOpen && desktopUrl && (
-          <div className="hidden md:block w-[55%] min-w-[480px] shrink-0">
+          <div className="hidden md:block w-[55%] min-w-[480px] h-full shrink-0">
             <DesktopPanel vncUrl={desktopUrl} onClose={onToggleDesktop!} />
           </div>
         )}


### PR DESCRIPTION
## Summary

- Loading overlay (`absolute inset-0`) was blocking all mouse/keyboard input to the noVNC iframe — added `pointer-events-none` so clicks pass through to the iframe
- Added `z-10` for proper overlay layering
- Focus iframe on container click so keyboard events reach noVNC
- Added 8s safety timeout to dismiss spinner if iframe `onLoad` doesn't fire
- Added `h-full` to panel wrapper in ChatView so the iframe stretches to fill available space

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: open desktop panel, verify mouse clicks register in VNC
- [ ] Manual: verify keyboard input reaches VNC after clicking inside
- [ ] Manual: spinner dismisses on load (or after 8s timeout)