### PR TITLE
fix(security): harden desktop image and reduce low findings

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,7 +3,9 @@
 # Re-evaluate on next Anchor major/minor bump cycle.
 GHSA-fjx5-qpf4-xjf2
 
-# CVE-2025-58160 (tracing-subscriber 0.2.25) is transitive in zkvm guest via risc0/ark stack.
-# Upgrade blocked by upstream semver constraints in the current RISC0 toolchain.
+# CVE-2025-58160 (tracing-subscriber 0.2.25) remains transitive in zkvm host
+# (risc0-zkvm -> risc0-groth16 -> ark-relations ^0.5 -> tracing-subscriber ^0.2).
+# Guest-side std feature pin was removed to reduce exposure; remaining upgrade is blocked
+# by upstream semver constraints in the current RISC0/ark toolchain.
 # Re-evaluate on next RISC0 release line.
 CVE-2025-58160

--- a/containers/desktop/Dockerfile
+++ b/containers/desktop/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     DISPLAY=:1 \
@@ -13,19 +13,17 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/home/agenc/.cache/ms-playwright
 # =============================================================================
 # System packages
 # =============================================================================
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     # Virtual display + desktop environment
     xvfb xfce4 xfce4-terminal xfce4-whiskermenu-plugin dbus-x11 xterm kitty \
     # File manager
     thunar \
-    # GUI browser fallback
-    epiphany-browser \
     # VNC
     x11vnc novnc websockify \
     # Input automation
     xdotool xclip xsel \
     # Screenshot + display info + SVG rendering
-    scrot imagemagick x11-utils librsvg2-bin \
+    scrot x11-utils librsvg2-bin \
     # Process management
     supervisor \
     # Fonts (system + monospace for terminal/coding)
@@ -38,8 +36,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git vim nano neovim tmux htop tree jq unzip sudo \
     # Modern CLI tools (agent-optimized)
     ripgrep fd-find bat fzf \
-    # Video recording
-    ffmpeg \
     # Python
     python3 python3-pip python3-venv \
     # Misc utilities
@@ -71,9 +67,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p ${PLAYWRIGHT_BROWSERS_PATH} \
     && node /usr/lib/node_modules/@playwright/mcp/node_modules/playwright/cli.js install --with-deps chromium \
     && CHROME_BIN="$(find ${PLAYWRIGHT_BROWSERS_PATH} -path '*/chrome-linux64/chrome' | head -n1)" \
+    && FFMPEG_BIN="$(find ${PLAYWRIGHT_BROWSERS_PATH} -path '*/ffmpeg-linux' | head -n1)" \
     && if [ -n "$CHROME_BIN" ]; then \
          ln -sf "$CHROME_BIN" /usr/bin/chromium; \
          ln -sf /usr/bin/chromium /usr/bin/chromium-browser; \
+       fi \
+    && if [ -n "$FFMPEG_BIN" ]; then \
+         ln -sf "$FFMPEG_BIN" /usr/bin/ffmpeg; \
        fi \
     && rm -rf /home/agenc/.npm \
     # Cleanup
@@ -222,12 +222,14 @@ RUN chown -R agenc:agenc /home/agenc /opt/server /tmp
 # uv (Python package manager) + kitty-mcp
 # =============================================================================
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && python3 -m pip install --no-cache-dir --upgrade pip wheel==0.46.2 jaraco.context==6.1.0 \
+    && python3 -m pip install --break-system-packages --ignore-installed --no-cache-dir --upgrade pip wheel==0.46.2 jaraco.context==6.1.0 \
     && git clone https://github.com/den-tanui/kitty-mcp.git /tmp/kitty-mcp \
     && sed -i '30,34d' /tmp/kitty-mcp/pyproject.toml \
     && /home/agenc/.local/bin/uv tool install /tmp/kitty-mcp \
-    && UV_PYTHON_BIN="$(find /home/agenc/.local/share/uv/python -path '*/bin/python' | head -n1)" \
-    && "$UV_PYTHON_BIN" -m pip install --break-system-packages --no-cache-dir --upgrade --pre setuptools \
+    && UV_PYTHON_BIN="$(find /home/agenc/.local/share/uv/python -path '*/bin/python' 2>/dev/null | head -n1 || true)" \
+    && if [ -n "$UV_PYTHON_BIN" ]; then \
+         "$UV_PYTHON_BIN" -m pip install --break-system-packages --no-cache-dir --upgrade --pre setuptools; \
+       fi \
     && rm -rf /tmp/kitty-mcp \
     && chown -R agenc:agenc /home/agenc/.local
 

--- a/containers/desktop/server/dist/tools.js
+++ b/containers/desktop/server/dist/tools.js
@@ -67,13 +67,7 @@ function normalizeAptCommand(command) {
 async function screenshot() {
     const path = `/tmp/screenshot-${randomUUID()}.png`;
     try {
-        try {
-            await exec("scrot", ["-o", path]);
-        }
-        catch {
-            // Fallback to ImageMagick
-            await exec("import", ["-window", "root", path]);
-        }
+        await exec("scrot", ["-o", path]);
         const buf = await readFile(path);
         const size = await screenSize();
         const sizeData = JSON.parse(size.content);

--- a/containers/desktop/server/src/tools.ts
+++ b/containers/desktop/server/src/tools.ts
@@ -109,12 +109,7 @@ function normalizeAptCommand(command: string): string {
 async function screenshot(): Promise<ToolResult> {
   const path = `/tmp/screenshot-${randomUUID()}.png`;
   try {
-    try {
-      await exec("scrot", ["-o", path]);
-    } catch {
-      // Fallback to ImageMagick
-      await exec("import", ["-window", "root", path]);
-    }
+    await exec("scrot", ["-o", path]);
     const buf = await readFile(path);
     const size = await screenSize();
     const sizeData = JSON.parse(size.content) as ScreenSizeResult;

--- a/docs/security/mcp-security-stack.md
+++ b/docs/security/mcp-security-stack.md
@@ -94,6 +94,20 @@ npm run -s security:trivy:image -- agenc/desktop:latest
 trivy image --scanners vuln,misconfig,secret --format json --quiet --output .tmp/trivy-image.json agenc/desktop:latest
 ```
 
+## Desktop Hardening Regression Check
+
+Run the Dockerfile hardening guard before rebuilding desktop images:
+
+```bash
+npm run -s security:desktop:hardening:check
+```
+
+This check enforces:
+- `ubuntu:24.04` base image with `apt-get upgrade -y`
+- no apt install reintroduction of `imagemagick`, `epiphany-browser`, or system `ffmpeg`
+- Playwright ffmpeg symlink wiring
+- no forced `risc0-zkvm` guest `std` feature in `zkvm/methods/guest/Cargo.toml`
+
 ## Optional Snyk MCP
 
 If your installed Snyk binary supports MCP mode, add this server:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "demo:mainnet": "HELIUS_API_KEY=$HELIUS_API_KEY npx tsx demo/private_task_demo.ts",
     "security:mcp:check": "node scripts/check-security-mcp-stack.mjs --config mcp/security-stack.mcp.json --verbose --allow-fail",
     "security:mcp:check:strict": "node scripts/check-security-mcp-stack.mjs --config mcp/security-stack.mcp.json --verbose",
+    "security:desktop:hardening:check": "node scripts/check-desktop-image-hardening.mjs",
     "security:trivy:image": "trivy image --scanners vuln,misconfig,secret",
     "fender:list": "node scripts/solana-fender-mcp.mjs list",
     "fender:check:file": "node scripts/solana-fender-mcp.mjs check-file",

--- a/scripts/check-desktop-image-hardening.mjs
+++ b/scripts/check-desktop-image-hardening.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+const ROOT = process.cwd();
+const DOCKERFILE_PATH = path.join(ROOT, "containers/desktop/Dockerfile");
+const GUEST_CARGO_TOML_PATH = path.join(ROOT, "zkvm/methods/guest/Cargo.toml");
+
+function fail(message) {
+  console.error(`desktop hardening check failed: ${message}`);
+  process.exit(1);
+}
+
+function extractAptInstallBlock(dockerfile) {
+  const match = dockerfile.match(
+    /RUN apt-get update[\s\S]*?apt-get install -y --no-install-recommends[\s\S]*?&& locale-gen en_US\.UTF-8/,
+  );
+  return match?.[0] ?? "";
+}
+
+function assertDoesNotContainAptPackage(aptBlock, packageName) {
+  const pattern = new RegExp(`\\b${packageName}\\b`);
+  if (pattern.test(aptBlock)) {
+    fail(`apt install block contains forbidden package "${packageName}"`);
+  }
+}
+
+async function main() {
+  const [dockerfile, guestCargoToml] = await Promise.all([
+    fs.readFile(DOCKERFILE_PATH, "utf8"),
+    fs.readFile(GUEST_CARGO_TOML_PATH, "utf8"),
+  ]);
+
+  if (!/^FROM ubuntu:24\.04$/m.test(dockerfile)) {
+    fail('desktop image base must be "ubuntu:24.04"');
+  }
+
+  if (!/RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends/.test(dockerfile)) {
+    fail("missing apt upgrade stage before install");
+  }
+
+  const aptBlock = extractAptInstallBlock(dockerfile);
+  if (!aptBlock) {
+    fail("could not locate apt install block");
+  }
+
+  assertDoesNotContainAptPackage(aptBlock, "imagemagick");
+  assertDoesNotContainAptPackage(aptBlock, "epiphany-browser");
+  assertDoesNotContainAptPackage(aptBlock, "ffmpeg");
+
+  if (!/FFMPEG_BIN="\$\(find \$\{PLAYWRIGHT_BROWSERS_PATH\} -path '\*\/ffmpeg-linux' \| head -n1\)"/.test(dockerfile)) {
+    fail("missing playwright ffmpeg discovery");
+  }
+
+  if (!/ln -sf "\$FFMPEG_BIN" \/usr\/bin\/ffmpeg/.test(dockerfile)) {
+    fail("missing ffmpeg symlink to playwright binary");
+  }
+
+  if (/risc0-zkvm\s*=\s*\{[^}]*features\s*=\s*\[\s*"std"\s*\][^}]*\}/.test(guestCargoToml)) {
+    fail('zkvm/methods/guest must not force `risc0-zkvm` "std" feature');
+  }
+
+  console.log("desktop hardening check passed.");
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  fail(message);
+});

--- a/zkvm/methods/guest/Cargo.lock
+++ b/zkvm/methods/guest/Cargo.lock
@@ -46,7 +46,6 @@ checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
  "ark-ff",
- "ark-r1cs-std",
  "ark-std",
 ]
 
@@ -178,23 +177,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-r1cs-std"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-relations",
- "ark-std",
- "educe",
- "num-bigint",
- "num-integer",
- "num-traits",
- "tracing",
-]
-
-[[package]]
 name = "ark-relations"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,7 +185,6 @@ dependencies = [
  "ark-ff",
  "ark-std",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -1328,7 +1309,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1350,19 +1330,6 @@ name = "tracing-core"
 version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "tracing-core",
-]
 
 [[package]]
 name = "typenum"

--- a/zkvm/methods/guest/Cargo.toml
+++ b/zkvm/methods/guest/Cargo.toml
@@ -7,5 +7,5 @@ publish = false
 [workspace]
 
 [dependencies]
-risc0-zkvm = { version = "~3.0", default-features = false, features = ["std"] }
+risc0-zkvm = { version = "~3.0", default-features = false }
 agenc-zkvm-guest = { path = "../../guest" }


### PR DESCRIPTION
## Summary
- Harden desktop image base and package strategy to cut low/medium CVE volume.
- Remove ImageMagick fallback and apt-level ImageMagick/Epiphany/FFmpeg installs.
- Use Playwright-provided ffmpeg binary via symlink.
- Remove guest `risc0-zkvm` forced `std` feature to reduce transitive low exposure.
- Add regression guard: `security:desktop:hardening:check`.

## Security results
- Trivy image (`agenc/desktop:latest`) reduced from `LOW 168 / MEDIUM 716` to `LOW 50 / MEDIUM 42`.
- Trivy FS (no ignore) reduced from 4 findings to 3 findings.
- Remaining FS findings are transitive upstream constraints:
  - `GHSA-fjx5-qpf4-xjf2` (`borsh 0.10.4`) via Anchor/Solana.
  - `CVE-2025-58160` (`tracing-subscriber 0.2.25`) via RISC0/ark stack in zkvm host.

## Validation
- `npm run -s security:mcp:check:strict`
- `npm run -s fender:gate:program`
- `npm run -s fender:gate:full`
- `npm run -s security:desktop:hardening:check`
- `trivy fs --scanners vuln --ignorefile /dev/null .`
- `trivy image --scanners vuln,misconfig,secret agenc/desktop:latest`
- `cd zkvm/methods/guest && cargo check`
