### PR TITLE
refactor(program): split private completion flow and centralize fender baselines

### DIFF
--- a/docs/security/FENDER_BASELINE.md
+++ b/docs/security/FENDER_BASELINE.md
@@ -11,9 +11,15 @@ The machine-readable baselines are:
 - `docs/security/fender-medium-baseline.json`
 - `docs/security/fender-full-baseline.json`
 
+Shared source of truth:
+
+- `scripts/fender-baseline-shared.mjs`
+
 The gate script is:
 
 - `scripts/check-fender-baseline.mjs`
+- `scripts/generate-fender-baselines.mjs`
+- `npm run -s fender:baseline:generate`
 - `npm run -s fender:gate:program`
 - `npm run -s fender:gate:full`
 
@@ -27,18 +33,19 @@ The gate script is:
 - Finding: account reinitialization risk.
 - Why false positive: no account creation/reinitialization in the handler. Accounts are validated with PDA seeds and status constraints.
 
-3. `src/instructions/complete_task_private.rs` line 194 (`complete_task_private`)
+3. `src/instructions/complete_task_private.rs` lines 288/461 (`decode_private_completion_payload`, `build_router_verify_ix`)
 - Finding: account reinitialization risk.
-- Why false positive: spend accounts use `init` (not `init_if_needed`) and deterministic one-time seeds (`binding_spend`, `nullifier_spend`) to enforce replay resistance. Existing accounts are PDA-constrained.
+- Why false positive: helper extraction split validation/CPI-construction into additional pure functions, but none introduces `init_if_needed`/reinit behavior. Spend accounts still use one-time `init` seeds (`binding_spend`, `nullifier_spend`) for replay resistance, and mutable task/claim/escrow accounts remain PDA-constrained.
 
-4. `src/instructions/complete_task_private.rs` line 298 (CPI validation)
+4. `src/instructions/complete_task_private.rs` lines 284/396/444 (CPI validation)
 - Finding: arbitrary CPI without program-id validation.
 - Why false positive: router CPI is pinned in three layers:
 - account constraint `router_program` fixed to trusted id
 - explicit runtime `require!` id checks
 - `Instruction.program_id` fixed to trusted router id and checked against `router_program`
+- strict instruction-shape/meta validation via `validate_router_verify_ix(...)` before `invoke`
 
-5. `src/lib.rs` lines 285/296/393/414
+5. `src/lib.rs` lines 302/321/442/463
 - Finding: account reinitialization risk on `#[program]` entrypoint functions.
 - Why false positive: these are thin wrappers delegating to instruction handlers; they do not perform account init/reinit themselves.
 

--- a/docs/security/fender-full-baseline.json
+++ b/docs/security/fender-full-baseline.json
@@ -11,18 +11,32 @@
       "rationale": "False positive: RISC Zero guest entrypoint reads inputs and commits journal bytes only; it does not perform Solana account initialization/reinitialization."
     },
     {
+      "id": "cancel-task-reinit-heuristic",
+      "severity": "Medium",
+      "file": "programs/agenc-coordination/src/instructions/cancel_task.rs",
+      "descriptionRegex": "Function 'process_cancel_task_impl' may be vulnerable to account reinitialization",
+      "rationale": "False positive: instruction does not use init/init_if_needed. It mutates existing PDA accounts validated by seeds/bump and closes claim accounts explicitly."
+    },
+    {
+      "id": "cancel-dispute-reinit-heuristic",
+      "severity": "Medium",
+      "file": "programs/agenc-coordination/src/instructions/cancel_dispute.rs",
+      "descriptionRegex": "Function 'handler' may be vulnerable to account reinitialization",
+      "rationale": "False positive: no account initialization path in handler. Accounts are pre-existing PDAs validated by Anchor account constraints."
+    },
+    {
       "id": "complete-task-private-reinit-heuristic",
       "severity": "Medium",
       "file": "programs/agenc-coordination/src/instructions/complete_task_private.rs",
-      "descriptionRegex": "Function 'complete_task_private' may be vulnerable to account reinitialization",
-      "rationale": "False positive: spend-tracking accounts use init (not init_if_needed) with one-time seeds, and existing task/claim/escrow accounts are PDA-constrained."
+      "descriptionRegex": "Function '(complete_task_private|decode_private_completion_payload|build_router_verify_ix)' may be vulnerable to account reinitialization",
+      "rationale": "False positive: helper split moved logic into pure validation/CPI-construction functions; no helper introduces init_if_needed or account reinitialization. Spend-tracking accounts still use one-time init seeds and mutable accounts remain PDA-constrained."
     },
     {
       "id": "complete-task-private-cpi-heuristic",
       "severity": "Medium",
       "file": "programs/agenc-coordination/src/instructions/complete_task_private.rs",
       "descriptionRegex": "Potential arbitrary CPI detected without program ID validation",
-      "rationale": "False positive: CPI program is hard-pinned via account address constraint, explicit runtime equality checks, and Instruction.program_id fixed to trusted router id."
+      "rationale": "False positive: CPI program is hard-pinned via account address constraint, explicit runtime equality checks, strict instruction-shape validation (validate_router_verify_ix), and Instruction.program_id fixed to trusted router id."
     },
     {
       "id": "lib-wrapper-apply-initiator-slash",
@@ -51,20 +65,6 @@
       "file": "programs/agenc-coordination/src/lib.rs",
       "descriptionRegex": "Function 'create_proposal' may be vulnerable to account reinitialization",
       "rationale": "False positive: wrapper forwards to create_proposal handler; no account reinitialization surface in wrapper."
-    },
-    {
-      "id": "cancel-task-reinit-heuristic",
-      "severity": "Medium",
-      "file": "programs/agenc-coordination/src/instructions/cancel_task.rs",
-      "descriptionRegex": "Function 'process_cancel_task_impl' may be vulnerable to account reinitialization",
-      "rationale": "False positive: instruction does not use init/init_if_needed. It mutates existing PDA accounts validated by seeds/bump and closes claim accounts explicitly."
-    },
-    {
-      "id": "cancel-dispute-reinit-heuristic",
-      "severity": "Medium",
-      "file": "programs/agenc-coordination/src/instructions/cancel_dispute.rs",
-      "descriptionRegex": "Function 'handler' may be vulnerable to account reinitialization",
-      "rationale": "False positive: no account initialization path in handler. Accounts are pre-existing PDAs validated by Anchor account constraints."
     }
   ]
 }

--- a/docs/security/fender-medium-baseline.json
+++ b/docs/security/fender-medium-baseline.json
@@ -21,15 +21,15 @@
       "id": "complete-task-private-reinit-heuristic",
       "severity": "Medium",
       "file": "src/instructions/complete_task_private.rs",
-      "descriptionRegex": "Function 'complete_task_private' may be vulnerable to account reinitialization",
-      "rationale": "False positive: spend-tracking accounts use init (not init_if_needed) with one-time seeds, and existing task/claim/escrow accounts are PDA-constrained."
+      "descriptionRegex": "Function '(complete_task_private|decode_private_completion_payload|build_router_verify_ix)' may be vulnerable to account reinitialization",
+      "rationale": "False positive: helper split moved logic into pure validation/CPI-construction functions; no helper introduces init_if_needed or account reinitialization. Spend-tracking accounts still use one-time init seeds and mutable accounts remain PDA-constrained."
     },
     {
       "id": "complete-task-private-cpi-heuristic",
       "severity": "Medium",
       "file": "src/instructions/complete_task_private.rs",
       "descriptionRegex": "Potential arbitrary CPI detected without program ID validation",
-      "rationale": "False positive: CPI program is hard-pinned via account address constraint, explicit runtime equality checks, and Instruction.program_id fixed to trusted router id."
+      "rationale": "False positive: CPI program is hard-pinned via account address constraint, explicit runtime equality checks, strict instruction-shape validation (validate_router_verify_ix), and Instruction.program_id fixed to trusted router id."
     },
     {
       "id": "lib-wrapper-apply-initiator-slash",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fender:list": "node scripts/solana-fender-mcp.mjs list",
     "fender:check:file": "node scripts/solana-fender-mcp.mjs check-file",
     "fender:check:program": "node scripts/solana-fender-mcp.mjs check-program",
+    "fender:baseline:generate": "node scripts/generate-fender-baselines.mjs",
     "fender:gate:program": "npm run -s fender:check:program -- programs/agenc-coordination > .tmp/fender-program-scan-current.txt && node scripts/check-fender-baseline.mjs --scan .tmp/fender-program-scan-current.txt --baseline docs/security/fender-medium-baseline.json",
     "fender:gate:full": "npm run -s fender:check:program -- . > .tmp/fender-full-scan-current.txt && node scripts/check-fender-baseline.mjs --scan .tmp/fender-full-scan-current.txt --baseline docs/security/fender-full-baseline.json"
   },

--- a/programs/agenc-coordination/src/instructions/complete_task_private.rs
+++ b/programs/agenc-coordination/src/instructions/complete_task_private.rs
@@ -192,222 +192,35 @@ pub struct CompleteTaskPrivate<'info> {
 }
 
 pub fn complete_task_private(
-    ctx: Context<CompleteTaskPrivate>,
+    mut ctx: Context<CompleteTaskPrivate>,
     task_id: u64,
     proof: PrivateCompletionPayload,
 ) -> Result<()> {
     let clock = Clock::get()?;
+    let task_key = ctx.accounts.task.key();
+    let decoded_proof = verify_private_completion_stage(&ctx, &task_key, task_id, &proof, &clock)?;
+    settle_private_completion(&mut ctx, &decoded_proof, &clock)
+}
 
-    let task = &ctx.accounts.task;
-    let claim = &ctx.accounts.claim;
-
-    let task_id_bytes: [u8; 8] = task.task_id[..8]
-        .try_into()
-        .map_err(|_| error!(CoordinationError::CorruptedData))?;
-    let expected_task_id = u64::from_le_bytes(task_id_bytes);
-    require!(task_id == expected_task_id, CoordinationError::TaskNotFound);
-
-    require!(
-        task.deadline == 0 || clock.unix_timestamp <= task.deadline,
-        CoordinationError::DeadlinePassed
+fn settle_private_completion(
+    ctx: &mut Context<CompleteTaskPrivate>,
+    decoded_proof: &DecodedPrivateProof,
+    clock: &Clock,
+) -> Result<()> {
+    record_private_spends(
+        &mut ctx.accounts,
+        &decoded_proof.parsed_journal,
+        clock,
+        ctx.bumps.binding_spend,
+        ctx.bumps.nullifier_spend,
     );
-
-    check_version_compatible(&ctx.accounts.protocol_config)?;
-    validate_task_dependency(task, ctx.remaining_accounts, ctx.program_id)?;
-    validate_completion_prereqs(task, claim, &clock)?;
-
-    require!(
-        task.constraint_hash != [0u8; HASH_SIZE],
-        CoordinationError::NotPrivateTask
-    );
-
-    require!(
-        proof.seal_bytes.len() == RISC0_SEAL_BORSH_LEN,
-        CoordinationError::InvalidSealEncoding
-    );
-    let decoded_seal = Risc0Seal::try_from_slice(&proof.seal_bytes)
-        .map_err(|_| error!(CoordinationError::InvalidSealEncoding))?;
-    require!(
-        decoded_seal.selector == TRUSTED_RISC0_SELECTOR,
-        CoordinationError::TrustedSelectorMismatch
-    );
-    let parsed_journal = parse_and_validate_journal(&proof.journal)?;
-
-    require!(
-        parsed_journal.task_pda == task.key().to_bytes(),
-        CoordinationError::InvalidJournalTask
-    );
-    require!(
-        parsed_journal.agent_authority == ctx.accounts.authority.key().to_bytes(),
-        CoordinationError::InvalidJournalAuthority
-    );
-    require!(
-        parsed_journal.constraint_hash == task.constraint_hash,
-        CoordinationError::ConstraintHashMismatch
-    );
-    require!(
-        parsed_journal.binding == proof.binding_seed,
-        CoordinationError::InvalidJournalBinding
-    );
-    require!(
-        parsed_journal.nullifier == proof.nullifier_seed,
-        CoordinationError::InvalidNullifier
-    );
-    require!(
-        proof.image_id == TRUSTED_RISC0_IMAGE_ID,
-        CoordinationError::InvalidImageId
-    );
-
-    validate_verifier_entry(&ctx.accounts.verifier_entry, &ctx.accounts.verifier_program)?;
-
-    let journal_digest = hashv(&[proof.journal.as_slice()]).to_bytes();
-    require!(
-        ctx.accounts.router_program.key() == TRUSTED_RISC0_ROUTER_PROGRAM_ID,
-        CoordinationError::RouterAccountMismatch
-    );
-    require!(
-        ctx.accounts.verifier_program.key() == TRUSTED_RISC0_VERIFIER_PROGRAM_ID,
-        CoordinationError::TrustedVerifierProgramMismatch
-    );
-
-    let mut cpi_data = Vec::with_capacity(332);
-    cpi_data.extend_from_slice(&ROUTER_VERIFY_IX_DISCRIMINATOR);
-    RouterVerifyArgs {
-        seal: decoded_seal,
-        image_id: proof.image_id,
-        journal_digest,
-    }
-    .serialize(&mut cpi_data)
-    .map_err(|_| error!(CoordinationError::InvalidSealEncoding))?;
-
-    let verify_ix = Instruction {
-        program_id: TRUSTED_RISC0_ROUTER_PROGRAM_ID,
-        accounts: vec![
-            AccountMeta::new_readonly(ctx.accounts.router.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.verifier_entry.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.verifier_program.key(), false),
-            AccountMeta::new_readonly(ctx.accounts.system_program.key(), false),
-        ],
-        data: cpi_data,
-    };
-    require!(
-        verify_ix.program_id == ctx.accounts.router_program.key(),
-        CoordinationError::RouterAccountMismatch
-    );
-
-    invoke(
-        &verify_ix,
-        &[
-            ctx.accounts.router_program.to_account_info(),
-            ctx.accounts.router.to_account_info(),
-            ctx.accounts.verifier_entry.to_account_info(),
-            ctx.accounts.verifier_program.to_account_info(),
-            ctx.accounts.system_program.to_account_info(),
-        ],
-    )
-    .map_err(|err| {
-        msg!("router verification CPI failed: {:?}", err);
-        error!(CoordinationError::ZkVerificationFailed)
-    })?;
-
-    let binding_spend = &mut ctx.accounts.binding_spend;
-    binding_spend.binding = parsed_journal.binding;
-    binding_spend.task = task.key();
-    binding_spend.agent = ctx.accounts.worker.key();
-    binding_spend.spent_at = clock.unix_timestamp;
-    binding_spend.bump = ctx.bumps.binding_spend;
-
-    let nullifier_spend = &mut ctx.accounts.nullifier_spend;
-    nullifier_spend.nullifier = parsed_journal.nullifier;
-    nullifier_spend.task = task.key();
-    nullifier_spend.agent = ctx.accounts.worker.key();
-    nullifier_spend.spent_at = clock.unix_timestamp;
-    nullifier_spend.bump = ctx.bumps.nullifier_spend;
-
-    let task = &mut ctx.accounts.task;
-    let claim = &mut ctx.accounts.claim;
-    let escrow = &mut ctx.accounts.escrow;
-    let worker = &mut ctx.accounts.worker;
-
-    let token_accounts = if task.reward_mint.is_some() {
-        let mint = match ctx.accounts.reward_mint.as_ref() {
-            Some(value) => value,
-            None => return err!(CoordinationError::MissingTokenAccounts),
-        };
-        let token_escrow = match ctx.accounts.token_escrow_ata.as_ref() {
-            Some(value) => value,
-            None => return err!(CoordinationError::MissingTokenAccounts),
-        };
-        let worker_token_account = match ctx.accounts.worker_token_account.as_ref() {
-            Some(value) => value,
-            None => return err!(CoordinationError::MissingTokenAccounts),
-        };
-        let treasury_ta = match ctx.accounts.treasury_token_account.as_ref() {
-            Some(value) => value,
-            None => return err!(CoordinationError::MissingTokenAccounts),
-        };
-        let token_program = match ctx.accounts.token_program.as_ref() {
-            Some(value) => value,
-            None => return err!(CoordinationError::MissingTokenAccounts),
-        };
-
-        require!(
-            mint.key() == task.reward_mint.unwrap_or_default(),
-            CoordinationError::InvalidTokenMint
-        );
-
-        validate_token_account(token_escrow, &mint.key(), &escrow.key())?;
-        validate_token_account(
-            treasury_ta,
-            &mint.key(),
-            &ctx.accounts.protocol_config.treasury,
-        )?;
-        let token_escrow_starting_amount =
-            anchor_spl::token::accessor::amount(&token_escrow.to_account_info())
-                .map_err(|_| CoordinationError::TokenTransferFailed)?;
-        validate_unchecked_token_mint(
-            &worker_token_account.to_account_info(),
-            &mint.key(),
-            &ctx.accounts.authority.key(),
-        )?;
-
-        Some(TokenPaymentAccounts {
-            token_escrow_ata: token_escrow.to_account_info(),
-            token_escrow_starting_amount,
-            worker_token_account: worker_token_account.to_account_info(),
-            treasury_token_account: treasury_ta.to_account_info(),
-            token_program: token_program.to_account_info(),
-            escrow_authority: escrow.to_account_info(),
-            escrow_bump: escrow.bump,
-            task_key: task.key(),
-        })
-    } else {
-        None
-    };
-
-    claim.proof_hash = parsed_journal.output_commitment;
-    claim.result_data = [0u8; RESULT_DATA_SIZE];
-    claim.is_completed = true;
-    claim.completed_at = clock.unix_timestamp;
-
-    let protocol_fee_bps = calculate_fee_with_reputation(task.protocol_fee_bps, worker.reputation);
-
-    execute_completion_rewards(
-        task,
-        claim,
-        escrow,
-        worker,
-        &mut ctx.accounts.protocol_config,
-        &ctx.accounts.authority.to_account_info(),
-        &ctx.accounts.treasury.to_account_info(),
-        &ctx.accounts.creator.to_account_info(),
-        protocol_fee_bps,
-        None,
-        &clock,
+    let token_accounts = build_token_payment_accounts(&ctx.accounts)?;
+    finalize_private_completion(
+        &mut ctx.accounts,
+        decoded_proof.parsed_journal.output_commitment,
+        clock,
         token_accounts,
-    )?;
-
-    Ok(())
+    )
 }
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
@@ -438,6 +251,404 @@ struct ParsedJournal {
     output_commitment: [u8; HASH_SIZE],
     binding: [u8; HASH_SIZE],
     nullifier: [u8; HASH_SIZE],
+}
+
+#[derive(Clone, Debug)]
+struct DecodedPrivateProof {
+    seal: Risc0Seal,
+    parsed_journal: ParsedJournal,
+    journal_digest: [u8; HASH_SIZE],
+}
+
+fn verify_private_completion_stage(
+    ctx: &Context<CompleteTaskPrivate>,
+    task_key: &Pubkey,
+    task_id: u64,
+    proof: &PrivateCompletionPayload,
+    clock: &Clock,
+) -> Result<DecodedPrivateProof> {
+    let decoded_proof = decode_private_completion_payload(proof)?;
+    validate_completion_inputs(
+        &ctx.accounts.task,
+        task_key,
+        &ctx.accounts.claim,
+        &ctx.accounts.protocol_config,
+        ctx.remaining_accounts,
+        ctx.program_id,
+        &ctx.accounts.authority.key(),
+        task_id,
+        proof,
+        &decoded_proof.parsed_journal,
+        clock,
+    )?;
+    invoke_router_verification(&ctx.accounts, proof, &decoded_proof)?;
+    Ok(decoded_proof)
+}
+
+fn decode_private_completion_payload(
+    proof: &PrivateCompletionPayload,
+) -> Result<DecodedPrivateProof> {
+    require!(
+        proof.seal_bytes.len() == RISC0_SEAL_BORSH_LEN,
+        CoordinationError::InvalidSealEncoding
+    );
+    let seal = Risc0Seal::try_from_slice(&proof.seal_bytes)
+        .map_err(|_| error!(CoordinationError::InvalidSealEncoding))?;
+    require!(
+        seal.selector == TRUSTED_RISC0_SELECTOR,
+        CoordinationError::TrustedSelectorMismatch
+    );
+
+    let parsed_journal = parse_and_validate_journal(&proof.journal)?;
+    let journal_digest = hashv(&[proof.journal.as_slice()]).to_bytes();
+
+    Ok(DecodedPrivateProof {
+        seal,
+        parsed_journal,
+        journal_digest,
+    })
+}
+
+fn validate_completion_inputs<'info>(
+    task: &Task,
+    task_key: &Pubkey,
+    claim: &TaskClaim,
+    protocol_config: &ProtocolConfig,
+    remaining_accounts: &[AccountInfo<'info>],
+    program_id: &Pubkey,
+    authority: &Pubkey,
+    task_id: u64,
+    proof: &PrivateCompletionPayload,
+    parsed_journal: &ParsedJournal,
+    clock: &Clock,
+) -> Result<()> {
+    validate_task_id(task, task_id)?;
+    require!(
+        task.deadline == 0 || clock.unix_timestamp <= task.deadline,
+        CoordinationError::DeadlinePassed
+    );
+
+    check_version_compatible(protocol_config)?;
+    validate_task_dependency(task, remaining_accounts, program_id)?;
+    validate_completion_prereqs(task, claim, clock)?;
+
+    require!(
+        task.constraint_hash != [0u8; HASH_SIZE],
+        CoordinationError::NotPrivateTask
+    );
+    validate_parsed_journal(task, task_key, authority, proof, parsed_journal)?;
+
+    Ok(())
+}
+
+fn validate_task_id(task: &Task, task_id: u64) -> Result<()> {
+    let task_id_bytes: [u8; 8] = task.task_id[..8]
+        .try_into()
+        .map_err(|_| error!(CoordinationError::CorruptedData))?;
+    let expected_task_id = u64::from_le_bytes(task_id_bytes);
+    require!(task_id == expected_task_id, CoordinationError::TaskNotFound);
+    Ok(())
+}
+
+fn validate_parsed_journal(
+    task: &Task,
+    task_key: &Pubkey,
+    authority: &Pubkey,
+    proof: &PrivateCompletionPayload,
+    parsed_journal: &ParsedJournal,
+) -> Result<()> {
+    require!(
+        parsed_journal.task_pda == task_key.to_bytes(),
+        CoordinationError::InvalidJournalTask
+    );
+    require!(
+        parsed_journal.agent_authority == authority.to_bytes(),
+        CoordinationError::InvalidJournalAuthority
+    );
+    require!(
+        parsed_journal.constraint_hash == task.constraint_hash,
+        CoordinationError::ConstraintHashMismatch
+    );
+    require!(
+        parsed_journal.binding == proof.binding_seed,
+        CoordinationError::InvalidJournalBinding
+    );
+    require!(
+        parsed_journal.nullifier == proof.nullifier_seed,
+        CoordinationError::InvalidNullifier
+    );
+    require!(
+        proof.image_id == TRUSTED_RISC0_IMAGE_ID,
+        CoordinationError::InvalidImageId
+    );
+    Ok(())
+}
+
+fn invoke_router_verification<'info>(
+    accounts: &CompleteTaskPrivate<'info>,
+    proof: &PrivateCompletionPayload,
+    decoded_proof: &DecodedPrivateProof,
+) -> Result<()> {
+    validate_verifier_entry(&accounts.verifier_entry, &accounts.verifier_program)?;
+    let router_program_key = validate_router_program_accounts(accounts)?;
+    let verify_ix =
+        build_and_validate_router_verify_ix(accounts, proof, decoded_proof, &router_program_key)?;
+    invoke_router_verify_ix(accounts, &verify_ix)
+}
+
+fn validate_router_program_accounts<'info>(
+    accounts: &CompleteTaskPrivate<'info>,
+) -> Result<Pubkey> {
+    let router_program_key = accounts.router_program.key();
+    require!(
+        router_program_key == TRUSTED_RISC0_ROUTER_PROGRAM_ID,
+        CoordinationError::RouterAccountMismatch
+    );
+    require!(
+        accounts.verifier_program.key() == TRUSTED_RISC0_VERIFIER_PROGRAM_ID,
+        CoordinationError::TrustedVerifierProgramMismatch
+    );
+    Ok(router_program_key)
+}
+
+fn build_and_validate_router_verify_ix<'info>(
+    accounts: &CompleteTaskPrivate<'info>,
+    proof: &PrivateCompletionPayload,
+    decoded_proof: &DecodedPrivateProof,
+    router_program_key: &Pubkey,
+) -> Result<Instruction> {
+    let verify_ix = build_router_verify_ix(
+        router_program_key,
+        &accounts.router.key(),
+        &accounts.verifier_entry.key(),
+        &accounts.verifier_program.key(),
+        &accounts.system_program.key(),
+        &decoded_proof.seal,
+        proof.image_id,
+        decoded_proof.journal_digest,
+    )?;
+    validate_router_verify_ix(
+        &verify_ix,
+        &accounts.router.key(),
+        &accounts.verifier_entry.key(),
+        &accounts.verifier_program.key(),
+        &accounts.system_program.key(),
+    )?;
+    Ok(verify_ix)
+}
+
+fn invoke_router_verify_ix<'info>(
+    accounts: &CompleteTaskPrivate<'info>,
+    verify_ix: &Instruction,
+) -> Result<()> {
+    invoke(
+        verify_ix,
+        &[
+            accounts.router.to_account_info(),
+            accounts.verifier_entry.to_account_info(),
+            accounts.verifier_program.to_account_info(),
+            accounts.system_program.to_account_info(),
+            accounts.router_program.to_account_info(),
+        ],
+    )
+    .map_err(|err| {
+        msg!("router verification CPI failed: {:?}", err);
+        error!(CoordinationError::ZkVerificationFailed)
+    })?;
+    Ok(())
+}
+
+fn build_router_verify_ix(
+    router_program_key: &Pubkey,
+    router: &Pubkey,
+    verifier_entry: &Pubkey,
+    verifier_program: &Pubkey,
+    system_program: &Pubkey,
+    seal: &Risc0Seal,
+    image_id: [u8; RISC0_IMAGE_ID_LEN],
+    journal_digest: [u8; HASH_SIZE],
+) -> Result<Instruction> {
+    let mut cpi_data = Vec::with_capacity(332);
+    cpi_data.extend_from_slice(&ROUTER_VERIFY_IX_DISCRIMINATOR);
+    RouterVerifyArgs {
+        seal: seal.clone(),
+        image_id,
+        journal_digest,
+    }
+    .serialize(&mut cpi_data)
+    .map_err(|_| error!(CoordinationError::InvalidSealEncoding))?;
+
+    Ok(Instruction {
+        program_id: *router_program_key,
+        accounts: vec![
+            AccountMeta::new_readonly(*router, false),
+            AccountMeta::new_readonly(*verifier_entry, false),
+            AccountMeta::new_readonly(*verifier_program, false),
+            AccountMeta::new_readonly(*system_program, false),
+        ],
+        data: cpi_data,
+    })
+}
+
+fn record_private_spends<'info>(
+    accounts: &mut CompleteTaskPrivate<'info>,
+    parsed_journal: &ParsedJournal,
+    clock: &Clock,
+    binding_spend_bump: u8,
+    nullifier_spend_bump: u8,
+) {
+    let task_key = accounts.task.key();
+    let worker_key = accounts.worker.key();
+
+    let binding_spend = &mut accounts.binding_spend;
+    binding_spend.binding = parsed_journal.binding;
+    binding_spend.task = task_key;
+    binding_spend.agent = worker_key;
+    binding_spend.spent_at = clock.unix_timestamp;
+    binding_spend.bump = binding_spend_bump;
+
+    let nullifier_spend = &mut accounts.nullifier_spend;
+    nullifier_spend.nullifier = parsed_journal.nullifier;
+    nullifier_spend.task = task_key;
+    nullifier_spend.agent = worker_key;
+    nullifier_spend.spent_at = clock.unix_timestamp;
+    nullifier_spend.bump = nullifier_spend_bump;
+}
+
+fn finalize_private_completion<'info>(
+    accounts: &mut CompleteTaskPrivate<'info>,
+    output_commitment: [u8; HASH_SIZE],
+    clock: &Clock,
+    token_accounts: Option<TokenPaymentAccounts<'info>>,
+) -> Result<()> {
+    let task = &mut accounts.task;
+    let claim = &mut accounts.claim;
+    let escrow = &mut accounts.escrow;
+    let worker = &mut accounts.worker;
+
+    claim.proof_hash = output_commitment;
+    claim.result_data = [0u8; RESULT_DATA_SIZE];
+    claim.is_completed = true;
+    claim.completed_at = clock.unix_timestamp;
+
+    let protocol_fee_bps = calculate_fee_with_reputation(task.protocol_fee_bps, worker.reputation);
+    execute_completion_rewards(
+        task,
+        claim,
+        escrow,
+        worker,
+        &mut accounts.protocol_config,
+        &accounts.authority.to_account_info(),
+        &accounts.treasury.to_account_info(),
+        &accounts.creator.to_account_info(),
+        protocol_fee_bps,
+        None,
+        clock,
+        token_accounts,
+    )
+}
+
+fn build_token_payment_accounts<'info>(
+    accounts: &CompleteTaskPrivate<'info>,
+) -> Result<Option<TokenPaymentAccounts<'info>>> {
+    let task = &accounts.task;
+    if task.reward_mint.is_none() {
+        return Ok(None);
+    }
+
+    let (mint, token_escrow, worker_token_account, treasury_ta, token_program, expected_mint) =
+        extract_required_token_accounts(accounts)?;
+    let token_payment_accounts = build_validated_token_payment_accounts(
+        accounts,
+        mint,
+        token_escrow,
+        worker_token_account,
+        treasury_ta,
+        token_program,
+        expected_mint,
+    )?;
+    Ok(Some(token_payment_accounts))
+}
+
+fn extract_required_token_accounts<'a, 'info>(
+    accounts: &'a CompleteTaskPrivate<'info>,
+) -> Result<(
+    &'a Account<'info, Mint>,
+    &'a Account<'info, TokenAccount>,
+    &'a UncheckedAccount<'info>,
+    &'a Account<'info, TokenAccount>,
+    &'a Program<'info, Token>,
+    Pubkey,
+)> {
+    let mint = accounts
+        .reward_mint
+        .as_ref()
+        .ok_or(CoordinationError::MissingTokenAccounts)?;
+    let token_escrow = accounts
+        .token_escrow_ata
+        .as_ref()
+        .ok_or(CoordinationError::MissingTokenAccounts)?;
+    let worker_token_account = accounts
+        .worker_token_account
+        .as_ref()
+        .ok_or(CoordinationError::MissingTokenAccounts)?;
+    let treasury_ta = accounts
+        .treasury_token_account
+        .as_ref()
+        .ok_or(CoordinationError::MissingTokenAccounts)?;
+    let token_program = accounts
+        .token_program
+        .as_ref()
+        .ok_or(CoordinationError::MissingTokenAccounts)?;
+    let expected_mint = accounts
+        .task
+        .reward_mint
+        .ok_or(CoordinationError::InvalidTokenMint)?;
+
+    Ok((
+        mint,
+        token_escrow,
+        worker_token_account,
+        treasury_ta,
+        token_program,
+        expected_mint,
+    ))
+}
+
+fn build_validated_token_payment_accounts<'a, 'info>(
+    accounts: &'a CompleteTaskPrivate<'info>,
+    mint: &'a Account<'info, Mint>,
+    token_escrow: &'a Account<'info, TokenAccount>,
+    worker_token_account: &'a UncheckedAccount<'info>,
+    treasury_ta: &'a Account<'info, TokenAccount>,
+    token_program: &'a Program<'info, Token>,
+    expected_mint: Pubkey,
+) -> Result<TokenPaymentAccounts<'info>> {
+    require!(
+        mint.key() == expected_mint,
+        CoordinationError::InvalidTokenMint
+    );
+    validate_token_account(token_escrow, &mint.key(), &accounts.escrow.key())?;
+    validate_token_account(treasury_ta, &mint.key(), &accounts.protocol_config.treasury)?;
+    let token_escrow_starting_amount =
+        anchor_spl::token::accessor::amount(&token_escrow.to_account_info())
+            .map_err(|_| CoordinationError::TokenTransferFailed)?;
+    validate_unchecked_token_mint(
+        &worker_token_account.to_account_info(),
+        &mint.key(),
+        &accounts.authority.key(),
+    )?;
+
+    Ok(TokenPaymentAccounts {
+        token_escrow_ata: token_escrow.to_account_info(),
+        token_escrow_starting_amount,
+        worker_token_account: worker_token_account.to_account_info(),
+        treasury_token_account: treasury_ta.to_account_info(),
+        token_program: token_program.to_account_info(),
+        escrow_authority: accounts.escrow.to_account_info(),
+        escrow_bump: accounts.escrow.bump,
+        task_key: accounts.task.key(),
+    })
 }
 
 fn parse_and_validate_journal(journal: &[u8]) -> Result<ParsedJournal> {
@@ -531,12 +742,49 @@ fn validate_verifier_entry(
     validate_verifier_entry_data(data.as_ref(), &verifier_program.key())
 }
 
+fn validate_router_verify_ix(
+    verify_ix: &Instruction,
+    router: &Pubkey,
+    verifier_entry: &Pubkey,
+    verifier_program: &Pubkey,
+    system_program: &Pubkey,
+) -> Result<()> {
+    require!(
+        verify_ix.program_id == TRUSTED_RISC0_ROUTER_PROGRAM_ID,
+        CoordinationError::RouterAccountMismatch
+    );
+    require!(
+        verify_ix.accounts.len() == 4,
+        CoordinationError::RouterAccountMismatch
+    );
+
+    let expected_keys = [*router, *verifier_entry, *verifier_program, *system_program];
+    for (meta, expected_key) in verify_ix.accounts.iter().zip(expected_keys.iter()) {
+        require!(
+            meta.pubkey == *expected_key,
+            CoordinationError::RouterAccountMismatch
+        );
+        require!(!meta.is_signer, CoordinationError::RouterAccountMismatch);
+        require!(!meta.is_writable, CoordinationError::RouterAccountMismatch);
+    }
+
+    Ok(())
+}
+
 fn validate_verifier_entry_data(data: &[u8], verifier_program_key: &Pubkey) -> Result<()> {
     require!(
         data.len() == VERIFIER_ENTRY_ACCOUNT_LEN,
         CoordinationError::RouterAccountMismatch
     );
+    validate_verifier_entry_discriminator(data)?;
+    validate_verifier_entry_selector(data)?;
+    validate_verifier_program_binding(data, verifier_program_key)?;
+    validate_verifier_entry_not_estopped(data)?;
 
+    Ok(())
+}
+
+fn validate_verifier_entry_discriminator(data: &[u8]) -> Result<()> {
     let discriminator = data
         .get(0..8)
         .ok_or(error!(CoordinationError::RouterAccountMismatch))?;
@@ -544,7 +792,10 @@ fn validate_verifier_entry_data(data: &[u8], verifier_program_key: &Pubkey) -> R
         discriminator == VERIFIER_ENTRY_DISCRIMINATOR.as_ref(),
         CoordinationError::RouterAccountMismatch
     );
+    Ok(())
+}
 
+fn validate_verifier_entry_selector(data: &[u8]) -> Result<()> {
     let selector_slice = data
         .get(VERIFIER_ENTRY_SELECTOR_OFFSET..VERIFIER_ENTRY_VERIFIER_OFFSET)
         .ok_or(error!(CoordinationError::RouterAccountMismatch))?;
@@ -554,15 +805,11 @@ fn validate_verifier_entry_data(data: &[u8], verifier_program_key: &Pubkey) -> R
         selector == TRUSTED_RISC0_SELECTOR,
         CoordinationError::TrustedSelectorMismatch
     );
+    Ok(())
+}
 
-    let verifier_slice = data
-        .get(VERIFIER_ENTRY_VERIFIER_OFFSET..VERIFIER_ENTRY_ESTOPPED_OFFSET)
-        .ok_or(error!(CoordinationError::RouterAccountMismatch))?;
-    let verifier_pubkey = Pubkey::new_from_array(
-        verifier_slice
-            .try_into()
-            .map_err(|_| error!(CoordinationError::RouterAccountMismatch))?,
-    );
+fn validate_verifier_program_binding(data: &[u8], verifier_program_key: &Pubkey) -> Result<()> {
+    let verifier_pubkey = parse_verifier_entry_program(data)?;
     require!(
         verifier_pubkey == TRUSTED_RISC0_VERIFIER_PROGRAM_ID,
         CoordinationError::TrustedVerifierProgramMismatch
@@ -571,12 +818,24 @@ fn validate_verifier_entry_data(data: &[u8], verifier_program_key: &Pubkey) -> R
         verifier_pubkey == *verifier_program_key,
         CoordinationError::TrustedVerifierProgramMismatch
     );
+    Ok(())
+}
 
+fn parse_verifier_entry_program(data: &[u8]) -> Result<Pubkey> {
+    let verifier_slice = data
+        .get(VERIFIER_ENTRY_VERIFIER_OFFSET..VERIFIER_ENTRY_ESTOPPED_OFFSET)
+        .ok_or(error!(CoordinationError::RouterAccountMismatch))?;
+    let verifier_bytes: [u8; 32] = verifier_slice
+        .try_into()
+        .map_err(|_| error!(CoordinationError::RouterAccountMismatch))?;
+    Ok(Pubkey::new_from_array(verifier_bytes))
+}
+
+fn validate_verifier_entry_not_estopped(data: &[u8]) -> Result<()> {
     let estopped = data
         .get(VERIFIER_ENTRY_ESTOPPED_OFFSET)
         .ok_or(error!(CoordinationError::RouterAccountMismatch))?;
     require!(*estopped == 0, CoordinationError::RouterAccountMismatch);
-
     Ok(())
 }
 
@@ -687,6 +946,100 @@ mod tests {
             verifier_entry_bytes(TRUSTED_RISC0_SELECTOR, TRUSTED_RISC0_VERIFIER_PROGRAM_ID, 1);
         let err = validate_verifier_entry_data(&data, &TRUSTED_RISC0_VERIFIER_PROGRAM_ID)
             .expect_err("must fail");
+        assert_error_name(err, "RouterAccountMismatch");
+    }
+
+    fn sample_router_ix(
+        program_id: Pubkey,
+        router: Pubkey,
+        verifier_entry: Pubkey,
+        verifier_program: Pubkey,
+        system_program: Pubkey,
+    ) -> Instruction {
+        Instruction {
+            program_id,
+            accounts: vec![
+                AccountMeta::new_readonly(router, false),
+                AccountMeta::new_readonly(verifier_entry, false),
+                AccountMeta::new_readonly(verifier_program, false),
+                AccountMeta::new_readonly(system_program, false),
+            ],
+            data: vec![],
+        }
+    }
+
+    #[test]
+    fn router_verify_ix_accepts_expected_shape() {
+        let router = Pubkey::new_unique();
+        let verifier_entry = Pubkey::new_unique();
+        let verifier_program = Pubkey::new_unique();
+        let system_program = anchor_lang::system_program::ID;
+        let ix = sample_router_ix(
+            TRUSTED_RISC0_ROUTER_PROGRAM_ID,
+            router,
+            verifier_entry,
+            verifier_program,
+            system_program,
+        );
+
+        validate_router_verify_ix(
+            &ix,
+            &router,
+            &verifier_entry,
+            &verifier_program,
+            &system_program,
+        )
+        .expect("must pass");
+    }
+
+    #[test]
+    fn router_verify_ix_rejects_wrong_program_id() {
+        let router = Pubkey::new_unique();
+        let verifier_entry = Pubkey::new_unique();
+        let verifier_program = Pubkey::new_unique();
+        let system_program = anchor_lang::system_program::ID;
+        let ix = sample_router_ix(
+            Pubkey::new_unique(),
+            router,
+            verifier_entry,
+            verifier_program,
+            system_program,
+        );
+
+        let err = validate_router_verify_ix(
+            &ix,
+            &router,
+            &verifier_entry,
+            &verifier_program,
+            &system_program,
+        )
+        .expect_err("must fail");
+        assert_error_name(err, "RouterAccountMismatch");
+    }
+
+    #[test]
+    fn router_verify_ix_rejects_writable_meta() {
+        let router = Pubkey::new_unique();
+        let verifier_entry = Pubkey::new_unique();
+        let verifier_program = Pubkey::new_unique();
+        let system_program = anchor_lang::system_program::ID;
+        let mut ix = sample_router_ix(
+            TRUSTED_RISC0_ROUTER_PROGRAM_ID,
+            router,
+            verifier_entry,
+            verifier_program,
+            system_program,
+        );
+        ix.accounts[0] = AccountMeta::new(router, false);
+
+        let err = validate_router_verify_ix(
+            &ix,
+            &router,
+            &verifier_entry,
+            &verifier_program,
+            &system_program,
+        )
+        .expect_err("must fail");
         assert_error_name(err, "RouterAccountMismatch");
     }
 

--- a/scripts/fender-baseline-shared.mjs
+++ b/scripts/fender-baseline-shared.mjs
@@ -1,0 +1,88 @@
+export const sharedBaseline = {
+  tool: "solana-fender",
+  version: 1,
+  programScope: "programs/agenc-coordination",
+  fullScope: ".",
+  programPathPrefix: "programs/agenc-coordination/",
+  programAllowlist: [
+    {
+      id: "cancel-task-reinit-heuristic",
+      severity: "Medium",
+      file: "src/instructions/cancel_task.rs",
+      descriptionRegex:
+        "Function 'process_cancel_task_impl' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: instruction does not use init/init_if_needed. It mutates existing PDA accounts validated by seeds/bump and closes claim accounts explicitly.",
+    },
+    {
+      id: "cancel-dispute-reinit-heuristic",
+      severity: "Medium",
+      file: "src/instructions/cancel_dispute.rs",
+      descriptionRegex: "Function 'handler' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: no account initialization path in handler. Accounts are pre-existing PDAs validated by Anchor account constraints.",
+    },
+    {
+      id: "complete-task-private-reinit-heuristic",
+      severity: "Medium",
+      file: "src/instructions/complete_task_private.rs",
+      descriptionRegex:
+        "Function '(complete_task_private|decode_private_completion_payload|build_router_verify_ix)' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: helper split moved logic into pure validation/CPI-construction functions; no helper introduces init_if_needed or account reinitialization. Spend-tracking accounts still use one-time init seeds and mutable accounts remain PDA-constrained.",
+    },
+    {
+      id: "complete-task-private-cpi-heuristic",
+      severity: "Medium",
+      file: "src/instructions/complete_task_private.rs",
+      descriptionRegex: "Potential arbitrary CPI detected without program ID validation",
+      rationale:
+        "False positive: CPI program is hard-pinned via account address constraint, explicit runtime equality checks, strict instruction-shape validation (validate_router_verify_ix), and Instruction.program_id fixed to trusted router id.",
+    },
+    {
+      id: "lib-wrapper-apply-initiator-slash",
+      severity: "Medium",
+      file: "src/lib.rs",
+      descriptionRegex:
+        "Function 'apply_initiator_slash' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: program entrypoint wrapper only delegates to instruction handler; no account init logic exists in wrapper.",
+    },
+    {
+      id: "lib-wrapper-initialize-protocol",
+      severity: "Medium",
+      file: "src/lib.rs",
+      descriptionRegex:
+        "Function 'initialize_protocol' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: wrapper forwards to initialize_protocol handler; Anchor account init constraints are implemented in instruction module.",
+    },
+    {
+      id: "lib-wrapper-initialize-governance",
+      severity: "Medium",
+      file: "src/lib.rs",
+      descriptionRegex:
+        "Function 'initialize_governance' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: wrapper forwards to initialize_governance handler; no direct initialization logic in wrapper.",
+    },
+    {
+      id: "lib-wrapper-create-proposal",
+      severity: "Medium",
+      file: "src/lib.rs",
+      descriptionRegex: "Function 'create_proposal' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: wrapper forwards to create_proposal handler; no account reinitialization surface in wrapper.",
+    },
+  ],
+  fullExtraAllowlist: [
+    {
+      id: "zkvm-methods-guest-entry-reinit-heuristic",
+      severity: "Medium",
+      file: "zkvm/methods/guest/src/main.rs",
+      descriptionRegex: "Function 'guest_entry' may be vulnerable to account reinitialization",
+      rationale:
+        "False positive: RISC Zero guest entrypoint reads inputs and commits journal bytes only; it does not perform Solana account initialization/reinitialization.",
+    },
+  ],
+};

--- a/scripts/generate-fender-baselines.mjs
+++ b/scripts/generate-fender-baselines.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { sharedBaseline } from "./fender-baseline-shared.mjs";
+
+const MEDIUM_PATH = "docs/security/fender-medium-baseline.json";
+const FULL_PATH = "docs/security/fender-full-baseline.json";
+
+function toAbs(relPath) {
+  return path.resolve(process.cwd(), relPath);
+}
+
+function withPrefix(entry, prefix) {
+  return {
+    ...entry,
+    file: `${prefix}${entry.file}`,
+  };
+}
+
+function writeJson(relPath, data) {
+  fs.writeFileSync(toAbs(relPath), `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+function main() {
+  const {
+    tool,
+    version,
+    programScope,
+    fullScope,
+    programPathPrefix,
+    programAllowlist,
+    fullExtraAllowlist,
+  } = sharedBaseline;
+
+  if (!Array.isArray(programAllowlist) || !Array.isArray(fullExtraAllowlist)) {
+    throw new Error("Shared baseline config must include array fields: programAllowlist and fullExtraAllowlist");
+  }
+
+  const mediumBaseline = {
+    tool,
+    scope: programScope,
+    version,
+    allowlist: programAllowlist,
+  };
+
+  const fullBaseline = {
+    tool,
+    scope: fullScope,
+    version,
+    allowlist: [
+      ...fullExtraAllowlist,
+      ...programAllowlist.map((entry) => withPrefix(entry, programPathPrefix)),
+    ],
+  };
+
+  writeJson(MEDIUM_PATH, mediumBaseline);
+  writeJson(FULL_PATH, fullBaseline);
+
+  console.log(`Wrote ${MEDIUM_PATH}`);
+  console.log(`Wrote ${FULL_PATH}`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- refactor `complete_task_private` into smaller verification/settlement/router/token helpers
- keep router CPI hardening and add helper-focused structure for auditability
- centralize Solana Fender baseline allowlist in a single shared source and generate both baseline JSON outputs

## Validation
- `cargo check --manifest-path programs/agenc-coordination/Cargo.toml`
- `cargo test --manifest-path programs/agenc-coordination/Cargo.toml complete_task_private -- --nocapture`
- `npm run -s fender:baseline:generate`
- `npm run -s fender:gate:program`
- `npm run -s fender:gate:full`