### PR TITLE
fix: resolve bn.js vulnerability (GHSA-378v-28hj-76wf)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/chai-as-promised": "^7.1.8",
     "@types/mocha": "^10.0.0",
     "anchor-litesvm": "^0.2.1",
-    "bn.js": "^5.2.2",
+    "bn.js": "^5.2.3",
     "chai": "^4.3.0",
     "chai-as-promised": "^7.1.2",
     "litesvm": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1206,10 +1206,10 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1, bn.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz"
-  integrity sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==
+bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1, bn.js@^5.2.2, bn.js@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz"
+  integrity sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==
 
 body-parser@^2.2.1:
   version "2.2.2"
@@ -2587,7 +2587,7 @@ keyv@^5.5.5, keyv@^5.6.0:
 
 "libsignal@git+https://github.com/whiskeysockets/libsignal-node.git":
   version "2.0.1"
-  resolved "git+ssh://git@github.com/whiskeysockets/libsignal-node.git"
+  resolved "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67"
   integrity sha512-yn/Hqz3DY3e7t+rUQ38kzlPiX5tdY5R/cLgjfUdZCUFWKoFTBIZNOz8o+oWvkr+ubPZ4IE66/OBFCSPDUa+p6w==
   dependencies:
     curve25519-js "^0.0.4"


### PR DESCRIPTION
## Summary
- upgrade `bn.js` from `^5.2.2` to `^5.2.3` in `package.json`
- update `yarn.lock` resolution to `bn.js@5.2.3`
- pin `libsignal` git dependency with an explicit commit hash in `yarn.lock` to fix Yarn resolution (`Commit hash required`)

## Validation
- `yarn install --frozen-lockfile` (with isolated cache) ✅
- `yarn why bn.js` shows `bn.js@5.2.3` hoisted ✅
- `yarn audit --json` no longer reports `GHSA-378v-28hj-76wf` / `bn.js` ✅
- `yarn test` ❌ fails early due missing `tsup` in this repo setup (`sh: tsup: command not found`), unrelated to this change

Closes #1323
