### PR TITLE
fix(runtime): enforce deny/allow policy checks in system.bash shell mode

### DIFF
--- a/runtime/src/tools/system/bash.test.ts
+++ b/runtime/src/tools/system/bash.test.ts
@@ -853,12 +853,12 @@ describe("system.bash tool", () => {
 
     it("executes backgrounded commands via spawn with temp script", async () => {
       const tool = createBashTool();
-      mockSpawnSuccess("12345\n");
+      mockSpawnSuccess("");
 
-      const result = await tool.execute({ command: "python3 -m http.server 8080 &" });
+      const result = await tool.execute({ command: "sleep 1 &" });
       expect(writeFileSync).toHaveBeenCalledWith(
         expect.stringMatching(/agenc-sh-[0-9a-f]+\.sh$/),
-        "python3 -m http.server 8080 &",
+        "sleep 1 &",
         { mode: 0o700 },
       );
       const [cmd, args] = mockSpawn.mock.calls[0];
@@ -1028,38 +1028,65 @@ describe("system.bash tool", () => {
       expect(parseContent(result).error).toContain("shell invocation");
     });
 
+    it("enforces deny list in shell mode (issue #1321 regression)", async () => {
+      const tool = createBashTool();
+
+      const result = await tool.execute({
+        command: "echo safe && python3 --version",
+      });
+      expect(result.isError).toBe(true);
+      expect(parseContent(result).error).toContain("denied");
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it("enforces allow list in shell mode", async () => {
+      const tool = createBashTool({ allowList: ["ls", "wc"] });
+      mockSpawnSuccess("1\n");
+
+      const allowed = await tool.execute({ command: "ls /tmp | wc -l" });
+      expect(allowed.isError).toBeUndefined();
+
+      const denied = await tool.execute({ command: "ls /tmp | grep txt" });
+      expect(denied.isError).toBe(true);
+      expect(parseContent(denied).error).toContain("allow list");
+    });
+
     // ---- Shell mode safe commands ----
 
-    it("allows rm of specific files (not root/home)", async () => {
+    it("blocks rm in shell mode via deny list", async () => {
       const tool = createBashTool();
-      mockSpawnSuccess("");
 
       const result = await tool.execute({ command: "rm /tmp/test.txt" });
-      expect(result.isError).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(parseContent(result).error).toContain("denied");
+      expect(mockSpawn).not.toHaveBeenCalled();
     });
 
-    it("allows curl piped to grep (not piped to shell)", async () => {
+    it("blocks curl in shell mode via deny list", async () => {
       const tool = createBashTool();
-      mockSpawnSuccess("result\n");
 
       const result = await tool.execute({ command: "curl -sS https://api.example.com | grep name" });
-      expect(result.isError).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(parseContent(result).error).toContain("denied");
+      expect(mockSpawn).not.toHaveBeenCalled();
     });
 
-    it("allows python3 in shell mode", async () => {
+    it("blocks python3 in shell mode", async () => {
       const tool = createBashTool();
-      mockSpawnSuccess("3.11.9\n");
 
       const result = await tool.execute({ command: "python3 --version" });
-      expect(result.isError).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(parseContent(result).error).toContain("denied");
+      expect(mockSpawn).not.toHaveBeenCalled();
     });
 
-    it("allows pkill in shell mode", async () => {
+    it("blocks pkill in shell mode", async () => {
       const tool = createBashTool();
-      mockSpawnSuccess("");
 
       const result = await tool.execute({ command: "pkill -f 'http.server'" });
-      expect(result.isError).toBeUndefined();
+      expect(result.isError).toBe(true);
+      expect(parseContent(result).error).toContain("denied");
+      expect(mockSpawn).not.toHaveBeenCalled();
     });
 
     it("allows cat with wc pipe", async () => {
@@ -1070,11 +1097,11 @@ describe("system.bash tool", () => {
       expect(result.isError).toBeUndefined();
     });
 
-    it("allows backgrounded python server", async () => {
+    it("allows backgrounded sleep command", async () => {
       const tool = createBashTool();
       mockSpawnSuccess("");
 
-      const result = await tool.execute({ command: "python3 -m http.server 8080 &" });
+      const result = await tool.execute({ command: "sleep 1 &" });
       expect(result.isError).toBeUndefined();
     });
   });

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -59,6 +59,37 @@ const SHELL_BUILTIN_COMMANDS = new Set([
 ]);
 const SINGLE_EXECUTABLE_RE = /^[A-Za-z0-9_./+-]+$/;
 const SHELL_OPERATOR_RE = /[|&;<>()`$\\\r\n]/;
+const SHELL_COMMAND_SEPARATORS = new Set([
+  "|",
+  "||",
+  "&&",
+  ";",
+  "&",
+  "(",
+  ")",
+  "`",
+]);
+const SHELL_REDIRECT_OPERATORS = new Set([
+  ">",
+  ">>",
+  "<",
+  "<<",
+  "<>",
+  ">&",
+  "<&",
+  ">|",
+]);
+const SHELL_PREFIX_COMMANDS = new Set([
+  "command",
+  "builtin",
+  "exec",
+  "time",
+  "env",
+  "nohup",
+  "nice",
+  "setsid",
+]);
+const ENV_ASSIGNMENT_RE = /^[A-Za-z_][A-Za-z0-9_]*=.*/;
 
 function errorResult(message: string): ToolResult {
   return { content: safeStringify({ error: message }), isError: true };
@@ -183,6 +214,169 @@ function isShellModeCommand(
 ): boolean {
   if (args !== undefined) return false;
   return SHELL_OPERATOR_RE.test(command) || /\s/.test(command);
+}
+
+/**
+ * Tokenize a shell command string while preserving shell operators.
+ * Used to extract executable candidates for policy checks in shell mode.
+ */
+function tokenizeShellCommand(command: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  const pushCurrent = () => {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = "";
+    }
+  };
+
+  const pushOperator = (operator: string) => {
+    pushCurrent();
+    tokens.push(operator);
+  };
+
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+
+    if (escaping) {
+      current += ch;
+      escaping = false;
+      continue;
+    }
+
+    if (quote !== null) {
+      if (ch === quote) {
+        quote = null;
+        continue;
+      }
+      if (quote === '"' && ch === "\\" && i + 1 < command.length) {
+        i += 1;
+        current += command[i];
+        continue;
+      }
+      current += ch;
+      continue;
+    }
+
+    if (ch === "\\" && i + 1 < command.length) {
+      escaping = true;
+      continue;
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch;
+      continue;
+    }
+
+    if (ch === "\n") {
+      pushOperator(";");
+      continue;
+    }
+    if (/\s/.test(ch)) {
+      pushCurrent();
+      continue;
+    }
+
+    if (
+      ch === "|" ||
+      ch === "&" ||
+      ch === ";" ||
+      ch === "<" ||
+      ch === ">" ||
+      ch === "(" ||
+      ch === ")" ||
+      ch === "`"
+    ) {
+      const next = command[i + 1] ?? "";
+      const pair = ch + next;
+      if (
+        pair === "||" ||
+        pair === "&&" ||
+        pair === ">>" ||
+        pair === "<<" ||
+        pair === ">&" ||
+        pair === "<&" ||
+        pair === ">|"
+      ) {
+        pushOperator(pair);
+        i += 1;
+        continue;
+      }
+      pushOperator(ch);
+      continue;
+    }
+
+    current += ch;
+  }
+
+  if (escaping) {
+    current += "\\";
+  }
+  pushCurrent();
+
+  return tokens;
+}
+
+/**
+ * Extract executable candidates from a shell command string.
+ * We validate every detected executable against deny/allow policy.
+ */
+function extractShellExecutables(command: string): string[] {
+  const tokens = tokenizeShellCommand(command);
+  const executables: string[] = [];
+  let expectCommand = true;
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
+    if (SHELL_COMMAND_SEPARATORS.has(token)) {
+      expectCommand = true;
+      continue;
+    }
+
+    if (!expectCommand) {
+      continue;
+    }
+
+    // Skip redirection operators and their operands while still waiting for a command.
+    if (SHELL_REDIRECT_OPERATORS.has(token)) {
+      if (i + 1 < tokens.length) {
+        i += 1;
+      }
+      continue;
+    }
+
+    // Handle numeric file-descriptor redirects like `2>/tmp/x`.
+    const next = tokens[i + 1];
+    if (/^\d+$/.test(token) && next && SHELL_REDIRECT_OPERATORS.has(next)) {
+      i += 2;
+      continue;
+    }
+
+    // Skip environment assignments (`FOO=bar cmd`).
+    if (ENV_ASSIGNMENT_RE.test(token)) {
+      continue;
+    }
+
+    // Skip command-substitution marker tokens.
+    if (token === "$") {
+      continue;
+    }
+
+    // Prefix commands still matter for policy checks, but the actual command follows.
+    const lower = token.toLowerCase();
+    if (SHELL_PREFIX_COMMANDS.has(lower)) {
+      executables.push(token);
+      continue;
+    }
+
+    executables.push(token);
+    expectCommand = false;
+  }
+
+  return executables;
 }
 
 /**
@@ -332,6 +526,23 @@ export function createBashTool(config?: BashToolConfig): Tool {
         if (!shellCheck.allowed) {
           logger.warn(`Bash tool shell-mode denied: ${shellCheck.reason}`);
           return errorResult(shellCheck.reason);
+        }
+
+        // Enforce deny/allow policy for each executable discovered in shell mode.
+        if (!unrestricted) {
+          const shellExecutables = extractShellExecutables(command);
+          for (const shellExecutable of shellExecutables) {
+            const check = isCommandAllowed(
+              shellExecutable,
+              denySet,
+              allowSet,
+              denyExclusionSet,
+            );
+            if (!check.allowed) {
+              logger.warn(`Bash tool shell-mode denied: ${check.reason}`);
+              return errorResult(check.reason);
+            }
+          }
         }
 
         execCommand = "/bin/bash";


### PR DESCRIPTION
## Summary
This PR fixes a critical policy bypass in `system.bash` where shell mode (`command` without `args`) validated only dangerous patterns and could skip deny/allow policy enforcement.

## Root Cause
- Direct mode validated commands via `isCommandAllowed(...)`.
- Shell mode only used `validateShellCommand(...)` and then executed the shell script.
- As a result, deny-listed commands (or allow-list violations) could run when embedded in shell-mode command strings.

## Implemented Solution
1. Added shell tokenization and executable extraction in `runtime/src/tools/system/bash.ts`.
2. Enforced `isCommandAllowed(...)` for each extracted executable before shell execution.
3. Preserved existing shell safety pattern checks and execution flow.
4. Added regression and behavior tests in `runtime/src/tools/system/bash.test.ts`:
   - `#1321` regression case (`echo safe && python3 --version`) now denied.
   - allow-list enforcement in shell mode (`ls|wc` allowed, `grep` denied).
   - deny-list parity in shell mode (`python3`, `pkill`, `rm`, `curl` blocked).

## Security Impact
- Closes the shell-mode policy bypass class by applying deny/allow controls consistently across both execution modes.
- Restores expected policy invariants: deny-first semantics and allow-list restrictions regardless of command format.

## Verification
- `npx vitest run src/tools/system/bash.test.ts` (103 passed)
- `npm run typecheck`

Refs: #1321
