### PR TITLE
fix(runtime): harden gateway auth for dotted messages and non-local binds

### DIFF
--- a/runtime/src/gateway/config-watcher.test.ts
+++ b/runtime/src/gateway/config-watcher.test.ts
@@ -10,6 +10,8 @@ function makeConfig(desktop?: Record<string, unknown>): Record<string, unknown> 
   };
 }
 
+const AUTH_SECRET = "test-secret-that-is-at-least-32-chars!!";
+
 describe("validateGatewayConfig desktop resource limits", () => {
   it("accepts valid desktop.maxMemory and desktop.maxCpu", () => {
     const result = validateGatewayConfig(
@@ -148,5 +150,35 @@ describe("validateGatewayConfig desktop resource limits", () => {
     expect(result.errors).toContain(
       "llm.subagents.hardBlockedTaskClasses[0] must be one of: wallet_signing, wallet_transfer, stake_or_rewards, destructive_host_mutation, credential_exfiltration",
     );
+  });
+});
+
+describe("validateGatewayConfig auth safety for bind address", () => {
+  it("rejects non-local bind without auth.secret", () => {
+    const result = validateGatewayConfig({
+      ...makeConfig(),
+      gateway: { port: 3100, bind: "0.0.0.0" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain(
+      "auth.secret is required when gateway.bind is non-local",
+    );
+  });
+
+  it("accepts non-local bind with auth.secret", () => {
+    const result = validateGatewayConfig({
+      ...makeConfig(),
+      gateway: { port: 3100, bind: "0.0.0.0" },
+      auth: { secret: AUTH_SECRET },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts loopback bind without auth.secret", () => {
+    const result = validateGatewayConfig({
+      ...makeConfig(),
+      gateway: { port: 3100, bind: "127.0.0.1" },
+    });
+    expect(result.valid).toBe(true);
   });
 });

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -120,6 +120,25 @@ const VALID_MESSAGING_MODES: ReadonlySet<string> = new Set([
 const DOCKER_MEMORY_LIMIT_RE = /^\d+(?:[bkmg])?$/i;
 const DOCKER_CPU_LIMIT_RE = /^(?:\d+(?:\.\d+)?|\.\d+)$/;
 
+function normalizeBindAddress(bind: string): string {
+  const normalized = bind.trim().toLowerCase();
+  if (normalized.startsWith("[") && normalized.endsWith("]")) {
+    return normalized.slice(1, -1);
+  }
+  return normalized;
+}
+
+function isLoopbackBind(bind: string | undefined): boolean {
+  if (bind === undefined) return true;
+  const normalized = normalizeBindAddress(bind);
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "::ffff:127.0.0.1"
+  );
+}
+
 /** Type predicate — returns true when `obj` satisfies the GatewayConfig shape. */
 export function isValidGatewayConfig(obj: unknown): obj is GatewayConfig {
   return validateGatewayConfig(obj).valid;
@@ -964,6 +983,18 @@ export function validateGatewayConfig(obj: unknown): ValidationResult {
         errors.push("auth.localBypass must be a boolean");
       }
     }
+  }
+
+  const bindAddress =
+    isRecord(obj.gateway) && typeof obj.gateway.bind === "string"
+      ? obj.gateway.bind
+      : undefined;
+  const authSecret =
+    isRecord(obj.auth) && typeof obj.auth.secret === "string"
+      ? obj.auth.secret
+      : undefined;
+  if (!isLoopbackBind(bindAddress) && !authSecret?.trim()) {
+    errors.push("auth.secret is required when gateway.bind is non-local");
   }
 
   // desktop (optional)

--- a/runtime/src/gateway/gateway.test.ts
+++ b/runtime/src/gateway/gateway.test.ts
@@ -320,6 +320,57 @@ describe("Gateway", () => {
       expect(response.type).toBe("status");
     });
 
+    it("no auth config rejects unauthenticated chat.message from non-local client", async () => {
+      await gateway.start();
+      const webchatHandler = { handleMessage: vi.fn() };
+      gateway.setWebChatHandler(webchatHandler);
+
+      const mockSocket = createMockSocket();
+      const mockRequest = { socket: { remoteAddress: "192.168.1.100" } };
+      wssConnectionHandler!(mockSocket, mockRequest);
+
+      mockSocket.simulateMessage({
+        type: "chat.message",
+        payload: { content: "hello" },
+      });
+
+      expect(webchatHandler.handleMessage).not.toHaveBeenCalled();
+      const response = JSON.parse(mockSocket.send.mock.calls[0][0]);
+      expect(response.type).toBe("error");
+      expect(response.error).toBe("Authentication required");
+    });
+
+    it("no auth config allows local chat.message via webchat handler", async () => {
+      await gateway.start();
+      const webchatHandler = {
+        handleMessage: vi.fn(
+          (
+            _clientId: string,
+            _type: string,
+            _msg: unknown,
+            send: (response: unknown) => void,
+          ) => {
+            send({ type: "chat.message", payload: { ok: true } });
+          },
+        ),
+      };
+      gateway.setWebChatHandler(webchatHandler);
+
+      const mockSocket = createMockSocket();
+      const mockRequest = { socket: { remoteAddress: "127.0.0.1" } };
+      wssConnectionHandler!(mockSocket, mockRequest);
+
+      mockSocket.simulateMessage({
+        type: "chat.message",
+        payload: { content: "hello" },
+      });
+
+      expect(webchatHandler.handleMessage).toHaveBeenCalledTimes(1);
+      const response = JSON.parse(mockSocket.send.mock.calls[0][0]);
+      expect(response.type).toBe("chat.message");
+      expect(response.payload.ok).toBe(true);
+    });
+
     it("auth config rejects unauthenticated non-local client", async () => {
       const authGw = new Gateway(
         makeConfig({ auth: { secret: AUTH_SECRET } }),
@@ -334,6 +385,32 @@ describe("Gateway", () => {
       mockSocket.simulateMessage({ type: "status" });
 
       expect(mockSocket.send).toHaveBeenCalled();
+      const response = JSON.parse(mockSocket.send.mock.calls[0][0]);
+      expect(response.type).toBe("error");
+      expect(response.error).toBe("Authentication required");
+
+      await authGw.stop();
+    });
+
+    it("auth config rejects unauthenticated chat.message", async () => {
+      const authGw = new Gateway(
+        makeConfig({ auth: { secret: AUTH_SECRET } }),
+        { logger: silentLogger },
+      );
+      await authGw.start();
+      const webchatHandler = { handleMessage: vi.fn() };
+      authGw.setWebChatHandler(webchatHandler);
+
+      const mockSocket = createMockSocket();
+      const mockRequest = { socket: { remoteAddress: "192.168.1.100" } };
+      wssConnectionHandler!(mockSocket, mockRequest);
+
+      mockSocket.simulateMessage({
+        type: "chat.message",
+        payload: { content: "hello" },
+      });
+
+      expect(webchatHandler.handleMessage).not.toHaveBeenCalled();
       const response = JSON.parse(mockSocket.send.mock.calls[0][0]);
       expect(response.type).toBe("error");
       expect(response.error).toBe("Authentication required");
@@ -383,6 +460,45 @@ describe("Gateway", () => {
       mockSocket.simulateMessage({ type: "status" });
       const statusResponse = JSON.parse(mockSocket.send.mock.calls[1][0]);
       expect(statusResponse.type).toBe("status");
+
+      await authGw.stop();
+    });
+
+    it("forwards chat.message after authentication", async () => {
+      const authGw = new Gateway(
+        makeConfig({ auth: { secret: AUTH_SECRET } }),
+        { logger: silentLogger },
+      );
+      await authGw.start();
+      const webchatHandler = {
+        handleMessage: vi.fn(
+          (
+            _clientId: string,
+            _type: string,
+            _msg: unknown,
+            send: (response: unknown) => void,
+          ) => {
+            send({ type: "chat.message", payload: { ok: true } });
+          },
+        ),
+      };
+      authGw.setWebChatHandler(webchatHandler);
+
+      const mockSocket = createMockSocket();
+      const mockRequest = { socket: { remoteAddress: "192.168.1.100" } };
+      wssConnectionHandler!(mockSocket, mockRequest);
+
+      const token = createToken(AUTH_SECRET, "agent_001");
+      mockSocket.simulateMessage({ type: "auth", payload: { token } });
+      mockSocket.simulateMessage({
+        type: "chat.message",
+        payload: { content: "hello" },
+      });
+
+      expect(webchatHandler.handleMessage).toHaveBeenCalledTimes(1);
+      const response = JSON.parse(mockSocket.send.mock.calls[1][0]);
+      expect(response.type).toBe("chat.message");
+      expect(response.payload.ok).toBe(true);
 
       await authGw.stop();
     });

--- a/runtime/src/gateway/gateway.ts
+++ b/runtime/src/gateway/gateway.ts
@@ -339,7 +339,9 @@ export class Gateway {
           remoteAddress === "::1" ||
           remoteAddress === "::ffff:127.0.0.1");
 
-      if (!authSecret || (isLocal && localBypass)) {
+      // In no-secret mode, only loopback connections are auto-authenticated.
+      // With a configured secret, local bypass remains opt-in.
+      if ((!authSecret && isLocal) || (isLocal && localBypass)) {
         this.authenticatedClients.add(clientId);
       }
 
@@ -429,14 +431,25 @@ export class Gateway {
     // Sanitize id: only echo back if it's a string
     const id = typeof msg.id === "string" ? msg.id : undefined;
 
-    // Auth guard: if auth is configured and client is not authenticated,
-    // only allow 'auth' and 'ping' messages
+    // Auth guard for secret-backed auth: if auth is configured and client is
+    // not authenticated, only allow 'auth' and 'ping' messages.
     if (
       this._config.auth?.secret &&
       !this.authenticatedClients.has(clientId) &&
       msg.type !== "auth" &&
       msg.type !== "ping"
     ) {
+      this.sendResponse(socket, {
+        type: "error",
+        error: "Authentication required",
+        id,
+      });
+      return;
+    }
+
+    // Any dotted control-plane message routes into channel/plugin handlers.
+    // Require an authenticated client even when auth.secret is unset.
+    if (msg.type.includes(".") && !this.authenticatedClients.has(clientId)) {
       this.sendResponse(socket, {
         type: "error",
         error: "Authentication required",


### PR DESCRIPTION
## Summary
This PR fixes issue #1320 by hardening gateway authentication behavior for WebSocket control-plane messages and rejecting insecure bind/auth configuration combinations.

Closes #1320.

## Problem
Two behaviors combined to create an unsafe path:

1. Clients could become effectively authenticated when `auth.secret` was unset.
2. Dotted message types (for example `chat.message`) were forwarded into WebChat handler paths without a mandatory auth check.

If `gateway.bind` was exposed beyond loopback and no secret was configured, this enabled unauthenticated chat execution paths.

## What Changed
### 1) Enforce secure bind/auth policy at config validation
**File:** `runtime/src/gateway/config-watcher.ts`

- Added loopback bind normalization/helpers.
- Added validation rule:
  - `auth.secret is required when gateway.bind is non-local`
- This makes insecure combinations fail validation/startup early.

### 2) Require authentication for dotted control-plane messages
**File:** `runtime/src/gateway/gateway.ts`

- Added guard that rejects any dotted message type (`type.includes(".")`) unless the client is authenticated.
- Response for unauthenticated dotted messages is:
  - `{ type: "error", error: "Authentication required" }`

### 3) Tighten no-secret auto-auth behavior
**File:** `runtime/src/gateway/gateway.ts`

- In no-secret mode, auto-auth is now loopback-only (`127.0.0.1`, `::1`, `::ffff:127.0.0.1`).
- No longer auto-authenticates non-local/unknown clients when secret is absent.

## Tests Added
### Gateway auth behavior tests
**File:** `runtime/src/gateway/gateway.test.ts`

- `no auth config rejects unauthenticated chat.message from non-local client`
- `no auth config allows local chat.message via webchat handler`
- `auth config rejects unauthenticated chat.message`
- `forwards chat.message after authentication`

### Config validation tests
**File:** `runtime/src/gateway/config-watcher.test.ts`

- `rejects non-local bind without auth.secret`
- `accepts non-local bind with auth.secret`
- `accepts loopback bind without auth.secret`

## Validation Performed
- `npx vitest run src/gateway/gateway.test.ts src/gateway/config-watcher.test.ts`
- `npm run typecheck --prefix runtime`

Both passed.

## Security Outcome
- Insecure config is rejected before runtime (`non-local bind + missing secret`).
- `chat.message` (and other dotted message paths) now require authenticated clients.
- Unauthenticated control-plane clients can no longer reach WebChat handler paths via dotted messages.
