### PR TITLE
refactor(runtime): extract tool-turn validator and LLM policy modules

### DIFF
--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -27,6 +27,7 @@ export { validateToolCall } from "./types.js";
 // Error classes
 export {
   LLMAuthenticationError,
+  LLMMessageValidationError,
   LLMProviderError,
   LLMRateLimitError,
   LLMResponseConversionError,
@@ -35,6 +36,29 @@ export {
   LLMTimeoutError,
   mapLLMError,
 } from "./errors.js";
+
+// Policy taxonomy (Phase 1)
+export {
+  DEFAULT_LLM_RETRY_POLICY_MATRIX,
+  toPipelineStopReason,
+} from "./policy.js";
+export type {
+  LLMFailureClass,
+  LLMPipelineStopReason,
+  LLMRetryPolicyRule,
+  LLMRetryPolicyMatrix,
+} from "./policy.js";
+
+// Tool-turn protocol validation (Phase 1)
+export {
+  findToolTurnValidationIssue,
+  validateToolTurnSequence,
+} from "./tool-turn-validator.js";
+export type {
+  ToolTurnValidationCode,
+  ToolTurnValidationIssue,
+  ToolTurnValidationOptions,
+} from "./tool-turn-validator.js";
 
 // Response converter
 export { responseToOutput } from "./response-converter.js";

--- a/runtime/src/llm/policy.test.ts
+++ b/runtime/src/llm/policy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LLM_RETRY_POLICY_MATRIX,
+  toPipelineStopReason,
+} from "./policy.js";
+
+describe("llm policy taxonomy", () => {
+  it("defines non-retriable validation/auth/budget failures", () => {
+    expect(DEFAULT_LLM_RETRY_POLICY_MATRIX.validation_error.maxRetries).toBe(0);
+    expect(DEFAULT_LLM_RETRY_POLICY_MATRIX.authentication_error.maxRetries).toBe(0);
+    expect(DEFAULT_LLM_RETRY_POLICY_MATRIX.budget_exceeded.maxRetries).toBe(0);
+  });
+
+  it("defines retriable transient provider classes", () => {
+    expect(DEFAULT_LLM_RETRY_POLICY_MATRIX.provider_error.maxRetries).toBeGreaterThan(0);
+    expect(DEFAULT_LLM_RETRY_POLICY_MATRIX.rate_limited.maxRetries).toBeGreaterThan(0);
+    expect(DEFAULT_LLM_RETRY_POLICY_MATRIX.timeout.maxRetries).toBeGreaterThan(0);
+  });
+
+  it("maps unknown failures to provider_error stop reason", () => {
+    expect(toPipelineStopReason("unknown")).toBe("provider_error");
+    expect(toPipelineStopReason("validation_error")).toBe("validation_error");
+  });
+});

--- a/runtime/src/llm/policy.ts
+++ b/runtime/src/llm/policy.ts
@@ -1,0 +1,141 @@
+/**
+ * Shared LLM pipeline failure taxonomy and retry/circuit-breaker policy schema.
+ *
+ * Phase 1 introduces these provider-agnostic types so later phases can reuse
+ * one canonical stop-reason and retry-decision contract.
+ */
+
+/** Canonical failure class used across provider adapters and chat orchestration. */
+export type LLMFailureClass =
+  | "validation_error"
+  | "provider_error"
+  | "authentication_error"
+  | "rate_limited"
+  | "timeout"
+  | "tool_error"
+  | "budget_exceeded"
+  | "no_progress"
+  | "cancelled"
+  | "unknown";
+
+/** Canonical stop reasons surfaced by the runtime pipeline. */
+export type LLMPipelineStopReason =
+  | "completed"
+  | "tool_calls"
+  | "validation_error"
+  | "provider_error"
+  | "authentication_error"
+  | "rate_limited"
+  | "timeout"
+  | "tool_error"
+  | "budget_exceeded"
+  | "no_progress"
+  | "cancelled";
+
+/** Retry/circuit-breaker behavior for one failure class. */
+export interface LLMRetryPolicyRule {
+  /** Maximum retry attempts after the initial call. */
+  readonly maxRetries: number;
+  /** Base backoff delay in milliseconds. */
+  readonly baseDelayMs: number;
+  /** Max backoff delay in milliseconds. */
+  readonly maxDelayMs: number;
+  /** Whether randomized backoff jitter is applied. */
+  readonly jitter: boolean;
+  /** Whether failures of this class should contribute to breaker windows. */
+  readonly circuitBreakerEligible: boolean;
+}
+
+/** Global retry policy matrix keyed by canonical failure class. */
+export type LLMRetryPolicyMatrix = {
+  readonly [K in LLMFailureClass]: LLMRetryPolicyRule;
+};
+
+/**
+ * Baseline retry policy matrix.
+ *
+ * - Deterministic/local failures do not retry.
+ * - Transient transport/provider failures can retry with capped backoff.
+ */
+export const DEFAULT_LLM_RETRY_POLICY_MATRIX: LLMRetryPolicyMatrix = {
+  validation_error: {
+    maxRetries: 0,
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+    jitter: false,
+    circuitBreakerEligible: false,
+  },
+  provider_error: {
+    maxRetries: 2,
+    baseDelayMs: 500,
+    maxDelayMs: 5_000,
+    jitter: true,
+    circuitBreakerEligible: true,
+  },
+  authentication_error: {
+    maxRetries: 0,
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+    jitter: false,
+    circuitBreakerEligible: false,
+  },
+  rate_limited: {
+    maxRetries: 3,
+    baseDelayMs: 1_000,
+    maxDelayMs: 15_000,
+    jitter: true,
+    circuitBreakerEligible: true,
+  },
+  timeout: {
+    maxRetries: 2,
+    baseDelayMs: 1_000,
+    maxDelayMs: 10_000,
+    jitter: true,
+    circuitBreakerEligible: true,
+  },
+  tool_error: {
+    maxRetries: 1,
+    baseDelayMs: 250,
+    maxDelayMs: 2_000,
+    jitter: true,
+    circuitBreakerEligible: true,
+  },
+  budget_exceeded: {
+    maxRetries: 0,
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+    jitter: false,
+    circuitBreakerEligible: false,
+  },
+  no_progress: {
+    maxRetries: 0,
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+    jitter: false,
+    circuitBreakerEligible: true,
+  },
+  cancelled: {
+    maxRetries: 0,
+    baseDelayMs: 0,
+    maxDelayMs: 0,
+    jitter: false,
+    circuitBreakerEligible: false,
+  },
+  unknown: {
+    maxRetries: 1,
+    baseDelayMs: 500,
+    maxDelayMs: 2_000,
+    jitter: true,
+    circuitBreakerEligible: true,
+  },
+};
+
+/** Map canonical failure classes to canonical stop reasons. */
+export function toPipelineStopReason(
+  failureClass: LLMFailureClass,
+): LLMPipelineStopReason {
+  if (failureClass === "unknown") {
+    return "provider_error";
+  }
+  return failureClass;
+}

--- a/runtime/src/llm/tool-turn-validator.test.ts
+++ b/runtime/src/llm/tool-turn-validator.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import type { LLMMessage } from "./types.js";
+import { LLMMessageValidationError } from "./errors.js";
+import {
+  findToolTurnValidationIssue,
+  validateToolTurnSequence,
+} from "./tool-turn-validator.js";
+
+describe("tool-turn validator", () => {
+  it("accepts a valid assistant tool_calls -> tool results sequence", () => {
+    const messages: LLMMessage[] = [
+      { role: "user", content: "run test" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "call_1", name: "desktop.bash", arguments: '{"command":"echo hi"}' },
+          { id: "call_2", name: "desktop.bash", arguments: '{"command":"pwd"}' },
+        ],
+      },
+      {
+        role: "tool",
+        content: '{"stdout":"hi\\n","exitCode":0}',
+        toolCallId: "call_2",
+      },
+      {
+        role: "tool",
+        content: '{"stdout":"/tmp\\n","exitCode":0}',
+        toolCallId: "call_1",
+      },
+      { role: "assistant", content: "done" },
+    ];
+
+    expect(() => validateToolTurnSequence(messages)).not.toThrow();
+    expect(findToolTurnValidationIssue(messages)).toBeNull();
+  });
+
+  it("rejects one malformed pair (assistant without tool_calls + tool)", () => {
+    const messages: LLMMessage[] = [
+      { role: "system", content: "You are helpful." },
+      { role: "user", content: "test" },
+      { role: "assistant", content: "" },
+      { role: "tool", content: '{"stdout":"","exitCode":0}', toolCallId: "call_1" },
+    ];
+
+    expect(() => validateToolTurnSequence(messages, { providerName: "grok" })).toThrow(
+      LLMMessageValidationError,
+    );
+
+    const issue = findToolTurnValidationIssue(messages);
+    expect(issue).toMatchObject({
+      code: "tool_result_without_assistant_call",
+      index: 3,
+    });
+  });
+
+  it("rejects two malformed pairs and fails fast at first invalid pair", () => {
+    const messages: LLMMessage[] = [
+      { role: "user", content: "test" },
+      { role: "assistant", content: "" },
+      { role: "tool", content: '{"stdout":"","exitCode":0}', toolCallId: "call_1" },
+      { role: "assistant", content: "" },
+      { role: "tool", content: '{"stdout":"","exitCode":0}', toolCallId: "call_2" },
+    ];
+
+    const issue = findToolTurnValidationIssue(messages);
+    expect(issue).toMatchObject({
+      code: "tool_result_without_assistant_call",
+      index: 2,
+    });
+  });
+
+  it("rejects mixed valid/invalid sequence", () => {
+    const messages: LLMMessage[] = [
+      { role: "user", content: "step 1" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "call_1", name: "desktop.bash", arguments: '{"command":"echo ok"}' }],
+      },
+      { role: "tool", content: '{"stdout":"ok\\n","exitCode":0}', toolCallId: "call_1" },
+      { role: "assistant", content: "" },
+      { role: "tool", content: '{"stdout":"","exitCode":0}', toolCallId: "call_2" },
+    ];
+
+    const issue = findToolTurnValidationIssue(messages);
+    expect(issue).toMatchObject({
+      code: "tool_result_without_assistant_call",
+      index: 4,
+    });
+  });
+
+  it("rejects duplicate tool_call ids declared by assistant", () => {
+    const messages: LLMMessage[] = [
+      { role: "user", content: "test" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "call_1", name: "desktop.bash", arguments: '{}' },
+          { id: "call_1", name: "desktop.bash", arguments: '{}' },
+        ],
+      },
+    ];
+
+    const issue = findToolTurnValidationIssue(messages);
+    expect(issue).toMatchObject({
+      code: "assistant_tool_call_id_duplicate",
+      index: 1,
+    });
+  });
+
+  it("rejects non-tool messages while tool results are still pending", () => {
+    const messages: LLMMessage[] = [
+      { role: "user", content: "test" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "call_1", name: "desktop.bash", arguments: '{}' }],
+      },
+      { role: "assistant", content: "done" },
+    ];
+
+    const issue = findToolTurnValidationIssue(messages);
+    expect(issue).toMatchObject({
+      code: "tool_result_missing",
+      index: 2,
+    });
+  });
+
+  it("rejects duplicate tool result messages for the same toolCallId", () => {
+    const messages: LLMMessage[] = [
+      { role: "user", content: "test" },
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [{ id: "call_1", name: "desktop.bash", arguments: '{}' }],
+      },
+      { role: "tool", content: '{"stdout":"ok","exitCode":0}', toolCallId: "call_1" },
+      { role: "tool", content: '{"stdout":"ok","exitCode":0}', toolCallId: "call_1" },
+    ];
+
+    const issue = findToolTurnValidationIssue(messages);
+    expect(issue).toMatchObject({
+      code: "tool_result_duplicate",
+      index: 3,
+    });
+  });
+});

--- a/runtime/src/llm/tool-turn-validator.ts
+++ b/runtime/src/llm/tool-turn-validator.ts
@@ -1,0 +1,169 @@
+import type { LLMMessage } from "./types.js";
+import { LLMMessageValidationError } from "./errors.js";
+
+const MAX_TOOL_IDS_IN_ERROR = 8;
+
+export type ToolTurnValidationCode =
+  | "assistant_tool_call_id_missing"
+  | "assistant_tool_call_id_duplicate"
+  | "assistant_tool_calls_started_before_results"
+  | "tool_message_missing_tool_call_id"
+  | "tool_result_without_assistant_call"
+  | "tool_result_unknown_id"
+  | "tool_result_duplicate"
+  | "tool_result_missing";
+
+export interface ToolTurnValidationIssue {
+  readonly code: ToolTurnValidationCode;
+  readonly index: number | null;
+  readonly reason: string;
+}
+
+export interface ToolTurnValidationOptions {
+  readonly providerName?: string;
+}
+
+function summarizeToolIds(ids: Iterable<string>): string {
+  const all = Array.from(ids);
+  if (all.length <= MAX_TOOL_IDS_IN_ERROR) {
+    return all.join(", ");
+  }
+  const head = all.slice(0, MAX_TOOL_IDS_IN_ERROR).join(", ");
+  return `${head} ... (+${all.length - MAX_TOOL_IDS_IN_ERROR} more)`;
+}
+
+function makeIssue(
+  code: ToolTurnValidationCode,
+  index: number | null,
+  reason: string,
+): ToolTurnValidationIssue {
+  return { code, index, reason };
+}
+
+/**
+ * Inspect messages and return the first tool-turn protocol violation, if any.
+ */
+export function findToolTurnValidationIssue(
+  messages: readonly LLMMessage[],
+): ToolTurnValidationIssue | null {
+  let pendingToolCallIds: Set<string> | null = null;
+  let pendingAssistantIndex = -1;
+  const issuedToolCallIds = new Set<string>();
+  const resolvedToolCallIds = new Set<string>();
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+
+    if (msg.role === "assistant" && msg.toolCalls && msg.toolCalls.length > 0) {
+      if (pendingToolCallIds && pendingToolCallIds.size > 0) {
+        return makeIssue(
+          "assistant_tool_calls_started_before_results",
+          i,
+          `new assistant tool_calls started before resolving all prior tool results from message[${pendingAssistantIndex}]`,
+        );
+      }
+
+      const ids = new Set<string>();
+      for (const toolCall of msg.toolCalls) {
+        const id = toolCall.id?.trim();
+        if (!id) {
+          return makeIssue(
+            "assistant_tool_call_id_missing",
+            i,
+            "assistant tool_calls contains an empty id",
+          );
+        }
+
+        if (ids.has(id) || issuedToolCallIds.has(id)) {
+          return makeIssue(
+            "assistant_tool_call_id_duplicate",
+            i,
+            `assistant tool_calls contains duplicate id \"${id}\"`,
+          );
+        }
+
+        ids.add(id);
+        issuedToolCallIds.add(id);
+      }
+
+      pendingToolCallIds = ids;
+      pendingAssistantIndex = i;
+      continue;
+    }
+
+    if (msg.role === "tool") {
+      const toolCallId = msg.toolCallId?.trim();
+      if (!toolCallId) {
+        return makeIssue(
+          "tool_message_missing_tool_call_id",
+          i,
+          "tool message is missing toolCallId",
+        );
+      }
+
+      if (resolvedToolCallIds.has(toolCallId)) {
+        return makeIssue(
+          "tool_result_duplicate",
+          i,
+          `tool message duplicates result for toolCallId \"${toolCallId}\"`,
+        );
+      }
+
+      if (!pendingToolCallIds || pendingToolCallIds.size === 0) {
+        return makeIssue(
+          "tool_result_without_assistant_call",
+          i,
+          `tool message references \"${toolCallId}\" without a preceding assistant tool_calls message`,
+        );
+      }
+
+      if (!pendingToolCallIds.has(toolCallId)) {
+        return makeIssue(
+          "tool_result_unknown_id",
+          i,
+          `tool message references unknown toolCallId \"${toolCallId}\" (expected one of: ${summarizeToolIds(pendingToolCallIds)})`,
+        );
+      }
+
+      pendingToolCallIds.delete(toolCallId);
+      resolvedToolCallIds.add(toolCallId);
+      continue;
+    }
+
+    if (pendingToolCallIds && pendingToolCallIds.size > 0) {
+      return makeIssue(
+        "tool_result_missing",
+        i,
+        `missing tool result message(s) for toolCallId(s): ${summarizeToolIds(pendingToolCallIds)}. Tool results must immediately follow assistant tool_calls.`,
+      );
+    }
+  }
+
+  if (pendingToolCallIds && pendingToolCallIds.size > 0) {
+    return makeIssue(
+      "tool_result_missing",
+      null,
+      `missing tool result message(s) for toolCallId(s): ${summarizeToolIds(pendingToolCallIds)}.`,
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Validate tool-turn ordering for outbound provider calls.
+ * Throws a local 400-class error when sequence is malformed.
+ */
+export function validateToolTurnSequence(
+  messages: readonly LLMMessage[],
+  options?: ToolTurnValidationOptions,
+): void {
+  const issue = findToolTurnValidationIssue(messages);
+  if (!issue) return;
+
+  throw new LLMMessageValidationError(options?.providerName ?? "llm", {
+    validationCode: issue.code,
+    messageIndex: issue.index,
+    reason: issue.reason,
+  });
+}


### PR DESCRIPTION
## Summary

- Extract `ToolTurnValidator` from Grok adapter into standalone reusable module (`runtime/src/llm/tool-turn-validator.ts`)
- Add LLM policy engine with retry budgets, rate limit backoff, and token budget guards (`runtime/src/llm/policy.ts`)
- Add LLM error classification helpers for transient vs permanent failures and rate limit detection (`runtime/src/llm/errors.ts`)
- Wire tool-turn validation into Ollama adapter for consistent tool-turn ordering across all providers

## Test plan

- [ ] `cd runtime && npm run test` — runtime vitest suite passes
- [ ] Verify tool-turn validator catches orphan tool messages across Grok and Ollama adapters
- [ ] Verify LLM policy rate limit backoff and retry budget enforcement