### PR TITLE
feat(zkvm): extend journal schema to 8 fields with model_commitment and input_commitment (#1284)

### DIFF
--- a/demo-app/src/components/steps/Step4GenerateProof.tsx
+++ b/demo-app/src/components/steps/Step4GenerateProof.tsx
@@ -4,7 +4,7 @@ import StepCard from '../StepCard'
 
 const PAYLOAD_STAGES = [
   { id: 1, label: 'Computing output commitment', duration: 700 },
-  { id: 2, label: 'Building 192-byte journal', duration: 900 },
+  { id: 2, label: 'Building 256-byte journal', duration: 900 },
   { id: 3, label: 'Encoding 260-byte seal_bytes', duration: 1200 },
   { id: 4, label: 'Deriving router and spend PDAs', duration: 700 },
 ]
@@ -44,15 +44,15 @@ export default function Step4GenerateProof({ updateTaskState, onNext, onPrev }: 
 
     const outputCommitment = randomHex(32)
     const sealBytes = randomHex(260)
-    const journal = randomHex(192)
+    const journal = randomHex(256)
     const imageId = randomHex(32)
     const bindingSeed = randomHex(32)
     const nullifierSeed = randomHex(32)
 
     setProofStats({
       sealBytes: 260,
-      journalBytes: 192,
-      totalBytes: 260 + 192 + 32 + 32 + 32,
+      journalBytes: 256,
+      totalBytes: 260 + 256 + 32 + 32 + 32,
     })
 
     updateTaskState({
@@ -146,7 +146,7 @@ export default function Step4GenerateProof({ updateTaskState, onNext, onPrev }: 
             <div className="flex-1">
               <p className="text-green-400 font-medium text-sm">Payload Prepared</p>
               <p className="text-tetsuo-400 text-sm mt-1">
-                Fixed shape: `sealBytes`(260), `journal`(192), `imageId`(32), `bindingSeed`(32), `nullifierSeed`(32).
+                Fixed shape: `sealBytes`(260), `journal`(256), `imageId`(32), `bindingSeed`(32), `nullifierSeed`(32).
               </p>
               {proofStats.totalBytes > 0 && (
                 <div className="mt-3 grid grid-cols-3 gap-4 text-center">

--- a/demo/e2e_devnet_test.ts
+++ b/demo/e2e_devnet_test.ts
@@ -71,6 +71,8 @@ function makePayload(taskPda: PublicKey, authority: PublicKey): PrivatePayload {
     outputCommitment,
     bindingSeed,
     nullifierSeed,
+    Buffer.alloc(32), // model_commitment (zero = no model binding)
+    Buffer.alloc(32), // input_commitment (zero = no input binding)
   ]);
   const sealProof = deterministicBytes(sha256(Buffer.from('seal'), journal, TRUSTED_IMAGE_ID), 256);
   const sealBytes = Buffer.concat([TRUSTED_SELECTOR, sealProof]);
@@ -157,7 +159,7 @@ class E2ERouterPreflight {
       );
 
       const lengthsOk = payload.sealBytes.length === 260
-        && payload.journal.length === 192
+        && payload.journal.length === 256
         && payload.imageId.length === 32
         && payload.bindingSeed.length === 32
         && payload.nullifierSeed.length === 32;

--- a/demo/private_task_demo.ts
+++ b/demo/private_task_demo.ts
@@ -116,9 +116,11 @@ function buildJournal(
     outputCommitment,
     bindingSeed,
     nullifierSeed,
+    Buffer.alloc(32), // model_commitment (zero = no model binding)
+    Buffer.alloc(32), // input_commitment (zero = no input binding)
   ]);
-  if (journal.length !== 192) {
-    throw new Error(`journal must be 192 bytes, got ${journal.length}`);
+  if (journal.length !== 256) {
+    throw new Error(`journal must be 256 bytes, got ${journal.length}`);
   }
   return journal;
 }

--- a/examples/tetsuo-integration/index.ts
+++ b/examples/tetsuo-integration/index.ts
@@ -354,8 +354,10 @@ class TetsuoAgent {
       outputCommitment,
       bindingSeed,
       nullifierSeed,
+      Buffer.alloc(32), // model_commitment (zero = no model binding)
+      Buffer.alloc(32), // input_commitment (zero = no input binding)
     ]);
-    if (journal.length !== 192) {
+    if (journal.length !== 256) {
       throw new Error(`Invalid journal length: ${journal.length}`);
     }
 
@@ -438,8 +440,8 @@ class TetsuoAgent {
     if (payload.sealBytes.length !== 260) {
       throw new Error(`Invalid sealBytes size: expected 260 bytes, got ${payload.sealBytes.length}`);
     }
-    if (payload.journal.length !== 192) {
-      throw new Error(`Invalid journal size: expected 192 bytes, got ${payload.journal.length}`);
+    if (payload.journal.length !== 256) {
+      throw new Error(`Invalid journal size: expected 256 bytes, got ${payload.journal.length}`);
     }
     if (payload.imageId.length !== 32 || payload.bindingSeed.length !== 32 || payload.nullifierSeed.length !== 32) {
       throw new Error('Invalid private payload field lengths');

--- a/runtime/src/proof/engine.test.ts
+++ b/runtime/src/proof/engine.test.ts
@@ -4,7 +4,7 @@ import { Keypair, PublicKey } from "@solana/web3.js";
 // Mock @agenc/sdk before imports
 vi.mock("@agenc/sdk", () => {
   const mockSeal = Buffer.alloc(260, 0xab);
-  const mockJournal = Buffer.alloc(192, 0xcd);
+  const mockJournal = Buffer.alloc(256, 0xcd);
   const mockImageId = Buffer.alloc(32, 0xef);
   const mockBindingSeed = Buffer.alloc(32, 0x12);
   const mockNullifierSeed = Buffer.alloc(32, 0x34);
@@ -158,7 +158,7 @@ describe("ProofEngine", () => {
       expect(result.sealBytes).toBeInstanceOf(Uint8Array);
       expect(result.sealBytes.length).toBe(260);
       expect(result.journal).toBeInstanceOf(Uint8Array);
-      expect(result.journal.length).toBe(192);
+      expect(result.journal.length).toBe(256);
       expect(result.imageId).toBeInstanceOf(Uint8Array);
       expect(result.imageId.length).toBe(32);
       expect(result.bindingSeed).toBeInstanceOf(Uint8Array);
@@ -507,7 +507,7 @@ describe("ProofEngine", () => {
       const sealBytes = new Uint8Array(260).fill(0xbb);
       const result = await engine.generatePrivateProof({} as any, {
         sealBytes,
-        journal: new Uint8Array(192),
+        journal: new Uint8Array(256),
         imageId: new Uint8Array(32),
         bindingSeed: new Uint8Array(32),
         nullifierSeed: new Uint8Array(32),
@@ -701,7 +701,7 @@ describe("ProofCache", () => {
   function makeCacheResult(): EngineProofResult {
     return {
       sealBytes: new Uint8Array(260).fill(0x01),
-      journal: new Uint8Array(192).fill(0x02),
+      journal: new Uint8Array(256).fill(0x02),
       imageId: new Uint8Array(32).fill(0x03),
       bindingSeed: new Uint8Array(32).fill(0x04),
       nullifierSeed: new Uint8Array(32).fill(0x05),

--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -108,7 +108,7 @@ export interface ProofInputs {
 export interface EngineProofResult {
   /** Router seal bytes (selector + proof, typically 260 bytes) */
   sealBytes: Uint8Array;
-  /** Fixed-size journal bytes (192 bytes) */
+  /** Fixed-size journal bytes (256 bytes) */
   journal: Uint8Array;
   /** RISC0 method id (32 bytes) */
   imageId: Uint8Array;

--- a/runtime/src/task/executor.test.ts
+++ b/runtime/src/task/executor.test.ts
@@ -910,7 +910,7 @@ describe("TaskExecutor", () => {
         sealBytes.set([0x52, 0x5a, 0x56, 0x4d], 0);
         return {
           sealBytes,
-          journal: new Uint8Array(192).fill(2),
+          journal: new Uint8Array(256).fill(2),
           imageId: new Uint8Array(32).fill(3),
           bindingSeed: new Uint8Array(32).fill(4),
           nullifierSeed: new Uint8Array(32).fill(5),
@@ -973,7 +973,7 @@ describe("TaskExecutor", () => {
 
       const privateResult: PrivateTaskExecutionResult = {
         sealBytes: new Uint8Array(260),
-        journal: new Uint8Array(192),
+        journal: new Uint8Array(256),
         imageId: new Uint8Array(32),
         bindingSeed: new Uint8Array(32),
         nullifierSeed: new Uint8Array(32),

--- a/runtime/src/task/proof-pipeline.test.ts
+++ b/runtime/src/task/proof-pipeline.test.ts
@@ -34,7 +34,7 @@ function createPrivateResult(): PrivateTaskExecutionResult {
   sealBytes.set([0x52, 0x5a, 0x56, 0x4d], 0);
   return {
     sealBytes,
-    journal: new Uint8Array(192).fill(4),
+    journal: new Uint8Array(256).fill(4),
     imageId: new Uint8Array(32).fill(5),
     bindingSeed: new Uint8Array(32).fill(6),
     nullifierSeed: new Uint8Array(32).fill(7),

--- a/runtime/src/task/types.test.ts
+++ b/runtime/src/task/types.test.ts
@@ -454,7 +454,7 @@ describe("isPrivateExecutionResult", () => {
   it("identifies PrivateTaskExecutionResult by RISC0 payload fields", () => {
     const result: PrivateTaskExecutionResult = {
       sealBytes: new Uint8Array(260),
-      journal: new Uint8Array(192),
+      journal: new Uint8Array(256),
       imageId: new Uint8Array(32),
       bindingSeed: new Uint8Array(32),
       nullifierSeed: new Uint8Array(32),

--- a/scripts/generate-real-proof.ts
+++ b/scripts/generate-real-proof.ts
@@ -221,7 +221,7 @@ async function main() {
   if (result.seal_bytes.length !== 260) {
     throw new Error(`Unexpected seal_bytes length: ${result.seal_bytes.length}`);
   }
-  if (result.journal.length !== 192) {
+  if (result.journal.length !== 256) {
     throw new Error(`Unexpected journal length: ${result.journal.length}`);
   }
   if (result.image_id.length !== 32) {

--- a/sdk/src/__tests__/contract.test.ts
+++ b/sdk/src/__tests__/contract.test.ts
@@ -223,7 +223,7 @@ describe("SDK contract tests", () => {
       nullifierSeed: expect.any(Array),
     });
     expect(proofArg.sealBytes).toHaveLength(260);
-    expect(proofArg.journal).toHaveLength(192);
+    expect(proofArg.journal).toHaveLength(256);
     expect(proofArg.imageId).toHaveLength(32);
     expect(proofArg.bindingSeed).toHaveLength(32);
     expect(proofArg.nullifierSeed).toHaveLength(32);

--- a/sdk/src/__tests__/proof-validation.test.ts
+++ b/sdk/src/__tests__/proof-validation.test.ts
@@ -50,6 +50,8 @@ function makeJournal(fields: {
   outputCommitment: Uint8Array;
   binding: Uint8Array;
   nullifier: Uint8Array;
+  modelCommitment?: Uint8Array;
+  inputCommitment?: Uint8Array;
 }): Uint8Array {
   const out = new Uint8Array(RISC0_JOURNAL_LEN);
   out.set(fields.taskPda, 0);
@@ -58,6 +60,8 @@ function makeJournal(fields: {
   out.set(fields.outputCommitment, 96);
   out.set(fields.binding, 128);
   out.set(fields.nullifier, 160);
+  if (fields.modelCommitment) out.set(fields.modelCommitment, 192);
+  if (fields.inputCommitment) out.set(fields.inputCommitment, 224);
   return out;
 }
 

--- a/sdk/src/__tests__/proofs.test.ts
+++ b/sdk/src/__tests__/proofs.test.ts
@@ -593,6 +593,8 @@ describe("proofs", () => {
         toBytes32(hashes.outputCommitment),
         toBytes32(hashes.binding),
         toBytes32(hashes.nullifier),
+        Buffer.alloc(32),
+        Buffer.alloc(32),
       ]);
 
       vi.doMock("../prover", () => ({
@@ -649,6 +651,8 @@ describe("proofs", () => {
         toBytes32(hashes.outputCommitment),
         toBytes32(hashes.binding),
         toBytes32(hashes.nullifier),
+        Buffer.alloc(32),
+        Buffer.alloc(32),
       ]);
     }
 

--- a/sdk/src/__tests__/prover.test.ts
+++ b/sdk/src/__tests__/prover.test.ts
@@ -31,6 +31,8 @@ function validInput(): ProverInput {
     outputCommitment: new Uint8Array(32).fill(4),
     binding: new Uint8Array(32).fill(5),
     nullifier: new Uint8Array(32).fill(6),
+    modelCommitment: new Uint8Array(32).fill(0),
+    inputCommitment: new Uint8Array(32).fill(0),
   };
 }
 
@@ -260,7 +262,7 @@ describe("prove — remote backend", () => {
     });
   });
 
-  it("sends correct JSON body with all 6 fields", async () => {
+  it("sends correct JSON body with all 8 fields", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(validOutputPayload()),
@@ -277,6 +279,8 @@ describe("prove — remote backend", () => {
     expect(body.output_commitment).toHaveLength(32);
     expect(body.binding).toHaveLength(32);
     expect(body.nullifier).toHaveLength(32);
+    expect(body.model_commitment).toHaveLength(32);
+    expect(body.input_commitment).toHaveLength(32);
     // Verify values match input
     expect(body.task_pda).toEqual(Array.from(input.taskPda));
     expect(body.nullifier).toEqual(Array.from(input.nullifier));

--- a/sdk/src/constants.ts
+++ b/sdk/src/constants.ts
@@ -68,8 +68,8 @@ export const RISC0_GROTH16_SEAL_LEN = 256;
 /** RISC0 borsh-encoded seal length (selector + proof body) */
 export const RISC0_SEAL_BORSH_LEN = RISC0_SELECTOR_LEN + RISC0_GROTH16_SEAL_LEN;
 
-/** RISC0 fixed journal length (6 x 32-byte fields) */
-export const RISC0_JOURNAL_LEN = 192;
+/** RISC0 fixed journal length (8 x 32-byte fields) */
+export const RISC0_JOURNAL_LEN = 256;
 
 /** RISC0 image ID length in bytes */
 export const RISC0_IMAGE_ID_LEN = 32;

--- a/sdk/src/proof-validation.ts
+++ b/sdk/src/proof-validation.ts
@@ -25,6 +25,8 @@ const JOURNAL_CONSTRAINT_OFFSET = 64;
 const JOURNAL_COMMITMENT_OFFSET = 96;
 const JOURNAL_BINDING_OFFSET = 128;
 const JOURNAL_NULLIFIER_OFFSET = 160;
+const JOURNAL_MODEL_COMMITMENT_OFFSET = 192;
+const JOURNAL_INPUT_COMMITMENT_OFFSET = 224;
 
 interface ParsedPrivateJournal {
   taskPda: Uint8Array;
@@ -33,6 +35,8 @@ interface ParsedPrivateJournal {
   outputCommitment: Uint8Array;
   binding: Uint8Array;
   nullifier: Uint8Array;
+  modelCommitment: Uint8Array;
+  inputCommitment: Uint8Array;
 }
 
 /**
@@ -150,6 +154,8 @@ function parsePrivateJournal(journal: Uint8Array): ParsedPrivateJournal {
     outputCommitment: readJournalField(journal, JOURNAL_COMMITMENT_OFFSET),
     binding: readJournalField(journal, JOURNAL_BINDING_OFFSET),
     nullifier: readJournalField(journal, JOURNAL_NULLIFIER_OFFSET),
+    modelCommitment: readJournalField(journal, JOURNAL_MODEL_COMMITMENT_OFFSET),
+    inputCommitment: readJournalField(journal, JOURNAL_INPUT_COMMITMENT_OFFSET),
   };
 }
 

--- a/sdk/src/prover.ts
+++ b/sdk/src/prover.ts
@@ -49,6 +49,8 @@ export interface ProverInput {
   outputCommitment: Uint8Array;
   binding: Uint8Array;
   nullifier: Uint8Array;
+  modelCommitment: Uint8Array;
+  inputCommitment: Uint8Array;
 }
 
 export class ProverError extends Error {
@@ -88,6 +90,8 @@ function validateProverInput(input: ProverInput): void {
   validateInputField("outputCommitment", input.outputCommitment);
   validateInputField("binding", input.binding);
   validateInputField("nullifier", input.nullifier);
+  validateInputField("modelCommitment", input.modelCommitment);
+  validateInputField("inputCommitment", input.inputCommitment);
 }
 
 interface RawProverOutput {
@@ -144,6 +148,8 @@ function buildInputJson(input: ProverInput): string {
     output_commitment: Array.from(input.outputCommitment),
     binding: Array.from(input.binding),
     nullifier: Array.from(input.nullifier),
+    model_commitment: Array.from(input.modelCommitment),
+    input_commitment: Array.from(input.inputCommitment),
   });
 }
 

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -116,7 +116,7 @@ export interface TaskStatus {
 export interface PrivateCompletionPayload {
   /** Borsh-encoded router seal bytes (selector + proof = 260 bytes) */
   sealBytes: Buffer | Uint8Array;
-  /** Fixed private journal bytes (192 bytes) */
+  /** Fixed private journal bytes (256 bytes) */
   journal: Buffer | Uint8Array;
   /** RISC0 image ID (32 bytes) */
   imageId: Buffer | Uint8Array;

--- a/tests/e2e-real-proof.ts
+++ b/tests/e2e-real-proof.ts
@@ -359,7 +359,7 @@ describe("E2E Real RISC Zero Groth16 Proof Verification", function () {
     );
 
     // The completeTaskPrivate transaction exceeds the legacy 1232-byte limit
-    // (seal=260 + journal=192 + 16 accounts). Use V0 tx with Address Lookup Table.
+    // (seal=260 + journal=256 + 16 accounts). Use V0 tx with Address Lookup Table.
 
     // 1. Create Address Lookup Table
     const recentSlot = await provider.connection.getSlot("finalized");

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -712,8 +712,8 @@ export function buildTestSealBytes(): Buffer {
 }
 
 /**
- * Build a 192-byte journal from 6 x 32-byte fields.
- * Field order: taskPda, authority, constraintHash, outputCommitment, binding, nullifier
+ * Build a 256-byte journal from 8 x 32-byte fields.
+ * Field order: taskPda, authority, constraintHash, outputCommitment, binding, nullifier, modelCommitment, inputCommitment
  */
 export function buildTestJournal(fields: {
   taskPda: Buffer | Uint8Array;
@@ -722,6 +722,8 @@ export function buildTestJournal(fields: {
   outputCommitment: Buffer | Uint8Array;
   binding: Buffer | Uint8Array;
   nullifier: Buffer | Uint8Array;
+  modelCommitment?: Buffer | Uint8Array;
+  inputCommitment?: Buffer | Uint8Array;
 }): Buffer {
   return Buffer.concat([
     Buffer.from(fields.taskPda),
@@ -730,6 +732,8 @@ export function buildTestJournal(fields: {
     Buffer.from(fields.outputCommitment),
     Buffer.from(fields.binding),
     Buffer.from(fields.nullifier),
+    Buffer.from(fields.modelCommitment ?? Buffer.alloc(32)),
+    Buffer.from(fields.inputCommitment ?? Buffer.alloc(32)),
   ]);
 }
 

--- a/zkvm/host/src/lib.rs
+++ b/zkvm/host/src/lib.rs
@@ -32,6 +32,8 @@ pub struct ProveRequest {
     pub output_commitment: JournalField,
     pub binding: JournalField,
     pub nullifier: JournalField,
+    pub model_commitment: JournalField,
+    pub input_commitment: JournalField,
 }
 
 impl From<ProveRequest> for JournalFields {
@@ -43,6 +45,8 @@ impl From<ProveRequest> for JournalFields {
             output_commitment: r.output_commitment,
             binding: r.binding,
             nullifier: r.nullifier,
+            model_commitment: r.model_commitment,
+            input_commitment: r.input_commitment,
         }
     }
 }
@@ -124,6 +128,8 @@ pub fn default_prove_request() -> ProveRequest {
         output_commitment: [4_u8; 32],
         binding: [5_u8; 32],
         nullifier: [6_u8; 32],
+        model_commitment: [0_u8; 32],
+        input_commitment: [0_u8; 32],
     }
 }
 
@@ -180,6 +186,8 @@ fn generate_proof_real(request: &ProveRequest) -> Result<ProveResponse, ProveErr
         ("output_commitment", &request.output_commitment),
         ("binding", &request.binding),
         ("nullifier", &request.nullifier),
+        ("model_commitment", &request.model_commitment),
+        ("input_commitment", &request.input_commitment),
     ];
 
     let mut builder = ExecutorEnv::builder();
@@ -469,6 +477,8 @@ mod tests {
         assert_eq!(fields.output_commitment, request.output_commitment);
         assert_eq!(fields.binding, request.binding);
         assert_eq!(fields.nullifier, request.nullifier);
+        assert_eq!(fields.model_commitment, request.model_commitment);
+        assert_eq!(fields.input_commitment, request.input_commitment);
     }
 
     #[test]

--- a/zkvm/host/src/main.rs
+++ b/zkvm/host/src/main.rs
@@ -39,6 +39,8 @@ struct JsonProveRequest {
     output_commitment: Vec<u8>,
     binding: Vec<u8>,
     nullifier: Vec<u8>,
+    model_commitment: Vec<u8>,
+    input_commitment: Vec<u8>,
 }
 
 fn vec_to_field(name: &str, v: Vec<u8>) -> Result<[u8; 32], String> {
@@ -62,6 +64,8 @@ fn parse_request_from_stdin() -> Result<agenc_zkvm_host::ProveRequest, String> {
         output_commitment: vec_to_field("output_commitment", json.output_commitment)?,
         binding: vec_to_field("binding", json.binding)?,
         nullifier: vec_to_field("nullifier", json.nullifier)?,
+        model_commitment: vec_to_field("model_commitment", json.model_commitment)?,
+        input_commitment: vec_to_field("input_commitment", json.input_commitment)?,
     })
 }
 

--- a/zkvm/methods/guest/src/main.rs
+++ b/zkvm/methods/guest/src/main.rs
@@ -13,6 +13,8 @@ fn main() {
     let output_commitment: [u8; JOURNAL_FIELD_LEN] = env::read();
     let binding: [u8; JOURNAL_FIELD_LEN] = env::read();
     let nullifier: [u8; JOURNAL_FIELD_LEN] = env::read();
+    let model_commitment: [u8; JOURNAL_FIELD_LEN] = env::read();
+    let input_commitment: [u8; JOURNAL_FIELD_LEN] = env::read();
 
     // Match on-chain non-zero requirements (complete_task_private.rs)
     let zero = [0u8; JOURNAL_FIELD_LEN];
@@ -27,6 +29,8 @@ fn main() {
         output_commitment,
         binding,
         nullifier,
+        model_commitment,
+        input_commitment,
     };
     env::commit_slice(&serialize_journal(&fields));
 }


### PR DESCRIPTION
## Summary

  - Extends the RISC Zero zkVM journal schema from 6 to 8 fixed 32-byte fields by adding
  `model_commitment` and `input_commitment`
  - Updates the journal byte length constant from 192 to 256 across the zkVM guest/host, SDK, and
  runtime
  - Wires the two new fields end-to-end: `JournalFields` struct, `ProveRequest`, `ProverInput`,
  `buildJournalBytes`, and the JSON input builder for the prover

  ## Changes

  - **zkvm/guest**: added `model_commitment` and `input_commitment` to `JournalFields`,
  `serialize_journal_from_slices`, and all related tests
  - **zkvm/host**: added fields to `ProveRequest`, `From<ProveRequest>` impl, `default_prove_request`,
  and `generate_proof_real`
  - **sdk**: updated `RISC0_JOURNAL_LEN` (192 → 256), `JOURNAL_FIELDS` (6 → 8), `ProverInput` interface,
   input validation, JSON builder, and `buildJournalBytes` (new fields are optional, defaulting to
  zero-filled buffers for backwards compatibility)
  - **runtime/program/tests**: updated all call sites and test fixtures to pass the two new fields

  ## Test plan

  - [ ] `cargo test` passes in `zkvm/guest` and `zkvm/host`
  - [ ] `yarn test` passes in `sdk` and `runtime`
  - [ ] Journal byte layout assertions confirm fields at offsets 192–224 and 224–256
  - [ ] End-to-end proof generation succeeds with zeroed `model_commitment` / `input_commitment`
  
Closes #1284