### PR TITLE
fix(runtime): harden Linux desktop bash env and deny exclusions

### DIFF
--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -61,6 +61,8 @@ import {
   summarizeLLMFailureForSurface,
   formatEvalScriptReply,
   didEvalScriptPass,
+  resolveBashToolEnv,
+  resolveBashDenyExclusions,
   DaemonManager,
   generateSystemdUnit,
   generateLaunchdPlist,
@@ -275,6 +277,72 @@ describe("resolveTraceLoggingConfig", () => {
       trace: { enabled: true, maxChars: 9_999_999 },
     });
     expect(high.maxChars).toBe(200_000);
+  });
+});
+
+describe("resolveBashToolEnv", () => {
+  const hostEnv = {
+    PATH: "/usr/bin:/bin",
+    HOME: "/home/tester",
+    USER: "tester",
+    SHELL: "/bin/zsh",
+    LANG: "en_US.UTF-8",
+    TERM: "xterm-256color",
+    SOLANA_RPC_URL: "https://rpc.example.com",
+    DOCKER_HOST: "unix:///var/run/docker.sock",
+    CARGO_HOME: "/home/tester/.cargo",
+    GOPATH: "/home/tester/go",
+    DISPLAY: ":0",
+    GITHUB_TOKEN: "ghs_secret",
+    GH_TOKEN: "ghp_secret",
+    NPM_TOKEN: "npm_secret",
+  } as NodeJS.ProcessEnv;
+
+  it("never forwards token-like keys by default", () => {
+    const env = resolveBashToolEnv({ desktop: { enabled: true } }, hostEnv);
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+    expect(env.GH_TOKEN).toBeUndefined();
+    expect(env.NPM_TOKEN).toBeUndefined();
+  });
+
+  it("includes desktop runtime keys only when desktop mode is enabled", () => {
+    const desktopEnv = resolveBashToolEnv({ desktop: { enabled: true } }, hostEnv);
+    expect(desktopEnv.DOCKER_HOST).toBe("unix:///var/run/docker.sock");
+    expect(desktopEnv.CARGO_HOME).toBe("/home/tester/.cargo");
+    expect(desktopEnv.GOPATH).toBe("/home/tester/go");
+    expect(desktopEnv.DISPLAY).toBe(":0");
+
+    const nonDesktopEnv = resolveBashToolEnv({ desktop: { enabled: false } }, hostEnv);
+    expect(nonDesktopEnv.DOCKER_HOST).toBeUndefined();
+    expect(nonDesktopEnv.CARGO_HOME).toBeUndefined();
+    expect(nonDesktopEnv.GOPATH).toBeUndefined();
+    expect(nonDesktopEnv.DISPLAY).toBeUndefined();
+  });
+});
+
+describe("resolveBashDenyExclusions", () => {
+  it("uses minimal Linux desktop exclusions", () => {
+    const exclusions = resolveBashDenyExclusions(
+      { desktop: { enabled: true } },
+      "linux",
+    );
+    expect(exclusions).toEqual(["killall", "pkill"]);
+  });
+
+  it("keeps desktop-only exclusions off for non-desktop Linux", () => {
+    const exclusions = resolveBashDenyExclusions(
+      { desktop: { enabled: false } },
+      "linux",
+    );
+    expect(exclusions).toBeUndefined();
+  });
+
+  it("preserves mac desktop exclusions", () => {
+    const exclusions = resolveBashDenyExclusions(
+      { desktop: { enabled: true } },
+      "darwin",
+    );
+    expect(exclusions).toEqual(["killall", "pkill", "curl", "wget"]);
   });
 });
 

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -217,6 +217,49 @@ const DEFAULT_HARD_BLOCKED_TASK_CLASSES: readonly DelegationHardBlockedTaskClass
     "stake_or_rewards",
     "credential_exfiltration",
   ];
+const BASH_SAFE_ENV_KEYS = ['PATH', 'HOME', 'USER', 'SHELL', 'LANG', 'TERM', 'SOLANA_RPC_URL'] as const;
+const BASH_DESKTOP_ENV_KEYS = ['DOCKER_HOST', 'CARGO_HOME', 'GOPATH', 'DISPLAY'] as const;
+const MAC_DESKTOP_BASH_DENY_EXCLUSIONS = ['killall', 'pkill', 'curl', 'wget'] as const;
+const LINUX_DESKTOP_BASH_DENY_EXCLUSIONS = ['killall', 'pkill'] as const;
+
+/**
+ * Build a minimal environment for system.bash.
+ * Never forwards token-like host secrets by default.
+ */
+export function resolveBashToolEnv(
+  config: Pick<GatewayConfig, 'desktop'>,
+  hostEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const envKeys = config.desktop?.enabled
+    ? [...BASH_SAFE_ENV_KEYS, ...BASH_DESKTOP_ENV_KEYS]
+    : BASH_SAFE_ENV_KEYS;
+
+  const safeEnv: Record<string, string> = {};
+  for (const key of envKeys) {
+    const value = hostEnv[key];
+    if (value !== undefined) {
+      safeEnv[key] = value;
+    }
+  }
+  return safeEnv;
+}
+
+/**
+ * Resolve deny-list exclusions for system.bash by platform.
+ * Linux desktop mode intentionally keeps this minimal.
+ */
+export function resolveBashDenyExclusions(
+  config: Pick<GatewayConfig, 'desktop'>,
+  platform: NodeJS.Platform = process.platform,
+): string[] | undefined {
+  if (platform === 'darwin') {
+    return [...MAC_DESKTOP_BASH_DENY_EXCLUSIONS];
+  }
+  if (config.desktop?.enabled && platform === 'linux') {
+    return [...LINUX_DESKTOP_BASH_DENY_EXCLUSIONS];
+  }
+  return undefined;
+}
 
 interface ResolvedSubAgentRuntimeConfig {
   readonly enabled: boolean;
@@ -3593,20 +3636,9 @@ export class DaemonManager {
   ): Promise<ToolRegistry> {
     const registry = new ToolRegistry({ logger: this.logger });
 
-    // Security: Only expose necessary environment variables to the bash tool.
-    // Never pass the full process.env as it contains secrets (API keys, private key paths, etc.).
-    const SAFE_ENV_KEYS = ['PATH', 'HOME', 'USER', 'SHELL', 'LANG', 'TERM', 'SOLANA_RPC_URL'];
-    // When desktop containers are enabled (Linux desktop agent mode), the host
-    // needs additional env keys for development tools (gh, docker, npm, cargo).
-    const DESKTOP_ENV_KEYS = ['GITHUB_TOKEN', 'GH_TOKEN', 'DOCKER_HOST', 'NPM_TOKEN', 'CARGO_HOME', 'GOPATH', 'DISPLAY'];
-    const envKeys = config.desktop?.enabled ? [...SAFE_ENV_KEYS, ...DESKTOP_ENV_KEYS] : SAFE_ENV_KEYS;
-    const safeEnv: Record<string, string> = {};
-    for (const key of envKeys) {
-      const value = process.env[key];
-      if (value !== undefined) {
-        safeEnv[key] = value;
-      }
-    }
+    // Security: Only expose a minimal host env to system.bash.
+    // Token-like secrets are intentionally excluded by default.
+    const safeEnv = resolveBashToolEnv(config);
 
     // Security: Do NOT use unrestricted mode — the default deny list prevents
     // dangerous commands (rm -rf, curl for exfiltration, etc.) from being
@@ -3615,16 +3647,9 @@ export class DaemonManager {
     // On macOS desktop agents, allow process management (killall, pkill) and
     // network tools for closing apps — the security boundary is Telegram user auth.
     //
-    // On Linux with desktop containers enabled, the host needs development tools
-    // (curl, wget, python, node, rm, chmod, etc.) while still blocking shell
-    // re-invocation (bash, sh, env, xargs) to preserve the execFile() security model.
-    const isMacDesktop = process.platform === 'darwin';
-    const isLinuxDesktop = config.desktop?.enabled && process.platform !== 'darwin';
-    const denyExclusions = isMacDesktop
-      ? ['killall', 'pkill', 'curl', 'wget']
-      : isLinuxDesktop
-        ? ['curl', 'wget', 'python', 'python3', 'node', 'rm', 'chmod', 'chown', 'tee', 'awk', 'killall', 'pkill']
-        : undefined;
+    // On Linux desktop mode keep exclusions minimal (process cleanup only)
+    // to reduce command-exfiltration and interpreter bypass surface.
+    const denyExclusions = resolveBashDenyExclusions(config);
 
     registry.register(createBashTool({
       logger: this.logger,


### PR DESCRIPTION
## Summary
This PR fixes the Linux desktop-mode security gap from #1324 by hardening `system.bash` defaults in gateway tool registration.

## Security context
Issue #1324 identified two coupled risks in desktop Linux mode:
1. Token-like host secrets (`GITHUB_TOKEN`, `GH_TOKEN`, `NPM_TOKEN`) were forwarded into `system.bash` env.
2. Linux desktop mode broadly removed deny-list entries for network/interpreter/destructive commands (`curl`, `wget`, `python`, `node`, `rm`, etc.).

Together, this increased secret exposure and exfiltration potential in an LLM-executed shell surface.

## Root cause
`createToolRegistry()` in `daemon.ts` used a desktop env key set that included token secrets and used a broad non-macOS deny-exclusion list.

## Changes
### 1) Env filtering hardening
- Added `resolveBashToolEnv()`.
- Keeps a minimal safe baseline (`PATH`, `HOME`, `USER`, `SHELL`, `LANG`, `TERM`, `SOLANA_RPC_URL`).
- In desktop mode, allows only runtime-oriented additions (`DOCKER_HOST`, `CARGO_HOME`, `GOPATH`, `DISPLAY`).
- **No token-like secrets are forwarded by default** (`GITHUB_TOKEN`, `GH_TOKEN`, `NPM_TOKEN` removed).

### 2) Deny-exclusion hardening
- Added `resolveBashDenyExclusions()`.
- Preserves current mac behavior (`killall`, `pkill`, `curl`, `wget`).
- Linux desktop mode is now explicitly minimal: `killall`, `pkill` only.
- Removes broad Linux re-allows for interpreters/network/destructive-capable commands.

### 3) Regression tests
Added tests in `runtime/src/gateway/daemon.test.ts` for:
- env filtering and token exclusion behavior,
- desktop/non-desktop env key resolution,
- platform-specific deny-exclusion resolution (linux/mac).

## Behavioral impact
- `system.bash` in Linux desktop mode no longer receives host token secrets by default.
- Linux desktop mode no longer re-allows high-risk command classes by default.
- Existing mac desktop deny-exclusion behavior remains unchanged.

## Test evidence
Executed:

```bash
npm --prefix /Users/pchmirenko/Desktop/AgenC/runtime run test -- src/gateway/daemon.test.ts
```

Result:
- 1/1 test files passed
- 67/67 tests passed

Fixes #1324
