### PR TITLE
refactor(repo): remediate tech debt and stabilize test suites

### DIFF
--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -28,6 +28,10 @@ import {
   safeBigInt,
 } from "../utils/formatting.js";
 import { toolErrorResponse } from "./response.js";
+import {
+  filterAccountsByStatus,
+  formatEmptyStatusResult,
+} from "./status-filter.js";
 
 function formatAgentState(
   account: Record<string, unknown>,
@@ -222,25 +226,18 @@ export function registerAgentTools(server: McpServer): void {
         const program = getReadOnlyProgram();
         const accounts = await program.account.agentRegistration.all();
 
-        let filtered = accounts;
-        if (status_filter) {
-          filtered = accounts.filter((a) => {
-            const status = a.account.status as Record<string, unknown>;
-            if (typeof status === "object" && status !== null) {
-              return Object.keys(status).some((k) => k === status_filter);
-            }
-            return false;
-          });
-        }
+        const filtered = filterAccountsByStatus(
+          accounts,
+          status_filter,
+          (account) => (account.account as Record<string, unknown>).status,
+        );
 
         if (filtered.length === 0) {
           return {
             content: [
               {
                 type: "text" as const,
-                text: status_filter
-                  ? "No agents found with status: " + status_filter
-                  : "No agents found",
+                text: formatEmptyStatusResult("agents", status_filter),
               },
             ],
           };

--- a/mcp/src/tools/disputes.ts
+++ b/mcp/src/tools/disputes.ts
@@ -13,6 +13,10 @@ import {
   safePubkey,
 } from "../utils/formatting.js";
 import { toolErrorResponse } from "./response.js";
+import {
+  filterAccountsByStatus,
+  formatEmptyStatusResult,
+} from "./status-filter.js";
 
 function formatDisputeAccount(
   account: Record<string, unknown>,
@@ -117,25 +121,18 @@ export function registerDisputeTools(server: McpServer): void {
         const program = getReadOnlyProgram();
         const accounts = await program.account.dispute.all();
 
-        let filtered = accounts;
-        if (status_filter) {
-          filtered = accounts.filter((a) => {
-            const status = a.account.status as Record<string, unknown>;
-            if (typeof status === "object" && status !== null) {
-              return Object.keys(status).some((k) => k === status_filter);
-            }
-            return false;
-          });
-        }
+        const filtered = filterAccountsByStatus(
+          accounts,
+          status_filter,
+          (account) => (account.account as Record<string, unknown>).status,
+        );
 
         if (filtered.length === 0) {
           return {
             content: [
               {
                 type: "text" as const,
-                text: status_filter
-                  ? "No disputes found with status: " + status_filter
-                  : "No disputes found",
+                text: formatEmptyStatusResult("disputes", status_filter),
               },
             ],
           };

--- a/mcp/src/tools/inspector.ts
+++ b/mcp/src/tools/inspector.ts
@@ -873,8 +873,16 @@ export function registerInspectorTools(server: McpServer): void {
             } else {
               lines.push("[" + ixIndex + "] AgenC: (could not decode)");
             }
-          } catch {
-            lines.push("[" + ixIndex + "] AgenC: (decode error)");
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            lines.push(
+              "[" +
+                ixIndex +
+                "] AgenC: (decode error: " +
+                message +
+                ")",
+            );
           }
         } else {
           lines.push(

--- a/mcp/src/tools/status-filter.ts
+++ b/mcp/src/tools/status-filter.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared helpers for filtering Anchor enum-style account status objects.
+ */
+
+export function matchesStatusFilter(
+  status: unknown,
+  statusFilter: string,
+): boolean {
+  if (typeof status !== "object" || status === null) {
+    return false;
+  }
+  return Object.keys(status as Record<string, unknown>).some(
+    (key) => key === statusFilter,
+  );
+}
+
+export function filterAccountsByStatus<T>(
+  accounts: readonly T[],
+  statusFilter: string | undefined,
+  getStatus: (account: T) => unknown,
+): T[] {
+  if (!statusFilter) {
+    return [...accounts];
+  }
+  return accounts.filter((account) =>
+    matchesStatusFilter(getStatus(account), statusFilter),
+  );
+}
+
+export function formatEmptyStatusResult(
+  entityPlural: string,
+  statusFilter?: string,
+): string {
+  return statusFilter
+    ? `No ${entityPlural} found with status: ${statusFilter}`
+    : `No ${entityPlural} found`;
+}

--- a/mobile/src/hooks/useRemoteGateway.ts
+++ b/mobile/src/hooks/useRemoteGateway.ts
@@ -8,7 +8,10 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
 import type { ConnectionStatus, GatewayConnection } from '../types';
 import {
+  classifyGatewayControlMessage,
   computeReconnectDelayMs,
+  DEFAULT_GATEWAY_MAX_OFFLINE_QUEUE,
+  DEFAULT_GATEWAY_PING_INTERVAL_MS,
   DEFAULT_GATEWAY_SOCKET_BACKOFF,
   enqueueBounded,
   flushQueueIfOpen,
@@ -16,9 +19,6 @@ import {
   serializeAuthMessage,
   serializePingMessage,
 } from '../../../runtime/src/channels/webchat/socket-client-core';
-
-const MAX_OFFLINE_QUEUE = 1000;
-const PING_INTERVAL_MS = 30_000;
 
 interface UseRemoteGatewayOptions {
   connection: GatewayConnection | null;
@@ -70,7 +70,7 @@ export function useRemoteGateway({
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(serializePingMessage());
       }
-    }, PING_INTERVAL_MS);
+    }, DEFAULT_GATEWAY_PING_INTERVAL_MS);
   }, [stopPing]);
 
   const clearReconnect = useCallback(() => {
@@ -90,7 +90,11 @@ export function useRemoteGateway({
   }, []);
 
   const enqueue = useCallback((msg: string) => {
-    enqueueBounded(offlineQueueRef.current, msg, MAX_OFFLINE_QUEUE);
+    enqueueBounded(
+      offlineQueueRef.current,
+      msg,
+      DEFAULT_GATEWAY_MAX_OFFLINE_QUEUE,
+    );
     setQueueSize(offlineQueueRef.current.length);
   }, []);
 
@@ -118,23 +122,24 @@ export function useRemoteGateway({
         return;
       }
 
-      if (parsed && typeof parsed === 'object') {
-        const msg = parsed as Record<string, unknown>;
-        if (msg.type === 'auth') {
-          if (msg.error) {
-            offlineQueueRef.current.length = 0;
-            setQueueSize(0);
-            setStatus('disconnected');
-            onAuthFailedRef.current?.(String(msg.error));
-            ws.close();
-            return;
-          }
-          reconnectAttemptRef.current = 0;
-          setStatus('connected');
-          startPing();
-          flushQueue();
-          return;
-        }
+      const control = classifyGatewayControlMessage(parsed);
+      if (control.kind === 'auth_error') {
+        offlineQueueRef.current.length = 0;
+        setQueueSize(0);
+        setStatus('disconnected');
+        onAuthFailedRef.current?.(control.error ?? 'Authentication failed');
+        ws.close();
+        return;
+      }
+      if (control.kind === 'auth_ok') {
+        reconnectAttemptRef.current = 0;
+        setStatus('connected');
+        startPing();
+        flushQueue();
+        return;
+      }
+      if (control.kind === 'pong') {
+        return;
       }
 
       onMessageRef.current?.(parsed);

--- a/runtime/src/autonomous/desktop-executor.ts
+++ b/runtime/src/autonomous/desktop-executor.ts
@@ -87,6 +87,7 @@ export interface DesktopExecutorResult {
 // ============================================================================
 
 const DESKTOP_EXECUTOR_SESSION = "desktop-executor";
+const PROGRESS_BROADCAST_EVERY_STEPS = 3;
 let goalCounter = 0;
 
 function generateGoalId(): string {
@@ -416,7 +417,10 @@ export class DesktopExecutor {
         }
 
         // d. PROGRESS — broadcast every 3 steps
-        if (this.communicator && stepNumber % 3 === 0) {
+        if (
+          this.communicator &&
+          stepNumber % PROGRESS_BROADCAST_EVERY_STEPS === 0
+        ) {
           await this.communicator
             .broadcast(
               `Desktop executor progress: step ${stepNumber}/${planSteps.length} — ${planStep.description}`,

--- a/runtime/src/channels/webchat/socket-client-core.ts
+++ b/runtime/src/channels/webchat/socket-client-core.ts
@@ -10,6 +10,9 @@ export const DEFAULT_GATEWAY_SOCKET_BACKOFF: GatewaySocketBackoffConfig = {
   jitterFactor: 0.2,
 };
 
+export const DEFAULT_GATEWAY_PING_INTERVAL_MS = 30_000;
+export const DEFAULT_GATEWAY_MAX_OFFLINE_QUEUE = 1_000;
+
 export function computeReconnectDelayMs(
   attempt: number,
   config: GatewaySocketBackoffConfig = DEFAULT_GATEWAY_SOCKET_BACKOFF,
@@ -66,4 +69,34 @@ export function serializeAuthMessage(token: string): string {
 export function parseJsonMessage(raw: unknown): unknown {
   if (typeof raw !== "string") return raw;
   return JSON.parse(raw);
+}
+
+export type GatewayControlMessageKind =
+  | "auth_ok"
+  | "auth_error"
+  | "pong"
+  | "other";
+
+export interface GatewayControlMessage {
+  kind: GatewayControlMessageKind;
+  error?: string;
+}
+
+export function classifyGatewayControlMessage(
+  parsed: unknown,
+): GatewayControlMessage {
+  if (!parsed || typeof parsed !== "object") {
+    return { kind: "other" };
+  }
+  const message = parsed as Record<string, unknown>;
+  if (message.type === "auth") {
+    if (message.error) {
+      return { kind: "auth_error", error: String(message.error) };
+    }
+    return { kind: "auth_ok" };
+  }
+  if (message.type === "pong") {
+    return { kind: "pong" };
+  }
+  return { kind: "other" };
 }

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -1257,6 +1257,22 @@ interface WebChatSignals {
   signalIdle: (sessionId: string) => void;
 }
 
+interface WebChatMessageHandlerDeps {
+  webChat: WebChatChannel;
+  commandRegistry: SlashCommandRegistry;
+  getChatExecutor: () => ChatExecutor | null;
+  getLoggingConfig: () => GatewayLoggingConfig | undefined;
+  hooks: HookDispatcher;
+  sessionMgr: SessionManager;
+  getSystemPrompt: () => string;
+  baseToolHandler: ToolHandler;
+  approvalEngine: ApprovalEngine;
+  memoryBackend: MemoryBackend;
+  signals: WebChatSignals;
+  sessionTokenBudget: number;
+  contextWindowTokens?: number;
+}
+
 // ============================================================================
 // PID File Types
 // ============================================================================
@@ -1902,26 +1918,9 @@ export class DaemonManager {
    */
   private async wireWebChat(gateway: Gateway, config: GatewayConfig): Promise<void> {
     const hooks = await this.createHookDispatcher(config);
-    const discovered = await this.discoverSkills();
-    const availableSkills = discovered.filter((d) => d.available);
-    const skillList: WebChatSkillSummary[] = discovered.map((d) => ({
-      name: d.skill.name,
-      description: d.skill.description,
-      enabled: d.available,
-    }));
-    const skillToggle = (name: string, enabled: boolean): void => {
-      const skill = skillList.find((entry) => entry.name === name);
-      if (skill) skill.enabled = enabled;
-    };
-
-    let telemetry: UnifiedTelemetryCollector | null = null;
-    if (config.telemetry?.enabled !== false) {
-      telemetry = new UnifiedTelemetryCollector(
-        { flushIntervalMs: config.telemetry?.flushIntervalMs ?? 60_000 },
-        this.logger,
-      );
-      this._telemetry = telemetry;
-    }
+    const { availableSkills, skillList, skillToggle } =
+      await this.buildWebChatSkillState();
+    const telemetry = this.createWebChatTelemetry(config);
 
     const registry = await this.createToolRegistry(config, telemetry ?? undefined);
     this.refreshSubAgentToolCatalog(registry);
@@ -1929,47 +1928,11 @@ export class DaemonManager {
     const llmTools = registry.toLLMTools();
     let baseToolHandler = registry.createToolHandler();
 
-    // Wrap base tool handler with desktop routing if enabled
-    if (config.desktop?.enabled && this._desktopManager) {
-      const { createDesktopAwareToolHandler } = await import('../desktop/session-router.js');
-      const desktopManager = this._desktopManager;
-      const desktopBridges = this._desktopBridges;
-      const playwrightBridges = this._playwrightBridges;
-      const desktopLogger = this.logger;
-      const playwrightEnabled = config.desktop?.playwright?.enabled !== false;
-
-      // Desktop tools are lazily initialized per session via the router.
-      // Add static desktop tool definitions to LLM tools so the model knows
-      // the full schemas (parameter names, types, required fields).
-      const { TOOL_DEFINITIONS } = await import('../desktop/tool-definitions.js');
-      const desktopToolDefs: LLMTool[] = TOOL_DEFINITIONS
-        .filter((def) => def.name !== 'screenshot')
-        .map((def) => ({
-          type: 'function' as const,
-          function: {
-            name: `desktop.${def.name}`,
-            description: def.description,
-            parameters: def.inputSchema,
-          },
-        }));
-      llmTools.push(...desktopToolDefs);
-
-      // Store the original so per-session wrapping can use it
-      const originalBaseHandler = baseToolHandler;
-      const containerMCPConfigs = this._containerMCPConfigs;
-      const containerMCPBridges = this._containerMCPBridges;
-      this._desktopRouterFactory = (sessionId: string) =>
-        createDesktopAwareToolHandler(originalBaseHandler, sessionId, {
-          desktopManager,
-          bridges: desktopBridges,
-          playwrightBridges: playwrightEnabled ? playwrightBridges : undefined,
-          containerMCPConfigs: containerMCPConfigs.length > 0 ? containerMCPConfigs : undefined,
-          containerMCPBridges: containerMCPConfigs.length > 0 ? containerMCPBridges : undefined,
-          logger: desktopLogger,
-          // Force-disable automatic screenshot capture for action tools.
-          autoScreenshot: false,
-        });
-    }
+    await this.configureDesktopRoutingForWebChat(
+      config,
+      llmTools,
+      baseToolHandler,
+    );
 
     this._llmTools = llmTools;
     this._toolRouter = new ToolRouter(
@@ -1984,93 +1947,12 @@ export class DaemonManager {
     const memoryBackend = await this.createMemoryBackend(config, telemetry ?? undefined);
     this._memoryBackend = memoryBackend;
 
-    // --- Semantic memory stack ---
-    const embeddingProvider = await createEmbeddingProvider({
-      preferred: config.memory?.embeddingProvider,
-      apiKey: config.memory?.embeddingApiKey ?? config.llm?.apiKey,
-      baseUrl: config.memory?.embeddingBaseUrl,
-      model: config.memory?.embeddingModel,
-    });
-
-    const isSemanticAvailable = embeddingProvider.name !== 'noop';
-    let memoryRetriever: MemoryRetriever;
-
-    if (isSemanticAvailable) {
-      const workspacePath = getDefaultWorkspacePath();
-      const vectorStore = new InMemoryVectorStore({ dimension: embeddingProvider.dimension });
-
-      const curatedMemory = new CuratedMemoryManager(join(workspacePath, 'MEMORY.md'));
-      const logManager = new DailyLogManager(join(workspacePath, 'logs'));
-
-      const ingestionEngine = new MemoryIngestionEngine({
-        embeddingProvider,
-        vectorStore,
-        logManager,
-        curatedMemory,
-        generateSummaries: false,
-        enableDailyLogs: true,
-        enableEntityExtraction: false,
-        logger: this.logger,
+    const { memoryRetriever, learningProvider } =
+      await this.createWebChatMemoryRetrievers({
+        config,
+        hooks,
+        memoryBackend,
       });
-
-      const ingestionHooks = createIngestionHooks(ingestionEngine, this.logger);
-      for (const hook of ingestionHooks) {
-        hooks.on(hook);
-      }
-
-      memoryRetriever = new SemanticMemoryRetriever({
-        vectorBackend: vectorStore,
-        embeddingProvider,
-        curatedMemory,
-        maxTokenBudget: SEMANTIC_MEMORY_DEFAULTS.MAX_TOKEN_BUDGET,
-        maxResults: SEMANTIC_MEMORY_DEFAULTS.MAX_RESULTS,
-        recencyWeight: SEMANTIC_MEMORY_DEFAULTS.RECENCY_WEIGHT,
-        recencyHalfLifeMs: SEMANTIC_MEMORY_DEFAULTS.RECENCY_HALF_LIFE_MS,
-        hybridVectorWeight: SEMANTIC_MEMORY_DEFAULTS.HYBRID_VECTOR_WEIGHT,
-        hybridKeywordWeight: SEMANTIC_MEMORY_DEFAULTS.HYBRID_KEYWORD_WEIGHT,
-        logger: this.logger,
-      });
-
-      this.logger.info(`Semantic memory enabled (embedding: ${embeddingProvider.name}, dim: ${embeddingProvider.dimension})`);
-    } else {
-      memoryRetriever = this.createMemoryRetriever(memoryBackend);
-      this.logger.info('Semantic memory unavailable — using basic history retriever');
-    }
-
-    // Learning context provider — reads self-learning patterns per message
-    const learningProvider: MemoryRetriever = {
-      async retrieve(): Promise<string | undefined> {
-        if (!memoryBackend) return undefined;
-        try {
-          const learning = await memoryBackend.get<{
-            patterns: Array<{ type: string; description: string; lesson: string; confidence: number }>;
-            strategies: Array<{ name: string; description: string; steps: string[] }>;
-            preferences: Record<string, string>;
-          }>('learning:latest');
-          if (!learning) return undefined;
-
-          const parts: string[] = [];
-          const lessons = (learning.patterns ?? [])
-            .filter((p) => p.confidence >= MIN_LEARNING_CONFIDENCE)
-            .slice(0, 10)
-            .map((p) => `- ${p.lesson}`);
-          if (lessons.length > 0) parts.push('Lessons:\n' + lessons.join('\n'));
-
-          const strats = (learning.strategies ?? []).slice(0, 5)
-            .map((s) => `- ${s.name}: ${s.description}`);
-          if (strats.length > 0) parts.push('Strategies:\n' + strats.join('\n'));
-
-          const prefs = Object.entries(learning.preferences ?? {}).slice(0, 5)
-            .map(([k, v]) => `- ${k}: ${v}`);
-          if (prefs.length > 0) parts.push('Preferences:\n' + prefs.join('\n'));
-
-          if (parts.length === 0) return undefined;
-          return '## Learned Patterns\n\n' + parts.join('\n\n');
-        } catch {
-          return undefined;
-        }
-      },
-    };
 
     // --- Cross-session progress tracker ---
     const progressTracker = new ProgressTracker({ memoryBackend, logger: this.logger });
@@ -2092,51 +1974,11 @@ export class DaemonManager {
       },
     });
 
-    // Wire PolicyEngine as tool:before hook
-    if (config.policy?.enabled) {
-      try {
-        const { PolicyEngine } = await import('../policy/engine.js');
-        this._policyEngine = new PolicyEngine({
-          policy: {
-            enabled: true,
-            toolAllowList: config.policy.toolAllowList,
-            toolDenyList: config.policy.toolDenyList,
-            actionBudgets: config.policy.actionBudgets,
-            spendBudget: config.policy.spendBudget
-              ? { limitLamports: BigInt(config.policy.spendBudget.limitLamports), windowMs: config.policy.spendBudget.windowMs }
-              : undefined,
-            maxRiskScore: config.policy.maxRiskScore,
-            circuitBreaker: config.policy.circuitBreaker,
-          },
-          logger: this.logger,
-          metrics: telemetry ?? undefined,
-        });
-        hooks.on({
-          event: 'tool:before',
-          name: 'policy-gate',
-          priority: HOOK_PRIORITIES.POLICY_GATE,
-          handler: async (ctx) => {
-            const payload = ctx.payload as Record<string, unknown>;
-            const decision = this._policyEngine!.evaluate({
-              type: 'tool_call',
-              name: payload.toolName as string,
-              access: 'write',
-              metadata: payload,
-            });
-            if (!decision.allowed) {
-              this.logger.warn?.(
-                `Policy blocked tool "${payload.toolName}": ${decision.violations.map((v) => v.message).join('; ')}`,
-              );
-              return { continue: false };
-            }
-            return { continue: true };
-          },
-        });
-        this.logger.info('Policy engine initialized');
-      } catch (err) {
-        this.logger.warn?.('Policy engine initialization failed:', err);
-      }
-    }
+    await this.attachWebChatPolicyHook({
+      config,
+      hooks,
+      telemetry,
+    });
 
     const approvalEngine = new ApprovalEngine();
     this._approvalEngine = approvalEngine;
@@ -2287,7 +2129,324 @@ export class DaemonManager {
     this._webChatChannel = webChat;
     this.attachSubAgentLifecycleBridge(webChat);
 
-    // Hot-swap LLM provider and voice bridge when config changes at runtime
+    this.registerWebChatConfigReloadHandler({
+      gateway,
+      skillInjector,
+      memoryRetriever,
+      learningProvider,
+      progressTracker,
+      pipelineExecutor,
+      llmTools,
+      baseToolHandler,
+      voiceDeps,
+    });
+
+    const toolCount = registry.size;
+    const skillCount = availableSkills.length;
+    const providerNames = providers.map((p) => p.name).join(' → ') || 'none';
+    this.logger.info(
+      `WebChat wired` +
+      ` with LLM [${providerNames}]` +
+      `, ${toolCount} tools, ${skillCount} skills` +
+      `, memory=${memoryBackend.name}` +
+      `, ${commandRegistry.size} commands` +
+      (telemetry ? ', telemetry' : '') +
+      `, budget=${sessionTokenBudget}` +
+      (voiceBridge ? ', voice' : '') +
+      ', hooks, sessions, approvals',
+    );
+  }
+
+  private async buildWebChatSkillState(): Promise<{
+    availableSkills: DiscoveredSkill[];
+    skillList: WebChatSkillSummary[];
+    skillToggle: (name: string, enabled: boolean) => void;
+  }> {
+    const discovered = await this.discoverSkills();
+    const availableSkills = discovered.filter((entry) => entry.available);
+    const skillList: WebChatSkillSummary[] = discovered.map((entry) => ({
+      name: entry.skill.name,
+      description: entry.skill.description,
+      enabled: entry.available,
+    }));
+    const skillToggle = (name: string, enabled: boolean): void => {
+      const skill = skillList.find((entry) => entry.name === name);
+      if (skill) {
+        skill.enabled = enabled;
+      }
+    };
+    return { availableSkills, skillList, skillToggle };
+  }
+
+  private createWebChatTelemetry(
+    config: GatewayConfig,
+  ): UnifiedTelemetryCollector | null {
+    if (config.telemetry?.enabled === false) {
+      return null;
+    }
+    const telemetry = new UnifiedTelemetryCollector(
+      { flushIntervalMs: config.telemetry?.flushIntervalMs ?? 60_000 },
+      this.logger,
+    );
+    this._telemetry = telemetry;
+    return telemetry;
+  }
+
+  private async configureDesktopRoutingForWebChat(
+    config: GatewayConfig,
+    llmTools: LLMTool[],
+    baseToolHandler: ToolHandler,
+  ): Promise<void> {
+    if (!config.desktop?.enabled || !this._desktopManager) {
+      return;
+    }
+
+    const { createDesktopAwareToolHandler } = await import('../desktop/session-router.js');
+    const desktopManager = this._desktopManager;
+    const desktopBridges = this._desktopBridges;
+    const playwrightBridges = this._playwrightBridges;
+    const desktopLogger = this.logger;
+    const playwrightEnabled = config.desktop?.playwright?.enabled !== false;
+
+    // Desktop tools are lazily initialized per session via the router.
+    // Add static desktop tool definitions to LLM tools so the model knows
+    // the full schemas (parameter names, types, required fields).
+    const { TOOL_DEFINITIONS } = await import('../desktop/tool-definitions.js');
+    const desktopToolDefs: LLMTool[] = TOOL_DEFINITIONS
+      .filter((def) => def.name !== 'screenshot')
+      .map((def) => ({
+        type: 'function' as const,
+        function: {
+          name: `desktop.${def.name}`,
+          description: def.description,
+          parameters: def.inputSchema,
+        },
+      }));
+    llmTools.push(...desktopToolDefs);
+
+    const containerMCPConfigs = this._containerMCPConfigs;
+    const containerMCPBridges = this._containerMCPBridges;
+    this._desktopRouterFactory = (sessionId: string) =>
+      createDesktopAwareToolHandler(baseToolHandler, sessionId, {
+        desktopManager,
+        bridges: desktopBridges,
+        playwrightBridges: playwrightEnabled ? playwrightBridges : undefined,
+        containerMCPConfigs:
+          containerMCPConfigs.length > 0 ? containerMCPConfigs : undefined,
+        containerMCPBridges:
+          containerMCPConfigs.length > 0 ? containerMCPBridges : undefined,
+        logger: desktopLogger,
+        // Force-disable automatic screenshot capture for action tools.
+        autoScreenshot: false,
+      });
+  }
+
+  private async createWebChatMemoryRetrievers(params: {
+    config: GatewayConfig;
+    hooks: HookDispatcher;
+    memoryBackend: MemoryBackend;
+  }): Promise<{
+    memoryRetriever: MemoryRetriever;
+    learningProvider: MemoryRetriever;
+  }> {
+    const { config, hooks, memoryBackend } = params;
+
+    const embeddingProvider = await createEmbeddingProvider({
+      preferred: config.memory?.embeddingProvider,
+      apiKey: config.memory?.embeddingApiKey ?? config.llm?.apiKey,
+      baseUrl: config.memory?.embeddingBaseUrl,
+      model: config.memory?.embeddingModel,
+    });
+    const isSemanticAvailable = embeddingProvider.name !== 'noop';
+
+    const memoryRetriever = isSemanticAvailable
+      ? await this.createSemanticMemoryRetriever(
+        embeddingProvider,
+        hooks,
+      )
+      : this.createMemoryRetriever(memoryBackend);
+
+    if (!isSemanticAvailable) {
+      this.logger.info('Semantic memory unavailable — using basic history retriever');
+    }
+
+    return {
+      memoryRetriever,
+      learningProvider: this.createLearningProvider(memoryBackend),
+    };
+  }
+
+  private async createSemanticMemoryRetriever(
+    embeddingProvider: Awaited<ReturnType<typeof createEmbeddingProvider>>,
+    hooks: HookDispatcher,
+  ): Promise<MemoryRetriever> {
+    const workspacePath = getDefaultWorkspacePath();
+    const vectorStore = new InMemoryVectorStore({ dimension: embeddingProvider.dimension });
+
+    const curatedMemory = new CuratedMemoryManager(join(workspacePath, 'MEMORY.md'));
+    const logManager = new DailyLogManager(join(workspacePath, 'logs'));
+
+    const ingestionEngine = new MemoryIngestionEngine({
+      embeddingProvider,
+      vectorStore,
+      logManager,
+      curatedMemory,
+      generateSummaries: false,
+      enableDailyLogs: true,
+      enableEntityExtraction: false,
+      logger: this.logger,
+    });
+
+    const ingestionHooks = createIngestionHooks(ingestionEngine, this.logger);
+    for (const hook of ingestionHooks) {
+      hooks.on(hook);
+    }
+
+    this.logger.info(
+      `Semantic memory enabled (embedding: ${embeddingProvider.name}, dim: ${embeddingProvider.dimension})`,
+    );
+
+    return new SemanticMemoryRetriever({
+      vectorBackend: vectorStore,
+      embeddingProvider,
+      curatedMemory,
+      maxTokenBudget: SEMANTIC_MEMORY_DEFAULTS.MAX_TOKEN_BUDGET,
+      maxResults: SEMANTIC_MEMORY_DEFAULTS.MAX_RESULTS,
+      recencyWeight: SEMANTIC_MEMORY_DEFAULTS.RECENCY_WEIGHT,
+      recencyHalfLifeMs: SEMANTIC_MEMORY_DEFAULTS.RECENCY_HALF_LIFE_MS,
+      hybridVectorWeight: SEMANTIC_MEMORY_DEFAULTS.HYBRID_VECTOR_WEIGHT,
+      hybridKeywordWeight: SEMANTIC_MEMORY_DEFAULTS.HYBRID_KEYWORD_WEIGHT,
+      logger: this.logger,
+    });
+  }
+
+  private createLearningProvider(memoryBackend: MemoryBackend): MemoryRetriever {
+    return {
+      async retrieve(): Promise<string | undefined> {
+        if (!memoryBackend) return undefined;
+        try {
+          const learning = await memoryBackend.get<{
+            patterns: Array<{ type: string; description: string; lesson: string; confidence: number }>;
+            strategies: Array<{ name: string; description: string; steps: string[] }>;
+            preferences: Record<string, string>;
+          }>('learning:latest');
+          if (!learning) return undefined;
+
+          const parts: string[] = [];
+          const lessons = (learning.patterns ?? [])
+            .filter((pattern) => pattern.confidence >= MIN_LEARNING_CONFIDENCE)
+            .slice(0, 10)
+            .map((pattern) => `- ${pattern.lesson}`);
+          if (lessons.length > 0) parts.push('Lessons:\n' + lessons.join('\n'));
+
+          const strategies = (learning.strategies ?? [])
+            .slice(0, 5)
+            .map((strategy) => `- ${strategy.name}: ${strategy.description}`);
+          if (strategies.length > 0) {
+            parts.push('Strategies:\n' + strategies.join('\n'));
+          }
+
+          const preferences = Object.entries(learning.preferences ?? {})
+            .slice(0, 5)
+            .map(([key, value]) => `- ${key}: ${value}`);
+          if (preferences.length > 0) {
+            parts.push('Preferences:\n' + preferences.join('\n'));
+          }
+
+          if (parts.length === 0) return undefined;
+          return '## Learned Patterns\n\n' + parts.join('\n\n');
+        } catch {
+          return undefined;
+        }
+      },
+    };
+  }
+
+  private async attachWebChatPolicyHook(params: {
+    config: GatewayConfig;
+    hooks: HookDispatcher;
+    telemetry: UnifiedTelemetryCollector | null;
+  }): Promise<void> {
+    const { config, hooks, telemetry } = params;
+    if (!config.policy?.enabled) {
+      return;
+    }
+    try {
+      const { PolicyEngine } = await import('../policy/engine.js');
+      this._policyEngine = new PolicyEngine({
+        policy: {
+          enabled: true,
+          toolAllowList: config.policy.toolAllowList,
+          toolDenyList: config.policy.toolDenyList,
+          actionBudgets: config.policy.actionBudgets,
+          spendBudget: config.policy.spendBudget
+            ? {
+              limitLamports: BigInt(config.policy.spendBudget.limitLamports),
+              windowMs: config.policy.spendBudget.windowMs,
+            }
+            : undefined,
+          maxRiskScore: config.policy.maxRiskScore,
+          circuitBreaker: config.policy.circuitBreaker,
+        },
+        logger: this.logger,
+        metrics: telemetry ?? undefined,
+      });
+      hooks.on({
+        event: 'tool:before',
+        name: 'policy-gate',
+        priority: HOOK_PRIORITIES.POLICY_GATE,
+        handler: async (ctx) => {
+          const payload = ctx.payload as Record<string, unknown>;
+          const decision = this._policyEngine!.evaluate({
+            type: 'tool_call',
+            name: payload.toolName as string,
+            access: 'write',
+            metadata: payload,
+          });
+          if (!decision.allowed) {
+            this.logger.warn?.(
+              `Policy blocked tool "${payload.toolName}": ${decision.violations.map((v) => v.message).join('; ')}`,
+            );
+            return { continue: false };
+          }
+          return { continue: true };
+        },
+      });
+      this.logger.info('Policy engine initialized');
+    } catch (error) {
+      this.logger.warn?.('Policy engine initialization failed:', error);
+    }
+  }
+
+  private registerWebChatConfigReloadHandler(params: {
+    gateway: Gateway;
+    skillInjector: SkillInjector;
+    memoryRetriever: MemoryRetriever;
+    learningProvider: MemoryRetriever;
+    progressTracker: ProgressTracker;
+    pipelineExecutor: PipelineExecutor;
+    llmTools: LLMTool[];
+    baseToolHandler: ToolHandler;
+    voiceDeps: {
+      chatExecutor: ChatExecutor | undefined;
+      sessionManager: SessionManager;
+      hooks: HookDispatcher;
+      approvalEngine: ApprovalEngine;
+      memoryBackend: MemoryBackend;
+      delegation: DelegationToolCompositionResolver;
+    };
+  }): void {
+    const {
+      gateway,
+      skillInjector,
+      memoryRetriever,
+      learningProvider,
+      progressTracker,
+      pipelineExecutor,
+      llmTools,
+      baseToolHandler,
+      voiceDeps,
+    } = params;
     gateway.on('configReloaded', (...args: unknown[]) => {
       const diff = args[0] as ConfigDiff;
       const logLevelChanged = diff.safe.includes('logging.level');
@@ -2334,7 +2493,10 @@ export class DaemonManager {
             toolDenyList: newConfig.policy.toolDenyList,
             actionBudgets: newConfig.policy.actionBudgets,
             spendBudget: newConfig.policy.spendBudget
-              ? { limitLamports: BigInt(newConfig.policy.spendBudget.limitLamports), windowMs: newConfig.policy.spendBudget.windowMs }
+              ? {
+                limitLamports: BigInt(newConfig.policy.spendBudget.limitLamports),
+                windowMs: newConfig.policy.spendBudget.windowMs,
+              }
               : undefined,
             maxRiskScore: newConfig.policy.maxRiskScore,
             circuitBreaker: newConfig.policy.circuitBreaker,
@@ -2342,10 +2504,19 @@ export class DaemonManager {
           this.logger.info('Policy engine config reloaded');
         }
       }
-      const voiceChanged = diff.safe.some((key) => key.startsWith('voice.') || key.startsWith('llm.apiKey'));
+      const voiceChanged = diff.safe.some((key) =>
+        key.startsWith('voice.') || key.startsWith('llm.apiKey'),
+      );
       if (voiceChanged) {
         void this._voiceBridge?.stopAll();
-        const newBridge = this.createOptionalVoiceBridge(gateway.config, llmTools, baseToolHandler, this._systemPrompt, voiceDeps, this._voiceSystemPrompt);
+        const newBridge = this.createOptionalVoiceBridge(
+          gateway.config,
+          llmTools,
+          baseToolHandler,
+          this._systemPrompt,
+          voiceDeps,
+          this._voiceSystemPrompt,
+        );
         this._voiceBridge = newBridge ?? null;
         if (this._webChatChannel) {
           this._webChatChannel.updateVoiceBridge(newBridge ?? null);
@@ -2353,21 +2524,6 @@ export class DaemonManager {
         this.logger.info(`Voice bridge ${newBridge ? 'recreated' : 'disabled'}`);
       }
     });
-
-    const toolCount = registry.size;
-    const skillCount = availableSkills.length;
-    const providerNames = providers.map((p) => p.name).join(' → ') || 'none';
-    this.logger.info(
-      `WebChat wired` +
-      ` with LLM [${providerNames}]` +
-      `, ${toolCount} tools, ${skillCount} skills` +
-      `, memory=${memoryBackend.name}` +
-      `, ${commandRegistry.size} commands` +
-      (telemetry ? ', telemetry' : '') +
-      `, budget=${sessionTokenBudget}` +
-      (voiceBridge ? ', voice' : '') +
-      ', hooks, sessions, approvals',
-    );
   }
 
   /**
@@ -5231,21 +5387,17 @@ export class DaemonManager {
     this._subAgentLifecycleUnsubscribe = null;
   }
 
-  private createWebChatMessageHandler(params: {
-    webChat: WebChatChannel;
-    commandRegistry: SlashCommandRegistry;
-    getChatExecutor: () => ChatExecutor | null;
-    getLoggingConfig: () => GatewayLoggingConfig | undefined;
-    hooks: HookDispatcher;
-    sessionMgr: SessionManager;
-    getSystemPrompt: () => string;
-    baseToolHandler: ToolHandler;
-    approvalEngine: ApprovalEngine;
-    memoryBackend: MemoryBackend;
-    signals: WebChatSignals;
-    sessionTokenBudget: number;
-    contextWindowTokens?: number;
-  }): (msg: GatewayMessage) => Promise<void> {
+  private createWebChatMessageHandler(
+    params: WebChatMessageHandlerDeps,
+  ): (msg: GatewayMessage) => Promise<void> {
+    return async (msg: GatewayMessage): Promise<void> =>
+      this.handleWebChatInboundMessage(msg, params);
+  }
+
+  private async handleWebChatInboundMessage(
+    msg: GatewayMessage,
+    params: WebChatMessageHandlerDeps,
+  ): Promise<void> {
     const {
       webChat,
       commandRegistry,
@@ -5261,424 +5413,472 @@ export class DaemonManager {
       sessionTokenBudget,
       contextWindowTokens,
     } = params;
+    const hasAttachments = msg.attachments && msg.attachments.length > 0;
+    if (!msg.content.trim() && !hasAttachments) {
+      return;
+    }
+    const turnTraceId = createTurnTraceId(msg);
 
-    return async (msg: GatewayMessage): Promise<void> => {
-      const hasAttachments = msg.attachments && msg.attachments.length > 0;
-      if (!msg.content.trim() && !hasAttachments) {
-        return;
-      }
-      const turnTraceId = createTurnTraceId(msg);
+    const traceConfig = resolveTraceLoggingConfig(getLoggingConfig());
+    if (traceConfig.enabled) {
+      this.logger.info('[trace] webchat.inbound', {
+        traceId: turnTraceId,
+        sessionId: msg.sessionId,
+        message: summarizeGatewayMessageForTrace(msg, traceConfig.maxChars),
+      });
+    }
 
-      const traceConfig = resolveTraceLoggingConfig(getLoggingConfig());
+    const reply = async (content: string): Promise<void> => {
       if (traceConfig.enabled) {
-        this.logger.info('[trace] webchat.inbound', {
+        this.logger.info("[trace] webchat.command.reply", {
           traceId: turnTraceId,
           sessionId: msg.sessionId,
-          message: summarizeGatewayMessageForTrace(msg, traceConfig.maxChars),
+          content: truncateToolLogText(content, traceConfig.maxChars),
         });
       }
-
-      const reply = async (content: string): Promise<void> => {
-        if (traceConfig.enabled) {
-          this.logger.info("[trace] webchat.command.reply", {
-            traceId: turnTraceId,
-            sessionId: msg.sessionId,
-            content: truncateToolLogText(content, traceConfig.maxChars),
-          });
-        }
-        await webChat.send({ sessionId: msg.sessionId, content });
-      };
-      const handled = await commandRegistry.dispatch(
-        msg.content,
-        msg.sessionId,
-        msg.senderId,
-        'webchat',
-        reply,
-      );
-      if (handled) {
-        if (traceConfig.enabled) {
-          this.logger.info("[trace] webchat.command.handled", {
-            traceId: turnTraceId,
-            sessionId: msg.sessionId,
-            command: truncateToolLogText(msg.content.trim(), traceConfig.maxChars),
-          });
-        }
-        return;
+      await webChat.send({ sessionId: msg.sessionId, content });
+    };
+    const handled = await commandRegistry.dispatch(
+      msg.content,
+      msg.sessionId,
+      msg.senderId,
+      'webchat',
+      reply,
+    );
+    if (handled) {
+      if (traceConfig.enabled) {
+        this.logger.info("[trace] webchat.command.handled", {
+          traceId: turnTraceId,
+          sessionId: msg.sessionId,
+          command: truncateToolLogText(msg.content.trim(), traceConfig.maxChars),
+        });
       }
+      return;
+    }
 
-      // Resolve model/provider questions from runtime metadata instead of letting
-      // the model hallucinate or mirror static configuration text.
-      if (MODEL_QUERY_RE.test(msg.content)) {
-        const last = this._sessionModelInfo.get(msg.sessionId);
-        if (last) {
-          await webChat.send({
-            sessionId: msg.sessionId,
-            content:
-              `Last completion model: ${last.model} ` +
-              `(provider: ${last.provider}${last.usedFallback ? ', fallback used' : ''})`,
-          });
-          return;
-        }
-
-        const configuredProvider = this.gateway?.config.llm?.provider ?? 'none';
-        const configuredModel = normalizeGrokModel(this.gateway?.config.llm?.model) ??
-          (configuredProvider === 'grok' ? DEFAULT_GROK_MODEL : 'unknown');
+    // Resolve model/provider questions from runtime metadata instead of letting
+    // the model hallucinate or mirror static configuration text.
+    if (MODEL_QUERY_RE.test(msg.content)) {
+      const last = this._sessionModelInfo.get(msg.sessionId);
+      if (last) {
         await webChat.send({
           sessionId: msg.sessionId,
           content:
-            `No completion recorded yet for this session. ` +
-            `Configured primary is ${configuredProvider}:${configuredModel}.`,
+            `Last completion model: ${last.model} ` +
+            `(provider: ${last.provider}${last.usedFallback ? ', fallback used' : ''})`,
         });
         return;
       }
 
-      const chatExecutor = getChatExecutor();
-      if (!chatExecutor) {
-        await webChat.send({
-          sessionId: msg.sessionId,
-          content: 'No LLM provider configured. Add an `llm` section to ~/.agenc/config.json.',
-        });
-        return;
-      }
-
-      const inboundResult = await hooks.dispatch('message:inbound', {
+      const configuredProvider = this.gateway?.config.llm?.provider ?? 'none';
+      const configuredModel = normalizeGrokModel(this.gateway?.config.llm?.model) ??
+        (configuredProvider === 'grok' ? DEFAULT_GROK_MODEL : 'unknown');
+      await webChat.send({
         sessionId: msg.sessionId,
-        content: msg.content,
-        senderId: msg.senderId,
+        content:
+          `No completion recorded yet for this session. ` +
+          `Configured primary is ${configuredProvider}:${configuredModel}.`,
       });
-      if (!inboundResult.completed) {
-        return;
-      }
+      return;
+    }
 
-      webChat.broadcastEvent('chat.inbound', { sessionId: msg.sessionId });
+    const chatExecutor = getChatExecutor();
+    if (!chatExecutor) {
+      await webChat.send({
+        sessionId: msg.sessionId,
+        content: 'No LLM provider configured. Add an `llm` section to ~/.agenc/config.json.',
+      });
+      return;
+    }
 
-      const sessionStreamCallback: StreamProgressCallback = (chunk) => {
+    const inboundResult = await hooks.dispatch('message:inbound', {
+      sessionId: msg.sessionId,
+      content: msg.content,
+      senderId: msg.senderId,
+    });
+    if (!inboundResult.completed) {
+      return;
+    }
+
+    webChat.broadcastEvent('chat.inbound', { sessionId: msg.sessionId });
+
+    const sessionStreamCallback: StreamProgressCallback = (chunk) => {
+      webChat.pushToSession(msg.sessionId, {
+        type: 'chat.stream',
+        payload: { content: chunk.content, done: chunk.done },
+      });
+    };
+
+    // Detect greeting messages — block tool execution for casual conversation
+    const GREETING_RE = /^(h(i|ello|ey|ola|owdy)|yo|sup|what'?s\s*up|greetings?|good\s*(morning|afternoon|evening)|gm|gn)\s*[!?.,:;\-)*]*$/i;
+    const isGreeting = GREETING_RE.test(msg.content.trim());
+
+    const baseSessionHandler = createSessionToolHandler({
+      sessionId: msg.sessionId,
+      baseHandler: baseToolHandler,
+      desktopRouterFactory: this._desktopRouterFactory ?? undefined,
+      routerId: msg.sessionId,
+      send: (m) => webChat.pushToSession(msg.sessionId, m),
+      hooks,
+      approvalEngine,
+      delegation: this.resolveDelegationToolContext,
+      onToolStart: (name) => {
         webChat.pushToSession(msg.sessionId, {
-          type: 'chat.stream',
-          payload: { content: chunk.content, done: chunk.done },
+          type: 'agent.status',
+          payload: { phase: 'tool_call', detail: `Calling ${name}` },
         });
-      };
+      },
+      onToolEnd: (toolName, _result, durationMs) => {
+        webChat.broadcastEvent('tool.executed', {
+          toolName,
+          durationMs,
+          sessionId: msg.sessionId,
+        });
+        webChat.pushToSession(msg.sessionId, {
+          type: 'agent.status',
+          payload: { phase: 'generating' },
+        });
+      },
+    });
 
-      // Detect greeting messages — block tool execution for casual conversation
-      const GREETING_RE = /^(h(i|ello|ey|ola|owdy)|yo|sup|what'?s\s*up|greetings?|good\s*(morning|afternoon|evening)|gm|gn)\s*[!?.,:;\-)*]*$/i;
-      const isGreeting = GREETING_RE.test(msg.content.trim());
+    const sessionToolHandler: ToolHandler = async (name, args) => {
+      if (isGreeting) {
+        return JSON.stringify({
+          error: 'This is a greeting message. Respond conversationally without using any tools.',
+        });
+      }
+      if (traceConfig.enabled) {
+        this.logger.info('[trace] webchat.tool.call', {
+          traceId: turnTraceId,
+          sessionId: msg.sessionId,
+          tool: name,
+          ...(traceConfig.includeToolArgs
+            ? { args: summarizeTraceValue(args, traceConfig.maxChars) }
+            : {}),
+        });
+      }
 
-      const baseSessionHandler = createSessionToolHandler({
-        sessionId: msg.sessionId,
-        baseHandler: baseToolHandler,
-        desktopRouterFactory: this._desktopRouterFactory ?? undefined,
-        routerId: msg.sessionId,
-        send: (m) => webChat.pushToSession(msg.sessionId, m),
-        hooks,
-        approvalEngine,
-        delegation: this.resolveDelegationToolContext,
-        onToolStart: (name) => {
-          webChat.pushToSession(msg.sessionId, {
-            type: 'agent.status',
-            payload: { phase: 'tool_call', detail: `Calling ${name}` },
-          });
-        },
-        onToolEnd: (toolName, _result, durationMs) => {
-          webChat.broadcastEvent('tool.executed', {
-            toolName,
-            durationMs,
-            sessionId: msg.sessionId,
-          });
-          webChat.pushToSession(msg.sessionId, {
-            type: 'agent.status',
-            payload: { phase: 'generating' },
-          });
-        },
-      });
-
-      const sessionToolHandler: ToolHandler = async (name, args) => {
-        if (isGreeting) {
-          return JSON.stringify({
-            error: 'This is a greeting message. Respond conversationally without using any tools.',
-          });
-        }
+      const toolStart = Date.now();
+      try {
+        const result = await baseSessionHandler(name, args);
         if (traceConfig.enabled) {
-          this.logger.info('[trace] webchat.tool.call', {
+          this.logger.info('[trace] webchat.tool.result', {
             traceId: turnTraceId,
             sessionId: msg.sessionId,
             tool: name,
-            ...(traceConfig.includeToolArgs
-              ? { args: summarizeTraceValue(args, traceConfig.maxChars) }
+            durationMs: Date.now() - toolStart,
+            ...(traceConfig.includeToolResults
+              ? { result: summarizeToolResultForTrace(result, traceConfig.maxChars) }
               : {}),
           });
         }
-
-        const toolStart = Date.now();
-        try {
-          const result = await baseSessionHandler(name, args);
-          if (traceConfig.enabled) {
-            this.logger.info('[trace] webchat.tool.result', {
-              traceId: turnTraceId,
-              sessionId: msg.sessionId,
-              tool: name,
-              durationMs: Date.now() - toolStart,
-              ...(traceConfig.includeToolResults
-                ? { result: summarizeToolResultForTrace(result, traceConfig.maxChars) }
-                : {}),
-            });
-          }
-          return result;
-        } catch (error) {
-          if (traceConfig.enabled) {
-            this.logger.error('[trace] webchat.tool.error', {
-              traceId: turnTraceId,
-              sessionId: msg.sessionId,
-              tool: name,
-              durationMs: Date.now() - toolStart,
-              error: toErrorMessage(error),
-            });
-          }
-          throw error;
-        }
-      };
-
-      this._activeSessionTraceIds.set(msg.sessionId, turnTraceId);
-      try {
-        signals.signalThinking(msg.sessionId);
-
-        const session = sessionMgr.getOrCreate({
-          channel: 'webchat',
-          senderId: msg.sessionId,
-          scope: 'dm',
-          workspaceId: 'default',
-        });
-
+        return result;
+      } catch (error) {
         if (traceConfig.enabled) {
-          const currentPrompt = getSystemPrompt();
-          this.logger.info('[trace] webchat.chat.request', {
+          this.logger.error('[trace] webchat.tool.error', {
             traceId: turnTraceId,
             sessionId: msg.sessionId,
-            historyLength: session.history.length,
-            historyRoleCounts: summarizeRoleCounts(session.history),
-            systemPromptChars: currentPrompt.length,
-            ...(traceConfig.includeSystemPrompt
-              ? { systemPrompt: truncateToolLogText(currentPrompt, traceConfig.maxChars) }
+            tool: name,
+            durationMs: Date.now() - toolStart,
+            error: toErrorMessage(error),
+          });
+        }
+        throw error;
+      }
+    };
+
+    await this.executeWebChatConversationTurn({
+      msg,
+      webChat,
+      chatExecutor,
+      sessionMgr,
+      getSystemPrompt,
+      sessionToolHandler,
+      sessionStreamCallback,
+      signals,
+      hooks,
+      memoryBackend,
+      sessionTokenBudget,
+      contextWindowTokens,
+      traceConfig,
+      turnTraceId,
+    });
+  }
+
+  private async executeWebChatConversationTurn(params: {
+    msg: GatewayMessage;
+    webChat: WebChatChannel;
+    chatExecutor: ChatExecutor;
+    sessionMgr: SessionManager;
+    getSystemPrompt: () => string;
+    sessionToolHandler: ToolHandler;
+    sessionStreamCallback: StreamProgressCallback;
+    signals: WebChatSignals;
+    hooks: HookDispatcher;
+    memoryBackend: MemoryBackend;
+    sessionTokenBudget: number;
+    contextWindowTokens?: number;
+    traceConfig: ResolvedTraceLoggingConfig;
+    turnTraceId: string;
+  }): Promise<void> {
+    const {
+      msg,
+      webChat,
+      chatExecutor,
+      sessionMgr,
+      getSystemPrompt,
+      sessionToolHandler,
+      sessionStreamCallback,
+      signals,
+      hooks,
+      memoryBackend,
+      sessionTokenBudget,
+      contextWindowTokens,
+      traceConfig,
+      turnTraceId,
+    } = params;
+
+    this._activeSessionTraceIds.set(msg.sessionId, turnTraceId);
+    try {
+      signals.signalThinking(msg.sessionId);
+
+      const session = sessionMgr.getOrCreate({
+        channel: 'webchat',
+        senderId: msg.sessionId,
+        scope: 'dm',
+        workspaceId: 'default',
+      });
+
+      if (traceConfig.enabled) {
+        const currentPrompt = getSystemPrompt();
+        this.logger.info('[trace] webchat.chat.request', {
+          traceId: turnTraceId,
+          sessionId: msg.sessionId,
+          historyLength: session.history.length,
+          historyRoleCounts: summarizeRoleCounts(session.history),
+          systemPromptChars: currentPrompt.length,
+          ...(traceConfig.includeSystemPrompt
+            ? { systemPrompt: truncateToolLogText(currentPrompt, traceConfig.maxChars) }
+            : {}),
+          ...(traceConfig.includeHistory
+            ? {
+              history: summarizeHistoryForTrace(session.history, traceConfig),
+            }
+            : {}),
+        });
+      }
+      const toolRoutingDecision = this.buildToolRoutingDecision(
+        msg.sessionId,
+        msg.content,
+        session.history,
+      );
+      if (traceConfig.enabled && toolRoutingDecision) {
+        this.logger.info('[trace] webchat.tool_routing', {
+          traceId: turnTraceId,
+          sessionId: msg.sessionId,
+          routing: summarizeToolRoutingDecisionForTrace(toolRoutingDecision),
+        });
+      }
+
+      // Create an AbortController so the user can cancel mid-execution
+      const abortController = webChat.createAbortController(msg.sessionId);
+
+      const result = await chatExecutor.execute({
+        message: msg,
+        history: session.history,
+        systemPrompt: getSystemPrompt(),
+        sessionId: msg.sessionId,
+        toolHandler: sessionToolHandler,
+        onStreamChunk: sessionStreamCallback,
+        signal: abortController.signal,
+        toolRouting: toolRoutingDecision
+          ? {
+            routedToolNames: toolRoutingDecision.routedToolNames,
+            expandedToolNames: toolRoutingDecision.expandedToolNames,
+            expandOnMiss: true,
+          }
+          : undefined,
+      });
+      this.recordToolRoutingOutcome(
+        msg.sessionId,
+        result.toolRoutingSummary,
+      );
+
+      webChat.clearAbortController(msg.sessionId);
+
+      if (result.model) {
+        this._sessionModelInfo.set(msg.sessionId, {
+          provider: result.provider,
+          model: result.model,
+          usedFallback: result.usedFallback,
+          updatedAt: Date.now(),
+        });
+      }
+
+      if (traceConfig.enabled) {
+        this.logger.info('[trace] webchat.chat.response', {
+          traceId: turnTraceId,
+          sessionId: msg.sessionId,
+          provider: result.provider,
+          model: result.model,
+          usedFallback: result.usedFallback,
+          durationMs: result.durationMs,
+          compacted: result.compacted,
+          tokenUsage: result.tokenUsage,
+          requestShape: summarizeInitialRequestShape(result.callUsage),
+          callUsage: summarizeCallUsageForTrace(result.callUsage),
+          statefulSummary: result.statefulSummary,
+          toolRoutingDecision: summarizeToolRoutingDecisionForTrace(
+            toolRoutingDecision,
+          ),
+          toolRoutingSummary: summarizeToolRoutingSummaryForTrace(
+            result.toolRoutingSummary,
+          ),
+          stopReason: result.stopReason,
+          stopReasonDetail: result.stopReasonDetail,
+          response: truncateToolLogText(result.content, traceConfig.maxChars),
+          toolCalls: result.toolCalls.map((toolCall) => ({
+            name: toolCall.name,
+            durationMs: toolCall.durationMs,
+            isError: toolCall.isError,
+            ...(traceConfig.includeToolArgs
+              ? { args: summarizeTraceValue(toolCall.args, traceConfig.maxChars) }
               : {}),
-            ...(traceConfig.includeHistory
+            ...(traceConfig.includeToolResults
               ? {
-                history: summarizeHistoryForTrace(session.history, traceConfig),
+                result: summarizeToolResultForTrace(
+                  toolCall.result,
+                  traceConfig.maxChars,
+                ),
               }
               : {}),
-          });
-        }
-        const toolRoutingDecision = this.buildToolRoutingDecision(
-          msg.sessionId,
-          msg.content,
-          session.history,
-        );
-        if (traceConfig.enabled && toolRoutingDecision) {
-          this.logger.info('[trace] webchat.tool_routing', {
-            traceId: turnTraceId,
-            sessionId: msg.sessionId,
-            routing: summarizeToolRoutingDecisionForTrace(toolRoutingDecision),
-          });
-        }
-
-        // Create an AbortController so the user can cancel mid-execution
-        const abortController = webChat.createAbortController(msg.sessionId);
-
-        const result = await chatExecutor.execute({
-          message: msg,
-          history: session.history,
-          systemPrompt: getSystemPrompt(),
-          sessionId: msg.sessionId,
-          toolHandler: sessionToolHandler,
-          onStreamChunk: sessionStreamCallback,
-          signal: abortController.signal,
-          toolRouting: toolRoutingDecision
-            ? {
-              routedToolNames: toolRoutingDecision.routedToolNames,
-              expandedToolNames: toolRoutingDecision.expandedToolNames,
-              expandOnMiss: true,
-            }
-            : undefined,
+          })),
         });
-        this.recordToolRoutingOutcome(
-          msg.sessionId,
-          result.toolRoutingSummary,
-        );
+      }
+      if ((result.statefulSummary?.fallbackCalls ?? 0) > 0) {
+        this.logger.warn("[stateful] webchat fallback_to_stateless", {
+          traceId: turnTraceId,
+          sessionId: msg.sessionId,
+          summary: result.statefulSummary,
+        });
+      }
 
-        webChat.clearAbortController(msg.sessionId);
+      // If ChatExecutor compacted context, also trim session history
+      if (result.compacted) {
+        void sessionMgr.compact(session.id);
+      }
 
-        if (result.model) {
-          this._sessionModelInfo.set(msg.sessionId, {
-            provider: result.provider,
-            model: result.model,
-            usedFallback: result.usedFallback,
-            updatedAt: Date.now(),
-          });
-        }
+      signals.signalIdle(msg.sessionId);
+      sessionMgr.appendMessage(session.id, { role: 'user', content: msg.content });
+      sessionMgr.appendMessage(session.id, { role: 'assistant', content: result.content });
 
-        if (traceConfig.enabled) {
-          this.logger.info('[trace] webchat.chat.response', {
-            traceId: turnTraceId,
-            sessionId: msg.sessionId,
-            provider: result.provider,
-            model: result.model,
-            usedFallback: result.usedFallback,
-            durationMs: result.durationMs,
-            compacted: result.compacted,
-            tokenUsage: result.tokenUsage,
-            requestShape: summarizeInitialRequestShape(result.callUsage),
-            callUsage: summarizeCallUsageForTrace(result.callUsage),
-            statefulSummary: result.statefulSummary,
-            toolRoutingDecision: summarizeToolRoutingDecisionForTrace(
-              toolRoutingDecision,
-            ),
-            toolRoutingSummary: summarizeToolRoutingSummaryForTrace(
-              result.toolRoutingSummary,
-            ),
+      await webChat.send({
+        sessionId: msg.sessionId,
+        content: result.content || '(no response)',
+      });
+
+      // Send cumulative token usage to browser
+      webChat.pushToSession(msg.sessionId, {
+        type: 'chat.usage',
+        payload: buildChatUsagePayload({
+          totalTokens: chatExecutor.getSessionTokenUsage(msg.sessionId),
+          sessionTokenBudget,
+          compacted: result.compacted ?? false,
+          contextWindowTokens,
+          callUsage: result.callUsage,
+        }),
+      });
+
+      if (
+        this._subagentActivityTraceBySession.get(msg.sessionId) === turnTraceId
+      ) {
+        this.relaySubAgentLifecycleEvent(webChat, {
+          type: "subagents.synthesized",
+          timestamp: Date.now(),
+          sessionId: msg.sessionId,
+          parentSessionId: msg.sessionId,
+          payload: {
             stopReason: result.stopReason,
-            stopReasonDetail: result.stopReasonDetail,
-            response: truncateToolLogText(result.content, traceConfig.maxChars),
-            toolCalls: result.toolCalls.map((toolCall) => ({
-              name: toolCall.name,
-              durationMs: toolCall.durationMs,
-              isError: toolCall.isError,
-              ...(traceConfig.includeToolArgs
-                ? { args: summarizeTraceValue(toolCall.args, traceConfig.maxChars) }
-                : {}),
-              ...(traceConfig.includeToolResults
-                ? {
-                  result: summarizeToolResultForTrace(
-                    toolCall.result,
-                    traceConfig.maxChars,
-                  ),
-                }
-                : {}),
-            })),
-          });
-        }
-        if ((result.statefulSummary?.fallbackCalls ?? 0) > 0) {
-          this.logger.warn("[stateful] webchat fallback_to_stateless", {
-            traceId: turnTraceId,
-            sessionId: msg.sessionId,
-            summary: result.statefulSummary,
-          });
-        }
-
-        // If ChatExecutor compacted context, also trim session history
-        if (result.compacted) {
-          void sessionMgr.compact(session.id);
-        }
-
-        signals.signalIdle(msg.sessionId);
-        sessionMgr.appendMessage(session.id, { role: 'user', content: msg.content });
-        sessionMgr.appendMessage(session.id, { role: 'assistant', content: result.content });
-
-        await webChat.send({
-          sessionId: msg.sessionId,
-          content: result.content || '(no response)',
+            outputChars: result.content.length,
+            toolCalls: result.toolCalls.length,
+          },
         });
+        this._subagentActivityTraceBySession.delete(msg.sessionId);
+      }
 
-        // Send cumulative token usage to browser
-        webChat.pushToSession(msg.sessionId, {
-          type: 'chat.usage',
-          payload: buildChatUsagePayload({
-            totalTokens: chatExecutor.getSessionTokenUsage(msg.sessionId),
-            sessionTokenBudget,
-            compacted: result.compacted ?? false,
-            contextWindowTokens,
-            callUsage: result.callUsage,
-          }),
-        });
+      webChat.broadcastEvent('chat.response', { sessionId: msg.sessionId });
 
-        if (
-          this._subagentActivityTraceBySession.get(msg.sessionId) === turnTraceId
-        ) {
-          this.relaySubAgentLifecycleEvent(webChat, {
-            type: "subagents.synthesized",
-            timestamp: Date.now(),
-            sessionId: msg.sessionId,
-            parentSessionId: msg.sessionId,
-            payload: {
-              stopReason: result.stopReason,
-              outputChars: result.content.length,
-              toolCalls: result.toolCalls.length,
-            },
-          });
-          this._subagentActivityTraceBySession.delete(msg.sessionId);
-        }
+      await hooks.dispatch('message:outbound', {
+        sessionId: msg.sessionId,
+        content: result.content,
+        provider: result.provider,
+        userMessage: msg.content,
+        agentResponse: result.content,
+      });
 
-        webChat.broadcastEvent('chat.response', { sessionId: msg.sessionId });
-
-        await hooks.dispatch('message:outbound', {
+      try {
+        await memoryBackend.addEntry({
           sessionId: msg.sessionId,
+          role: 'user',
+          content: msg.content,
+        });
+        await memoryBackend.addEntry({
+          sessionId: msg.sessionId,
+          role: 'assistant',
           content: result.content,
-          provider: result.provider,
-          userMessage: msg.content,
-          agentResponse: result.content,
         });
-
-        try {
-          await memoryBackend.addEntry({
-            sessionId: msg.sessionId,
-            role: 'user',
-            content: msg.content,
-          });
-          await memoryBackend.addEntry({
-            sessionId: msg.sessionId,
-            role: 'assistant',
-            content: result.content,
-          });
-        } catch (error) {
-          this.logger.warn?.('Failed to persist messages to memory:', error);
-        }
-
-        if (result.toolCalls.length > 0) {
-          const failures = result.toolCalls
-            .map((toolCall) => summarizeToolFailureForLog(toolCall))
-            .filter((entry): entry is ToolFailureSummary => entry !== null);
-
-          this.logger.info(`Chat used ${result.toolCalls.length} tool call(s)`, {
-            traceId: turnTraceId,
-            tools: result.toolCalls.map((toolCall) => toolCall.name),
-            provider: result.provider,
-            failedToolCalls: failures.length,
-            ...(failures.length > 0 ? { failureDetails: failures } : {}),
-          });
-        }
       } catch (error) {
-        const failure = summarizeLLMFailureForSurface(error);
-        webChat.clearAbortController(msg.sessionId);
-        signals.signalIdle(msg.sessionId);
-        if (traceConfig.enabled) {
-          this.logger.error('[trace] webchat.chat.error', {
-            traceId: turnTraceId,
-            sessionId: msg.sessionId,
-            stopReason: failure.stopReason,
-            stopReasonDetail: failure.stopReasonDetail,
-            error: toErrorMessage(error),
-            ...(error instanceof Error && error.stack
-              ? { stack: truncateToolLogText(error.stack, traceConfig.maxChars) }
-              : {}),
-          });
-        }
-        this.logger.error('LLM chat error:', {
+        this.logger.warn?.('Failed to persist messages to memory:', error);
+      }
+
+      if (result.toolCalls.length > 0) {
+        const failures = result.toolCalls
+          .map((toolCall) => summarizeToolFailureForLog(toolCall))
+          .filter((entry): entry is ToolFailureSummary => entry !== null);
+
+        this.logger.info(`Chat used ${result.toolCalls.length} tool call(s)`, {
+          traceId: turnTraceId,
+          tools: result.toolCalls.map((toolCall) => toolCall.name),
+          provider: result.provider,
+          failedToolCalls: failures.length,
+          ...(failures.length > 0 ? { failureDetails: failures } : {}),
+        });
+      }
+    } catch (error) {
+      const failure = summarizeLLMFailureForSurface(error);
+      webChat.clearAbortController(msg.sessionId);
+      signals.signalIdle(msg.sessionId);
+      if (traceConfig.enabled) {
+        this.logger.error('[trace] webchat.chat.error', {
+          traceId: turnTraceId,
+          sessionId: msg.sessionId,
           stopReason: failure.stopReason,
           stopReasonDetail: failure.stopReasonDetail,
           error: toErrorMessage(error),
+          ...(error instanceof Error && error.stack
+            ? { stack: truncateToolLogText(error.stack, traceConfig.maxChars) }
+            : {}),
         });
-        await webChat.send({
-          sessionId: msg.sessionId,
-          content: failure.userMessage,
-        });
-      } finally {
-        if (this._activeSessionTraceIds.get(msg.sessionId) === turnTraceId) {
-          this._activeSessionTraceIds.delete(msg.sessionId);
-        }
-        if (
-          this._subagentActivityTraceBySession.get(msg.sessionId) === turnTraceId
-        ) {
-          this._subagentActivityTraceBySession.delete(msg.sessionId);
-        }
       }
-    };
+      this.logger.error('LLM chat error:', {
+        stopReason: failure.stopReason,
+        stopReasonDetail: failure.stopReasonDetail,
+        error: toErrorMessage(error),
+      });
+      await webChat.send({
+        sessionId: msg.sessionId,
+        content: failure.userMessage,
+      });
+    } finally {
+      if (this._activeSessionTraceIds.get(msg.sessionId) === turnTraceId) {
+        this._activeSessionTraceIds.delete(msg.sessionId);
+      }
+      if (
+        this._subagentActivityTraceBySession.get(msg.sessionId) === turnTraceId
+      ) {
+        this._subagentActivityTraceBySession.delete(msg.sessionId);
+      }
+    }
   }
 
   /**

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -107,6 +107,401 @@ function parseDelegationFailureReason(output: string): string {
   return trimmed;
 }
 
+type DelegationContext = NonNullable<
+  ReturnType<NonNullable<DelegationToolCompositionResolver>>
+>;
+type DelegationSubAgentManager = NonNullable<DelegationContext["subAgentManager"]>;
+type DelegationSubAgentInfo = ReturnType<DelegationSubAgentManager["getInfo"]>;
+type DelegationLifecycleEmitter = DelegationContext["lifecycleEmitter"];
+type DelegationVerifier = DelegationContext["verifier"];
+
+function sendDeniedToolResult(params: {
+  send: (msg: ControlResponse) => void;
+  toolName: string;
+  result: string;
+  toolCallId: string;
+  sessionId: string;
+  isSubAgentSession: boolean;
+}): void {
+  const { send, toolName, result, toolCallId, sessionId, isSubAgentSession } =
+    params;
+  send({
+    type: "tools.result",
+    payload: {
+      toolName,
+      result,
+      durationMs: 0,
+      isError: true,
+      toolCallId,
+      ...(isSubAgentSession ? { subagentSessionId: sessionId } : {}),
+    },
+  });
+}
+
+function buildApprovalMessage(params: {
+  ruleDescription?: string;
+  toolName: string;
+  sessionId: string;
+  isSubAgentSession: boolean;
+  subAgentInfo: DelegationSubAgentInfo | null;
+}): string {
+  const {
+    ruleDescription,
+    toolName,
+    sessionId,
+    isSubAgentSession,
+    subAgentInfo,
+  } = params;
+  const baseMessage = ruleDescription ?? `Approval required for ${toolName}`;
+  if (!isSubAgentSession || !subAgentInfo) return baseMessage;
+  const taskPreview = truncateText(
+    subAgentInfo.task.trim(),
+    APPROVAL_TASK_PREVIEW_MAX_CHARS,
+  );
+  return (
+    `${baseMessage}\n` +
+    `Parent session: ${subAgentInfo.parentSessionId}\n` +
+    `Sub-agent session: ${sessionId}\n` +
+    `Delegated task: ${taskPreview}`
+  );
+}
+
+async function runApprovalGate(params: {
+  approvalEngine: ApprovalEngine | undefined;
+  name: string;
+  args: Record<string, unknown>;
+  sessionId: string;
+  parentSessionId: string | undefined;
+  isSubAgentSession: boolean;
+  subAgentInfo: DelegationSubAgentInfo | null;
+  lifecycleEmitter: DelegationLifecycleEmitter;
+  send: (msg: ControlResponse) => void;
+  onToolEnd: SessionToolHandlerConfig["onToolEnd"];
+  toolCallId: string;
+}): Promise<string | null> {
+  const {
+    approvalEngine,
+    name,
+    args,
+    sessionId,
+    parentSessionId,
+    isSubAgentSession,
+    subAgentInfo,
+    lifecycleEmitter,
+    send,
+    onToolEnd,
+    toolCallId,
+  } = params;
+  if (!approvalEngine) {
+    return null;
+  }
+
+  const rule = approvalEngine.requiresApproval(name, args);
+  if (!rule || approvalEngine.isToolElevated(sessionId, name)) {
+    return null;
+  }
+
+  if (approvalEngine.isToolDenied(sessionId, name, parentSessionId)) {
+    const err = JSON.stringify({
+      error:
+        `Tool "${name}" blocked because this action was denied earlier in the request tree`,
+    });
+    sendDeniedToolResult({
+      send,
+      toolName: name,
+      result: err,
+      toolCallId,
+      sessionId,
+      isSubAgentSession,
+    });
+    if (isSubAgentSession && lifecycleEmitter) {
+      lifecycleEmitter.emit({
+        type: "subagents.failed",
+        timestamp: Date.now(),
+        sessionId,
+        subagentSessionId: sessionId,
+        ...(parentSessionId ? { parentSessionId } : {}),
+        toolName: name,
+        payload: {
+          stage: "approval",
+          reason: "denied_previously",
+          toolCallId,
+        },
+      });
+    }
+    onToolEnd?.(name, err, 0, toolCallId);
+    return err;
+  }
+
+  const approvalMessage = buildApprovalMessage({
+    ruleDescription: rule.description,
+    toolName: name,
+    sessionId,
+    isSubAgentSession,
+    subAgentInfo,
+  });
+  const request = approvalEngine.createRequest(
+    name,
+    args,
+    sessionId,
+    approvalMessage,
+    rule,
+    {
+      ...(parentSessionId ? { parentSessionId } : {}),
+      ...(isSubAgentSession ? { subagentSessionId: sessionId } : {}),
+    },
+  );
+  send({
+    type: "approval.request",
+    payload: {
+      requestId: request.id,
+      action: name,
+      details: args,
+      message: request.message,
+      ...(request.parentSessionId
+        ? { parentSessionId: request.parentSessionId }
+        : {}),
+      ...(request.subagentSessionId
+        ? { subagentSessionId: request.subagentSessionId }
+        : {}),
+    },
+  });
+
+  const response = await approvalEngine.requestApproval(request);
+  if (response.disposition === "no") {
+    const err = JSON.stringify({ error: `Tool "${name}" denied by user` });
+    sendDeniedToolResult({
+      send,
+      toolName: name,
+      result: err,
+      toolCallId,
+      sessionId,
+      isSubAgentSession,
+    });
+    if (isSubAgentSession && lifecycleEmitter) {
+      lifecycleEmitter.emit({
+        type: "subagents.failed",
+        timestamp: Date.now(),
+        sessionId,
+        subagentSessionId: sessionId,
+        toolName: name,
+        payload: {
+          stage: "approval",
+          reason: "denied",
+          toolCallId,
+        },
+      });
+    }
+    onToolEnd?.(name, err, 0, toolCallId);
+    return err;
+  }
+
+  if (response.disposition === "always") {
+    approvalEngine.elevate(sessionId, name);
+  }
+  return null;
+}
+
+async function executeDelegationTool(params: {
+  toolArgs: Record<string, unknown>;
+  name: string;
+  sessionId: string;
+  toolCallId: string;
+  subAgentManager: DelegationSubAgentManager | null;
+  lifecycleEmitter: DelegationLifecycleEmitter;
+  verifier: DelegationVerifier;
+}): Promise<string> {
+  const {
+    toolArgs,
+    name,
+    sessionId,
+    toolCallId,
+    subAgentManager,
+    lifecycleEmitter,
+    verifier,
+  } = params;
+  if (!subAgentManager) {
+    return JSON.stringify({
+      error:
+        "Delegation runtime unavailable: sub-agent manager is not initialized",
+    });
+  }
+
+  const parsedInput = parseExecuteWithAgentInput(toolArgs);
+  if (!parsedInput.ok) {
+    lifecycleEmitter?.emit({
+      type: "subagents.failed",
+      timestamp: Date.now(),
+      sessionId,
+      parentSessionId: sessionId,
+      toolName: name,
+      payload: {
+        stage: "validation",
+        reason: parsedInput.error,
+        toolCallId,
+      },
+    });
+    return JSON.stringify({ error: parsedInput.error });
+  }
+
+  const input = parsedInput.value;
+  const objective = input.objective ?? input.task;
+  let childSessionId: string;
+  try {
+    childSessionId = await subAgentManager.spawn({
+      parentSessionId: sessionId,
+      task: input.task,
+      ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.tools ? { tools: input.tools } : {}),
+      ...(input.requiredToolCapabilities
+        ? { requiredCapabilities: input.requiredToolCapabilities }
+        : {}),
+    });
+  } catch (error) {
+    const message = toErrorString(error);
+    lifecycleEmitter?.emit({
+      type: "subagents.failed",
+      timestamp: Date.now(),
+      sessionId,
+      parentSessionId: sessionId,
+      toolName: name,
+      payload: {
+        stage: "spawn",
+        objective,
+        reason: message,
+        toolCallId,
+      },
+    });
+    return JSON.stringify({
+      error: `Failed to spawn sub-agent: ${message}`,
+    });
+  }
+
+  const startedAt = Date.now();
+  lifecycleEmitter?.emit({
+    type: "subagents.spawned",
+    timestamp: startedAt,
+    sessionId,
+    parentSessionId: sessionId,
+    subagentSessionId: childSessionId,
+    toolName: name,
+    payload: {
+      objective,
+      ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
+      ...(input.tools ? { tools: input.tools } : {}),
+      ...(input.requiredToolCapabilities
+        ? { requiredToolCapabilities: input.requiredToolCapabilities }
+        : {}),
+      toolCallId,
+    },
+  });
+  lifecycleEmitter?.emit({
+    type: "subagents.started",
+    timestamp: Date.now(),
+    sessionId,
+    parentSessionId: sessionId,
+    subagentSessionId: childSessionId,
+    toolName: name,
+    payload: {
+      objective,
+      toolCallId,
+    },
+  });
+
+  let lastProgressAt = startedAt;
+  while (true) {
+    const childResult = subAgentManager.getResult(childSessionId);
+    if (!childResult) {
+      const now = Date.now();
+      if (now - lastProgressAt >= DELEGATION_PROGRESS_INTERVAL_MS) {
+        lifecycleEmitter?.emit({
+          type: "subagents.progress",
+          timestamp: now,
+          sessionId,
+          parentSessionId: sessionId,
+          subagentSessionId: childSessionId,
+          toolName: name,
+          payload: {
+            objective,
+            elapsedMs: now - startedAt,
+            toolCallId,
+          },
+        });
+        lastProgressAt = now;
+      }
+      await sleepMs(DELEGATION_POLL_INTERVAL_MS);
+      continue;
+    }
+
+    const childInfo = subAgentManager.getInfo(childSessionId);
+    const finalStatus =
+      childInfo?.status ?? (childResult.success ? "completed" : "failed");
+
+    if (childResult.success) {
+      lifecycleEmitter?.emit({
+        type: "subagents.completed",
+        timestamp: Date.now(),
+        sessionId,
+        parentSessionId: sessionId,
+        subagentSessionId: childSessionId,
+        toolName: name,
+        payload: {
+          objective,
+          durationMs: childResult.durationMs,
+          toolCalls: childResult.toolCalls.length,
+          providerName: childResult.providerName,
+          output: childResult.output,
+          toolCallId,
+          verifyRequested: verifier?.shouldVerifySubAgentResult() ?? false,
+        },
+      });
+      return JSON.stringify({
+        success: true,
+        status: finalStatus,
+        subagentSessionId: childSessionId,
+        objective,
+        output: childResult.output,
+        durationMs: childResult.durationMs,
+        toolCalls: childResult.toolCalls.length,
+        providerName: childResult.providerName,
+        tokenUsage: childResult.tokenUsage,
+      });
+    }
+
+    const reason = parseDelegationFailureReason(childResult.output);
+    const terminalType =
+      finalStatus === "cancelled" ? "subagents.cancelled" : "subagents.failed";
+    lifecycleEmitter?.emit({
+      type: terminalType,
+      timestamp: Date.now(),
+      sessionId,
+      parentSessionId: sessionId,
+      subagentSessionId: childSessionId,
+      toolName: name,
+      payload: {
+        objective,
+        reason,
+        output: childResult.output,
+        durationMs: childResult.durationMs,
+        toolCalls: childResult.toolCalls.length,
+        toolCallId,
+      },
+    });
+    return JSON.stringify({
+      success: false,
+      status: finalStatus,
+      subagentSessionId: childSessionId,
+      objective,
+      error: reason,
+      output: childResult.output,
+      durationMs: childResult.durationMs,
+      toolCalls: childResult.toolCalls.length,
+      providerName: childResult.providerName,
+      tokenUsage: childResult.tokenUsage,
+    });
+  }
+}
+
 // ============================================================================
 // Config
 // ============================================================================
@@ -184,12 +579,13 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
 
   return async (name: string, args: Record<string, unknown>): Promise<string> => {
     const delegationContext = delegation?.();
+    const subAgentManager = delegationContext?.subAgentManager ?? null;
     const policyEngine = delegationContext?.policyEngine ?? null;
     const verifier = delegationContext?.verifier ?? null;
     const lifecycleEmitter = delegationContext?.lifecycleEmitter ?? null;
     const isSubAgentSession = isSubAgentSessionId(sessionId);
     const subAgentInfo = isSubAgentSession
-      ? delegationContext?.subAgentManager?.getInfo(sessionId) ?? null
+      ? subAgentManager?.getInfo(sessionId) ?? null
       : null;
     const parentSessionId = subAgentInfo?.parentSessionId;
 
@@ -303,118 +699,21 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     });
 
     // 4. Approval gate
-    if (approvalEngine) {
-      const rule = approvalEngine.requiresApproval(name, args);
-      if (rule && !approvalEngine.isToolElevated(sessionId, name)) {
-        if (approvalEngine.isToolDenied(sessionId, name, parentSessionId)) {
-          const err = JSON.stringify({
-            error:
-              `Tool "${name}" blocked because this action was denied earlier in the request tree`,
-          });
-          send({
-            type: 'tools.result',
-            payload: {
-              toolName: name,
-              result: err,
-              durationMs: 0,
-              isError: true,
-              toolCallId,
-              ...(isSubAgentSession ? { subagentSessionId: sessionId } : {}),
-            },
-          });
-          if (isSubAgentSession && lifecycleEmitter) {
-            lifecycleEmitter.emit({
-              type: 'subagents.failed',
-              timestamp: Date.now(),
-              sessionId,
-              subagentSessionId: sessionId,
-              ...(parentSessionId ? { parentSessionId } : {}),
-              toolName: name,
-              payload: {
-                stage: 'approval',
-                reason: 'denied_previously',
-                toolCallId,
-              },
-            });
-          }
-          onToolEnd?.(name, err, 0, toolCallId);
-          return err;
-        }
-        const approvalMessage = (() => {
-          const baseMessage = rule.description ?? `Approval required for ${name}`;
-          if (!isSubAgentSession || !subAgentInfo) return baseMessage;
-          const taskPreview = truncateText(
-            subAgentInfo.task.trim(),
-            APPROVAL_TASK_PREVIEW_MAX_CHARS,
-          );
-          return (
-            `${baseMessage}\n` +
-            `Parent session: ${subAgentInfo.parentSessionId}\n` +
-            `Sub-agent session: ${sessionId}\n` +
-            `Delegated task: ${taskPreview}`
-          );
-        })();
-        const request = approvalEngine.createRequest(
-          name,
-          args,
-          sessionId,
-          approvalMessage,
-          rule,
-          {
-            ...(parentSessionId ? { parentSessionId } : {}),
-            ...(isSubAgentSession ? { subagentSessionId: sessionId } : {}),
-          },
-        );
-        send({
-          type: 'approval.request',
-          payload: {
-            requestId: request.id,
-            action: name,
-            details: args,
-            message: request.message,
-            ...(request.parentSessionId
-              ? { parentSessionId: request.parentSessionId }
-              : {}),
-            ...(request.subagentSessionId
-              ? { subagentSessionId: request.subagentSessionId }
-              : {}),
-          },
-        });
-        const response = await approvalEngine.requestApproval(request);
-        if (response.disposition === 'no') {
-          const err = JSON.stringify({ error: `Tool "${name}" denied by user` });
-          send({
-            type: 'tools.result',
-            payload: {
-              toolName: name,
-              result: err,
-              durationMs: 0,
-              isError: true,
-              toolCallId,
-              ...(isSubAgentSession ? { subagentSessionId: sessionId } : {}),
-            },
-          });
-          if (isSubAgentSession && lifecycleEmitter) {
-            lifecycleEmitter.emit({
-              type: 'subagents.failed',
-              timestamp: Date.now(),
-              sessionId,
-              subagentSessionId: sessionId,
-              toolName: name,
-              payload: {
-                stage: 'approval',
-                reason: 'denied',
-                toolCallId,
-              },
-            });
-          }
-          onToolEnd?.(name, err, 0, toolCallId);
-          return err;
-        }
-        if (response.disposition === 'always') {
-          approvalEngine.elevate(sessionId, name);
-        }
-      }
+    const approvalError = await runApprovalGate({
+      approvalEngine,
+      name,
+      args,
+      sessionId,
+      parentSessionId,
+      isSubAgentSession,
+      subAgentInfo,
+      lifecycleEmitter,
+      send,
+      onToolEnd,
+      toolCallId,
+    });
+    if (approvalError) {
+      return approvalError;
     }
 
     // 5. Select handler: delegation executor or desktop-aware/base handler
@@ -422,191 +721,16 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       ? desktopRouterFactory(routerId)
       : baseHandler;
     const activeHandler: ToolHandler = name === EXECUTE_WITH_AGENT_TOOL_NAME
-      ? async (_toolName, toolArgs) => {
-        const subAgentManager = delegationContext?.subAgentManager ?? null;
-        if (!subAgentManager) {
-          return JSON.stringify({
-            error:
-              "Delegation runtime unavailable: sub-agent manager is not initialized",
-          });
-        }
-
-        const parsedInput = parseExecuteWithAgentInput(toolArgs);
-        if (!parsedInput.ok) {
-          lifecycleEmitter?.emit({
-            type: "subagents.failed",
-            timestamp: Date.now(),
-            sessionId,
-            parentSessionId: sessionId,
-            toolName: name,
-            payload: {
-              stage: "validation",
-              reason: parsedInput.error,
-              toolCallId,
-            },
-          });
-          return JSON.stringify({ error: parsedInput.error });
-        }
-
-        const input = parsedInput.value;
-        const objective = input.objective ?? input.task;
-        let childSessionId: string;
-        try {
-          childSessionId = await subAgentManager.spawn({
-            parentSessionId: sessionId,
-            task: input.task,
-            ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
-            ...(input.tools ? { tools: input.tools } : {}),
-            ...(input.requiredToolCapabilities
-              ? { requiredCapabilities: input.requiredToolCapabilities }
-              : {}),
-          });
-        } catch (error) {
-          const message = toErrorString(error);
-          lifecycleEmitter?.emit({
-            type: "subagents.failed",
-            timestamp: Date.now(),
-            sessionId,
-            parentSessionId: sessionId,
-            toolName: name,
-            payload: {
-              stage: "spawn",
-              objective,
-              reason: message,
-              toolCallId,
-            },
-          });
-          return JSON.stringify({
-            error: `Failed to spawn sub-agent: ${message}`,
-          });
-        }
-
-        const startedAt = Date.now();
-        lifecycleEmitter?.emit({
-          type: "subagents.spawned",
-          timestamp: startedAt,
+      ? async (_toolName, toolArgs) =>
+        executeDelegationTool({
+          toolArgs,
+          name,
           sessionId,
-          parentSessionId: sessionId,
-          subagentSessionId: childSessionId,
-          toolName: name,
-          payload: {
-            objective,
-            ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
-            ...(input.tools ? { tools: input.tools } : {}),
-            ...(input.requiredToolCapabilities
-              ? { requiredToolCapabilities: input.requiredToolCapabilities }
-              : {}),
-            toolCallId,
-          },
-        });
-        lifecycleEmitter?.emit({
-          type: "subagents.started",
-          timestamp: Date.now(),
-          sessionId,
-          parentSessionId: sessionId,
-          subagentSessionId: childSessionId,
-          toolName: name,
-          payload: {
-            objective,
-            toolCallId,
-          },
-        });
-
-        let lastProgressAt = startedAt;
-        while (true) {
-          const childResult = subAgentManager.getResult(childSessionId);
-          if (!childResult) {
-            const now = Date.now();
-            if (now - lastProgressAt >= DELEGATION_PROGRESS_INTERVAL_MS) {
-              lifecycleEmitter?.emit({
-                type: "subagents.progress",
-                timestamp: now,
-                sessionId,
-                parentSessionId: sessionId,
-                subagentSessionId: childSessionId,
-                toolName: name,
-                payload: {
-                  objective,
-                  elapsedMs: now - startedAt,
-                  toolCallId,
-                },
-              });
-              lastProgressAt = now;
-            }
-            await sleepMs(DELEGATION_POLL_INTERVAL_MS);
-            continue;
-          }
-
-          const childInfo = subAgentManager.getInfo(childSessionId);
-          const finalStatus =
-            childInfo?.status ?? (childResult.success ? "completed" : "failed");
-
-          if (childResult.success) {
-            lifecycleEmitter?.emit({
-              type: "subagents.completed",
-              timestamp: Date.now(),
-              sessionId,
-              parentSessionId: sessionId,
-              subagentSessionId: childSessionId,
-              toolName: name,
-              payload: {
-                objective,
-                durationMs: childResult.durationMs,
-                toolCalls: childResult.toolCalls.length,
-                providerName: childResult.providerName,
-                output: childResult.output,
-                toolCallId,
-                verifyRequested:
-                  verifier?.shouldVerifySubAgentResult() ?? false,
-              },
-            });
-            return JSON.stringify({
-              success: true,
-              status: finalStatus,
-              subagentSessionId: childSessionId,
-              objective,
-              output: childResult.output,
-              durationMs: childResult.durationMs,
-              toolCalls: childResult.toolCalls.length,
-              providerName: childResult.providerName,
-              tokenUsage: childResult.tokenUsage,
-            });
-          }
-
-          const reason = parseDelegationFailureReason(childResult.output);
-          const terminalType = finalStatus === "cancelled"
-            ? "subagents.cancelled"
-            : "subagents.failed";
-          lifecycleEmitter?.emit({
-            type: terminalType,
-            timestamp: Date.now(),
-            sessionId,
-            parentSessionId: sessionId,
-            subagentSessionId: childSessionId,
-            toolName: name,
-            payload: {
-              objective,
-              reason,
-              output: childResult.output,
-              durationMs: childResult.durationMs,
-              toolCalls: childResult.toolCalls.length,
-              toolCallId,
-            },
-          });
-          return JSON.stringify({
-            success: false,
-            status: finalStatus,
-            subagentSessionId: childSessionId,
-            objective,
-            error: reason,
-            output: childResult.output,
-            durationMs: childResult.durationMs,
-            toolCalls: childResult.toolCalls.length,
-            providerName: childResult.providerName,
-            tokenUsage: childResult.tokenUsage,
-          });
-        }
-      }
+          toolCallId,
+          subAgentManager,
+          lifecycleEmitter,
+          verifier,
+        })
       : routedHandler;
 
     // 6. Execute and time

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -515,6 +515,44 @@ interface ResolvedSubagentVerifierConfig {
   readonly maxRounds: number;
 }
 
+interface MutablePlannerVerificationSummary {
+  enabled: boolean;
+  performed: boolean;
+  rounds: number;
+  overall: "pass" | "retry" | "fail" | "skipped";
+  confidence: number;
+  unresolvedItems: string[];
+}
+
+interface MutablePlannerSummaryState {
+  deterministicStepsExecuted: number;
+  diagnostics: PlannerDiagnostic[];
+  subagentVerification: MutablePlannerVerificationSummary;
+}
+
+interface PlannerPipelineVerifierLoopInput {
+  pipeline: Pipeline;
+  plannerPlan: PlannerPlan;
+  subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+  deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
+  plannerExecutionContext: PipelinePlannerContext;
+  shouldRunSubagentVerifier: boolean;
+  plannerSummaryState: MutablePlannerSummaryState;
+  checkRequestTimeout: (stage: string) => boolean;
+  runPipelineWithGlobalTimeout: (
+    pipeline: Pipeline,
+  ) => Promise<PipelineResult | undefined>;
+  runSubagentVerifierRound: (input: {
+    plannerPlan: PlannerPlan;
+    subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+    pipelineResult: PipelineResult;
+    plannerContext: PipelinePlannerContext;
+    round: number;
+  }) => Promise<SubagentVerifierDecision>;
+  appendToolRecord: (record: ToolCallRecord) => void;
+  setStopReason: (reason: LLMPipelineStopReason, detail?: string) => void;
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -977,6 +1015,12 @@ export class ChatExecutor {
    * Execute a chat message against the provider chain.
    */
   async execute(params: ChatExecuteParams): Promise<ChatExecutorResult> {
+    return this.executeRequest(params);
+  }
+
+  private async executeRequest(
+    params: ChatExecuteParams,
+  ): Promise<ChatExecutorResult> {
     const {
       message,
       systemPrompt,
@@ -1607,101 +1651,24 @@ export class ChatExecutor {
                   this.subagentVerifierConfig.enabled ||
                   this.subagentVerifierConfig.force
                 );
-              let verifierRounds = 0;
-              let verificationDecision: SubagentVerifierDecision | undefined;
-              let pipelineResult: PipelineResult | undefined;
-
-              while (true) {
-                if (checkRequestTimeout("planner pipeline execution")) break;
-                const nextPipelineResult = await runPipelineWithGlobalTimeout(
-                  pipeline,
-                );
-                if (!nextPipelineResult) break;
-                pipelineResult = nextPipelineResult;
-
-                for (const record of ChatExecutor.pipelineResultToToolCalls(
-                  plannerPlan.steps,
-                  nextPipelineResult,
-                )) {
-                  appendToolRecord(record);
-                }
-                plannerSummaryState.deterministicStepsExecuted =
-                  deterministicSteps.filter((step) =>
-                    typeof nextPipelineResult.context.results[step.name] === "string"
-                  ).length;
-
-                if (
-                  !shouldRunSubagentVerifier ||
-                  nextPipelineResult.status !== "completed"
-                ) {
-                  break;
-                }
-
-                verifierRounds++;
-                verificationDecision = await runSubagentVerifierRound({
-                  plannerPlan,
-                  subagentSteps,
-                  pipelineResult: nextPipelineResult,
-                  plannerContext: plannerExecutionContext,
-                  round: verifierRounds,
-                });
-                plannerSummaryState.subagentVerification = {
-                  enabled: true,
-                  performed: true,
-                  rounds: verifierRounds,
-                  overall: verificationDecision.overall,
-                  confidence: verificationDecision.confidence,
-                  unresolvedItems: [...verificationDecision.unresolvedItems],
-                };
-
-                const belowConfidence =
-                  verificationDecision.confidence <
-                  this.subagentVerifierConfig.minConfidence;
-                const retryable =
-                  verificationDecision.steps.some((step) => step.retryable);
-                const canRetry =
-                  verifierRounds < this.subagentVerifierConfig.maxRounds &&
-                  (
-                    verificationDecision.overall === "retry" ||
-                    belowConfidence
-                  ) &&
-                  retryable;
-
-                if (canRetry) {
-                  plannerSummaryState.diagnostics.push({
-                    category: "policy",
-                    code: "subagent_verifier_retry",
-                    message:
-                      "Sub-agent verifier requested retry; rerunning planner pipeline",
-                    details: {
-                      round: verifierRounds,
-                      maxRounds: this.subagentVerifierConfig.maxRounds,
-                      confidence: Number(
-                        verificationDecision.confidence.toFixed(3),
-                      ),
-                      minConfidence: Number(
-                        this.subagentVerifierConfig.minConfidence.toFixed(3),
-                      ),
-                    },
-                  });
-                  continue;
-                }
-
-                if (
-                  verificationDecision.overall !== "pass" ||
-                  belowConfidence
-                ) {
-                  const unresolvedPreview =
-                    verificationDecision.unresolvedItems.slice(0, 3).join("; ");
-                  setStopReason(
-                    "validation_error",
-                    unresolvedPreview.length > 0
-                      ? `Sub-agent verifier rejected child outputs: ${unresolvedPreview}`
-                      : "Sub-agent verifier rejected child outputs",
-                  );
-                }
-                break;
-              }
+              const {
+                verifierRounds,
+                verificationDecision,
+                pipelineResult,
+              } = await this.executePlannerPipelineWithVerifier({
+                pipeline,
+                plannerPlan,
+                subagentSteps,
+                deterministicSteps,
+                plannerExecutionContext,
+                shouldRunSubagentVerifier,
+                plannerSummaryState,
+                checkRequestTimeout,
+                runPipelineWithGlobalTimeout,
+                runSubagentVerifierRound,
+                appendToolRecord,
+                setStopReason,
+              });
 
               if (
                 shouldRunSubagentVerifier &&
@@ -2663,6 +2630,114 @@ export class ChatExecutor {
       stopReason,
       stopReasonDetail,
       evaluation,
+    };
+  }
+
+  private async executePlannerPipelineWithVerifier(
+    input: PlannerPipelineVerifierLoopInput,
+  ): Promise<{
+    verifierRounds: number;
+    verificationDecision?: SubagentVerifierDecision;
+    pipelineResult?: PipelineResult;
+  }> {
+    let verifierRounds = 0;
+    let verificationDecision: SubagentVerifierDecision | undefined;
+    let pipelineResult: PipelineResult | undefined;
+
+    while (true) {
+      if (input.checkRequestTimeout("planner pipeline execution")) break;
+      const nextPipelineResult = await input.runPipelineWithGlobalTimeout(
+        input.pipeline,
+      );
+      if (!nextPipelineResult) break;
+      pipelineResult = nextPipelineResult;
+
+      for (const record of ChatExecutor.pipelineResultToToolCalls(
+        input.plannerPlan.steps,
+        nextPipelineResult,
+      )) {
+        input.appendToolRecord(record);
+      }
+      input.plannerSummaryState.deterministicStepsExecuted =
+        input.deterministicSteps.filter((step) =>
+          typeof nextPipelineResult.context.results[step.name] === "string"
+        ).length;
+
+      if (
+        !input.shouldRunSubagentVerifier ||
+        nextPipelineResult.status !== "completed"
+      ) {
+        break;
+      }
+
+      verifierRounds++;
+      verificationDecision = await input.runSubagentVerifierRound({
+        plannerPlan: input.plannerPlan,
+        subagentSteps: input.subagentSteps,
+        pipelineResult: nextPipelineResult,
+        plannerContext: input.plannerExecutionContext,
+        round: verifierRounds,
+      });
+      input.plannerSummaryState.subagentVerification = {
+        enabled: true,
+        performed: true,
+        rounds: verifierRounds,
+        overall: verificationDecision.overall,
+        confidence: verificationDecision.confidence,
+        unresolvedItems: [...verificationDecision.unresolvedItems],
+      };
+
+      const belowConfidence =
+        verificationDecision.confidence <
+        this.subagentVerifierConfig.minConfidence;
+      const retryable =
+        verificationDecision.steps.some((step) => step.retryable);
+      const canRetry =
+        verifierRounds < this.subagentVerifierConfig.maxRounds &&
+        (
+          verificationDecision.overall === "retry" ||
+          belowConfidence
+        ) &&
+        retryable;
+
+      if (canRetry) {
+        input.plannerSummaryState.diagnostics.push({
+          category: "policy",
+          code: "subagent_verifier_retry",
+          message:
+            "Sub-agent verifier requested retry; rerunning planner pipeline",
+          details: {
+            round: verifierRounds,
+            maxRounds: this.subagentVerifierConfig.maxRounds,
+            confidence: Number(verificationDecision.confidence.toFixed(3)),
+            minConfidence: Number(
+              this.subagentVerifierConfig.minConfidence.toFixed(3),
+            ),
+          },
+        });
+        continue;
+      }
+
+      if (
+        verificationDecision.overall !== "pass" ||
+        belowConfidence
+      ) {
+        const unresolvedPreview =
+          verificationDecision.unresolvedItems.slice(0, 3).join("; ");
+        input.setStopReason(
+          "validation_error",
+          unresolvedPreview.length > 0
+            ? `Sub-agent verifier rejected child outputs: ${unresolvedPreview}`
+            : "Sub-agent verifier rejected child outputs",
+        );
+      }
+      break;
+    }
+
+    return {
+      verifierRounds,
+      verificationDecision,
+      pipelineResult,
     };
   }
 

--- a/runtime/src/replay/backfill.ts
+++ b/runtime/src/replay/backfill.ts
@@ -7,15 +7,12 @@
 import { projectOnChainEvents } from "../eval/projector.js";
 import type {
   OnChainProjectionInput,
-  ProjectedTimelineEvent,
 } from "../eval/projector.js";
 import {
   buildReplayKey,
-  computeProjectionHash,
   stableReplayCursorString,
   type BackfillFetcher,
   type BackfillResult,
-  type ReplayTimelineRecord,
   type ReplayTimelineStore,
   type ProjectedTimelineInput,
 } from "./types.js";
@@ -23,11 +20,10 @@ import {
   buildReplaySpanEvent,
   buildReplaySpanName,
   buildReplayTraceContext,
-  deriveTraceId,
   startReplaySpan,
 } from "./trace.js";
 import type { ReplayAlertDispatcher } from "./alerting.js";
-import { extractDisputePdaFromPayload } from "./pda-utils.js";
+import { toReplayStoreRecord } from "./record.js";
 
 const DEFAULT_BACKFILL_PAGE_SIZE = 100;
 
@@ -356,56 +352,4 @@ export class ReplayBackfillService {
       previousCursor = stableReplayCursorString(cursor);
     }
   }
-}
-
-function toReplayStoreRecord(
-  event: ProjectedTimelineEvent,
-): ReplayTimelineRecord {
-  const trace = (event.payload.onchain as Record<string, unknown> | undefined)
-    ?.trace as
-    | undefined
-    | {
-        traceId?: string;
-        spanId?: string;
-        parentSpanId?: string;
-        sampled?: boolean;
-      };
-
-  // Synthesize traceId from canonical tuple when trace context is absent
-  const resolvedTraceId =
-    trace?.traceId ??
-    deriveTraceId(
-      undefined,
-      event.slot,
-      event.signature,
-      event.sourceEventName,
-      event.sourceEventSequence,
-    );
-
-  const recordEvent = {
-    seq: event.seq,
-    type: event.type,
-    taskPda: event.taskPda,
-    disputePda: extractDisputePdaFromPayload(event.payload),
-    timestampMs: event.timestampMs,
-    payload: event.payload,
-    slot: event.slot,
-    signature: event.signature,
-    sourceEventName: event.sourceEventName,
-    sourceEventSequence: event.sourceEventSequence,
-    sourceEventType: event.type,
-    traceId: resolvedTraceId,
-    traceSpanId: trace?.spanId,
-    traceParentSpanId: trace?.parentSpanId,
-    traceSampled: trace?.sampled === true,
-  } as Omit<ReplayTimelineRecord, "projectionHash">;
-
-  return {
-    ...recordEvent,
-    projectionHash: computeProjectionHash({
-      ...recordEvent,
-      sourceEventName: event.sourceEventName,
-      sourceEventSequence: event.sourceEventSequence,
-    } as ReturnType<typeof projectOnChainEvents>["events"][number]),
-  };
 }

--- a/runtime/src/replay/bridge.ts
+++ b/runtime/src/replay/bridge.ts
@@ -27,22 +27,17 @@ import {
   type ReplayAlertDispatcher,
   type ReplayAlertingPolicyOptions,
 } from "./alerting.js";
-import { computeProjectionHash } from "./types.js";
-import { extractDisputePdaFromPayload } from "./pda-utils.js";
+import { toReplayStoreRecord } from "./record.js";
 import {
   buildReplayTraceContext,
   DEFAULT_TRACE_SAMPLE_RATE,
   buildReplaySpanEvent,
   buildReplaySpanName,
-  deriveTraceId,
   startReplaySpan,
   type ReplayTracingPolicy,
 } from "./trace.js";
 import type { OnChainProjectionInput } from "../eval/projector.js";
-import {
-  projectOnChainEvents,
-  type ProjectedTimelineEvent,
-} from "../eval/projector.js";
+import { projectOnChainEvents } from "../eval/projector.js";
 
 export type ReplayBridgeStoreType = "memory" | "sqlite";
 
@@ -151,59 +146,6 @@ function buildStore(
     );
   }
   return new InMemoryReplayTimelineStore();
-}
-
-function toReplayStoreRecord(
-  event: ProjectedTimelineEvent,
-): ReplayTimelineRecord {
-  const base = event.type;
-  const trace = (event.payload.onchain as Record<string, unknown> | undefined)
-    ?.trace as
-    | undefined
-    | {
-        traceId?: string;
-        spanId?: string;
-        parentSpanId?: string;
-        sampled?: boolean;
-      };
-
-  // Synthesize traceId from canonical tuple when trace context is absent
-  const resolvedTraceId =
-    trace?.traceId ??
-    deriveTraceId(
-      undefined,
-      event.slot,
-      event.signature,
-      event.sourceEventName,
-      event.sourceEventSequence,
-    );
-
-  const recordEvent: Omit<ReplayTimelineRecord, "projectionHash"> = {
-    seq: event.seq,
-    type: event.type,
-    taskPda: event.taskPda,
-    disputePda: extractDisputePdaFromPayload(event.payload),
-    timestampMs: event.timestampMs,
-    payload: event.payload,
-    slot: event.slot,
-    signature: event.signature,
-    sourceEventName: event.sourceEventName,
-    sourceEventType: base,
-    sourceEventSequence: event.sourceEventSequence,
-    traceId: resolvedTraceId,
-    traceSpanId: trace?.spanId,
-    traceParentSpanId: trace?.parentSpanId,
-    traceSampled: trace?.sampled === true,
-  };
-
-  return {
-    ...recordEvent,
-    projectionHash: computeProjectionHash({
-      ...recordEvent,
-      sourceEventName: event.sourceEventName,
-      sourceEventSequence: event.sourceEventSequence,
-    } as unknown as Parameters<typeof computeProjectionHash>[0]),
-  };
 }
 
 function strictTelemetryErrors(

--- a/runtime/src/replay/index.ts
+++ b/runtime/src/replay/index.ts
@@ -11,6 +11,7 @@ export { FileReplayTimelineStore } from "./file-store.js";
 export { SqliteReplayTimelineStore } from "./sqlite-store.js";
 
 export { ReplayBackfillService } from "./backfill.js";
+export { toReplayStoreRecord } from "./record.js";
 
 export {
   ReplayEventBridge,

--- a/runtime/src/replay/record.ts
+++ b/runtime/src/replay/record.ts
@@ -1,0 +1,62 @@
+import type { ProjectedTimelineEvent } from "../eval/projector.js";
+import type { ReplayTimelineRecord } from "./types.js";
+import { computeProjectionHash } from "./types.js";
+import { extractDisputePdaFromPayload } from "./pda-utils.js";
+import { deriveTraceId } from "./trace.js";
+
+/**
+ * Normalize a projected timeline event into a replay store record.
+ *
+ * Shared by realtime bridge ingestion and historical backfill so both paths
+ * persist exactly the same record shape and hash semantics.
+ */
+export function toReplayStoreRecord(
+  event: ProjectedTimelineEvent,
+): ReplayTimelineRecord {
+  const trace = (event.payload.onchain as Record<string, unknown> | undefined)
+    ?.trace as
+    | undefined
+    | {
+        traceId?: string;
+        spanId?: string;
+        parentSpanId?: string;
+        sampled?: boolean;
+      };
+
+  const resolvedTraceId =
+    trace?.traceId ??
+    deriveTraceId(
+      undefined,
+      event.slot,
+      event.signature,
+      event.sourceEventName,
+      event.sourceEventSequence,
+    );
+
+  const recordEvent: Omit<ReplayTimelineRecord, "projectionHash"> = {
+    seq: event.seq,
+    type: event.type,
+    taskPda: event.taskPda,
+    disputePda: extractDisputePdaFromPayload(event.payload),
+    timestampMs: event.timestampMs,
+    payload: event.payload,
+    slot: event.slot,
+    signature: event.signature,
+    sourceEventName: event.sourceEventName,
+    sourceEventType: event.type,
+    sourceEventSequence: event.sourceEventSequence,
+    traceId: resolvedTraceId,
+    traceSpanId: trace?.spanId,
+    traceParentSpanId: trace?.parentSpanId,
+    traceSampled: trace?.sampled === true,
+  };
+
+  return {
+    ...recordEvent,
+    projectionHash: computeProjectionHash({
+      ...recordEvent,
+      sourceEventName: event.sourceEventName,
+      sourceEventSequence: event.sourceEventSequence,
+    } as Parameters<typeof computeProjectionHash>[0]),
+  };
+}

--- a/runtime/src/task/dependency-graph.ts
+++ b/runtime/src/task/dependency-graph.ts
@@ -390,21 +390,7 @@ export class DependencyGraph {
         const childColor = color.get(childKey) ?? WHITE;
 
         if (childColor === GRAY) {
-          const cycle: PublicKey[] = [];
-          let currentKey: string | null = nodeKey;
-          while (currentKey !== null && currentKey !== childKey) {
-            const node = this.nodes.get(currentKey);
-            if (node) {
-              cycle.unshift(node.taskPda);
-            }
-            currentKey = parent.get(currentKey) ?? null;
-          }
-
-          const closingNode = this.nodes.get(childKey);
-          if (closingNode) {
-            cycle.unshift(closingNode.taskPda);
-          }
-
+          const cycle = this.buildCyclePath(parent, nodeKey, childKey);
           if (cycle.length > 0) {
             cycles.push(cycle);
           }
@@ -427,6 +413,30 @@ export class DependencyGraph {
     }
 
     return cycles;
+  }
+
+  private buildCyclePath(
+    parent: Map<string, string | null>,
+    nodeKey: string,
+    childKey: string,
+  ): PublicKey[] {
+    const cycle: PublicKey[] = [];
+    let currentKey: string | null = nodeKey;
+
+    while (currentKey !== null && currentKey !== childKey) {
+      const node = this.nodes.get(currentKey);
+      if (node) {
+        cycle.unshift(node.taskPda);
+      }
+      currentKey = parent.get(currentKey) ?? null;
+    }
+
+    const closingNode = this.nodes.get(childKey);
+    if (closingNode) {
+      cycle.unshift(closingNode.taskPda);
+    }
+
+    return cycle;
   }
 
   /**

--- a/runtime/src/task/executor.ts
+++ b/runtime/src/task/executor.ts
@@ -74,6 +74,11 @@ const DEFAULT_BACKPRESSURE_CONFIG: BackpressureConfig = {
   pauseDiscovery: true,
 };
 
+const ACTIVE_TASK_WAIT_TIMEOUT_MS = 5_000;
+const ACTIVE_TASK_POLL_INTERVAL_MS = 50;
+const AUTONOMOUS_LOOP_INTERVAL_MS = 100;
+const BATCH_DRAIN_INTERVAL_MS = 50;
+
 interface PipelineRuntimeState {
   timeoutId: ReturnType<typeof setTimeout> | null;
   deadlineTimerId: ReturnType<typeof setTimeout> | null;
@@ -279,14 +284,16 @@ export class TaskExecutor {
   /**
    * Wait for all active tasks to finish or abort, with a timeout safety net.
    */
-  private async waitForActiveTasks(timeoutMs = 5000): Promise<void> {
+  private async waitForActiveTasks(
+    timeoutMs = ACTIVE_TASK_WAIT_TIMEOUT_MS,
+  ): Promise<void> {
     if (this.activeTasks.size === 0) return;
     await new Promise<void>((resolve) => {
       const checkDone = () => {
         if (this.activeTasks.size === 0) {
           resolve();
         } else {
-          setTimeout(checkDone, 50);
+          setTimeout(checkDone, ACTIVE_TASK_POLL_INTERVAL_MS);
         }
       };
       // Timeout safety: resolve after timeoutMs regardless
@@ -681,7 +688,7 @@ export class TaskExecutor {
     // Keep running until stopped — discovery callbacks drive task processing
     while (this.running) {
       this.drainQueue();
-      await sleep(100);
+      await sleep(AUTONOMOUS_LOOP_INTERVAL_MS);
     }
   }
 
@@ -725,7 +732,7 @@ export class TaskExecutor {
 
     // Wait for all active tasks to complete
     while (this.activeTasks.size > 0 || this.taskQueue.size > 0) {
-      await sleep(50);
+      await sleep(BATCH_DRAIN_INTERVAL_MS);
     }
   }
 

--- a/runtime/src/tools/marketplace/tools.ts
+++ b/runtime/src/tools/marketplace/tools.ts
@@ -11,6 +11,10 @@ import type { Tool, ToolResult } from "../types.js";
 import { safeStringify } from "../types.js";
 import type { ServiceMarketplace } from "../../marketplace/service-marketplace.js";
 import type { Logger } from "../../utils/logger.js";
+import {
+  parseBigIntArg,
+  toolErrorResult,
+} from "../shared/helpers.js";
 
 // ============================================================================
 // Context
@@ -20,25 +24,6 @@ export interface MarketplaceToolsContext {
   getMarketplace: () => ServiceMarketplace | null;
   actorId: string;
   logger: Logger;
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function errorResult(message: string): ToolResult {
-  return { content: safeStringify({ error: message }), isError: true };
-}
-
-function safeBigInt(
-  value: unknown,
-  fieldName: string,
-): [bigint, null] | [null, ToolResult] {
-  try {
-    return [BigInt(value as string), null];
-  } catch {
-    return [null, errorResult(`Invalid ${fieldName}: must be a numeric string`)];
-  }
 }
 
 // ============================================================================
@@ -97,24 +82,24 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const marketplace = ctx.getMarketplace();
-        if (!marketplace) return errorResult("Marketplace not enabled");
+        if (!marketplace) return toolErrorResult("Marketplace not enabled");
 
         if (
           typeof args.serviceId !== "string" ||
           args.serviceId.length === 0
         ) {
-          return errorResult("serviceId must be a non-empty string");
+          return toolErrorResult("serviceId must be a non-empty string");
         }
         if (typeof args.title !== "string" || args.title.length === 0) {
-          return errorResult("title must be a non-empty string");
+          return toolErrorResult("title must be a non-empty string");
         }
 
-        const [budget, budgetErr] = safeBigInt(args.budget, "budget");
+        const [budget, budgetErr] = parseBigIntArg(args.budget, "budget");
         if (budgetErr) return budgetErr;
 
         let requiredCapabilities = 0n;
         if (args.requiredCapabilities !== undefined) {
-          const [caps, capsErr] = safeBigInt(
+          const [caps, capsErr] = parseBigIntArg(
             args.requiredCapabilities,
             "requiredCapabilities",
           );
@@ -143,7 +128,7 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`marketplace.createService failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },
@@ -179,23 +164,23 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const marketplace = ctx.getMarketplace();
-        if (!marketplace) return errorResult("Marketplace not enabled");
+        if (!marketplace) return toolErrorResult("Marketplace not enabled");
 
         if (
           typeof args.serviceId !== "string" ||
           args.serviceId.length === 0
         ) {
-          return errorResult("serviceId must be a non-empty string");
+          return toolErrorResult("serviceId must be a non-empty string");
         }
 
-        const [price, priceErr] = safeBigInt(args.price, "price");
+        const [price, priceErr] = parseBigIntArg(args.price, "price");
         if (priceErr) return priceErr;
 
         if (
           typeof args.deliveryTime !== "number" ||
           args.deliveryTime <= 0
         ) {
-          return errorResult("deliveryTime must be a positive number");
+          return toolErrorResult("deliveryTime must be a positive number");
         }
 
         try {
@@ -213,7 +198,7 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`marketplace.bidOnService failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },
@@ -245,7 +230,7 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const marketplace = ctx.getMarketplace();
-        if (!marketplace) return errorResult("Marketplace not enabled");
+        if (!marketplace) return toolErrorResult("Marketplace not enabled");
 
         try {
           const filters: Record<string, unknown> = {};
@@ -254,12 +239,12 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
             filters.status = args.status;
           }
           if (args.minBudget !== undefined) {
-            const [min, minErr] = safeBigInt(args.minBudget, "minBudget");
+            const [min, minErr] = parseBigIntArg(args.minBudget, "minBudget");
             if (minErr) return minErr;
             filters.minBudget = min;
           }
           if (args.maxBudget !== undefined) {
-            const [max, maxErr] = safeBigInt(args.maxBudget, "maxBudget");
+            const [max, maxErr] = parseBigIntArg(args.maxBudget, "maxBudget");
             if (maxErr) return maxErr;
             filters.maxBudget = max;
           }
@@ -277,7 +262,7 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`marketplace.listServices failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },
@@ -301,13 +286,13 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const marketplace = ctx.getMarketplace();
-        if (!marketplace) return errorResult("Marketplace not enabled");
+        if (!marketplace) return toolErrorResult("Marketplace not enabled");
 
         if (
           typeof args.serviceId !== "string" ||
           args.serviceId.length === 0
         ) {
-          return errorResult("serviceId must be a non-empty string");
+          return toolErrorResult("serviceId must be a non-empty string");
         }
 
         try {
@@ -323,7 +308,7 @@ export function createMarketplaceTools(ctx: MarketplaceToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`marketplace.listBids failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },

--- a/runtime/src/tools/shared/helpers.ts
+++ b/runtime/src/tools/shared/helpers.ts
@@ -1,0 +1,20 @@
+import type { ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+
+export function toolErrorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+export function parseBigIntArg(
+  value: unknown,
+  fieldName: string,
+): [bigint, null] | [null, ToolResult] {
+  try {
+    return [BigInt(value as string), null];
+  } catch {
+    return [
+      null,
+      toolErrorResult(`Invalid ${fieldName}: must be a numeric string`),
+    ];
+  }
+}

--- a/runtime/src/tools/social/tools.ts
+++ b/runtime/src/tools/social/tools.ts
@@ -17,6 +17,10 @@ import type { AgentMessaging } from "../../social/messaging.js";
 import type { AgentFeed } from "../../social/feed.js";
 import type { CollaborationProtocol } from "../../social/collaboration.js";
 import type { Logger } from "../../utils/logger.js";
+import {
+  parseBigIntArg,
+  toolErrorResult,
+} from "../shared/helpers.js";
 
 // ============================================================================
 // Context
@@ -34,34 +38,19 @@ export interface SocialToolsContext {
 // Helpers
 // ============================================================================
 
-function errorResult(message: string): ToolResult {
-  return { content: safeStringify({ error: message }), isError: true };
-}
-
-function safeBigInt(
-  value: unknown,
-  fieldName: string,
-): [bigint, null] | [null, ToolResult] {
-  try {
-    return [BigInt(value as string), null];
-  } catch {
-    return [null, errorResult(`Invalid ${fieldName}: must be a numeric string`)];
-  }
-}
-
 function safePublicKey(
   value: unknown,
   fieldName: string,
 ): [PublicKey, null] | [null, ToolResult] {
   if (typeof value !== "string" || value.length === 0) {
-    return [null, errorResult(`Missing or invalid ${fieldName}`)];
+    return [null, toolErrorResult(`Missing or invalid ${fieldName}`)];
   }
   try {
     return [new PublicKey(value), null];
   } catch {
     return [
       null,
-      errorResult(`Invalid ${fieldName}: must be a base58 public key`),
+      toolErrorResult(`Invalid ${fieldName}: must be a base58 public key`),
     ];
   }
 }
@@ -74,7 +63,7 @@ function validateHex(
   if (typeof value !== "string" || value.length !== expectedLength) {
     return [
       null,
-      errorResult(
+      toolErrorResult(
         `Invalid ${fieldName}: must be a ${expectedLength}-char hex string`,
       ),
     ];
@@ -88,7 +77,7 @@ function validateHex(
     if (!isNumber && !isLowerHex && !isUpperHex) {
       return [
         null,
-        errorResult(
+        toolErrorResult(
           `Invalid ${fieldName}: must be a ${expectedLength}-char hex string`,
         ),
       ];
@@ -140,12 +129,12 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const discovery = ctx.getDiscovery();
-        if (!discovery) return errorResult("Social module not enabled");
+        if (!discovery) return toolErrorResult("Social module not enabled");
 
         try {
           let capabilities: bigint | undefined;
           if (args.capabilities !== undefined) {
-            const [caps, err] = safeBigInt(args.capabilities, "capabilities");
+            const [caps, err] = parseBigIntArg(args.capabilities, "capabilities");
             if (err) return err;
             capabilities = caps;
           }
@@ -183,7 +172,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`social.searchAgents failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },
@@ -216,7 +205,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const messaging = ctx.getMessaging();
-        if (!messaging) return errorResult("Social module not enabled");
+        if (!messaging) return toolErrorResult("Social module not enabled");
 
         const [recipient, recipientErr] = safePublicKey(
           args.recipient,
@@ -225,7 +214,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
         if (recipientErr) return recipientErr;
 
         if (typeof args.content !== "string" || args.content.length === 0) {
-          return errorResult("content must be a non-empty string");
+          return toolErrorResult("content must be a non-empty string");
         }
 
         const mode = (args.mode as "on-chain" | "off-chain" | "auto") ?? "auto";
@@ -236,7 +225,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`social.sendMessage failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },
@@ -268,7 +257,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const feed = ctx.getFeed();
-        if (!feed) return errorResult("Social module not enabled");
+        if (!feed) return toolErrorResult("Social module not enabled");
 
         const [contentHash, chErr] = validateHex(
           args.contentHash,
@@ -299,7 +288,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`social.postToFeed failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },
@@ -323,14 +312,14 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const discovery = ctx.getDiscovery();
-        if (!discovery) return errorResult("Social module not enabled");
+        if (!discovery) return toolErrorResult("Social module not enabled");
 
         const [pda, pdaErr] = safePublicKey(args.agentPda, "agentPda");
         if (pdaErr) return pdaErr;
 
         try {
           const profile = await discovery.getProfile(pda);
-          if (!profile) return errorResult(`Agent not found: ${pda.toBase58()}`);
+          if (!profile) return toolErrorResult(`Agent not found: ${pda.toBase58()}`);
 
           return {
             content: safeStringify({
@@ -345,7 +334,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`social.getReputation failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },
@@ -391,26 +380,26 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
       },
       async execute(args: Record<string, unknown>): Promise<ToolResult> {
         const collab = ctx.getCollaboration();
-        if (!collab) return errorResult("Social module not enabled");
+        if (!collab) return toolErrorResult("Social module not enabled");
 
         if (typeof args.title !== "string" || args.title.length === 0) {
-          return errorResult("title must be a non-empty string");
+          return toolErrorResult("title must be a non-empty string");
         }
         if (args.title.length > 128) {
-          return errorResult("title must be at most 128 characters");
+          return toolErrorResult("title must be at most 128 characters");
         }
 
         if (
           typeof args.description !== "string" ||
           args.description.length === 0
         ) {
-          return errorResult("description must be a non-empty string");
+          return toolErrorResult("description must be a non-empty string");
         }
         if (args.description.length > 1024) {
-          return errorResult("description must be at most 1024 characters");
+          return toolErrorResult("description must be at most 1024 characters");
         }
 
-        const [caps, capsErr] = safeBigInt(
+        const [caps, capsErr] = parseBigIntArg(
           args.requiredCapabilities,
           "requiredCapabilities",
         );
@@ -421,7 +410,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
           args.maxMembers < 2 ||
           args.maxMembers > 20
         ) {
-          return errorResult("maxMembers must be a number between 2 and 20");
+          return toolErrorResult("maxMembers must be a number between 2 and 20");
         }
 
         const payoutMode =
@@ -454,7 +443,7 @@ export function createSocialTools(ctx: SocialToolsContext): Tool[] {
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           ctx.logger.error?.(`social.requestCollaboration failed: ${msg}`);
-          return errorResult(msg);
+          return toolErrorResult(msg);
         }
       },
     },

--- a/runtime/src/tools/system/bash.ts
+++ b/runtime/src/tools/system/bash.ts
@@ -678,22 +678,37 @@ export function createBashTool(config?: BashToolConfig): Tool {
             stderrBuf += chunk.toString();
           });
 
-          const timer = setTimeout(() => {
-            timedOut = true;
-            // Kill entire process group (bash + any backgrounded children)
-            try {
-              process.kill(-child.pid!, "SIGTERM");
-            } catch {
-              child.kill("SIGTERM");
-            }
-            try { unlinkSync(scriptPath); } catch { /* best-effort */ }
-          }, timeout);
+	          const timer = setTimeout(() => {
+	            timedOut = true;
+	            // Kill entire process group (bash + any backgrounded children)
+	            try {
+	              process.kill(-child.pid!, "SIGTERM");
+	            } catch (error) {
+	              logger.debug("Bash tool process-group SIGTERM failed; falling back to child.kill", {
+	                error: error instanceof Error ? error.message : String(error),
+	              });
+	              child.kill("SIGTERM");
+	            }
+	            try {
+	              unlinkSync(scriptPath);
+	            } catch (error) {
+	              logger.debug("Bash tool script cleanup failed after timeout", {
+	                error: error instanceof Error ? error.message : String(error),
+	              });
+	            }
+	          }, timeout);
 
-          const doResolve = (code: number | null) => {
-            if (resolved) return;
-            resolved = true;
-            clearTimeout(timer);
-            try { unlinkSync(scriptPath); } catch { /* best-effort cleanup */ }
+	          const doResolve = (code: number | null) => {
+	            if (resolved) return;
+	            resolved = true;
+	            clearTimeout(timer);
+	            try {
+	              unlinkSync(scriptPath);
+	            } catch (error) {
+	              logger.debug("Bash tool script cleanup failed on resolve", {
+	                error: error instanceof Error ? error.message : String(error),
+	              });
+	            }
 
             const durationMs = Date.now() - startTime;
             const exitCode = timedOut ? null : (code ?? 1);
@@ -751,12 +766,18 @@ export function createBashTool(config?: BashToolConfig): Tool {
             setTimeout(() => doResolve(code), 50);
           });
 
-          child.on("error", (err) => {
-            if (resolved) return;
-            resolved = true;
-            clearTimeout(timer);
-            try { unlinkSync(scriptPath); } catch { /* best-effort cleanup */ }
-            const durationMs = Date.now() - startTime;
+	          child.on("error", (err) => {
+	            if (resolved) return;
+	            resolved = true;
+	            clearTimeout(timer);
+	            try {
+	              unlinkSync(scriptPath);
+	            } catch (error) {
+	              logger.debug("Bash tool script cleanup failed on child error", {
+	                error: error instanceof Error ? error.message : String(error),
+	              });
+	            }
+	            const durationMs = Date.now() - startTime;
             resolve({
               content: safeStringify({
                 error: err.message,

--- a/runtime/tests/litesvm-setup.ts
+++ b/runtime/tests/litesvm-setup.ts
@@ -18,13 +18,38 @@ import {
   LAMPORTS_PER_SOL,
   SendTransactionError,
 } from '@solana/web3.js';
-import * as bs58 from 'bs58';
+import * as bs58Module from 'bs58';
 import { fileURLToPath } from 'node:url';
 import type { AgencCoordination } from '../src/types/agenc_coordination.js';
 
 const BPF_LOADER_UPGRADEABLE_ID = new PublicKey(
   'BPFLoaderUpgradeab1e11111111111111111111111'
 );
+
+const bs58 = (() => {
+  const candidate = bs58Module as unknown as {
+    encode?: (input: Uint8Array | Buffer) => string;
+    decode?: (input: string) => Uint8Array;
+    default?: {
+      encode?: (input: Uint8Array | Buffer) => string;
+      decode?: (input: string) => Uint8Array;
+    };
+  };
+  if (typeof candidate.encode === 'function' && typeof candidate.decode === 'function') {
+    return candidate as {
+      encode: (input: Uint8Array | Buffer) => string;
+      decode: (input: string) => Uint8Array;
+    };
+  }
+  const fallback = candidate.default;
+  if (fallback && typeof fallback.encode === 'function' && typeof fallback.decode === 'function') {
+    return fallback as {
+      encode: (input: Uint8Array | Buffer) => string;
+      decode: (input: string) => Uint8Array;
+    };
+  }
+  throw new Error('Unsupported bs58 module shape');
+})();
 
 /**
  * Patch LiteSVMProvider.sendAndConfirm to fix anchor-litesvm's sendWithErr

--- a/scripts/gitguardian-mcp-scan.mjs
+++ b/scripts/gitguardian-mcp-scan.mjs
@@ -8,6 +8,7 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { normalizeMcpContent } from "./lib/mcp-content-normalize.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -185,32 +186,8 @@ function toErrorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
-function normalizeContent(content) {
-  if (Array.isArray(content)) {
-    return content
-      .map((item) => {
-        if (item && typeof item === "object" && item.type === "text") {
-          return item.text ?? "";
-        }
-        try {
-          return JSON.stringify(item);
-        } catch {
-          return String(item);
-        }
-      })
-      .join("\n");
-  }
-  if (typeof content === "string") return content;
-  if (content === undefined || content === null) return "";
-  try {
-    return JSON.stringify(content);
-  } catch {
-    return String(content);
-  }
-}
-
 function parseToolPayload(content) {
-  const text = normalizeContent(content).trim();
+  const text = normalizeMcpContent(content).trim();
   if (!text) return {};
   try {
     return JSON.parse(text);

--- a/scripts/lib/mcp-content-normalize.mjs
+++ b/scripts/lib/mcp-content-normalize.mjs
@@ -1,0 +1,37 @@
+/**
+ * Normalize MCP tool content payloads into printable text.
+ */
+export function normalizeMcpContent(
+  content,
+  options = {},
+) {
+  const { pretty = false, emptyOnNull = true } = options;
+
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        if (item && typeof item === "object" && item.type === "text") {
+          return item.text ?? "";
+        }
+        try {
+          const serialized = JSON.stringify(item, null, pretty ? 2 : undefined);
+          return serialized ?? (emptyOnNull ? "" : String(item));
+        } catch {
+          return String(item);
+        }
+      })
+      .join("\n");
+  }
+
+  if (typeof content === "string") return content;
+  if (content === undefined || content === null) {
+    return emptyOnNull ? "" : String(content);
+  }
+
+  try {
+    const serialized = JSON.stringify(content, null, pretty ? 2 : undefined);
+    return serialized ?? (emptyOnNull ? "" : String(content));
+  } catch {
+    return String(content);
+  }
+}

--- a/scripts/solana-fender-mcp.mjs
+++ b/scripts/solana-fender-mcp.mjs
@@ -5,6 +5,7 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
+import { normalizeMcpContent } from "./lib/mcp-content-normalize.mjs";
 
 function defaultAnchorWalletPath() {
   const home = process.env.HOME;
@@ -90,29 +91,6 @@ function usage() {
   );
 }
 
-function normalizeContent(content) {
-  if (Array.isArray(content)) {
-    return content
-      .map((item) => {
-        if (item && typeof item === "object" && item.type === "text") {
-          return item.text ?? "";
-        }
-        try {
-          return JSON.stringify(item);
-        } catch {
-          return String(item);
-        }
-      })
-      .join("\n");
-  }
-  if (typeof content === "string") return content;
-  try {
-    return JSON.stringify(content, null, 2);
-  } catch {
-    return String(content);
-  }
-}
-
 async function main() {
   const action = process.argv[2];
   const target = process.argv[3];
@@ -151,7 +129,7 @@ async function main() {
         DEFAULT_SERVER_CONFIG.timeout,
         "security_check_file",
       );
-      const text = normalizeContent(result?.content);
+      const text = normalizeMcpContent(result?.content, { pretty: true });
       if (text) console.log(text);
       process.exit(result?.isError ? 1 : 0);
       return;
@@ -167,7 +145,7 @@ async function main() {
         DEFAULT_SERVER_CONFIG.timeout,
         "security_check_program",
       );
-      const text = normalizeContent(result?.content);
+      const text = normalizeMcpContent(result?.content, { pretty: true });
       if (text) console.log(text);
       process.exit(result?.isError ? 1 : 0);
       return;

--- a/sdk/src/proofs.ts
+++ b/sdk/src/proofs.ts
@@ -299,13 +299,6 @@ function copyFixedBytes(
   return out;
 }
 
-function validateSelector(selector: Buffer): Buffer {
-  if (!selector.equals(Buffer.from(TRUSTED_RISC0_SELECTOR))) {
-    throw new Error("sealSelector must match TRUSTED_RISC0_SELECTOR");
-  }
-  return selector;
-}
-
 export function buildJournalBytes(fields: {
   taskPda: Uint8Array | Buffer;
   agentAuthority: Uint8Array | Buffer;

--- a/tests/litesvm-helpers.ts
+++ b/tests/litesvm-helpers.ts
@@ -20,13 +20,38 @@ import {
   LAMPORTS_PER_SOL,
   SendTransactionError,
 } from "@solana/web3.js";
-import * as bs58 from "bs58";
+import * as bs58Module from "bs58";
 import * as path from "path";
 import { AgencCoordination } from "../target/types/agenc_coordination";
 
 const BPF_LOADER_UPGRADEABLE_ID = new PublicKey(
   "BPFLoaderUpgradeab1e11111111111111111111111",
 );
+
+const bs58 = (() => {
+  const candidate = bs58Module as unknown as {
+    encode?: (input: Uint8Array | Buffer) => string;
+    decode?: (input: string) => Uint8Array;
+    default?: {
+      encode?: (input: Uint8Array | Buffer) => string;
+      decode?: (input: string) => Uint8Array;
+    };
+  };
+  if (typeof candidate.encode === "function" && typeof candidate.decode === "function") {
+    return candidate as {
+      encode: (input: Uint8Array | Buffer) => string;
+      decode: (input: string) => Uint8Array;
+    };
+  }
+  const fallback = candidate.default;
+  if (fallback && typeof fallback.encode === "function" && typeof fallback.decode === "function") {
+    return fallback as {
+      encode: (input: Uint8Array | Buffer) => string;
+      decode: (input: string) => Uint8Array;
+    };
+  }
+  throw new Error("Unsupported bs58 module shape");
+})();
 
 export interface LiteSVMContext {
   svm: LiteSVM;

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -1,7 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { ConnectionState, WSMessage } from '../types';
 import {
+  classifyGatewayControlMessage,
   computeReconnectDelayMs,
+  DEFAULT_GATEWAY_MAX_OFFLINE_QUEUE,
+  DEFAULT_GATEWAY_PING_INTERVAL_MS,
   DEFAULT_GATEWAY_SOCKET_BACKOFF,
   enqueueBounded,
   flushQueueIfOpen,
@@ -22,8 +25,6 @@ function getDefaultWsUrl(): string {
 }
 
 const DEFAULT_URL = getDefaultWsUrl();
-const PING_INTERVAL_MS = 30_000;
-const MAX_OFFLINE_QUEUE = 1_000;
 
 interface UseWebSocketOptions {
   url?: string;
@@ -68,7 +69,7 @@ export function useWebSocket(options?: UseWebSocketOptions): UseWebSocketReturn 
       if (wsRef.current?.readyState === WebSocket.OPEN) {
         wsRef.current.send(serializePingMessage());
       }
-    }, PING_INTERVAL_MS);
+    }, DEFAULT_GATEWAY_PING_INTERVAL_MS);
   }, [stopPing]);
 
   const clearReconnect = useCallback(() => {
@@ -83,7 +84,11 @@ export function useWebSocket(options?: UseWebSocketOptions): UseWebSocketReturn 
   }, []);
 
   const enqueue = useCallback((payload: string) => {
-    enqueueBounded(offlineQueueRef.current, payload, MAX_OFFLINE_QUEUE);
+    enqueueBounded(
+      offlineQueueRef.current,
+      payload,
+      DEFAULT_GATEWAY_MAX_OFFLINE_QUEUE,
+    );
   }, []);
 
   const connect = useCallback(() => {
@@ -128,24 +133,22 @@ export function useWebSocket(options?: UseWebSocketOptions): UseWebSocketReturn 
         return;
       }
 
-      if (parsed && typeof parsed === 'object') {
-        const message = parsed as Record<string, unknown>;
-        if (message.type === 'auth') {
-          if (message.error) {
-            offlineQueueRef.current.length = 0;
-            setState('disconnected');
-            ws.close();
-            return;
-          }
-          reconnectAttemptRef.current = 0;
-          setState('connected');
-          startPing();
-          flushQueue();
-          return;
-        }
-        if (message.type === 'pong') {
-          return;
-        }
+      const control = classifyGatewayControlMessage(parsed);
+      if (control.kind === 'auth_error') {
+        offlineQueueRef.current.length = 0;
+        setState('disconnected');
+        ws.close();
+        return;
+      }
+      if (control.kind === 'auth_ok') {
+        reconnectAttemptRef.current = 0;
+        setState('connected');
+        startPing();
+        flushQueue();
+        return;
+      }
+      if (control.kind === 'pong') {
+        return;
       }
 
       const typedMessage = parsed as WSMessage;


### PR DESCRIPTION
## Summary\n- remediate duplicated logic across replay, MCP status filtering, runtime tool helpers, and MCP script normalization\n- reduce complexity in gateway/webchat and chat executor hot paths via helper extraction\n- improve non-fatal error diagnostics and replace embedded magic thresholds with named constants\n- fix LiteSVM test helpers to handle  module interop shape consistently\n\n## Validation\n- npm --prefix runtime run typecheck\n- npm --prefix mcp run typecheck\n- npm --prefix sdk run typecheck\n- npm run test:fast\n- npm test\n