### PR TITLE
feat(runtime,web,desktop): desktop hardening, Grok 4.1 models, webchat session lifecycle

### DIFF
--- a/containers/desktop/Dockerfile
+++ b/containers/desktop/Dockerfile
@@ -8,14 +8,18 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PORT=9990 \
     HOME=/home/agenc
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/home/agenc/.cache/ms-playwright
+
 # =============================================================================
 # System packages
 # =============================================================================
 RUN apt-get update && apt-get install -y --no-install-recommends \
     # Virtual display + desktop environment
-    xvfb xfce4 xfce4-terminal xfce4-whiskermenu-plugin dbus-x11 \
+    xvfb xfce4 xfce4-terminal xfce4-whiskermenu-plugin dbus-x11 xterm kitty \
     # File manager
     thunar \
+    # GUI browser fallback
+    epiphany-browser \
     # VNC
     x11vnc novnc websockify \
     # Input automation
@@ -41,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Python
     python3 python3-pip python3-venv \
     # Misc utilities
-    bash-completion locales software-properties-common \
+    bash-completion locales software-properties-common sqlite3 \
     && locale-gen en_US.UTF-8 \
     # =========================================================================
     # Playwright MCP uses its own bundled Chromium (installed below).
@@ -56,8 +60,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # =========================================================================
     # Playwright MCP + bundled Chromium
     # =========================================================================
-    && npm install -g @playwright/mcp@1.8.0 \
-    && npx playwright@1.52.0 install --with-deps chromium \
+    && npm install -g @playwright/mcp@0.0.68 tmux-mcp mcp-neovim-server \
+    && mkdir -p ${PLAYWRIGHT_BROWSERS_PATH} \
+    && node /usr/lib/node_modules/@playwright/mcp/node_modules/playwright/cli.js install --with-deps chromium \
+    && CHROME_BIN="$(find ${PLAYWRIGHT_BROWSERS_PATH} -path '*/chrome-linux64/chrome' | head -n1)" \
+    && if [ -n "$CHROME_BIN" ]; then \
+         ln -sf "$CHROME_BIN" /usr/bin/chromium; \
+         ln -sf /usr/bin/chromium /usr/bin/chromium-browser; \
+       fi \
     # Cleanup
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -83,6 +93,36 @@ RUN rsvg-convert -w 1920 -h 1080 /tmp/agenc-wallpaper.svg -o /usr/share/backgrou
     && chmod 644 /usr/share/backgrounds/agenc-wallpaper.png \
     && chmod 644 /usr/share/icons/hicolor/scalable/apps/agenc-logo.svg \
     && (gtk-update-icon-cache /usr/share/icons/hicolor/ 2>/dev/null || true)
+
+# Chromium wrapper: force no-sandbox inside containerized desktop.
+RUN printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    '' \
+    'CHROME_BIN="$(find /home/agenc/.cache/ms-playwright -path '\''*/chrome-linux64/chrome'\'' | head -n1 || true)"' \
+    'if [ -z "${CHROME_BIN}" ]; then' \
+    '  echo "chromium-wrapper: Chrome binary not found under /home/agenc/.cache/ms-playwright" >&2' \
+    '  exit 1' \
+    'fi' \
+    '' \
+    'has_no_sandbox=0' \
+    'has_disable_setuid=0' \
+    'for arg in "$@"; do' \
+    '  [ "$arg" = "--no-sandbox" ] && has_no_sandbox=1' \
+    '  [ "$arg" = "--disable-setuid-sandbox" ] && has_disable_setuid=1' \
+    'done' \
+    '' \
+    'extra=()' \
+    '[ "$has_no_sandbox" -eq 0 ] && extra+=(--no-sandbox)' \
+    '[ "$has_disable_setuid" -eq 0 ] && extra+=(--disable-setuid-sandbox)' \
+    'extra+=(--disable-gpu --use-gl=swiftshader --disable-dev-shm-usage)' \
+    '' \
+    'exec "${CHROME_BIN}" "${extra[@]}" "$@"' \
+    > /usr/local/bin/chromium-wrapper
+
+RUN chmod +x /usr/local/bin/chromium-wrapper \
+    && ln -sf /usr/local/bin/chromium-wrapper /usr/bin/chromium \
+    && ln -sf /usr/local/bin/chromium-wrapper /usr/bin/chromium-browser
 
 # =============================================================================
 # XFCE configuration (dark theme, branded wallpaper, clean panel, no screensaver)

--- a/containers/desktop/server/src/tools.ts
+++ b/containers/desktop/server/src/tools.ts
@@ -24,6 +24,10 @@ const BASH_TIMEOUT_MS = 600_000;
 const MAX_OUTPUT_BYTES = 100 * 1024; // 100KB
 const TYPE_CHUNK_SIZE = 50;
 const TYPE_DELAY_MS = 12;
+const GUI_LAUNCH_CMD_RE =
+  /^\s*(?:sudo\s+)?(?:env\s+[^;]+\s+)?(?:nohup\s+|setsid\s+)?(?:xfce4-terminal|gnome-terminal|xterm|kitty|firefox|chromium|chromium-browser|google-chrome|thunar|nautilus|mousepad|gedit)\b/i;
+const APT_PREFIX_RE =
+  /^\s*(?:sudo\s+)?(?:(?:DEBIAN_FRONTEND|APT_LISTCHANGES_FRONTEND)=[^\s]+\s+)*(?:apt-get|apt)\b/i;
 
 function exec(
   cmd: string,
@@ -53,6 +57,42 @@ function ok(content: unknown): ToolResult {
 
 function fail(message: string): ToolResult {
   return { content: JSON.stringify({ error: message }), isError: true };
+}
+
+function normalizeAptCommand(command: string): string {
+  const trimmed = command.trim();
+  if (!APT_PREFIX_RE.test(trimmed)) {
+    return command;
+  }
+
+  let normalized = trimmed;
+  if (!/^sudo\b/i.test(normalized)) {
+    normalized = `sudo ${normalized}`;
+  }
+
+  normalized = normalized.replace(
+    /^sudo\s+((?:DEBIAN_FRONTEND|APT_LISTCHANGES_FRONTEND)=[^\s]+\s+)*apt\s+/i,
+    (_full, envPrefix: string) => `sudo ${envPrefix ?? ""}apt-get `,
+  );
+
+  const isInstall = /^sudo\s+.*apt-get\s+install\b/i.test(normalized);
+  if (!isInstall) {
+    return normalized;
+  }
+
+  const hasYesFlag = /\s(?:-y|--yes)\b/i.test(normalized);
+  if (!hasYesFlag) {
+    normalized = normalized.replace(/\binstall\b/i, "install -y");
+  }
+
+  const alreadyUpdates =
+    /\bapt(?:-get)?\s+update\b/i.test(normalized) ||
+    /\b&&\s*sudo\s+.*apt-get\s+install\b/i.test(normalized);
+  if (alreadyUpdates) {
+    return normalized;
+  }
+
+  return `sudo apt-get update && ${normalized}`;
 }
 
 // --- Tool implementations ---
@@ -224,11 +264,39 @@ async function keyboardKey(
 async function bash(args: Record<string, unknown>): Promise<ToolResult> {
   const command = String(args.command ?? "");
   if (!command) return fail("command is required");
+  const normalizedCommand = normalizeAptCommand(command);
   const timeoutMs = Number(args.timeoutMs ?? BASH_TIMEOUT_MS);
+
+  // GUI launch commands should be detached automatically so the tool call
+  // doesn't block on an interactive app (e.g. `xfce4-terminal`).
+  const trimmed = command.trim();
+  const alreadyBackgrounded = /&\s*(?:disown\s*)?$/.test(trimmed);
+  const autoDetachGui = GUI_LAUNCH_CMD_RE.test(trimmed) && !alreadyBackgrounded;
+
   try {
+    if (autoDetachGui) {
+      const detachedCommand =
+        `mkdir -p /tmp/agenc-gui && ` +
+        `nohup /bin/bash -lc ${JSON.stringify(trimmed)} ` +
+        `>/tmp/agenc-gui/last-launch.log 2>&1 & echo $!`;
+      const { stdout } = await exec(
+        "/bin/bash",
+        ["-c", detachedCommand],
+        15_000,
+      );
+      const pid = Number(stdout.trim());
+      return ok({
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        backgrounded: true,
+        ...(Number.isFinite(pid) ? { pid } : {}),
+      });
+    }
+
     const { stdout, stderr } = await exec(
       "/bin/bash",
-      ["-c", command],
+      ["-c", normalizedCommand],
       timeoutMs,
     );
     const output = stdout.length > MAX_OUTPUT_BYTES
@@ -265,7 +333,19 @@ async function windowList(): Promise<ToolResult> {
         windows.push({ id, title: "(unknown)" });
       }
     }
-    return ok({ windows });
+    // Most X11 windows in the desktop session are untitled internal wrappers.
+    // Return only meaningful entries to keep tool output compact for the LLM.
+    const meaningful = windows
+      .filter((w) => {
+        const title = w.title.trim();
+        return title.length > 0 && title !== "(unknown)";
+      })
+      .slice(0, 25);
+    return ok({
+      windows: meaningful,
+      totalWindows: windows.length,
+      omittedUntitled: windows.length - meaningful.length,
+    });
   } catch (e) {
     return fail(`window_list failed: ${e instanceof Error ? e.message : e}`);
   }

--- a/runtime/src/channels/webchat/types.ts
+++ b/runtime/src/channels/webchat/types.ts
@@ -52,6 +52,8 @@ export interface WebChatDeps {
   broadcastEvent?: (eventType: string, data: Record<string, unknown>) => void;
   /** Optional desktop sandbox manager for desktop.* handlers. */
   desktopManager?: import("../../desktop/manager.js").DesktopSandboxManager;
+  /** Optional callback to fully reset backend context for a web session. */
+  resetSessionContext?: (sessionId: string) => Promise<void> | void;
 }
 
 // ============================================================================
@@ -89,6 +91,11 @@ export interface ChatHistoryRequest {
 export interface ChatResumeRequest {
   type: "chat.resume";
   sessionId: string;
+  id?: string;
+}
+
+export interface ChatNewRequest {
+  type: "chat.new";
   id?: string;
 }
 

--- a/runtime/src/desktop/manager.ts
+++ b/runtime/src/desktop/manager.ts
@@ -391,6 +391,7 @@ export class DesktopSandboxManager {
         "--cap-add", "SETUID",
         "--cap-add", "SETGID",
         "--cap-add", "DAC_OVERRIDE",
+        "--cap-add", "FOWNER",
         "--cap-add", "KILL",
         "--cap-add", "NET_BIND_SERVICE",
       );

--- a/runtime/src/desktop/rest-bridge.test.ts
+++ b/runtime/src/desktop/rest-bridge.test.ts
@@ -152,6 +152,7 @@ describe("DesktopRESTBridge", () => {
       const result = await ssTool.execute({});
       const parsed = JSON.parse(result.content);
       expect(parsed.dataUrl).toBe("data:image/png;base64,iVBORw0KGgoAAAAN");
+      expect(parsed.image).toBeUndefined();
       expect(parsed.width).toBe(1024);
       expect(parsed.height).toBe(768);
     });

--- a/runtime/src/desktop/rest-bridge.ts
+++ b/runtime/src/desktop/rest-bridge.ts
@@ -157,10 +157,11 @@ export class DesktopRESTBridge {
             def.name === "screenshot" &&
             typeof inner.image === "string"
           ) {
+            const { image, ...rest } = inner;
             return {
               content: safeStringify({
-                ...inner,
-                dataUrl: `data:image/png;base64,${inner.image as string}`,
+                ...rest,
+                dataUrl: `data:image/png;base64,${image}`,
               }),
             };
           }

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -280,8 +280,10 @@ export class VoiceBridge {
       voice: this.config.voice ?? "Ara",
       modalities: ["text", "audio"],
       instructions: voiceInstructions,
-      input_audio_format: "pcm16",
-      output_audio_format: "pcm16",
+      audio: {
+        input: { format: { type: "audio/pcm", rate: 24000 } },
+        output: { format: { type: "audio/pcm", rate: 24000 } },
+      },
       input_audio_transcription: { model: "whisper-1" },
       turn_detection:
         this.config.mode === "push-to-talk"

--- a/runtime/src/voice/realtime/client.ts
+++ b/runtime/src/voice/realtime/client.ts
@@ -185,12 +185,13 @@ export class XaiRealtimeClient {
     messages: ReadonlyArray<{ role: "user" | "assistant"; content: string }>,
   ): void {
     for (const msg of messages) {
+      const contentType = msg.role === "assistant" ? "text" : "input_text";
       this.sendEvent({
         type: "conversation.item.create",
         item: {
           type: "message",
           role: msg.role,
-          content: [{ type: "input_text", text: msg.content }],
+          content: [{ type: contentType, text: msg.content }],
         },
       });
     }

--- a/runtime/src/voice/realtime/types.ts
+++ b/runtime/src/voice/realtime/types.ts
@@ -15,7 +15,34 @@
 export type XaiVoice = "Ara" | "Rex" | "Sal" | "Eve" | "Leo";
 
 /** Supported audio wire formats. */
-export type XaiAudioFormat = "pcm16" | "g711_ulaw" | "g711_alaw";
+export type XaiAudioFormat = "audio/pcm" | "audio/pcmu" | "audio/pcma";
+
+/** PCM sample rates supported by xAI realtime session audio config. */
+export type XaiPcmSampleRate =
+  | 8000
+  | 16000
+  | 21050
+  | 24000
+  | 32000
+  | 44100
+  | 48000;
+
+/** Audio format settings for input/output stream configuration. */
+export interface VoiceAudioFormatConfig {
+  readonly type: XaiAudioFormat;
+  /** Only applies to audio/pcm. */
+  readonly rate?: XaiPcmSampleRate;
+}
+
+/** Session audio block used by xAI Voice Agent session.update. */
+export interface VoiceAudioConfig {
+  readonly input?: {
+    readonly format: VoiceAudioFormatConfig;
+  };
+  readonly output?: {
+    readonly format: VoiceAudioFormatConfig;
+  };
+}
 
 /** Voice Activity Detection (VAD) configuration. */
 export interface VadConfig {
@@ -55,8 +82,7 @@ export interface VoiceSessionConfig {
   readonly voice?: XaiVoice;
   readonly modalities?: ReadonlyArray<"text" | "audio">;
   readonly instructions?: string;
-  readonly input_audio_format?: XaiAudioFormat;
-  readonly output_audio_format?: XaiAudioFormat;
+  readonly audio?: VoiceAudioConfig;
   readonly turn_detection?: VadConfig | null;
   readonly tools?: readonly VoiceTool[];
   readonly temperature?: number;
@@ -109,7 +135,7 @@ export interface ConversationItemCreateFunctionOutputEvent {
 
 /** Content part for message conversation items. */
 export interface ConversationItemContentPart {
-  readonly type: "input_text" | "input_audio";
+  readonly type: "input_text" | "text" | "input_audio";
   readonly text?: string;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   WS_VOICE_DELEGATION,
   WS_VOICE_USER_TRANSCRIPT,
   WS_VOICE_TRANSCRIPT,
+  WS_VOICE_RESPONSE_DONE,
 } from './constants';
 import { useWebSocket } from './hooks/useWebSocket';
 import { useTheme } from './hooks/useTheme';
@@ -139,6 +140,9 @@ export default function App() {
       } else if (status === 'started' || status === 'error' || status === 'blocked') {
         suppressNextVoiceTranscript.current = false;
       }
+    }
+    if (msg.type === WS_VOICE_RESPONSE_DONE) {
+      suppressNextVoiceTranscript.current = false;
     }
 
     if (msg.type === WS_VOICE_SPEECH_STOPPED) {

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -21,9 +21,9 @@ const LLM_PROVIDERS = [
   {
     value: 'grok',
     label: 'Grok (x.ai)',
-    defaultModel: 'grok-4-fast-reasoning',
+    defaultModel: 'grok-4-1-fast-reasoning',
     defaultBaseUrl: 'https://api.x.ai/v1',
-    models: ['grok-4', 'grok-4-fast-reasoning', 'grok-4-fast-non-reasoning', 'grok-code-fast-1', 'grok-3'],
+    models: ['grok-4-1-fast-reasoning', 'grok-4-1-fast-non-reasoning', 'grok-code-fast-1'],
   },
   {
     value: 'ollama',

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -97,6 +97,15 @@ export function ChatView({
     : 0;
 
   const isEmpty = messages.length === 0 && !isTyping;
+  const tokenUsageRatio =
+    tokenUsage && tokenUsage.budget > 0
+      ? tokenUsage.totalTokens / tokenUsage.budget
+      : 0;
+  const tokenUsagePercent = tokenUsageRatio * 100;
+  const tokenUsageLabel =
+    tokenUsage && tokenUsage.totalTokens > 0 && tokenUsagePercent < 1
+      ? '<1%'
+      : `${Math.round(tokenUsagePercent)}%`;
 
   // ── Welcome / landing state ──
   if (isEmpty) {
@@ -194,15 +203,15 @@ export function ChatView({
           {tokenUsage && tokenUsage.budget > 0 && (
             <div
               className={`px-2 py-0.5 rounded-full text-xs font-mono tabular-nums ${
-                tokenUsage.totalTokens / tokenUsage.budget > 0.85
+                tokenUsageRatio > 0.85
                   ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-                  : tokenUsage.totalTokens / tokenUsage.budget > 0.6
+                  : tokenUsageRatio > 0.6
                     ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
                     : 'bg-tetsuo-100 text-tetsuo-500 dark:bg-tetsuo-800 dark:text-tetsuo-400'
               }`}
               title={`${tokenUsage.totalTokens.toLocaleString()} / ${tokenUsage.budget.toLocaleString()} tokens${tokenUsage.compacted ? ' (auto-compacted)' : ''}`}
             >
-              {Math.round((tokenUsage.totalTokens / tokenUsage.budget) * 100)}%
+              {tokenUsageLabel}
               {tokenUsage.compacted && ' ~'}
             </div>
           )}

--- a/web/src/components/settings/SettingsView.tsx
+++ b/web/src/components/settings/SettingsView.tsx
@@ -13,9 +13,9 @@ const LLM_PROVIDERS: LLMProviderDef[] = [
   {
     value: 'grok',
     label: 'Grok (x.ai)',
-    defaultModel: 'grok-4-fast-reasoning',
+    defaultModel: 'grok-4-1-fast-reasoning',
     defaultBaseUrl: 'https://api.x.ai/v1',
-    models: ['grok-4', 'grok-4-fast-reasoning', 'grok-4-fast-non-reasoning', 'grok-code-fast-1', 'grok-3'],
+    models: ['grok-4-1-fast-reasoning', 'grok-4-1-fast-non-reasoning', 'grok-code-fast-1'],
   },
   {
     value: 'ollama',

--- a/web/src/constants.ts
+++ b/web/src/constants.ts
@@ -13,6 +13,7 @@ export const WS_CHAT_MESSAGE = 'chat.message' as const;
 export const WS_CHAT_TYPING = 'chat.typing' as const;
 export const WS_CHAT_HISTORY = 'chat.history' as const;
 export const WS_CHAT_SESSION = 'chat.session' as const;
+export const WS_CHAT_NEW = 'chat.new' as const;
 export const WS_CHAT_RESUMED = 'chat.resumed' as const;
 export const WS_CHAT_SESSIONS = 'chat.sessions' as const;
 export const WS_CHAT_CANCELLED = 'chat.cancelled' as const;

--- a/web/src/hooks/useSettings.ts
+++ b/web/src/hooks/useSettings.ts
@@ -28,7 +28,7 @@ export interface GatewaySettings {
 }
 
 const DEFAULT_SETTINGS: GatewaySettings = {
-  llm: { provider: 'grok', apiKey: '', model: 'grok-4-fast-reasoning', baseUrl: 'https://api.x.ai/v1' },
+  llm: { provider: 'grok', apiKey: '', model: 'grok-4-1-fast-reasoning', baseUrl: 'https://api.x.ai/v1' },
   voice: { enabled: true, mode: 'vad', voice: 'Ara', apiKey: '' },
   memory: { backend: 'memory' },
   connection: { rpcUrl: 'https://api.devnet.solana.com' },

--- a/web/src/hooks/useVoice.ts
+++ b/web/src/hooks/useVoice.ts
@@ -210,12 +210,10 @@ export function useVoice({ send, onDelegationResult }: UseVoiceOptions) {
         const errMsg = (payload.message as string) ?? 'Voice error';
         setTranscript(errMsg);
         // If we were connecting, the session failed to start — go inactive
-        if (voiceState === 'connecting' || awaitingStartRef.current) {
-          recorder.stop();
-          awaitingStartRef.current = false;
-          player.stop();
-          setVoiceState('inactive');
-        }
+        recorder.stop();
+        player.stop();
+        awaitingStartRef.current = false;
+        setVoiceState('inactive');
         break;
       }
 


### PR DESCRIPTION
## Summary

- **Desktop container**: Pin Playwright MCP to 0.0.68 with chromium-wrapper (no-sandbox), auto-detach GUI launch commands in bash tool, normalize apt commands (auto update+sudo+-y), filter untitled windows from window_list, add epiphany browser/kitty/xterm/sqlite3/tmux-mcp/mcp-neovim-server
- **Grok adapter**: Update to grok-4-1-fast-reasoning/non-reasoning models, add streaming support with token usage tracking, handle reasoning model content blocks
- **WebChat**: `chat.new` session lifecycle with server-side context reset + salted session IDs to prevent stale memory reuse, message ID dedup for replay safety, voice error envelope normalization
- **ChatExecutor**: Structured tool result rendering, prevent empty assistant messages, tool call ID validation
- **Web UI**: Token usage <1% display fix, Grok model list updated, startNewChat wiring, new tests

## Test plan

- [ ] Verify runtime tests pass (`cd runtime && npm run test`)
- [ ] Verify web tests pass (`cd web && npx vitest run`)
- [ ] Test desktop container builds and tools work (`docker build -t agenc/desktop:latest containers/desktop/`)
- [ ] Verify Grok streaming with grok-4-1-fast-reasoning model
- [ ] Test chat.new session reset flow in web UI