### PR TITLE
feat(runtime): register marketplace and social tools in daemon registry

### DIFF
--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -662,6 +662,29 @@ describe("DaemonManager", () => {
     expect(directResult).toContain("session-scoped tool handler");
   });
 
+  it("registers marketplace and social tools when enabled", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    const registry = await (dm as any).createToolRegistry({
+      desktop: { enabled: false },
+      marketplace: { enabled: true },
+      social: { enabled: true },
+    });
+
+    expect(registry.listNames()).toContain("marketplace.createService");
+    expect(registry.listNames()).toContain("social.searchAgents");
+
+    const toolHandler = registry.createToolHandler();
+    const marketplaceResult = await toolHandler("marketplace.createService", {
+      serviceId: "svc-1",
+      title: "Test service",
+      budget: "1",
+    });
+    const socialResult = await toolHandler("social.searchAgents", {});
+
+    expect(marketplaceResult).toContain("Marketplace not enabled");
+    expect(socialResult).toContain("Social module not enabled");
+  });
+
   it("auto-creates missing default workspace for sub-agent isolation", async () => {
     const dm = new DaemonManager({ configPath: "/tmp/config.json" });
     const workspaceManager = {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -3670,6 +3670,38 @@ export class DaemonManager {
     }));
     registry.registerAll(createBrowserTools({ mode: 'basic' }, this.logger));
     registry.register(createExecuteWithAgentTool());
+    const walletResult = await this.loadWallet(config);
+    const marketplaceActorId = walletResult
+      ? Buffer.from(walletResult.agentId).toString('hex')
+      : 'gateway-agent';
+
+    if (config.marketplace?.enabled) {
+      try {
+        const { createMarketplaceTools } = await import('../tools/marketplace/index.js');
+        registry.registerAll(createMarketplaceTools({
+          getMarketplace: () => this._marketplace,
+          actorId: marketplaceActorId,
+          logger: this.logger,
+        }));
+      } catch (error) {
+        this.logger.warn?.('Marketplace tools unavailable:', error);
+      }
+    }
+
+    if (config.social?.enabled) {
+      try {
+        const { createSocialTools } = await import('../tools/social/index.js');
+        registry.registerAll(createSocialTools({
+          getDiscovery: () => this._agentDiscovery,
+          getMessaging: () => this._agentMessaging,
+          getFeed: () => this._agentFeed,
+          getCollaboration: () => this._collaborationProtocol,
+          logger: this.logger,
+        }));
+      } catch (error) {
+        this.logger.warn?.('Social tools unavailable:', error);
+      }
+    }
 
     // macOS native automation tools (AppleScript, JXA, open, notifications)
     if (process.platform === 'darwin') {
@@ -3856,7 +3888,6 @@ export class DaemonManager {
         this._connectionManager = connMgr;
 
         const { createAgencTools } = await import('../tools/agenc/index.js');
-        const walletResult = await this.loadWallet(config);
         registry.registerAll(createAgencTools({
           connection: connMgr.getConnection(),
           wallet: walletResult?.wallet,


### PR DESCRIPTION
# Summary
Register marketplace and social tool sets in the daemon tool registry when their config flags are enabled.

# Changes
- Load wallet once before tool registration and derive `actorId` for marketplace tools.
- Register marketplace tools in `createToolRegistry` when `config.marketplace.enabled` is true.
- Register social tools in `createToolRegistry` when `config.social.enabled` is true.
- Add regression test to verify both tool namespaces are registered and return expected disabled-module responses in this test environment.

# Testing
- [x] `npm --prefix runtime run test -- src/gateway/daemon.test.ts` (fails in environment: missing `@solana/codecs` package path from `@solana/spl-token-metadata`)
- [x] `npm --prefix runtime run typecheck` (fails in environment: existing unresolved `@agenc/sdk` module and unrelated marketplace typing errors)

# Security / Risk
- [x] No authority bypass introduced
- [x] Tool registration remains gated by explicit feature flags

# Checklist
- [x] Tests added/updated (or N/A)
- [ ] Docs updated (if needed)

# Issue link(s)
- N/A
