### PR TITLE
feat(runtime,web): token usage UI, voice context/memory, chat executor streaming

### DIFF
--- a/containers/desktop/Dockerfile
+++ b/containers/desktop/Dockerfile
@@ -44,18 +44,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bash-completion locales software-properties-common \
     && locale-gen en_US.UTF-8 \
     # =========================================================================
-    # Firefox (Mozilla PPA — snap doesn't work in Docker)
+    # Playwright MCP uses its own bundled Chromium (installed below).
+    # No need for standalone Firefox or Chromium packages.
     # =========================================================================
-    && add-apt-repository -y ppa:mozillateam/ppa \
-    && printf 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001\n' > /etc/apt/preferences.d/mozilla-firefox \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends firefox \
-    # =========================================================================
-    # Chromium (chromium-team PPA — snap doesn't work in Docker)
-    # =========================================================================
-    && add-apt-repository -y ppa:saiarcot895/chromium-beta \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends chromium-browser \
+    \
     # =========================================================================
     # Node.js 20 LTS
     # =========================================================================
@@ -105,16 +97,6 @@ COPY xfce-config/xfce4-panel.xml /home/agenc/.config/xfce4/xfconf/xfce-perchanne
 
 # Terminal config (dark theme, JetBrains Mono, Tokyo Night palette)
 COPY xfce-config/xfce4-terminal/ /home/agenc/.config/xfce4/terminal/
-
-# =============================================================================
-# Chromium defaults (no first-run, no crash report, dark mode)
-# =============================================================================
-RUN mkdir -p /home/agenc/.config/chromium/Default \
-    && echo '{ "browser": { "has_seen_welcome_page": true, "check_default_browser": false }, "distribution": { "skip_first_run_ui": true, "suppress_first_run_default_browser_prompt": true } }' > /home/agenc/.config/chromium/Default/Preferences \
-    && echo 'CHROMIUM_FLAGS="--no-first-run --disable-sync --disable-background-networking --no-default-browser-check"' > /home/agenc/.chromium-browser.init \
-    # Firefox: disable first-run wizard and telemetry
-    && mkdir -p /usr/lib/firefox/distribution \
-    && echo '{"policies":{"DontCheckDefaultBrowser":true,"OverrideFirstRunPage":"","OverridePostUpdatePage":"","DisableTelemetry":true,"Preferences":{"datareporting.policy.dataSubmissionEnabled":{"Value":false},"browser.shell.checkDefaultBrowser":{"Value":false},"toolkit.telemetry.reportingpolicy.firstRun":{"Value":false},"browser.aboutwelcome.enabled":{"Value":false}}}}' > /usr/lib/firefox/distribution/policies.json
 
 # =============================================================================
 # Shell configuration (nice prompt, aliases)

--- a/containers/desktop/xfce-config/xfce4-panel.xml
+++ b/containers/desktop/xfce-config/xfce4-panel.xml
@@ -23,8 +23,6 @@
         <value type="int" value="2"/>
         <value type="int" value="3"/>
         <value type="int" value="4"/>
-        <value type="int" value="5"/>
-        <value type="int" value="6"/>
         <value type="int" value="7"/>
         <value type="int" value="8"/>
         <value type="int" value="9"/>
@@ -53,18 +51,6 @@
     <property name="plugin-4" type="string" value="launcher">
       <property name="items" type="array">
         <value type="string" value="thunar.desktop"/>
-      </property>
-    </property>
-    <!-- Launcher: Firefox -->
-    <property name="plugin-5" type="string" value="launcher">
-      <property name="items" type="array">
-        <value type="string" value="firefox.desktop"/>
-      </property>
-    </property>
-    <!-- Launcher: Chromium -->
-    <property name="plugin-6" type="string" value="launcher">
-      <property name="items" type="array">
-        <value type="string" value="chromium-browser.desktop"/>
       </property>
     </property>
     <!-- Expanding separator (pushes clock right) -->

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -297,9 +297,12 @@ export class WebChatChannel
     }
 
     switch (type) {
-      case "voice.start":
-        void bridge.startSession(clientId, send);
+      case "voice.start": {
+        // Pass the client's current sessionId so voice and text share history
+        const voiceSessionId = this.clientSessions.get(clientId);
+        void bridge.startSession(clientId, send, voiceSessionId);
         break;
+      }
       case "voice.audio": {
         const audio = payload?.audio;
         if (typeof audio === "string") {

--- a/runtime/src/desktop/session-router.test.ts
+++ b/runtime/src/desktop/session-router.test.ts
@@ -227,7 +227,7 @@ describe("createDesktopAwareToolHandler", () => {
       expect(parsed._screenshot).toBeUndefined();
     });
 
-    it("skips for bash commands (not a GUI action)", async () => {
+    it("captures screenshot after bash commands with longer delay", async () => {
       const manager = mockManager();
       const handler = createDesktopAwareToolHandler(baseHandler, "sess1", {
         desktopManager: manager,
@@ -235,10 +235,15 @@ describe("createDesktopAwareToolHandler", () => {
         autoScreenshot: true,
       });
 
+      const start = Date.now();
       const result = await handler("desktop.bash", { command: "ls" });
+      const elapsed = Date.now() - start;
       const parsed = JSON.parse(result);
       expect(parsed.stdout).toBe("hello");
-      expect(parsed._screenshot).toBeUndefined();
+      expect(parsed._screenshot).toBeDefined();
+      expect(parsed._screenshot.dataUrl).toBe("data:image/png;base64,abc");
+      // Bash uses a longer delay (1500ms) than regular action tools (300ms)
+      expect(elapsed).toBeGreaterThanOrEqual(1400);
     });
 
     it("disabled by default", async () => {

--- a/runtime/src/desktop/session-router.ts
+++ b/runtime/src/desktop/session-router.ts
@@ -30,9 +30,12 @@ const DESKTOP_ACTION_TOOLS = new Set([
   "keyboard_type",
   "keyboard_key",
   "window_focus",
+  "bash",
 ]);
 
 const AUTO_SCREENSHOT_DELAY_MS = 300;
+/** GUI apps launched via bash need more time to render. */
+const BASH_SCREENSHOT_DELAY_MS = 1500;
 
 // ============================================================================
 // Desktop tool definitions (static — same across all containers)
@@ -159,7 +162,10 @@ export function createDesktopAwareToolHandler(
     // Auto-capture screenshot after action tools so the LLM can see the result
     if (autoScreenshot && DESKTOP_ACTION_TOOLS.has(toolName)) {
       try {
-        await new Promise((r) => setTimeout(r, AUTO_SCREENSHOT_DELAY_MS));
+        const delay = toolName === "bash"
+          ? BASH_SCREENSHOT_DELAY_MS
+          : AUTO_SCREENSHOT_DELAY_MS;
+        await new Promise((r) => setTimeout(r, delay));
         const screenshotTool = bridge.getTools().find((t) => t.name === "desktop.screenshot");
         if (screenshotTool) {
           const screenshot: ToolResult = await screenshotTool.execute({});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -248,6 +248,7 @@ export default function App() {
                 desktopUrl={sessionDesktopUrl}
                 desktopOpen={desktopPanelOpen}
                 onToggleDesktop={toggleDesktopPanel}
+                tokenUsage={chat.tokenUsage}
               />
             )}
             {currentView === 'status' && (

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ChatMessage, VoiceState, VoiceMode } from '../../types';
+import type { ChatMessage, TokenUsage, VoiceState, VoiceMode } from '../../types';
 
 const APP_DISPLAY_NAME = 'AgenC';
 import type { ChatSessionInfo } from '../../hooks/useChat';
@@ -31,6 +31,7 @@ interface ChatViewProps {
   desktopUrl?: string | null;
   desktopOpen?: boolean;
   onToggleDesktop?: () => void;
+  tokenUsage?: TokenUsage | null;
 }
 
 export function ChatView({
@@ -56,6 +57,7 @@ export function ChatView({
   desktopUrl,
   desktopOpen = false,
   onToggleDesktop,
+  tokenUsage,
 }: ChatViewProps) {
   const isDark = theme === 'dark';
   const [searchOpen, setSearchOpen] = useState(false);
@@ -189,6 +191,21 @@ export function ChatView({
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           </button>
+          {tokenUsage && tokenUsage.budget > 0 && (
+            <div
+              className={`px-2 py-0.5 rounded-full text-xs font-mono tabular-nums ${
+                tokenUsage.totalTokens / tokenUsage.budget > 0.85
+                  ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                  : tokenUsage.totalTokens / tokenUsage.budget > 0.6
+                    ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+                    : 'bg-tetsuo-100 text-tetsuo-500 dark:bg-tetsuo-800 dark:text-tetsuo-400'
+              }`}
+              title={`${tokenUsage.totalTokens.toLocaleString()} / ${tokenUsage.budget.toLocaleString()} tokens${tokenUsage.compacted ? ' (auto-compacted)' : ''}`}
+            >
+              {Math.round((tokenUsage.totalTokens / tokenUsage.budget) * 100)}%
+              {tokenUsage.compacted && ' ~'}
+            </div>
+          )}
           <button className="ml-2 flex items-center gap-2 px-4 py-2 rounded-lg border border-tetsuo-200 text-sm font-medium text-tetsuo-700 hover:bg-tetsuo-50 transition-colors">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             Download App

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -18,6 +18,7 @@ export const WS_CHAT_SESSIONS = 'chat.sessions' as const;
 export const WS_CHAT_CANCELLED = 'chat.cancelled' as const;
 export const WS_CHAT_CANCEL = 'chat.cancel' as const;
 export const WS_CHAT_RESUME = 'chat.resume' as const;
+export const WS_CHAT_USAGE = 'chat.usage' as const;
 
 // Tools
 export const WS_TOOLS_EXECUTING = 'tools.executing' as const;

--- a/web/src/hooks/useVoice.ts
+++ b/web/src/hooks/useVoice.ts
@@ -16,6 +16,7 @@ import {
   WS_VOICE_DELEGATION,
   WS_VOICE_STATE,
   WS_VOICE_ERROR,
+  WS_TOOLS_EXECUTING,
 } from '../constants';
 
 interface UseVoiceOptions {
@@ -154,19 +155,13 @@ export function useVoice({ send, onDelegationResult }: UseVoiceOptions) {
             setDelegationTask((payload.task as string) ?? '');
             setTranscript('');
             break;
-          case 'progress': {
-            const content = payload.content as string;
-            if (content) {
-              setTranscript(content);
-            }
-            break;
-          }
           case 'completed': {
             const task = (payload.task as string) ?? '';
             const content = (payload.content as string) ?? '';
             // Inject result into chat panel
             onDelegationResult?.(task, content);
-            // Transition back — xAI will speak a summary, triggering 'speaking'
+            setTranscript('');
+            // Transition back — xAI will speak a short summary
             setVoiceState('processing');
             setDelegationTask('');
             break;
@@ -177,6 +172,15 @@ export function useVoice({ send, onDelegationResult }: UseVoiceOptions) {
             setVoiceState('listening');
             setDelegationTask('');
             break;
+        }
+        break;
+      }
+
+      // During delegation, show tool names in the voice overlay bar
+      case WS_TOOLS_EXECUTING: {
+        if (voiceState === 'delegating') {
+          const toolName = (payload.toolName as string) ?? '';
+          setTranscript(toolName);
         }
         break;
       }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -33,6 +33,15 @@ export interface ChatMessage {
   attachments?: ChatMessageAttachment[];
 }
 
+export interface TokenUsage {
+  /** Cumulative tokens used this session. */
+  totalTokens: number;
+  /** Session token budget. */
+  budget: number;
+  /** Whether context was auto-compacted this round. */
+  compacted?: boolean;
+}
+
 export interface ToolCall {
   toolName: string;
   args: Record<string, unknown>;
@@ -172,7 +181,7 @@ export interface WSMessage {
 // Keep in sync with runtime/src/channels/webchat/types.ts voice protocol types
 // ============================================================================
 
-export type VoiceState = 'inactive' | 'connecting' | 'listening' | 'speaking' | 'processing';
+export type VoiceState = 'inactive' | 'connecting' | 'listening' | 'speaking' | 'processing' | 'delegating';
 
 export type VoiceMode = 'vad' | 'push-to-talk';
 


### PR DESCRIPTION
## Summary

- **Token usage UI**: Add token pill to web ChatView and VoiceOverlay showing cumulative session token usage with budget indicator
- **Voice context restoration**: Inject conversation history into xAI Realtime sessions on reconnect via `conversation.item.create` with `type: "message"` items — prevents context loss when stopping/restarting voice
- **Session ID mismatch fix**: `recordTranscript()` and `persistDelegationResult()` now use `managedSessionId` (the derived hash from `SessionManager.getOrCreate`) instead of `effectiveSessionId` — fixes silent transcript recording failure where `appendMessage` never found the session
- **Voice memory injection**: Query `MemoryBackend.getThread()` for recent entries and append to voice instructions for cross-session awareness
- **xAI arg sanitization**: `sanitizeXaiArgs()` normalizes Python-style `"None"`, `"null"`, and empty strings to `"{}"` before `JSON.parse`
- **Phantom tool guard**: Unknown tool names from xAI hallucinations return a JSON error instead of crashing
- **Legacy voice mode removal**: Delete dead code (`handleLegacyToolCall`, `convertTools`, `VOICE_CONCISENESS_PROMPT`, `delegationEnabled` getter, `tools` config field) — `chatExecutor` is now required
- **ChatExecutor streaming and token tracking improvements**
- **Desktop container and session router updates**
- **Whitepaper speculative execution updates**

## Test plan

- [x] `npx tsc --noEmit` — clean typecheck
- [x] `npx vitest run` — all 4950 tests pass (234 files)
- [ ] Manual: start voice → talk → stop voice → start voice again → model remembers prior conversation
- [ ] Manual: voice delegation → no "None" JSON errors in logs
- [ ] Manual: token pill updates after delegation in both chat and voice views