### PR TITLE
feat(runtime,web): model-aware context window resolution and usage panel

### DIFF
--- a/runtime/src/gateway/chat-usage.test.ts
+++ b/runtime/src/gateway/chat-usage.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { PromptBudgetDiagnostics, PromptBudgetSection } from "../llm/prompt-budget.js";
+import type { ChatCallUsageRecord } from "../llm/chat-executor.js";
+import { buildChatUsagePayload } from "./chat-usage.js";
+
+const ALL_SECTIONS: readonly PromptBudgetSection[] = [
+  "system_anchor",
+  "system_runtime",
+  "memory_working",
+  "memory_episodic",
+  "memory_semantic",
+  "history",
+  "tools",
+  "user",
+  "assistant_runtime",
+  "other",
+];
+
+function makeSectionStats(afterChars: number) {
+  return {
+    capChars: 4_000,
+    beforeMessages: 2,
+    afterMessages: 2,
+    beforeChars: afterChars,
+    afterChars,
+    droppedMessages: 0,
+    truncatedMessages: 0,
+  };
+}
+
+function makeDiagnostics(): PromptBudgetDiagnostics {
+  const sections: Record<PromptBudgetSection, ReturnType<typeof makeSectionStats>> = {
+    system_anchor: makeSectionStats(2_000),
+    system_runtime: makeSectionStats(500),
+    memory_working: makeSectionStats(1_500),
+    memory_episodic: makeSectionStats(1_000),
+    memory_semantic: makeSectionStats(500),
+    history: makeSectionStats(2_000),
+    tools: makeSectionStats(1_500),
+    user: makeSectionStats(700),
+    assistant_runtime: makeSectionStats(200),
+    other: makeSectionStats(100),
+  };
+  const totalAfterChars = ALL_SECTIONS.reduce(
+    (sum, section) => sum + sections[section].afterChars,
+    0,
+  );
+  return {
+    model: {
+      contextWindowTokens: 128_000,
+      maxOutputTokens: 8_192,
+      safetyMarginTokens: 2_048,
+      promptTokenBudget: 117_760,
+      charPerToken: 4,
+    },
+    caps: {
+      totalChars: totalAfterChars,
+      systemChars: 2_500,
+      systemAnchorChars: 2_000,
+      systemRuntimeChars: 500,
+      memoryChars: 3_000,
+      memoryRoleChars: {
+        working: 1_500,
+        episodic: 1_000,
+        semantic: 500,
+      },
+      historyChars: 2_000,
+      toolChars: 1_500,
+      userChars: 700,
+      assistantRuntimeChars: 200,
+      otherChars: 100,
+    },
+    totalBeforeChars: totalAfterChars,
+    totalAfterChars,
+    constrained: false,
+    droppedSections: [],
+    sections,
+  };
+}
+
+function makeCallUsage(
+  estimatedChars: number,
+  diagnostics?: PromptBudgetDiagnostics,
+): ChatCallUsageRecord {
+  return {
+    callIndex: 1,
+    phase: "initial",
+    provider: "grok",
+    model: "grok-4-1-fast-reasoning",
+    finishReason: "stop",
+    usage: {
+      promptTokens: 100,
+      completionTokens: 50,
+      totalTokens: 150,
+    },
+    beforeBudget: {
+      messageCount: 8,
+      systemMessages: 2,
+      userMessages: 2,
+      assistantMessages: 3,
+      toolMessages: 1,
+      estimatedChars: estimatedChars + 100,
+      systemPromptChars: 2_500,
+    },
+    afterBudget: {
+      messageCount: 8,
+      systemMessages: 2,
+      userMessages: 2,
+      assistantMessages: 3,
+      toolMessages: 1,
+      estimatedChars,
+      systemPromptChars: 2_500,
+    },
+    budgetDiagnostics: diagnostics,
+  };
+}
+
+describe("buildChatUsagePayload", () => {
+  it("includes model window and section breakdown when diagnostics exist", () => {
+    const payload = buildChatUsagePayload({
+      totalTokens: 12_345,
+      sessionTokenBudget: 90_000,
+      compacted: true,
+      callUsage: [makeCallUsage(9_600, makeDiagnostics())],
+    });
+
+    expect(payload).toMatchObject({
+      totalTokens: 12_345,
+      budget: 90_000,
+      compacted: true,
+      contextWindowTokens: 128_000,
+      promptTokens: 2_400,
+      promptTokenBudget: 117_760,
+      maxOutputTokens: 8_192,
+      safetyMarginTokens: 2_048,
+    });
+
+    const memory = payload.sections?.find((section) => section.id === "memory");
+    expect(memory).toMatchObject({
+      label: "Memory",
+      tokens: 750,
+      percent: 30,
+    });
+  });
+
+  it("falls back to provided context window without diagnostics", () => {
+    const payload = buildChatUsagePayload({
+      totalTokens: 500,
+      sessionTokenBudget: 0,
+      compacted: false,
+      contextWindowTokens: 64_000,
+      callUsage: [makeCallUsage(800)],
+    });
+
+    expect(payload).toMatchObject({
+      totalTokens: 500,
+      budget: 0,
+      compacted: false,
+      contextWindowTokens: 64_000,
+      promptTokens: 200,
+    });
+    expect(payload.sections).toBeUndefined();
+  });
+
+  it("reuses earlier diagnostics when later calls omit them", () => {
+    const payload = buildChatUsagePayload({
+      totalTokens: 4_000,
+      sessionTokenBudget: 50_000,
+      compacted: false,
+      contextWindowTokens: 16_000,
+      callUsage: [
+        makeCallUsage(6_400, makeDiagnostics()),
+        makeCallUsage(1_200),
+      ],
+    });
+
+    expect(payload.contextWindowTokens).toBe(128_000);
+    expect(payload.promptTokenBudget).toBe(117_760);
+    expect(payload.sections?.length).toBeGreaterThan(0);
+  });
+});

--- a/runtime/src/gateway/chat-usage.ts
+++ b/runtime/src/gateway/chat-usage.ts
@@ -1,0 +1,147 @@
+import type { ChatCallUsageRecord } from "../llm/chat-executor.js";
+
+export type ChatUsageSectionId =
+  | "system"
+  | "memory"
+  | "history"
+  | "tools"
+  | "user"
+  | "assistant_runtime"
+  | "other";
+
+export interface ChatUsageSection {
+  readonly id: ChatUsageSectionId;
+  readonly label: string;
+  readonly tokens: number;
+  readonly percent: number;
+}
+
+export interface ChatUsagePayload {
+  readonly totalTokens: number;
+  readonly budget: number;
+  readonly compacted: boolean;
+  readonly contextWindowTokens?: number;
+  readonly promptTokens?: number;
+  readonly promptTokenBudget?: number;
+  readonly maxOutputTokens?: number;
+  readonly safetyMarginTokens?: number;
+  readonly sections?: readonly ChatUsageSection[];
+}
+
+interface BuildChatUsagePayloadInput {
+  readonly totalTokens: number;
+  readonly sessionTokenBudget: number;
+  readonly compacted: boolean;
+  readonly contextWindowTokens?: number;
+  readonly callUsage?: readonly ChatCallUsageRecord[];
+}
+
+const DEFAULT_CHAR_PER_TOKEN = 4;
+
+const SECTION_GROUPS: ReadonlyArray<{
+  readonly id: ChatUsageSectionId;
+  readonly label: string;
+  readonly keys: readonly string[];
+}> = [
+  { id: "system", label: "System prompt", keys: ["system_anchor", "system_runtime"] },
+  { id: "memory", label: "Memory", keys: ["memory_working", "memory_episodic", "memory_semantic"] },
+  { id: "history", label: "Chat history", keys: ["history"] },
+  { id: "tools", label: "Tool schema/results", keys: ["tools"] },
+  { id: "user", label: "Current user turn", keys: ["user"] },
+  { id: "assistant_runtime", label: "Runtime assistant hints", keys: ["assistant_runtime"] },
+  { id: "other", label: "Other", keys: ["other"] },
+];
+
+function normalizeNonNegativeInt(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.floor(value));
+}
+
+function charsToTokens(chars: number, charPerToken: number): number {
+  if (!Number.isFinite(chars) || chars <= 0) return 0;
+  const normalized = Number.isFinite(charPerToken) && charPerToken > 0
+    ? charPerToken
+    : DEFAULT_CHAR_PER_TOKEN;
+  return Math.max(0, Math.round(chars / normalized));
+}
+
+function roundPercent(percent: number): number {
+  if (!Number.isFinite(percent) || percent <= 0) return 0;
+  return Math.round(percent * 10) / 10;
+}
+
+function selectUsageRecord(
+  callUsage: readonly ChatCallUsageRecord[] | undefined,
+): ChatCallUsageRecord | undefined {
+  if (!callUsage || callUsage.length === 0) return undefined;
+  for (let idx = callUsage.length - 1; idx >= 0; idx -= 1) {
+    if (callUsage[idx]?.budgetDiagnostics) return callUsage[idx];
+  }
+  return callUsage[callUsage.length - 1];
+}
+
+export function buildChatUsagePayload(
+  input: BuildChatUsagePayloadInput,
+): ChatUsagePayload {
+  const payload: ChatUsagePayload = {
+    totalTokens: normalizeNonNegativeInt(input.totalTokens),
+    budget: normalizeNonNegativeInt(input.sessionTokenBudget),
+    compacted: input.compacted === true,
+  };
+
+  const usageRecord = selectUsageRecord(input.callUsage);
+  if (!usageRecord) {
+    if ((input.contextWindowTokens ?? 0) > 0) {
+      return {
+        ...payload,
+        contextWindowTokens: normalizeNonNegativeInt(input.contextWindowTokens ?? 0),
+      };
+    }
+    return payload;
+  }
+
+  const diagnostics = usageRecord.budgetDiagnostics;
+  const charPerToken = diagnostics?.model.charPerToken ?? DEFAULT_CHAR_PER_TOKEN;
+  const promptTokens = charsToTokens(usageRecord.afterBudget.estimatedChars, charPerToken);
+  const contextWindowTokens = diagnostics?.model.contextWindowTokens ?? input.contextWindowTokens;
+
+  const withPromptShape: ChatUsagePayload = {
+    ...payload,
+    promptTokens,
+    ...(contextWindowTokens && contextWindowTokens > 0
+      ? { contextWindowTokens: normalizeNonNegativeInt(contextWindowTokens) }
+      : {}),
+    ...(diagnostics
+      ? {
+        promptTokenBudget: normalizeNonNegativeInt(diagnostics.model.promptTokenBudget),
+        maxOutputTokens: normalizeNonNegativeInt(diagnostics.model.maxOutputTokens),
+        safetyMarginTokens: normalizeNonNegativeInt(diagnostics.model.safetyMarginTokens),
+      }
+      : {}),
+  };
+
+  if (!diagnostics) return withPromptShape;
+
+  const totalAfterChars = diagnostics.totalAfterChars;
+  if (!Number.isFinite(totalAfterChars) || totalAfterChars <= 0) {
+    return withPromptShape;
+  }
+
+  const sections = SECTION_GROUPS.map((group) => {
+    const chars = group.keys.reduce((sum, key) => {
+      const stats = diagnostics.sections[key as keyof typeof diagnostics.sections];
+      if (!stats) return sum;
+      return sum + stats.afterChars;
+    }, 0);
+    if (chars <= 0) return null;
+    return {
+      id: group.id,
+      label: group.label,
+      tokens: charsToTokens(chars, charPerToken),
+      percent: roundPercent((chars / totalAfterChars) * 100),
+    } satisfies ChatUsageSection;
+  }).filter((section): section is ChatUsageSection => section !== null);
+
+  if (sections.length === 0) return withPromptShape;
+  return { ...withPromptShape, sections };
+}

--- a/runtime/src/gateway/context-window.test.ts
+++ b/runtime/src/gateway/context-window.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearDynamicContextWindowCache,
+  inferContextWindowTokens,
+  inferGrokContextWindowTokens,
+  normalizeGrokModel,
+  resolveDynamicContextWindowTokens,
+} from "./context-window.js";
+
+beforeEach(() => {
+  clearDynamicContextWindowCache();
+});
+
+describe("normalizeGrokModel", () => {
+  it("maps legacy grok-4 aliases to current fast variants", () => {
+    expect(normalizeGrokModel("grok-4")).toBe("grok-4-1-fast-reasoning");
+    expect(normalizeGrokModel("grok-4-fast-reasoning")).toBe("grok-4-1-fast-reasoning");
+    expect(normalizeGrokModel("grok-4-fast-non-reasoning")).toBe("grok-4-1-fast-non-reasoning");
+  });
+});
+
+describe("inferGrokContextWindowTokens", () => {
+  it("resolves 2M windows for grok-4 fast models", () => {
+    expect(inferGrokContextWindowTokens("grok-4-1-fast")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4-1-fast-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4-1-fast-non-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4-fast")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4-fast-reasoning")).toBe(2_000_000);
+    expect(inferGrokContextWindowTokens("grok-4-fast-non-reasoning")).toBe(2_000_000);
+  });
+
+  it("resolves model-specific windows for non-fast variants", () => {
+    expect(inferGrokContextWindowTokens("grok-4-0709")).toBe(256_000);
+    expect(inferGrokContextWindowTokens("grok-code-fast-1")).toBe(256_000);
+    expect(inferGrokContextWindowTokens("grok-3")).toBe(131_072);
+    expect(inferGrokContextWindowTokens("grok-3-mini")).toBe(131_072);
+    expect(inferGrokContextWindowTokens("grok-2-vision-1212")).toBe(32_768);
+  });
+});
+
+describe("inferContextWindowTokens", () => {
+  it("uses explicit llm.contextWindowTokens when set", () => {
+    expect(inferContextWindowTokens({
+      provider: "grok",
+      contextWindowTokens: 123_456,
+    })).toBe(123_456);
+  });
+
+  it("infers per-model windows for grok and provider default for ollama", () => {
+    expect(inferContextWindowTokens({
+      provider: "grok",
+      model: "grok-3-mini",
+    })).toBe(131_072);
+    expect(inferContextWindowTokens({
+      provider: "grok",
+      model: "grok-4-1-fast-reasoning",
+    })).toBe(2_000_000);
+    expect(inferContextWindowTokens({
+      provider: "ollama",
+    })).toBe(32_768);
+  });
+});
+
+describe("resolveDynamicContextWindowTokens", () => {
+  it("uses /models metadata when available", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          { id: "grok-4-1-fast-reasoning", context_window: 2_000_000 },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const result = await resolveDynamicContextWindowTokens({
+      provider: "grok",
+      apiKey: "xai-key",
+      model: "grok-4-1-fast-reasoning",
+    }, {
+      fetchImpl: fetchMock,
+      cacheTtlMs: 60_000,
+    });
+
+    expect(result).toBe(2_000_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to /language-models and supports nested/string values", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({}),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: [
+            {
+              id: "grok-3-mini",
+              capabilities: {
+                context_window_tokens: "131,072",
+              },
+            },
+          ],
+        }),
+      }) as unknown as typeof fetch;
+
+    const result = await resolveDynamicContextWindowTokens({
+      provider: "grok",
+      apiKey: "xai-key",
+      model: "grok-3-mini",
+    }, {
+      fetchImpl: fetchMock,
+      cacheTtlMs: 60_000,
+    });
+
+    expect(result).toBe(131_072);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("/models"),
+      expect.any(Object),
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("/language-models"),
+      expect.any(Object),
+    );
+  });
+
+  it("caches metadata between lookups", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: [
+          { id: "grok-4-0709", context_length: 256_000 },
+        ],
+      }),
+    })) as unknown as typeof fetch;
+
+    const first = await resolveDynamicContextWindowTokens({
+      provider: "grok",
+      apiKey: "xai-key",
+      model: "grok-4-0709",
+    }, {
+      fetchImpl: fetchMock,
+      cacheTtlMs: 60_000,
+    });
+    const second = await resolveDynamicContextWindowTokens({
+      provider: "grok",
+      apiKey: "xai-key",
+      model: "grok-4-0709",
+    }, {
+      fetchImpl: fetchMock,
+      cacheTtlMs: 60_000,
+    });
+
+    expect(first).toBe(256_000);
+    expect(second).toBe(256_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/runtime/src/gateway/context-window.ts
+++ b/runtime/src/gateway/context-window.ts
@@ -1,0 +1,352 @@
+import { createHash } from "node:crypto";
+import type { GatewayLLMConfig } from "./types.js";
+
+const DEFAULT_GROK_API_BASE_URL = "https://api.x.ai/v1";
+const DEFAULT_GROK_CONTEXT_WINDOW_TOKENS = 256_000;
+const DEFAULT_OLLAMA_CONTEXT_WINDOW_TOKENS = 32_768;
+const MIN_CONTEXT_WINDOW_TOKENS = 2_048;
+const MAX_CONTEXT_WINDOW_TOKENS = 10_000_000;
+const DYNAMIC_MODELS_FETCH_TIMEOUT_MS = 8_000;
+const DYNAMIC_MODELS_CACHE_TTL_MS = 15 * 60_000;
+
+const LEGACY_GROK_MODEL_ALIASES: Record<string, string> = {
+  "grok-4": "grok-4-1-fast-reasoning",
+  "grok-4-fast-reasoning": "grok-4-1-fast-reasoning",
+  "grok-4-fast-non-reasoning": "grok-4-1-fast-non-reasoning",
+};
+
+const GROK_CONTEXT_WINDOW_BY_PREFIX: ReadonlyArray<{
+  readonly prefix: string;
+  readonly contextWindowTokens: number;
+}> = [
+  // Source: xAI Docs MCP page developers/models (retrieved March 2, 2026)
+  { prefix: "grok-4-1-fast", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4-fast", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4-1-fast-reasoning", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4-1-fast-non-reasoning", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4-fast-reasoning", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-4-fast-non-reasoning", contextWindowTokens: 2_000_000 },
+  { prefix: "grok-code-fast-1", contextWindowTokens: 256_000 },
+  { prefix: "grok-4-0709", contextWindowTokens: 256_000 },
+  { prefix: "grok-3-mini", contextWindowTokens: 131_072 },
+  { prefix: "grok-3", contextWindowTokens: 131_072 },
+  { prefix: "grok-2-vision-1212", contextWindowTokens: 32_768 },
+];
+
+interface LoggerLike {
+  debug?: (message: string, ...args: unknown[]) => void;
+  warn?: (message: string, ...args: unknown[]) => void;
+}
+
+interface DynamicContextWindowOptions {
+  readonly fetchImpl?: typeof fetch;
+  readonly cacheTtlMs?: number;
+  readonly logger?: LoggerLike;
+}
+
+interface CachedModelCatalog {
+  readonly expiresAtMs: number;
+  readonly byModelId: Map<string, number>;
+}
+
+const dynamicCatalogCache = new Map<string, CachedModelCatalog>();
+
+function normalizeBaseUrl(baseUrl: string | undefined): string {
+  const raw = baseUrl?.trim() || DEFAULT_GROK_API_BASE_URL;
+  return raw.replace(/\/+$/, "");
+}
+
+function buildDynamicCacheKey(baseUrl: string, apiKey: string): string {
+  const digest = createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+  return `${baseUrl}#${digest}`;
+}
+
+function parseContextTokenValue(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    const normalized = Math.floor(value);
+    if (
+      normalized >= MIN_CONTEXT_WINDOW_TOKENS &&
+      normalized <= MAX_CONTEXT_WINDOW_TOKENS
+    ) {
+      return normalized;
+    }
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const compact = value.trim();
+    if (!/^\d[\d,_\s]*$/.test(compact)) return undefined;
+    const parsed = Number(compact.replace(/[,_\s]/g, ""));
+    if (!Number.isFinite(parsed)) return undefined;
+    const normalized = Math.floor(parsed);
+    if (
+      normalized >= MIN_CONTEXT_WINDOW_TOKENS &&
+      normalized <= MAX_CONTEXT_WINDOW_TOKENS
+    ) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+function isContextCandidatePath(path: string): boolean {
+  const normalized = path.toLowerCase();
+  if (/(^|[._])(rpm|tpm|rate|pricing|price|cost|throughput)($|[._])/.test(normalized)) {
+    return false;
+  }
+  if (
+    normalized.includes("context") ||
+    normalized.includes("window") ||
+    normalized.includes("length")
+  ) {
+    return true;
+  }
+  if (
+    normalized.includes("input") &&
+    normalized.includes("token") &&
+    (normalized.includes("max") || normalized.includes("limit"))
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function collectContextCandidates(
+  node: unknown,
+  path: string[],
+  out: number[],
+): void {
+  if (node === null || node === undefined) return;
+  if (typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    node.forEach((entry, idx) => {
+      collectContextCandidates(entry, [...path, String(idx)], out);
+    });
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    const nextPath = [...path, key];
+    const pathLabel = nextPath.join(".");
+    const parsed = parseContextTokenValue(value);
+    if (parsed !== undefined && isContextCandidatePath(pathLabel)) {
+      out.push(parsed);
+    }
+    collectContextCandidates(value, nextPath, out);
+  }
+}
+
+function toModelEntryArray(payload: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(payload)) {
+    return payload.filter(
+      (entry): entry is Record<string, unknown> =>
+        typeof entry === "object" && entry !== null && !Array.isArray(entry),
+    );
+  }
+  if (typeof payload !== "object" || payload === null) return [];
+  const record = payload as Record<string, unknown>;
+  const candidates = [record.data, record.models, record.items, record.results];
+  for (const candidate of candidates) {
+    if (!Array.isArray(candidate)) continue;
+    return candidate.filter(
+      (entry): entry is Record<string, unknown> =>
+        typeof entry === "object" && entry !== null && !Array.isArray(entry),
+    );
+  }
+  return [];
+}
+
+function extractModelId(entry: Record<string, unknown>): string | undefined {
+  const raw =
+    (typeof entry.id === "string" && entry.id) ||
+    (typeof entry.model_id === "string" && entry.model_id) ||
+    (typeof entry.model === "string" && entry.model) ||
+    (typeof entry.name === "string" && entry.name) ||
+    (typeof entry.slug === "string" && entry.slug) ||
+    undefined;
+  const normalized = raw?.trim();
+  return normalized ? normalized.toLowerCase() : undefined;
+}
+
+function extractContextWindowFromModel(entry: Record<string, unknown>): number | undefined {
+  const directFields = [
+    entry.context_window,
+    entry.contextWindow,
+    entry.context_length,
+    entry.contextLength,
+    entry.max_context_tokens,
+    entry.maxContextTokens,
+    entry.input_token_limit,
+    entry.inputTokenLimit,
+    entry.max_input_tokens,
+    entry.maxInputTokens,
+  ];
+  for (const value of directFields) {
+    const parsed = parseContextTokenValue(value);
+    if (parsed !== undefined) return parsed;
+  }
+
+  const candidates: number[] = [];
+  collectContextCandidates(entry, [], candidates);
+  if (candidates.length === 0) return undefined;
+  return Math.max(...candidates);
+}
+
+function buildCatalogFromPayload(payload: unknown): Map<string, number> {
+  const catalog = new Map<string, number>();
+  for (const entry of toModelEntryArray(payload)) {
+    const modelId = extractModelId(entry);
+    if (!modelId) continue;
+    const contextWindow = extractContextWindowFromModel(entry);
+    if (contextWindow === undefined) continue;
+    catalog.set(modelId, contextWindow);
+  }
+  return catalog;
+}
+
+function lookupCatalogContextWindow(
+  catalog: Map<string, number>,
+  model: string | undefined,
+): number | undefined {
+  const normalized = normalizeGrokModel(model)?.toLowerCase();
+  if (!normalized) return undefined;
+
+  const candidates = new Set<string>([normalized]);
+  if (normalized.endsWith("-latest")) {
+    candidates.add(normalized.slice(0, -"-latest".length));
+  }
+
+  for (const candidate of candidates) {
+    const exact = catalog.get(candidate);
+    if (exact !== undefined) return exact;
+  }
+
+  let bestMatch: { id: string; tokens: number } | undefined;
+  for (const [id, tokens] of catalog) {
+    for (const candidate of candidates) {
+      if (!id.startsWith(candidate) && !candidate.startsWith(id)) continue;
+      if (!bestMatch || id.length > bestMatch.id.length) {
+        bestMatch = { id, tokens };
+      }
+    }
+  }
+  return bestMatch?.tokens;
+}
+
+async function fetchModelCatalog(
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: typeof fetch,
+  logger: LoggerLike | undefined,
+): Promise<Map<string, number>> {
+  const endpoints = ["/models", "/language-models"];
+  let lastError: unknown;
+
+  for (const endpoint of endpoints) {
+    const url = `${baseUrl}${endpoint}`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DYNAMIC_MODELS_FETCH_TIMEOUT_MS);
+    try {
+      const response = await fetchImpl(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          Accept: "application/json",
+        },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        lastError = new Error(`HTTP ${response.status} from ${url}`);
+        continue;
+      }
+      const payload = await response.json();
+      const catalog = buildCatalogFromPayload(payload);
+      if (catalog.size > 0) return catalog;
+      lastError = new Error(`No context window fields found in ${url} response`);
+    } catch (error) {
+      lastError = error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  logger?.debug?.("Dynamic Grok model metadata fetch failed", {
+    baseUrl,
+    error:
+      lastError instanceof Error
+        ? lastError.message
+        : String(lastError ?? "unknown error"),
+  });
+  return new Map();
+}
+
+export function clearDynamicContextWindowCache(): void {
+  dynamicCatalogCache.clear();
+}
+
+export function normalizeGrokModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const trimmed = model.trim();
+  return LEGACY_GROK_MODEL_ALIASES[trimmed] ?? trimmed;
+}
+
+export function inferGrokContextWindowTokens(model: string | undefined): number {
+  const normalized = normalizeGrokModel(model);
+  if (!normalized) return DEFAULT_GROK_CONTEXT_WINDOW_TOKENS;
+
+  for (const entry of GROK_CONTEXT_WINDOW_BY_PREFIX) {
+    if (normalized.startsWith(entry.prefix)) return entry.contextWindowTokens;
+  }
+  return DEFAULT_GROK_CONTEXT_WINDOW_TOKENS;
+}
+
+export function inferContextWindowTokens(
+  llmConfig: GatewayLLMConfig | undefined,
+): number | undefined {
+  if (!llmConfig) return undefined;
+  if (
+    typeof llmConfig.contextWindowTokens === "number" &&
+    Number.isFinite(llmConfig.contextWindowTokens)
+  ) {
+    return Math.max(MIN_CONTEXT_WINDOW_TOKENS, Math.floor(llmConfig.contextWindowTokens));
+  }
+  if (llmConfig.provider === "grok") {
+    return inferGrokContextWindowTokens(llmConfig.model);
+  }
+  if (llmConfig.provider === "ollama") return DEFAULT_OLLAMA_CONTEXT_WINDOW_TOKENS;
+  return undefined;
+}
+
+export async function resolveDynamicContextWindowTokens(
+  llmConfig: GatewayLLMConfig | undefined,
+  options?: DynamicContextWindowOptions,
+): Promise<number | undefined> {
+  if (!llmConfig || llmConfig.provider !== "grok") return undefined;
+  if (!llmConfig.apiKey) return undefined;
+
+  const fetchImpl = options?.fetchImpl ?? fetch;
+  const logger = options?.logger;
+  const cacheTtlMs = options?.cacheTtlMs ?? DYNAMIC_MODELS_CACHE_TTL_MS;
+  const baseUrl = normalizeBaseUrl(llmConfig.baseUrl);
+  const cacheKey = buildDynamicCacheKey(baseUrl, llmConfig.apiKey);
+  const now = Date.now();
+  const cached = dynamicCatalogCache.get(cacheKey);
+
+  if (cached && cached.expiresAtMs > now) {
+    return lookupCatalogContextWindow(cached.byModelId, llmConfig.model);
+  }
+
+  const catalog = await fetchModelCatalog(baseUrl, llmConfig.apiKey, fetchImpl, logger);
+  if (catalog.size > 0) {
+    dynamicCatalogCache.set(cacheKey, {
+      byModelId: catalog,
+      expiresAtMs: now + Math.max(1_000, Math.floor(cacheTtlMs)),
+    });
+    return lookupCatalogContextWindow(catalog, llmConfig.model);
+  }
+
+  if (cached) {
+    logger?.warn?.("Using stale Grok model metadata cache after refresh failure");
+    return lookupCatalogContextWindow(cached.byModelId, llmConfig.model);
+  }
+
+  return undefined;
+}

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -72,6 +72,12 @@ import { loadPersonalityTemplate, mergePersonality } from './personality.js';
 import { SlashCommandRegistry, createDefaultCommands } from './commands.js';
 import { HookDispatcher, createBuiltinHooks } from './hooks.js';
 import { ProgressTracker, summarizeToolResult } from './progress.js';
+import { buildChatUsagePayload } from './chat-usage.js';
+import {
+  inferContextWindowTokens,
+  normalizeGrokModel,
+  resolveDynamicContextWindowTokens,
+} from './context-window.js';
 import { PipelineExecutor, type Pipeline, type PipelineStep } from '../workflow/pipeline.js';
 import { ConnectionManager } from '../connection/manager.js';
 import { DiscordChannel } from '../channels/discord/plugin.js';
@@ -90,13 +96,6 @@ import { ToolRouter, type ToolRoutingDecision } from './tool-routing.js';
 
 const DEFAULT_GROK_MODEL = 'grok-4-1-fast-reasoning';
 const DEFAULT_GROK_FALLBACK_MODEL = 'grok-4-1-fast-non-reasoning';
-const DEFAULT_GROK_CONTEXT_WINDOW_TOKENS = 256_000;
-const DEFAULT_OLLAMA_CONTEXT_WINDOW_TOKENS = 32_768;
-const LEGACY_GROK_MODEL_ALIASES: Record<string, string> = {
-  'grok-4': DEFAULT_GROK_MODEL,
-  'grok-4-fast-reasoning': DEFAULT_GROK_MODEL,
-  'grok-4-fast-non-reasoning': DEFAULT_GROK_FALLBACK_MODEL,
-};
 
 /** Minimum confidence score for injecting learned patterns into conversations. */
 const MIN_LEARNING_CONFIDENCE = 0.7;
@@ -132,8 +131,7 @@ const SEMANTIC_MEMORY_DEFAULTS = {
   HYBRID_KEYWORD_WEIGHT: 0.3,
 } as const;
 
-/** Default session token budget — enables auto-compaction out of the box.
- *  Model-specific: Grok=131K, Claude=200K, Ollama=varies. 120K is conservative. */
+/** Fallback session token budget when provider/model window is unknown. */
 const DEFAULT_SESSION_TOKEN_BUDGET = 120_000;
 /** Hard cap for assembled system prompt size to prevent prompt blowups. */
 const MAX_SYSTEM_PROMPT_CHARS = 60_000;
@@ -147,29 +145,25 @@ const TRACE_SANITIZE_MAX_ARRAY_ITEMS = 40;
 const TRACE_SANITIZE_MAX_OBJECT_KEYS = 80;
 const TRACE_HISTORY_MAX_MESSAGES = 500;
 
-function normalizeGrokModel(model: string | undefined): string | undefined {
-  if (!model) return undefined;
-  const trimmed = model.trim();
-  return LEGACY_GROK_MODEL_ALIASES[trimmed] ?? trimmed;
-}
-
-function inferContextWindowTokens(
+function resolveSessionTokenBudget(
   llmConfig: GatewayLLMConfig | undefined,
-): number | undefined {
-  if (!llmConfig) return undefined;
+  contextWindowTokens?: number,
+): number {
   if (
-    typeof llmConfig.contextWindowTokens === "number" &&
-    Number.isFinite(llmConfig.contextWindowTokens)
+    typeof llmConfig?.sessionTokenBudget === "number" &&
+    Number.isFinite(llmConfig.sessionTokenBudget)
   ) {
-    return Math.max(2_048, Math.floor(llmConfig.contextWindowTokens));
+    return Math.max(0, Math.floor(llmConfig.sessionTokenBudget));
   }
-  if (llmConfig.provider === "grok") return DEFAULT_GROK_CONTEXT_WINDOW_TOKENS;
-  if (llmConfig.provider === "ollama") return DEFAULT_OLLAMA_CONTEXT_WINDOW_TOKENS;
-  return undefined;
+  const inferredContextWindow =
+    contextWindowTokens ?? inferContextWindowTokens(llmConfig);
+  if (inferredContextWindow !== undefined) return inferredContextWindow;
+  return DEFAULT_SESSION_TOKEN_BUDGET;
 }
 
 function buildPromptBudgetConfig(
   llmConfig: GatewayLLMConfig | undefined,
+  contextWindowTokens?: number,
 ): {
   contextWindowTokens?: number;
   maxOutputTokens?: number;
@@ -180,7 +174,7 @@ function buildPromptBudgetConfig(
 } | undefined {
   if (!llmConfig) return undefined;
   return {
-    contextWindowTokens: inferContextWindowTokens(llmConfig),
+    contextWindowTokens: contextWindowTokens ?? inferContextWindowTokens(llmConfig),
     maxOutputTokens: llmConfig.maxTokens,
     hardMaxPromptChars: llmConfig.promptHardMaxChars,
     safetyMarginTokens: llmConfig.promptSafetyMarginTokens,
@@ -864,6 +858,7 @@ export class DaemonManager {
   private _hookDispatcher: HookDispatcher | null = null;
   private _connectionManager: ConnectionManager | null = null;
   private _chatExecutor: ChatExecutor | null = null;
+  private _resolvedContextWindowTokens: number | undefined;
   private _llmTools: LLMTool[] = [];
   private _llmProviders: LLMProvider[] = [];
   private _toolRouter: ToolRouter | null = null;
@@ -1259,6 +1254,13 @@ export class DaemonManager {
       logger: this.logger,
     });
 
+    const contextWindowTokens = await this.resolveLlmContextWindowTokens(config.llm);
+    this._resolvedContextWindowTokens = contextWindowTokens;
+    const sessionTokenBudget = resolveSessionTokenBudget(
+      config.llm,
+      contextWindowTokens,
+    );
+
     this._chatExecutor = providers.length > 0 ? new ChatExecutor({
       providers,
       toolHandler: baseToolHandler,
@@ -1266,7 +1268,7 @@ export class DaemonManager {
       memoryRetriever,
       learningProvider,
       progressProvider: progressTracker,
-      promptBudget: buildPromptBudgetConfig(config.llm),
+      promptBudget: buildPromptBudgetConfig(config.llm, contextWindowTokens),
       maxToolRounds: config.llm?.maxToolRounds ?? getDefaultMaxToolRounds(config),
       plannerEnabled: config.llm?.plannerEnabled,
       plannerMaxTokens: config.llm?.plannerMaxTokens,
@@ -1278,7 +1280,7 @@ export class DaemonManager {
       retryPolicyMatrix: config.llm?.retryPolicy,
       toolFailureCircuitBreaker: config.llm?.toolFailureCircuitBreaker,
       pipelineExecutor,
-      sessionTokenBudget: config.llm?.sessionTokenBudget ?? DEFAULT_SESSION_TOKEN_BUDGET,
+      sessionTokenBudget,
       onCompaction: this.handleCompaction,
     }) : null;
 
@@ -1327,7 +1329,6 @@ export class DaemonManager {
         }),
     });
     const signals = this.createWebChatSignals(webChat);
-    const sessionTokenBudget = config.llm?.sessionTokenBudget ?? DEFAULT_SESSION_TOKEN_BUDGET;
     const onMessage = this.createWebChatMessageHandler({
       webChat,
       commandRegistry,
@@ -1341,6 +1342,7 @@ export class DaemonManager {
       memoryBackend,
       signals,
       sessionTokenBudget,
+      contextWindowTokens,
     });
 
     await webChat.initialize({ onMessage, logger: this.logger, config: {} });
@@ -1414,7 +1416,7 @@ export class DaemonManager {
       `, memory=${memoryBackend.name}` +
       `, ${commandRegistry.size} commands` +
       (telemetry ? ', telemetry' : '') +
-      `, budget=${config.llm?.sessionTokenBudget ?? DEFAULT_SESSION_TOKEN_BUDGET}` +
+      `, budget=${sessionTokenBudget}` +
       (voiceBridge ? ', voice' : '') +
       ', hooks, sessions, approvals',
     );
@@ -2479,6 +2481,16 @@ export class DaemonManager {
     }
   };
 
+  private async resolveLlmContextWindowTokens(
+    llmConfig: GatewayLLMConfig | undefined,
+  ): Promise<number | undefined> {
+    const dynamic = await resolveDynamicContextWindowTokens(llmConfig, {
+      logger: this.logger,
+    });
+    if (dynamic !== undefined) return dynamic;
+    return inferContextWindowTokens(llmConfig);
+  }
+
   private async hotSwapLLMProvider(
     newConfig: GatewayConfig,
     skillInjector: SkillInjector,
@@ -2493,6 +2505,12 @@ export class DaemonManager {
         newConfig.llm?.toolRouting,
         this.logger,
       );
+      const contextWindowTokens = await this.resolveLlmContextWindowTokens(newConfig.llm);
+      this._resolvedContextWindowTokens = contextWindowTokens;
+      const sessionTokenBudget = resolveSessionTokenBudget(
+        newConfig.llm,
+        contextWindowTokens,
+      );
       const providers = await this.createLLMProviders(newConfig, this._llmTools);
       this._chatExecutor = providers.length > 0 ? new ChatExecutor({
         providers,
@@ -2501,7 +2519,7 @@ export class DaemonManager {
         memoryRetriever,
         learningProvider,
         progressProvider,
-        promptBudget: buildPromptBudgetConfig(newConfig.llm),
+        promptBudget: buildPromptBudgetConfig(newConfig.llm, contextWindowTokens),
         maxToolRounds: newConfig.llm?.maxToolRounds ?? getDefaultMaxToolRounds(newConfig),
         plannerEnabled: newConfig.llm?.plannerEnabled,
         plannerMaxTokens: newConfig.llm?.plannerMaxTokens,
@@ -2513,7 +2531,7 @@ export class DaemonManager {
         retryPolicyMatrix: newConfig.llm?.retryPolicy,
         toolFailureCircuitBreaker: newConfig.llm?.toolFailureCircuitBreaker,
         pipelineExecutor,
-        sessionTokenBudget: newConfig.llm?.sessionTokenBudget ?? DEFAULT_SESSION_TOKEN_BUDGET,
+        sessionTokenBudget,
         onCompaction: this.handleCompaction,
       }) : null;
 
@@ -3234,6 +3252,9 @@ export class DaemonManager {
       voicePrompt += '\n\n' + this.buildDesktopContext(config);
     }
 
+    const contextWindowTokens =
+      this._resolvedContextWindowTokens ?? inferContextWindowTokens(config.llm);
+
     return new VoiceBridge({
       apiKey: voiceApiKey,
       toolHandler,
@@ -3251,7 +3272,8 @@ export class DaemonManager {
       hooks: deps.hooks,
       approvalEngine: deps.approvalEngine,
       memoryBackend: deps.memoryBackend,
-      sessionTokenBudget: config.llm?.sessionTokenBudget ?? DEFAULT_SESSION_TOKEN_BUDGET,
+      sessionTokenBudget: resolveSessionTokenBudget(config.llm, contextWindowTokens),
+      contextWindowTokens,
     });
   }
 
@@ -3322,6 +3344,7 @@ export class DaemonManager {
     memoryBackend: MemoryBackend;
     signals: WebChatSignals;
     sessionTokenBudget: number;
+    contextWindowTokens?: number;
   }): (msg: GatewayMessage) => Promise<void> {
     const {
       webChat,
@@ -3336,6 +3359,7 @@ export class DaemonManager {
       memoryBackend,
       signals,
       sessionTokenBudget,
+      contextWindowTokens,
     } = params;
 
     return async (msg: GatewayMessage): Promise<void> => {
@@ -3653,11 +3677,13 @@ export class DaemonManager {
         // Send cumulative token usage to browser
         webChat.pushToSession(msg.sessionId, {
           type: 'chat.usage',
-          payload: {
+          payload: buildChatUsagePayload({
             totalTokens: chatExecutor.getSessionTokenUsage(msg.sessionId),
-            budget: sessionTokenBudget,
+            sessionTokenBudget,
             compacted: result.compacted ?? false,
-          },
+            contextWindowTokens,
+            callUsage: result.callUsage,
+          }),
         });
 
         webChat.broadcastEvent('chat.response', { sessionId: msg.sessionId });

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -26,6 +26,7 @@ import type { ApprovalEngine } from "./approvals.js";
 import type { MemoryBackend } from "../memory/types.js";
 import { createGatewayMessage } from "./message.js";
 import { createSessionToolHandler } from "./tool-handler-factory.js";
+import { buildChatUsagePayload } from "./chat-usage.js";
 
 const DEFAULT_MAX_SESSIONS = 10;
 
@@ -156,6 +157,8 @@ export interface VoiceBridgeConfig {
   memoryBackend?: MemoryBackend;
   /** Session token budget (for reporting usage to the browser). */
   sessionTokenBudget?: number;
+  /** Model context window used for context-usage display in the web UI. */
+  contextWindowTokens?: number;
 }
 
 interface ActiveSession {
@@ -571,11 +574,13 @@ export class VoiceBridge {
       // Send cumulative token usage to browser chat panel
       send({
         type: "chat.usage",
-        payload: {
+        payload: buildChatUsagePayload({
           totalTokens: this.config.chatExecutor.getSessionTokenUsage(sessionId),
-          budget: this.config.sessionTokenBudget ?? 0,
+          sessionTokenBudget: this.config.sessionTokenBudget ?? 0,
           compacted: result.compacted ?? false,
-        },
+          contextWindowTokens: this.config.contextWindowTokens,
+          callUsage: result.callUsage,
+        }),
       });
 
       if (result.toolCalls.length > 0) {

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -63,6 +63,7 @@ export function ChatView({
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [sessionsOpen, setSessionsOpen] = useState(false);
+  const [contextPanelOpen, setContextPanelOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   const toggleSearch = useCallback(() => {
@@ -97,15 +98,54 @@ export function ChatView({
     : 0;
 
   const isEmpty = messages.length === 0 && !isTyping;
-  const tokenUsageRatio =
-    tokenUsage && tokenUsage.budget > 0
-      ? tokenUsage.totalTokens / tokenUsage.budget
+  const contextWindowTokens =
+    tokenUsage && tokenUsage.contextWindowTokens && tokenUsage.contextWindowTokens > 0
+      ? tokenUsage.contextWindowTokens
       : 0;
-  const tokenUsagePercent = tokenUsageRatio * 100;
-  const tokenUsageLabel =
-    tokenUsage && tokenUsage.totalTokens > 0 && tokenUsagePercent < 1
+  const promptTokens =
+    tokenUsage && tokenUsage.promptTokens && tokenUsage.promptTokens > 0
+      ? tokenUsage.promptTokens
+      : tokenUsage?.totalTokens ?? 0;
+  const contextUsageRatio = contextWindowTokens > 0
+    ? promptTokens / contextWindowTokens
+    : 0;
+  const sessionBudgetTokens =
+    tokenUsage && tokenUsage.budget > 0
+      ? tokenUsage.budget
+      : 0;
+  const sessionBudgetRatio = sessionBudgetTokens > 0
+    ? (tokenUsage?.totalTokens ?? 0) / sessionBudgetTokens
+    : 0;
+  const hasModelContextWindow = contextWindowTokens > 0;
+  const displayUsedTokens = hasModelContextWindow
+    ? promptTokens
+    : tokenUsage?.totalTokens ?? 0;
+  const displayTotalTokens = hasModelContextWindow
+    ? contextWindowTokens
+    : sessionBudgetTokens;
+  const displayRatio = hasModelContextWindow
+    ? contextUsageRatio
+    : sessionBudgetRatio;
+  const contextUsagePercent = contextUsageRatio * 100;
+  const displayPercent = displayRatio * 100;
+  const contextUsageLabel =
+    displayUsedTokens > 0 && displayPercent < 1
       ? '<1%'
-      : `${Math.round(tokenUsagePercent)}%`;
+      : `${Math.round(displayPercent)}%`;
+  const contextBarPercent = Math.min(100, Math.max(0, displayPercent));
+  const contextToneClass =
+    displayRatio > 0.85
+      ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+      : displayRatio > 0.6
+        ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+        : 'bg-tetsuo-100 text-tetsuo-500 dark:bg-tetsuo-800 dark:text-tetsuo-400';
+  const contextBarClass =
+    displayRatio > 0.85
+      ? 'bg-red-500'
+      : displayRatio > 0.6
+        ? 'bg-amber-500'
+        : 'bg-accent';
+  const sessionBudgetPercent = sessionBudgetRatio * 100;
 
   // ── Welcome / landing state ──
   if (isEmpty) {
@@ -199,21 +239,6 @@ export function ChatView({
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
           </button>
-          {tokenUsage && tokenUsage.budget > 0 && (
-            <div
-              className={`px-2 py-0.5 rounded-full text-xs font-mono tabular-nums ${
-                tokenUsageRatio > 0.85
-                  ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-                  : tokenUsageRatio > 0.6
-                    ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
-                    : 'bg-tetsuo-100 text-tetsuo-500 dark:bg-tetsuo-800 dark:text-tetsuo-400'
-              }`}
-              title={`${tokenUsage.totalTokens.toLocaleString()} / ${tokenUsage.budget.toLocaleString()} tokens${tokenUsage.compacted ? ' (auto-compacted)' : ''}`}
-            >
-              {tokenUsageLabel}
-              {tokenUsage.compacted && ' ~'}
-            </div>
-          )}
           <button className="ml-2 flex items-center gap-2 px-4 py-2 rounded-lg border border-tetsuo-200 text-sm font-medium text-tetsuo-700 hover:bg-tetsuo-50 transition-colors">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
             Download App
@@ -295,6 +320,136 @@ export function ChatView({
           onPushToTalkStop={onPushToTalkStop}
           delegationTask={delegationTask}
         />
+      )}
+
+      {tokenUsage && displayTotalTokens > 0 && (
+        <div className="relative px-4 md:px-6 py-2 border-t border-tetsuo-200 bg-tetsuo-50/40 dark:bg-tetsuo-900/10">
+          <div className="flex justify-end">
+            <button
+              onClick={() => setContextPanelOpen((prev) => !prev)}
+              className={`inline-flex items-center gap-2 pl-2 pr-3 py-1.5 rounded-full border border-tetsuo-200 dark:border-tetsuo-700 transition-colors ${contextToneClass}`}
+              title="View context usage breakdown"
+              aria-expanded={contextPanelOpen}
+            >
+              <span className="text-[11px] uppercase tracking-[0.08em] font-semibold">
+                {hasModelContextWindow ? 'Context' : 'Budget'}
+              </span>
+              <span className="font-mono tabular-nums text-xs">{contextUsageLabel}</span>
+            </button>
+          </div>
+
+          {contextPanelOpen && (
+            <div className="absolute bottom-[52px] right-4 md:right-6 z-20 w-[min(420px,calc(100vw-2rem))] rounded-xl border border-tetsuo-200 dark:border-tetsuo-800 bg-surface shadow-xl p-3">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="text-xs font-semibold text-tetsuo-700 dark:text-tetsuo-100">
+                    {hasModelContextWindow ? 'Model Context Window' : 'Session Token Budget'}
+                  </p>
+                  <p className="text-xs text-tetsuo-500 dark:text-tetsuo-400">
+                    {displayUsedTokens.toLocaleString()} / {displayTotalTokens.toLocaleString()} tokens
+                  </p>
+                </div>
+                <span className={`px-2 py-0.5 rounded-full text-xs font-mono tabular-nums ${contextToneClass}`}>
+                  {contextUsageLabel}
+                </span>
+              </div>
+
+              <div className="mt-2 h-1.5 rounded-full bg-tetsuo-200/70 dark:bg-tetsuo-800/70 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all duration-300 ${contextBarClass}`}
+                  style={{ width: `${contextBarPercent}%` }}
+                />
+              </div>
+
+              <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                {hasModelContextWindow ? (
+                  <div className="rounded-lg border border-tetsuo-200 dark:border-tetsuo-800 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-[0.08em] text-tetsuo-500 dark:text-tetsuo-400">Prompt In Model Window</p>
+                    <p className="text-sm font-semibold text-tetsuo-700 dark:text-tetsuo-100">
+                      {Math.round(contextUsagePercent)}%
+                    </p>
+                  </div>
+                ) : (
+                  <div className="rounded-lg border border-tetsuo-200 dark:border-tetsuo-800 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-[0.08em] text-tetsuo-500 dark:text-tetsuo-400">Cumulative Session Budget</p>
+                    <p className="text-sm font-semibold text-tetsuo-700 dark:text-tetsuo-100">
+                      {Math.round(sessionBudgetPercent)}%
+                    </p>
+                  </div>
+                )}
+                {sessionBudgetTokens > 0 && (
+                  <div className="rounded-lg border border-tetsuo-200 dark:border-tetsuo-800 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-[0.08em] text-tetsuo-500 dark:text-tetsuo-400">Session Budget</p>
+                    <p className="text-sm font-semibold text-tetsuo-700 dark:text-tetsuo-100">
+                      {tokenUsage.totalTokens.toLocaleString()} / {sessionBudgetTokens.toLocaleString()}
+                    </p>
+                  </div>
+                )}
+                {tokenUsage.promptTokenBudget && tokenUsage.promptTokenBudget > 0 && (
+                  <div className="rounded-lg border border-tetsuo-200 dark:border-tetsuo-800 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-[0.08em] text-tetsuo-500 dark:text-tetsuo-400">Prompt Budget</p>
+                    <p className="text-sm font-semibold text-tetsuo-700 dark:text-tetsuo-100">
+                      {tokenUsage.promptTokenBudget.toLocaleString()} tokens
+                    </p>
+                  </div>
+                )}
+                {tokenUsage.maxOutputTokens && tokenUsage.maxOutputTokens > 0 && (
+                  <div className="rounded-lg border border-tetsuo-200 dark:border-tetsuo-800 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-[0.08em] text-tetsuo-500 dark:text-tetsuo-400">Output Reserve</p>
+                    <p className="text-sm font-semibold text-tetsuo-700 dark:text-tetsuo-100">
+                      {tokenUsage.maxOutputTokens.toLocaleString()} tokens
+                    </p>
+                  </div>
+                )}
+                {tokenUsage.safetyMarginTokens && tokenUsage.safetyMarginTokens > 0 && (
+                  <div className="rounded-lg border border-tetsuo-200 dark:border-tetsuo-800 px-3 py-2">
+                    <p className="text-[11px] uppercase tracking-[0.08em] text-tetsuo-500 dark:text-tetsuo-400">Safety Margin</p>
+                    <p className="text-sm font-semibold text-tetsuo-700 dark:text-tetsuo-100">
+                      {tokenUsage.safetyMarginTokens.toLocaleString()} tokens
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {tokenUsage.sections && tokenUsage.sections.length > 0 ? (
+                <div className="mt-3 space-y-2">
+                  {tokenUsage.sections.map((section) => (
+                    <div key={section.id}>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-tetsuo-600 dark:text-tetsuo-300">{section.label}</span>
+                        <span className="font-mono tabular-nums text-tetsuo-500 dark:text-tetsuo-400">
+                          {section.percent.toFixed(section.percent >= 10 ? 0 : 1)}% · {section.tokens.toLocaleString()}
+                        </span>
+                      </div>
+                      <div className="mt-1 h-1.5 rounded-full bg-tetsuo-200/70 dark:bg-tetsuo-800/70 overflow-hidden">
+                        <div
+                          className="h-full rounded-full bg-tetsuo-500/70 dark:bg-tetsuo-400/70"
+                          style={{ width: `${Math.min(100, Math.max(0, section.percent))}%` }}
+                        />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="mt-3 text-xs text-tetsuo-500 dark:text-tetsuo-400">
+                  Section breakdown appears after the next model response.
+                </p>
+              )}
+
+              {!hasModelContextWindow && (
+                <p className="mt-3 text-xs text-tetsuo-500 dark:text-tetsuo-400">
+                  Model context window is unavailable from runtime metadata; showing session budget instead.
+                </p>
+              )}
+
+              {tokenUsage.compacted && (
+                <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
+                  Context was auto-compacted to stay within budget.
+                </p>
+              )}
+            </div>
+          )}
+        </div>
       )}
 
       <ChatInput

--- a/web/src/hooks/useChat.test.ts
+++ b/web/src/hooks/useChat.test.ts
@@ -251,4 +251,36 @@ describe("useChat session lifecycle", () => {
       }),
     );
   });
+
+  it("parses extended chat.usage payload for context breakdown", () => {
+    const send = vi.fn();
+    const { result } = renderHook(() => useChat({ send, connected: true }));
+
+    act(() => {
+      result.current.handleMessage({
+        type: "chat.usage",
+        payload: {
+          totalTokens: 1234,
+          budget: 64_000,
+          compacted: false,
+          contextWindowTokens: 128_000,
+          promptTokens: 2048,
+          promptTokenBudget: 117_760,
+          maxOutputTokens: 8192,
+          safetyMarginTokens: 2048,
+          sections: [
+            { id: "memory", label: "Memory", tokens: 800, percent: 31.2 },
+          ],
+        },
+      } as WSMessage);
+    });
+
+    expect(result.current.tokenUsage).toMatchObject({
+      totalTokens: 1234,
+      budget: 64_000,
+      contextWindowTokens: 128_000,
+      promptTokens: 2048,
+      sections: [{ id: "memory", label: "Memory", tokens: 800, percent: 31.2 }],
+    });
+  });
 });

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ChatMessage, ChatMessageAttachment, TokenUsage, ToolCall, WSMessage } from '../types';
+import type {
+  ChatMessage,
+  ChatMessageAttachment,
+  ContextUsageSection,
+  TokenUsage,
+  ToolCall,
+  WSMessage,
+} from '../types';
 import {
   WS_CHAT_MESSAGE,
   WS_CHAT_TYPING,
@@ -53,6 +60,30 @@ export interface UseChatReturn {
 interface UseChatOptions {
   send: (msg: Record<string, unknown>) => void;
   connected?: boolean;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  return value;
+}
+
+function parseUsageSections(value: unknown): ContextUsageSection[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const sections = value
+    .map((entry) => {
+      if (typeof entry !== 'object' || entry === null) return null;
+      const row = entry as Record<string, unknown>;
+      const id = typeof row.id === 'string' ? row.id : '';
+      const label = typeof row.label === 'string' ? row.label : '';
+      const tokens = asNumber(row.tokens);
+      const percent = asNumber(row.percent);
+      if (!id || !label || tokens === undefined || percent === undefined) {
+        return null;
+      }
+      return { id, label, tokens, percent } satisfies ContextUsageSection;
+    })
+    .filter((section): section is ContextUsageSection => section !== null);
+  return sections.length > 0 ? sections : undefined;
 }
 
 export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
@@ -272,9 +303,15 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
       case WS_CHAT_USAGE: {
         const payload = (msg.payload ?? msg) as Record<string, unknown>;
         setTokenUsage({
-          totalTokens: (payload.totalTokens as number) ?? 0,
-          budget: (payload.budget as number) ?? 0,
+          totalTokens: asNumber(payload.totalTokens) ?? 0,
+          budget: asNumber(payload.budget) ?? 0,
           compacted: (payload.compacted as boolean) ?? false,
+          contextWindowTokens: asNumber(payload.contextWindowTokens),
+          promptTokens: asNumber(payload.promptTokens),
+          promptTokenBudget: asNumber(payload.promptTokenBudget),
+          maxOutputTokens: asNumber(payload.maxOutputTokens),
+          safetyMarginTokens: asNumber(payload.safetyMarginTokens),
+          sections: parseUsageSections(payload.sections),
         });
         break;
       }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -33,13 +33,32 @@ export interface ChatMessage {
   attachments?: ChatMessageAttachment[];
 }
 
+export interface ContextUsageSection {
+  id: string;
+  label: string;
+  tokens: number;
+  percent: number;
+}
+
 export interface TokenUsage {
   /** Cumulative tokens used this session. */
   totalTokens: number;
-  /** Session token budget. */
+  /** Session token budget used for auto-compaction. */
   budget: number;
   /** Whether context was auto-compacted this round. */
   compacted?: boolean;
+  /** Model context window for the active provider/model, when available. */
+  contextWindowTokens?: number;
+  /** Estimated prompt tokens for the latest request. */
+  promptTokens?: number;
+  /** Prompt token budget after output+safety reservations. */
+  promptTokenBudget?: number;
+  /** Max completion tokens reserved by provider config. */
+  maxOutputTokens?: number;
+  /** Safety margin reserved for protocol/provider overhead. */
+  safetyMarginTokens?: number;
+  /** Prompt composition breakdown by context section. */
+  sections?: ContextUsageSection[];
 }
 
 export interface ToolCall {


### PR DESCRIPTION
## Summary

- Extract context window inference into `context-window.ts` with per-model Grok sizes (2M for grok-4-1-fast variants), dynamic xAI `/models` API metadata fetching with TTL cache, and legacy alias normalization
- Build structured `chat.usage` payloads via `chat-usage.ts` with prompt token breakdown by section (system, memory, history, tools, user) from PromptBudgetDiagnostics
- Replace inline token badge in ChatView with expandable context panel showing model window fill, session budget, prompt composition bars, output reserve, and safety margin
- Graceful degradation to session budget display when model window metadata is unavailable

## Test plan

- [ ] Verify `context-window.test.ts` passes (model alias resolution, per-model inference, dynamic API fetch with caching)
- [ ] Verify `chat-usage.test.ts` passes (payload building with/without diagnostics, section breakdown)
- [ ] Verify `useChat.test.ts` passes (extended usage payload parsing)
- [ ] Manual: open web UI, send a message, click context badge to expand panel and verify breakdown renders
- [ ] Manual: verify panel shows color-coded thresholds at >60% and >85% usage