### PR TITLE
fix(runtime,web,desktop): tool pipeline integrity guards, Grok Responses API, daemon hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,11 @@ Create `~/.agenc/config.json`:
     "dbPath": "~/.agenc/memory.db"
   },
   "logging": {
-    "level": "info"
+    "level": "info",
+    "trace": {
+      "enabled": false,
+      "maxChars": 20000
+    }
   }
 }
 ```
@@ -206,7 +210,7 @@ Create `~/.agenc/config.json`:
 | `mcp` | External MCP servers | `servers[]` with `name`, `command`, `args`, `env` |
 | `auth` | JWT/auth | `jwtSecret` |
 | `telemetry` | Metrics | `enabled`, `flushIntervalMs` |
-| `logging` | Log level | `level` (`debug` / `info` / `warn` / `error`) |
+| `logging` | Runtime logging + trace verbosity | `level` (`debug` / `info` / `warn` / `error`), `trace.enabled`, `trace.includeHistory`, `trace.includeSystemPrompt`, `trace.includeToolArgs`, `trace.includeToolResults`, `trace.maxChars` |
 
 </details>
 
@@ -232,6 +236,28 @@ npx agenc-runtime daemon restart --config ~/.agenc/config.json     # Restart
 ```
 
 The daemon writes a PID file to `~/.agenc/daemon.pid` and handles SIGTERM/SIGINT for graceful shutdown.
+
+### Full Chat/Tool Trace Logging
+
+When debugging tool-turn sequencing, context carryover, or sandbox/tool failures, enable full trace logs:
+
+```json
+{
+  "logging": {
+    "level": "info",
+    "trace": {
+      "enabled": true,
+      "includeHistory": true,
+      "includeSystemPrompt": true,
+      "includeToolArgs": true,
+      "includeToolResults": true,
+      "maxChars": 20000
+    }
+  }
+}
+```
+
+Trace output includes inbound messages, serialized session history, per-tool args/results, final LLM response metadata, and errors in `~/.agenc/daemon.log`.
 
 ### What Happens on Startup
 

--- a/containers/desktop/Dockerfile
+++ b/containers/desktop/Dockerfile
@@ -106,15 +106,12 @@ RUN printf '%s\n' \
     'fi' \
     '' \
     'has_no_sandbox=0' \
-    'has_disable_setuid=0' \
     'for arg in "$@"; do' \
     '  [ "$arg" = "--no-sandbox" ] && has_no_sandbox=1' \
-    '  [ "$arg" = "--disable-setuid-sandbox" ] && has_disable_setuid=1' \
     'done' \
     '' \
     'extra=()' \
     '[ "$has_no_sandbox" -eq 0 ] && extra+=(--no-sandbox)' \
-    '[ "$has_disable_setuid" -eq 0 ] && extra+=(--disable-setuid-sandbox)' \
     'extra+=(--disable-gpu --use-gl=swiftshader --disable-dev-shm-usage)' \
     '' \
     'exec "${CHROME_BIN}" "${extra[@]}" "$@"' \

--- a/docs/INCIDENT_REPLAY_RUNBOOK.md
+++ b/docs/INCIDENT_REPLAY_RUNBOOK.md
@@ -3,6 +3,9 @@
 This runbook provides a deterministic, command-by-command workflow for replay-based incident reconstruction.
 It covers both the CLI (`agenc-runtime replay ...`) and MCP tool paths (`agenc_replay_*`).
 
+For runtime LLM/tool-pipeline incidents (context growth, tool-turn ordering, desktop hangs), use:
+`docs/RUNTIME_PIPELINE_DEBUG_BUNDLE.md`.
+
 ---
 
 ## CLI path
@@ -184,4 +187,3 @@ structuredContent.schema: replay.incident.output.v1
   - `mcp/src/tools/replay-types.ts` for MCP response schemas
   - `runtime/docs/replay-cli.md` for CLI usage
 - Replay outputs may include optional `schema_hash` to detect schema drift.
-

--- a/runtime/package.json
+++ b/runtime/package.json
@@ -29,6 +29,7 @@
     "pretest": "npm run build --prefix ../sdk",
     "test": "vitest run",
     "test:watch": "vitest",
+    "repro:pipeline:http": "npx tsx scripts/repro-pipeline-http.ts",
     "benchmark": "npx tsx scripts/run-benchmarks.ts",
     "benchmark:ci": "npx tsx scripts/run-benchmarks.ts --output benchmarks/artifacts/ci.json",
     "mutation": "npx tsx scripts/run-mutations.ts",

--- a/runtime/scripts/repro-pipeline-http.ts
+++ b/runtime/scripts/repro-pipeline-http.ts
@@ -1,0 +1,208 @@
+/**
+ * Deterministic local pipeline repro harness for desktop/system command flow.
+ *
+ * Reproduces the canonical HTTP fixture sequence used in debugging:
+ * 1) create fixture
+ * 2) start local HTTP server
+ * 3) optional Playwright navigation
+ * 4) verify HTTP content
+ * 5) verify process
+ * 6) teardown and verify port release
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+type StepResult = {
+  step: number;
+  tool: string;
+  ok: boolean;
+  preview: string;
+  skipped?: boolean;
+};
+
+type BashResult = {
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+};
+
+async function runBash(command: string, timeoutMs = 30_000): Promise<BashResult> {
+  try {
+    const { stdout, stderr } = await execFileAsync("bash", ["-lc", command], {
+      timeout: timeoutMs,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    return {
+      ok: true,
+      stdout: stdout.trim(),
+      stderr: stderr.trim(),
+      exitCode: 0,
+    };
+  } catch (error) {
+    const err = error as {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+      signal?: string;
+      message?: string;
+    };
+    const code =
+      typeof err.code === "number"
+        ? err.code
+        : err.signal
+          ? -1
+          : 1;
+    return {
+      ok: false,
+      stdout: String(err.stdout ?? "").trim(),
+      stderr: String(err.stderr ?? err.message ?? "command failed").trim(),
+      exitCode: code,
+    };
+  }
+}
+
+function preview(result: BashResult): string {
+  if (result.ok) {
+    return result.stdout || "ok";
+  }
+  const stderr = result.stderr || "failed";
+  return `exit=${result.exitCode} ${stderr}`.slice(0, 240);
+}
+
+async function runOptionalPlaywrightStep(url: string): Promise<StepResult> {
+  try {
+    const playwright = await import("playwright");
+    const browser = await playwright.chromium.launch({
+      headless: true,
+      timeout: 10_000,
+    });
+    try {
+      const page = await browser.newPage();
+      await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15_000 });
+      const html = await page.content();
+      const ok = html.includes("pipeline-ok");
+      return {
+        step: 3,
+        tool: "playwright.browser_navigate",
+        ok,
+        preview: ok ? "pipeline-ok detected in page content" : "page loaded but marker missing",
+      };
+    } finally {
+      await browser.close();
+    }
+  } catch {
+    return {
+      step: 3,
+      tool: "playwright.browser_navigate",
+      ok: true,
+      skipped: true,
+      preview: "Playwright unavailable; step skipped",
+    };
+  }
+}
+
+async function main(): Promise<void> {
+  const steps: StepResult[] = [];
+  const workspace = "/tmp/agenc-pipeline-test";
+  const port = 8123;
+  let serverPid: string | undefined;
+
+  const step1 = await runBash(
+    [
+      "set -euo pipefail",
+      `rm -rf ${workspace}`,
+      `mkdir -p ${workspace}`,
+      `cat > ${workspace}/index.html <<'HTML'`,
+      "<!doctype html><title>AgenC Pipeline OK</title><h1>pipeline-ok</h1>",
+      "HTML",
+    ].join("\n"),
+  );
+  steps.push({
+    step: 1,
+    tool: "system.bash",
+    ok: step1.ok,
+    preview: preview(step1),
+  });
+
+  const step2 = await runBash(
+    `cd ${workspace} && python3 -m http.server ${port} >/tmp/agenc-http.log 2>&1 & echo $!`,
+  );
+  if (step2.ok) {
+    serverPid = step2.stdout.split(/\s+/)[0]?.trim();
+  }
+  steps.push({
+    step: 2,
+    tool: "system.bash",
+    ok: step2.ok && Boolean(serverPid),
+    preview: step2.ok ? `server pid=${serverPid ?? "unknown"}` : preview(step2),
+  });
+
+  steps.push(await runOptionalPlaywrightStep(`http://127.0.0.1:${port}`));
+
+  const step4 = await runBash(
+    `curl -sSf http://127.0.0.1:${port} | grep -q 'pipeline-ok' && echo HTTP_OK`,
+  );
+  steps.push({
+    step: 4,
+    tool: "system.bash",
+    ok: step4.ok,
+    preview: preview(step4),
+  });
+
+  const step5 = await runBash(`pgrep -fa 'python3 -m http.server ${port}'`);
+  const step5HasHttpServer =
+    step5.ok &&
+    step5.stdout
+      .split("\n")
+      .some((line) => line.includes(`python3 -m http.server ${port}`));
+  steps.push({
+    step: 5,
+    tool: "system.bash",
+    ok: step5HasHttpServer,
+    preview: preview(step5),
+  });
+
+  const step6 = await runBash(
+    [
+      `pkill -f '[p]ython3 -m http.server ${port}' || true`,
+      "sleep 1",
+      `if command -v ss >/dev/null 2>&1; then`,
+      `  ss -ltn '( sport = :${port} )' | tail -n +2 | wc -l`,
+      "elif command -v lsof >/dev/null 2>&1; then",
+      `  lsof -nP -iTCP:${port} -sTCP:LISTEN 2>/dev/null | tail -n +2 | wc -l`,
+      "else",
+      `  if curl -fsS --max-time 1 http://127.0.0.1:${port} >/dev/null 2>&1; then echo 1; else echo 0; fi`,
+      "fi",
+    ].join("\n"),
+  );
+  const portListeners = Number(step6.stdout.trim() || "0");
+  steps.push({
+    step: 6,
+    tool: "system.bash",
+    ok: step6.ok && Number.isFinite(portListeners) && portListeners === 0,
+    preview: step6.ok ? `listeners_on_${port}=${step6.stdout.trim()}` : preview(step6),
+  });
+
+  // Final safety cleanup in case intermediate steps failed.
+  if (serverPid) {
+    await runBash(`kill ${serverPid} >/dev/null 2>&1 || true`);
+  }
+  await runBash(`pkill -f '[p]ython3 -m http.server ${port}' || true`);
+
+  const overall = steps.every((step) => step.ok);
+  const output = {
+    overall: overall ? "pass" : "fail",
+    steps,
+  };
+  console.log(JSON.stringify(output, null, 2));
+
+  if (!overall) {
+    process.exitCode = 1;
+  }
+}
+
+void main();

--- a/runtime/src/cli/logs.test.ts
+++ b/runtime/src/cli/logs.test.ts
@@ -93,7 +93,10 @@ describe("logs: runLogsCommand", () => {
     expect(payload.pid).toBe(process.pid);
     expect(payload.port).toBe(3100);
     expect(Array.isArray(payload.methods)).toBe(true);
-    expect((payload.methods as Array<unknown>).length).toBe(3);
+    expect((payload.methods as Array<unknown>).length).toBe(4);
+    const methods = payload.methods as Array<{ mode: string; command: string }>;
+    const backgroundMethod = methods.find((m) => m.mode === "background");
+    expect(backgroundMethod?.command).toContain("daemon.log");
   });
 
   it("includes session filter when sessionId is provided", async () => {
@@ -138,5 +141,7 @@ describe("logs: runLogsCommand", () => {
     const methods = payload.methods as Array<{ mode: string; command: string }>;
     const systemdMethod = methods.find((m) => m.mode === "systemd");
     expect(systemdMethod?.command).toContain("-n 50");
+    const backgroundMethod = methods.find((m) => m.mode === "background");
+    expect(backgroundMethod?.command).toContain("-n 50");
   });
 });

--- a/runtime/src/gateway/approvals.test.ts
+++ b/runtime/src/gateway/approvals.test.ts
@@ -128,9 +128,13 @@ describe('ApprovalEngine', () => {
 
   describe('requiresApproval', () => {
     it('matches exact tool name', () => {
-      const rule = engine.requiresApproval('system.bash', {});
+      const rule = engine.requiresApproval('system.delete', {});
       expect(rule).not.toBeNull();
-      expect(rule!.tool).toBe('system.bash');
+      expect(rule!.tool).toBe('system.delete');
+    });
+
+    it('does not require approval for system.bash by default', () => {
+      expect(engine.requiresApproval('system.bash', { command: 'npm' })).toBeNull();
     });
 
     it('returns null for unmatched tool', () => {
@@ -227,7 +231,7 @@ describe('ApprovalEngine', () => {
   describe('approval flow', () => {
     it('resolves with yes — returns approved response', async () => {
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
 
       const promise = engine.requestApproval(req);
       engine.resolve(req.id, { requestId: req.id, disposition: 'yes' });
@@ -238,7 +242,7 @@ describe('ApprovalEngine', () => {
 
     it('resolves with no — returns denied response', async () => {
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
 
       const promise = engine.requestApproval(req);
       engine.resolve(req.id, { requestId: req.id, disposition: 'no' });
@@ -256,7 +260,7 @@ describe('ApprovalEngine', () => {
           generateId: () => 'timeout-req',
         });
         const rule = DEFAULT_APPROVAL_RULES[0];
-        const req = eng.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+        const req = eng.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
 
         const promise = eng.requestApproval(req);
         vi.advanceTimersByTime(200);
@@ -270,14 +274,14 @@ describe('ApprovalEngine', () => {
     });
 
     it('always disposition elevates the session', async () => {
-      const rule = DEFAULT_APPROVAL_RULES[0]; // system.bash
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const rule = DEFAULT_APPROVAL_RULES[0]; // system.delete
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
 
       const promise = engine.requestApproval(req);
       engine.resolve(req.id, { requestId: req.id, disposition: 'always' });
 
       await promise;
-      expect(engine.isToolElevated('sess-1', 'system.bash')).toBe(true);
+      expect(engine.isToolElevated('sess-1', 'system.delete')).toBe(true);
     });
 
     it('resolve of nonexistent request is a no-op', () => {
@@ -296,7 +300,7 @@ describe('ApprovalEngine', () => {
       engine.onResponse(handler);
 
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
 
       const promise = engine.requestApproval(req);
       const response: ApprovalResponse = { requestId: req.id, disposition: 'yes' };
@@ -318,7 +322,7 @@ describe('ApprovalEngine', () => {
         eng.onResponse(handler);
 
         const rule = DEFAULT_APPROVAL_RULES[0];
-        const req = eng.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+        const req = eng.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
 
         const promise = eng.requestApproval(req);
         vi.advanceTimersByTime(100);
@@ -377,7 +381,7 @@ describe('ApprovalEngine', () => {
 
     it('returns pending requests', () => {
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
       engine.requestApproval(req);
 
       const pending = engine.getPending();
@@ -390,7 +394,7 @@ describe('ApprovalEngine', () => {
 
     it('removes resolved requests from pending', async () => {
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
       const promise = engine.requestApproval(req);
       engine.resolve(req.id, { requestId: req.id, disposition: 'yes' });
       await promise;
@@ -406,7 +410,7 @@ describe('ApprovalEngine', () => {
   describe('dispose', () => {
     it('clears all pending timers and requests', () => {
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req1 = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req1 = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
       const req2 = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
       engine.requestApproval(req1);
       engine.requestApproval(req2);
@@ -420,7 +424,7 @@ describe('ApprovalEngine', () => {
 
     it('auto-denies pending requests so promises resolve', async () => {
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
       const promise = engine.requestApproval(req);
 
       engine.dispose();
@@ -442,7 +446,7 @@ describe('ApprovalEngine', () => {
       });
 
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+      const req = engine.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
       const promise = engine.requestApproval(req);
       engine.resolve(req.id, { requestId: req.id, disposition: 'yes' });
 
@@ -463,7 +467,7 @@ describe('ApprovalEngine', () => {
         });
 
         const rule = DEFAULT_APPROVAL_RULES[0];
-        const req = eng.createRequest('system.bash', {}, 'sess-1', 'Approve?', rule);
+        const req = eng.createRequest('system.delete', {}, 'sess-1', 'Approve?', rule);
         const promise = eng.requestApproval(req);
         vi.advanceTimersByTime(100);
 
@@ -482,10 +486,10 @@ describe('ApprovalEngine', () => {
   describe('createRequest', () => {
     it('creates a request with injected id and timestamp', () => {
       const rule = DEFAULT_APPROVAL_RULES[0];
-      const req = engine.createRequest('system.bash', { cmd: 'ls' }, 'sess-1', 'Check', rule);
+      const req = engine.createRequest('system.delete', { cmd: 'ls' }, 'sess-1', 'Check', rule);
 
       expect(req.id).toBe('req-1');
-      expect(req.toolName).toBe('system.bash');
+      expect(req.toolName).toBe('system.delete');
       expect(req.args).toEqual({ cmd: 'ls' });
       expect(req.sessionId).toBe('sess-1');
       expect(req.message).toBe('Check');
@@ -499,13 +503,12 @@ describe('ApprovalEngine', () => {
   // ============================================================================
 
   describe('DEFAULT_APPROVAL_RULES', () => {
-    it('has 11 rules', () => {
-      expect(DEFAULT_APPROVAL_RULES).toHaveLength(11);
+    it('has 10 rules', () => {
+      expect(DEFAULT_APPROVAL_RULES).toHaveLength(10);
     });
 
-    it('covers system.bash, system.delete, system.evaluateJs', () => {
+    it('covers system.delete and system.evaluateJs', () => {
       const tools = DEFAULT_APPROVAL_RULES.map((r) => r.tool);
-      expect(tools).toContain('system.bash');
       expect(tools).toContain('system.delete');
       expect(tools).toContain('system.evaluateJs');
     });

--- a/runtime/src/gateway/approvals.ts
+++ b/runtime/src/gateway/approvals.ts
@@ -124,12 +124,14 @@ export function extractAmount(
 // Default Rules
 // ============================================================================
 
-/** Built-in approval rules for common dangerous operations. */
+/**
+ * Built-in approval rules for common dangerous operations.
+ *
+ * Note: `system.bash` is intentionally not included by default. The bash tool
+ * already enforces a deny-list policy at execution time, and requiring manual
+ * approval for every shell command can deadlock non-interactive channels.
+ */
 export const DEFAULT_APPROVAL_RULES: readonly ApprovalRule[] = [
-  {
-    tool: "system.bash",
-    description: "Shell command execution",
-  },
   {
     tool: "system.delete",
     description: "File deletion",

--- a/runtime/src/gateway/commands.test.ts
+++ b/runtime/src/gateway/commands.test.ts
@@ -49,8 +49,15 @@ describe("parseCommand", () => {
     expect(parseCommand("  ").isCommand).toBe(false);
   });
 
+  it("maps bare slash to help command", () => {
+    const result = parseCommand("/");
+    expect(result.isCommand).toBe(true);
+    expect(result.name).toBe("help");
+    expect(result.args).toBe("");
+    expect(result.argv).toEqual([]);
+  });
+
   it("rejects slash without valid command name", () => {
-    expect(parseCommand("/").isCommand).toBe(false);
     expect(parseCommand("/ help").isCommand).toBe(false);
     expect(parseCommand("/123").isCommand).toBe(false);
   });

--- a/runtime/src/gateway/commands.ts
+++ b/runtime/src/gateway/commands.ts
@@ -78,6 +78,14 @@ const COMMAND_PATTERN = /^\/([a-zA-Z][a-zA-Z0-9_-]*)(?:\s+(.*))?$/;
  */
 export function parseCommand(message: string): ParsedCommand {
   const trimmed = message.trim();
+  if (trimmed === "/") {
+    return {
+      isCommand: true,
+      name: "help",
+      args: "",
+      argv: [],
+    };
+  }
   const match = COMMAND_PATTERN.exec(trimmed);
 
   if (!match) {

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -143,13 +143,45 @@ export function validateGatewayConfig(obj: unknown): ValidationResult {
   if (obj.logging !== undefined) {
     if (!isRecord(obj.logging)) {
       errors.push("logging must be an object");
-    } else if (obj.logging.level !== undefined) {
-      requireOneOf(
-        obj.logging.level,
-        "logging.level",
-        VALID_LOG_LEVELS,
-        errors,
-      );
+    } else {
+      if (obj.logging.level !== undefined) {
+        requireOneOf(
+          obj.logging.level,
+          "logging.level",
+          VALID_LOG_LEVELS,
+          errors,
+        );
+      }
+      if (obj.logging.trace !== undefined) {
+        if (!isRecord(obj.logging.trace)) {
+          errors.push("logging.trace must be an object");
+        } else {
+          const boolFields = [
+            "enabled",
+            "includeHistory",
+            "includeSystemPrompt",
+            "includeToolArgs",
+            "includeToolResults",
+          ];
+          for (const field of boolFields) {
+            if (
+              obj.logging.trace[field] !== undefined &&
+              typeof obj.logging.trace[field] !== "boolean"
+            ) {
+              errors.push(`logging.trace.${field} must be a boolean`);
+            }
+          }
+          if (obj.logging.trace.maxChars !== undefined) {
+            requireIntRange(
+              obj.logging.trace.maxChars,
+              "logging.trace.maxChars",
+              256,
+              200_000,
+              errors,
+            );
+          }
+        }
+      }
     }
   }
 
@@ -164,6 +196,21 @@ export function validateGatewayConfig(obj: unknown): ValidationResult {
         VALID_LLM_PROVIDERS,
         errors,
       );
+      if (obj.llm.timeoutMs !== undefined) {
+        requireIntRange(
+          obj.llm.timeoutMs,
+          "llm.timeoutMs",
+          1_000,
+          3_600_000,
+          errors,
+        );
+      }
+      if (
+        obj.llm.parallelToolCalls !== undefined &&
+        typeof obj.llm.parallelToolCalls !== "boolean"
+      ) {
+        errors.push("llm.parallelToolCalls must be a boolean");
+      }
     }
   }
 

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -19,10 +19,14 @@ export interface GatewayLLMConfig {
   apiKey?: string;
   model?: string;
   baseUrl?: string;
+  /** Request timeout in milliseconds for provider calls (default: provider-specific). */
+  timeoutMs?: number;
   /** Maximum token budget per session. 0 or undefined = unlimited. */
   sessionTokenBudget?: number;
   /** Maximum tool call rounds per message. Default: 5. */
   maxToolRounds?: number;
+  /** Allow model-emitted parallel tool calls. Default: false (serialized). */
+  parallelToolCalls?: boolean;
   /** Additional LLM providers for fallback (tried in order after primary fails). */
   fallback?: GatewayLLMConfig[];
 }
@@ -73,6 +77,20 @@ export interface GatewayConnectionConfig {
 
 export interface GatewayLoggingConfig {
   level?: "debug" | "info" | "warn" | "error";
+  trace?: {
+    /** Enable verbose per-turn chat/tool tracing in daemon logs. */
+    enabled?: boolean;
+    /** Include serialized session history in trace output. */
+    includeHistory?: boolean;
+    /** Include the assembled system prompt in trace output. */
+    includeSystemPrompt?: boolean;
+    /** Include raw tool-call arguments in trace output. */
+    includeToolArgs?: boolean;
+    /** Include raw tool-call results in trace output. */
+    includeToolResults?: boolean;
+    /** Max characters retained for any traced text field. */
+    maxChars?: number;
+  };
 }
 
 export interface GatewayBindConfig {

--- a/runtime/src/llm/grok/types.ts
+++ b/runtime/src/llm/grok/types.ts
@@ -15,6 +15,8 @@ export interface GrokProviderConfig extends LLMProviderConfig {
   apiKey: string;
   /** Base URL for the xAI API (default: 'https://api.x.ai/v1') */
   baseURL?: string;
+  /** Allow the model to emit multiple tool calls in parallel (default: false). */
+  parallelToolCalls?: boolean;
   /** Enable web search tool (injects a web_search tool) */
   webSearch?: boolean;
   /** Search mode when web search is enabled */

--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -49,6 +49,8 @@ export type {
   ChatExecutorConfig,
   ChatExecuteParams,
   ChatExecutorResult,
+  ChatPromptShape,
+  ChatCallUsageRecord,
   ToolCallRecord,
   SkillInjector,
   MemoryRetriever,

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -68,6 +68,26 @@ export interface LLMUsage {
 }
 
 /**
+ * Provider-specific request-shape diagnostics for one LLM call.
+ *
+ * These values are intended for observability/debugging (not billing).
+ */
+export interface LLMRequestMetrics {
+  messageCount: number;
+  systemMessages: number;
+  userMessages: number;
+  assistantMessages: number;
+  toolMessages: number;
+  totalContentChars: number;
+  maxMessageChars: number;
+  textParts: number;
+  imageParts: number;
+  toolCount: number;
+  toolSchemaChars: number;
+  serializedChars: number;
+}
+
+/**
  * Response from an LLM provider
  */
 export interface LLMResponse {
@@ -75,6 +95,8 @@ export interface LLMResponse {
   toolCalls: LLMToolCall[];
   usage: LLMUsage;
   model: string;
+  /** Provider-computed request diagnostics for this call. */
+  requestMetrics?: LLMRequestMetrics;
   finishReason: "stop" | "tool_calls" | "length" | "content_filter" | "error";
   /** Underlying error when finishReason is "error". */
   error?: Error;

--- a/runtime/src/mcp-client/manager.ts
+++ b/runtime/src/mcp-client/manager.ts
@@ -59,7 +59,15 @@ export class MCPManager {
       enabledConfigs.map(async (config) => {
         const client = await createMCPConnection(config, this.logger);
         try {
-          const rawBridge = await createToolBridge(client, config.name, this.logger);
+          const rawBridge = await createToolBridge(
+            client,
+            config.name,
+            this.logger,
+            {
+              listToolsTimeoutMs: config.timeout,
+              callToolTimeoutMs: config.timeout,
+            },
+          );
           const bridge = new ResilientMCPBridge(config, rawBridge, this.logger);
           this.bridges.set(config.name, bridge);
           return bridge;

--- a/runtime/src/mcp-client/resilient-bridge.ts
+++ b/runtime/src/mcp-client/resilient-bridge.ts
@@ -142,7 +142,15 @@ export class ResilientMCPBridge implements MCPToolBridge {
       const { createToolBridge } = await import("./tool-bridge.js");
 
       const client = await createMCPConnection(this.config, this.logger);
-      const newBridge = await createToolBridge(client, this.serverName, this.logger);
+      const newBridge = await createToolBridge(
+        client,
+        this.serverName,
+        this.logger,
+        {
+          listToolsTimeoutMs: this.config.timeout,
+          callToolTimeoutMs: this.config.timeout,
+        },
+      );
 
       this.inner = newBridge;
       this.reconnecting = false;

--- a/runtime/src/memory/structured.test.ts
+++ b/runtime/src/memory/structured.test.ts
@@ -133,6 +133,16 @@ describe("DailyLogManager", () => {
     expect(mgr.todayPath).toContain(formatLogDate());
     expect(mgr.todayPath).toMatch(/\.md$/);
   });
+
+  it("truncates oversized log entries", async () => {
+    const mgr = new DailyLogManager(logDir);
+    const huge = "x".repeat(20_000);
+    await mgr.append("sess-1", "assistant", huge);
+    const content = await mgr.readLog(formatLogDate());
+    expect(content).toBeDefined();
+    expect(content!.length).toBeLessThan(13_000);
+    expect(content).toContain("...");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/runtime/src/tools/system/browser.test.ts
+++ b/runtime/src/tools/system/browser.test.ts
@@ -1078,6 +1078,7 @@ describe("domain validation", () => {
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content);
     expect(parsed.error).toContain("blocked");
+    expect(parsed.error).toContain("desktop.bash");
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/runtime/src/tools/system/browser.ts
+++ b/runtime/src/tools/system/browser.ts
@@ -13,7 +13,7 @@ import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import type { Logger } from "../../utils/logger.js";
 import { silentLogger } from "../../utils/logger.js";
-import { isDomainAllowed } from "./http.js";
+import { isDomainAllowed, formatDomainBlockReason } from "./http.js";
 import { ensureLazyModule } from "../../utils/lazy-import.js";
 
 // ============================================================================
@@ -69,7 +69,7 @@ function validateUrl(
     config.blockedDomains,
   );
   if (!check.allowed) {
-    return errorResult(check.reason!);
+    return errorResult(formatDomainBlockReason(check.reason!));
   }
   return null;
 }

--- a/runtime/src/tools/system/http.test.ts
+++ b/runtime/src/tools/system/http.test.ts
@@ -584,6 +584,7 @@ describe("error handling", () => {
     expect(result.isError).toBe(true);
     const parsed = JSON.parse(result.content);
     expect(parsed.error).toContain("blocked");
+    expect(parsed.error).toContain("desktop.bash");
     // fetch should never be called for blocked domains
     expect(mockFetch).not.toHaveBeenCalled();
   });

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -39,7 +39,7 @@ export function ChatView({
   isTyping,
   onSend,
   onStop,
-  connected,
+  connected: _connected,
   voiceState = 'inactive',
   voiceTranscript = '',
   voiceMode = 'vad',
@@ -128,7 +128,6 @@ export function ChatView({
               onSend={onSend}
               onStop={onStop}
               isGenerating={isTyping}
-              disabled={!connected}
               voiceState={voiceState}
               voiceMode={voiceMode}
               onVoiceToggle={onVoiceToggle}
@@ -302,7 +301,6 @@ export function ChatView({
         onSend={onSend}
         onStop={onStop}
         isGenerating={isTyping}
-        disabled={!connected}
         voiceState={voiceState}
         voiceMode={voiceMode}
         onVoiceToggle={onVoiceToggle}


### PR DESCRIPTION
## Summary

- Migrate Grok adapter from Chat Completions to xAI Responses API with `function_call`/`function_call_output` item linkage and `store: false` default
- Add tool-turn message ordering validation in ChatExecutor and Grok adapter to prevent orphan tool messages and misleading context-overflow errors
- Enforce per-chunk stream inactivity timeout and non-zero request timeout for Grok streaming calls
- Add `system.bash` structured exec validation (single command token, args separation) with actionable error text
- Add one-shot recovery hints for known tool misuse patterns (bash shell-builtin misuse, localhost SSRF blocks)
- Harden SSRF blocking in `system.http`/`system.browse` with remediation text pointing to desktop-local alternatives
- Add daemon lifecycle split-brain prevention (PID ownership verification, multi-process stop/restart)
- Add config watcher with hot-reload for gateway personality, LLM provider, and tool settings
- Add MCP tool bridge timeout enforcement and deadline threading through all bridge creation paths
- Add desktop session router Playwright and container MCP bridge management with per-session lifecycle
- Add pipeline repro harness (`npm run repro:pipeline:http`) for deterministic local pipeline debugging
- Add structured pipeline status output consistency validation (overall vs step alignment)
- Harden memory ingestion (session:compact phase filtering, truncation guards for oversized payloads)
- Harden approval engine defaults (scoped approval, no blanket `system.bash` gating)
- Web: ChatInput voice/settings UX improvements, useSettings test coverage

## Test plan

- [ ] `cd runtime && npm run test` — runtime vitest suite passes
- [ ] `npm run repro:pipeline:http` — pipeline repro harness passes
- [ ] `cd web && npm run test` — web test suite passes
- [ ] Verify Grok tool-calling flows work end-to-end with Responses API
- [ ] Verify daemon start/stop/restart has no split-brain PID issues
- [ ] Verify config hot-reload updates personality/LLM without restart