### PR TITLE
fix(solana): harden account handling and remove panic paths

### DIFF
--- a/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
@@ -90,7 +90,10 @@ pub struct ApplyDisputeSlash<'info> {
 }
 
 pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
-    require!(ctx.accounts.authority.is_signer, CoordinationError::InvalidInput);
+    require!(
+        ctx.accounts.authority.is_signer,
+        CoordinationError::InvalidInput
+    );
 
     let dispute = &mut ctx.accounts.dispute;
     let worker_agent = &mut ctx.accounts.worker_agent;
@@ -205,11 +208,36 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
             CoordinationError::MissingTokenAccounts
         );
 
-        let escrow = ctx.accounts.escrow.as_mut().unwrap();
-        let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-        let treasury_ta = ctx.accounts.treasury_token_account.as_ref().unwrap();
-        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
-        let token_program = ctx.accounts.token_program.as_ref().unwrap();
+        let escrow = ctx
+            .accounts
+            .escrow
+            .as_mut()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_escrow = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let treasury_ta = ctx
+            .accounts
+            .treasury_token_account
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let mint = ctx
+            .accounts
+            .reward_mint
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_program = ctx
+            .accounts
+            .token_program
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let expected_mint = ctx
+            .accounts
+            .task
+            .reward_mint
+            .ok_or(CoordinationError::InvalidTokenMint)?;
         let token_escrow_starting_amount =
             anchor_spl::token::accessor::amount(&token_escrow.to_account_info())
                 .map_err(|_| CoordinationError::TokenTransferFailed)?;
@@ -219,7 +247,7 @@ pub fn handler(ctx: Context<ApplyDisputeSlash>) -> Result<()> {
             CoordinationError::TaskNotFound
         );
         require!(
-            mint.key() == ctx.accounts.task.reward_mint.unwrap(),
+            mint.key() == expected_mint,
             CoordinationError::InvalidTokenMint
         );
         validate_token_account(token_escrow, &mint.key(), &escrow.key())?;

--- a/programs/agenc-coordination/src/instructions/apply_initiator_slash.rs
+++ b/programs/agenc-coordination/src/instructions/apply_initiator_slash.rs
@@ -59,7 +59,10 @@ pub struct ApplyInitiatorSlash<'info> {
 }
 
 pub fn handler(ctx: Context<ApplyInitiatorSlash>) -> Result<()> {
-    require!(ctx.accounts.authority.is_signer, CoordinationError::InvalidInput);
+    require!(
+        ctx.accounts.authority.is_signer,
+        CoordinationError::InvalidInput
+    );
 
     let dispute = &mut ctx.accounts.dispute;
     let task = &ctx.accounts.task;

--- a/programs/agenc-coordination/src/instructions/cancel_task.rs
+++ b/programs/agenc-coordination/src/instructions/cancel_task.rs
@@ -126,13 +126,32 @@ fn process_cancel_task_impl(ctx: Context<CancelTask>) -> Result<()> {
             CoordinationError::MissingTokenAccounts
         );
 
-        let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-        let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
-        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
-        let token_program = ctx.accounts.token_program.as_ref().unwrap();
+        let token_escrow = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let creator_ta = ctx
+            .accounts
+            .creator_token_account
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let mint = ctx
+            .accounts
+            .reward_mint
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_program = ctx
+            .accounts
+            .token_program
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let expected_mint = task
+            .reward_mint
+            .ok_or(CoordinationError::InvalidTokenMint)?;
 
         require!(
-            mint.key() == task.reward_mint.unwrap(),
+            mint.key() == expected_mint,
             CoordinationError::InvalidTokenMint
         );
         validate_token_account(token_escrow, &mint.key(), &escrow.key())?;
@@ -270,9 +289,21 @@ fn process_cancel_task_impl(ctx: Context<CancelTask>) -> Result<()> {
 
     // Close token escrow ATA AFTER all worker claims are processed
     if is_token_task {
-        let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-        let token_program = ctx.accounts.token_program.as_ref().unwrap();
-        let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
+        let token_escrow = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_program = ctx
+            .accounts
+            .token_program
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let creator_ta = ctx
+            .accounts
+            .creator_token_account
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
         let residual_amount = token_escrow_starting_amount
             .ok_or(CoordinationError::MissingTokenAccounts)?
             .checked_sub(refund_amount)

--- a/programs/agenc-coordination/src/instructions/complete_task.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task.rs
@@ -156,12 +156,27 @@ pub fn handler(
             CoordinationError::MissingTokenAccounts
         );
 
-        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
-        let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-        let treasury_ta = ctx.accounts.treasury_token_account.as_ref().unwrap();
+        let mint = ctx
+            .accounts
+            .reward_mint
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_escrow = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let treasury_ta = ctx
+            .accounts
+            .treasury_token_account
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let expected_mint = task
+            .reward_mint
+            .ok_or(CoordinationError::InvalidTokenMint)?;
 
         require!(
-            mint.key() == task.reward_mint.unwrap(),
+            mint.key() == expected_mint,
             CoordinationError::InvalidTokenMint
         );
 
@@ -179,7 +194,7 @@ pub fn handler(
             .accounts
             .worker_token_account
             .as_ref()
-            .unwrap()
+            .ok_or(CoordinationError::MissingTokenAccounts)?
             .to_account_info();
         validate_unchecked_token_mint(&worker_ta_info, &mint.key(), &ctx.accounts.authority.key())?;
 
@@ -192,7 +207,7 @@ pub fn handler(
                 .accounts
                 .token_program
                 .as_ref()
-                .unwrap()
+                .ok_or(CoordinationError::MissingTokenAccounts)?
                 .to_account_info(),
             escrow_authority: escrow.to_account_info(),
             escrow_bump: escrow.bump,

--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -592,19 +592,6 @@ mod tests {
         );
     }
 
-    fn sample_seal_bytes(selector: [u8; 4]) -> Vec<u8> {
-        Risc0Seal {
-            selector,
-            proof: Risc0Groth16Proof {
-                pi_a: [1u8; 64],
-                pi_b: [2u8; 128],
-                pi_c: [3u8; 64],
-            },
-        }
-        .try_to_vec()
-        .expect("test seal serialization")
-    }
-
     fn sample_journal(
         task_pda: [u8; HASH_SIZE],
         authority: [u8; HASH_SIZE],

--- a/programs/agenc-coordination/src/instructions/create_dependent_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_dependent_task.rs
@@ -157,11 +157,31 @@ pub fn handler(
             CoordinationError::MissingTokenAccounts
         );
 
-        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
-        let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
-        let token_escrow_ata = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-        let token_program = ctx.accounts.token_program.as_ref().unwrap();
-        let ata_program = ctx.accounts.associated_token_program.as_ref().unwrap();
+        let mint = ctx
+            .accounts
+            .reward_mint
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let creator_ta = ctx
+            .accounts
+            .creator_token_account
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_escrow_ata = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_program = ctx
+            .accounts
+            .token_program
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let ata_program = ctx
+            .accounts
+            .associated_token_program
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
 
         require!(
             mint.key() == expected_mint,

--- a/programs/agenc-coordination/src/instructions/create_task.rs
+++ b/programs/agenc-coordination/src/instructions/create_task.rs
@@ -140,11 +140,31 @@ pub fn handler(
             CoordinationError::MissingTokenAccounts
         );
 
-        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
-        let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
-        let token_escrow_ata = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-        let token_program = ctx.accounts.token_program.as_ref().unwrap();
-        let ata_program = ctx.accounts.associated_token_program.as_ref().unwrap();
+        let mint = ctx
+            .accounts
+            .reward_mint
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let creator_ta = ctx
+            .accounts
+            .creator_token_account
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_escrow_ata = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let token_program = ctx
+            .accounts
+            .token_program
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let ata_program = ctx
+            .accounts
+            .associated_token_program
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
 
         // Validate mint matches the provided reward_mint
         require!(

--- a/programs/agenc-coordination/src/instructions/expire_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/expire_dispute.rs
@@ -123,7 +123,10 @@ pub struct ExpireDispute<'info> {
 /// - Allows third-party cleanup services
 /// - No economic risk since only valid expirations succeed
 pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
-    require!(ctx.accounts.authority.is_signer, CoordinationError::InvalidInput);
+    require!(
+        ctx.accounts.authority.is_signer,
+        CoordinationError::InvalidInput
+    );
 
     let dispute = &mut ctx.accounts.dispute;
     let task = &mut ctx.accounts.task;
@@ -190,7 +193,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
         .accounts
         .worker_claim
         .as_ref()
-        .expect("worker claim validated above")
+        .ok_or(CoordinationError::WorkerClaimRequired)?
         .is_completed;
     let no_votes = dispute.total_voters == 0;
 
@@ -202,17 +205,32 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
                     && ctx.accounts.token_program.is_some(),
                 CoordinationError::MissingTokenAccounts
             );
-            let mint = ctx.accounts.reward_mint.as_ref().unwrap();
+            let mint = ctx
+                .accounts
+                .reward_mint
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
+            let expected_mint = task
+                .reward_mint
+                .ok_or(CoordinationError::InvalidTokenMint)?;
             require!(
-                mint.key() == task.reward_mint.unwrap(),
+                mint.key() == expected_mint,
                 CoordinationError::InvalidTokenMint
             );
-            let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
+            let token_escrow = ctx
+                .accounts
+                .token_escrow_ata
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
             validate_token_account(token_escrow, &mint.key(), &escrow.key())?;
             let token_escrow_starting_amount =
                 anchor_spl::token::accessor::amount(&token_escrow.to_account_info())
                     .map_err(|_| CoordinationError::TokenTransferFailed)?;
-            let token_program = ctx.accounts.token_program.as_ref().unwrap();
+            let token_program = ctx
+                .accounts
+                .token_program
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
             let task_key_bytes = task_key.to_bytes();
             let bump_slice = [escrow.bump];
             let escrow_seeds: &[&[u8]] = &[b"escrow", task_key_bytes.as_ref(), &bump_slice];
@@ -240,7 +258,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
                         &ctx.accounts
                             .worker_wallet
                             .as_ref()
-                            .expect("worker wallet validated above")
+                            .ok_or(CoordinationError::IncompleteWorkerAccounts)?
                             .key(),
                     )?;
                 }
@@ -262,7 +280,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
                         &ctx.accounts
                             .worker_wallet
                             .as_ref()
-                            .expect("worker wallet validated above")
+                            .ok_or(CoordinationError::IncompleteWorkerAccounts)?
                             .key(),
                     )?;
                 }
@@ -326,7 +344,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
                 &ctx.accounts
                     .worker_wallet
                     .as_ref()
-                    .expect("worker wallet validated above")
+                    .ok_or(CoordinationError::IncompleteWorkerAccounts)?
                     .to_account_info(),
                 remaining_funds,
                 worker_completed,
@@ -342,7 +360,7 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
         .accounts
         .worker
         .as_mut()
-        .expect("worker account validated above");
+        .ok_or(CoordinationError::WorkerAgentRequired)?;
     worker.active_tasks = worker
         .active_tasks
         .checked_sub(1)
@@ -426,12 +444,12 @@ pub fn handler(ctx: Context<ExpireDispute>) -> Result<()> {
         .accounts
         .worker_claim
         .as_ref()
-        .expect("worker claim validated above");
+        .ok_or(CoordinationError::WorkerClaimRequired)?;
     let worker_wallet = ctx
         .accounts
         .worker_wallet
         .as_ref()
-        .expect("worker wallet validated above");
+        .ok_or(CoordinationError::IncompleteWorkerAccounts)?;
     claim.close(worker_wallet.to_account_info())?;
 
     emit!(DisputeExpired {

--- a/programs/agenc-coordination/src/instructions/purchase_skill.rs
+++ b/programs/agenc-coordination/src/instructions/purchase_skill.rs
@@ -127,9 +127,16 @@ pub fn handler(ctx: Context<PurchaseSkill>, expected_price: u64) -> Result<()> {
                 CoordinationError::MissingTokenAccounts
             );
 
-            let mint = ctx.accounts.price_mint.as_ref().unwrap();
+            let mint = ctx
+                .accounts
+                .price_mint
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
+            let expected_mint = skill
+                .price_mint
+                .ok_or(CoordinationError::InvalidTokenMint)?;
             require!(
-                mint.key() == skill.price_mint.unwrap(),
+                mint.key() == expected_mint,
                 CoordinationError::InvalidTokenMint
             );
 
@@ -143,10 +150,26 @@ pub fn handler(ctx: Context<PurchaseSkill>, expected_price: u64) -> Result<()> {
                 .checked_sub(protocol_fee)
                 .ok_or(CoordinationError::ArithmeticOverflow)?;
 
-            let buyer_ta = ctx.accounts.buyer_token_account.as_ref().unwrap();
-            let author_ta = ctx.accounts.author_token_account.as_ref().unwrap();
-            let treasury_ta = ctx.accounts.treasury_token_account.as_ref().unwrap();
-            let token_program = ctx.accounts.token_program.as_ref().unwrap();
+            let buyer_ta = ctx
+                .accounts
+                .buyer_token_account
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
+            let author_ta = ctx
+                .accounts
+                .author_token_account
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
+            let treasury_ta = ctx
+                .accounts
+                .treasury_token_account
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
+            let token_program = ctx
+                .accounts
+                .token_program
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
 
             // Validate token account mints match the skill's price mint
             let expected_mint = mint.key();

--- a/programs/agenc-coordination/src/instructions/resolve_dispute.rs
+++ b/programs/agenc-coordination/src/instructions/resolve_dispute.rs
@@ -203,16 +203,31 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
                 && ctx.accounts.token_program.is_some(),
             CoordinationError::MissingTokenAccounts
         );
-        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
+        let mint = ctx
+            .accounts
+            .reward_mint
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
+        let expected_mint = task
+            .reward_mint
+            .ok_or(CoordinationError::InvalidTokenMint)?;
         require!(
-            mint.key() == task.reward_mint.unwrap(),
+            mint.key() == expected_mint,
             CoordinationError::InvalidTokenMint
         );
-        let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
+        let token_escrow = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
         validate_token_account(token_escrow, &mint.key(), &escrow.key())?;
     }
     let token_escrow_starting_amount = if is_token_task {
-        let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
+        let token_escrow = ctx
+            .accounts
+            .token_escrow_ata
+            .as_ref()
+            .ok_or(CoordinationError::MissingTokenAccounts)?;
         anchor_spl::token::accessor::amount(&token_escrow.to_account_info())
             .map_err(|_| CoordinationError::TokenTransferFailed)?
     } else {
@@ -254,14 +269,30 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         match dispute.resolution_type {
             ResolutionType::Refund => {
                 if is_token_task {
-                    let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-                    let token_program = ctx.accounts.token_program.as_ref().unwrap();
-                    let mint = ctx.accounts.reward_mint.as_ref().unwrap();
+                    let token_escrow = ctx
+                        .accounts
+                        .token_escrow_ata
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    let token_program = ctx
+                        .accounts
+                        .token_program
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    let mint = ctx
+                        .accounts
+                        .reward_mint
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
                     require!(
                         ctx.accounts.creator_token_account.is_some(),
                         CoordinationError::MissingTokenAccounts
                     );
-                    let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
+                    let creator_ta = ctx
+                        .accounts
+                        .creator_token_account
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
                     validate_unchecked_token_mint(
                         &creator_ta.to_account_info(),
                         &mint.key(),
@@ -302,16 +333,36 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
                 task.status = TaskStatus::Cancelled;
             }
             ResolutionType::Complete => {
-                let worker_wallet = ctx.accounts.worker_wallet.as_ref().unwrap();
+                let worker_wallet = ctx
+                    .accounts
+                    .worker_wallet
+                    .as_ref()
+                    .ok_or(CoordinationError::IncompleteWorkerAccounts)?;
                 if is_token_task {
-                    let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-                    let token_program = ctx.accounts.token_program.as_ref().unwrap();
-                    let mint = ctx.accounts.reward_mint.as_ref().unwrap();
+                    let token_escrow = ctx
+                        .accounts
+                        .token_escrow_ata
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    let token_program = ctx
+                        .accounts
+                        .token_program
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
+                    let mint = ctx
+                        .accounts
+                        .reward_mint
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
                     require!(
                         ctx.accounts.worker_token_account_ata.is_some(),
                         CoordinationError::MissingTokenAccounts
                     );
-                    let worker_ta = ctx.accounts.worker_token_account_ata.as_ref().unwrap();
+                    let worker_ta = ctx
+                        .accounts
+                        .worker_token_account_ata
+                        .as_ref()
+                        .ok_or(CoordinationError::MissingTokenAccounts)?;
                     validate_unchecked_token_mint(
                         &worker_ta.to_account_info(),
                         &mint.key(),
@@ -360,19 +411,43 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
                         .checked_sub(worker_share)
                         .ok_or(CoordinationError::ArithmeticOverflow)?;
 
-                    let worker_wallet = ctx.accounts.worker_wallet.as_ref().unwrap();
+                    let worker_wallet = ctx
+                        .accounts
+                        .worker_wallet
+                        .as_ref()
+                        .ok_or(CoordinationError::IncompleteWorkerAccounts)?;
 
                     if is_token_task {
-                        let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-                        let token_program = ctx.accounts.token_program.as_ref().unwrap();
-                        let mint = ctx.accounts.reward_mint.as_ref().unwrap();
+                        let token_escrow = ctx
+                            .accounts
+                            .token_escrow_ata
+                            .as_ref()
+                            .ok_or(CoordinationError::MissingTokenAccounts)?;
+                        let token_program = ctx
+                            .accounts
+                            .token_program
+                            .as_ref()
+                            .ok_or(CoordinationError::MissingTokenAccounts)?;
+                        let mint = ctx
+                            .accounts
+                            .reward_mint
+                            .as_ref()
+                            .ok_or(CoordinationError::MissingTokenAccounts)?;
                         require!(
                             ctx.accounts.creator_token_account.is_some()
                                 && ctx.accounts.worker_token_account_ata.is_some(),
                             CoordinationError::MissingTokenAccounts
                         );
-                        let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
-                        let worker_ta = ctx.accounts.worker_token_account_ata.as_ref().unwrap();
+                        let creator_ta = ctx
+                            .accounts
+                            .creator_token_account
+                            .as_ref()
+                            .ok_or(CoordinationError::MissingTokenAccounts)?;
+                        let worker_ta = ctx
+                            .accounts
+                            .worker_token_account_ata
+                            .as_ref()
+                            .ok_or(CoordinationError::MissingTokenAccounts)?;
                         validate_unchecked_token_mint(
                             &creator_ta.to_account_info(),
                             &mint.key(),
@@ -429,14 +504,30 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
     } else {
         // Dispute rejected - refund to creator by default
         if is_token_task {
-            let token_escrow = ctx.accounts.token_escrow_ata.as_ref().unwrap();
-            let token_program = ctx.accounts.token_program.as_ref().unwrap();
-            let mint = ctx.accounts.reward_mint.as_ref().unwrap();
+            let token_escrow = ctx
+                .accounts
+                .token_escrow_ata
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
+            let token_program = ctx
+                .accounts
+                .token_program
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
+            let mint = ctx
+                .accounts
+                .reward_mint
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
             require!(
                 ctx.accounts.creator_token_account.is_some(),
                 CoordinationError::MissingTokenAccounts
             );
-            let creator_ta = ctx.accounts.creator_token_account.as_ref().unwrap();
+            let creator_ta = ctx
+                .accounts
+                .creator_token_account
+                .as_ref()
+                .ok_or(CoordinationError::MissingTokenAccounts)?;
             validate_unchecked_token_mint(
                 &creator_ta.to_account_info(),
                 &mint.key(),
@@ -477,7 +568,7 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
         .accounts
         .worker
         .as_mut()
-        .expect("worker account validated above");
+        .ok_or(CoordinationError::WorkerAgentRequired)?;
     worker.active_tasks = worker
         .active_tasks
         .checked_sub(1)
@@ -570,12 +661,12 @@ pub fn handler(ctx: Context<ResolveDispute>) -> Result<()> {
             .accounts
             .worker_claim
             .as_ref()
-            .expect("worker claim validated above");
+            .ok_or(CoordinationError::WorkerClaimRequired)?;
         let worker_wallet = ctx
             .accounts
             .worker_wallet
             .as_ref()
-            .expect("worker wallet validated above");
+            .ok_or(CoordinationError::IncompleteWorkerAccounts)?;
         claim.close(worker_wallet.to_account_info())?;
     }
 

--- a/zkvm/host/src/lib.rs
+++ b/zkvm/host/src/lib.rs
@@ -4,9 +4,9 @@ use std::{ffi::OsStr, fmt};
 
 pub mod config;
 
-use agenc_zkvm_guest::{JournalField, JournalFields};
 #[cfg(feature = "production-prover")]
 use agenc_zkvm_guest::{serialize_journal, JOURNAL_TOTAL_LEN};
+use agenc_zkvm_guest::{JournalField, JournalFields};
 #[cfg(feature = "production-prover")]
 use borsh::BorshSerialize;
 use verifier_router::Selector;
@@ -158,7 +158,8 @@ fn generate_proof_with_dev_mode(
         let _ = request;
         Err(ProveError::ProverFailed(
             "Proof generation requires building with --features production-prover. \
-             Install the RISC Zero toolchain: curl -L https://risczero.com/install | bash && rzup".into()
+             Install the RISC Zero toolchain: curl -L https://risczero.com/install | bash && rzup"
+                .into(),
         ))
     }
 }
@@ -258,7 +259,8 @@ pub fn render_prove_response(response: &ProveResponse) -> String {
         journal: response.journal.clone(),
         image_id: response.image_id.to_vec(),
     };
-    serde_json::to_string(&json_resp).expect("ProveResponse serialization cannot fail")
+    serde_json::to_string(&json_resp)
+        .unwrap_or_else(|_| "{\"seal_bytes\":[],\"journal\":[],\"image_id\":[]}".to_string())
 }
 
 #[cfg(feature = "production-prover")]
@@ -341,7 +343,10 @@ mod tests {
                 .expect_err("must fail without production-prover");
             match err {
                 ProveError::ProverFailed(msg) => {
-                    assert!(msg.contains("--features production-prover"), "error should mention feature flag: {msg}");
+                    assert!(
+                        msg.contains("--features production-prover"),
+                        "error should mention feature flag: {msg}"
+                    );
                 }
                 other => panic!("expected ProverFailed, got: {other}"),
             }


### PR DESCRIPTION
## Summary
- removed panic-prone runtime `unwrap`/`expect` paths in on-chain production handlers
- replaced optional account extraction with explicit `ok_or(...)` error paths for token flows
- normalized formatting and removed unused test helper flagged by strict clippy
- made zkVM host proof JSON rendering fail-safe (no runtime panic path)

## Files changed
- programs/agenc-coordination/src/instructions/apply_dispute_slash.rs
- programs/agenc-coordination/src/instructions/apply_initiator_slash.rs
- programs/agenc-coordination/src/instructions/cancel_task.rs
- programs/agenc-coordination/src/instructions/complete_task.rs
- programs/agenc-coordination/src/instructions/complete_task_private.rs
- programs/agenc-coordination/src/instructions/create_dependent_task.rs
- programs/agenc-coordination/src/instructions/create_task.rs
- programs/agenc-coordination/src/instructions/expire_dispute.rs
- programs/agenc-coordination/src/instructions/purchase_skill.rs
- programs/agenc-coordination/src/instructions/resolve_dispute.rs
- zkvm/host/src/lib.rs

## Validation
- `cargo clippy --manifest-path programs/agenc-coordination/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path zkvm/host/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path zkvm/guest/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path programs/agenc-coordination/Cargo.toml --all --check`
- `cargo fmt --manifest-path zkvm/Cargo.toml --all --check`
- `anchor build`
- `npm run -s typecheck`
- `npm run -s test:fast`
- `npm run -s fender:gate:program`
- `npm run -s fender:gate:full`
