### PR TITLE
fix(runtime): preserve assistant tool_calls, Grok overflow diagnostics, remove desktop auto-screenshot

### DIFF
--- a/runtime/src/desktop/types.ts
+++ b/runtime/src/desktop/types.ts
@@ -67,7 +67,7 @@ export interface DesktopSandboxConfig {
   readonly securityProfile?: "strict" | "permissive";
   /** Extra Docker labels. */
   readonly labels?: Record<string, string>;
-  /** Auto-capture screenshot after GUI action tools (mouse, keyboard). Default: false */
+  /** Deprecated no-op. Automatic screenshot capture is disabled. */
   readonly autoScreenshot?: boolean;
   /** Playwright MCP browser automation options. */
   readonly playwright?: {

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -452,6 +452,15 @@ describe("ChatExecutor", () => {
       expect(result.toolCalls[0].isError).toBe(false);
       expect(result.toolCalls[0].durationMs).toBeGreaterThanOrEqual(0);
       expect(toolHandler).toHaveBeenCalledWith("search", { query: "test" });
+
+      const followupMessages = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1][0] as LLMMessage[];
+      const assistantWithToolCall = followupMessages.find(
+        (m) => m.role === "assistant" && Array.isArray(m.toolCalls),
+      );
+      expect(assistantWithToolCall?.toolCalls).toEqual([
+        { id: "tc-1", name: "search", arguments: '{"query":"test"}' },
+      ]);
     });
 
     it("sanitizes screenshot tool payloads before follow-up model call", async () => {

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -373,7 +373,11 @@ export class ChatExecutor {
       rounds++;
 
       // Append the assistant message with tool calls
-      messages.push({ role: "assistant", content: response.content });
+      messages.push({
+        role: "assistant",
+        content: response.content,
+        toolCalls: response.toolCalls,
+      });
       for (const toolCall of response.toolCalls) {
         if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name) && sideEffectExecuted) {
           const skipResult = safeStringify({

--- a/runtime/src/llm/executor.test.ts
+++ b/runtime/src/llm/executor.test.ts
@@ -150,6 +150,13 @@ describe("LLMTaskExecutor", () => {
 
     expect(chatFn).toHaveBeenCalledTimes(2);
     expect(toolHandler).toHaveBeenCalledWith("lookup", { key: "val" });
+    const followupMessages = chatFn.mock.calls[1][0] as LLMMessage[];
+    const assistantWithToolCalls = followupMessages.find(
+      (message) => message.role === "assistant" && Array.isArray(message.toolCalls),
+    );
+    expect(assistantWithToolCalls?.toolCalls).toEqual([
+      { id: "call_1", name: "lookup", arguments: '{"key":"val"}' },
+    ]);
     expect(output).toHaveLength(4);
   });
 

--- a/runtime/src/llm/executor.ts
+++ b/runtime/src/llm/executor.ts
@@ -152,6 +152,9 @@ export class LLMTaskExecutor implements TaskExecutor {
     const assistantMsg: LLMMessage = {
       role: "assistant",
       content: response.content,
+      ...(response.toolCalls.length > 0
+        ? { toolCalls: response.toolCalls }
+        : {}),
     };
     messages.push(assistantMsg);
     await this.persistMessage(sessionId, assistantMsg, taskPda);
@@ -252,6 +255,9 @@ export class LLMTaskExecutor implements TaskExecutor {
       const nextAssistantMsg: LLMMessage = {
         role: "assistant",
         content: response.content,
+        ...(response.toolCalls.length > 0
+          ? { toolCalls: response.toolCalls }
+          : {}),
       };
       messages.push(nextAssistantMsg);
       await this.persistMessage(sessionId, nextAssistantMsg, taskPda);

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -29,6 +29,8 @@ export type LLMContentPart =
 export interface LLMMessage {
   role: MessageRole;
   content: string | LLMContentPart[];
+  /** For assistant messages that request tool execution */
+  toolCalls?: LLMToolCall[];
   /** For tool result messages — the ID of the tool call being responded to */
   toolCallId?: string;
   /** For tool result messages — the name of the tool */


### PR DESCRIPTION
## Summary

- **Tool calls preservation**: `LLMMessage` now carries `toolCalls` on assistant messages. `ChatExecutor`, `LLMTaskExecutor`, and `GrokProvider` all preserve and serialize tool calls correctly before tool result messages, fixing Grok context-overflow errors caused by missing `tool_calls` entries
- **Grok overflow diagnostics**: Logs message counts, content sizes, and tool schema sizes when the provider returns a 400 prompt overflow error
- **Desktop auto-screenshot removal**: Removes the auto-screenshot feature entirely (delays, noise, token waste). `desktop.screenshot` is now disabled — filtered from LLM tools and returns an error from the session router
- **Session management**: Adds `/restart` command (alias for `/reset`), resets `ChatExecutor` session tokens on reset

## Test plan

- [x] Regression tests for `toolCalls` preservation in `chat-executor.test.ts`
- [x] Regression tests for `toolCalls` preservation in `executor.test.ts`
- [x] Regression tests for `tool_calls` serialization in `grok/adapter.test.ts`
- [x] Updated `session-router.test.ts` for screenshot disabling and auto-screenshot removal