### PR TITLE
fix(runtime,web,mcp): voice pipeline hardening, web test suite, MCP replay safety

### DIFF
--- a/mcp/tests/fixtures/golden/mcp-replay-backfill-error-slot-window.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-backfill-error-slot-window.json
@@ -25,7 +25,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:13:59.196Z",
+    "generatedAt": "2026-02-28T06:38:16.776Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/mcp/tests/fixtures/golden/mcp-replay-backfill-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-backfill-success.json
@@ -40,7 +40,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:13:59.195Z",
+    "generatedAt": "2026-02-28T06:38:16.775Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/mcp/tests/fixtures/golden/mcp-replay-compare-empty-store.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-compare-empty-store.json
@@ -66,7 +66,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:20:55.076Z",
+    "generatedAt": "2026-02-28T06:38:16.783Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/mcp/tests/fixtures/golden/mcp-replay-compare-failure-invalid-trace.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-compare-failure-invalid-trace.json
@@ -19,7 +19,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:20:55.076Z",
+    "generatedAt": "2026-02-28T06:38:16.783Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/mcp/tests/fixtures/golden/mcp-replay-compare-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-compare-success.json
@@ -25,17 +25,17 @@
         "mismatch_count": 7,
         "match_rate": 0,
         "anomaly_ids": [
-          "0432da73d04ecdd1",
-          "b6961ff1271e0c48",
-          "986e74b6a2765550",
-          "6c220700b73fad63",
-          "0f3700ab7e6a3bcc",
-          "81b465c6012f2ac2",
-          "2de5e4cbd3ca0d2e"
+          "33f8f2cbf33484ff",
+          "0d17f75e98f59abf",
+          "bdd2bf347d184d56",
+          "c15375b25487482b",
+          "8161b2be10a8d23e",
+          "07b7ffcaed563553",
+          "dc8cbbfd265715d6"
         ],
         "top_anomalies": [
           {
-            "anomaly_id": "0432da73d04ecdd1",
+            "anomaly_id": "33f8f2cbf33484ff",
             "code": "hash_mismatch",
             "severity": "error",
             "message": "projected event hash mismatch",
@@ -44,7 +44,7 @@
             "seq": 1
           },
           {
-            "anomaly_id": "b6961ff1271e0c48",
+            "anomaly_id": "0d17f75e98f59abf",
             "code": "task_id_mismatch",
             "severity": "warning",
             "message": "signature mismatch at seq=1",
@@ -53,7 +53,7 @@
             "seq": 1
           },
           {
-            "anomaly_id": "986e74b6a2765550",
+            "anomaly_id": "bdd2bf347d184d56",
             "code": "hash_mismatch",
             "severity": "error",
             "message": "projected event hash mismatch",
@@ -62,7 +62,7 @@
             "seq": 2
           },
           {
-            "anomaly_id": "6c220700b73fad63",
+            "anomaly_id": "c15375b25487482b",
             "code": "task_id_mismatch",
             "severity": "warning",
             "message": "signature mismatch at seq=2",
@@ -71,7 +71,7 @@
             "seq": 2
           },
           {
-            "anomaly_id": "0f3700ab7e6a3bcc",
+            "anomaly_id": "8161b2be10a8d23e",
             "code": "hash_mismatch",
             "severity": "error",
             "message": "projected event hash mismatch",
@@ -80,7 +80,7 @@
             "seq": 3
           },
           {
-            "anomaly_id": "81b465c6012f2ac2",
+            "anomaly_id": "07b7ffcaed563553",
             "code": "task_id_mismatch",
             "severity": "warning",
             "message": "signature mismatch at seq=3",
@@ -89,7 +89,7 @@
             "seq": 3
           },
           {
-            "anomaly_id": "30366d07cde6ba9d",
+            "anomaly_id": "cfa9f3d1de92b439",
             "code": "hash_mismatch",
             "severity": "error",
             "message": "deterministic replay hash mismatch"
@@ -138,7 +138,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:20:55.075Z",
+    "generatedAt": "2026-02-28T06:38:16.782Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/mcp/tests/fixtures/golden/mcp-replay-incident-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-incident-success.json
@@ -61,7 +61,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:13:59.203Z",
+    "generatedAt": "2026-02-28T06:38:16.784Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/mcp/tests/fixtures/golden/mcp-replay-incident-truncated.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-incident-truncated.json
@@ -62,7 +62,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:13:59.203Z",
+    "generatedAt": "2026-02-28T06:38:16.785Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/mcp/tests/fixtures/golden/mcp-replay-status-success.json
+++ b/mcp/tests/fixtures/golden/mcp-replay-status-success.json
@@ -26,7 +26,7 @@
     }
   },
   "metadata": {
-    "generatedAt": "2026-02-14T20:13:59.204Z",
+    "generatedAt": "2026-02-28T06:38:16.785Z",
     "generatedBy": "contract-validator"
   }
 }

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -299,7 +299,7 @@ export class WebChatChannel
     switch (type) {
       case "voice.start": {
         // Pass the client's current sessionId so voice and text share history
-        const voiceSessionId = this.clientSessions.get(clientId);
+        const voiceSessionId = this.ensureSession(clientId);
         void bridge.startSession(clientId, send, voiceSessionId);
         break;
       }

--- a/runtime/src/channels/webchat/types.ts
+++ b/runtime/src/channels/webchat/types.ts
@@ -211,12 +211,14 @@ export interface ChatResumedResponse {
 export interface ToolExecutingResponse {
   type: "tools.executing";
   toolName: string;
+  toolCallId?: string;
   args: Record<string, unknown>;
 }
 
 export interface ToolResultResponse {
   type: "tools.result";
   toolName: string;
+  toolCallId?: string;
   result: string;
   durationMs: number;
   isError?: boolean;

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ControlResponse } from "./types.js";
+import type { ApprovalEngine } from "./approvals.js";
+import { createSessionToolHandler } from "./tool-handler-factory.js";
+
+describe("createSessionToolHandler", () => {
+  it("reuses a single toolCallId for tool start/result and callbacks", async () => {
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+
+    const onToolStart = vi.fn();
+    const onToolEnd = vi.fn();
+
+    const baseHandler = vi.fn(async () => "result-value");
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler,
+      routerId: "router-a",
+      send,
+      onToolStart,
+      onToolEnd,
+    });
+
+    const result = await handler("system.health", { check: true });
+
+    const executing = sentMessages.find((msg) => msg.type === "tools.executing");
+    const toolResult = sentMessages.find((msg) => msg.type === "tools.result");
+
+    expect(result).toBe("result-value");
+    expect(baseHandler).toHaveBeenCalledWith("system.health", { check: true });
+    expect(executing).toBeDefined();
+    expect(toolResult).toBeDefined();
+
+    const toolCallId = (executing!.payload as { toolCallId?: string }).toolCallId;
+    const resultToolCallId = (toolResult!.payload as { toolCallId?: string }).toolCallId;
+
+    expect(toolCallId).toBeDefined();
+    expect(toolCallId).toBe(resultToolCallId);
+    expect(onToolStart).toHaveBeenCalledWith("system.health", { check: true }, toolCallId);
+    expect(onToolEnd).toHaveBeenCalledWith(
+      "system.health",
+      "result-value",
+      expect.any(Number),
+      toolCallId,
+    );
+  });
+
+  it("reuses toolCallId when approval is denied and tool does not execute", async () => {
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+
+    const onToolStart = vi.fn();
+    const onToolEnd = vi.fn();
+
+    const baseHandler = vi.fn();
+    const approvalEngine = {
+      requiresApproval: vi.fn().mockReturnValue({
+        description: "Requires explicit approval",
+      }),
+      isToolElevated: vi.fn().mockReturnValue(false),
+      createRequest: vi.fn((toolName: string, args: Record<string, unknown>) => ({
+        id: "approval-1",
+        toolName,
+        args,
+        sessionId: "session-1",
+        message: "Requires explicit approval",
+        createdAt: 1_700_000_000_000,
+        rule: { tool: "system.delete" },
+      })),
+      requestApproval: vi.fn().mockResolvedValue({
+        requestId: "approval-1",
+        disposition: "no",
+      }),
+    } as unknown as ApprovalEngine;
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler,
+      routerId: "router-a",
+      send,
+      approvalEngine,
+      onToolStart,
+      onToolEnd,
+    });
+
+    const result = await handler("system.delete", { target: "/tmp/file" });
+
+    const executing = sentMessages.find((msg) => msg.type === "tools.executing");
+    const approvalRequest = sentMessages.find((msg) => msg.type === "approval.request");
+    const toolResult = sentMessages.find((msg) => msg.type === "tools.result");
+
+    const expectedError = JSON.stringify({
+      error: 'Tool "system.delete" denied by user',
+    });
+
+    expect(result).toBe(expectedError);
+    expect(baseHandler).not.toHaveBeenCalled();
+    expect(executing).toBeDefined();
+    expect(approvalRequest).toBeDefined();
+    expect(toolResult).toBeDefined();
+
+    const toolCallId = (executing!.payload as { toolCallId?: string }).toolCallId;
+    const resultToolCallId = (toolResult!.payload as { toolCallId?: string }).toolCallId;
+    expect(resultToolCallId).toBe(toolCallId);
+    expect(onToolStart).toHaveBeenCalledWith("system.delete", { target: "/tmp/file" }, toolCallId);
+    expect(onToolEnd).toHaveBeenCalledWith(
+      "system.delete",
+      expectedError,
+      0,
+      toolCallId,
+    );
+  });
+
+  it("generates a unique toolCallId for each separate invocation", async () => {
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler: vi.fn(async () => "ok"),
+      routerId: "router-a",
+      send,
+    });
+
+    await handler("system.health", { check: "first" });
+    await handler("system.health", { check: "second" });
+
+    const toolCallIds = sentMessages
+      .filter((msg) => msg.type === "tools.executing")
+      .map((msg) => (msg.payload as { toolCallId?: string }).toolCallId);
+
+    expect(toolCallIds).toHaveLength(2);
+    expect(toolCallIds[0]).toBeDefined();
+    expect(toolCallIds[1]).toBeDefined();
+    expect(toolCallIds[0]).not.toBe(toolCallIds[1]);
+  });
+});

--- a/runtime/src/skills/registry/payment.ts
+++ b/runtime/src/skills/registry/payment.ts
@@ -12,7 +12,10 @@ import {
   getAssociatedTokenAddressSync,
   TOKEN_PROGRAM_ID,
 } from "@solana/spl-token";
-import { type Program, BN } from "@coral-xyz/anchor";
+import * as anchor from "@coral-xyz/anchor";
+import type { Program } from "@coral-xyz/anchor";
+
+const { BN } = anchor;
 import type { AgencCoordination } from "../../types/agenc_coordination.js";
 import type { Logger } from "../../utils/logger.js";
 import { silentLogger } from "../../utils/logger.js";

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -15,15 +20,19 @@
     "react-syntax-highlighter": "^15.6.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.2.0",
     "autoprefixer": "^10.4.16",
+    "jsdom": "^28.1.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0",
     "vite": "^5.0.0",
+    "vitest": "^4.0.18",
     "ws": "^8.19.0"
   }
 }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,41 @@
+import { defineConfig } from '@playwright/test';
+
+const port = 5173;
+const wsPort = Number(process.env.WEBCHAT_WS_PORT ?? 3600);
+const webPort = Number(process.env.WEBCHAT_WEB_PORT ?? port);
+const wsUrl = `ws://127.0.0.1:${wsPort}`;
+process.env.WEBCHAT_WS_URL = wsUrl;
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  use: {
+    baseURL: `http://127.0.0.1:${webPort}`,
+    trace: 'on-first-retry',
+  },
+  expect: {
+    timeout: 10_000,
+  },
+  webServer: [
+    {
+      command: `WEBCHAT_WS_PORT=${wsPort} node test-server.mjs`,
+      port: wsPort,
+      reuseExistingServer: true,
+      timeout: 120_000,
+    },
+    {
+      command: `VITE_WEBCHAT_WS_URL=${wsUrl} npm run dev -- --host 127.0.0.1 --port ${webPort}`,
+      port: webPort,
+      reuseExistingServer: true,
+      timeout: 120_000,
+    },
+  ],
+  projects: [
+    {
+      name: 'chromium',
+      use: {},
+    },
+  ],
+});

--- a/web/src/App.integration.test.tsx
+++ b/web/src/App.integration.test.tsx
@@ -1,0 +1,158 @@
+import { act, render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WSMessage } from './types';
+import App from './App';
+
+let capturedOnMessage: ((msg: WSMessage) => void) | null = null;
+let chatMessages: MockChatViewMessage[] = [];
+let chatIsTyping = false;
+
+interface MockChatViewMessage {
+  id: string;
+  sender: 'user' | 'agent';
+  content: string;
+  toolCalls?: Array<{ toolName: string; status: 'executing' | 'completed'; toolCallId?: string; result?: string }>;
+}
+
+vi.mock('./hooks/useWebSocket', () => ({
+  useWebSocket: ({ onMessage }: { onMessage?: (msg: WSMessage) => void }) => {
+    capturedOnMessage = onMessage ?? null;
+    return {
+      state: 'connected',
+      send: () => {},
+      lastMessage: null,
+    };
+  },
+}));
+
+vi.mock('./hooks/useVoice', () => ({
+  useVoice: () => ({
+    isVoiceActive: false,
+    isRecording: false,
+    isSpeaking: false,
+    voiceState: 'inactive',
+    transcript: '',
+    delegationTask: '',
+    startVoice: () => {},
+    stopVoice: () => {},
+    mode: 'vad',
+    setMode: () => {},
+    pushToTalkStart: () => {},
+    pushToTalkStop: () => {},
+    handleMessage: () => {},
+  }),
+}));
+
+vi.mock('./components/chat/ChatView', () => ({
+  ChatView: ({ messages, isTyping }: { messages: MockChatViewMessage[]; isTyping: boolean }) => {
+    chatMessages = messages;
+    chatIsTyping = isTyping;
+    return (
+      <div>
+        <div data-testid="chat-messages">{JSON.stringify(messages)}</div>
+      </div>
+    );
+  },
+}));
+
+beforeEach(() => {
+  capturedOnMessage = null;
+  chatMessages = [];
+  chatIsTyping = false;
+});
+
+describe('App websocket integration', () => {
+  it('routes tool call updates to the chat stream by toolCallId', () => {
+    render(<App />);
+
+    expect(capturedOnMessage).toBeTypeOf('function');
+
+    act(() => {
+      capturedOnMessage!({
+        type: 'tools.executing',
+        payload: {
+          toolName: 'system.task',
+          toolCallId: 'tool-b',
+          args: { round: 'b' },
+        },
+      });
+      capturedOnMessage!({
+        type: 'tools.executing',
+        payload: {
+          toolName: 'system.task',
+          toolCallId: 'tool-a',
+          args: { round: 'a' },
+        },
+      });
+      capturedOnMessage!({
+        type: 'tools.result',
+        payload: {
+          toolName: 'system.task',
+          toolCallId: 'tool-a',
+          result: 'result-a',
+          durationMs: 11,
+        },
+      });
+      capturedOnMessage!({
+        type: 'tools.result',
+        payload: {
+          toolName: 'system.task',
+          toolCallId: 'tool-b',
+          result: 'result-b',
+          durationMs: 22,
+        },
+      });
+    });
+
+    expect(chatMessages).toHaveLength(1);
+    const toolCalls = chatMessages[0]?.toolCalls ?? [];
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0]).toMatchObject({
+      toolName: 'system.task',
+      toolCallId: 'tool-b',
+      status: 'completed',
+      result: 'result-b',
+    });
+    expect(toolCalls[1]).toMatchObject({
+      toolName: 'system.task',
+      toolCallId: 'tool-a',
+      status: 'completed',
+      result: 'result-a',
+    });
+  });
+
+  it('bridges voice transcripts to chat and suppresses delegated completion text', () => {
+    render(<App />);
+
+    act(() => {
+      capturedOnMessage!({ type: 'voice.speech_stopped' });
+    });
+
+    expect(chatMessages).toHaveLength(1);
+    expect(chatMessages[0]?.content).toBe('[Voice]');
+
+    act(() => {
+      capturedOnMessage!({ type: 'voice.user_transcript', payload: { text: 'live user text' } });
+    });
+
+    expect(chatMessages[0]?.content).toBe('live user text');
+
+    act(() => {
+      capturedOnMessage!({ type: 'voice.transcript', payload: { done: true, text: 'agent response' } });
+    });
+
+    expect(chatMessages).toHaveLength(2);
+    expect(chatMessages[1]?.content).toBe('agent response');
+    expect(chatIsTyping).toBe(false);
+
+    act(() => {
+      capturedOnMessage!({ type: 'voice.delegation', payload: { status: 'completed' } });
+      capturedOnMessage!({ type: 'voice.transcript', payload: { done: true, text: 'delegated response should suppress' } });
+    });
+
+    expect(chatMessages).toHaveLength(2);
+    expect(
+      chatMessages.some((m) => m.content === 'delegated response should suppress'),
+    ).toBe(false);
+  });
+});

--- a/web/src/components/chat/ChatInput.test.tsx
+++ b/web/src/components/chat/ChatInput.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ChatInput } from './ChatInput';
+
+describe('ChatInput', () => {
+  it('sends text messages and clears input', () => {
+    const onSend = vi.fn();
+    const { container } = render(<ChatInput onSend={onSend} />);
+
+    const input = container.querySelector(
+      'textarea[placeholder="Message to AgenC..."]',
+    ) as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'hello from tests' } });
+
+    const sendButton = input.closest('div')?.parentElement?.querySelector(
+      'button[title="Send message"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(sendButton);
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith('hello from tests', undefined);
+    expect((input as HTMLTextAreaElement).value).toBe('');
+  });
+
+  it('sends on Enter without shift and ignores shift+Enter submit path', () => {
+    const onSend = vi.fn();
+    const { container } = render(<ChatInput onSend={onSend} />);
+
+    const input = container.querySelector(
+      'textarea[placeholder="Message to AgenC..."]',
+    ) as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'line one' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', shiftKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', shiftKey: false });
+    expect(onSend).toHaveBeenCalledWith('line one', undefined);
+  });
+
+  it('attaches files and sends them with the message', async () => {
+    const onSend = vi.fn();
+    const { container } = render(<ChatInput onSend={onSend} />);
+
+    const input = container.querySelector(
+      'textarea[placeholder="Message to AgenC..."]',
+    ) as HTMLTextAreaElement;
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    const files = [
+      new File(['alpha'], 'alpha.txt', { type: 'text/plain' }),
+      new File(['beta'], 'beta.txt', { type: 'text/plain' }),
+    ];
+
+    fireEvent.change(fileInput, { target: { files } });
+    fireEvent.change(input, { target: { value: 'with files' } });
+
+    const sendButton = input.closest('div')?.parentElement?.querySelector(
+      'button[title="Send message"]',
+    ) as HTMLButtonElement;
+    fireEvent.click(sendButton);
+
+    expect(onSend).toHaveBeenCalledTimes(1);
+    const [content, attachments] = onSend.mock.calls[0];
+    expect(content).toBe('with files');
+    expect(Array.isArray(attachments)).toBe(true);
+    expect(attachments).toHaveLength(2);
+  });
+});

--- a/web/src/components/chat/ChatMessage.test.tsx
+++ b/web/src/components/chat/ChatMessage.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ChatMessage } from './ChatMessage';
+import type { ChatMessage as ChatMessageType } from '../../types';
+
+describe('ChatMessage', () => {
+  it('renders markdown content for agent messages', () => {
+    const message: ChatMessageType = {
+      id: '1',
+      sender: 'agent',
+      content: '# Hello\n\nThis is **bold** markdown.',
+      timestamp: Date.now(),
+    };
+
+    render(<ChatMessage message={message} />);
+    expect(screen.getAllByRole('img', { name: 'AgenC' }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('heading', { name: 'Hello' })).toBeDefined();
+    expect(screen.getByText(/bold/i)).toBeDefined();
+  });
+
+  it('renders attached tool calls with execution status', () => {
+    const message: ChatMessageType = {
+      id: '2',
+      sender: 'agent',
+      content: 'Running a tool',
+      timestamp: Date.now(),
+      toolCalls: [
+        {
+          toolName: 'agenc.listTasks',
+          status: 'executing',
+          args: { page: 1 },
+        },
+      ],
+    };
+
+    render(<ChatMessage message={message} />);
+
+    expect(screen.getByText('1 tool call', { exact: false })).toBeDefined();
+    const toolCallButton = screen.getByRole('button', { name: /tool call/i });
+    fireEvent.click(toolCallButton);
+    expect(screen.getByText('agenc.listTasks')).toBeDefined();
+  });
+});

--- a/web/src/components/chat/MessageList.test.tsx
+++ b/web/src/components/chat/MessageList.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MessageList } from './MessageList';
+import type { ChatMessage } from '../../types';
+
+describe('MessageList', () => {
+  it('shows empty state when there are no messages', () => {
+    render(<MessageList messages={[]} isTyping={false} />);
+
+    expect(screen.getByText('Send a message to start the conversation')).toBeDefined();
+  });
+
+  it('shows filtering message when query misses all messages', () => {
+    const messages: ChatMessage[] = [
+      { id: '1', sender: 'user', content: 'first message', timestamp: 1 },
+      { id: '2', sender: 'agent', content: 'second message', timestamp: 2 },
+    ];
+
+    render(<MessageList messages={messages} isTyping={false} searchQuery="non-match" />);
+
+    expect(screen.getByText('No messages match "non-match"')).toBeDefined();
+  });
+
+  it('filters messages by query text', () => {
+    const messages: ChatMessage[] = [
+      { id: '1', sender: 'user', content: 'alpha', timestamp: 1 },
+      { id: '2', sender: 'agent', content: 'beta', timestamp: 2 },
+    ];
+
+    render(<MessageList messages={messages} isTyping={false} searchQuery="beta" />);
+
+    expect(screen.getByText('beta')).toBeDefined();
+    expect(screen.queryByText('alpha')).toBeNull();
+  });
+});

--- a/web/src/components/chat/ToolCallCard.test.tsx
+++ b/web/src/components/chat/ToolCallCard.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ToolCallCard } from './ToolCallCard';
+
+describe('ToolCallCard', () => {
+  it('renders the tool call metadata and JSON result summary', () => {
+    render(
+      <ToolCallCard
+        toolCall={{
+          toolName: 'agenc.listTasks',
+          args: { status: 'open' },
+          result: JSON.stringify({ status: 'ok', resultCount: 1 }),
+          status: 'completed',
+          durationMs: 42,
+        }}
+      />,
+    );
+
+    expect(screen.getByText('agenc.listTasks')).toBeDefined();
+    const expandButton = screen.getByRole('button', { name: /agenc\.listTasks/i });
+    fireEvent.click(expandButton);
+
+    expect(screen.getByText('42ms')).toBeDefined();
+    expect(screen.getByText('Arguments:')).toBeDefined();
+    expect(screen.getByText('Result:')).toBeDefined();
+    expect(screen.getByText(/"status":\s*"open"/)).toBeDefined();
+    expect(screen.getByText(/"resultCount":\s*1/)).toBeDefined();
+  });
+});

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -39,7 +39,6 @@ export const WS_VOICE_RESPONSE_DONE = 'voice.response_done' as const;
 export const WS_VOICE_DELEGATION = 'voice.delegation' as const;
 export const WS_VOICE_STATE = 'voice.state' as const;
 export const WS_VOICE_ERROR = 'voice.error' as const;
-export const WS_VOICE_TOOL_CALL = 'voice.tool_call' as const;
 
 // Desktop
 export const WS_DESKTOP_LIST = 'desktop.list' as const;

--- a/web/src/hooks/useActivityFeed.test.ts
+++ b/web/src/hooks/useActivityFeed.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useActivityFeed } from './useActivityFeed';
+import type { WSMessage } from '../types';
+
+type ActivityFeedHook = ReturnType<typeof useActivityFeed> & { handleMessage: (msg: WSMessage) => void };
+
+describe('useActivityFeed', () => {
+  it('auto-subscribes when connected', () => {
+    const send = vi.fn();
+    const { rerender } = renderHook(({ connected }) => useActivityFeed({ send, connected }), {
+      initialProps: { connected: false },
+    });
+
+    expect(send).not.toHaveBeenCalled();
+
+    rerender({ connected: true });
+
+    expect(send).toHaveBeenCalledWith({ type: 'events.subscribe', payload: { filters: undefined } });
+  });
+
+  it('appends event payloads and can clear', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useActivityFeed({ send, connected: true }));
+
+    act(() => {
+      result.current.subscribe(['task']);
+      (result.current as ActivityFeedHook).handleMessage({ type: 'events.event', payload: { eventType: 'task.created', data: { taskId: '1' } } });
+      (result.current as ActivityFeedHook).handleMessage({ type: 'events.event', payload: { eventType: 'task.created', data: { taskId: '2' } } });
+    });
+
+    expect(send).toHaveBeenCalledWith({ type: 'events.subscribe', payload: { filters: undefined } });
+    expect(send).toHaveBeenCalledWith({ type: 'events.subscribe', payload: { filters: ['task'] } });
+    expect(result.current.events).toHaveLength(2);
+
+    act(() => {
+      result.current.unsubscribe();
+      result.current.clear();
+    });
+
+    expect(result.current.events).toEqual([]);
+    expect(send).toHaveBeenCalledWith({ type: 'events.unsubscribe' });
+    expect(result.current.events).toHaveLength(0);
+  });
+});

--- a/web/src/hooks/useAgentStatus.test.ts
+++ b/web/src/hooks/useAgentStatus.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAgentStatus } from './useAgentStatus';
+import type { WSMessage } from '../types';
+
+type AgentStatusHook = ReturnType<typeof useAgentStatus> & { handleMessage: (msg: WSMessage) => void };
+
+describe('useAgentStatus', () => {
+  it('refreshes on connect and updates status messages', () => {
+    const send = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ connected }) => useAgentStatus({ send, connected }),
+      { initialProps: { connected: false } },
+    );
+
+    expect(send).not.toHaveBeenCalled();
+
+    rerender({ connected: true });
+
+    expect(send).toHaveBeenCalledWith({ type: 'status.get' });
+
+    act(() => {
+      (result.current as AgentStatusHook).handleMessage({
+        type: 'status.update',
+        payload: { state: 'running', uptimeMs: 1000, channels: ['chat'], activeSessions: 2, controlPlanePort: 4000, agentName: 'alpha' },
+      } as never,
+      );
+    });
+
+    expect(result.current.status?.state).toBe('running');
+    expect(result.current.status?.agentName).toBe('alpha');
+  });
+});

--- a/web/src/hooks/useAgents.test.ts
+++ b/web/src/hooks/useAgents.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useAgents } from './useAgents';
+
+describe('useAgents', () => {
+  it('refreshes on connect and handles list responses', () => {
+    const send = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ connected }) => useAgents({ send, connected }),
+      { initialProps: { connected: false } },
+    );
+
+    expect(result.current.agents).toEqual([]);
+    expect(send).not.toHaveBeenCalled();
+
+    rerender({ connected: true });
+
+    expect(send).toHaveBeenCalledWith({ type: 'agents.list' });
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'agents.list',
+        payload: [{ pda: 'A', status: 'running', capabilities: [], metadataUri: '', tasksCompleted: 0, reputation: 0, stake: '0', endpoint: '' }],
+      } as never);
+    });
+
+    expect(result.current.agents).toHaveLength(1);
+    expect(result.current.agents[0].pda).toBe('A');
+  });
+});

--- a/web/src/hooks/useApprovals.test.ts
+++ b/web/src/hooks/useApprovals.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useApprovals } from './useApprovals';
+import type { WSMessage } from '../types';
+
+type UseApprovalsHook = ReturnType<typeof useApprovals> & {
+  handleMessage: (msg: WSMessage) => void;
+};
+
+describe('useApprovals', () => {
+  it('adds incoming approval requests when not auto-approving', () => {
+    const send = vi.fn();
+    localStorage.setItem('agenc-auto-approve', 'false');
+
+    const { result } = renderHook(() => useApprovals({ send }));
+
+    act(() => {
+      (result.current as UseApprovalsHook).handleMessage({
+        type: 'approval.request',
+        payload: {
+          requestId: 'req-1',
+          action: 'transfer',
+          details: { amount: '1' },
+        },
+      });
+    });
+
+    expect(result.current.pending).toHaveLength(1);
+    expect(result.current.pending[0]).toMatchObject({ requestId: 'req-1', action: 'transfer' });
+  });
+
+  it('auto-approves when enabled and does not keep request in pending', () => {
+    const send = vi.fn();
+    localStorage.setItem('agenc-auto-approve', 'true');
+
+    const { result } = renderHook(() => useApprovals({ send }));
+
+    act(() => {
+      (result.current as UseApprovalsHook).handleMessage({
+        type: 'approval.request',
+        payload: {
+          requestId: 'req-auto',
+          action: 'doit',
+          details: {},
+        },
+      });
+    });
+
+    expect(result.current.pending).toHaveLength(0);
+    expect(send).toHaveBeenCalledWith({
+      type: 'approval.respond',
+      payload: { requestId: 'req-auto', approved: true },
+    });
+  });
+
+  it('responds and removes pending item', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useApprovals({ send }));
+
+    act(() => {
+      (result.current as UseApprovalsHook).handleMessage({
+        type: 'approval.request',
+        payload: { requestId: 'req-2', action: 'approve', details: {} },
+      });
+    });
+
+    act(() => {
+      result.current.respond('req-2', false);
+    });
+
+    expect(result.current.pending).toHaveLength(0);
+    expect(send).toHaveBeenCalledWith({
+      type: 'approval.respond',
+      payload: { requestId: 'req-2', approved: false },
+    });
+  });
+
+  it('ignores duplicate approval requests and already responded ones', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useApprovals({ send }));
+
+    act(() => {
+      (result.current as UseApprovalsHook).handleMessage({
+        type: 'approval.request',
+        payload: { requestId: 'req-dup', action: 'x', details: {} },
+      });
+      (result.current as UseApprovalsHook).handleMessage({
+        type: 'approval.request',
+        payload: { requestId: 'req-dup', action: 'x', details: {} },
+      });
+    });
+
+    expect(result.current.pending).toHaveLength(1);
+
+    act(() => {
+      result.current.respond('req-dup', true);
+      (result.current as UseApprovalsHook).handleMessage({
+        type: 'approval.request',
+        payload: { requestId: 'req-dup', action: 'x', details: {} },
+      });
+    });
+
+    expect(result.current.pending).toHaveLength(0);
+  });
+});

--- a/web/src/hooks/useChat.test.ts
+++ b/web/src/hooks/useChat.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { WSMessage } from "../types";
+import { useChat } from "./useChat";
+
+describe("useChat tool result matching", () => {
+  it("matches tools.result to the exact toolCallId", () => {
+    const send = vi.fn();
+
+    const { result } = renderHook(() => useChat({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.executing",
+        payload: {
+          toolName: "system.task",
+          args: { round: "first" },
+          toolCallId: "tool-1",
+        },
+      } as WSMessage);
+
+      result.current.handleMessage({
+        type: "tools.executing",
+        payload: {
+          toolName: "system.task",
+          args: { round: "second" },
+          toolCallId: "tool-2",
+        },
+      } as WSMessage);
+    });
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.result",
+        payload: {
+          toolName: "system.task",
+          toolCallId: "tool-1",
+          result: "first-done",
+          durationMs: 12,
+          isError: false,
+        },
+      } as WSMessage);
+    });
+
+    const message = result.current.messages[0];
+    const toolCalls = message?.toolCalls ?? [];
+
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0]).toMatchObject({
+      toolName: "system.task",
+      status: "completed",
+      result: "first-done",
+      toolCallId: "tool-1",
+    });
+    expect(toolCalls[1]).toMatchObject({
+      toolName: "system.task",
+      status: "executing",
+      toolCallId: "tool-2",
+    });
+  });
+
+  it("does not match tool results by name when toolCallId is present", () => {
+    const send = vi.fn();
+
+    const { result } = renderHook(() => useChat({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.executing",
+        payload: {
+          toolName: "system.task",
+          args: { round: "first-no-id" },
+        },
+      } as WSMessage);
+    });
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.result",
+        payload: {
+          toolName: "system.task",
+          toolCallId: "tool-missing",
+          result: "late-result",
+          durationMs: 8,
+        },
+      } as WSMessage);
+    });
+
+    const message = result.current.messages[0];
+    const toolCalls = message?.toolCalls ?? [];
+
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toMatchObject({
+      toolName: "system.task",
+      status: "executing",
+      toolCallId: undefined,
+    });
+    expect(toolCalls[0].result).toBeUndefined();
+  });
+
+  it("falls back to tool name matching when tool result has no toolCallId", () => {
+    const send = vi.fn();
+
+    const { result } = renderHook(() => useChat({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.executing",
+        payload: {
+          toolName: "system.task",
+          args: { phase: "legacy" },
+        },
+      } as WSMessage);
+    });
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.result",
+        payload: {
+          toolName: "system.task",
+          result: "legacy-done",
+          durationMs: 5,
+          isError: false,
+        },
+      } as WSMessage);
+    });
+
+    const toolCalls = (result.current.messages[0]?.toolCalls ?? []);
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toMatchObject({
+      toolName: "system.task",
+      status: "completed",
+      result: "legacy-done",
+      toolCallId: undefined,
+    });
+  });
+
+  it("correctly matches out-of-order tool results by toolCallId", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useChat({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.executing",
+        payload: {
+          toolName: "system.task",
+          args: { round: "A" },
+          toolCallId: "tool-a",
+        },
+      } as WSMessage);
+
+      result.current.handleMessage({
+        type: "tools.executing",
+        payload: {
+          toolName: "system.task",
+          args: { round: "B" },
+          toolCallId: "tool-b",
+        },
+      } as WSMessage);
+    });
+
+    act(() => {
+      result.current.handleMessage({
+        type: "tools.result",
+        payload: {
+          toolName: "system.task",
+          toolCallId: "tool-b",
+          result: "result-b",
+          durationMs: 20,
+          isError: false,
+        },
+      } as WSMessage);
+
+      result.current.handleMessage({
+        type: "tools.result",
+        payload: {
+          toolName: "system.task",
+          toolCallId: "tool-a",
+          result: "result-a",
+          durationMs: 15,
+          isError: false,
+        },
+      } as WSMessage);
+    });
+
+    const toolCalls = result.current.messages[0]?.toolCalls ?? [];
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0]).toMatchObject({
+      toolName: "system.task",
+      args: { round: "A" },
+      toolCallId: "tool-a",
+      status: "completed",
+      result: "result-a",
+    });
+    expect(toolCalls[1]).toMatchObject({
+      toolName: "system.task",
+      args: { round: "B" },
+      toolCallId: "tool-b",
+      status: "completed",
+      result: "result-b",
+    });
+  });
+});

--- a/web/src/hooks/useDesktop.test.ts
+++ b/web/src/hooks/useDesktop.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useDesktop } from './useDesktop';
+
+describe('useDesktop', () => {
+  it('refreshes when connected', () => {
+    const send = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ connected }) => useDesktop({ send, connected }),
+      { initialProps: { connected: false } },
+    );
+
+    expect(result.current.sandboxes).toEqual([]);
+    expect(send).not.toHaveBeenCalled();
+
+    rerender({ connected: true });
+    expect(send).toHaveBeenCalledWith({ type: 'desktop.list' });
+  });
+
+  it('handles list/created/destroyed/error messages', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useDesktop({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'desktop.list',
+        payload: [{ containerId: 'c', sessionId: 's', status: 'ready', createdAt: 0, lastActivityAt: 0, vncUrl: 'http://example', uptimeMs: 100 }],
+      } as never);
+      result.current.create('session-1');
+      result.current.handleMessage({ type: 'desktop.created' } as never);
+      result.current.handleMessage({
+        type: 'desktop.destroyed',
+        payload: { containerId: 'c' },
+      } as never);
+      result.current.handleMessage({ type: 'desktop.error', error: 'failed' } as never);
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.sandboxes).toEqual([]);
+    expect(result.current.error).toBe('failed');
+    expect(send).toHaveBeenCalledWith({ type: 'desktop.create', payload: { sessionId: 'session-1' } });
+    expect(send).toHaveBeenCalledWith({ type: 'desktop.list' });
+  });
+
+  it('computes vnc helpers', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useDesktop({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'desktop.list',
+        payload: [{ containerId: 'c', sessionId: 's', status: 'ready', createdAt: 1, lastActivityAt: 2, vncUrl: 'http://vnc', uptimeMs: 0 }],
+      } as never);
+    });
+
+    expect(result.current.activeVncUrl).toBe('http://vnc');
+    expect(result.current.vncUrlForSession('missing')).toBeNull();
+    expect(result.current.vncUrlForSession('s')).toBe('http://vnc');
+  });
+});

--- a/web/src/hooks/useMemory.test.ts
+++ b/web/src/hooks/useMemory.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useMemory } from './useMemory';
+import type { WSMessage } from '../types';
+
+type UseMemoryHook = ReturnType<typeof useMemory> & { handleMessage: (msg: WSMessage) => void };
+
+describe('useMemory', () => {
+  it('sends search and refresh sessions commands', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useMemory({ send }));
+
+    act(() => {
+      result.current.search('hello');
+      result.current.refreshSessions();
+    });
+
+    expect(send).toHaveBeenNthCalledWith(1, { type: 'memory.search', payload: { query: 'hello' } });
+    expect(send).toHaveBeenNthCalledWith(2, { type: 'memory.sessions' });
+  });
+
+  it('handles memory responses', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useMemory({ send }));
+
+    act(() => {
+      (result.current as UseMemoryHook).handleMessage({ type: 'memory.results', payload: [{ content: 'c', timestamp: 1, role: 'user' }] });
+      (result.current as UseMemoryHook).handleMessage({
+        type: 'memory.sessions',
+        payload: [{ id: 's', messageCount: 2, lastActiveAt: 5 }],
+      });
+    });
+
+    expect(result.current.results).toHaveLength(1);
+    expect(result.current.sessions).toHaveLength(1);
+    expect(result.current.results[0].content).toBe('c');
+  });
+});

--- a/web/src/hooks/useSettings.test.ts
+++ b/web/src/hooks/useSettings.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useSettings } from './useSettings';
+
+describe('useSettings', () => {
+  it('auto-requests config when connected', () => {
+    const send = vi.fn();
+
+    renderHook(() => useSettings({ send, connected: true }));
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenLastCalledWith({ type: 'config.get' });
+  });
+
+  it('supports config.get and parse fallback values', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useSettings({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'config.get',
+        payload: {
+          llm: { provider: 'ollama', model: 'llama3', baseUrl: 'http://localhost:11434' },
+          voice: { enabled: false, mode: 'push-to-talk', voice: 'Eve' },
+          memory: { backend: 'redis' },
+          connection: { rpcUrl: 'https://api.mainnet-beta.solana.com' },
+          logging: { level: 'warn' },
+          extra: 'ignore',
+        },
+      } as never);
+    });
+
+    expect(result.current.loaded).toBe(true);
+    expect(result.current.settings.llm.provider).toBe('ollama');
+    expect(result.current.settings.voice.enabled).toBe(false);
+    expect(result.current.settings.memory.backend).toBe('redis');
+    expect(result.current.settings.connection.rpcUrl).toBe('https://api.mainnet-beta.solana.com');
+  });
+
+  it('sends config.set payload with saving state and clears saving on success', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useSettings({ send, connected: true }));
+
+    act(() => {
+      result.current.save({
+        llm: {
+          provider: 'grok',
+          model: 'grok-4',
+          apiKey: 'x',
+          baseUrl: 'https://api.x.ai/v1',
+        },
+      });
+    });
+
+    expect(result.current.saving).toBe(true);
+    expect(send).toHaveBeenLastCalledWith({
+      type: 'config.set',
+      payload: {
+        llm: {
+          provider: 'grok',
+          model: 'grok-4',
+          apiKey: 'x',
+          baseUrl: 'https://api.x.ai/v1',
+        },
+      },
+    });
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'config.set',
+        payload: {
+          config: {
+            llm: {
+              provider: 'ollama',
+              model: 'llama3',
+              apiKey: '***',
+              baseUrl: 'http://localhost:11434',
+            },
+            voice: { enabled: true, mode: 'vad', voice: 'Ara', apiKey: '' },
+            memory: { backend: 'memory' },
+            connection: { rpcUrl: 'https://api.devnet.solana.com' },
+            logging: { level: 'info' },
+          },
+        },
+      });
+    });
+
+    expect(result.current.saving).toBe(false);
+    expect(result.current.settings.llm.provider).toBe('ollama');
+    expect(result.current.lastError).toBeNull();
+  });
+
+  it('handles ollama model errors and empty model list', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useSettings({ send, connected: true }));
+
+    act(() => {
+      result.current.fetchOllamaModels();
+    });
+    expect(send).toHaveBeenLastCalledWith({ type: 'ollama.models' });
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'ollama.models',
+        payload: {},
+      });
+    });
+
+    expect(result.current.ollamaModels).toEqual([]);
+    expect(result.current.ollamaError).toBe('No models installed in Ollama');
+  });
+
+  it('records save errors and keeps saving false', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useSettings({ send, connected: true }));
+
+    act(() => {
+      result.current.save({});
+    });
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'config.set',
+        error: 'invalid config',
+      });
+    });
+
+    expect(result.current.saving).toBe(false);
+    expect(result.current.lastError).toBe('invalid config');
+  });
+});

--- a/web/src/hooks/useSkills.test.ts
+++ b/web/src/hooks/useSkills.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useSkills } from './useSkills';
+import type { WSMessage } from '../types';
+
+type UseSkillsHook = ReturnType<typeof useSkills> & { handleMessage: (msg: WSMessage) => void };
+
+describe('useSkills', () => {
+  it('refreshes and toggles skills', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useSkills({ send }));
+
+    act(() => {
+      result.current.refresh();
+      result.current.toggle('desk', true);
+    });
+
+    expect(send).toHaveBeenNthCalledWith(1, { type: 'skills.list' });
+    expect(send).toHaveBeenNthCalledWith(2, { type: 'skills.toggle', payload: { skillName: 'desk', enabled: true } });
+  });
+
+  it('handles skills.list response', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useSkills({ send }));
+
+    act(() => {
+      (result.current as UseSkillsHook).handleMessage({
+        type: 'skills.list',
+        payload: [{ name: 'math', description: 'Math', enabled: true }],
+      });
+    });
+
+    expect(result.current.skills).toEqual([{ name: 'math', description: 'Math', enabled: true } as never]);
+  });
+});

--- a/web/src/hooks/useTasks.test.ts
+++ b/web/src/hooks/useTasks.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useTasks } from './useTasks';
+import type { WSMessage } from '../types';
+
+type UseTasksHook = ReturnType<typeof useTasks> & { handleMessage: (msg: WSMessage) => void };
+
+describe('useTasks', () => {
+  it('sends refresh/create/cancel payloads', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useTasks({ send }));
+
+    act(() => {
+      result.current.refresh();
+    });
+    act(() => {
+      result.current.create({ description: 'Build feature' });
+    });
+    act(() => {
+      result.current.cancel('task-1');
+    });
+
+    expect(send).toHaveBeenNthCalledWith(1, { type: 'tasks.list' });
+    expect(send).toHaveBeenNthCalledWith(2, { type: 'tasks.create', payload: { params: { description: 'Build feature' } } });
+    expect(send).toHaveBeenNthCalledWith(3, { type: 'tasks.cancel', payload: { taskId: 'task-1' } });
+  });
+
+  it('handles tasks.list response', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useTasks({ send }));
+
+    act(() => {
+      (result.current as UseTasksHook).handleMessage({
+        type: 'tasks.list',
+        payload: [{ id: 't-1', status: 'open', description: 'A' }],
+      });
+    });
+
+    expect(result.current.tasks).toEqual([{ id: 't-1', status: 'open', description: 'A' }]);
+  });
+});

--- a/web/src/hooks/useTheme.test.ts
+++ b/web/src/hooks/useTheme.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useTheme } from './useTheme';
+
+describe('useTheme', () => {
+  it('reads theme from localStorage', () => {
+    localStorage.setItem('agenc-theme', 'dark');
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('dark');
+  });
+
+  it('falls back to matchMedia and toggles theme', () => {
+    localStorage.removeItem('agenc-theme');
+
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.theme).toBe('light');
+
+    act(() => {
+      result.current.toggle();
+    });
+
+    expect(result.current.theme).toBe('dark');
+    expect(localStorage.getItem('agenc-theme')).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+  });
+});

--- a/web/src/hooks/useWallet.test.ts
+++ b/web/src/hooks/useWallet.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import type { WSMessage } from '../types';
+import { useWallet } from './useWallet';
+
+describe('useWallet', () => {
+  it('fetches wallet info automatically when connected', () => {
+    const send = vi.fn();
+    renderHook(() => useWallet({ send, connected: true }));
+
+    expect(send).toHaveBeenCalledWith({ type: 'wallet.info' });
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles wallet.info success and loading states', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useWallet({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'wallet.info',
+        payload: {
+          address: 'Wallet123',
+          lamports: 12_345,
+          sol: 1.23,
+          network: 'devnet',
+          rpcUrl: 'https://api.devnet.solana.com',
+          explorerUrl: 'https://explorer.solana.com',
+        },
+      } as WSMessage,
+      );
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.wallet?.address).toBe('Wallet123');
+    expect(result.current.wallet?.sol).toBe(1.23);
+  });
+
+  it('records wallet.info errors', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useWallet({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({ type: 'wallet.info', error: 'denied' } as WSMessage);
+    });
+
+    expect(result.current.lastError).toBe('denied');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('sends and handles airdrop updates', () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useWallet({ send, connected: true }));
+
+    act(() => {
+      result.current.airdrop(2);
+    });
+
+    expect(send).toHaveBeenCalledWith({ type: 'wallet.airdrop', payload: { amount: 2 } });
+
+    act(() => {
+      result.current.handleMessage({
+        type: 'wallet.airdrop',
+        payload: { newBalance: 12.34, newLamports: 12_340_000_000 },
+      } as WSMessage);
+    });
+
+    expect(result.current.airdropping).toBe(false);
+    expect(result.current.wallet).toBeNull();
+  });
+
+  it('resets request on connect false -> true', () => {
+    const send = vi.fn();
+    const { rerender } = renderHook(
+      ({ connected }) => useWallet({ send, connected }),
+      { initialProps: { connected: false } },
+    );
+
+    expect(send).not.toHaveBeenCalled();
+
+    rerender({ connected: true });
+    rerender({ connected: false });
+    rerender({ connected: true });
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenCalledWith({ type: 'wallet.info' });
+  });
+});

--- a/web/src/hooks/useWebSocket.test.ts
+++ b/web/src/hooks/useWebSocket.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useWebSocket } from './useWebSocket';
+
+const CONNECTING = 0;
+const OPEN = 1;
+
+interface WsMockInstance {
+  readyState: number;
+  sent: string[];
+  onopen: ((ev?: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  onclose: (() => void) | null;
+  onerror: (() => void) | null;
+  triggerOpen: () => void;
+  triggerMessage: (data: unknown) => void;
+  triggerClose: () => void;
+  close: ReturnType<typeof vi.fn>;
+}
+
+const instances: WsMockInstance[] = [];
+
+class WsMock {
+  static CONNECTING = CONNECTING;
+  static OPEN = OPEN;
+
+  readyState: number = CONNECTING;
+  sent: string[] = [];
+  onopen: ((ev?: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  close = vi.fn(() => {
+    this.readyState = 3;
+    if (this.onclose) {
+      this.onclose();
+    }
+  });
+
+  constructor() {
+    instances.push(this);
+  }
+
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+
+  triggerOpen() {
+    this.readyState = OPEN;
+    if (this.onopen) {
+      this.onopen();
+    }
+  }
+
+  triggerMessage(data: unknown) {
+    if (!this.onmessage) return;
+    this.onmessage({ data: JSON.stringify(data) } as MessageEvent);
+  }
+
+  triggerClose() {
+    this.readyState = 3;
+    if (this.onclose) {
+      this.onclose();
+    }
+  }
+}
+
+describe('useWebSocket', () => {
+  it('queues sends until connected then flushes', async () => {
+    vi.useFakeTimers();
+    (globalThis as unknown as { WebSocket: typeof WsMock }).WebSocket = WsMock as never;
+
+    const onMessage = vi.fn();
+    const { result } = renderHook(() => useWebSocket({ onMessage }));
+
+    expect(result.current.state).toBe('connecting');
+
+    act(() => {
+      result.current.send({ type: 'queued' });
+    });
+    expect(instances).toHaveLength(1);
+
+    act(() => {
+      instances[0].triggerOpen();
+      instances[0].triggerMessage({ type: 'chat.response', payload: { ok: true } });
+    });
+
+    expect(result.current.state).toBe('connected');
+    expect(instances[0].sent).toEqual([JSON.stringify({ type: 'queued' })]);
+    expect(onMessage).toHaveBeenCalledWith({ type: 'chat.response', payload: { ok: true } });
+    expect(result.current.lastMessage).toEqual({ type: 'chat.response', payload: { ok: true } });
+    vi.useRealTimers();
+  });
+
+  it('reconnects after close with backoff', () => {
+    vi.useFakeTimers();
+    instances.length = 0;
+    (globalThis as unknown as { WebSocket: typeof WsMock }).WebSocket = WsMock as never;
+
+    const { result } = renderHook(() => useWebSocket());
+
+    act(() => {
+      result.current.send({ type: 'hello' });
+      instances[0].triggerOpen();
+      instances[0].triggerClose();
+    });
+
+    expect(result.current.state).toBe('reconnecting');
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(instances.length).toBeGreaterThan(1);
+    vi.useRealTimers();
+  });
+});

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -1,7 +1,18 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ConnectionState, WSMessage } from '../types';
 
-const DEFAULT_URL = 'ws://127.0.0.1:3100';
+function getDefaultWsUrl(): string {
+  if (typeof window !== 'undefined') {
+    const query = new URLSearchParams(window.location.search);
+    const queryWsUrl = query.get('ws');
+    if (queryWsUrl) return queryWsUrl;
+  }
+
+  return (import.meta as { env?: Record<string, string | undefined> })?.env?.VITE_WEBCHAT_WS_URL
+    ?? 'ws://127.0.0.1:3100';
+}
+
+const DEFAULT_URL = getDefaultWsUrl();
 const PING_INTERVAL_MS = 30_000;
 const RECONNECT_BASE_DELAY_MS = 1_000;
 const RECONNECT_MAX_DELAY_MS = 30_000;

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,0 +1,81 @@
+Object.defineProperty(window, 'matchMedia', {
+  configurable: true,
+  writable: true,
+  value: (query: string) => ({
+    matches: query === '(prefers-color-scheme: dark)' ? false : false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+  }),
+});
+
+import { afterEach, beforeEach } from 'vitest';
+
+interface MemoryStorage {
+  [key: string]: string;
+}
+
+function createMemoryStorage() {
+  const store: MemoryStorage = {};
+
+  return {
+    getItem: (key: string) => (Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = `${value}`;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+      }
+    },
+    key: (index: number) => {
+      const keys = Object.keys(store);
+      return keys[index] ?? null;
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+
+const hasWorkingStorage = (() => {
+  const localStorageCandidate = window.localStorage;
+  if (!localStorageCandidate) return false;
+  return (
+    typeof localStorageCandidate.getItem === 'function'
+    && typeof localStorageCandidate.setItem === 'function'
+    && typeof localStorageCandidate.removeItem === 'function'
+    && typeof localStorageCandidate.clear === 'function'
+  );
+})();
+
+if (!hasWorkingStorage) {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: createMemoryStorage(),
+  });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  document.documentElement.classList.remove('dark');
+});
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark');
+});
+
+if (!window.requestAnimationFrame) {
+  window.requestAnimationFrame = (cb: FrameRequestCallback): number => window.setTimeout(() => cb(Date.now()), 0);
+}
+
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -44,6 +44,7 @@ export interface TokenUsage {
 
 export interface ToolCall {
   toolName: string;
+  toolCallId?: string;
   args: Record<string, unknown>;
   result?: string;
   durationMs?: number;
@@ -159,6 +160,7 @@ export interface WSMessage {
   timestamp?: number;
   // Tool fields
   toolName?: string;
+  toolCallId?: string;
   args?: Record<string, unknown>;
   result?: string;
   durationMs?: number;

--- a/web/tests/e2e/site.spec.ts
+++ b/web/tests/e2e/site.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const WS_URL = process.env.WEBCHAT_WS_URL ?? 'ws://127.0.0.1:3600';
+
+function appUrl(path = '/') {
+  return `${path}?ws=${encodeURIComponent(WS_URL)}`;
+}
+
+const VIEWS: Array<{ nav: string; heading: string }> = [
+  { nav: 'Status', heading: 'Agent Status' },
+  { nav: 'Skills', heading: 'Skills' },
+  { nav: 'Tasks', heading: 'Tasks' },
+  { nav: 'Memory', heading: 'Memory' },
+  { nav: 'Activity', heading: 'Activity Feed' },
+  { nav: 'Desktop', heading: 'Desktop Sandboxes' },
+];
+
+async function sendChatMessage(page: Page, text: string) {
+  const sendButton = page.getByRole('button', { name: 'Send' });
+  const input = page.getByPlaceholder('Message to AgenC...');
+  await expect(input).toBeEditable();
+  await input.fill(text);
+  await expect(sendButton).toBeEnabled({ timeout: 12_000 });
+  await sendButton.click();
+}
+
+test.describe('Web chat and tool execution', () => {
+  test('connects, sends a message, and receives a response', async ({ page }) => {
+    await page.goto(appUrl());
+
+    await expect(page.getByPlaceholder('Message to AgenC...')).toBeVisible();
+    await sendChatMessage(page, 'hello from e2e');
+
+    await expect(page.getByText('You said: "hello from e2e"', { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('renders tool call progress and result for tool-tagged messages', async ({ page }) => {
+    await page.goto(appUrl());
+
+    await sendChatMessage(page, 'please run tool chain');
+    await expect(page.getByRole('button', { name: /tool call/i })).toBeVisible({ timeout: 15_000 });
+
+    const toolGroup = page.getByRole('button', { name: /tool call/i });
+    await toolGroup.click();
+    await expect(page.getByText('agenc.listTasks')).toBeVisible();
+    const toolCallEntry = page.getByRole('button', { name: /agenc\.listTasks/i });
+    await toolCallEntry.click();
+    await expect(page.getByText('"task_1"')).toBeVisible();
+  });
+});
+
+test.describe('site navigation paths', () => {
+  test('loads each main web view', async ({ page }) => {
+    await page.goto(appUrl());
+
+    await sendChatMessage(page, 'seed for nav flow');
+    await expect(page.getByText('You said: "seed for nav flow"', { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    for (const { nav, heading } of VIEWS) {
+      await page.locator(`button[title="${nav}"]`).click();
+      await expect(page.getByRole('heading', { name: heading, exact: true })).toBeVisible({ timeout: 10_000 });
+    }
+
+    await page.locator('button[title="Chat"]').click();
+    await expect(page.getByPlaceholder('Message to AgenC...')).toBeVisible();
+  });
+
+  test('opens right panel settings and payment tabs', async ({ page }) => {
+    await page.goto(appUrl());
+
+    await expect(page.getByText('Recent Chats')).toBeVisible();
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await expect(page.getByText('LLM Provider')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Payment' }).click();
+    await expect(page.getByText('SOL Balance')).toBeVisible();
+    await expect(page.getByText('Protocol Fees')).toBeVisible();
+  });
+});
+
+test('displays pending approval from gateway', async ({ page }) => {
+  await page.goto(appUrl());
+  await expect(page.getByText('Review', { exact: false })).toBeVisible({ timeout: 12_000 });
+  await expect(page.getByText('pending approval', { exact: false })).toBeVisible();
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['**/node_modules/**', 'tests/e2e/**'],
+  },
+});


### PR DESCRIPTION
## Summary

- **Voice bridge**: Restore delegation abort controller and audio-clearing on speech start; remove abort-during-speech regression
- **Tool handler factory**: Add desktop action auto-screenshot with configurable delay, extract `DESKTOP_ACTION_TOOLS` constant
- **MCP replay tools**: Use `safeStringify` for bigint-safe JSON serialization, update golden fixture snapshots
- **Web test suite**: Comprehensive vitest unit tests for all hooks + Playwright e2e config + test-server improvements
- **Web hooks**: Fix useWebSocket reconnection logic, useVoice cleanup
- **Skill payment**: Fix optional chaining for token balance check
- **Whitepaper**: Speculative execution updates

## Test plan

- [x] Runtime typecheck clean
- [x] Runtime vitest passes
- [ ] Web vitest passes
- [ ] Manual voice start/stop/delegation flow