### PR TITLE
fix(program): harden dispute token settlement and slash accounting

### DIFF
--- a/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
@@ -146,7 +146,6 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
     };
 
     require!(worker_lost, CoordinationError::InvalidInput);
-    require!(worker_agent.stake > 0, CoordinationError::InsufficientStake);
 
     // Calculate slash from stake snapshot and cap by current stake (fix #836).
     let slash_amount = calculate_slash_amount(
@@ -154,8 +153,6 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
         worker_agent.stake,
         config.slash_percentage,
     )?;
-
-    require!(slash_amount > 0, CoordinationError::InvalidSlashAmount);
 
     // Apply reputation penalty for losing the dispute (before lamport transfer to satisfy borrow checker)
     apply_reputation_penalty(worker_agent, &clock)?;
@@ -169,8 +166,7 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
 
     // Token-denominated disputes that slash a losing worker must settle reserved
     // tokens during this instruction.
-    let token_task_requires_settlement =
-        ctx.accounts.task.reward_mint.is_some() && worker_lost && slash_amount > 0;
+    let token_task_requires_settlement = ctx.accounts.task.reward_mint.is_some() && worker_lost;
 
     // If any token accounts are provided, require a complete set.
     let token_accounts_provided = ctx.accounts.escrow.is_some()
@@ -214,7 +210,9 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
         let bump_slice = [escrow.bump];
         let escrow_seeds: &[&[u8]] = &[b"escrow", task_key_bytes.as_ref(), &bump_slice];
 
-        let token_slash_amount = slash_amount.min(token_escrow.amount);
+        // ResolveDispute leaves only the token slash reserve in escrow ATA.
+        // Settling the slash transfers the full remaining escrow token balance.
+        let token_slash_amount = token_escrow.amount;
         if token_slash_amount > 0 {
             transfer_tokens_from_escrow(
                 token_escrow,
@@ -237,6 +235,12 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
         escrow.is_closed = true;
         escrow.close(ctx.accounts.treasury.to_account_info())?;
     }
+
+    // If neither lamports nor token reserves can be slashed, fail explicitly.
+    require!(
+        slash_amount > 0 || token_task_requires_settlement,
+        CoordinationError::InvalidSlashAmount
+    );
 
     // Perform lamport transfer after all CPIs. Direct lamport mutations are
     // checked against CPI boundaries by the runtime.

--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -21,6 +21,7 @@ use crate::instructions::dispute_helpers::{
 use crate::instructions::lamport_transfer::{credit_lamports, debit_lamports, transfer_lamports};
 use crate::instructions::token_helpers::{
     close_token_escrow, transfer_tokens_from_escrow, validate_token_account,
+    validate_unchecked_token_mint,
 };
 use crate::state::{
     AgentRegistration, Dispute, DisputeStatus, ProtocolConfig, Task, TaskClaim, TaskEscrow,
@@ -209,20 +210,73 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
             let task_key_bytes = task_key.to_bytes();
             let bump_slice = [escrow.bump];
             let escrow_seeds: &[&[u8]] = &[b"escrow", task_key_bytes.as_ref(), &bump_slice];
+            let creator_ta_info = ctx
+                .accounts
+                .creator_token_account
+                .as_ref()
+                .map(|a| a.to_account_info());
+            let worker_ta_info = ctx
+                .accounts
+                .worker_token_account_ata
+                .as_ref()
+                .map(|a| a.to_account_info());
+
+            // Validate destination token accounts before any escrow transfers.
+            // This prevents permissionless expiration callers from redirecting payouts.
+            match (no_votes, worker_completed) {
+                (true, true) => {
+                    let worker_ta = worker_ta_info
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    validate_unchecked_token_mint(
+                        worker_ta,
+                        &mint.key(),
+                        &ctx.accounts
+                            .worker_authority
+                            .as_ref()
+                            .expect("worker authority validated above")
+                            .key(),
+                    )?;
+                }
+                (true, false) => {
+                    let creator_ta = creator_ta_info
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    let worker_ta = worker_ta_info
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    validate_unchecked_token_mint(
+                        creator_ta,
+                        &mint.key(),
+                        &ctx.accounts.creator.key(),
+                    )?;
+                    validate_unchecked_token_mint(
+                        worker_ta,
+                        &mint.key(),
+                        &ctx.accounts
+                            .worker_authority
+                            .as_ref()
+                            .expect("worker authority validated above")
+                            .key(),
+                    )?;
+                }
+                (false, _) => {
+                    let creator_ta = creator_ta_info
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    validate_unchecked_token_mint(
+                        creator_ta,
+                        &mint.key(),
+                        &ctx.accounts.creator.key(),
+                    )?;
+                }
+            }
 
             let (ca, wa) = distribute_expired_tokens(
                 token_escrow,
                 &escrow.to_account_info(),
-                ctx.accounts
-                    .creator_token_account
-                    .as_ref()
-                    .map(|a| a.to_account_info())
-                    .as_ref(),
-                ctx.accounts
-                    .worker_token_account_ata
-                    .as_ref()
-                    .map(|a| a.to_account_info())
-                    .as_ref(),
+                creator_ta_info.as_ref(),
+                worker_ta_info.as_ref(),
                 remaining_funds,
                 worker_completed,
                 no_votes,

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -12,6 +12,7 @@ use crate::instructions::lamport_transfer::{credit_lamports, debit_lamports, tra
 use crate::instructions::slash_helpers::calculate_slash_amount;
 use crate::instructions::token_helpers::{
     close_token_escrow, transfer_tokens_from_escrow, validate_token_account,
+    validate_unchecked_token_mint,
 };
 use crate::state::{
     AgentRegistration, Dispute, DisputeStatus, ProtocolConfig, ResolutionType, Task, TaskClaim,
@@ -56,7 +57,6 @@ pub struct ResolveDispute<'info> {
 
     #[account(
         constraint = resolver.key() == protocol_config.authority
-            || resolver.key() == dispute.initiator_authority
             @ CoordinationError::UnauthorizedResolver
     )]
     pub resolver: Signer<'info>,
@@ -130,12 +130,6 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         CoordinationError::DisputeNotActive
     );
 
-    // Prevent initiator from resolving their own dispute (fix #458)
-    require!(
-        ctx.accounts.resolver.key() != dispute.initiator_authority,
-        CoordinationError::InitiatorCannotResolve
-    );
-
     // Verify voting period has ended
     require!(
         clock.unix_timestamp >= dispute.voting_deadline,
@@ -175,8 +169,12 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         CoordinationError::InvalidStatusTransition
     );
 
-    let (approved, outcome) =
-        determine_dispute_outcome(dispute.votes_for, dispute.votes_against, total_votes, config)?;
+    let (approved, outcome) = determine_dispute_outcome(
+        dispute.votes_for,
+        dispute.votes_against,
+        total_votes,
+        config,
+    )?;
 
     // Calculate remaining escrow funds
     let remaining_funds = escrow
@@ -223,12 +221,16 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         0
     };
     let token_slash_reserve = if is_token_task && worker_lost {
-        slash_amount.min(remaining_funds)
+        remaining_funds
+            .checked_mul(config.slash_percentage as u64)
+            .ok_or(CoordinationError::ArithmeticOverflow)?
+            .checked_div(PERCENT_BASE)
+            .ok_or(CoordinationError::ArithmeticOverflow)?
     } else {
         0
     };
-    let worker_slash_pending = worker_lost && slash_amount > 0;
-    let defer_token_escrow_close = is_token_task && worker_slash_pending;
+    let worker_slash_pending = worker_lost && (slash_amount > 0 || token_slash_reserve > 0);
+    let defer_token_escrow_close = is_token_task && token_slash_reserve > 0;
     let defer_worker_claim_close = worker_slash_pending;
 
     // Pre-compute escrow PDA signer seeds (used by all token paths)
@@ -243,11 +245,17 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
                 if is_token_task {
                     let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
                     let token_program = ctx.accounts.token_program.as_ref().unwrap();
+                    let mint = ctx.accounts.reward_mint.as_ref().unwrap();
                     require!(
                         ctx.accounts.creator_token_account.is_some(),
                         CoordinationError::MissingTokenAccounts
                     );
                     let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
+                    validate_unchecked_token_mint(
+                        &creator_ta.to_account_info(),
+                        &mint.key(),
+                        &ctx.accounts.creator.key(),
+                    )?;
                     let creator_refund = remaining_funds
                         .checked_sub(token_slash_reserve)
                         .ok_or(CoordinationError::ArithmeticOverflow)?;
@@ -282,11 +290,17 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
                 if is_token_task {
                     let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
                     let token_program = ctx.accounts.token_program.as_ref().unwrap();
+                    let mint = ctx.accounts.reward_mint.as_ref().unwrap();
                     require!(
                         ctx.accounts.worker_token_account_ata.is_some(),
                         CoordinationError::MissingTokenAccounts
                     );
                     let worker_ta = ctx.accounts.worker_token_account_ata.as_ref().unwrap();
+                    validate_unchecked_token_mint(
+                        &worker_ta.to_account_info(),
+                        &mint.key(),
+                        &worker_authority.key(),
+                    )?;
                     transfer_tokens_from_escrow(
                         token_escrow,
                         &worker_ta.to_account_info(),
@@ -330,6 +344,7 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
                     if is_token_task {
                         let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
                         let token_program = ctx.accounts.token_program.as_ref().unwrap();
+                        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
                         require!(
                             ctx.accounts.creator_token_account.is_some()
                                 && ctx.accounts.worker_token_account_ata.is_some(),
@@ -337,6 +352,16 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
                         );
                         let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
                         let worker_ta = ctx.accounts.worker_token_account_ata.as_ref().unwrap();
+                        validate_unchecked_token_mint(
+                            &creator_ta.to_account_info(),
+                            &mint.key(),
+                            &ctx.accounts.creator.key(),
+                        )?;
+                        validate_unchecked_token_mint(
+                            &worker_ta.to_account_info(),
+                            &mint.key(),
+                            &worker_authority.key(),
+                        )?;
                         transfer_tokens_from_escrow(
                             token_escrow,
                             &creator_ta.to_account_info(),
@@ -377,11 +402,17 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         if is_token_task {
             let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
             let token_program = ctx.accounts.token_program.as_ref().unwrap();
+            let mint = ctx.accounts.reward_mint.as_ref().unwrap();
             require!(
                 ctx.accounts.creator_token_account.is_some(),
                 CoordinationError::MissingTokenAccounts
             );
             let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
+            validate_unchecked_token_mint(
+                &creator_ta.to_account_info(),
+                &mint.key(),
+                &ctx.accounts.creator.key(),
+            )?;
             transfer_tokens_from_escrow(
                 token_escrow,
                 &creator_ta.to_account_info(),

--- a/tests/spl-token-tasks.ts
+++ b/tests/spl-token-tasks.ts
@@ -306,10 +306,17 @@ describe("spl-token-tasks (issue #860)", () => {
     maxWorkers?: number;
     taskType?: number;
     constraintHash?: number[] | null;
+    deadline?: BN;
   }) {
     const taskPda = deriveTaskPda(opts.creatorKp.publicKey, opts.taskId);
     const escrowPda = deriveEscrowPda(taskPda);
     const escrowAta = deriveEscrowAta(opts.tokenMint, escrowPda);
+
+    const minFutureDeadline = new BN(Number(svm.getClock().unixTimestamp) + 7200);
+    const deadline =
+      opts.deadline && opts.deadline.gt(minFutureDeadline)
+        ? opts.deadline
+        : minFutureDeadline;
 
     await program.methods
       .createTask(
@@ -318,7 +325,7 @@ describe("spl-token-tasks (issue #860)", () => {
         Buffer.from("Token task description".padEnd(64, "\0")),
         new BN(opts.rewardAmount),
         opts.maxWorkers ?? 1,
-        getDefaultDeadline(),
+        deadline,
         opts.taskType ?? TASK_TYPE_EXCLUSIVE,
         opts.constraintHash ?? null,
         0,
@@ -1531,7 +1538,9 @@ describe("spl-token-tasks (issue #860)", () => {
           config.slashPercentage) /
           100,
       );
-      const expectedReserved = Math.min(expectedSlash, rewardAmount);
+      const expectedReserved = Math.floor(
+        (rewardAmount * config.slashPercentage) / 100,
+      );
       expect(workerBeforeResolve.stake.toNumber()).to.be.greaterThan(0);
       expect(expectedSlash).to.be.greaterThan(0);
       expect(taskBeforeResolve.rewardMint?.toBase58()).to.equal(
@@ -1654,6 +1663,216 @@ describe("spl-token-tasks (issue #860)", () => {
         await provider.connection.getAccountInfo(escrowAta);
       expect(escrowPdaAccount).to.equal(null);
       expect(escrowAtaAccount).to.equal(null);
+    });
+  });
+
+  describe("token dispute destination validation", () => {
+    it("should reject resolveDispute when creator token destination is not owned by creator", async () => {
+      const taskId = makeId("t-resolve-val");
+      const disputeId = makeId("d-resolve-val");
+      const rewardAmount = 3_000_000_000;
+
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+      const arbiter1Pda = deriveAgentPda(arbiter1AgentId);
+      const arbiter2Pda = deriveAgentPda(arbiter2AgentId);
+      const arbiter3Pda = deriveAgentPda(arbiter3AgentId);
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+      });
+
+      const claimPda = await claimTask(taskPda, workerAgentPda, worker);
+      const disputePda = deriveDisputePda(disputeId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.from("resolve-validation-evidence".padEnd(32, "\0"))),
+          RESOLUTION_TYPE_REFUND,
+          VALID_EVIDENCE,
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: creatorAgentPda,
+          protocolConfig: protocolPda,
+          initiatorClaim: null,
+          workerAgent: workerAgentPda,
+          workerClaim: claimPda,
+          authority: creator.publicKey,
+        })
+        .signers([creator])
+        .rpc();
+
+      const arbiters = [
+        { kp: arbiter1, pda: arbiter1Pda },
+        { kp: arbiter2, pda: arbiter2Pda },
+        { kp: arbiter3, pda: arbiter3Pda },
+      ];
+
+      for (const arbiter of arbiters) {
+        const votePda = deriveVotePda(disputePda, arbiter.pda);
+        const authorityVotePda = deriveAuthorityVotePda(
+          disputePda,
+          arbiter.kp.publicKey,
+        );
+        await program.methods
+          .voteDispute(true)
+          .accountsPartial({
+            dispute: disputePda,
+            task: taskPda,
+            workerClaim: claimPda,
+            defendantAgent: workerAgentPda,
+            vote: votePda,
+            authorityVote: authorityVotePda,
+            arbiter: arbiter.pda,
+            protocolConfig: protocolPda,
+            authority: arbiter.kp.publicKey,
+          })
+          .signers([arbiter.kp])
+          .rpc();
+      }
+
+      const secondsUntilVotingEnds = Math.max(
+        1,
+        (
+          await program.account.dispute.fetch(disputePda)
+        ).votingDeadline.toNumber() -
+          Number(svm.getClock().unixTimestamp) +
+          1,
+      );
+      advanceClock(svm, secondsUntilVotingEnds);
+
+      try {
+        await program.methods
+          .resolveDispute()
+          .accountsPartial({
+            dispute: disputePda,
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            resolver: provider.wallet.publicKey,
+            creator: creator.publicKey,
+            workerClaim: claimPda,
+            worker: workerAgentPda,
+            workerAuthority: worker.publicKey,
+            systemProgram: SystemProgram.programId,
+            tokenEscrowAta: escrowAta,
+            creatorTokenAccount: workerAta, // wrong owner: worker, not creator
+            workerTokenAccountAta: workerAta,
+            treasuryTokenAccount: treasuryAta,
+            rewardMint: mint,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .remainingAccounts([
+            {
+              pubkey: deriveVotePda(disputePda, arbiter1Pda),
+              isSigner: false,
+              isWritable: true,
+            },
+            { pubkey: arbiter1Pda, isSigner: false, isWritable: true },
+            {
+              pubkey: deriveVotePda(disputePda, arbiter2Pda),
+              isSigner: false,
+              isWritable: true,
+            },
+            { pubkey: arbiter2Pda, isSigner: false, isWritable: true },
+            {
+              pubkey: deriveVotePda(disputePda, arbiter3Pda),
+              isSigner: false,
+              isWritable: true,
+            },
+            { pubkey: arbiter3Pda, isSigner: false, isWritable: true },
+          ])
+          .rpc();
+        expect.fail("resolveDispute should reject unauthorized creator token destination");
+      } catch (e: unknown) {
+        const err = e as any;
+        expect(err.error?.errorCode?.code).to.equal("InvalidTokenAccountOwner");
+      }
+    });
+
+    it("should reject permissionless expireDispute when creator token destination is not owned by creator", async () => {
+      const taskId = makeId("t-expire-val");
+      const disputeId = makeId("d-expire-val");
+      const rewardAmount = 2_000_000_000;
+
+      const creatorAgentPda = deriveAgentPda(creatorAgentId);
+      const workerAgentPda = deriveAgentPda(workerAgentId);
+
+      const { taskPda, escrowPda, escrowAta } = await createTokenTask({
+        taskId,
+        tokenMint: mint,
+        creatorKp: creator,
+        creatorAgentPda,
+        creatorTokenAccount: creatorAta,
+        rewardAmount,
+      });
+
+      const claimPda = await claimTask(taskPda, workerAgentPda, worker);
+      const disputePda = deriveDisputePda(disputeId);
+
+      await program.methods
+        .initiateDispute(
+          Array.from(disputeId),
+          Array.from(taskId),
+          Array.from(Buffer.from("expire-validation-evidence".padEnd(32, "\0"))),
+          RESOLUTION_TYPE_REFUND,
+          VALID_EVIDENCE,
+        )
+        .accountsPartial({
+          dispute: disputePda,
+          task: taskPda,
+          agent: creatorAgentPda,
+          protocolConfig: protocolPda,
+          initiatorClaim: null,
+          workerAgent: workerAgentPda,
+          workerClaim: claimPda,
+          authority: creator.publicKey,
+        })
+        .signers([creator])
+        .rpc();
+
+      const dispute = await program.account.dispute.fetch(disputePda);
+      const secondsUntilExpirable = Math.max(
+        1,
+        dispute.votingDeadline.toNumber() +
+          121 -
+          Number(svm.getClock().unixTimestamp),
+      );
+      advanceClock(svm, secondsUntilExpirable);
+
+      try {
+        await program.methods
+          .expireDispute()
+          .accountsPartial({
+            dispute: disputePda,
+            task: taskPda,
+            escrow: escrowPda,
+            protocolConfig: protocolPda,
+            creator: creator.publicKey,
+            workerClaim: claimPda,
+            worker: workerAgentPda,
+            workerAuthority: worker.publicKey,
+            tokenEscrowAta: escrowAta,
+            creatorTokenAccount: workerAta, // wrong owner: worker, not creator
+            workerTokenAccountAta: workerAta,
+            rewardMint: mint,
+            tokenProgram: TOKEN_PROGRAM_ID,
+          })
+          .rpc();
+        expect.fail("expireDispute should reject unauthorized creator token destination");
+      } catch (e: unknown) {
+        const err = e as any;
+        expect(err.error?.errorCode?.code).to.equal("InvalidTokenAccountOwner");
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary\n- enforce token destination owner/mint validation in dispute resolution and expiration paths\n- remove contradictory resolver authorization path and require protocol authority explicitly\n- normalize token slash reserve/settlement accounting for token-denominated disputes\n- add integration regressions for dispute token payout redirection and update token slash expectation\n\n## Testing\n- cargo test --manifest-path programs/agenc-coordination/Cargo.toml --lib\n- npx ts-mocha -p ./tsconfig.json -t 600000 tests/spl-token-tasks.ts\n- npm run test:fast