### PR TITLE
fix(runtime): chat executor overhaul, prompt budget engine, memory hardening, gateway tool routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ npm run test:anchor  # Full Anchor integration tests
 npm run test:matrix:phase01 # Full Phase 0/1 verification matrix (fast + runtime + anchor integration/smoke)
 ```
 
+Anchor-based tests require these env vars:
+
+```bash
+export ANCHOR_PROVIDER_URL=http://127.0.0.1:8899
+export ANCHOR_WALLET=~/.config/solana/id.json
+```
+
 `test:matrix:phase01` bootstrap behavior:
 - defaults: `ANCHOR_PROVIDER_URL=http://127.0.0.1:8899`, `ANCHOR_WALLET=~/.config/solana/id.json`
 - on local provider URLs, starts `solana-test-validator` if needed, then runs `anchor build` + `anchor deploy` before integration/smoke tests

--- a/docs/RUNTIME_PIPELINE_DEBUG_BUNDLE.md
+++ b/docs/RUNTIME_PIPELINE_DEBUG_BUNDLE.md
@@ -1,0 +1,125 @@
+# Runtime Pipeline Debug Bundle Runbook
+
+Use this runbook when diagnosing:
+
+- context growth ("why is prompt huge?")
+- tool-turn ordering failures
+- post-tool hangs/stalls
+
+## 1) Enable trace logging
+
+Edit `~/.agenc/config.json`:
+
+```json
+{
+  "logging": {
+    "level": "info",
+    "trace": {
+      "enabled": true,
+      "includeHistory": true,
+      "includeSystemPrompt": true,
+      "includeToolArgs": true,
+      "includeToolResults": true,
+      "maxChars": 20000
+    }
+  }
+}
+```
+
+Restart daemon after changing config.
+
+## 2) Run the canonical repro harness
+
+From repository root:
+
+```bash
+npm --prefix runtime run repro:pipeline:http
+```
+
+Expected output is JSON with:
+
+- `overall: "pass"|"fail"`
+- step-by-step records for fixture create, HTTP server start, optional Playwright navigate, curl verification, process verification, teardown.
+
+## 3) Capture a minimal provider repro payload
+
+For malformed tool-turn validation bugs, keep payloads tiny and explicit.
+
+Malformed example (missing assistant `tool_calls` linkage):
+
+```json
+{
+  "model": "grok-code-fast-1",
+  "messages": [
+    { "role": "system", "content": "You are helpful." },
+    { "role": "user", "content": "test" },
+    { "role": "assistant", "content": "" },
+    { "role": "tool", "tool_call_id": "call_1", "content": "{\"stdout\":\"\",\"exitCode\":0}" }
+  ],
+  "max_tokens": 16
+}
+```
+
+Control example (valid linkage):
+
+```json
+{
+  "model": "grok-code-fast-1",
+  "messages": [
+    { "role": "system", "content": "You are helpful." },
+    { "role": "user", "content": "test" },
+    {
+      "role": "assistant",
+      "content": "",
+      "tool_calls": [
+        {
+          "id": "call_1",
+          "type": "function",
+          "function": { "name": "desktop.bash", "arguments": "{\"command\":\"echo hi\"}" }
+        }
+      ]
+    },
+    { "role": "tool", "tool_call_id": "call_1", "content": "{\"stdout\":\"hi\\n\",\"exitCode\":0}" }
+  ],
+  "max_tokens": 16
+}
+```
+
+## 4) Collect the debug bundle
+
+Bundle these files/artifacts:
+
+- `~/.agenc/daemon.log` (trace-enabled window only)
+- `~/.agenc/config.json` (redact API keys/secrets)
+- repro harness JSON output
+- raw provider request/response JSON for the failing call
+- exact user prompt used
+
+## 5) Correlate one turn end-to-end
+
+Trace logs include a per-turn `traceId`. Use it to join:
+
+- `[trace] *.inbound`
+- `[trace] *.chat.request`
+- `[trace] *.tool.call` / `.tool.result` / `.tool.error`
+- `[trace] *.chat.response`
+
+Example:
+
+```bash
+rg "traceId\":\"<TRACE_ID>\"" ~/.agenc/daemon.log
+```
+
+Key fields for context diagnostics in `*.chat.response`:
+
+- `requestShape.messageCountsBeforeBudget`
+- `requestShape.messageCountsAfterBudget`
+- `requestShape.estimatedPromptCharsBeforeBudget`
+- `requestShape.estimatedPromptCharsAfterBudget`
+- `requestShape.systemPromptCharsAfterBudget`
+- `requestShape.toolSchemaChars`
+- `callUsage[]` (per-provider-call usage attribution)
+
+## 6) Disable trace after triage
+
+Set `logging.trace.enabled` back to `false` once incident capture is complete to keep log size bounded.

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -205,11 +205,272 @@ export function validateGatewayConfig(obj: unknown): ValidationResult {
           errors,
         );
       }
+      if (obj.llm.maxTokens !== undefined) {
+        requireIntRange(
+          obj.llm.maxTokens,
+          "llm.maxTokens",
+          1,
+          262_144,
+          errors,
+        );
+      }
+      if (obj.llm.contextWindowTokens !== undefined) {
+        requireIntRange(
+          obj.llm.contextWindowTokens,
+          "llm.contextWindowTokens",
+          2_048,
+          2_000_000,
+          errors,
+        );
+      }
+      if (obj.llm.promptHardMaxChars !== undefined) {
+        requireIntRange(
+          obj.llm.promptHardMaxChars,
+          "llm.promptHardMaxChars",
+          8_000,
+          1_500_000,
+          errors,
+        );
+      }
+      if (obj.llm.promptSafetyMarginTokens !== undefined) {
+        requireIntRange(
+          obj.llm.promptSafetyMarginTokens,
+          "llm.promptSafetyMarginTokens",
+          128,
+          200_000,
+          errors,
+        );
+      }
+      if (obj.llm.promptCharPerToken !== undefined) {
+        requireIntRange(
+          obj.llm.promptCharPerToken,
+          "llm.promptCharPerToken",
+          1,
+          12,
+          errors,
+        );
+      }
+      if (obj.llm.maxRuntimeHints !== undefined) {
+        requireIntRange(
+          obj.llm.maxRuntimeHints,
+          "llm.maxRuntimeHints",
+          0,
+          32,
+          errors,
+        );
+      }
+      if (obj.llm.maxToolRounds !== undefined) {
+        requireIntRange(
+          obj.llm.maxToolRounds,
+          "llm.maxToolRounds",
+          1,
+          64,
+          errors,
+        );
+      }
+      if (
+        obj.llm.plannerEnabled !== undefined &&
+        typeof obj.llm.plannerEnabled !== "boolean"
+      ) {
+        errors.push("llm.plannerEnabled must be a boolean");
+      }
+      if (obj.llm.plannerMaxTokens !== undefined) {
+        requireIntRange(
+          obj.llm.plannerMaxTokens,
+          "llm.plannerMaxTokens",
+          16,
+          8_192,
+          errors,
+        );
+      }
+      if (obj.llm.toolBudgetPerRequest !== undefined) {
+        requireIntRange(
+          obj.llm.toolBudgetPerRequest,
+          "llm.toolBudgetPerRequest",
+          1,
+          256,
+          errors,
+        );
+      }
+      if (obj.llm.maxModelRecallsPerRequest !== undefined) {
+        requireIntRange(
+          obj.llm.maxModelRecallsPerRequest,
+          "llm.maxModelRecallsPerRequest",
+          0,
+          128,
+          errors,
+        );
+      }
+      if (obj.llm.maxFailureBudgetPerRequest !== undefined) {
+        requireIntRange(
+          obj.llm.maxFailureBudgetPerRequest,
+          "llm.maxFailureBudgetPerRequest",
+          1,
+          256,
+          errors,
+        );
+      }
       if (
         obj.llm.parallelToolCalls !== undefined &&
         typeof obj.llm.parallelToolCalls !== "boolean"
       ) {
         errors.push("llm.parallelToolCalls must be a boolean");
+      }
+      if (obj.llm.statefulResponses !== undefined) {
+        if (!isRecord(obj.llm.statefulResponses)) {
+          errors.push("llm.statefulResponses must be an object");
+        } else {
+          if (
+            obj.llm.statefulResponses.enabled !== undefined &&
+            typeof obj.llm.statefulResponses.enabled !== "boolean"
+          ) {
+            errors.push("llm.statefulResponses.enabled must be a boolean");
+          }
+          if (
+            obj.llm.statefulResponses.store !== undefined &&
+            typeof obj.llm.statefulResponses.store !== "boolean"
+          ) {
+            errors.push("llm.statefulResponses.store must be a boolean");
+          }
+          if (
+            obj.llm.statefulResponses.fallbackToStateless !== undefined &&
+            typeof obj.llm.statefulResponses.fallbackToStateless !== "boolean"
+          ) {
+            errors.push("llm.statefulResponses.fallbackToStateless must be a boolean");
+          }
+        }
+      }
+      if (obj.llm.toolRouting !== undefined) {
+        if (!isRecord(obj.llm.toolRouting)) {
+          errors.push("llm.toolRouting must be an object");
+        } else {
+          if (
+            obj.llm.toolRouting.enabled !== undefined &&
+            typeof obj.llm.toolRouting.enabled !== "boolean"
+          ) {
+            errors.push("llm.toolRouting.enabled must be a boolean");
+          }
+          if (obj.llm.toolRouting.minToolsPerTurn !== undefined) {
+            requireIntRange(
+              obj.llm.toolRouting.minToolsPerTurn,
+              "llm.toolRouting.minToolsPerTurn",
+              1,
+              256,
+              errors,
+            );
+          }
+          if (obj.llm.toolRouting.maxToolsPerTurn !== undefined) {
+            requireIntRange(
+              obj.llm.toolRouting.maxToolsPerTurn,
+              "llm.toolRouting.maxToolsPerTurn",
+              1,
+              256,
+              errors,
+            );
+          }
+          if (obj.llm.toolRouting.maxExpandedToolsPerTurn !== undefined) {
+            requireIntRange(
+              obj.llm.toolRouting.maxExpandedToolsPerTurn,
+              "llm.toolRouting.maxExpandedToolsPerTurn",
+              1,
+              256,
+              errors,
+            );
+          }
+          if (obj.llm.toolRouting.cacheTtlMs !== undefined) {
+            requireIntRange(
+              obj.llm.toolRouting.cacheTtlMs,
+              "llm.toolRouting.cacheTtlMs",
+              10_000,
+              86_400_000,
+              errors,
+            );
+          }
+          if (obj.llm.toolRouting.minCacheConfidence !== undefined) {
+            if (
+              typeof obj.llm.toolRouting.minCacheConfidence !== "number" ||
+              !Number.isFinite(obj.llm.toolRouting.minCacheConfidence) ||
+              obj.llm.toolRouting.minCacheConfidence < 0 ||
+              obj.llm.toolRouting.minCacheConfidence > 1
+            ) {
+              errors.push(
+                "llm.toolRouting.minCacheConfidence must be a number between 0 and 1",
+              );
+            }
+          }
+          if (obj.llm.toolRouting.pivotSimilarityThreshold !== undefined) {
+            if (
+              typeof obj.llm.toolRouting.pivotSimilarityThreshold !== "number" ||
+              !Number.isFinite(obj.llm.toolRouting.pivotSimilarityThreshold) ||
+              obj.llm.toolRouting.pivotSimilarityThreshold < 0 ||
+              obj.llm.toolRouting.pivotSimilarityThreshold > 1
+            ) {
+              errors.push(
+                "llm.toolRouting.pivotSimilarityThreshold must be a number between 0 and 1",
+              );
+            }
+          }
+          if (obj.llm.toolRouting.pivotMissThreshold !== undefined) {
+            requireIntRange(
+              obj.llm.toolRouting.pivotMissThreshold,
+              "llm.toolRouting.pivotMissThreshold",
+              1,
+              64,
+              errors,
+            );
+          }
+          if (
+            obj.llm.toolRouting.mandatoryTools !== undefined &&
+            !isStringArray(obj.llm.toolRouting.mandatoryTools)
+          ) {
+            errors.push("llm.toolRouting.mandatoryTools must be a string array");
+          }
+          if (obj.llm.toolRouting.familyCaps !== undefined) {
+            if (!isRecord(obj.llm.toolRouting.familyCaps)) {
+              errors.push("llm.toolRouting.familyCaps must be an object");
+            } else {
+              for (const [family, cap] of Object.entries(
+                obj.llm.toolRouting.familyCaps,
+              )) {
+                if (
+                  typeof cap !== "number" ||
+                  !Number.isFinite(cap) ||
+                  cap < 1 ||
+                  cap > 256 ||
+                  !Number.isInteger(cap)
+                ) {
+                  errors.push(
+                    `llm.toolRouting.familyCaps.${family} must be an integer between 1 and 256`,
+                  );
+                }
+              }
+            }
+          }
+          if (
+            obj.llm.toolRouting.minToolsPerTurn !== undefined &&
+            obj.llm.toolRouting.maxToolsPerTurn !== undefined &&
+            typeof obj.llm.toolRouting.minToolsPerTurn === "number" &&
+            typeof obj.llm.toolRouting.maxToolsPerTurn === "number" &&
+            obj.llm.toolRouting.minToolsPerTurn >
+              obj.llm.toolRouting.maxToolsPerTurn
+          ) {
+            errors.push(
+              "llm.toolRouting.minToolsPerTurn must be less than or equal to llm.toolRouting.maxToolsPerTurn",
+            );
+          }
+          if (
+            obj.llm.toolRouting.maxToolsPerTurn !== undefined &&
+            obj.llm.toolRouting.maxExpandedToolsPerTurn !== undefined &&
+            typeof obj.llm.toolRouting.maxToolsPerTurn === "number" &&
+            typeof obj.llm.toolRouting.maxExpandedToolsPerTurn === "number" &&
+            obj.llm.toolRouting.maxExpandedToolsPerTurn <
+              obj.llm.toolRouting.maxToolsPerTurn
+          ) {
+            errors.push(
+              "llm.toolRouting.maxExpandedToolsPerTurn must be greater than or equal to llm.toolRouting.maxToolsPerTurn",
+            );
+          }
+        }
       }
     }
   }

--- a/runtime/src/gateway/session-isolation.ts
+++ b/runtime/src/gateway/session-isolation.ts
@@ -19,6 +19,7 @@ import type {
   LLMProvider,
   LLMResponse,
   LLMMessage,
+  LLMChatOptions,
   StreamProgressCallback,
 } from "../llm/types.js";
 import type { MarkdownSkill } from "../skills/markdown/types.js";
@@ -76,7 +77,10 @@ class NoopLLMProvider implements LLMProvider {
     this.workspaceId = workspaceId;
   }
 
-  async chat(_messages: LLMMessage[]): Promise<LLMResponse> {
+  async chat(
+    _messages: LLMMessage[],
+    _options?: LLMChatOptions,
+  ): Promise<LLMResponse> {
     throw new Error(
       `No LLM provider configured for workspace '${this.workspaceId}'`,
     );
@@ -85,6 +89,7 @@ class NoopLLMProvider implements LLMProvider {
   async chatStream(
     _messages: LLMMessage[],
     _onChunk: StreamProgressCallback,
+    _options?: LLMChatOptions,
   ): Promise<LLMResponse> {
     throw new Error(
       `No LLM provider configured for workspace '${this.workspaceId}'`,

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import type { LLMTool } from "../llm/types.js";
+import { ToolRouter } from "./tool-routing.js";
+
+function makeTool(name: string, description: string): LLMTool {
+  return {
+    type: "function",
+    function: {
+      name,
+      description,
+      parameters: {
+        type: "object",
+        properties: {
+          input: { type: "string" },
+        },
+      },
+    },
+  };
+}
+
+const TOOLS: LLMTool[] = [
+  makeTool("system.bash", "Run terminal commands"),
+  makeTool("desktop.bash", "Run shell commands in desktop sandbox"),
+  makeTool("system.readFile", "Read a file"),
+  makeTool("system.writeFile", "Write a file"),
+  makeTool("system.listDir", "List files in directory"),
+  makeTool("system.httpGet", "HTTP GET request"),
+  makeTool("desktop.click", "Click on screen"),
+  makeTool("desktop.type", "Type into focused element"),
+  makeTool("playwright.browser_navigate", "Navigate browser to a URL"),
+  makeTool("playwright.browser_click", "Click browser element"),
+  makeTool("agenc.createTask", "Create on-chain task"),
+  makeTool("agenc.getTask", "Read task details"),
+];
+
+describe("ToolRouter", () => {
+  it("returns full toolset when disabled", () => {
+    const router = new ToolRouter(TOOLS, { enabled: false });
+    const decision = router.route({
+      sessionId: "s1",
+      messageText: "run ls",
+      history: [],
+    });
+
+    expect(decision.routedToolNames.length).toBe(TOOLS.length);
+    expect(decision.expandedToolNames.length).toBe(TOOLS.length);
+    expect(decision.diagnostics.invalidatedReason).toBe("disabled");
+  });
+
+  it("routes to a compact subset and keeps mandatory tools pinned", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 6,
+      minToolsPerTurn: 4,
+      maxExpandedToolsPerTurn: 10,
+    });
+
+    const decision = router.route({
+      sessionId: "s2",
+      messageText: "open the browser and click the page",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("system.bash");
+    expect(decision.routedToolNames).toContain("desktop.bash");
+    expect(decision.routedToolNames.length).toBeLessThan(TOOLS.length);
+    expect(decision.expandedToolNames.length).toBeGreaterThanOrEqual(
+      decision.routedToolNames.length,
+    );
+    expect(decision.diagnostics.schemaCharsSaved).toBeGreaterThan(0);
+  });
+
+  it("reuses cached routing decision for similar turns", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 6,
+      minCacheConfidence: 0,
+      pivotSimilarityThreshold: 0,
+    });
+
+    const first = router.route({
+      sessionId: "s3",
+      messageText: "read a file and write changes",
+      history: [],
+    });
+
+    const second = router.route({
+      sessionId: "s3",
+      messageText: "also read files in this folder",
+      history: [],
+    });
+
+    expect(second.diagnostics.cacheHit).toBe(true);
+    expect(second.routedToolNames).toEqual(first.routedToolNames);
+  });
+
+  it("invalidates cached cluster on explicit pivot", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 6,
+      minCacheConfidence: 0,
+    });
+
+    router.route({
+      sessionId: "s4",
+      messageText: "read a file and write changes",
+      history: [],
+    });
+
+    const next = router.route({
+      sessionId: "s4",
+      messageText: "instead switch to browser navigation",
+      history: [],
+    });
+
+    expect(next.diagnostics.cacheHit).toBe(false);
+    expect(next.diagnostics.invalidatedReason).toBe("explicit_redirect");
+  });
+
+  it("invalidates cache after repeated routing misses", () => {
+    const router = new ToolRouter(TOOLS, {
+      minCacheConfidence: 0,
+      pivotMissThreshold: 2,
+    });
+
+    router.route({
+      sessionId: "s5",
+      messageText: "read files",
+      history: [],
+    });
+
+    router.recordOutcome("s5", {
+      enabled: true,
+      initialToolCount: 4,
+      finalToolCount: 8,
+      routeMisses: 1,
+      expanded: true,
+    });
+    router.recordOutcome("s5", {
+      enabled: true,
+      initialToolCount: 4,
+      finalToolCount: 8,
+      routeMisses: 1,
+      expanded: true,
+    });
+
+    const next = router.route({
+      sessionId: "s5",
+      messageText: "read files",
+      history: [],
+    });
+
+    expect(next.diagnostics.cacheHit).toBe(false);
+    expect(next.diagnostics.invalidatedReason).toBe("tool_miss_threshold");
+  });
+});

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -1,0 +1,658 @@
+import type { LLMMessage, LLMTool } from "../llm/types.js";
+import type { ChatToolRoutingSummary } from "../llm/chat-executor.js";
+import type { Logger } from "../utils/logger.js";
+import { silentLogger } from "../utils/logger.js";
+
+const TOKEN_RE = /[a-z0-9_]+/g;
+
+const STOP_TERMS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "but",
+  "by",
+  "for",
+  "from",
+  "how",
+  "i",
+  "if",
+  "in",
+  "into",
+  "is",
+  "it",
+  "its",
+  "me",
+  "my",
+  "of",
+  "on",
+  "or",
+  "our",
+  "please",
+  "that",
+  "the",
+  "their",
+  "them",
+  "then",
+  "there",
+  "these",
+  "this",
+  "to",
+  "us",
+  "we",
+  "with",
+  "you",
+  "your",
+]);
+
+const DEFAULT_MANDATORY_TOOLS = [
+  "system.bash",
+  "desktop.bash",
+  "system.readFile",
+  "system.writeFile",
+  "system.listDir",
+];
+
+const DEFAULT_FAMILY_CAPS: Record<string, number> = {
+  system: 12,
+  desktop: 10,
+  playwright: 8,
+  agenc: 8,
+  wallet: 6,
+  social: 6,
+  default: 6,
+};
+
+const EXPLICIT_PIVOT_RE = /\b(instead|different|switch|forget that|new task|change of plan|another thing|start over|use .* now)\b/i;
+
+const SHELL_TERMS = new Set([
+  "bash",
+  "shell",
+  "terminal",
+  "command",
+  "script",
+  "cli",
+  "run",
+  "execute",
+]);
+
+const BROWSER_TERMS = new Set([
+  "browser",
+  "page",
+  "website",
+  "navigate",
+  "click",
+  "type",
+  "scroll",
+  "tab",
+  "vnc",
+]);
+
+const FILE_TERMS = new Set([
+  "file",
+  "files",
+  "read",
+  "write",
+  "append",
+  "directory",
+  "folder",
+  "path",
+]);
+
+const NETWORK_TERMS = new Set([
+  "http",
+  "https",
+  "api",
+  "request",
+  "curl",
+  "fetch",
+  "endpoint",
+  "url",
+]);
+
+interface NormalizedRoutingConfig {
+  enabled: boolean;
+  minToolsPerTurn: number;
+  maxToolsPerTurn: number;
+  maxExpandedToolsPerTurn: number;
+  cacheTtlMs: number;
+  minCacheConfidence: number;
+  pivotSimilarityThreshold: number;
+  pivotMissThreshold: number;
+  mandatoryTools: string[];
+  familyCaps: Readonly<Record<string, number>>;
+}
+
+interface IndexedTool {
+  readonly name: string;
+  readonly family: string;
+  readonly keywords: ReadonlySet<string>;
+  readonly descriptionTerms: ReadonlySet<string>;
+  readonly schemaChars: number;
+}
+
+interface CachedIntentRoute {
+  clusterKey: string;
+  terms: string[];
+  confidence: number;
+  routedToolNames: string[];
+  expandedToolNames: string[];
+  missCount: number;
+  expiresAt: number;
+  updatedAt: number;
+}
+
+export interface ToolRoutingConfig {
+  enabled?: boolean;
+  minToolsPerTurn?: number;
+  maxToolsPerTurn?: number;
+  maxExpandedToolsPerTurn?: number;
+  cacheTtlMs?: number;
+  minCacheConfidence?: number;
+  pivotSimilarityThreshold?: number;
+  pivotMissThreshold?: number;
+  mandatoryTools?: string[];
+  familyCaps?: Record<string, number>;
+}
+
+export interface ToolRoutingDecision {
+  readonly routedToolNames: readonly string[];
+  readonly expandedToolNames: readonly string[];
+  readonly diagnostics: {
+    readonly cacheHit: boolean;
+    readonly clusterKey: string;
+    readonly confidence: number;
+    readonly invalidatedReason?: string;
+    readonly totalToolCount: number;
+    readonly routedToolCount: number;
+    readonly expandedToolCount: number;
+    readonly schemaCharsFull: number;
+    readonly schemaCharsRouted: number;
+    readonly schemaCharsExpanded: number;
+    readonly schemaCharsSaved: number;
+  };
+}
+
+export interface RouteToolParams {
+  readonly sessionId: string;
+  readonly messageText: string;
+  readonly history: readonly LLMMessage[];
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function toTerms(value: string): string[] {
+  const lower = value.toLowerCase();
+  const matches = lower.match(TOKEN_RE) ?? [];
+  const unique = new Set<string>();
+  for (const raw of matches) {
+    const term = raw.trim();
+    if (term.length < 2) continue;
+    if (STOP_TERMS.has(term)) continue;
+    unique.add(term);
+  }
+  return Array.from(unique);
+}
+
+function jaccardSimilarity(a: readonly string[], b: readonly string[]): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const aSet = new Set(a);
+  const bSet = new Set(b);
+  let intersection = 0;
+  for (const term of aSet) {
+    if (bSet.has(term)) intersection += 1;
+  }
+  const union = aSet.size + bSet.size - intersection;
+  if (union <= 0) return 0;
+  return intersection / union;
+}
+
+function familyFromToolName(name: string): string {
+  const firstDot = name.indexOf(".");
+  if (firstDot <= 0) return "default";
+  return name.slice(0, firstDot).toLowerCase();
+}
+
+function normalizeConfig(config: ToolRoutingConfig | undefined): NormalizedRoutingConfig {
+  const minToolsPerTurn = clamp(
+    Math.floor(config?.minToolsPerTurn ?? 6),
+    1,
+    64,
+  );
+  const maxToolsPerTurn = clamp(
+    Math.floor(config?.maxToolsPerTurn ?? 18),
+    minToolsPerTurn,
+    256,
+  );
+  const maxExpandedToolsPerTurn = clamp(
+    Math.floor(config?.maxExpandedToolsPerTurn ?? Math.max(maxToolsPerTurn * 2, maxToolsPerTurn + 4)),
+    maxToolsPerTurn,
+    256,
+  );
+  const cacheTtlMs = clamp(
+    Math.floor(config?.cacheTtlMs ?? 10 * 60_000),
+    10_000,
+    24 * 60 * 60_000,
+  );
+  const minCacheConfidence = clamp(
+    typeof config?.minCacheConfidence === "number"
+      ? config.minCacheConfidence
+      : 0.5,
+    0,
+    1,
+  );
+  const pivotSimilarityThreshold = clamp(
+    typeof config?.pivotSimilarityThreshold === "number"
+      ? config.pivotSimilarityThreshold
+      : 0.25,
+    0,
+    1,
+  );
+  const pivotMissThreshold = clamp(
+    Math.floor(config?.pivotMissThreshold ?? 2),
+    1,
+    20,
+  );
+
+  const mandatoryTools = Array.from(
+    new Set([
+      ...DEFAULT_MANDATORY_TOOLS,
+      ...(config?.mandatoryTools ?? []),
+    ]),
+  );
+
+  const familyCaps: Record<string, number> = {
+    ...DEFAULT_FAMILY_CAPS,
+  };
+  for (const [family, cap] of Object.entries(config?.familyCaps ?? {})) {
+    if (!Number.isFinite(cap)) continue;
+    familyCaps[family.toLowerCase()] = clamp(Math.floor(cap), 1, 128);
+  }
+
+  return {
+    enabled: config?.enabled ?? true,
+    minToolsPerTurn,
+    maxToolsPerTurn,
+    maxExpandedToolsPerTurn,
+    cacheTtlMs,
+    minCacheConfidence,
+    pivotSimilarityThreshold,
+    pivotMissThreshold,
+    mandatoryTools,
+    familyCaps,
+  };
+}
+
+export class ToolRouter {
+  private readonly logger: Logger;
+  private readonly config: NormalizedRoutingConfig;
+  private readonly indexedTools: IndexedTool[];
+  private readonly allToolNames: string[];
+  private readonly fullSchemaChars: number;
+  private readonly cache = new Map<string, CachedIntentRoute>();
+
+  constructor(
+    tools: readonly LLMTool[],
+    config?: ToolRoutingConfig,
+    logger?: Logger,
+  ) {
+    this.logger = logger ?? silentLogger;
+    this.config = normalizeConfig(config);
+    this.indexedTools = tools.map((tool) => {
+      const name = tool.function.name;
+      const family = familyFromToolName(name);
+      const nameTerms = toTerms(name.replaceAll(".", " ").replaceAll("_", " "));
+      const descriptionTerms = toTerms(tool.function.description ?? "");
+      return {
+        name,
+        family,
+        keywords: new Set(nameTerms),
+        descriptionTerms: new Set(descriptionTerms),
+        schemaChars: JSON.stringify(tool).length,
+      };
+    });
+    this.allToolNames = this.indexedTools.map((tool) => tool.name);
+    this.fullSchemaChars = this.indexedTools.reduce(
+      (sum, tool) => sum + tool.schemaChars,
+      0,
+    );
+  }
+
+  route(params: RouteToolParams): ToolRoutingDecision {
+    if (!this.config.enabled || this.indexedTools.length === 0) {
+      return {
+        routedToolNames: this.allToolNames,
+        expandedToolNames: this.allToolNames,
+        diagnostics: {
+          cacheHit: false,
+          clusterKey: "disabled",
+          confidence: 1,
+          invalidatedReason: this.config.enabled ? "no_tools" : "disabled",
+          totalToolCount: this.allToolNames.length,
+          routedToolCount: this.allToolNames.length,
+          expandedToolCount: this.allToolNames.length,
+          schemaCharsFull: this.fullSchemaChars,
+          schemaCharsRouted: this.fullSchemaChars,
+          schemaCharsExpanded: this.fullSchemaChars,
+          schemaCharsSaved: 0,
+        },
+      };
+    }
+
+    const intentTerms = this.extractIntentTerms(params.messageText, params.history);
+    const clusterKey = intentTerms.slice(0, 6).join("|") || "general";
+    const now = Date.now();
+    const cached = this.cache.get(params.sessionId);
+
+    let invalidatedReason: string | undefined;
+    if (cached) {
+      if (cached.missCount >= this.config.pivotMissThreshold) {
+        invalidatedReason = "tool_miss_threshold";
+      } else if (cached.expiresAt <= now) {
+        invalidatedReason = "ttl_expired";
+      } else if (EXPLICIT_PIVOT_RE.test(params.messageText)) {
+        invalidatedReason = "explicit_redirect";
+      } else {
+        const similarity = jaccardSimilarity(intentTerms, cached.terms);
+        if (intentTerms.length > 0 && similarity < this.config.pivotSimilarityThreshold) {
+          invalidatedReason = "domain_shift";
+        }
+      }
+
+      if (
+        !invalidatedReason &&
+        cached.confidence >= this.config.minCacheConfidence
+      ) {
+        return this.buildDecision(
+          cached.routedToolNames,
+          cached.expandedToolNames,
+          {
+            cacheHit: true,
+            clusterKey: cached.clusterKey,
+            confidence: cached.confidence,
+          },
+        );
+      }
+    }
+
+    const scored = this.scoreTools(intentTerms);
+    const routedToolNames = this.selectRoutedTools(scored);
+    const expandedToolNames = this.selectExpandedTools(scored, routedToolNames);
+    const confidence = this.estimateConfidence(scored, intentTerms, routedToolNames);
+
+    this.cache.set(params.sessionId, {
+      clusterKey,
+      terms: intentTerms,
+      confidence,
+      routedToolNames,
+      expandedToolNames,
+      missCount: 0,
+      expiresAt: now + this.config.cacheTtlMs,
+      updatedAt: now,
+    });
+
+    if (invalidatedReason) {
+      this.logger.debug?.("tool routing cache invalidated", {
+        sessionId: params.sessionId,
+        reason: invalidatedReason,
+      });
+    }
+
+    return this.buildDecision(
+      routedToolNames,
+      expandedToolNames,
+      {
+        cacheHit: false,
+        clusterKey,
+        confidence,
+        invalidatedReason,
+      },
+    );
+  }
+
+  recordOutcome(
+    sessionId: string,
+    summary: ChatToolRoutingSummary | undefined,
+  ): void {
+    if (!summary) return;
+    const cached = this.cache.get(sessionId);
+    if (!cached) return;
+
+    if (summary.routeMisses > 0) {
+      cached.missCount += summary.routeMisses;
+    } else {
+      cached.missCount = Math.max(0, cached.missCount - 1);
+    }
+
+    if (summary.expanded) {
+      cached.confidence = Math.min(cached.confidence, 0.49);
+    }
+
+    if (cached.missCount >= this.config.pivotMissThreshold) {
+      cached.expiresAt = 0;
+    }
+    cached.updatedAt = Date.now();
+  }
+
+  resetSession(sessionId: string): void {
+    this.cache.delete(sessionId);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  private extractIntentTerms(
+    messageText: string,
+    history: readonly LLMMessage[],
+  ): string[] {
+    const terms = new Set<string>(toTerms(messageText));
+
+    for (let i = history.length - 1; i >= 0; i--) {
+      const entry = history[i];
+      if (entry.role !== "user") continue;
+      if (typeof entry.content !== "string") continue;
+      for (const term of toTerms(entry.content).slice(0, 6)) {
+        terms.add(term);
+      }
+      break;
+    }
+
+    return Array.from(terms).sort();
+  }
+
+  private scoreTools(intentTerms: readonly string[]): Array<{ tool: IndexedTool; score: number }> {
+    const hasShellIntent = intentTerms.some((term) => SHELL_TERMS.has(term));
+    const hasBrowserIntent = intentTerms.some((term) => BROWSER_TERMS.has(term));
+    const hasFileIntent = intentTerms.some((term) => FILE_TERMS.has(term));
+    const hasNetworkIntent = intentTerms.some((term) => NETWORK_TERMS.has(term));
+
+    const scored = this.indexedTools.map((tool) => {
+      let score = 0;
+
+      for (const term of intentTerms) {
+        if (tool.keywords.has(term)) score += 3;
+        if (tool.descriptionTerms.has(term)) score += 1;
+      }
+
+      if (hasShellIntent && (tool.name === "system.bash" || tool.name === "desktop.bash")) {
+        score += 4;
+      }
+      if (hasBrowserIntent) {
+        if (
+          tool.family === "desktop" ||
+          tool.family === "playwright" ||
+          tool.name.startsWith("system.browse")
+        ) {
+          score += 2;
+        }
+      }
+      if (hasFileIntent && tool.family === "system") {
+        if (
+          tool.name.startsWith("system.read") ||
+          tool.name.startsWith("system.write") ||
+          tool.name.startsWith("system.list") ||
+          tool.name.startsWith("system.stat") ||
+          tool.name.startsWith("system.append")
+        ) {
+          score += 2;
+        }
+      }
+      if (hasNetworkIntent && tool.name.startsWith("system.http")) {
+        score += 2;
+      }
+
+      if (this.config.mandatoryTools.includes(tool.name)) {
+        score += 1;
+      }
+
+      return { tool, score };
+    });
+
+    scored.sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      return a.tool.name.localeCompare(b.tool.name);
+    });
+
+    return scored;
+  }
+
+  private selectRoutedTools(
+    scored: ReadonlyArray<{ tool: IndexedTool; score: number }>,
+  ): string[] {
+    const selected = new Set<string>();
+    const familyCounts = new Map<string, number>();
+
+    for (const mandatoryTool of this.config.mandatoryTools) {
+      if (!this.allToolNames.includes(mandatoryTool)) continue;
+      selected.add(mandatoryTool);
+      const family = familyFromToolName(mandatoryTool);
+      familyCounts.set(family, (familyCounts.get(family) ?? 0) + 1);
+    }
+
+    const maxTools = this.config.maxToolsPerTurn;
+    const minTools = this.config.minToolsPerTurn;
+
+    const tryAdd = (candidate: IndexedTool): void => {
+      if (selected.has(candidate.name)) return;
+      if (selected.size >= maxTools) return;
+
+      const familyCap = this.config.familyCaps[candidate.family] ??
+        this.config.familyCaps.default ??
+        DEFAULT_FAMILY_CAPS.default;
+      const usedInFamily = familyCounts.get(candidate.family) ?? 0;
+      if (usedInFamily >= familyCap) return;
+
+      selected.add(candidate.name);
+      familyCounts.set(candidate.family, usedInFamily + 1);
+    };
+
+    for (const entry of scored) {
+      if (entry.score <= 0 && selected.size >= minTools) break;
+      tryAdd(entry.tool);
+    }
+
+    if (selected.size < minTools) {
+      for (const entry of scored) {
+        if (selected.size >= minTools) break;
+        if (selected.size >= maxTools) break;
+        if (selected.has(entry.tool.name)) continue;
+        selected.add(entry.tool.name);
+      }
+    }
+
+    if (selected.size === 0 && this.allToolNames.length > 0) {
+      selected.add(this.allToolNames[0]);
+    }
+
+    return Array.from(selected);
+  }
+
+  private selectExpandedTools(
+    scored: ReadonlyArray<{ tool: IndexedTool; score: number }>,
+    routedToolNames: readonly string[],
+  ): string[] {
+    const selected = new Set(routedToolNames);
+    const maxExpanded = this.config.maxExpandedToolsPerTurn;
+
+    for (const entry of scored) {
+      if (selected.size >= maxExpanded) break;
+      selected.add(entry.tool.name);
+    }
+
+    if (selected.size < routedToolNames.length) {
+      for (const name of routedToolNames) selected.add(name);
+    }
+
+    return Array.from(selected);
+  }
+
+  private estimateConfidence(
+    scored: ReadonlyArray<{ tool: IndexedTool; score: number }>,
+    intentTerms: readonly string[],
+    routedToolNames: readonly string[],
+  ): number {
+    if (scored.length === 0 || routedToolNames.length === 0) return 0;
+    if (intentTerms.length === 0) return 0.4;
+
+    const topScore = scored[0]?.score ?? 0;
+    const routedSet = new Set(routedToolNames);
+    const matchedTerms = new Set<string>();
+
+    for (const entry of scored) {
+      if (!routedSet.has(entry.tool.name)) continue;
+      for (const term of intentTerms) {
+        if (entry.tool.keywords.has(term) || entry.tool.descriptionTerms.has(term)) {
+          matchedTerms.add(term);
+        }
+      }
+    }
+
+    const termCoverage = matchedTerms.size / Math.max(1, intentTerms.length);
+    return clamp(topScore / 10 + termCoverage * 0.5, 0, 1);
+  }
+
+  private buildDecision(
+    routedToolNames: readonly string[],
+    expandedToolNames: readonly string[],
+    diagnostics: {
+      cacheHit: boolean;
+      clusterKey: string;
+      confidence: number;
+      invalidatedReason?: string;
+    },
+  ): ToolRoutingDecision {
+    const routedSet = new Set(routedToolNames);
+    const expandedSet = new Set(expandedToolNames);
+    const schemaCharsRouted = this.indexedTools.reduce((sum, tool) => (
+      routedSet.has(tool.name)
+        ? sum + tool.schemaChars
+        : sum
+    ), 0);
+    const schemaCharsExpanded = this.indexedTools.reduce((sum, tool) => (
+      expandedSet.has(tool.name)
+        ? sum + tool.schemaChars
+        : sum
+    ), 0);
+
+    return {
+      routedToolNames,
+      expandedToolNames,
+      diagnostics: {
+        ...diagnostics,
+        totalToolCount: this.indexedTools.length,
+        routedToolCount: routedToolNames.length,
+        expandedToolCount: expandedToolNames.length,
+        schemaCharsFull: this.fullSchemaChars,
+        schemaCharsRouted,
+        schemaCharsExpanded,
+        schemaCharsSaved: Math.max(0, this.fullSchemaChars - schemaCharsRouted),
+      },
+    };
+  }
+}

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -19,14 +19,68 @@ export interface GatewayLLMConfig {
   apiKey?: string;
   model?: string;
   baseUrl?: string;
+  /** Maximum output tokens per completion (provider request parameter). */
+  maxTokens?: number;
+  /** Model context window in tokens for adaptive prompt budgeting. */
+  contextWindowTokens?: number;
+  /** Hard cap (chars) applied after adaptive prompt budget calculation. */
+  promptHardMaxChars?: number;
+  /** Reserved tokens for protocol overhead when sizing prompt budget. */
+  promptSafetyMarginTokens?: number;
+  /** Approximate chars/token ratio used by the prompt allocator. */
+  promptCharPerToken?: number;
+  /** Upper bound for additive runtime hint system messages per execution. */
+  maxRuntimeHints?: number;
   /** Request timeout in milliseconds for provider calls (default: provider-specific). */
   timeoutMs?: number;
   /** Maximum token budget per session. 0 or undefined = unlimited. */
   sessionTokenBudget?: number;
   /** Maximum tool call rounds per message. Default: 5. */
   maxToolRounds?: number;
+  /** Enable planner/executor split for high-complexity turns. */
+  plannerEnabled?: boolean;
+  /** Maximum output tokens for the planner pass. */
+  plannerMaxTokens?: number;
+  /** Maximum tool calls allowed in one request execution. */
+  toolBudgetPerRequest?: number;
+  /** Maximum model recalls after the initial call per request. */
+  maxModelRecallsPerRequest?: number;
+  /** Maximum failed tool calls allowed per request before aborting. */
+  maxFailureBudgetPerRequest?: number;
   /** Allow model-emitted parallel tool calls. Default: false (serialized). */
   parallelToolCalls?: boolean;
+  /** Optional xAI Responses API stateful continuation controls. */
+  statefulResponses?: {
+    /** Enable session-scoped continuation using provider-managed response IDs. */
+    enabled?: boolean;
+    /** Explicit `store` value sent to provider calls while stateful mode is enabled. */
+    store?: boolean;
+    /** Retry once statelessly when continuation anchors are missing/mismatched/stale. */
+    fallbackToStateless?: boolean;
+  };
+  /** Optional Phase 6 dynamic tool-routing controls. */
+  toolRouting?: {
+    /** Enable per-turn tool subset routing. */
+    enabled?: boolean;
+    /** Minimum tools to include in a routed subset. */
+    minToolsPerTurn?: number;
+    /** Maximum tools to include in a routed subset. */
+    maxToolsPerTurn?: number;
+    /** Maximum tools to include in one-turn expanded retry subsets. */
+    maxExpandedToolsPerTurn?: number;
+    /** Session intent-cluster route cache TTL in milliseconds. */
+    cacheTtlMs?: number;
+    /** Minimum cache confidence required before route reuse. */
+    minCacheConfidence?: number;
+    /** Jaccard threshold below which intent shift invalidates cached routes. */
+    pivotSimilarityThreshold?: number;
+    /** Consecutive routing misses required before cache invalidation. */
+    pivotMissThreshold?: number;
+    /** Tool names always pinned in routed subsets when available. */
+    mandatoryTools?: string[];
+    /** Optional per-family tool caps (desktop/system/playwright/etc). */
+    familyCaps?: Record<string, number>;
+  };
   /** Additional LLM providers for fallback (tried in order after primary fails). */
   fallback?: GatewayLLMConfig[];
 }

--- a/runtime/src/llm/executor.test.ts
+++ b/runtime/src/llm/executor.test.ts
@@ -5,6 +5,7 @@ import type {
   LLMProvider,
   LLMResponse,
   LLMMessage,
+  LLMChatOptions,
   StreamProgressCallback,
 } from "./types.js";
 import type { Task } from "../autonomous/types.js";
@@ -20,7 +21,7 @@ import type { MemoryGraphResult } from "../memory/graph.js";
 function createMockProvider(overrides: Partial<LLMProvider> = {}): LLMProvider {
   return {
     name: "mock",
-    chat: vi.fn<[LLMMessage[]], Promise<LLMResponse>>().mockResolvedValue({
+    chat: vi.fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>().mockResolvedValue({
       content: "mock response",
       toolCalls: [],
       usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
@@ -28,7 +29,7 @@ function createMockProvider(overrides: Partial<LLMProvider> = {}): LLMProvider {
       finishReason: "stop",
     }),
     chatStream: vi
-      .fn<[LLMMessage[], StreamProgressCallback], Promise<LLMResponse>>()
+      .fn<[LLMMessage[], StreamProgressCallback, LLMChatOptions?], Promise<LLMResponse>>()
       .mockResolvedValue({
         content: "mock stream response",
         toolCalls: [],
@@ -138,7 +139,7 @@ describe("LLMTaskExecutor", () => {
     };
 
     const chatFn = vi
-      .fn<[LLMMessage[]], Promise<LLMResponse>>()
+      .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
       .mockResolvedValueOnce(toolCallResponse)
       .mockResolvedValueOnce(finalResponse);
 
@@ -177,7 +178,7 @@ describe("LLMTaskExecutor", () => {
     };
 
     const chatFn = vi
-      .fn<[LLMMessage[]], Promise<LLMResponse>>()
+      .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
       .mockResolvedValueOnce(invalidToolCallResponse)
       .mockResolvedValueOnce(finalResponse);
 
@@ -213,7 +214,7 @@ describe("LLMTaskExecutor", () => {
     };
 
     const chatFn = vi
-      .fn<[LLMMessage[]], Promise<LLMResponse>>()
+      .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
       .mockResolvedValueOnce(invalidShapeResponse)
       .mockResolvedValueOnce(finalResponse);
     const provider = createMockProvider({ chat: chatFn });
@@ -233,7 +234,7 @@ describe("LLMTaskExecutor", () => {
   it("rejects when provider returns an error finish reason", async () => {
     const streamError = new Error("partial stream failed");
     const provider = createMockProvider({
-      chat: vi.fn<[LLMMessage[]], Promise<LLMResponse>>().mockResolvedValue({
+      chat: vi.fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>().mockResolvedValue({
         content: "partial",
         toolCalls: [],
         usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
@@ -260,7 +261,7 @@ describe("LLMTaskExecutor", () => {
     };
 
     const chatFn = vi
-      .fn<[LLMMessage[]], Promise<LLMResponse>>()
+      .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
       .mockResolvedValue(toolCallResponse);
 
     const provider = createMockProvider({ chat: chatFn });
@@ -485,7 +486,7 @@ describe("LLMTaskExecutor", () => {
       };
 
       const chatFn = vi
-        .fn<[LLMMessage[]], Promise<LLMResponse>>()
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
         .mockResolvedValueOnce(toolCallResponse)
         .mockResolvedValueOnce(finalResponse);
 
@@ -570,7 +571,7 @@ describe("LLMTaskExecutor", () => {
       };
       const task = createTaskWithUniquePda();
       const chatFn = vi
-        .fn<[LLMMessage[]], Promise<LLMResponse>>()
+        .fn<[LLMMessage[], LLMChatOptions?], Promise<LLMResponse>>()
         .mockResolvedValueOnce(toolCallResponse)
         .mockResolvedValueOnce(finalResponse);
       const provider = createMockProvider({ chat: chatFn });

--- a/runtime/src/llm/fallback.test.ts
+++ b/runtime/src/llm/fallback.test.ts
@@ -5,7 +5,13 @@ import {
   LLMTimeoutError,
 } from "./errors.js";
 import { FallbackLLMProvider } from "./fallback.js";
-import type { LLMMessage, LLMProvider, LLMResponse } from "./types.js";
+import type {
+  LLMChatOptions,
+  LLMMessage,
+  LLMProvider,
+  LLMResponse,
+  StreamProgressCallback,
+} from "./types.js";
 
 function makeResponse(content: string): LLMResponse {
   return {
@@ -19,14 +25,20 @@ function makeResponse(content: string): LLMResponse {
 
 function createMockProvider(
   name: string,
-  chatImpl?: (messages: LLMMessage[]) => Promise<LLMResponse>,
+  chatImpl?: (messages: LLMMessage[], options?: LLMChatOptions) => Promise<LLMResponse>,
 ): LLMProvider {
   return {
     name,
     chat: vi.fn(
       chatImpl ?? (async () => makeResponse(`response from ${name}`)),
     ),
-    chatStream: vi.fn(async () => makeResponse(`stream response from ${name}`)),
+    chatStream: vi.fn(
+      async (
+        _messages: LLMMessage[],
+        _onChunk: StreamProgressCallback,
+        _options?: LLMChatOptions,
+      ) => makeResponse(`stream response from ${name}`),
+    ),
     healthCheck: vi.fn(async () => true),
   };
 }

--- a/runtime/src/llm/grok/index.ts
+++ b/runtime/src/llm/grok/index.ts
@@ -5,4 +5,7 @@
  */
 
 export { GrokProvider } from "./adapter.js";
-export type { GrokProviderConfig } from "./types.js";
+export type {
+  GrokProviderConfig,
+  GrokStatefulResponsesConfig,
+} from "./types.js";

--- a/runtime/src/llm/grok/types.ts
+++ b/runtime/src/llm/grok/types.ts
@@ -6,6 +6,17 @@
 
 import type { LLMProviderConfig } from "../types.js";
 
+export interface GrokStatefulResponsesConfig {
+  /** Enable session-scoped stateful continuation via `previous_response_id`. */
+  enabled?: boolean;
+  /** Explicit `store` value for Responses API calls while stateful mode is enabled. */
+  store?: boolean;
+  /** Retry once without `previous_response_id` on continuation failures. */
+  fallbackToStateless?: boolean;
+  /** Number of recent normalized turns used for reconciliation hashing. */
+  reconciliationWindow?: number;
+}
+
 /**
  * Configuration specific to the Grok (xAI) provider.
  * Uses the `openai` SDK pointed at the xAI API.
@@ -23,4 +34,6 @@ export interface GrokProviderConfig extends LLMProviderConfig {
   searchMode?: "auto" | "on" | "off";
   /** Vision-capable model to auto-switch to when images are present (default: 'grok-2-vision-1212') */
   visionModel?: string;
+  /** Optional stateful continuation controls for Responses API. */
+  statefulResponses?: GrokStatefulResponsesConfig;
 }

--- a/runtime/src/llm/index.ts
+++ b/runtime/src/llm/index.ts
@@ -13,6 +13,12 @@ export type {
   LLMProviderConfig,
   LLMContentPart,
   LLMMessage,
+  LLMChatOptions,
+  LLMChatStatefulOptions,
+  LLMStatefulDiagnostics,
+  LLMStatefulEvent,
+  LLMStatefulEventType,
+  LLMStatefulFallbackReason,
   LLMResponse,
   LLMStreamChunk,
   LLMTool,
@@ -60,6 +66,24 @@ export type {
   ToolTurnValidationOptions,
 } from "./tool-turn-validator.js";
 
+// Prompt budgeting (Phase 2)
+export {
+  applyPromptBudget,
+  derivePromptBudgetPlan,
+} from "./prompt-budget.js";
+export type {
+  PromptBudgetConfig,
+  PromptBudgetPlan,
+  PromptBudgetCaps,
+  PromptBudgetSection,
+  PromptBudgetMessage,
+  PromptBudgetDiagnostics,
+  PromptBudgetSectionStats,
+  PromptBudgetMemoryRole,
+  PromptBudgetMemoryRoleContract,
+  PromptBudgetMemoryRoleContracts,
+} from "./prompt-budget.js";
+
 // Response converter
 export { responseToOutput } from "./response-converter.js";
 
@@ -73,6 +97,7 @@ export type {
   ChatExecutorConfig,
   ChatExecuteParams,
   ChatExecutorResult,
+  ChatStatefulSummary,
   ChatPromptShape,
   ChatCallUsageRecord,
   ToolCallRecord,

--- a/runtime/src/llm/prompt-budget.test.ts
+++ b/runtime/src/llm/prompt-budget.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyPromptBudget,
+  derivePromptBudgetPlan,
+  type PromptBudgetMessage,
+} from "./prompt-budget.js";
+import type { LLMMessage } from "./types.js";
+
+function textMessage(role: LLMMessage["role"], size: number): LLMMessage {
+  return {
+    role,
+    content: `${role}:` + "x".repeat(size),
+  };
+}
+
+describe("prompt-budget", () => {
+  it("adapts prompt chars when max output tokens increase", () => {
+    const base = derivePromptBudgetPlan({
+      contextWindowTokens: 32_768,
+      maxOutputTokens: 2_048,
+      hardMaxPromptChars: 200_000,
+    });
+    const tighter = derivePromptBudgetPlan({
+      contextWindowTokens: 32_768,
+      maxOutputTokens: 8_192,
+      hardMaxPromptChars: 200_000,
+    });
+
+    expect(tighter.caps.totalChars).toBeLessThan(base.caps.totalChars);
+  });
+
+  it("adapts prompt chars when context window shrinks", () => {
+    const large = derivePromptBudgetPlan({
+      contextWindowTokens: 64_000,
+      maxOutputTokens: 2_048,
+      hardMaxPromptChars: 300_000,
+    });
+    const small = derivePromptBudgetPlan({
+      contextWindowTokens: 8_192,
+      maxOutputTokens: 2_048,
+      hardMaxPromptChars: 300_000,
+    });
+
+    expect(small.caps.totalChars).toBeLessThan(large.caps.totalChars);
+  });
+
+  it("keeps exactly one system anchor under pressure", () => {
+    const input: PromptBudgetMessage[] = [
+      { message: textMessage("system", 8_000), section: "system_anchor" },
+      { message: textMessage("system", 8_000), section: "system_anchor" },
+      { message: textMessage("system", 8_000), section: "system_runtime" },
+      { message: textMessage("assistant", 8_000), section: "history" },
+      { message: textMessage("user", 8_000), section: "user" },
+    ];
+
+    const result = applyPromptBudget(input, {
+      contextWindowTokens: 4_096,
+      maxOutputTokens: 2_048,
+      hardMaxPromptChars: 8_000,
+    });
+
+    expect(result.diagnostics.sections.system_anchor.afterMessages).toBe(1);
+    expect(result.diagnostics.sections.system_runtime.droppedMessages).toBeGreaterThan(0);
+  });
+
+  it("respects memory role contracts in caps", () => {
+    const result = applyPromptBudget(
+      [
+        { message: textMessage("system", 2_000), section: "system_anchor" },
+        { message: textMessage("system", 2_000), section: "memory_working" },
+        { message: textMessage("system", 2_000), section: "memory_episodic" },
+        { message: textMessage("system", 2_000), section: "memory_semantic" },
+        { message: textMessage("user", 2_000), section: "user" },
+      ],
+      {
+        contextWindowTokens: 8_192,
+        maxOutputTokens: 2_048,
+        hardMaxPromptChars: 16_000,
+        memoryRoleContracts: {
+          working: { weight: 0.7, minChars: 1_000 },
+          episodic: { weight: 0.2, minChars: 512 },
+          semantic: { weight: 0.1, minChars: 256 },
+        },
+      },
+    );
+
+    const roleCaps = result.diagnostics.caps.memoryRoleChars;
+    expect(roleCaps.working).toBeGreaterThan(roleCaps.episodic);
+    expect(roleCaps.episodic).toBeGreaterThanOrEqual(roleCaps.semantic);
+  });
+
+  it("records dropped/truncated diagnostics by section", () => {
+    const history = Array.from({ length: 20 }, () => ({
+      message: textMessage("assistant", 3_000),
+      section: "history" as const,
+    }));
+    const tools = Array.from({ length: 6 }, () => ({
+      message: textMessage("tool", 3_000),
+      section: "tools" as const,
+    }));
+    const input: PromptBudgetMessage[] = [
+      { message: textMessage("system", 6_000), section: "system_anchor" },
+      ...history,
+      ...tools,
+      { message: textMessage("user", 2_000), section: "user" },
+    ];
+
+    const result = applyPromptBudget(input, {
+      contextWindowTokens: 4_096,
+      maxOutputTokens: 2_048,
+      hardMaxPromptChars: 8_000,
+    });
+
+    expect(result.diagnostics.constrained).toBe(true);
+    expect(result.diagnostics.sections.history.droppedMessages).toBeGreaterThan(0);
+    expect(result.diagnostics.sections.tools.truncatedMessages).toBeGreaterThan(0);
+  });
+});

--- a/runtime/src/llm/prompt-budget.ts
+++ b/runtime/src/llm/prompt-budget.ts
@@ -1,0 +1,839 @@
+import type { LLMContentPart, LLMMessage } from "./types.js";
+
+export type PromptBudgetMemoryRole = "working" | "episodic" | "semantic";
+
+export type PromptBudgetSection =
+  | "system_anchor"
+  | "system_runtime"
+  | "memory_working"
+  | "memory_episodic"
+  | "memory_semantic"
+  | "history"
+  | "tools"
+  | "user"
+  | "assistant_runtime"
+  | "other";
+
+export interface PromptBudgetMemoryRoleContract {
+  /** Relative share of the memory section budget. */
+  readonly weight?: number;
+  /** Minimum chars reserved for this memory role (before global normalization). */
+  readonly minChars?: number;
+  /** Maximum chars allowed for this memory role (before global normalization). */
+  readonly maxChars?: number;
+}
+
+export type PromptBudgetMemoryRoleContracts = Partial<
+  Record<PromptBudgetMemoryRole, PromptBudgetMemoryRoleContract>
+>;
+
+export interface PromptBudgetConfig {
+  /** Provider/model context window in tokens. */
+  readonly contextWindowTokens?: number;
+  /** Requested max output tokens (provider max output setting). */
+  readonly maxOutputTokens?: number;
+  /** Approximate chars-per-token used for prompt sizing. */
+  readonly charPerToken?: number;
+  /** Safety margin reserved for protocol overhead and provider variance. */
+  readonly safetyMarginTokens?: number;
+  /** Optional hard upper bound on prompt chars after allocation. */
+  readonly hardMaxPromptChars?: number;
+  /** Memory role contracts (working/episodic/semantic) for Phase 5 compatibility. */
+  readonly memoryRoleContracts?: PromptBudgetMemoryRoleContracts;
+  /** Upper bound for additive runtime hint system messages per execution. */
+  readonly maxRuntimeHints?: number;
+}
+
+export interface PromptBudgetModelProfile {
+  readonly contextWindowTokens: number;
+  readonly maxOutputTokens: number;
+  readonly safetyMarginTokens: number;
+  readonly promptTokenBudget: number;
+  readonly charPerToken: number;
+}
+
+export interface PromptBudgetCaps {
+  readonly totalChars: number;
+  readonly systemChars: number;
+  readonly systemAnchorChars: number;
+  readonly systemRuntimeChars: number;
+  readonly memoryChars: number;
+  readonly memoryRoleChars: Record<PromptBudgetMemoryRole, number>;
+  readonly historyChars: number;
+  readonly toolChars: number;
+  readonly userChars: number;
+  readonly assistantRuntimeChars: number;
+  readonly otherChars: number;
+}
+
+export interface PromptBudgetSectionStats {
+  readonly capChars: number;
+  readonly beforeMessages: number;
+  readonly afterMessages: number;
+  readonly beforeChars: number;
+  readonly afterChars: number;
+  readonly droppedMessages: number;
+  readonly truncatedMessages: number;
+}
+
+export interface PromptBudgetDiagnostics {
+  readonly model: PromptBudgetModelProfile;
+  readonly caps: PromptBudgetCaps;
+  readonly totalBeforeChars: number;
+  readonly totalAfterChars: number;
+  readonly constrained: boolean;
+  readonly droppedSections: readonly PromptBudgetSection[];
+  readonly sections: Record<PromptBudgetSection, PromptBudgetSectionStats>;
+}
+
+export interface PromptBudgetMessage {
+  readonly message: LLMMessage;
+  readonly section?: PromptBudgetSection;
+}
+
+export interface PromptBudgetPlan {
+  readonly model: PromptBudgetModelProfile;
+  readonly caps: PromptBudgetCaps;
+}
+
+export interface PromptBudgetAllocationResult {
+  readonly messages: LLMMessage[];
+  readonly diagnostics: PromptBudgetDiagnostics;
+}
+
+const DEFAULT_CONTEXT_WINDOW_TOKENS = 32_768;
+const DEFAULT_MAX_OUTPUT_TOKENS = 2_048;
+const DEFAULT_CHAR_PER_TOKEN = 4;
+const DEFAULT_SAFETY_MARGIN_TOKENS = 1_024;
+const DEFAULT_HARD_MAX_PROMPT_CHARS = 100_000;
+const MIN_PROMPT_CHAR_BUDGET = 8_000;
+const MAX_PROMPT_CHAR_BUDGET = 1_500_000;
+
+const ROLE_DEFAULT_WEIGHTS: Record<PromptBudgetMemoryRole, number> = {
+  working: 0.45,
+  episodic: 0.3,
+  semantic: 0.25,
+};
+
+const SECTION_KEYS = [
+  "system",
+  "memory",
+  "history",
+  "tools",
+  "user",
+  "assistantRuntime",
+] as const;
+
+type BaseSectionKey = (typeof SECTION_KEYS)[number];
+
+interface SectionSpec {
+  readonly key: BaseSectionKey;
+  readonly weight: number;
+  readonly minChars: number;
+  readonly maxChars: number;
+}
+
+const BASE_SECTION_SPECS: readonly SectionSpec[] = [
+  { key: "system", weight: 0.2, minChars: 2_048, maxChars: 32_000 },
+  { key: "memory", weight: 0.18, minChars: 1_536, maxChars: 28_000 },
+  { key: "history", weight: 0.28, minChars: 2_048, maxChars: 36_000 },
+  { key: "tools", weight: 0.22, minChars: 2_048, maxChars: 36_000 },
+  { key: "user", weight: 0.1, minChars: 1_536, maxChars: 12_000 },
+  { key: "assistantRuntime", weight: 0.02, minChars: 1_024, maxChars: 12_000 },
+];
+
+const SECTION_ORDER: readonly PromptBudgetSection[] = [
+  "system_anchor",
+  "system_runtime",
+  "memory_working",
+  "memory_episodic",
+  "memory_semantic",
+  "history",
+  "tools",
+  "user",
+  "assistant_runtime",
+  "other",
+];
+
+interface SectionBehavior {
+  readonly dropAllowed: boolean;
+  readonly newestFirst: boolean;
+}
+
+const SECTION_BEHAVIOR: Record<PromptBudgetSection, SectionBehavior> = {
+  system_anchor: { dropAllowed: false, newestFirst: false },
+  system_runtime: { dropAllowed: true, newestFirst: true },
+  memory_working: { dropAllowed: true, newestFirst: true },
+  memory_episodic: { dropAllowed: true, newestFirst: true },
+  memory_semantic: { dropAllowed: true, newestFirst: true },
+  history: { dropAllowed: true, newestFirst: true },
+  tools: { dropAllowed: false, newestFirst: false },
+  user: { dropAllowed: false, newestFirst: false },
+  assistant_runtime: { dropAllowed: false, newestFirst: false },
+  other: { dropAllowed: true, newestFirst: true },
+};
+
+interface WorkingEntry {
+  readonly index: number;
+  readonly beforeChars: number;
+  readonly section: PromptBudgetSection;
+  message: LLMMessage;
+  dropped: boolean;
+  truncated: boolean;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function normalizeWeight(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
+  return value.slice(0, maxChars - 3) + "...";
+}
+
+function truncateContent(
+  content: string | LLMContentPart[],
+  maxChars: number,
+): string | LLMContentPart[] {
+  if (maxChars <= 0) return "";
+  if (typeof content === "string") {
+    return truncateText(content, maxChars);
+  }
+
+  const out: LLMContentPart[] = [];
+  let used = 0;
+  for (const part of content) {
+    const remaining = maxChars - used;
+    if (remaining <= 0) break;
+
+    if (part.type === "text") {
+      const text = truncateText(part.text, remaining);
+      if (text.length > 0) {
+        out.push({ type: "text", text });
+        used += text.length;
+      }
+      continue;
+    }
+
+    const placeholder = "[image omitted]";
+    const text = truncateText(placeholder, remaining);
+    if (text.length > 0) {
+      out.push({ type: "text", text });
+      used += text.length;
+    }
+  }
+
+  return out.length > 0 ? out : [{ type: "text", text: "" }];
+}
+
+function estimateContentChars(content: string | LLMContentPart[]): number {
+  if (typeof content === "string") return content.length;
+  return content.reduce((sum, part) => {
+    if (part.type === "text") return sum + part.text.length;
+    return sum + part.image_url.url.length;
+  }, 0);
+}
+
+function estimateMessageChars(message: LLMMessage): number {
+  return estimateContentChars(message.content) + 64;
+}
+
+function normalizeCaps(
+  rawCaps: Record<BaseSectionKey, number>,
+  specs: readonly SectionSpec[],
+  totalChars: number,
+): Record<BaseSectionKey, number> {
+  let normalized = { ...rawCaps };
+  const rawTotal = SECTION_KEYS.reduce((sum, key) => sum + normalized[key], 0);
+
+  if (rawTotal > totalChars) {
+    const scaled: Record<BaseSectionKey, number> = {
+      system: 0,
+      memory: 0,
+      history: 0,
+      tools: 0,
+      user: 0,
+      assistantRuntime: 0,
+    };
+    for (const spec of specs) {
+      const scaledValue = Math.floor((normalized[spec.key] * totalChars) / rawTotal);
+      scaled[spec.key] = clamp(scaledValue, spec.minChars, spec.maxChars);
+    }
+    normalized = scaled;
+  }
+
+  let adjustedTotal = SECTION_KEYS.reduce((sum, key) => sum + normalized[key], 0);
+  if (adjustedTotal > totalChars) {
+    for (const spec of [...specs].sort((a, b) => b.weight - a.weight)) {
+      if (adjustedTotal <= totalChars) break;
+      const reducible = normalized[spec.key] - spec.minChars;
+      if (reducible <= 0) continue;
+      const delta = Math.min(reducible, adjustedTotal - totalChars);
+      normalized[spec.key] -= delta;
+      adjustedTotal -= delta;
+    }
+  } else if (adjustedTotal < totalChars) {
+    for (const spec of [...specs].sort((a, b) => b.weight - a.weight)) {
+      if (adjustedTotal >= totalChars) break;
+      const expandable = spec.maxChars - normalized[spec.key];
+      if (expandable <= 0) continue;
+      const delta = Math.min(expandable, totalChars - adjustedTotal);
+      normalized[spec.key] += delta;
+      adjustedTotal += delta;
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeRoleCaps(
+  totalMemoryChars: number,
+  contracts: PromptBudgetMemoryRoleContracts | undefined,
+): Record<PromptBudgetMemoryRole, number> {
+  const roles: PromptBudgetMemoryRole[] = ["working", "episodic", "semantic"];
+  const weighted = roles.map((role) => {
+    const contract = contracts?.[role];
+    return {
+      role,
+      weight: normalizeWeight(contract?.weight, ROLE_DEFAULT_WEIGHTS[role]),
+      minChars: clamp(
+        Math.floor(contract?.minChars ?? 256),
+        64,
+        Math.max(64, totalMemoryChars),
+      ),
+      maxChars: clamp(
+        Math.floor(contract?.maxChars ?? totalMemoryChars),
+        64,
+        Math.max(64, totalMemoryChars),
+      ),
+    };
+  });
+
+  const weightTotal = weighted.reduce((sum, entry) => sum + entry.weight, 0);
+  const raw: Record<PromptBudgetMemoryRole, number> = {
+    working: 0,
+    episodic: 0,
+    semantic: 0,
+  };
+  for (const entry of weighted) {
+    const proportional = Math.floor((totalMemoryChars * entry.weight) / weightTotal);
+    raw[entry.role] = clamp(proportional, entry.minChars, entry.maxChars);
+  }
+
+  let currentTotal = roles.reduce((sum, role) => sum + raw[role], 0);
+  if (currentTotal > totalMemoryChars) {
+    for (const entry of weighted.sort((a, b) => b.weight - a.weight)) {
+      if (currentTotal <= totalMemoryChars) break;
+      const reducible = raw[entry.role] - entry.minChars;
+      if (reducible <= 0) continue;
+      const delta = Math.min(reducible, currentTotal - totalMemoryChars);
+      raw[entry.role] -= delta;
+      currentTotal -= delta;
+    }
+  } else if (currentTotal < totalMemoryChars) {
+    for (const entry of weighted.sort((a, b) => b.weight - a.weight)) {
+      if (currentTotal >= totalMemoryChars) break;
+      const expandable = entry.maxChars - raw[entry.role];
+      if (expandable <= 0) continue;
+      const delta = Math.min(expandable, totalMemoryChars - currentTotal);
+      raw[entry.role] += delta;
+      currentTotal += delta;
+    }
+  }
+
+  return raw;
+}
+
+export function derivePromptBudgetPlan(
+  config: PromptBudgetConfig | undefined,
+): PromptBudgetPlan {
+  const contextWindowTokens = clamp(
+    Math.floor(config?.contextWindowTokens ?? DEFAULT_CONTEXT_WINDOW_TOKENS),
+    2_048,
+    2_000_000,
+  );
+  const maxOutputTokens = clamp(
+    Math.floor(config?.maxOutputTokens ?? DEFAULT_MAX_OUTPUT_TOKENS),
+    128,
+    Math.max(256, contextWindowTokens - 1_024),
+  );
+  const safetyMarginTokens = clamp(
+    Math.floor(
+      config?.safetyMarginTokens ??
+        Math.max(
+          DEFAULT_SAFETY_MARGIN_TOKENS,
+          Math.floor(contextWindowTokens * 0.05),
+        ),
+    ),
+    256,
+    Math.max(512, Math.floor(contextWindowTokens * 0.5)),
+  );
+  const promptTokenBudget = Math.max(
+    1_024,
+    contextWindowTokens - maxOutputTokens - safetyMarginTokens,
+  );
+  const charPerToken = clamp(
+    Math.floor(config?.charPerToken ?? DEFAULT_CHAR_PER_TOKEN),
+    2,
+    8,
+  );
+  const hardMaxPromptChars = clamp(
+    Math.floor(config?.hardMaxPromptChars ?? DEFAULT_HARD_MAX_PROMPT_CHARS),
+    MIN_PROMPT_CHAR_BUDGET,
+    MAX_PROMPT_CHAR_BUDGET,
+  );
+  const totalChars = clamp(
+    Math.floor(promptTokenBudget * charPerToken),
+    MIN_PROMPT_CHAR_BUDGET,
+    hardMaxPromptChars,
+  );
+
+  const rawCaps: Record<BaseSectionKey, number> = {
+    system: 0,
+    memory: 0,
+    history: 0,
+    tools: 0,
+    user: 0,
+    assistantRuntime: 0,
+  };
+  for (const spec of BASE_SECTION_SPECS) {
+    const proportional = Math.floor(totalChars * spec.weight);
+    rawCaps[spec.key] = clamp(proportional, spec.minChars, spec.maxChars);
+  }
+  const normalizedBase = normalizeCaps(rawCaps, BASE_SECTION_SPECS, totalChars);
+  const memoryRoleChars = normalizeRoleCaps(
+    normalizedBase.memory,
+    config?.memoryRoleContracts,
+  );
+  const systemAnchorChars = clamp(
+    Math.floor(normalizedBase.system * 0.75),
+    512,
+    normalizedBase.system,
+  );
+  const systemRuntimeChars = Math.max(0, normalizedBase.system - systemAnchorChars);
+  const usedByTopSections =
+    normalizedBase.system +
+    normalizedBase.memory +
+    normalizedBase.history +
+    normalizedBase.tools +
+    normalizedBase.user +
+    normalizedBase.assistantRuntime;
+  const otherChars = Math.max(0, totalChars - usedByTopSections);
+
+  return {
+    model: {
+      contextWindowTokens,
+      maxOutputTokens,
+      safetyMarginTokens,
+      promptTokenBudget,
+      charPerToken,
+    },
+    caps: {
+      totalChars,
+      systemChars: normalizedBase.system,
+      systemAnchorChars,
+      systemRuntimeChars,
+      memoryChars: normalizedBase.memory,
+      memoryRoleChars,
+      historyChars: normalizedBase.history,
+      toolChars: normalizedBase.tools,
+      userChars: normalizedBase.user,
+      assistantRuntimeChars: normalizedBase.assistantRuntime,
+      otherChars,
+    },
+  };
+}
+
+function getSectionCap(caps: PromptBudgetCaps, section: PromptBudgetSection): number {
+  switch (section) {
+    case "system_anchor":
+      return caps.systemAnchorChars;
+    case "system_runtime":
+      return caps.systemRuntimeChars;
+    case "memory_working":
+      return caps.memoryRoleChars.working;
+    case "memory_episodic":
+      return caps.memoryRoleChars.episodic;
+    case "memory_semantic":
+      return caps.memoryRoleChars.semantic;
+    case "history":
+      return caps.historyChars;
+    case "tools":
+      return caps.toolChars;
+    case "user":
+      return caps.userChars;
+    case "assistant_runtime":
+      return caps.assistantRuntimeChars;
+    case "other":
+      return caps.otherChars;
+    default:
+      return 0;
+  }
+}
+
+function createSectionCapMap(caps: PromptBudgetCaps): Record<PromptBudgetSection, number> {
+  return {
+    system_anchor: getSectionCap(caps, "system_anchor"),
+    system_runtime: getSectionCap(caps, "system_runtime"),
+    memory_working: getSectionCap(caps, "memory_working"),
+    memory_episodic: getSectionCap(caps, "memory_episodic"),
+    memory_semantic: getSectionCap(caps, "memory_semantic"),
+    history: getSectionCap(caps, "history"),
+    tools: getSectionCap(caps, "tools"),
+    user: getSectionCap(caps, "user"),
+    assistant_runtime: getSectionCap(caps, "assistant_runtime"),
+    other: getSectionCap(caps, "other"),
+  };
+}
+
+function rebalanceSectionCaps(
+  baseCaps: Record<PromptBudgetSection, number>,
+  beforeChars: Record<PromptBudgetSection, number>,
+): Record<PromptBudgetSection, number> {
+  const effective = { ...baseCaps };
+  let slack = 0;
+  for (const section of SECTION_ORDER) {
+    const unused = effective[section] - beforeChars[section];
+    if (unused > 0) slack += unused;
+  }
+  if (slack <= 0) return effective;
+
+  const deficitOrder: PromptBudgetSection[] = [
+    "tools",
+    "history",
+    "system_runtime",
+    "memory_working",
+    "memory_episodic",
+    "memory_semantic",
+    "assistant_runtime",
+    "user",
+    "system_anchor",
+    "other",
+  ];
+  for (const section of deficitOrder) {
+    if (slack <= 0) break;
+    const deficit = beforeChars[section] - effective[section];
+    if (deficit <= 0) continue;
+    const delta = Math.min(deficit, slack);
+    effective[section] += delta;
+    slack -= delta;
+  }
+  return effective;
+}
+
+function resolveSections(
+  input: readonly PromptBudgetMessage[],
+): PromptBudgetSection[] {
+  const lastUserIndex = (() => {
+    for (let i = input.length - 1; i >= 0; i--) {
+      if (input[i].message.role === "user") return i;
+    }
+    return -1;
+  })();
+
+  let anchorAssigned = false;
+  return input.map((entry, index) => {
+    if (entry.section) {
+      if (entry.section === "system_anchor") {
+        if (!anchorAssigned) {
+          anchorAssigned = true;
+          return "system_anchor";
+        }
+        return "system_runtime";
+      }
+      return entry.section;
+    }
+
+    const msg = entry.message;
+    if (msg.role === "system") {
+      if (!anchorAssigned) {
+        anchorAssigned = true;
+        return "system_anchor";
+      }
+      return "system_runtime";
+    }
+    if (msg.role === "tool") return "tools";
+    if (msg.role === "assistant" && msg.toolCalls && msg.toolCalls.length > 0) {
+      return "assistant_runtime";
+    }
+    if (msg.role === "user") {
+      return index === lastUserIndex ? "user" : "history";
+    }
+    if (msg.role === "assistant") return "history";
+    return "other";
+  });
+}
+
+function truncateMessage(entry: WorkingEntry, maxChars: number): void {
+  const nextContent = truncateContent(entry.message.content, Math.max(0, maxChars));
+  const nextMessage: LLMMessage = { ...entry.message, content: nextContent };
+  const nextChars = estimateMessageChars(nextMessage);
+  if (nextChars < entry.beforeChars) {
+    entry.truncated = true;
+  }
+  entry.message = nextMessage;
+}
+
+export function applyPromptBudget(
+  input: readonly PromptBudgetMessage[],
+  config?: PromptBudgetConfig,
+): PromptBudgetAllocationResult {
+  const plan = derivePromptBudgetPlan(config);
+  const sections = resolveSections(input);
+
+  const working: WorkingEntry[] = input.map((entry, index) => ({
+    index,
+    beforeChars: estimateMessageChars(entry.message),
+    section: sections[index],
+    message: entry.message,
+    dropped: false,
+    truncated: false,
+  }));
+
+  const bySection = new Map<PromptBudgetSection, WorkingEntry[]>();
+  for (const section of SECTION_ORDER) {
+    bySection.set(section, []);
+  }
+  for (const entry of working) {
+    bySection.get(entry.section)?.push(entry);
+  }
+
+  const baseSectionCaps = createSectionCapMap(plan.caps);
+  const sectionBeforeChars: Record<PromptBudgetSection, number> = {
+    system_anchor: 0,
+    system_runtime: 0,
+    memory_working: 0,
+    memory_episodic: 0,
+    memory_semantic: 0,
+    history: 0,
+    tools: 0,
+    user: 0,
+    assistant_runtime: 0,
+    other: 0,
+  };
+  for (const section of SECTION_ORDER) {
+    const entries = bySection.get(section) ?? [];
+    sectionBeforeChars[section] = entries.reduce(
+      (sum, entry) => sum + entry.beforeChars,
+      0,
+    );
+  }
+  const totalBeforeChars = working.reduce(
+    (sum, entry) => sum + entry.beforeChars,
+    0,
+  );
+  const constrainedByTotal = totalBeforeChars > plan.caps.totalChars;
+  const sectionCaps = constrainedByTotal
+    ? rebalanceSectionCaps(baseSectionCaps, sectionBeforeChars)
+    : baseSectionCaps;
+
+  if (constrainedByTotal) {
+    for (const section of SECTION_ORDER) {
+      const entries = bySection.get(section) ?? [];
+      if (entries.length === 0) continue;
+
+      const behavior = SECTION_BEHAVIOR[section];
+      const cap = sectionCaps[section];
+
+      if (behavior.dropAllowed) {
+        const ordered = behavior.newestFirst
+          ? [...entries].sort((a, b) => b.index - a.index)
+          : [...entries].sort((a, b) => a.index - b.index);
+        let used = 0;
+        let kept = 0;
+
+        for (const entry of ordered) {
+          const remaining = cap - used;
+          if (remaining <= 0) {
+            entry.dropped = true;
+            continue;
+          }
+
+          if (entry.beforeChars <= remaining) {
+            used += entry.beforeChars;
+            kept++;
+            continue;
+          }
+
+          if (kept === 0) {
+            truncateMessage(entry, remaining);
+            used += estimateMessageChars(entry.message);
+            kept++;
+            continue;
+          }
+
+          entry.dropped = true;
+        }
+        continue;
+      }
+
+      const ordered = behavior.newestFirst
+        ? [...entries].sort((a, b) => b.index - a.index)
+        : [...entries].sort((a, b) => a.index - b.index);
+      let used = 0;
+      for (let i = 0; i < ordered.length; i++) {
+        const entry = ordered[i];
+        const remainingEntries = ordered.length - i;
+        const remainingBudget = Math.max(0, cap - used);
+        const perMessageBudget =
+          remainingEntries > 0
+            ? Math.max(16, Math.floor(remainingBudget / remainingEntries))
+            : 16;
+        truncateMessage(entry, perMessageBudget);
+        used += estimateMessageChars(entry.message);
+      }
+    }
+  }
+
+  const finalEntries = working
+    .filter((entry) => !entry.dropped)
+    .sort((a, b) => a.index - b.index);
+  const finalMessages = finalEntries.map((entry) => entry.message);
+
+  const totalAfterChars = finalEntries.reduce(
+    (sum, entry) => sum + estimateMessageChars(entry.message),
+    0,
+  );
+
+  const sectionStats: Record<PromptBudgetSection, PromptBudgetSectionStats> = {
+    system_anchor: {
+      capChars: sectionCaps.system_anchor,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    system_runtime: {
+      capChars: sectionCaps.system_runtime,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    memory_working: {
+      capChars: sectionCaps.memory_working,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    memory_episodic: {
+      capChars: sectionCaps.memory_episodic,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    memory_semantic: {
+      capChars: sectionCaps.memory_semantic,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    history: {
+      capChars: sectionCaps.history,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    tools: {
+      capChars: sectionCaps.tools,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    user: {
+      capChars: sectionCaps.user,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    assistant_runtime: {
+      capChars: sectionCaps.assistant_runtime,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+    other: {
+      capChars: sectionCaps.other,
+      beforeMessages: 0,
+      afterMessages: 0,
+      beforeChars: 0,
+      afterChars: 0,
+      droppedMessages: 0,
+      truncatedMessages: 0,
+    },
+  };
+
+  for (const entry of working) {
+    const current = sectionStats[entry.section];
+    sectionStats[entry.section] = {
+      ...current,
+      beforeMessages: current.beforeMessages + 1,
+      beforeChars: current.beforeChars + entry.beforeChars,
+      droppedMessages: current.droppedMessages + (entry.dropped ? 1 : 0),
+      truncatedMessages: current.truncatedMessages + (entry.truncated ? 1 : 0),
+    };
+  }
+  for (const entry of finalEntries) {
+    const current = sectionStats[entry.section];
+    sectionStats[entry.section] = {
+      ...current,
+      afterMessages: current.afterMessages + 1,
+      afterChars: current.afterChars + estimateMessageChars(entry.message),
+    };
+  }
+
+  const droppedSections = SECTION_ORDER.filter((section) => {
+    const stats = sectionStats[section];
+    return stats.beforeChars > 0 && stats.afterChars === 0;
+  });
+  const constrained =
+    totalAfterChars < totalBeforeChars ||
+    droppedSections.length > 0 ||
+    SECTION_ORDER.some((section) => sectionStats[section].truncatedMessages > 0);
+
+  return {
+    messages: finalMessages,
+    diagnostics: {
+      model: plan.model,
+      caps: plan.caps,
+      totalBeforeChars,
+      totalAfterChars,
+      constrained,
+      droppedSections,
+      sections: sectionStats,
+    },
+  };
+}

--- a/runtime/src/memory/retriever.test.ts
+++ b/runtime/src/memory/retriever.test.ts
@@ -10,30 +10,40 @@ import type { VectorMemoryBackend, ScoredMemoryEntry } from "./vector-store.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import type { CuratedMemoryManager } from "./structured.js";
 
-// ============================================================================
-// Test helpers
-// ============================================================================
-
 function makeEntry(
   content: string,
   timestamp = 1_000_000,
   sessionId = "sess-1",
+  metadata?: Record<string, unknown>,
 ): MemoryEntry {
   return {
-    id: `entry-${content.slice(0, 8)}`,
+    id: `entry-${Math.random().toString(16).slice(2, 8)}`,
     sessionId,
     role: "assistant",
     content,
     timestamp,
+    metadata,
   };
 }
 
 function makeScoredEntry(
   content: string,
   score: number,
-  timestamp = 1_000_000,
+  opts?: {
+    timestamp?: number;
+    sessionId?: string;
+    metadata?: Record<string, unknown>;
+  },
 ): ScoredMemoryEntry {
-  return { entry: makeEntry(content, timestamp), score };
+  return {
+    entry: makeEntry(
+      content,
+      opts?.timestamp ?? 1_000_000,
+      opts?.sessionId ?? "sess-1",
+      opts?.metadata,
+    ),
+    score,
+  };
 }
 
 function createMockEmbedding(): EmbeddingProvider {
@@ -46,12 +56,10 @@ function createMockEmbedding(): EmbeddingProvider {
   };
 }
 
-function createMockVectorBackend(
-  results: ScoredMemoryEntry[] = [],
-): VectorMemoryBackend {
+function createMockVectorBackend(): VectorMemoryBackend {
   return {
     name: "mock-vector",
-    searchHybrid: vi.fn().mockResolvedValue(results),
+    searchHybrid: vi.fn().mockResolvedValue([]),
     searchSimilar: vi.fn().mockResolvedValue([]),
     storeWithEmbedding: vi.fn(),
     getVectorDimension: vi.fn().mockReturnValue(8),
@@ -98,41 +106,20 @@ function createRetriever(
   });
 }
 
-// ============================================================================
-// estimateTokens
-// ============================================================================
-
 describe("estimateTokens", () => {
   it("returns 0 for empty string", () => {
     expect(estimateTokens("")).toBe(0);
   });
 
-  it("returns 1 for a single character", () => {
-    expect(estimateTokens("a")).toBe(1);
-  });
-
-  it("returns 1 for exactly 4 characters", () => {
+  it("returns ceil(chars / 4)", () => {
     expect(estimateTokens("abcd")).toBe(1);
-  });
-
-  it("returns 2 for 5 characters", () => {
     expect(estimateTokens("abcde")).toBe(2);
-  });
-
-  it("scales linearly", () => {
-    expect(estimateTokens("a".repeat(16))).toBe(4);
-    expect(estimateTokens("a".repeat(17))).toBe(5);
-    expect(estimateTokens("a".repeat(100))).toBe(25);
   });
 });
 
-// ============================================================================
-// computeRetrievalScore
-// ============================================================================
-
 describe("computeRetrievalScore", () => {
   const now = 1_000_000;
-  const halfLife = 86_400_000; // 24h
+  const halfLife = 86_400_000;
 
   it("returns pure relevance when recencyWeight=0", () => {
     const score = computeRetrievalScore(0.8, now - halfLife, now, 0, halfLife);
@@ -140,458 +127,195 @@ describe("computeRetrievalScore", () => {
   });
 
   it("returns pure recency when recencyWeight=1", () => {
-    // At exactly halfLife age, recency should be 0.5
     const score = computeRetrievalScore(0.8, now - halfLife, now, 1, halfLife);
     expect(score).toBeCloseTo(0.5, 5);
   });
 
-  it("returns 1.0 for perfect relevance and zero age", () => {
-    const score = computeRetrievalScore(1.0, now, now, 0.5, halfLife);
-    // relevance * 0.5 + 1.0 * 0.5 = 0.5 + 0.5 = 1.0
-    expect(score).toBeCloseTo(1.0, 5);
-  });
-
-  it("recency decays to 0.5 at half-life", () => {
-    const score = computeRetrievalScore(
-      0.0,
-      now - halfLife,
-      now,
-      1.0,
-      halfLife,
-    );
-    expect(score).toBeCloseTo(0.5, 5);
-  });
-
-  it("recency decays to 0.25 at two half-lives", () => {
-    const score = computeRetrievalScore(
-      0.0,
-      now - 2 * halfLife,
-      now,
-      1.0,
-      halfLife,
-    );
-    expect(score).toBeCloseTo(0.25, 5);
-  });
-
-  it("handles future timestamps (clamped age to 0)", () => {
-    const score = computeRetrievalScore(0.5, now + 1000, now, 0.5, halfLife);
-    // age clamped to 0 → recency = 1.0
-    // 0.5 * 0.5 + 1.0 * 0.5 = 0.75
-    expect(score).toBeCloseTo(0.75, 5);
-  });
-
-  it("blends relevance and recency correctly", () => {
-    // weight=0.3, halfLife=24h, age=12h → recency ≈ 0.707
-    const age = halfLife / 2;
-    const score = computeRetrievalScore(0.6, now - age, now, 0.3, halfLife);
-    const expectedRecency = Math.exp(-Math.LN2 * 0.5); // ≈ 0.707
-    const expected = 0.6 * 0.7 + expectedRecency * 0.3;
-    expect(score).toBeCloseTo(expected, 5);
+  it("clamps future timestamps to recency=1", () => {
+    const score = computeRetrievalScore(0.4, now + 10_000, now, 0.5, halfLife);
+    expect(score).toBeCloseTo(0.7, 5);
   });
 });
 
-// ============================================================================
-// SemanticMemoryRetriever — basic flow
-// ============================================================================
-
 describe("SemanticMemoryRetriever", () => {
-  describe("basic flow", () => {
-    it("returns formatted memory blocks", async () => {
-      const results = [makeScoredEntry("relevant fact", 0.9)];
-      const backend = createMockVectorBackend(results);
-      const retriever = createRetriever({ vectorBackend: backend });
-
-      const content = await retriever.retrieve("query", "sess-1");
-
-      expect(content).toContain('<memory source="vector"');
-      expect(content).toContain("relevant fact");
-      expect(content).toContain("</memory>");
-    });
-
-    it("returns undefined when no results found", async () => {
-      const retriever = createRetriever();
-      const content = await retriever.retrieve("query", "sess-1");
-      expect(content).toBeUndefined();
-    });
-
-    it("retrieve() delegates to retrieveDetailed()", async () => {
-      const results = [makeScoredEntry("data", 0.8)];
-      const backend = createMockVectorBackend(results);
-      const retriever = createRetriever({ vectorBackend: backend });
-
-      const detailed = await retriever.retrieveDetailed("query", "sess-1");
-      const simple = await retriever.retrieve("query", "sess-1");
-
-      expect(simple).toBe(detailed.content);
-    });
-
-    it("returns correct result shape from retrieveDetailed", async () => {
-      const results = [makeScoredEntry("fact", 0.85)];
-      const backend = createMockVectorBackend(results);
-      const retriever = createRetriever({ vectorBackend: backend });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      expect(result.entries).toHaveLength(1);
-      expect(result.entries[0].relevanceScore).toBe(0.85);
-      expect(result.entries[0].combinedScore).toBeGreaterThan(0);
-      expect(result.estimatedTokens).toBeGreaterThan(0);
-    });
-
-    it("returns empty result when embedding is empty", async () => {
-      const embedding = createMockEmbedding();
-      (embedding.embed as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-      const retriever = createRetriever({ embeddingProvider: embedding });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      expect(result.content).toBeUndefined();
-      expect(result.entries).toHaveLength(0);
-    });
-
-    it("logs debug when embedding is empty", async () => {
-      const embedding = createMockEmbedding();
-      (embedding.embed as ReturnType<typeof vi.fn>).mockResolvedValue([]);
-      const logger = {
-        debug: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      };
-      const retriever = createRetriever({
-        embeddingProvider: embedding,
-        logger: logger as any,
-      });
-
-      await retriever.retrieveDetailed("query", "sess-1");
-      expect(logger.debug).toHaveBeenCalledWith(
-        expect.stringContaining("Empty embedding"),
-      );
-    });
+  beforeEach(() => {
+    vi.restoreAllMocks();
   });
 
-  // ==========================================================================
-  // Token budget
-  // ==========================================================================
-
-  describe("token budget", () => {
-    it("curated memory takes priority over vector results", async () => {
-      const results = [makeScoredEntry("vector data", 0.9)];
-      const backend = createMockVectorBackend(results);
-      const curated = createMockCurated("important curated fact");
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        curatedMemory: curated,
-        maxTokenBudget: 2000,
-      });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      expect(result.curatedIncluded).toBe(true);
-      expect(result.content).toContain('source="curated"');
-      // Curated appears before vector in the output
-      const curatedIdx = result.content!.indexOf('source="curated"');
-      const vectorIdx = result.content!.indexOf('source="vector"');
-      expect(curatedIdx).toBeLessThan(vectorIdx);
-    });
-
-    it("greedy packing skips large entries and includes smaller ones", async () => {
-      // Create a tight budget
-      const largeContent = "x".repeat(200); // ~50 tokens content + block overhead
-      const smallContent = "y".repeat(20); // ~5 tokens content + block overhead
-      const results = [
-        makeScoredEntry(largeContent, 0.9),
-        makeScoredEntry(smallContent, 0.8),
-      ];
-      const backend = createMockVectorBackend(results);
-      // Budget enough for only the small entry (with block markup overhead)
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        maxTokenBudget: 25, // ~100 chars — fits small block but not large
-      });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      expect(result.content).toContain(smallContent);
-      expect(result.content).not.toContain(largeContent);
-    });
-
-    it("returns undefined content when budget is zero", async () => {
-      const results = [makeScoredEntry("data", 0.9)];
-      const backend = createMockVectorBackend(results);
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        maxTokenBudget: 0,
-      });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-      expect(result.content).toBeUndefined();
-      expect(result.estimatedTokens).toBe(0);
-    });
-
-    it("logs warning when curated exceeds budget", async () => {
-      const curated = createMockCurated("x".repeat(10_000));
-      const logger = {
-        debug: vi.fn(),
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      };
-      const retriever = createRetriever({
-        curatedMemory: curated,
-        maxTokenBudget: 10,
-        logger: logger as any,
-      });
-
-      await retriever.retrieveDetailed("query", "sess-1");
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining("exceeds remaining budget"),
-      );
-    });
-
-    it("reports accurate estimatedTokens", async () => {
-      const content = "short fact";
-      const results = [makeScoredEntry(content, 0.9)];
-      const backend = createMockVectorBackend(results);
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        maxTokenBudget: 2000,
-      });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      expect(result.estimatedTokens).toBe(estimateTokens(result.content!));
-    });
+  it("returns undefined when no candidates are available", async () => {
+    const retriever = createRetriever();
+    const result = await retriever.retrieveDetailed("query", "sess-1");
+    expect(result.content).toBeUndefined();
+    expect(result.entries).toHaveLength(0);
   });
 
-  // ==========================================================================
-  // Curated memory
-  // ==========================================================================
+  it("retrieves working, episodic, and semantic roles separately", async () => {
+    const backend = createMockVectorBackend();
+    (backend.getThread as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeEntry("working context", Date.now(), "sess-1", {
+        memoryRole: "working",
+        confidence: 0.7,
+        provenance: "ingestion:turn",
+      }),
+    ]);
 
-  describe("curated memory", () => {
-    it("includes curated content when available", async () => {
-      const curated = createMockCurated("User prefers TypeScript");
-      const retriever = createRetriever({ curatedMemory: curated });
+    (backend.searchHybrid as ReturnType<typeof vi.fn>).mockImplementation(
+      async (
+        _query: string,
+        _embedding: number[],
+        options?: { memoryRoles?: readonly ("working" | "episodic" | "semantic")[] },
+      ) => {
+        if (options?.memoryRoles?.includes("episodic")) {
+          return [
+            makeScoredEntry("episodic summary", 0.82, {
+              metadata: {
+                memoryRole: "episodic",
+                confidence: 0.9,
+                provenance: "ingestion:session_end",
+              },
+            }),
+          ];
+        }
+        if (options?.memoryRoles?.includes("semantic")) {
+          return [
+            makeScoredEntry("semantic fact", 0.91, {
+              metadata: {
+                memoryRole: "semantic",
+                confidence: 0.88,
+                provenance: "entity_extractor:conversation",
+              },
+            }),
+          ];
+        }
+        return [];
+      },
+    );
 
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-      expect(result.curatedIncluded).toBe(true);
-      expect(result.content).toContain("User prefers TypeScript");
-    });
+    const retriever = createRetriever({ vectorBackend: backend, maxTokenBudget: 4000 });
+    const result = await retriever.retrieveDetailed("query semantic fact", "sess-1");
 
-    it("curatedIncluded is false when load returns empty", async () => {
-      const curated = createMockCurated("");
-      const retriever = createRetriever({ curatedMemory: curated });
+    expect(result.content).toContain('role="working"');
+    expect(result.content).toContain('role="episodic"');
+    expect(result.content).toContain('role="semantic"');
+    expect(result.content).toContain('provenance="ingestion:session_end"');
+    expect(result.content).toContain('confidence="0.90"');
 
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-      expect(result.curatedIncluded).toBe(false);
-    });
-
-    it("curatedIncluded is false when no curatedMemory configured", async () => {
-      const retriever = createRetriever();
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-      expect(result.curatedIncluded).toBe(false);
-    });
-
-    it('curated gets score="1.00" in block', async () => {
-      const curated = createMockCurated("important");
-      const retriever = createRetriever({ curatedMemory: curated });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-      expect(result.content).toContain('score="1.00"');
-    });
+    expect(backend.searchHybrid).toHaveBeenCalledTimes(2);
+    expect(backend.searchHybrid).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ memoryRoles: ["semantic"], sessionId: "sess-1" }),
+    );
+    expect(backend.searchHybrid).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ memoryRoles: ["episodic"], sessionId: "sess-1" }),
+    );
   });
 
-  // ==========================================================================
-  // Curated caching
-  // ==========================================================================
+  it("enforces diversity-aware packing by dropping near-duplicates", async () => {
+    const backend = createMockVectorBackend();
+    (backend.searchHybrid as ReturnType<typeof vi.fn>).mockImplementation(
+      async (
+        _query: string,
+        _embedding: number[],
+        options?: { memoryRoles?: readonly ("working" | "episodic" | "semantic")[] },
+      ) => {
+        if (!options?.memoryRoles?.includes("semantic")) return [];
+        return [
+          makeScoredEntry("The server failed on port 8123 with timeout", 0.95, {
+            metadata: { memoryRole: "semantic", confidence: 0.9 },
+          }),
+          makeScoredEntry("Server failed on port 8123 due to timeout", 0.94, {
+            metadata: { memoryRole: "semantic", confidence: 0.88 },
+          }),
+          makeScoredEntry("Use retry budget to avoid infinite loops", 0.7, {
+            metadata: { memoryRole: "semantic", confidence: 0.8 },
+          }),
+        ];
+      },
+    );
 
-  describe("curated caching", () => {
-    it("caches within TTL", async () => {
-      const curated = createMockCurated("cached fact");
-      const retriever = createRetriever({
-        curatedMemory: curated,
-        curatedCacheTtlMs: 60_000,
-      });
-
-      await retriever.retrieveDetailed("q1", "sess-1");
-      await retriever.retrieveDetailed("q2", "sess-1");
-
-      expect(curated.load).toHaveBeenCalledTimes(1);
+    const retriever = createRetriever({
+      vectorBackend: backend,
+      maxTokenBudget: 2000,
+      diversityThreshold: 0.6,
     });
 
-    it("reloads after TTL expires", async () => {
-      const curated = createMockCurated("fact v1");
-      const retriever = createRetriever({
-        curatedMemory: curated,
-        curatedCacheTtlMs: 100,
-      });
+    const result = await retriever.retrieveDetailed("port timeout retry", "sess-1");
 
-      await retriever.retrieveDetailed("q1", "sess-1");
-
-      // Advance time past TTL
-      vi.spyOn(Date, "now").mockReturnValue(Date.now() + 200);
-      (curated.load as ReturnType<typeof vi.fn>).mockResolvedValue("fact v2");
-
-      const result = await retriever.retrieveDetailed("q2", "sess-1");
-
-      expect(curated.load).toHaveBeenCalledTimes(2);
-      expect(result.content).toContain("fact v2");
-
-      vi.restoreAllMocks();
-    });
-
-    it("clearCache forces reload on next call", async () => {
-      const curated = createMockCurated("original");
-      const retriever = createRetriever({ curatedMemory: curated });
-
-      await retriever.retrieveDetailed("q1", "sess-1");
-      retriever.clearCache();
-      (curated.load as ReturnType<typeof vi.fn>).mockResolvedValue("updated");
-
-      const result = await retriever.retrieveDetailed("q2", "sess-1");
-      expect(curated.load).toHaveBeenCalledTimes(2);
-      expect(result.content).toContain("updated");
-    });
+    const blockCount = (result.content?.match(/<memory /g) ?? []).length;
+    expect(blockCount).toBe(2);
+    expect(result.content).toContain("retry budget");
   });
 
-  // ==========================================================================
-  // Re-ranking
-  // ==========================================================================
+  it("forwards session id for isolation in both thread and vector retrieval", async () => {
+    const backend = createMockVectorBackend();
+    const retriever = createRetriever({ vectorBackend: backend });
 
-  describe("re-ranking", () => {
-    it("boosts recent entries", async () => {
-      const now = Date.now();
-      const old = makeScoredEntry("old fact", 0.8, now - 86_400_000 * 7); // 7 days old
-      const recent = makeScoredEntry("new fact", 0.8, now - 1000); // 1 second old
-      const backend = createMockVectorBackend([old, recent]);
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        recencyWeight: 0.5,
-      });
+    await retriever.retrieveDetailed("query", "ws-a:sess-22");
 
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      // Recent entry should rank higher
-      expect(result.entries[0].entry.content).toBe("new fact");
-      expect(result.entries[0].combinedScore).toBeGreaterThan(
-        result.entries[1].combinedScore,
-      );
-    });
-
-    it("uses pure relevance when recencyWeight=0", async () => {
-      const now = Date.now();
-      const highRelevance = makeScoredEntry("high", 0.9, now - 86_400_000 * 30);
-      const lowRelevance = makeScoredEntry("low", 0.3, now);
-      const backend = createMockVectorBackend([highRelevance, lowRelevance]);
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        recencyWeight: 0,
-      });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      expect(result.entries[0].entry.content).toBe("high");
-      expect(result.entries[0].combinedScore).toBeCloseTo(0.9, 2);
-    });
-
-    it("uses pure recency when recencyWeight=1", async () => {
-      const now = Date.now();
-      const oldHighRelevance = makeScoredEntry(
-        "old-high",
-        0.95,
-        now - 86_400_000 * 10,
-      );
-      const recentLowRelevance = makeScoredEntry("new-low", 0.1, now - 1000);
-      const backend = createMockVectorBackend([
-        oldHighRelevance,
-        recentLowRelevance,
-      ]);
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        recencyWeight: 1,
-      });
-
-      const result = await retriever.retrieveDetailed("query", "sess-1");
-
-      expect(result.entries[0].entry.content).toBe("new-low");
-    });
+    expect(backend.getThread).toHaveBeenCalledWith("ws-a:sess-22", expect.any(Number));
+    expect(backend.searchHybrid).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ sessionId: "ws-a:sess-22" }),
+    );
   });
 
-  // ==========================================================================
-  // Search params
-  // ==========================================================================
-
-  describe("search params", () => {
-    it("forwards sessionId to searchHybrid", async () => {
-      const backend = createMockVectorBackend();
-      const retriever = createRetriever({ vectorBackend: backend });
-
-      await retriever.retrieve("query", "my-session");
-
-      expect(backend.searchHybrid).toHaveBeenCalledWith(
-        "query",
-        expect.any(Array),
-        expect.objectContaining({ sessionId: "my-session" }),
-      );
+  it("includes curated memory with bounded budget", async () => {
+    const curated = createMockCurated("x".repeat(10_000));
+    const retriever = createRetriever({
+      curatedMemory: curated,
+      maxTokenBudget: 200,
     });
 
-    it("forwards maxResults as limit", async () => {
-      const backend = createMockVectorBackend();
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        maxResults: 3,
-      });
+    const result = await retriever.retrieveDetailed("query", "sess-1");
 
-      await retriever.retrieve("query", "sess-1");
-
-      expect(backend.searchHybrid).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Array),
-        expect.objectContaining({ limit: 3 }),
-      );
-    });
-
-    it("forwards hybrid weights", async () => {
-      const backend = createMockVectorBackend();
-      const retriever = createRetriever({
-        vectorBackend: backend,
-        hybridVectorWeight: 0.6,
-        hybridKeywordWeight: 0.4,
-      });
-
-      await retriever.retrieve("query", "sess-1");
-
-      expect(backend.searchHybrid).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Array),
-        expect.objectContaining({
-          vectorWeight: 0.6,
-          keywordWeight: 0.4,
-        }),
-      );
-    });
+    expect(result.curatedIncluded).toBe(true);
+    expect(result.content).toContain('source="curated"');
+    expect(result.estimatedTokens).toBeLessThanOrEqual(200);
   });
 
-  // ==========================================================================
-  // Config defaults
-  // ==========================================================================
-
-  describe("config defaults", () => {
-    it("applies sensible defaults with minimal config", async () => {
-      const backend = createMockVectorBackend();
-      const retriever = createRetriever({ vectorBackend: backend });
-
-      await retriever.retrieve("query", "sess-1");
-
-      expect(backend.searchHybrid).toHaveBeenCalledWith(
-        "query",
-        expect.any(Array),
-        expect.objectContaining({
-          limit: 5,
-          vectorWeight: 0.7,
-          keywordWeight: 0.3,
-        }),
-      );
+  it("uses curated cache and supports clearCache", async () => {
+    const curated = createMockCurated("fact-v1");
+    const retriever = createRetriever({
+      curatedMemory: curated,
+      curatedCacheTtlMs: 60_000,
     });
+
+    await retriever.retrieveDetailed("q1", "sess-1");
+    await retriever.retrieveDetailed("q2", "sess-1");
+    expect(curated.load).toHaveBeenCalledTimes(1);
+
+    retriever.clearCache();
+    (curated.load as ReturnType<typeof vi.fn>).mockResolvedValue("fact-v2");
+    const result = await retriever.retrieveDetailed("q3", "sess-1");
+
+    expect(curated.load).toHaveBeenCalledTimes(2);
+    expect(result.content).toContain("fact-v2");
+  });
+
+  it("still returns working/curated memory when embedding is empty", async () => {
+    const embedding = createMockEmbedding();
+    (embedding.embed as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    const backend = createMockVectorBackend();
+    (backend.getThread as ReturnType<typeof vi.fn>).mockResolvedValue([
+      makeEntry("working note", Date.now(), "sess-1", {
+        memoryRole: "working",
+      }),
+    ]);
+
+    const retriever = createRetriever({
+      embeddingProvider: embedding,
+      vectorBackend: backend,
+    });
+
+    const result = await retriever.retrieveDetailed("query", "sess-1");
+    expect(result.content).toContain("working note");
+    expect(backend.searchHybrid).not.toHaveBeenCalled();
   });
 });

--- a/runtime/src/memory/retriever.ts
+++ b/runtime/src/memory/retriever.ts
@@ -1,11 +1,13 @@
 /**
  * Semantic memory retriever — context-aware retrieval for prompt assembly.
  *
- * Embeds user messages, runs hybrid search on a VectorMemoryBackend,
- * re-ranks by recency * relevance, loads curated MEMORY.md, and
- * formats results as `<memory>` blocks within a token budget.
+ * Blends three memory roles before prompt injection:
+ * - working: recent session horizon
+ * - episodic: session/compaction summaries
+ * - semantic: long-lived retrieval index
  *
- * Implements the {@link MemoryRetriever} interface consumed by ChatExecutor.
+ * The retriever applies salience-aware ranking and diversity-aware packing,
+ * then emits auditable `<memory ...>` blocks with provenance/confidence tags.
  *
  * @module
  */
@@ -30,10 +32,22 @@ const DEFAULT_CURATED_CACHE_TTL_MS = 60_000; // 1min
 const DEFAULT_MIN_SCORE = 0.01;
 const DEFAULT_HYBRID_VECTOR_WEIGHT = 0.7;
 const DEFAULT_HYBRID_KEYWORD_WEIGHT = 0.3;
+const DEFAULT_WORKING_WINDOW = 12;
+const DEFAULT_MAX_CANDIDATES_PER_ROLE = 24;
+const DEFAULT_DIVERSITY_THRESHOLD = 0.86;
+const DEFAULT_ROLE_WEIGHTS = {
+  working: 0.34,
+  episodic: 0.22,
+  semantic: 0.44,
+} as const;
+
+const TOKEN_RE = /[a-z0-9]{3,}/g;
 
 // ============================================================================
 // Types
 // ============================================================================
+
+export type RetrievalMemoryRole = "working" | "episodic" | "semantic";
 
 export interface SemanticMemoryRetrieverConfig {
   vectorBackend: VectorMemoryBackend;
@@ -47,6 +61,14 @@ export interface SemanticMemoryRetrieverConfig {
   minScore?: number;
   hybridVectorWeight?: number;
   hybridKeywordWeight?: number;
+  /** How many latest thread messages to inspect for working-memory candidates. */
+  workingMemoryWindow?: number;
+  /** Candidate cap per memory role before cross-role packing. */
+  maxCandidatesPerRole?: number;
+  /** Near-duplicate threshold for diversity-aware packing (token Jaccard). */
+  diversityThreshold?: number;
+  /** Relative role budget split within memory budget. */
+  roleBudgetWeights?: Partial<Record<RetrievalMemoryRole, number>>;
   logger?: Logger;
 }
 
@@ -59,9 +81,21 @@ export interface RetrievalResult {
 
 export interface ScoredRetrievalEntry {
   entry: MemoryEntry;
+  role: RetrievalMemoryRole;
+  source: "thread" | "vector";
+  provenance: string;
+  confidence: number;
   relevanceScore: number;
   recencyScore: number;
+  salienceScore: number;
   combinedScore: number;
+}
+
+interface RetrievalCandidate extends ScoredRetrievalEntry {
+  canonical: string;
+  tokenSet: Set<string>;
+  formattedBlock: string;
+  blockTokens: number;
 }
 
 // ============================================================================
@@ -96,6 +130,151 @@ export function computeRetrievalScore(
   return relevanceScore * (1 - recencyWeight) + recencyScore * recencyWeight;
 }
 
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function attrEscape(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function normalizeWeight(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return value;
+}
+
+function normalizeRoleWeights(
+  overrides: Partial<Record<RetrievalMemoryRole, number>> | undefined,
+): Record<RetrievalMemoryRole, number> {
+  const raw = {
+    working: normalizeWeight(
+      overrides?.working,
+      DEFAULT_ROLE_WEIGHTS.working,
+    ),
+    episodic: normalizeWeight(
+      overrides?.episodic,
+      DEFAULT_ROLE_WEIGHTS.episodic,
+    ),
+    semantic: normalizeWeight(
+      overrides?.semantic,
+      DEFAULT_ROLE_WEIGHTS.semantic,
+    ),
+  };
+
+  const total = raw.working + raw.episodic + raw.semantic;
+  if (total <= 0) {
+    return { ...DEFAULT_ROLE_WEIGHTS };
+  }
+
+  return {
+    working: raw.working / total,
+    episodic: raw.episodic / total,
+    semantic: raw.semantic / total,
+  };
+}
+
+function tokenize(text: string): Set<string> {
+  const matches = text.toLowerCase().match(TOKEN_RE);
+  return new Set(matches ?? []);
+}
+
+function normalizeText(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[^\w\s]/g, "")
+    .trim();
+}
+
+function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection += 1;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+function keywordOverlapScore(queryTokens: Set<string>, text: string): number {
+  if (queryTokens.size === 0) return 0;
+  const textTokens = tokenize(text);
+  let overlap = 0;
+  for (const token of queryTokens) {
+    if (textTokens.has(token)) overlap += 1;
+  }
+  return clamp01(overlap / queryTokens.size);
+}
+
+function inferRole(
+  entry: MemoryEntry,
+  fallback: RetrievalMemoryRole,
+): RetrievalMemoryRole {
+  const metadata = entry.metadata;
+  if (metadata) {
+    const primary = metadata.memoryRole;
+    if (
+      primary === "working" ||
+      primary === "episodic" ||
+      primary === "semantic"
+    ) {
+      return primary;
+    }
+
+    const roles = metadata.memoryRoles;
+    if (Array.isArray(roles)) {
+      if (roles.includes("semantic")) return "semantic";
+      if (roles.includes("episodic")) return "episodic";
+      if (roles.includes("working")) return "working";
+    }
+
+    const type = metadata.type;
+    if (type === "session_summary" || type === "compaction_summary") {
+      return "episodic";
+    }
+  }
+  return fallback;
+}
+
+function inferConfidence(entry: MemoryEntry): number {
+  const confidence = entry.metadata?.confidence;
+  if (typeof confidence !== "number" || !Number.isFinite(confidence)) {
+    return 0.6;
+  }
+  return clamp01(confidence);
+}
+
+function inferSalience(entry: MemoryEntry): number {
+  const salience = entry.metadata?.salienceScore;
+  if (typeof salience === "number" && Number.isFinite(salience)) {
+    return clamp01(salience);
+  }
+  return clamp01(Math.min(1, entry.content.length / 1200));
+}
+
+function inferProvenance(entry: MemoryEntry): string {
+  const provenance = entry.metadata?.provenance;
+  if (typeof provenance === "string" && provenance.trim().length > 0) {
+    return provenance.trim();
+  }
+  return "unknown";
+}
+
+function truncateByTokens(text: string, maxTokens: number): string {
+  if (maxTokens <= 0) return "";
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+  if (text.length <= maxChars) return text;
+  if (maxChars <= 3) return text.slice(0, Math.max(0, maxChars));
+  return `${text.slice(0, maxChars - 3)}...`;
+}
+
 // ============================================================================
 // SemanticMemoryRetriever
 // ============================================================================
@@ -112,6 +291,10 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
   private readonly minScore: number;
   private readonly hybridVectorWeight: number;
   private readonly hybridKeywordWeight: number;
+  private readonly workingMemoryWindow: number;
+  private readonly maxCandidatesPerRole: number;
+  private readonly diversityThreshold: number;
+  private readonly roleBudgetWeights: Record<RetrievalMemoryRole, number>;
   private readonly logger: Logger | undefined;
 
   // Curated memory cache
@@ -134,6 +317,18 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
       config.hybridVectorWeight ?? DEFAULT_HYBRID_VECTOR_WEIGHT;
     this.hybridKeywordWeight =
       config.hybridKeywordWeight ?? DEFAULT_HYBRID_KEYWORD_WEIGHT;
+    this.workingMemoryWindow = Math.max(
+      1,
+      Math.floor(config.workingMemoryWindow ?? DEFAULT_WORKING_WINDOW),
+    );
+    this.maxCandidatesPerRole = Math.max(
+      this.maxResults,
+      Math.floor(config.maxCandidatesPerRole ?? DEFAULT_MAX_CANDIDATES_PER_ROLE),
+    );
+    this.diversityThreshold = clamp01(
+      config.diversityThreshold ?? DEFAULT_DIVERSITY_THRESHOLD,
+    );
+    this.roleBudgetWeights = normalizeRoleWeights(config.roleBudgetWeights);
     this.logger = config.logger;
   }
 
@@ -151,87 +346,118 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
     message: string,
     sessionId: string,
   ): Promise<RetrievalResult> {
-    // 1. Embed user message
-    const embedding = await this.embeddingProvider.embed(message);
-    if (embedding.length === 0) {
-      this.logger?.debug("Empty embedding returned, skipping retrieval");
-      return {
-        content: undefined,
-        entries: [],
-        curatedIncluded: false,
-        estimatedTokens: 0,
-      };
-    }
+    const queryTokens = tokenize(message);
+    const now = Date.now();
 
-    // 2. Hybrid search
-    const searchResults = await this.vectorBackend.searchHybrid(
-      message,
-      embedding,
-      {
-        limit: this.maxResults,
-        sessionId,
-        vectorWeight: this.hybridVectorWeight,
-        keywordWeight: this.hybridKeywordWeight,
-      },
+    const curatedContent = await this.loadCurated();
+    const workingCandidates = await this.retrieveWorkingCandidates(
+      queryTokens,
+      sessionId,
+      now,
     );
 
-    // 3. Re-rank with recency
-    const now = Date.now();
-    const scored: ScoredRetrievalEntry[] = searchResults.map((sr) => {
-      const recencyScore = this.computeRecency(sr.entry.timestamp, now);
-      const combinedScore = computeRetrievalScore(
-        sr.score,
-        sr.entry.timestamp,
-        now,
-        this.recencyWeight,
-        this.recencyHalfLifeMs,
-      );
-      return {
-        entry: sr.entry,
-        relevanceScore: sr.score,
-        recencyScore,
-        combinedScore,
-      };
-    });
+    // Semantic/episodic retrieval uses embeddings when available.
+    let semanticCandidates: RetrievalCandidate[] = [];
+    let episodicCandidates: RetrievalCandidate[] = [];
+    let embedding: number[] = [];
+    try {
+      embedding = await this.embeddingProvider.embed(message);
+    } catch (err) {
+      this.logger?.warn("Memory query embedding failed, using non-embedding roles", err);
+      embedding = [];
+    }
 
-    // 4. Filter by minScore and sort descending
-    const filtered = scored
-      .filter((e) => e.combinedScore >= this.minScore)
-      .sort((a, b) => b.combinedScore - a.combinedScore);
+    if (embedding.length > 0) {
+      [semanticCandidates, episodicCandidates] = await Promise.all([
+        this.retrieveVectorCandidates(
+          message,
+          sessionId,
+          now,
+          "semantic",
+          embedding,
+        ),
+        this.retrieveVectorCandidates(
+          message,
+          sessionId,
+          now,
+          "episodic",
+          embedding,
+        ),
+      ]);
+    } else {
+      this.logger?.debug("Empty memory query embedding, skipping semantic/episodic retrieval");
+    }
 
-    // 5. Load curated memory (with cache)
-    const curatedContent = await this.loadCurated();
+    const candidates = this.deduplicateCandidates([
+      ...workingCandidates,
+      ...episodicCandidates,
+      ...semanticCandidates,
+    ]);
 
-    // 6. Pack into token budget
     let remainingBudget = this.maxTokenBudget;
+    const selected: RetrievalCandidate[] = [];
     const blocks: string[] = [];
     let curatedIncluded = false;
 
-    // Curated memory first
-    if (curatedContent) {
-      const curatedTokens = estimateTokens(curatedContent);
+    // Curated memory is authoritative but bounded to avoid starving live context.
+    if (curatedContent && remainingBudget > 0) {
+      const curatedCap = Math.max(64, Math.floor(this.maxTokenBudget * 0.25));
+      const curatedText = truncateByTokens(
+        curatedContent,
+        Math.min(curatedCap, remainingBudget),
+      );
+      const curatedBlock = `<memory source="curated" role="semantic" provenance="curated:memory.md" confidence="1.00" salience="1.00" score="1.00">\n${curatedText}\n</memory>`;
+      const curatedTokens = estimateTokens(curatedBlock);
       if (curatedTokens <= remainingBudget) {
-        blocks.push(
-          `<memory source="curated" score="1.00">\n${curatedContent}\n</memory>`,
-        );
-        remainingBudget -= estimateTokens(blocks[blocks.length - 1]);
+        blocks.push(curatedBlock);
+        remainingBudget -= curatedTokens;
         curatedIncluded = true;
-      } else {
-        this.logger?.warn(
-          `Curated memory (${curatedTokens} tokens) exceeds remaining budget (${remainingBudget})`,
-        );
       }
     }
 
-    // Vector results — greedy packing with skip
-    for (const entry of filtered) {
-      const block = `<memory source="vector" score="${entry.combinedScore.toFixed(2)}">\n${entry.entry.content}\n</memory>`;
-      const blockTokens = estimateTokens(block);
-      if (blockTokens <= remainingBudget) {
-        blocks.push(block);
-        remainingBudget -= blockTokens;
+    const roleBudgets = {
+      working: Math.floor(remainingBudget * this.roleBudgetWeights.working),
+      episodic: Math.floor(remainingBudget * this.roleBudgetWeights.episodic),
+      semantic: Math.floor(remainingBudget * this.roleBudgetWeights.semantic),
+    };
+
+    const byRole: Record<RetrievalMemoryRole, RetrievalCandidate[]> = {
+      working: [],
+      episodic: [],
+      semantic: [],
+    };
+    for (const candidate of candidates) {
+      byRole[candidate.role].push(candidate);
+    }
+
+    for (const role of ["working", "episodic", "semantic"] as const) {
+      const picked = this.packRoleCandidates(
+        byRole[role],
+        roleBudgets[role],
+        selected,
+      );
+      for (const entry of picked) {
+        selected.push(entry);
+        blocks.push(entry.formattedBlock);
+        remainingBudget -= entry.blockTokens;
       }
-      // Skip (not break) — try smaller entries
+    }
+
+    // Fill leftover budget across all roles by score/diversity.
+    if (remainingBudget > 0) {
+      const selectedIds = new Set(selected.map((entry) => entry.entry.id));
+      const leftovers = candidates
+        .filter((candidate) => !selectedIds.has(candidate.entry.id))
+        .sort((a, b) => b.combinedScore - a.combinedScore);
+
+      for (const candidate of leftovers) {
+        if (candidate.blockTokens > remainingBudget) continue;
+        if (this.isTooSimilar(candidate, selected)) continue;
+        selected.push(candidate);
+        blocks.push(candidate.formattedBlock);
+        remainingBudget -= candidate.blockTokens;
+        if (remainingBudget <= 0) break;
+      }
     }
 
     const content = blocks.length > 0 ? blocks.join("\n") : undefined;
@@ -239,7 +465,7 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
 
     return {
       content,
-      entries: filtered,
+      entries: selected,
       curatedIncluded,
       estimatedTokens: totalTokens,
     };
@@ -252,6 +478,196 @@ export class SemanticMemoryRetriever implements MemoryRetriever {
   }
 
   // ---------- Private helpers ----------
+
+  private async retrieveWorkingCandidates(
+    queryTokens: Set<string>,
+    sessionId: string,
+    now: number,
+  ): Promise<RetrievalCandidate[]> {
+    let thread: MemoryEntry[] = [];
+    try {
+      thread = await this.vectorBackend.getThread(
+        sessionId,
+        this.workingMemoryWindow * 3,
+      );
+    } catch (err) {
+      this.logger?.warn("Working-memory retrieval failed", err);
+      return [];
+    }
+
+    const scored: RetrievalCandidate[] = [];
+    for (const entry of [...thread].reverse()) {
+      const role = inferRole(entry, "working");
+      if (role !== "working") continue;
+
+      const relevance = keywordOverlapScore(queryTokens, entry.content);
+      const recency = this.computeRecency(entry.timestamp, now);
+      const confidence = inferConfidence(entry);
+      const salience = inferSalience(entry);
+      const combined =
+        computeRetrievalScore(
+          relevance,
+          entry.timestamp,
+          now,
+          this.recencyWeight,
+          this.recencyHalfLifeMs,
+        ) *
+          0.45 +
+        confidence * 0.25 +
+        salience * 0.3;
+
+      if (combined < this.minScore) continue;
+      const candidate = this.toCandidate({
+        entry,
+        role,
+        source: "thread",
+        provenance: inferProvenance(entry),
+        confidence,
+        relevanceScore: relevance,
+        recencyScore: recency,
+        salienceScore: salience,
+        combinedScore: clamp01(combined),
+      });
+      scored.push(candidate);
+      if (scored.length >= this.maxCandidatesPerRole) break;
+    }
+
+    return scored.sort((a, b) => b.combinedScore - a.combinedScore);
+  }
+
+  private async retrieveVectorCandidates(
+    message: string,
+    sessionId: string,
+    now: number,
+    role: RetrievalMemoryRole,
+    embedding: number[],
+  ): Promise<RetrievalCandidate[]> {
+    const searchResults = await this.vectorBackend.searchHybrid(
+      message,
+      embedding,
+      {
+        limit: this.maxCandidatesPerRole,
+        sessionId,
+        vectorWeight: this.hybridVectorWeight,
+        keywordWeight: this.hybridKeywordWeight,
+        memoryRoles: [role],
+      },
+    );
+
+    const scored: RetrievalCandidate[] = [];
+    for (const result of searchResults) {
+      const entryRole = inferRole(result.entry, role);
+      if (entryRole !== role) continue;
+
+      const recency = this.computeRecency(result.entry.timestamp, now);
+      const confidence = inferConfidence(result.entry);
+      const salience = inferSalience(result.entry);
+      const blended =
+        computeRetrievalScore(
+          result.score,
+          result.entry.timestamp,
+          now,
+          this.recencyWeight,
+          this.recencyHalfLifeMs,
+        ) *
+          0.5 +
+        confidence * 0.2 +
+        salience * 0.3;
+
+      if (blended < this.minScore) continue;
+
+      scored.push(
+        this.toCandidate({
+          entry: result.entry,
+          role,
+          source: "vector",
+          provenance: inferProvenance(result.entry),
+          confidence,
+          relevanceScore: result.score,
+          recencyScore: recency,
+          salienceScore: salience,
+          combinedScore: clamp01(blended),
+        }),
+      );
+    }
+
+    return scored.sort((a, b) => b.combinedScore - a.combinedScore);
+  }
+
+  private toCandidate(base: ScoredRetrievalEntry): RetrievalCandidate {
+    const canonical = normalizeText(base.entry.content);
+    const tokenSet = tokenize(base.entry.content);
+    const block = this.formatMemoryBlock(base);
+    const blockTokens = estimateTokens(block);
+    return {
+      ...base,
+      canonical,
+      tokenSet,
+      formattedBlock: block,
+      blockTokens,
+    };
+  }
+
+  private formatMemoryBlock(entry: ScoredRetrievalEntry): string {
+    return `<memory source="${attrEscape(entry.source)}" role="${entry.role}" provenance="${attrEscape(entry.provenance)}" confidence="${entry.confidence.toFixed(2)}" salience="${entry.salienceScore.toFixed(2)}" score="${entry.combinedScore.toFixed(2)}">\n${entry.entry.content}\n</memory>`;
+  }
+
+  private packRoleCandidates(
+    candidates: readonly RetrievalCandidate[],
+    roleBudget: number,
+    alreadySelected: readonly RetrievalCandidate[],
+  ): RetrievalCandidate[] {
+    if (roleBudget <= 0) return [];
+
+    let remaining = roleBudget;
+    const selected: RetrievalCandidate[] = [];
+    for (const candidate of candidates) {
+      if (candidate.blockTokens > remaining) continue;
+      if (this.isTooSimilar(candidate, [...alreadySelected, ...selected])) {
+        continue;
+      }
+      selected.push(candidate);
+      remaining -= candidate.blockTokens;
+      if (remaining <= 0) break;
+    }
+    return selected;
+  }
+
+  private deduplicateCandidates(
+    candidates: readonly RetrievalCandidate[],
+  ): RetrievalCandidate[] {
+    const bestByCanonical = new Map<string, RetrievalCandidate>();
+    for (const candidate of candidates) {
+      const existing = bestByCanonical.get(candidate.canonical);
+      if (!existing || existing.combinedScore < candidate.combinedScore) {
+        bestByCanonical.set(candidate.canonical, candidate);
+      }
+    }
+
+    const deduped = Array.from(bestByCanonical.values()).sort(
+      (a, b) => b.combinedScore - a.combinedScore,
+    );
+
+    const selected: RetrievalCandidate[] = [];
+    for (const candidate of deduped) {
+      if (this.isTooSimilar(candidate, selected)) continue;
+      selected.push(candidate);
+    }
+    return selected;
+  }
+
+  private isTooSimilar(
+    candidate: RetrievalCandidate,
+    selected: readonly RetrievalCandidate[],
+  ): boolean {
+    for (const existing of selected) {
+      const similarity = jaccard(candidate.tokenSet, existing.tokenSet);
+      if (similarity >= this.diversityThreshold) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   private computeRecency(entryTimestamp: number, now: number): number {
     const age = Math.max(0, now - entryTimestamp);

--- a/runtime/src/memory/vector-store.test.ts
+++ b/runtime/src/memory/vector-store.test.ts
@@ -223,6 +223,36 @@ describe("InMemoryVectorStore", () => {
       expect(results.length).toBe(1);
       expect(results[0].entry.content).toBe("telegram msg");
     });
+
+    it("filters by memoryRoles metadata", async () => {
+      await store.storeWithEmbedding(
+        makeEntry("working note", "sess-1", { memoryRole: "working" }),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry("episodic summary", "sess-1", { memoryRoles: ["episodic"] }),
+        basisVector(4, 0),
+      );
+      await store.storeWithEmbedding(
+        makeEntry("semantic fact", "sess-1", {
+          memoryRole: "semantic",
+          memoryRoles: ["semantic", "working"],
+        }),
+        basisVector(4, 0),
+      );
+
+      const episodic = await store.searchSimilar(basisVector(4, 0), {
+        memoryRoles: ["episodic"],
+      });
+      expect(episodic).toHaveLength(1);
+      expect(episodic[0].entry.content).toBe("episodic summary");
+
+      const semantic = await store.searchSimilar(basisVector(4, 0), {
+        memoryRoles: ["semantic"],
+      });
+      expect(semantic).toHaveLength(1);
+      expect(semantic[0].entry.content).toBe("semantic fact");
+    });
   });
 
   // ==========================================================================


### PR DESCRIPTION
## Summary

- Overhaul ChatExecutor with structured prompt budget management and context windowing
- Add prompt-budget engine (`runtime/src/llm/prompt-budget.ts`) for token-aware message trimming and injection prioritization
- Add gateway tool routing module (`runtime/src/gateway/tool-routing.ts`) for deterministic tool dispatch across session types (desktop, playwright, container MCP, local)
- Enhance Grok adapter with expanded Responses API support and streaming hardening
- Harden memory ingestion with batch embedding, deduplication, and truncation safety
- Harden semantic retriever with score normalization, cache invalidation, and fallback paths
- Add vector store metadata filtering and batch upsert support
- Enhance gateway session lifecycle with isolation guards and config watcher integration
- Add runtime pipeline debug bundle documentation (`docs/RUNTIME_PIPELINE_DEBUG_BUNDLE.md`)
- Ollama adapter tool-turn validation and fallback provider improvements

## Test plan

- [ ] `cd runtime && npm run test` — runtime vitest suite passes
- [ ] Verify prompt budget respects token limits across multi-turn conversations
- [ ] Verify tool routing dispatches correctly for desktop/playwright/MCP/local tools
- [ ] Verify memory ingestion handles batch embedding and dedup correctly
- [ ] Verify semantic retriever fallback when embedding provider unavailable