### PR TITLE
refactor(llm): split chat-executor.ts into focused modules

### DIFF
--- a/runtime/src/llm/chat-executor-constants.ts
+++ b/runtime/src/llm/chat-executor-constants.ts
@@ -1,0 +1,201 @@
+/**
+ * Constants for ChatExecutor.
+ *
+ * @module
+ */
+
+// ============================================================================
+// Size and limit constants
+// ============================================================================
+
+/** Max chars for URL preview in tool summaries. */
+export const MAX_URL_PREVIEW_CHARS = 80;
+/** Max chars for bash output in tool summaries. */
+export const MAX_BASH_OUTPUT_CHARS = 2000;
+/** Max chars for command preview in tool summaries. */
+export const MAX_COMMAND_PREVIEW_CHARS = 60;
+/**
+ * Max consecutive identical failing tool calls before the loop is broken.
+ * When the LLM calls the same tool with the same arguments and gets an error
+ * N times in a row, we inject a hint after (N-1) and break after N.
+ */
+export const MAX_CONSECUTIVE_IDENTICAL_FAILURES = 3;
+/** Break tool loop after N rounds where every tool call failed. */
+export const MAX_CONSECUTIVE_ALL_FAILED_ROUNDS = 3;
+export const RECOVERY_HINT_PREFIX = "Tool recovery hint:";
+export const SHELL_BUILTIN_COMMANDS = new Set([
+  "set",
+  "cd",
+  "export",
+  "source",
+  "alias",
+  "unalias",
+  "unset",
+  "shopt",
+  "ulimit",
+  "umask",
+  "readonly",
+  "declare",
+  "typeset",
+  "builtin",
+]);
+/** Max chars for JSON result previews. */
+export const MAX_RESULT_PREVIEW_CHARS = 500;
+/** Max chars for error message previews. */
+export const MAX_ERROR_PREVIEW_CHARS = 300;
+/** Max chars of user message sent to the evaluator. */
+export const MAX_EVAL_USER_CHARS = 500;
+/** Max chars of response sent to the evaluator. */
+export const MAX_EVAL_RESPONSE_CHARS = 2000;
+/** Cap history depth sent to providers per request. */
+export const MAX_HISTORY_MESSAGES = 20;
+/** Max chars retained per history message. */
+export const MAX_HISTORY_MESSAGE_CHARS = 2_000;
+/** Max chars from a single injected system context block (skills/memory/progress). */
+export const MAX_CONTEXT_INJECTION_CHARS = 12_000;
+/** Hard prompt-size guard (approx chars) to avoid provider context-length errors. */
+export const MAX_PROMPT_CHARS_BUDGET = 100_000;
+/** Max chars kept from a tool result when feeding it back into the LLM. */
+export const MAX_TOOL_RESULT_CHARS = 12_000;
+/** Max chars retained for any single string field inside JSON tool output. */
+export const MAX_TOOL_RESULT_FIELD_CHARS = 2_000;
+/** Max chars retained for one replayed assistant tool-call argument payload. */
+export const MAX_TOOL_CALL_ARGUMENT_CHARS = 512;
+/** Max chars of raw preview kept when tool-call args are truncated for replay. */
+export const MAX_TOOL_CALL_ARGUMENT_PREVIEW_CHARS = 320;
+/** Max array items retained in JSON tool output summaries. */
+export const MAX_TOOL_RESULT_ARRAY_ITEMS = 40;
+/** Max object keys retained in JSON tool output summaries. */
+export const MAX_TOOL_RESULT_OBJECT_KEYS = 48;
+export const TOOL_RESULT_PRIORITY_KEYS = [
+  "error",
+  "stderr",
+  "stdout",
+  "exitcode",
+  "status",
+  "message",
+  "result",
+  "output",
+  "url",
+  "title",
+  "text",
+  "data",
+] as const;
+/** Global image-data budget (chars) for tool results in a single execution. */
+export const MAX_TOOL_IMAGE_CHARS_BUDGET = 100_000;
+/** Max chars retained from a single user text message. */
+export const MAX_USER_MESSAGE_CHARS = 8_000;
+/** Hard cap for final assistant response size (protects against runaway output). */
+export const MAX_FINAL_RESPONSE_CHARS = 24_000;
+/** Minimum line count before repetitive-output suppression is evaluated. */
+export const REPETITIVE_LINE_MIN_COUNT = 40;
+/** Dominant-line repetition threshold for runaway detection. */
+export const REPETITIVE_LINE_MIN_REPEATS = 20;
+/** Unique-line ratio threshold for runaway detection. */
+export const REPETITIVE_LINE_MAX_UNIQUE_RATIO = 0.35;
+/** Upper bound on additive runtime hint system messages per execution. */
+export const DEFAULT_MAX_RUNTIME_SYSTEM_HINTS = 4;
+/** Default max planner output budget in tokens (soft, prompt-enforced). */
+export const DEFAULT_PLANNER_MAX_TOKENS = 256;
+/** Maximum deterministic steps accepted from a planner pass. */
+export const MAX_PLANNER_STEPS = 24;
+/** Parent history slice candidates retained for per-subagent curation. */
+export const MAX_PLANNER_CONTEXT_HISTORY_CANDIDATES = 12;
+/** Max chars retained for one planner history candidate entry. */
+export const MAX_PLANNER_CONTEXT_HISTORY_CHARS = 600;
+/** Max chars retained for one planner memory candidate entry. */
+export const MAX_PLANNER_CONTEXT_MEMORY_CHARS = 1_200;
+/** Max chars retained for one planner tool-output candidate entry. */
+export const MAX_PLANNER_CONTEXT_TOOL_OUTPUT_CHARS = 1_200;
+/** Default per-request tool-call budget. */
+export const DEFAULT_TOOL_BUDGET_PER_REQUEST = 24;
+/** Default per-request model recall budget (calls after first). */
+export const DEFAULT_MODEL_RECALLS_PER_REQUEST = 24;
+/** Default per-request failed-tool-call budget. */
+export const DEFAULT_FAILURE_BUDGET_PER_REQUEST = 8;
+/** Default timeout for a single tool execution call in ms. */
+export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 180_000;
+/** Default end-to-end timeout for one execute() invocation in ms. */
+export const DEFAULT_REQUEST_TIMEOUT_MS = 600_000;
+/** Default minimum verifier confidence for accepting subagent outputs. */
+export const DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE = 0.65;
+/** Default max rounds for verifier/critique loops (initial round included). */
+export const DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS = 2;
+/** Max chars retained from one subagent output in verifier prompts. */
+export const MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS = 3_000;
+/** Max chars retained from one verifier artifact payload. */
+export const MAX_SUBAGENT_VERIFIER_ARTIFACT_CHARS = 2_000;
+/** Break no-progress loops after repeated semantically equivalent rounds. */
+export const MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS = 2;
+/** Default repeated-failure threshold before opening session breaker. */
+export const DEFAULT_TOOL_FAILURE_BREAKER_THRESHOLD = 5;
+/** Default rolling window for repeated-failure breaker accounting. */
+export const DEFAULT_TOOL_FAILURE_BREAKER_WINDOW_MS = 300_000;
+/** Default cooldown once repeated-failure breaker opens. */
+export const DEFAULT_TOOL_FAILURE_BREAKER_COOLDOWN_MS = 120_000;
+/** Keep raw tool image payloads out of model replay by default. */
+export const ENABLE_TOOL_IMAGE_REPLAY = false;
+
+// ============================================================================
+// Tool classification sets
+// ============================================================================
+
+/**
+ * macOS native tools that cause visible side-effects (opening apps, running scripts).
+ * Once any tool in this set executes, further calls to ANY tool in the set are
+ * skipped for the remainder of the request. This prevents the model from e.g.
+ * opening 3 YouTube tabs.
+ *
+ * NOTE: Desktop sandbox tools (`desktop.*`) are intentionally excluded — multi-step
+ * desktop automation (click → type → screenshot → verify) needs repeated calls.
+ */
+export const MACOS_SIDE_EFFECT_TOOLS = new Set([
+  "system.open",
+  "system.applescript",
+  "system.notification",
+]);
+
+/**
+ * High-risk side-effect tools MUST NOT be auto-retried unless an explicit
+ * idempotency token is provided in tool args.
+ */
+export const HIGH_RISK_TOOL_PREFIXES = [
+  "agenc.",
+  "wallet.",
+  "solana.",
+  "desktop.",
+];
+export const HIGH_RISK_TOOLS = new Set([
+  "system.bash",
+  "system.writeFile",
+  "system.delete",
+  "system.applescript",
+  "system.open",
+  "system.notification",
+  "system.execute",
+]);
+export const SAFE_TOOL_RETRY_PREFIXES = [
+  "system.http",
+  "system.browse",
+  "system.extract",
+  "system.read",
+  "playwright.browser_",
+];
+export const SAFE_TOOL_RETRY_TOOLS = new Set([
+  "system.listFiles",
+  "system.readFile",
+  "system.searchFiles",
+  "system.htmlToMarkdown",
+]);
+
+// ============================================================================
+// Class-level constants (formerly private static readonly on ChatExecutor)
+// ============================================================================
+
+export const DEFAULT_EVAL_RUBRIC =
+  "Rate this AI response 0.0-1.0. Consider accuracy, completeness, clarity, " +
+  "and appropriate use of tool results.\n" +
+  'Return ONLY JSON: {"score": 0.0-1.0, "feedback": "brief explanation"}';
+
+/** Max chars of history text sent to the summarization call. */
+export const MAX_COMPACT_INPUT = 20_000;

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -1,0 +1,1155 @@
+/**
+ * Planner parsing, validation, and message-building functions for ChatExecutor.
+ *
+ * @module
+ */
+
+import type { LLMMessage } from "./types.js";
+import type {
+  PromptBudgetSection,
+} from "./prompt-budget.js";
+import type { LLMPipelineStopReason } from "./policy.js";
+import type {
+  PipelinePlannerContext,
+  PipelinePlannerContextMemorySource,
+  PipelineResult,
+} from "../workflow/pipeline.js";
+import type { WorkflowGraphEdge } from "../workflow/types.js";
+import type {
+  PlannerDecision,
+  PlannerStepType,
+  PlannerStepIntent,
+  PlannerSubAgentTaskStepIntent,
+  PlannerPlan,
+  PlannerParseResult,
+  PlannerDiagnostic,
+  PlannerGraphValidationConfig,
+  SubagentVerifierDecision,
+  SubagentVerifierStepAssessment,
+  ToolCallRecord,
+} from "./chat-executor-types.js";
+import {
+  MAX_PLANNER_STEPS,
+  MAX_PLANNER_CONTEXT_HISTORY_CANDIDATES,
+  MAX_PLANNER_CONTEXT_HISTORY_CHARS,
+  MAX_PLANNER_CONTEXT_MEMORY_CHARS,
+  MAX_PLANNER_CONTEXT_TOOL_OUTPUT_CHARS,
+  MAX_USER_MESSAGE_CHARS,
+  MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS,
+  RECOVERY_HINT_PREFIX,
+} from "./chat-executor-constants.js";
+import {
+  truncateText,
+  extractLLMMessageText,
+  parseJsonObjectFromText,
+  normalizeHistory,
+} from "./chat-executor-text.js";
+import { didToolCallFail } from "./chat-executor-tool-utils.js";
+import { safeStringify } from "../tools/types.js";
+
+// ============================================================================
+// Planner decision
+// ============================================================================
+
+export function assessPlannerDecision(
+  plannerEnabled: boolean,
+  messageText: string,
+  history: readonly LLMMessage[],
+): PlannerDecision {
+  if (!plannerEnabled) {
+    return {
+      score: 0,
+      shouldPlan: false,
+      reason: "planner_disabled",
+    };
+  }
+
+  let score = 0;
+  const reasons: string[] = [];
+  const normalized = messageText.toLowerCase();
+
+  const hasMultiStepCue =
+    /\b(first|second|third|then|after that|next|finally|step\b|in order|checklist|pipeline)\b/i.test(
+      messageText,
+    ) ||
+    /\b1[\).:]\s+.+\b2[\).:]/s.test(messageText);
+  if (hasMultiStepCue) {
+    score += 3;
+    reasons.push("multi_step_cues");
+  }
+
+  const hasToolDiversityCue =
+    /\b(browser|http|curl|bash|command|container|playwright|open|navigate|teardown|verify)\b/i.test(
+      messageText,
+    );
+  if (hasToolDiversityCue) {
+    score += 1;
+    reasons.push("multi_tool_candidates");
+  }
+
+  const hasDelegationCue =
+    /\b(sub[\s-]?agent|delegate|delegation|parallel(?:ize|ism)?|fanout)\b/i.test(
+      messageText,
+    );
+  if (hasDelegationCue) {
+    score += 4;
+    reasons.push("delegation_cue");
+  }
+
+  const hasImplementationScopeCue =
+    /\b(build|implement|create|scaffold|generate|refactor|migrate|api|endpoint|service|tests?|integration|unit test|e2e|makefile|project)\b/i.test(
+      messageText,
+    );
+  if (hasImplementationScopeCue) {
+    score += 3;
+    reasons.push("implementation_scope");
+  }
+
+  const longTask = messageText.length >= 320 || messageText.split(/\n/).length >= 4;
+  if (longTask) {
+    score += 1;
+    reasons.push("long_or_structured_request");
+  }
+
+  const historyTail = history.slice(-10);
+  const priorToolMessages = historyTail.filter(
+    (entry) => entry.role === "tool",
+  ).length;
+  if (priorToolMessages >= 4) {
+    score += 2;
+    reasons.push("prior_tool_loop_activity");
+  }
+  if (historyTail.some((entry) => typeof entry.content === "string" && entry.content.includes(RECOVERY_HINT_PREFIX))) {
+    score += 2;
+    reasons.push("prior_no_progress_signal");
+  }
+
+  const directFastPath =
+    score < 3 ||
+    normalized.trim().length < 20 ||
+    /\b(hi|hello|thanks|thank you)\b/.test(normalized);
+
+  return {
+    score,
+    shouldPlan: !directFastPath,
+    reason: reasons.length > 0 ? reasons.join("+") : "direct_fast_path",
+  };
+}
+
+// ============================================================================
+// Planner message building
+// ============================================================================
+
+export function buildPlannerMessages(
+  messageText: string,
+  history: readonly LLMMessage[],
+  plannerMaxTokens: number,
+): readonly LLMMessage[] {
+  const historyPreview = history
+    .slice(-6)
+    .map((entry) => {
+      const raw =
+        typeof entry.content === "string"
+          ? entry.content
+          : entry.content
+              .filter((part) => part.type === "text")
+              .map((part) => part.text)
+              .join(" ");
+      return `[${entry.role}] ${truncateText(raw, 300)}`;
+    })
+    .join("\n");
+  const maxSteps = Math.min(
+    MAX_PLANNER_STEPS,
+    Math.max(1, Math.floor(plannerMaxTokens / 8)),
+  );
+
+  return [
+    {
+      role: "system",
+      content:
+        "Plan this request into executable intents. Respond with strict JSON only.\n" +
+        "Schema:\n" +
+        "{\n" +
+        '  "reason": "short routing reason",\n' +
+        '  "requiresSynthesis": boolean,\n' +
+        '  "steps": [\n' +
+        "    {\n" +
+        '      "name": "step_name",\n' +
+        '      "step_type": "deterministic_tool|subagent_task|synthesis",\n' +
+        '      "depends_on": ["step_name"],\n' +
+        '      "tool": "tool.name",\n' +
+        '      "args": { "key": "value" },\n' +
+        '      "onError": "abort|retry|skip",\n' +
+        '      "maxRetries": number,\n' +
+        '      "objective": "required for subagent_task",\n' +
+        '      "input_contract": "required for subagent_task",\n' +
+        '      "acceptance_criteria": ["required for subagent_task"],\n' +
+        '      "required_tool_capabilities": ["required for subagent_task"],\n' +
+        '      "context_requirements": ["required for subagent_task"],\n' +
+        '      "max_budget_hint": "required for subagent_task",\n' +
+        '      "can_run_parallel": true\n' +
+        "    }\n" +
+        "  ]\n" +
+        "}\n" +
+        "Rules:\n" +
+        "- deterministic_tool steps are executable by the deterministic pipeline.\n" +
+        "- subagent_task steps MUST include all subagent fields.\n" +
+        "- Prefer subagent_task steps for broad coding/build requests that split into independent tracks (implementation, tests, verification).\n" +
+        "- synthesis steps describe final merge/synthesis intent and do not call tools.\n" +
+        `Keep output concise and below approximately ${plannerMaxTokens} tokens. ` +
+        `Never emit more than ${maxSteps} steps.`,
+    },
+    {
+      role: "user",
+      content:
+        `User request:\n${messageText}\n\n` +
+        (historyPreview.length > 0
+          ? `Recent conversation context:\n${historyPreview}\n\n`
+          : "") +
+        "Return JSON only.",
+    },
+  ];
+}
+
+// ============================================================================
+// Planner execution context
+// ============================================================================
+
+export function buildPlannerExecutionContext(
+  messageText: string,
+  history: readonly LLMMessage[],
+  messages: readonly LLMMessage[],
+  sections: readonly PromptBudgetSection[],
+  parentAllowedTools?: readonly string[],
+): PipelinePlannerContext {
+  const normalizedHist = normalizeHistory(history);
+  const historySlice = normalizedHist
+    .slice(-MAX_PLANNER_CONTEXT_HISTORY_CANDIDATES)
+    .map((entry) => ({
+      role: entry.role,
+      content: truncateText(
+        extractLLMMessageText(entry),
+        MAX_PLANNER_CONTEXT_HISTORY_CHARS,
+      ),
+      ...(entry.role === "tool" && entry.toolName
+        ? { toolName: entry.toolName }
+        : {}),
+    }))
+    .filter((entry) => entry.content.trim().length > 0);
+
+  const memory: Array<{
+    source: PipelinePlannerContextMemorySource;
+    content: string;
+  }> = [];
+  const bySection = (
+    section: PromptBudgetSection,
+  ): PipelinePlannerContextMemorySource | null => {
+    if (section === "memory_semantic") return "memory_semantic";
+    if (section === "memory_episodic") return "memory_episodic";
+    if (section === "memory_working") return "memory_working";
+    return null;
+  };
+  for (let i = 0; i < messages.length; i++) {
+    const source = bySection(sections[i] ?? "history");
+    if (!source) continue;
+    const message = messages[i];
+    if (!message || message.role !== "system") continue;
+    const content = truncateText(
+      extractLLMMessageText(message),
+      MAX_PLANNER_CONTEXT_MEMORY_CHARS,
+    );
+    if (content.trim().length === 0) continue;
+    memory.push({ source, content });
+  }
+
+  const toolOutputs = normalizedHist
+    .filter((entry) => entry.role === "tool")
+    .map((entry) => ({
+      ...(entry.toolName ? { toolName: entry.toolName } : {}),
+      content: truncateText(
+        extractLLMMessageText(entry),
+        MAX_PLANNER_CONTEXT_TOOL_OUTPUT_CHARS,
+      ),
+    }))
+    .filter((entry) => entry.content.trim().length > 0);
+
+  return {
+    parentRequest: truncateText(
+      messageText,
+      MAX_USER_MESSAGE_CHARS,
+    ),
+    history: historySlice,
+    memory,
+    toolOutputs,
+    ...(parentAllowedTools && parentAllowedTools.length > 0
+      ? { parentAllowedTools: [...new Set(parentAllowedTools)] }
+      : {}),
+  };
+}
+
+// ============================================================================
+// Planner plan parsing
+// ============================================================================
+
+export function parsePlannerPlan(content: string): PlannerParseResult {
+  const diagnostics: PlannerDiagnostic[] = [];
+  const parsed = parseJsonObjectFromText(content);
+  if (!parsed) {
+    diagnostics.push(
+      createPlannerDiagnostic(
+        "parse",
+        "invalid_json",
+        "Planner output is not parseable JSON object",
+      ),
+    );
+    return { diagnostics };
+  }
+  if (!Array.isArray(parsed.steps)) {
+    diagnostics.push(
+      createPlannerDiagnostic(
+        "parse",
+        "missing_steps_array",
+        'Planner output must include a "steps" array',
+      ),
+    );
+    return { diagnostics };
+  }
+
+  const steps: PlannerStepIntent[] = [];
+  const unresolvedDependencies = new Map<string, readonly string[]>();
+  const nameAliases = new Map<string, string>();
+  const usedStepNames = new Set<string>();
+  const maxSteps = Math.min(MAX_PLANNER_STEPS, parsed.steps.length);
+
+  for (const [index, rawStep] of parsed.steps.slice(0, maxSteps).entries()) {
+    if (
+      typeof rawStep !== "object" ||
+      rawStep === null ||
+      Array.isArray(rawStep)
+    ) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "parse",
+          "invalid_step_object",
+          `Planner step at index ${index} must be an object`,
+          { stepIndex: index },
+        ),
+      );
+      return { diagnostics };
+    }
+    const step = rawStep as Record<string, unknown>;
+    const stepType = parsePlannerStepType(step.step_type);
+    if (!stepType) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "parse",
+          "invalid_step_type",
+          `Planner step at index ${index} has invalid step_type`,
+          { stepIndex: index },
+        ),
+      );
+      return { diagnostics };
+    }
+
+    const rawName =
+      typeof step.name === "string" ? step.name.trim() : "";
+    const sanitizedName = sanitizePlannerStepName(
+      rawName.length > 0 ? rawName : `step_${steps.length + 1}`,
+    );
+    const safeName = dedupePlannerStepName(
+      sanitizedName,
+      usedStepNames,
+    );
+    usedStepNames.add(safeName);
+
+    if (rawName.length > 0) {
+      if (nameAliases.has(rawName)) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "duplicate_step_name",
+            `Planner step name "${rawName}" is duplicated`,
+            { stepIndex: index, stepName: rawName },
+          ),
+        );
+        return { diagnostics };
+      }
+      nameAliases.set(rawName, safeName);
+    }
+    nameAliases.set(safeName, safeName);
+
+    const dependsOn = parsePlannerDependsOn(step.depends_on);
+    if (!dependsOn) {
+      diagnostics.push(
+        createPlannerDiagnostic(
+          "parse",
+          "invalid_depends_on",
+          `Planner step "${safeName}" has invalid depends_on`,
+          { stepIndex: index, stepName: safeName },
+        ),
+      );
+      return { diagnostics };
+    }
+    unresolvedDependencies.set(safeName, dependsOn);
+
+    if (stepType === "deterministic_tool") {
+      if (typeof step.tool !== "string" || step.tool.trim().length === 0) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_tool_name",
+            `Deterministic planner step "${safeName}" must include a non-empty tool name`,
+            { stepIndex: index, stepName: safeName },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (
+        step.args !== undefined &&
+        (
+          typeof step.args !== "object" ||
+          step.args === null ||
+          Array.isArray(step.args)
+        )
+      ) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "invalid_tool_args",
+            `Planner step "${safeName}" has invalid args; expected JSON object`,
+            { stepIndex: index, stepName: safeName },
+          ),
+        );
+        return { diagnostics };
+      }
+      const args =
+        typeof step.args === "object" &&
+        step.args !== null &&
+        !Array.isArray(step.args)
+          ? (step.args as Record<string, unknown>)
+          : {};
+      const onError =
+        step.onError === "retry" ||
+        step.onError === "skip" ||
+        step.onError === "abort"
+          ? step.onError
+          : undefined;
+      const maxRetries =
+        typeof step.maxRetries === "number" && Number.isFinite(step.maxRetries)
+          ? Math.max(0, Math.min(5, Math.floor(step.maxRetries)))
+          : undefined;
+      steps.push({
+        name: safeName,
+        stepType,
+        tool: step.tool.trim(),
+        args,
+        onError,
+        maxRetries,
+      });
+      continue;
+    }
+
+    if (stepType === "subagent_task") {
+      const objective = parsePlannerRequiredString(step.objective);
+      const inputContract = parsePlannerRequiredString(
+        step.input_contract,
+      );
+      const acceptanceCriteria = parsePlannerStringArray(
+        step.acceptance_criteria,
+      );
+      const requiredToolCapabilities = parsePlannerStringArray(
+        step.required_tool_capabilities,
+      );
+      const contextRequirements = parsePlannerStringArray(
+        step.context_requirements,
+      );
+      const maxBudgetHint = parsePlannerRequiredString(
+        step.max_budget_hint,
+      );
+      const canRunParallel =
+        typeof step.can_run_parallel === "boolean"
+          ? step.can_run_parallel
+          : undefined;
+      if (!objective) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_subagent_field",
+            `Planner subagent step "${safeName}" is missing objective`,
+            { stepIndex: index, stepName: safeName, field: "objective" },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (!inputContract) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_subagent_field",
+            `Planner subagent step "${safeName}" is missing input_contract`,
+            { stepIndex: index, stepName: safeName, field: "input_contract" },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (!acceptanceCriteria || acceptanceCriteria.length === 0) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_subagent_field",
+            `Planner subagent step "${safeName}" is missing acceptance_criteria`,
+            {
+              stepIndex: index,
+              stepName: safeName,
+              field: "acceptance_criteria",
+            },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (!requiredToolCapabilities || requiredToolCapabilities.length === 0) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_subagent_field",
+            `Planner subagent step "${safeName}" is missing required_tool_capabilities`,
+            {
+              stepIndex: index,
+              stepName: safeName,
+              field: "required_tool_capabilities",
+            },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (!contextRequirements || contextRequirements.length === 0) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_subagent_field",
+            `Planner subagent step "${safeName}" is missing context_requirements`,
+            {
+              stepIndex: index,
+              stepName: safeName,
+              field: "context_requirements",
+            },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (!maxBudgetHint) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_subagent_field",
+            `Planner subagent step "${safeName}" is missing max_budget_hint`,
+            {
+              stepIndex: index,
+              stepName: safeName,
+              field: "max_budget_hint",
+            },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (canRunParallel === undefined) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "missing_subagent_field",
+            `Planner subagent step "${safeName}" is missing can_run_parallel`,
+            {
+              stepIndex: index,
+              stepName: safeName,
+              field: "can_run_parallel",
+            },
+          ),
+        );
+        return { diagnostics };
+      }
+
+      steps.push({
+        name: safeName,
+        stepType,
+        objective,
+        inputContract,
+        acceptanceCriteria,
+        requiredToolCapabilities,
+        contextRequirements,
+        maxBudgetHint,
+        canRunParallel,
+      });
+      continue;
+    }
+
+    const objective = parsePlannerOptionalString(step.objective);
+    steps.push({
+      name: safeName,
+      stepType,
+      ...(objective ? { objective } : {}),
+    });
+  }
+
+  const knownStepNames = new Set(steps.map((step) => step.name));
+  const edges: WorkflowGraphEdge[] = [];
+  for (const step of steps) {
+    const rawDepends = unresolvedDependencies.get(step.name) ?? [];
+    if (rawDepends.length === 0) continue;
+    const resolved = new Set<string>();
+    for (const dependencyName of rawDepends) {
+      const alias = nameAliases.get(dependencyName) ?? dependencyName;
+      if (!knownStepNames.has(alias)) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "unknown_dependency",
+            `Planner step "${step.name}" depends on unknown step "${dependencyName}"`,
+            { stepName: step.name, dependencyName },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (alias === step.name) {
+        diagnostics.push(
+          createPlannerDiagnostic(
+            "parse",
+            "self_dependency",
+            `Planner step "${step.name}" cannot depend on itself`,
+            { stepName: step.name },
+          ),
+        );
+        return { diagnostics };
+      }
+      if (resolved.has(alias)) continue;
+      resolved.add(alias);
+      edges.push({ from: alias, to: step.name });
+    }
+    if (resolved.size > 0) {
+      step.dependsOn = [...resolved];
+    }
+  }
+
+  const cyclePath = detectPlannerCycle(
+    steps.map((step) => step.name),
+    edges,
+  );
+  if (cyclePath) {
+    diagnostics.push(
+      createPlannerDiagnostic(
+        "validation",
+        "cyclic_dependency",
+        "Planner dependency graph contains a cycle",
+        {
+          cycle: cyclePath.join("->"),
+        },
+      ),
+    );
+    return { diagnostics };
+  }
+
+  const containsSynthesisStep = steps.some(
+    (step) => step.stepType === "synthesis",
+  );
+
+  return {
+    plan: {
+      reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
+      confidence: parsePlannerConfidence(parsed.confidence),
+      requiresSynthesis:
+        typeof parsed.requiresSynthesis === "boolean"
+          ? parsed.requiresSynthesis || containsSynthesisStep
+          : containsSynthesisStep || undefined,
+      steps,
+      edges,
+    },
+    diagnostics,
+  };
+}
+
+// ============================================================================
+// Planner graph validation
+// ============================================================================
+
+export function validatePlannerGraph(
+  plannerPlan: PlannerPlan,
+  config: PlannerGraphValidationConfig,
+): readonly PlannerDiagnostic[] {
+  const diagnostics: PlannerDiagnostic[] = [];
+  const subagentSteps = plannerPlan.steps.filter(
+    (step): step is PlannerSubAgentTaskStepIntent =>
+      step.stepType === "subagent_task",
+  );
+  if (subagentSteps.length === 0) return diagnostics;
+
+  if (subagentSteps.length > config.maxSubagentFanout) {
+    diagnostics.push(
+      createPlannerDiagnostic(
+        "validation",
+        "subagent_fanout_exceeded",
+        `Planner emitted ${subagentSteps.length} subagent tasks but maxFanoutPerTurn is ${config.maxSubagentFanout}`,
+        {
+          subagentSteps: subagentSteps.length,
+          maxFanoutPerTurn: config.maxSubagentFanout,
+        },
+      ),
+    );
+  }
+
+  const subagentStepNames = new Set(subagentSteps.map((step) => step.name));
+  const subagentEdges = plannerPlan.edges.filter((edge) =>
+    subagentStepNames.has(edge.from) && subagentStepNames.has(edge.to)
+  );
+  const graphDepth = computePlannerGraphDepth(
+    [...subagentStepNames],
+    subagentEdges,
+  );
+  if (graphDepth.cyclic) {
+    diagnostics.push(
+      createPlannerDiagnostic(
+        "validation",
+        "cyclic_dependency",
+        "Planner dependency graph contains a cycle",
+      ),
+    );
+    return diagnostics;
+  }
+  if (graphDepth.maxDepth > config.maxSubagentDepth) {
+    diagnostics.push(
+      createPlannerDiagnostic(
+        "validation",
+        "subagent_depth_exceeded",
+        `Planner subagent dependency depth ${graphDepth.maxDepth} exceeds maxDepth ${config.maxSubagentDepth}`,
+        {
+          depth: graphDepth.maxDepth,
+          maxDepth: config.maxSubagentDepth,
+        },
+      ),
+    );
+  }
+
+  return diagnostics;
+}
+
+// ============================================================================
+// Planner utility functions
+// ============================================================================
+
+export function createPlannerDiagnostic(
+  category: PlannerDiagnostic["category"],
+  code: string,
+  message: string,
+  details?: Readonly<Record<string, string | number | boolean>>,
+): PlannerDiagnostic {
+  return { category, code, message, ...(details ? { details } : {}) };
+}
+
+export function isHighRiskSubagentPlan(
+  steps: readonly PlannerSubAgentTaskStepIntent[],
+): boolean {
+  for (const step of steps) {
+    for (const capability of step.requiredToolCapabilities) {
+      const normalized = capability.trim().toLowerCase();
+      if (!normalized) continue;
+      if (
+        normalized.startsWith("wallet.") ||
+        normalized.startsWith("solana.") ||
+        normalized.startsWith("agenc.") ||
+        normalized.startsWith("desktop.") ||
+        normalized === "system.delete" ||
+        normalized === "system.writefile" ||
+        normalized === "system.execute" ||
+        normalized === "system.open" ||
+        normalized === "system.applescript" ||
+        normalized === "system.notification"
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function detectPlannerCycle(
+  nodes: readonly string[],
+  edges: readonly WorkflowGraphEdge[],
+): string[] | null {
+  const adjacency = new Map<string, string[]>();
+  for (const node of nodes) {
+    adjacency.set(node, []);
+  }
+  for (const edge of edges) {
+    if (!adjacency.has(edge.from) || !adjacency.has(edge.to)) continue;
+    adjacency.get(edge.from)!.push(edge.to);
+  }
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  const walk = (node: string): string[] | null => {
+    if (visiting.has(node)) {
+      const loopStart = stack.indexOf(node);
+      return loopStart >= 0
+        ? [...stack.slice(loopStart), node]
+        : [node, node];
+    }
+    if (visited.has(node)) return null;
+    visiting.add(node);
+    stack.push(node);
+    for (const next of adjacency.get(node) ?? []) {
+      const cycle = walk(next);
+      if (cycle) return cycle;
+    }
+    stack.pop();
+    visiting.delete(node);
+    visited.add(node);
+    return null;
+  };
+
+  for (const node of nodes) {
+    const cycle = walk(node);
+    if (cycle) return cycle;
+  }
+  return null;
+}
+
+export function computePlannerGraphDepth(
+  nodes: readonly string[],
+  edges: readonly WorkflowGraphEdge[],
+): { maxDepth: number; cyclic: boolean } {
+  if (nodes.length === 0) return { maxDepth: 0, cyclic: false };
+  const inDegree = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  const depth = new Map<string, number>();
+
+  for (const node of nodes) {
+    inDegree.set(node, 0);
+    outgoing.set(node, []);
+    depth.set(node, 1);
+  }
+  for (const edge of edges) {
+    if (!inDegree.has(edge.from) || !inDegree.has(edge.to)) continue;
+    outgoing.get(edge.from)!.push(edge.to);
+    inDegree.set(edge.to, (inDegree.get(edge.to) ?? 0) + 1);
+  }
+
+  const queue: string[] = [];
+  for (const [node, nodeInDegree] of inDegree.entries()) {
+    if (nodeInDegree === 0) queue.push(node);
+  }
+
+  let visited = 0;
+  let maxDepth = 1;
+  while (queue.length > 0) {
+    const node = queue.shift()!;
+    visited++;
+    const nodeDepth = depth.get(node) ?? 1;
+    maxDepth = Math.max(maxDepth, nodeDepth);
+    for (const next of outgoing.get(node) ?? []) {
+      const nextDepth = Math.max(depth.get(next) ?? 1, nodeDepth + 1);
+      depth.set(next, nextDepth);
+      const nextInDegree = (inDegree.get(next) ?? 0) - 1;
+      inDegree.set(next, nextInDegree);
+      if (nextInDegree === 0) queue.push(next);
+    }
+  }
+
+  return {
+    maxDepth,
+    cyclic: visited !== nodes.length,
+  };
+}
+
+export function parsePlannerStepType(
+  value: unknown,
+): PlannerStepType | undefined {
+  return value === "deterministic_tool" ||
+    value === "subagent_task" ||
+    value === "synthesis"
+    ? value
+    : undefined;
+}
+
+export function parsePlannerRequiredString(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function parsePlannerOptionalString(
+  value: unknown,
+): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function parsePlannerStringArray(
+  value: unknown,
+): readonly string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const items: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") return undefined;
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) return undefined;
+    items.push(trimmed);
+  }
+  return items;
+}
+
+export function parsePlannerDependsOn(
+  value: unknown,
+): readonly string[] | undefined {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) return undefined;
+  const items: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") return undefined;
+    const trimmed = entry.trim();
+    if (trimmed.length === 0) return undefined;
+    items.push(trimmed);
+  }
+  return items;
+}
+
+export function parsePlannerConfidence(
+  value: unknown,
+): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  if (value >= 0 && value <= 1) return value;
+  if (value >= 0 && value <= 100) return value / 100;
+  return undefined;
+}
+
+export function sanitizePlannerStepName(name: string): string {
+  const trimmed = name.trim();
+  const normalized = trimmed.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 48);
+  return normalized.length > 0 ? normalized : "step";
+}
+
+export function dedupePlannerStepName(
+  name: string,
+  used: ReadonlySet<string>,
+): string {
+  if (!used.has(name)) return name;
+  for (let i = 2; i <= 999; i++) {
+    const candidate = `${name}_${i}`;
+    if (!used.has(candidate)) return candidate;
+  }
+  return `${name}_${Date.now().toString(36)}`;
+}
+
+export function isPipelineStopReasonHint(
+  value: unknown,
+): value is Exclude<LLMPipelineStopReason, "completed" | "tool_calls"> {
+  return (
+    value === "validation_error" ||
+    value === "provider_error" ||
+    value === "authentication_error" ||
+    value === "rate_limited" ||
+    value === "timeout" ||
+    value === "tool_error" ||
+    value === "budget_exceeded" ||
+    value === "no_progress" ||
+    value === "cancelled"
+  );
+}
+
+// ============================================================================
+// Planner synthesis messages
+// ============================================================================
+
+export function buildPlannerSynthesisMessages(
+  systemPrompt: string,
+  messageText: string,
+  plannerPlan: PlannerPlan,
+  pipelineResult: PipelineResult,
+  verificationDecision?: SubagentVerifierDecision,
+): readonly LLMMessage[] {
+  const plannerSteps = plannerPlan.steps.map((step) => {
+    if (step.stepType === "deterministic_tool") {
+      return {
+        name: step.name,
+        stepType: step.stepType,
+        tool: step.tool,
+        dependsOn: step.dependsOn,
+      };
+    }
+    if (step.stepType === "subagent_task") {
+      return {
+        name: step.name,
+        stepType: step.stepType,
+        objective: step.objective,
+        dependsOn: step.dependsOn,
+        canRunParallel: step.canRunParallel,
+      };
+    }
+    return {
+      name: step.name,
+      stepType: step.stepType,
+      objective: step.objective,
+      dependsOn: step.dependsOn,
+    };
+  });
+  const subagentStepMap = new Map<
+    string,
+    SubagentVerifierStepAssessment
+  >(
+    (verificationDecision?.steps ?? []).map((step) => [step.name, step]),
+  );
+  const childOutputs = plannerPlan.steps
+    .filter((step): step is PlannerSubAgentTaskStepIntent => step.stepType === "subagent_task")
+    .map((step) => {
+      const raw = pipelineResult.context.results[step.name];
+      const parsed = typeof raw === "string"
+        ? parseJsonObjectFromText(raw)
+        : undefined;
+      const status =
+        typeof parsed?.status === "string" ? parsed.status : "unknown";
+      const output = typeof parsed?.output === "string"
+        ? parsed.output
+        : (typeof raw === "string" ? raw : "");
+      const marker =
+        status === "failed" || status === "cancelled"
+          ? status
+          : (
+              status === "delegation_fallback" ? "unresolved" : "completed"
+            );
+      const verification = subagentStepMap.get(step.name);
+      return {
+        name: step.name,
+        objective: step.objective,
+        status,
+        marker,
+        confidence: verification?.confidence ?? null,
+        verifierVerdict: verification?.verdict ?? null,
+        unresolvedIssues: verification?.issues ?? [],
+        output: truncateText(
+          output,
+          MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS,
+        ),
+        provenanceTag: `[source:${step.name}]`,
+      };
+    });
+  const unresolvedItems = [
+    ...(verificationDecision?.unresolvedItems ?? []),
+    ...childOutputs
+      .filter((child) => child.marker !== "completed")
+      .map((child) => `${child.name}:${child.marker}`),
+  ];
+  const renderedResults = safeStringify({
+    plannerReason: plannerPlan.reason,
+    status: pipelineResult.status,
+    completedSteps: pipelineResult.completedSteps,
+    totalSteps: pipelineResult.totalSteps,
+    resumeFrom: pipelineResult.resumeFrom,
+    error: pipelineResult.error,
+    plannerSteps,
+    plannerEdges: plannerPlan.edges,
+    results: pipelineResult.context.results,
+    childOutputs,
+    verifier: verificationDecision ?? null,
+    unresolvedItems,
+  });
+  return [
+    { role: "system", content: systemPrompt },
+    {
+      role: "system",
+      content:
+        "Synthesize the final user-facing answer from deterministic workflow and delegated child results. " +
+        "Do not invent unexecuted steps and do not call any tools. " +
+        "When a major claim is derived from child output, append provenance tags like [source:<step_name>]. " +
+        "Explicitly surface unresolved items or failed/cancelled child outputs.",
+    },
+    {
+      role: "user",
+      content:
+        `Original request:\n${messageText}\n\n` +
+        `Workflow execution bundle (with child confidence/provenance markers):\n${renderedResults}`,
+    },
+  ];
+}
+
+export function ensureSubagentProvenanceCitations(
+  content: string,
+  plannerPlan: PlannerPlan,
+  pipelineResult: PipelineResult,
+): string {
+  const trimmed = content.trim();
+  const subagentStepNames = plannerPlan.steps
+    .filter((step): step is PlannerSubAgentTaskStepIntent => step.stepType === "subagent_task")
+    .map((step) => step.name)
+    .filter((name) =>
+      typeof pipelineResult.context.results[name] === "string"
+    );
+  if (subagentStepNames.length === 0) return content;
+  if (/\[source:[^\]]+\]/.test(trimmed)) return content;
+  const citationLine = `Sources: ${subagentStepNames
+    .map((name) => `[source:${name}]`)
+    .join(" ")}`;
+  if (trimmed.length === 0) return citationLine;
+  return `${content}\n\n${citationLine}`;
+}
+
+export function pipelineResultToToolCalls(
+  steps: readonly PlannerStepIntent[],
+  pipelineResult: PipelineResult,
+): ToolCallRecord[] {
+  const records: ToolCallRecord[] = [];
+  for (const step of steps) {
+    const result = pipelineResult.context.results[step.name];
+    if (typeof result !== "string") continue;
+    if (step.stepType === "deterministic_tool") {
+      const inferredFailure =
+        result.startsWith("SKIPPED:") || didToolCallFail(false, result);
+      records.push({
+        name: step.tool,
+        args: step.args,
+        result,
+        isError: inferredFailure,
+        durationMs: 0,
+      });
+      continue;
+    }
+    if (step.stepType === "subagent_task") {
+      const inferredFailure = didSubagentStepFail(result);
+      records.push({
+        name: "execute_with_agent",
+        args: {
+          objective: step.objective,
+          requiredToolCapabilities: step.requiredToolCapabilities,
+          stepName: step.name,
+        },
+        result,
+        isError: inferredFailure,
+        durationMs: 0,
+      });
+    }
+  }
+  return records;
+}
+
+export function didSubagentStepFail(result: string): boolean {
+  if (result.startsWith("SKIPPED:")) return true;
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return didToolCallFail(false, result);
+    }
+    const obj = parsed as Record<string, unknown>;
+    if (obj.success === false) return true;
+    if (obj.status === "failed" || obj.status === "cancelled") return true;
+    if (typeof obj.error === "string" && obj.error.trim().length > 0) {
+      return true;
+    }
+    return false;
+  } catch {
+    return didToolCallFail(false, result);
+  }
+}

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -1,0 +1,170 @@
+/**
+ * Semantic key building, recovery hints, and stateful summary functions for ChatExecutor.
+ *
+ * @module
+ */
+
+import type {
+  ToolCallRecord,
+  RecoveryHint,
+  ChatCallUsageRecord,
+  ChatStatefulSummary,
+} from "./chat-executor-types.js";
+import type { LLMStatefulDiagnostics, LLMStatefulFallbackReason } from "./types.js";
+import { SHELL_BUILTIN_COMMANDS } from "./chat-executor-constants.js";
+import {
+  didToolCallFail,
+  extractToolFailureText,
+} from "./chat-executor-tool-utils.js";
+
+export function buildSemanticToolCallKey(
+  name: string,
+  args: Record<string, unknown>,
+): string {
+  return `${name}:${normalizeSemanticValue(args)}`;
+}
+
+export function normalizeSemanticValue(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "string") {
+    return value.trim().replace(/\s+/g, " ").toLowerCase();
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => normalizeSemanticValue(item)).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj).sort();
+    return `{${keys
+      .map(
+        (key) =>
+          `${key}:${normalizeSemanticValue(obj[key])}`,
+      )
+      .join(",")}}`;
+  }
+  return String(value);
+}
+
+export function summarizeStateful(
+  callUsage: readonly ChatCallUsageRecord[],
+): ChatStatefulSummary | undefined {
+  const entries = callUsage
+    .map((entry) => entry.statefulDiagnostics)
+    .filter(
+      (entry): entry is LLMStatefulDiagnostics =>
+        entry !== undefined && entry.enabled,
+    );
+  if (entries.length === 0) return undefined;
+
+  const fallbackReasons: Record<LLMStatefulFallbackReason, number> = {
+    missing_previous_response_id: 0,
+    provider_retrieval_failure: 0,
+    state_reconciliation_mismatch: 0,
+  };
+  let attemptedCalls = 0;
+  let continuedCalls = 0;
+  let fallbackCalls = 0;
+
+  for (const entry of entries) {
+    if (entry.attempted) attemptedCalls++;
+    if (entry.continued) continuedCalls++;
+    if (entry.fallbackReason) {
+      fallbackCalls++;
+      fallbackReasons[entry.fallbackReason] += 1;
+    }
+  }
+
+  return {
+    enabled: true,
+    attemptedCalls,
+    continuedCalls,
+    fallbackCalls,
+    fallbackReasons,
+  };
+}
+
+export function buildRecoveryHints(
+  roundCalls: readonly ToolCallRecord[],
+  emittedHints: Set<string>,
+): RecoveryHint[] {
+  const hints: RecoveryHint[] = [];
+  for (const call of roundCalls) {
+    const hint = inferRecoveryHint(call);
+    if (!hint) continue;
+    if (emittedHints.has(hint.key)) continue;
+    emittedHints.add(hint.key);
+    hints.push(hint);
+  }
+  return hints;
+}
+
+export function inferRecoveryHint(
+  call: ToolCallRecord,
+): RecoveryHint | undefined {
+  if (!didToolCallFail(call.isError, call.result)) return undefined;
+
+  const failureText = extractToolFailureText(call);
+  const failureTextLower = failureText.toLowerCase();
+
+  if (call.name === "system.bash") {
+    const command = String(call.args?.command ?? "").trim().toLowerCase();
+    const isBuiltin = command.length > 0 && SHELL_BUILTIN_COMMANDS.has(command);
+    if (
+      isBuiltin ||
+      failureTextLower.includes("shell builtin") ||
+      /spawn\s+\S+\s+enoent/i.test(failureText)
+    ) {
+      return {
+        key: "system-bash-shell-builtin",
+        message:
+          "system.bash executes one real binary only. Shell builtins (for example `set`, `cd`, `export`) " +
+          "and script-style command chains do not work there. Use executable + args, or move multi-line/chained logic to `desktop.bash`.",
+      };
+    }
+    if (
+      failureTextLower.includes("one executable token") ||
+      failureTextLower.includes("shell operators/newlines")
+    ) {
+      return {
+        key: "system-bash-command-shape",
+        message:
+          "system.bash `command` must be a single executable token. Put flags/operands in `args`. " +
+          "For pipes/redirection/heredocs or multi-line shell scripts, use `desktop.bash`.",
+      };
+    }
+    if (failureTextLower.includes("nested shell invocation")) {
+      return {
+        key: "system-bash-shell-reinvocation",
+        message:
+          "system.bash already runs commands in a shell. Do NOT wrap with `bash -c` or `sh -c`. " +
+          "Pass the inner command directly as `command` (omit `args` for shell mode). " +
+          'Example: instead of command="bash -c \'curl http://...\'" use command="curl http://...".',
+      };
+    }
+  }
+
+  if (
+    call.name === "system.browse" ||
+    call.name === "system.httpGet" ||
+    call.name === "system.httpPost" ||
+    call.name === "system.httpFetch"
+  ) {
+    if (
+      failureTextLower.includes("private/loopback address blocked") ||
+      failureTextLower.includes("ssrf target blocked")
+    ) {
+      return {
+        key: "localhost-ssrf-blocked",
+        message:
+          "system.browse/system.http* block localhost/private/internal addresses by design. " +
+          "For local service checks on the HOST, use system.bash with curl (e.g. command=\"curl -sSf http://127.0.0.1:PORT\"). " +
+          "Desktop tools run inside Docker and CANNOT reach the host's localhost.",
+      };
+    }
+  }
+
+  return undefined;
+}

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -1,0 +1,658 @@
+/**
+ * Text processing, formatting, and sanitization functions for ChatExecutor.
+ *
+ * @module
+ */
+
+import type { GatewayMessage } from "../gateway/message.js";
+import type {
+  LLMMessage,
+  LLMContentPart,
+  LLMToolCall,
+} from "./types.js";
+import type {
+  PromptBudgetSection,
+} from "./prompt-budget.js";
+import type { ToolCallRecord, ChatPromptShape } from "./chat-executor-types.js";
+import {
+  MAX_FINAL_RESPONSE_CHARS,
+  REPETITIVE_LINE_MIN_COUNT,
+  REPETITIVE_LINE_MIN_REPEATS,
+  REPETITIVE_LINE_MAX_UNIQUE_RATIO,
+  MAX_HISTORY_MESSAGES,
+  MAX_HISTORY_MESSAGE_CHARS,
+  MAX_TOOL_RESULT_CHARS,
+  MAX_TOOL_RESULT_FIELD_CHARS,
+  MAX_TOOL_CALL_ARGUMENT_CHARS,
+  MAX_TOOL_CALL_ARGUMENT_PREVIEW_CHARS,
+  MAX_TOOL_RESULT_ARRAY_ITEMS,
+  MAX_TOOL_RESULT_OBJECT_KEYS,
+  TOOL_RESULT_PRIORITY_KEYS,
+  MAX_USER_MESSAGE_CHARS,
+  MAX_URL_PREVIEW_CHARS,
+  MAX_BASH_OUTPUT_CHARS,
+  MAX_COMMAND_PREVIEW_CHARS,
+  MAX_RESULT_PREVIEW_CHARS,
+  MAX_ERROR_PREVIEW_CHARS,
+  ENABLE_TOOL_IMAGE_REPLAY,
+} from "./chat-executor-constants.js";
+import { didToolCallFail } from "./chat-executor-tool-utils.js";
+import { safeStringify } from "../tools/types.js";
+
+// ============================================================================
+// JSON parsing helpers (used by planner + verifier)
+// ============================================================================
+
+export function parseJsonObjectFromText(
+  content: string,
+): Record<string, unknown> | undefined {
+  const trimmed = content.trim();
+  const direct = tryParseObject(trimmed);
+  if (direct) return direct;
+
+  const start = trimmed.indexOf("{");
+  const end = trimmed.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    const candidate = trimmed.slice(start, end + 1);
+    return tryParseObject(candidate);
+  }
+  return undefined;
+}
+
+export function tryParseObject(
+  candidate: string,
+): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(candidate) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+    ) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // fall through
+  }
+  return undefined;
+}
+
+// ============================================================================
+// Message text extraction
+// ============================================================================
+
+/** Extract plain-text content from a gateway message. */
+export function extractMessageText(message: GatewayMessage): string {
+  return typeof message.content === "string" ? message.content : "";
+}
+
+/** Extract plain-text content from an LLM message. */
+export function extractLLMMessageText(message: LLMMessage): string {
+  if (typeof message.content === "string") return message.content;
+  return message.content
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join(" ");
+}
+
+// ============================================================================
+// Text truncation and sanitization
+// ============================================================================
+
+export function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
+  return value.slice(0, maxChars - 3) + "...";
+}
+
+export function sanitizeFinalContent(content: string): string {
+  if (!content) return content;
+  const collapsed = collapseRunawayRepetition(content);
+  if (collapsed.length <= MAX_FINAL_RESPONSE_CHARS) return collapsed;
+  return (
+    truncateText(collapsed, MAX_FINAL_RESPONSE_CHARS) +
+    "\n\n[response truncated: oversized model output suppressed]"
+  );
+}
+
+export function reconcileStructuredToolOutcome(
+  content: string,
+  toolCalls: readonly ToolCallRecord[],
+): string {
+  if (!content || toolCalls.length === 0) return content;
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return content;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    return content;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return content;
+  }
+
+  const payload = parsed as Record<string, unknown>;
+  if (typeof payload.overall !== "string" || !Array.isArray(payload.steps)) {
+    return content;
+  }
+
+  const normalizedOverall = payload.overall.trim().toLowerCase();
+  if (normalizedOverall !== "pass") {
+    return content;
+  }
+
+  const hasToolFailure = toolCalls.some((toolCall) =>
+    didToolCallFail(toolCall.isError, toolCall.result),
+  );
+
+  const executedTools = new Set(
+    toolCalls
+      .map((toolCall) => toolCall.name?.trim())
+      .filter((name): name is string => Boolean(name)),
+  );
+  const claimedTools = new Set<string>();
+  for (const step of payload.steps) {
+    if (typeof step !== "object" || step === null || Array.isArray(step)) {
+      continue;
+    }
+    const toolName = (step as { tool?: unknown }).tool;
+    if (typeof toolName === "string" && toolName.trim().length > 0) {
+      claimedTools.add(toolName.trim());
+    }
+  }
+
+  const claimsUnexecutedTool = Array.from(claimedTools).some(
+    (toolName) => !executedTools.has(toolName),
+  );
+
+  if (!hasToolFailure && !claimsUnexecutedTool) {
+    return content;
+  }
+
+  payload.overall = "fail";
+  return safeStringify(payload);
+}
+
+export function collapseRunawayRepetition(content: string): string {
+  const lines = content.split(/\r?\n/);
+  if (lines.length < REPETITIVE_LINE_MIN_COUNT) return content;
+
+  const normalized = lines.map((line) =>
+    line.trim().replace(/\s+/g, " ").toLowerCase(),
+  );
+  const nonEmpty = normalized.filter((line) => line.length > 0);
+  if (nonEmpty.length < REPETITIVE_LINE_MIN_COUNT) return content;
+
+  const freq = new Map<string, number>();
+  for (const line of nonEmpty) {
+    if (line.length > 80) continue;
+    freq.set(line, (freq.get(line) ?? 0) + 1);
+  }
+
+  let topCount = 0;
+  for (const count of freq.values()) {
+    if (count > topCount) topCount = count;
+  }
+
+  const uniqueRatio = new Set(nonEmpty).size / nonEmpty.length;
+  if (
+    topCount < REPETITIVE_LINE_MIN_REPEATS ||
+    uniqueRatio > REPETITIVE_LINE_MAX_UNIQUE_RATIO
+  ) {
+    return content;
+  }
+
+  const preview = lines.slice(0, 24).join("\n");
+  return `${preview}\n\n[response truncated: repetitive model output suppressed]`;
+}
+
+export function isBase64Like(value: string): boolean {
+  if (value.length < 128) return false;
+  return /^[A-Za-z0-9+/=\r\n]+$/.test(value);
+}
+
+// ============================================================================
+// Prompt shape estimation
+// ============================================================================
+
+export function estimateContentChars(
+  content: string | LLMContentPart[],
+): number {
+  if (typeof content === "string") return content.length;
+  return content.reduce((sum, part) => {
+    if (part.type === "text") return sum + part.text.length;
+    return sum + part.image_url.url.length;
+  }, 0);
+}
+
+export function estimateMessageChars(message: LLMMessage): number {
+  // Small role/metadata overhead for rough token approximation.
+  return (
+    estimateContentChars(message.content) +
+    estimateToolCallsChars(message.toolCalls) +
+    64
+  );
+}
+
+export function estimatePromptShape(
+  messages: readonly LLMMessage[],
+): ChatPromptShape {
+  let systemMessages = 0;
+  let userMessages = 0;
+  let assistantMessages = 0;
+  let toolMessages = 0;
+  let estimatedChars = 0;
+  let systemPromptChars = 0;
+
+  for (const message of messages) {
+    estimatedChars += estimateMessageChars(message);
+    if (message.role === "system") {
+      systemMessages++;
+      systemPromptChars += estimateContentChars(message.content);
+    } else if (message.role === "user") {
+      userMessages++;
+    } else if (message.role === "assistant") {
+      assistantMessages++;
+    } else if (message.role === "tool") {
+      toolMessages++;
+    }
+  }
+
+  return {
+    messageCount: messages.length,
+    systemMessages,
+    userMessages,
+    assistantMessages,
+    toolMessages,
+    estimatedChars,
+    systemPromptChars,
+  };
+}
+
+// ============================================================================
+// History normalization
+// ============================================================================
+
+export function normalizeHistory(history: readonly LLMMessage[]): LLMMessage[] {
+  const recent = history.slice(-MAX_HISTORY_MESSAGES);
+  return recent.map((entry) => {
+    const sanitizedToolCalls = sanitizeToolCallsForReplay(
+      entry.toolCalls,
+    );
+    const baseMessage = sanitizedToolCalls
+      ? { ...entry, toolCalls: sanitizedToolCalls }
+      : entry;
+    if (typeof entry.content === "string") {
+      if (entry.role === "tool") {
+        const prepared = prepareToolResultForPrompt(entry.content);
+        return { ...baseMessage, content: prepared.text };
+      }
+      return {
+        ...baseMessage,
+        content: truncateText(
+          entry.content,
+          MAX_HISTORY_MESSAGE_CHARS,
+        ),
+      };
+    }
+
+    const parts: LLMContentPart[] = entry.content.map((part) => {
+      if (part.type === "text") {
+        return {
+          type: "text" as const,
+          text: truncateText(
+            part.text,
+            MAX_HISTORY_MESSAGE_CHARS,
+          ),
+        };
+      }
+      // Never replay historical inline images into future prompts.
+      return {
+        type: "text" as const,
+        text: "[prior image omitted]",
+      };
+    });
+    return { ...baseMessage, content: parts };
+  });
+}
+
+// ============================================================================
+// Tool call serialization
+// ============================================================================
+
+export function estimateToolCallsChars(
+  toolCalls: readonly LLMToolCall[] | undefined,
+): number {
+  if (!toolCalls || toolCalls.length === 0) return 0;
+  return toolCalls.reduce((sum, call) => {
+    return sum + call.id.length + call.name.length + call.arguments.length + 16;
+  }, 0);
+}
+
+export function sanitizeToolCallsForReplay(
+  toolCalls: readonly LLMToolCall[] | undefined,
+): LLMToolCall[] | undefined {
+  if (!toolCalls || toolCalls.length === 0) return undefined;
+  return toolCalls.map((toolCall) => ({
+    ...toolCall,
+    arguments: sanitizeToolCallArgumentsForReplay(
+      toolCall.arguments,
+    ),
+  }));
+}
+
+export function sanitizeToolCallArgumentsForReplay(raw: string): string {
+  if (raw.length <= MAX_TOOL_CALL_ARGUMENT_CHARS) {
+    return raw;
+  }
+  const preview = truncateText(
+    raw,
+    MAX_TOOL_CALL_ARGUMENT_PREVIEW_CHARS,
+  );
+  return safeStringify({
+    __truncatedToolCallArgs: true,
+    originalChars: raw.length,
+    preview,
+  });
+}
+
+// ============================================================================
+// JSON sanitization for prompts
+// ============================================================================
+
+export function sanitizeJsonForPrompt(
+  value: unknown,
+  captureDataUrl: (url: string) => void,
+): unknown {
+  const keyPriority = (key: string): number => {
+    const normalized = key.toLowerCase();
+    const idx = TOOL_RESULT_PRIORITY_KEYS.indexOf(
+      normalized as (typeof TOOL_RESULT_PRIORITY_KEYS)[number],
+    );
+    return idx >= 0 ? idx : TOOL_RESULT_PRIORITY_KEYS.length + 1;
+  };
+
+  if (typeof value === "string") {
+    if (value.startsWith("data:image/")) {
+      captureDataUrl(value);
+      return "(see image)";
+    }
+    if (isBase64Like(value)) {
+      return "(base64 omitted)";
+    }
+    return truncateText(value, MAX_TOOL_RESULT_FIELD_CHARS);
+  }
+  if (Array.isArray(value)) {
+    const sanitizedItems = value
+      .slice(0, MAX_TOOL_RESULT_ARRAY_ITEMS)
+      .map((item) => sanitizeJsonForPrompt(item, captureDataUrl));
+    const omitted = value.length - sanitizedItems.length;
+    if (omitted > 0) {
+      sanitizedItems.push(`[${omitted} items omitted]`);
+    }
+    return sanitizedItems;
+  }
+  if (value && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    const orderedEntries = Object.entries(obj)
+      .sort(([a], [b]) => {
+        const priorityDelta = keyPriority(a) - keyPriority(b);
+        if (priorityDelta !== 0) return priorityDelta;
+        return a.localeCompare(b);
+      })
+      .slice(0, MAX_TOOL_RESULT_OBJECT_KEYS);
+    for (const [key, field] of orderedEntries) {
+      const keyLower = key.toLowerCase();
+      if (typeof field === "string") {
+        if (field.startsWith("data:image/")) {
+          captureDataUrl(field);
+          out[key] = "(see image)";
+          continue;
+        }
+        if (
+          keyLower === "image" ||
+          keyLower === "dataurl" ||
+          keyLower.endsWith("base64")
+        ) {
+          if (isBase64Like(field)) {
+            out[key] = "(base64 omitted)";
+            continue;
+          }
+        }
+        out[key] = truncateText(
+          field,
+          MAX_TOOL_RESULT_FIELD_CHARS,
+        );
+        continue;
+      }
+      out[key] = sanitizeJsonForPrompt(field, captureDataUrl);
+    }
+    const omittedKeys = Object.keys(obj).length - orderedEntries.length;
+    if (omittedKeys > 0) {
+      out.__truncatedKeys = omittedKeys;
+    }
+    return out;
+  }
+  return value;
+}
+
+export function prepareToolResultForPrompt(result: string): {
+  text: string;
+  dataUrl?: string;
+} {
+  let capturedDataUrl: string | undefined;
+  const setDataUrl = (url: string): void => {
+    if (!capturedDataUrl) capturedDataUrl = url;
+  };
+
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    const sanitized = sanitizeJsonForPrompt(parsed, setDataUrl);
+    return {
+      text: truncateText(
+        safeStringify(sanitized),
+        MAX_TOOL_RESULT_CHARS,
+      ),
+      ...(capturedDataUrl ? { dataUrl: capturedDataUrl } : {}),
+    };
+  } catch {
+    const dataUrlMatch = result.match(
+      /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/,
+    );
+    const text = result
+      .replace(
+        /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g,
+        "(see image)",
+      )
+      .replace(/"[Ii]mage"\s*:\s*"[A-Za-z0-9+/=\r\n]{128,}"/g, '"image":"(base64 omitted)"')
+      .trim();
+    return {
+      text: truncateText(text, MAX_TOOL_RESULT_CHARS),
+      ...(dataUrlMatch ? { dataUrl: dataUrlMatch[0] } : {}),
+    };
+  }
+}
+
+export function buildPromptToolContent(
+  result: string,
+  remainingImageBudget: number,
+): {
+  content: string | import("./types.js").LLMContentPart[];
+  remainingImageBudget: number;
+} {
+  const prepared = prepareToolResultForPrompt(result);
+  if (!prepared.dataUrl) {
+    return { content: prepared.text, remainingImageBudget };
+  }
+
+  if (!ENABLE_TOOL_IMAGE_REPLAY) {
+    const note = truncateText(
+      `${prepared.text}\n\n[Image artifact kept out-of-band by default; prefer URL/DOM/text/process checks before visual verification.]`,
+      MAX_TOOL_RESULT_CHARS,
+    );
+    return { content: note, remainingImageBudget };
+  }
+
+  // Prevent huge inline screenshots from blowing up prompt size.
+  if (prepared.dataUrl.length > remainingImageBudget) {
+    const note =
+      prepared.text +
+      "\n\n[Screenshot omitted from prompt due image context budget]";
+    return {
+      content: truncateText(note, MAX_TOOL_RESULT_CHARS),
+      remainingImageBudget,
+    };
+  }
+
+  return {
+    content: [
+      { type: "image_url" as const, image_url: { url: prepared.dataUrl } },
+      { type: "text" as const, text: prepared.text },
+    ],
+    remainingImageBudget: remainingImageBudget - prepared.dataUrl.length,
+  };
+}
+
+// ============================================================================
+// User message handling
+// ============================================================================
+
+/** Append a user message, handling multimodal (image) attachments. */
+export function appendUserMessage(
+  messages: LLMMessage[],
+  sections: PromptBudgetSection[],
+  message: GatewayMessage,
+): void {
+  const imageAttachments = (message.attachments ?? []).filter(
+    (a) => a.data && a.mimeType.startsWith("image/"),
+  );
+  const trimmedUserText = truncateText(
+    message.content,
+    MAX_USER_MESSAGE_CHARS,
+  );
+  if (imageAttachments.length > 0) {
+    const contentParts: LLMContentPart[] = [];
+    if (trimmedUserText) {
+      contentParts.push({ type: "text", text: trimmedUserText });
+    }
+    for (const att of imageAttachments) {
+      const base64 = Buffer.from(att.data!).toString("base64");
+      contentParts.push({
+        type: "image_url",
+        image_url: { url: `data:${att.mimeType};base64,${base64}` },
+      });
+    }
+    messages.push({ role: "user", content: contentParts });
+    sections.push("user");
+  } else {
+    messages.push({ role: "user", content: trimmedUserText });
+    sections.push("user");
+  }
+}
+
+// ============================================================================
+// Fallback content generation
+// ============================================================================
+
+/**
+ * Build a human-readable fallback when the LLM returned empty content
+ * after tool calls (e.g. when maxToolRounds is hit mid-loop).
+ */
+export function generateFallbackContent(
+  allToolCalls: readonly ToolCallRecord[],
+): string | undefined {
+  const successes = allToolCalls.filter((tc) => !tc.isError);
+  const lastSuccess = successes[successes.length - 1];
+  if (!lastSuccess) return undefined;
+
+  try {
+    const parsed = JSON.parse(lastSuccess.result);
+    if (parsed.taskPda) {
+      return `Task created successfully.\n\n**Task PDA:** ${parsed.taskPda}\n**Transaction:** ${parsed.transactionSignature ?? "confirmed"}`;
+    }
+    if (parsed.agentPda) {
+      return `Agent registered successfully.\n\n**Agent PDA:** ${parsed.agentPda}\n**Transaction:** ${parsed.transactionSignature ?? "confirmed"}`;
+    }
+    if (
+      parsed.success === true ||
+      parsed.exitCode === 0 ||
+      parsed.output !== undefined
+    ) {
+      return summarizeToolCalls(successes);
+    }
+    if (parsed.error) {
+      return `Something went wrong: ${String(parsed.error).slice(0, MAX_ERROR_PREVIEW_CHARS)}`;
+    }
+    if (parsed.exitCode != null && parsed.exitCode !== 0) {
+      const errOutput = parsed.stderr || parsed.stdout || "";
+      return errOutput.trim()
+        ? `Command failed: ${String(errOutput).slice(0, MAX_ERROR_PREVIEW_CHARS)}`
+        : "The command failed. Let me try a different approach.";
+    }
+    return `Operation completed. Result:\n\`\`\`json\n${lastSuccess.result.slice(0, MAX_RESULT_PREVIEW_CHARS)}\n\`\`\``;
+  } catch {
+    return `Operation completed. Result: ${lastSuccess.result.slice(0, MAX_RESULT_PREVIEW_CHARS)}`;
+  }
+}
+
+/** Build a human-readable summary from successful tool calls. */
+export function summarizeToolCalls(
+  successes: readonly ToolCallRecord[],
+): string {
+  const summaries: string[] = [];
+  for (const tc of successes) {
+    if (tc.name === "system.open") {
+      const target = String(tc.args?.target ?? "");
+      if (target.includes("youtube.com/watch")) {
+        summaries.push("Opened YouTube video");
+      } else if (target.includes("youtube.com")) {
+        summaries.push("Opened YouTube");
+      } else if (target) {
+        summaries.push(
+          `Opened ${target.slice(0, MAX_URL_PREVIEW_CHARS)}`,
+        );
+      }
+    } else if (tc.name === "system.bash") {
+      try {
+        const bashResult = JSON.parse(tc.result);
+        const bashOutput = bashResult.stdout || bashResult.output || "";
+        if (bashOutput.trim()) {
+          summaries.push(
+            bashOutput.trim().slice(0, MAX_BASH_OUTPUT_CHARS),
+          );
+        } else {
+          const cmd = String(tc.args?.command ?? "").slice(
+            0,
+            MAX_COMMAND_PREVIEW_CHARS,
+          );
+          if (cmd) summaries.push(`Ran: ${cmd}`);
+        }
+      } catch {
+        const cmd = String(tc.args?.command ?? "").slice(
+          0,
+          MAX_COMMAND_PREVIEW_CHARS,
+        );
+        if (cmd) summaries.push(`Ran: ${cmd}`);
+      }
+    } else if (tc.name === "system.applescript") {
+      const script = String(tc.args?.script ?? "");
+      if (script.includes("do script")) {
+        summaries.push("Opened Terminal and ran the command");
+      } else if (script.includes("activate")) {
+        summaries.push("Brought app to front");
+      } else if (script.includes("quit")) {
+        summaries.push("Closed the app");
+      } else {
+        summaries.push("Done");
+      }
+    } else if (tc.name === "system.notification") {
+      summaries.push("Notification sent");
+    } else {
+      summaries.push("Done");
+    }
+  }
+  return summaries.length > 0 ? summaries.join("\n") : "Done!";
+}

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -1,0 +1,131 @@
+/**
+ * Standalone tool helper functions for ChatExecutor.
+ *
+ * @module
+ */
+
+import type { ToolCallRecord } from "./chat-executor-types.js";
+import type { LLMRetryPolicyMatrix } from "./policy.js";
+import { DEFAULT_LLM_RETRY_POLICY_MATRIX } from "./policy.js";
+import type { LLMFailureClass, LLMRetryPolicyRule } from "./policy.js";
+import type { LLMRetryPolicyOverrides } from "./chat-executor-types.js";
+import {
+  HIGH_RISK_TOOLS,
+  HIGH_RISK_TOOL_PREFIXES,
+  SAFE_TOOL_RETRY_TOOLS,
+  SAFE_TOOL_RETRY_PREFIXES,
+} from "./chat-executor-constants.js";
+import { safeStringify } from "../tools/types.js";
+
+export function didToolCallFail(isError: boolean, result: string): boolean {
+  if (isError) return true;
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return false;
+    }
+    const obj = parsed as Record<string, unknown>;
+    if (typeof obj.error === "string" && obj.error.trim().length > 0) return true;
+    if (typeof obj.exitCode === "number" && obj.exitCode !== 0) return true;
+  } catch {
+    // Non-JSON tool output — treat as non-failure unless isError=true.
+  }
+  return false;
+}
+
+export function parseToolResultObject(
+  result: string,
+): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export function extractToolFailureText(record: ToolCallRecord): string {
+  const parsed = parseToolResultObject(record.result);
+  if (!parsed) return record.result;
+
+  const pieces: string[] = [];
+  if (typeof parsed.error === "string" && parsed.error.trim().length > 0) {
+    pieces.push(parsed.error.trim());
+  }
+  if (typeof parsed.stderr === "string" && parsed.stderr.trim().length > 0) {
+    pieces.push(parsed.stderr.trim());
+  }
+  if (pieces.length > 0) return pieces.join("\n");
+  return record.result;
+}
+
+export function resolveRetryPolicyMatrix(
+  overrides?: LLMRetryPolicyOverrides,
+): LLMRetryPolicyMatrix {
+  if (!overrides) return DEFAULT_LLM_RETRY_POLICY_MATRIX;
+  const merged = {
+    ...DEFAULT_LLM_RETRY_POLICY_MATRIX,
+  } as Record<LLMFailureClass, LLMRetryPolicyRule>;
+  for (const failureClass of Object.keys(
+    DEFAULT_LLM_RETRY_POLICY_MATRIX,
+  ) as LLMFailureClass[]) {
+    const baseRule = merged[failureClass];
+    const patch = overrides[failureClass];
+    if (!patch) continue;
+    merged[failureClass] = {
+      ...baseRule,
+      ...patch,
+    };
+  }
+  return merged;
+}
+
+export function hasExplicitIdempotencyKey(args: Record<string, unknown>): boolean {
+  const value = args.idempotencyKey;
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function isHighRiskToolCall(
+  toolName: string,
+): boolean {
+  if (HIGH_RISK_TOOLS.has(toolName)) return true;
+  return HIGH_RISK_TOOL_PREFIXES.some((prefix) => toolName.startsWith(prefix));
+}
+
+export function isToolRetrySafe(toolName: string): boolean {
+  if (SAFE_TOOL_RETRY_TOOLS.has(toolName)) return true;
+  return SAFE_TOOL_RETRY_PREFIXES.some((prefix) => toolName.startsWith(prefix));
+}
+
+export function isLikelyToolTransportFailure(
+  errorText: string,
+): boolean {
+  const lower = errorText.toLowerCase();
+  return (
+    lower.includes("timed out") ||
+    lower.includes("timeout") ||
+    lower.includes("fetch failed") ||
+    lower.includes("connection refused") ||
+    lower.includes("econnrefused") ||
+    lower.includes("econnreset") ||
+    lower.includes("etimedout") ||
+    lower.includes("network") ||
+    lower.includes("transport") ||
+    lower.includes("bridge")
+  );
+}
+
+export function enrichToolResultMetadata(
+  result: string,
+  metadata: Record<string, unknown>,
+): string {
+  const parsed = parseToolResultObject(result);
+  if (!parsed) return result;
+  return safeStringify({
+    ...parsed,
+    ...metadata,
+  });
+}

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -1,0 +1,620 @@
+/**
+ * Type definitions and error classes for ChatExecutor.
+ *
+ * @module
+ */
+
+import type { GatewayMessage } from "../gateway/message.js";
+import type {
+  LLMMessage,
+  LLMResponse,
+  LLMUsage,
+  LLMRequestMetrics,
+  LLMStatefulDiagnostics,
+  LLMStatefulFallbackReason,
+  StreamProgressCallback,
+  ToolHandler,
+  LLMProvider,
+} from "./types.js";
+import type {
+  PromptBudgetConfig,
+  PromptBudgetDiagnostics,
+  PromptBudgetSection,
+} from "./prompt-budget.js";
+import type {
+  LLMFailureClass,
+  LLMPipelineStopReason,
+  LLMRetryPolicyRule,
+} from "./policy.js";
+import type {
+  Pipeline,
+  PipelinePlannerContext,
+  PipelineResult,
+  PipelineStep,
+} from "../workflow/pipeline.js";
+import type { WorkflowGraphEdge } from "../workflow/types.js";
+import type { DelegationDecision, DelegationDecisionConfig } from "./delegation-decision.js";
+import type {
+  DelegationBanditPolicyTuner,
+  DelegationBanditSelection,
+  DelegationTrajectorySink,
+} from "./delegation-learning.js";
+import { RuntimeError, RuntimeErrorCodes } from "../types/errors.js";
+
+// ============================================================================
+// Error classes
+// ============================================================================
+
+/**
+ * Error thrown when a session's token budget is exceeded.
+ */
+export class ChatBudgetExceededError extends RuntimeError {
+  public readonly sessionId: string;
+  public readonly used: number;
+  public readonly limit: number;
+
+  constructor(sessionId: string, used: number, limit: number) {
+    super(
+      `Token budget exceeded for session "${sessionId}": ${used}/${limit}`,
+      RuntimeErrorCodes.CHAT_BUDGET_EXCEEDED,
+    );
+    this.name = "ChatBudgetExceededError";
+    this.sessionId = sessionId;
+    this.used = used;
+    this.limit = limit;
+  }
+}
+
+// ============================================================================
+// Injection interfaces
+// ============================================================================
+
+/** Injects skill context into a conversation. */
+export interface SkillInjector {
+  inject(message: string, sessionId: string): Promise<string | undefined>;
+}
+
+/** Retrieves memory context for a conversation. */
+export interface MemoryRetriever {
+  retrieve(message: string, sessionId: string): Promise<string | undefined>;
+}
+
+// ============================================================================
+// Core types
+// ============================================================================
+
+/** Record of a single tool call execution. */
+export interface ToolCallRecord {
+  readonly name: string;
+  readonly args: Record<string, unknown>;
+  readonly result: string;
+  readonly isError: boolean;
+  readonly durationMs: number;
+}
+
+/** Parameters for a single ChatExecutor.execute() call. */
+export interface ChatExecuteParams {
+  readonly message: GatewayMessage;
+  readonly history: readonly LLMMessage[];
+  readonly systemPrompt: string;
+  readonly sessionId: string;
+  /** Per-call tool handler — overrides the constructor handler for this call. */
+  readonly toolHandler?: ToolHandler;
+  /** Per-call stream callback — overrides the constructor callback for this call. */
+  readonly onStreamChunk?: StreamProgressCallback;
+  /** Abort signal — when aborted, the executor stops after the current tool call. */
+  readonly signal?: AbortSignal;
+  /** Per-call tool round limit — overrides the constructor default. */
+  readonly maxToolRounds?: number;
+  /** Optional per-turn tool-routing subset and expansion policy. */
+  readonly toolRouting?: {
+    /** Initial routed subset for this turn. */
+    readonly routedToolNames?: readonly string[];
+    /** One-turn expanded subset used on suspected routing misses. */
+    readonly expandedToolNames?: readonly string[];
+    /** Enable one-turn expansion retry on routed-tool misses. */
+    readonly expandOnMiss?: boolean;
+  };
+}
+
+/** Estimated prompt-shape statistics for one provider call. */
+export interface ChatPromptShape {
+  readonly messageCount: number;
+  readonly systemMessages: number;
+  readonly userMessages: number;
+  readonly assistantMessages: number;
+  readonly toolMessages: number;
+  readonly estimatedChars: number;
+  readonly systemPromptChars: number;
+}
+
+/** Per-provider-call usage attribution for one ChatExecutor execution. */
+export interface ChatCallUsageRecord {
+  /** 1-based call index within a single execute() invocation. */
+  readonly callIndex: number;
+  readonly phase:
+    | "initial"
+    | "planner"
+    | "planner_verifier"
+    | "planner_synthesis"
+    | "tool_followup"
+    | "evaluator"
+    | "evaluator_retry";
+  readonly provider: string;
+  readonly model?: string;
+  readonly finishReason: LLMResponse["finishReason"];
+  readonly usage: LLMUsage;
+  readonly beforeBudget: ChatPromptShape;
+  readonly afterBudget: ChatPromptShape;
+  /** Provider-specific request metrics (e.g. toolSchemaChars for Grok). */
+  readonly providerRequestMetrics?: LLMRequestMetrics;
+  /** Prompt-budget diagnostics (sections dropped/truncated, caps, and totals). */
+  readonly budgetDiagnostics?: PromptBudgetDiagnostics;
+  /** Stateful continuation diagnostics for this provider call (when supported). */
+  readonly statefulDiagnostics?: LLMStatefulDiagnostics;
+}
+
+/** Planner-routing decision and ROI summary for one execute() invocation. */
+export interface ChatPlannerSummary {
+  readonly enabled: boolean;
+  readonly used: boolean;
+  readonly routeReason?: string;
+  readonly complexityScore: number;
+  readonly plannerCalls: number;
+  readonly plannedSteps: number;
+  readonly deterministicStepsExecuted: number;
+  /** Estimated downstream model recalls avoided by deterministic execution. */
+  readonly estimatedRecallsAvoided: number;
+  /** Structured planner parse/validation/policy diagnostics for this turn. */
+  readonly diagnostics?: readonly PlannerDiagnostic[];
+  /** Sub-agent delegation utility decision for planner-emitted subagent tasks. */
+  readonly delegationDecision?: DelegationDecision;
+  /** Sub-agent verification/critic pass summary. */
+  readonly subagentVerification?: {
+    readonly enabled: boolean;
+    readonly performed: boolean;
+    readonly rounds: number;
+    readonly overall: "pass" | "retry" | "fail" | "skipped";
+    readonly confidence: number;
+    readonly unresolvedItems: readonly string[];
+  };
+  /** Online policy tuning diagnostics for delegation arm selection. */
+  readonly delegationPolicyTuning?: {
+    readonly enabled: boolean;
+    readonly contextClusterId?: string;
+    readonly selectedArmId?: string;
+    readonly selectedArmReason?: string;
+    readonly tunedThreshold?: number;
+    readonly exploration: boolean;
+    readonly finalReward?: number;
+    readonly usefulDelegation?: boolean;
+    readonly usefulDelegationScore?: number;
+    readonly rewardProxyVersion?: string;
+  };
+}
+
+export interface PlannerDiagnostic {
+  readonly category: "parse" | "validation" | "policy";
+  readonly code: string;
+  readonly message: string;
+  readonly details?: Readonly<Record<string, string | number | boolean>>;
+}
+
+/** Aggregated stateful continuation counters for one execute() invocation. */
+export interface ChatStatefulSummary {
+  readonly enabled: boolean;
+  readonly attemptedCalls: number;
+  readonly continuedCalls: number;
+  readonly fallbackCalls: number;
+  readonly fallbackReasons: Readonly<Record<LLMStatefulFallbackReason, number>>;
+}
+
+/** Aggregated tool-routing diagnostics for one execute() invocation. */
+export interface ChatToolRoutingSummary {
+  readonly enabled: boolean;
+  readonly initialToolCount: number;
+  readonly finalToolCount: number;
+  readonly routeMisses: number;
+  readonly expanded: boolean;
+}
+
+/** Result returned from ChatExecutor.execute(). */
+export interface ChatExecutorResult {
+  readonly content: string;
+  readonly provider: string;
+  /** Actual model identifier returned by the provider for the final response. */
+  readonly model?: string;
+  readonly usedFallback: boolean;
+  readonly toolCalls: readonly ToolCallRecord[];
+  readonly tokenUsage: LLMUsage;
+  /** Per-call token and prompt-shape attribution for this execution. */
+  readonly callUsage: readonly ChatCallUsageRecord[];
+  readonly durationMs: number;
+  /** True if conversation history was compacted during this execution. */
+  readonly compacted: boolean;
+  /** Aggregated stateful continuation diagnostics for this execution. */
+  readonly statefulSummary?: ChatStatefulSummary;
+  /** Per-turn dynamic tool-routing diagnostics for this execution. */
+  readonly toolRoutingSummary?: ChatToolRoutingSummary;
+  /** Planner/executor routing summary and ROI diagnostics. */
+  readonly plannerSummary?: ChatPlannerSummary;
+  /** Canonical stop reason for this request execution. */
+  readonly stopReason: LLMPipelineStopReason;
+  /** Optional detail for non-completed stop reasons. */
+  readonly stopReasonDetail?: string;
+  /** Result of response evaluation, if evaluator is configured. */
+  readonly evaluation?: EvaluationResult;
+}
+
+/** Minimal pipeline executor interface required by ChatExecutor planner path. */
+export interface DeterministicPipelineExecutor {
+  execute(pipeline: Pipeline, startFrom?: number): Promise<PipelineResult>;
+}
+
+export type LLMRetryPolicyOverrides = Partial<{
+  [K in LLMFailureClass]: Partial<LLMRetryPolicyRule>;
+}>;
+
+export interface ToolFailureCircuitBreakerConfig {
+  /** Enable per-session tool failure circuit breaker (default: true). */
+  readonly enabled?: boolean;
+  /** Repeated semantic failure threshold before opening breaker (default: 5). */
+  readonly threshold?: number;
+  /** Rolling window for counting repeated failures in ms (default: 300_000). */
+  readonly windowMs?: number;
+  /** Breaker open cooldown in ms (default: 120_000). */
+  readonly cooldownMs?: number;
+}
+
+/** Configuration for ChatExecutor construction. */
+export interface ChatExecutorConfig {
+  /** Ordered providers — first is primary, rest are fallbacks. */
+  readonly providers: readonly LLMProvider[];
+  readonly toolHandler?: ToolHandler;
+  readonly maxToolRounds?: number;
+  readonly onStreamChunk?: StreamProgressCallback;
+  readonly skillInjector?: SkillInjector;
+  readonly memoryRetriever?: MemoryRetriever;
+  readonly allowedTools?: readonly string[];
+  /**
+   * Maximum token budget per session. When cumulative usage meets or exceeds
+   * this value, the executor attempts to compact conversation history by
+   * summarizing older messages. If compaction fails, falls back to
+   * `ChatBudgetExceededError`.
+   */
+  readonly sessionTokenBudget?: number;
+  /** Callback when context compaction occurs (budget recovery). */
+  readonly onCompaction?: (sessionId: string, summary: string) => void;
+  /** Optional response evaluator/critic configuration. */
+  readonly evaluator?: EvaluatorConfig;
+  /** Optional provider that injects self-learning context per message. */
+  readonly learningProvider?: MemoryRetriever;
+  /** Optional provider that injects cross-session progress context per message. */
+  readonly progressProvider?: MemoryRetriever;
+  /** Prompt budget allocator configuration (Phase 2). */
+  readonly promptBudget?: PromptBudgetConfig;
+  /** Base cooldown period for failed providers in ms (default: 60_000). */
+  readonly providerCooldownMs?: number;
+  /** Maximum cooldown period in ms (default: 300_000). */
+  readonly maxCooldownMs?: number;
+  /** Maximum tracked sessions before eviction (default: 10_000). */
+  readonly maxTrackedSessions?: number;
+  /** Enable planner/executor split for high-complexity turns. */
+  readonly plannerEnabled?: boolean;
+  /** Max output tokens for the planner pass (bounded planning call). */
+  readonly plannerMaxTokens?: number;
+  /** Optional deterministic workflow executor used when planner emits executable steps. */
+  readonly pipelineExecutor?: DeterministicPipelineExecutor;
+  /** Delegation utility scoring controls for planner-emitted subagent tasks. */
+  readonly delegationDecision?: DelegationDecisionConfig;
+  /** Optional live resolver for delegation threshold overrides. */
+  readonly resolveDelegationScoreThreshold?: () => number | undefined;
+  /** Optional verifier/critic loop for planner-emitted subagent outputs. */
+  readonly subagentVerifier?: {
+    /** Enable verifier flow for planner-emitted subagent steps. */
+    readonly enabled?: boolean;
+    /** Enforce verification whenever subagent steps execute. */
+    readonly force?: boolean;
+    /** Minimum confidence required to accept child outputs. */
+    readonly minConfidence?: number;
+    /** Max verification rounds (initial verification included). */
+    readonly maxRounds?: number;
+  };
+  /** Optional delegation learning hooks (trajectory sink + online bandit tuner). */
+  readonly delegationLearning?: {
+    readonly trajectorySink?: DelegationTrajectorySink;
+    readonly banditTuner?: DelegationBanditPolicyTuner;
+    readonly defaultStrategyArmId?: string;
+  };
+  /** Maximum tool calls allowed for a single execute() invocation. */
+  readonly toolBudgetPerRequest?: number;
+  /** Maximum model recalls (calls after the first) for a single execute() invocation. */
+  readonly maxModelRecallsPerRequest?: number;
+  /** Maximum total failed tool calls allowed for a single execute() invocation. */
+  readonly maxFailureBudgetPerRequest?: number;
+  /** Timeout for a single tool execution call in milliseconds. */
+  readonly toolCallTimeoutMs?: number;
+  /** End-to-end timeout for one execute() invocation in milliseconds. */
+  readonly requestTimeoutMs?: number;
+  /** Failure-class retry policy overrides (merged with defaults). */
+  readonly retryPolicyMatrix?: LLMRetryPolicyOverrides;
+  /** Session-level breaker for repeated failing tool patterns. */
+  readonly toolFailureCircuitBreaker?: ToolFailureCircuitBreakerConfig;
+}
+
+// ============================================================================
+// Evaluator types
+// ============================================================================
+
+/** Configuration for optional response evaluation/critic. */
+export interface EvaluatorConfig {
+  readonly rubric?: string;
+  /** Minimum score (0.0–1.0) to accept the response. Default: 0.7. */
+  readonly minScore?: number;
+  /** Maximum retry attempts when score is below threshold. Default: 1. */
+  readonly maxRetries?: number;
+}
+
+/** Result of a response evaluation. */
+export interface EvaluationResult {
+  readonly score: number;
+  readonly feedback: string;
+  readonly passed: boolean;
+  readonly retryCount: number;
+}
+
+// ============================================================================
+// Internal types (used by sibling chat-executor-*.ts files)
+// ============================================================================
+
+export interface CooldownEntry {
+  availableAt: number;
+  failures: number;
+}
+
+export interface SessionToolFailurePattern {
+  count: number;
+  lastAt: number;
+}
+
+export interface SessionToolFailureCircuitState {
+  openUntil: number;
+  reason?: string;
+  patterns: Map<string, SessionToolFailurePattern>;
+}
+
+export interface FallbackResult {
+  response: LLMResponse;
+  providerName: string;
+  usedFallback: boolean;
+  beforeBudget: ChatPromptShape;
+  afterBudget: ChatPromptShape;
+  budgetDiagnostics: PromptBudgetDiagnostics;
+}
+
+export interface RecoveryHint {
+  key: string;
+  message: string;
+}
+
+export interface PlannerDecision {
+  score: number;
+  shouldPlan: boolean;
+  reason: string;
+}
+
+export type PlannerStepType = "deterministic_tool" | "subagent_task" | "synthesis";
+
+export interface PlannerStepBaseIntent {
+  name: string;
+  stepType: PlannerStepType;
+  dependsOn?: readonly string[];
+}
+
+export interface PlannerDeterministicToolStepIntent extends PlannerStepBaseIntent {
+  stepType: "deterministic_tool";
+  tool: string;
+  args: Record<string, unknown>;
+  onError?: PipelineStep["onError"];
+  maxRetries?: number;
+}
+
+export interface PlannerSubAgentTaskStepIntent extends PlannerStepBaseIntent {
+  stepType: "subagent_task";
+  objective: string;
+  inputContract: string;
+  acceptanceCriteria: readonly string[];
+  requiredToolCapabilities: readonly string[];
+  contextRequirements: readonly string[];
+  maxBudgetHint: string;
+  canRunParallel: boolean;
+}
+
+export interface PlannerSynthesisStepIntent extends PlannerStepBaseIntent {
+  stepType: "synthesis";
+  objective?: string;
+}
+
+export type PlannerStepIntent =
+  | PlannerDeterministicToolStepIntent
+  | PlannerSubAgentTaskStepIntent
+  | PlannerSynthesisStepIntent;
+
+export interface PlannerPlan {
+  reason?: string;
+  requiresSynthesis?: boolean;
+  confidence?: number;
+  steps: PlannerStepIntent[];
+  edges: readonly WorkflowGraphEdge[];
+}
+
+export interface PlannerParseResult {
+  readonly plan?: PlannerPlan;
+  readonly diagnostics: readonly PlannerDiagnostic[];
+}
+
+export interface PlannerGraphValidationConfig {
+  readonly maxSubagentFanout: number;
+  readonly maxSubagentDepth: number;
+}
+
+export type SubagentVerifierStepVerdict = "pass" | "retry" | "fail";
+
+export interface SubagentVerifierStepAssessment {
+  readonly name: string;
+  readonly verdict: SubagentVerifierStepVerdict;
+  readonly confidence: number;
+  readonly retryable: boolean;
+  readonly issues: readonly string[];
+  readonly summary: string;
+}
+
+export interface SubagentVerifierDecision {
+  readonly overall: "pass" | "retry" | "fail";
+  readonly confidence: number;
+  readonly unresolvedItems: readonly string[];
+  readonly steps: readonly SubagentVerifierStepAssessment[];
+  readonly source: "deterministic" | "model" | "merged";
+}
+
+export interface ResolvedSubagentVerifierConfig {
+  readonly enabled: boolean;
+  readonly force: boolean;
+  readonly minConfidence: number;
+  readonly maxRounds: number;
+}
+
+export interface MutablePlannerVerificationSummary {
+  enabled: boolean;
+  performed: boolean;
+  rounds: number;
+  overall: "pass" | "retry" | "fail" | "skipped";
+  confidence: number;
+  unresolvedItems: string[];
+}
+
+export interface MutablePlannerSummaryState {
+  deterministicStepsExecuted: number;
+  diagnostics: PlannerDiagnostic[];
+  subagentVerification: MutablePlannerVerificationSummary;
+}
+
+export interface PlannerPipelineVerifierLoopInput {
+  pipeline: Pipeline;
+  plannerPlan: PlannerPlan;
+  subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+  deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
+  plannerExecutionContext: PipelinePlannerContext;
+  shouldRunSubagentVerifier: boolean;
+  plannerSummaryState: MutablePlannerSummaryState;
+  checkRequestTimeout: (stage: string) => boolean;
+  runPipelineWithGlobalTimeout: (
+    pipeline: Pipeline,
+  ) => Promise<PipelineResult | undefined>;
+  runSubagentVerifierRound: (input: {
+    plannerPlan: PlannerPlan;
+    subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+    pipelineResult: PipelineResult;
+    plannerContext: PipelinePlannerContext;
+    round: number;
+  }) => Promise<SubagentVerifierDecision>;
+  appendToolRecord: (record: ToolCallRecord) => void;
+  setStopReason: (reason: LLMPipelineStopReason, detail?: string) => void;
+}
+
+/** Full planner summary state — extends the subset used by executePlannerPipelineWithVerifier. */
+export interface FullPlannerSummaryState extends MutablePlannerSummaryState {
+  enabled: boolean;
+  used: boolean;
+  routeReason: string;
+  complexityScore: number;
+  plannerCalls: number;
+  plannedSteps: number;
+  estimatedRecallsAvoided: number;
+  delegationDecision: DelegationDecision | undefined;
+  delegationPolicyTuning: {
+    enabled: boolean;
+    contextClusterId: string | undefined;
+    selectedArmId: string | undefined;
+    selectedArmReason: string | undefined;
+    tunedThreshold: number | undefined;
+    exploration: boolean;
+    finalReward: number | undefined;
+    usefulDelegation: boolean | undefined;
+    usefulDelegationScore: number | undefined;
+    rewardProxyVersion: string | undefined;
+  };
+}
+
+/** Loop-local mutable state shared across tool calls within a single round. */
+export interface ToolLoopState {
+  sideEffectExecuted: boolean;
+  remainingToolImageChars: number;
+  activeRoutedToolSet: Set<string> | null;
+  expandAfterRound: boolean;
+  lastFailKey: string;
+  consecutiveFailCount: number;
+}
+
+/** Control flow action returned by executeSingleToolCall(). */
+export type ToolCallAction = "processed" | "skip" | "abort_round" | "abort_loop";
+
+/** Mutable context threaded through all phases of executeRequest(). */
+export interface ExecutionContext {
+  // --- Immutable request params (set once in init, never mutated) ---
+  readonly message: GatewayMessage;
+  readonly messageText: string;
+  readonly systemPrompt: string;
+  readonly sessionId: string;
+  readonly signal?: AbortSignal;
+  readonly activeToolHandler?: ToolHandler;
+  readonly activeStreamCallback?: StreamProgressCallback;
+  readonly effectiveMaxToolRounds: number;
+  readonly effectiveToolBudget: number;
+  readonly effectiveMaxModelRecalls: number;
+  readonly effectiveFailureBudget: number;
+  readonly startTime: number;
+  readonly requestDeadlineAt: number;
+  readonly parentTurnId: string;
+  readonly trajectoryTraceId: string;
+  readonly initialRoutedToolNames: readonly string[];
+  readonly expandedRoutedToolNames: readonly string[];
+  readonly canExpandOnRoutingMiss: boolean;
+  readonly hasHistory: boolean;
+  readonly plannerDecision: PlannerDecision;
+  readonly baseDelegationThreshold: number;
+  readonly toolRouting?: ChatExecuteParams["toolRouting"];
+
+  // --- Mutable accumulator state ---
+  history: readonly LLMMessage[];
+  messages: LLMMessage[];
+  messageSections: PromptBudgetSection[];
+  cumulativeUsage: LLMUsage;
+  callUsage: ChatCallUsageRecord[];
+  callIndex: number;
+  modelCalls: number;
+  allToolCalls: ToolCallRecord[];
+  failedToolCalls: number;
+  usedFallback: boolean;
+  providerName: string;
+  responseModel?: string;
+  response?: LLMResponse;
+  evaluation?: EvaluationResult;
+  finalContent: string;
+  compacted: boolean;
+  stopReason: LLMPipelineStopReason;
+  stopReasonDetail?: string;
+  activeRoutedToolNames: readonly string[];
+  routedToolsExpanded: boolean;
+  routedToolMisses: number;
+  plannerHandled: boolean;
+  plannerSummaryState: FullPlannerSummaryState;
+  trajectoryContextClusterId: string;
+  selectedBanditArm?: DelegationBanditSelection;
+  tunedDelegationThreshold: number;
+  plannedSubagentSteps: number;
+  plannedDeterministicSteps: number;
+  plannedSynthesisSteps: number;
+  plannedDependencyDepth: number;
+  plannedFanout: number;
+}

--- a/runtime/src/llm/chat-executor-verifier.ts
+++ b/runtime/src/llm/chat-executor-verifier.ts
@@ -1,0 +1,421 @@
+/**
+ * Subagent verifier/critic functions for ChatExecutor.
+ *
+ * @module
+ */
+
+import type {
+  PipelinePlannerContext,
+  PipelineResult,
+} from "../workflow/pipeline.js";
+import type {
+  PlannerSubAgentTaskStepIntent,
+  PlannerPlan,
+  SubagentVerifierStepVerdict,
+  SubagentVerifierStepAssessment,
+  SubagentVerifierDecision,
+} from "./chat-executor-types.js";
+import type { LLMMessage } from "./types.js";
+import {
+  DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE,
+  MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS,
+  MAX_SUBAGENT_VERIFIER_ARTIFACT_CHARS,
+} from "./chat-executor-constants.js";
+import {
+  truncateText,
+  parseJsonObjectFromText,
+} from "./chat-executor-text.js";
+import {
+  parsePlannerRequiredString,
+  parsePlannerOptionalString,
+} from "./chat-executor-planner.js";
+import { safeStringify } from "../tools/types.js";
+
+export function evaluateSubagentDeterministicChecks(
+  subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
+  pipelineResult: PipelineResult,
+  plannerContext: PipelinePlannerContext,
+): SubagentVerifierDecision {
+  const stepAssessments: SubagentVerifierStepAssessment[] = [];
+  const unresolvedItems: string[] = [];
+  const artifactCorpus = collectVerifierArtifacts(
+    pipelineResult,
+    plannerContext,
+  );
+  const artifactText = artifactCorpus.join(" ").toLowerCase();
+
+  for (const step of subagentSteps) {
+    const raw = pipelineResult.context.results[step.name];
+    const issues: string[] = [];
+    let verdict: SubagentVerifierStepVerdict = "pass";
+    let retryable = true;
+    let output = "";
+    let status = "unknown";
+    let toolCallsCount = 0;
+
+    if (typeof raw !== "string") {
+      issues.push("missing_subagent_result");
+      verdict = "retry";
+    } else {
+      const parsed = parseJsonObjectFromText(raw);
+      if (!parsed) {
+        issues.push("malformed_subagent_result_payload");
+        verdict = "retry";
+        output = raw;
+      } else {
+        status = typeof parsed.status === "string"
+          ? parsed.status.toLowerCase()
+          : "unknown";
+        output = typeof parsed.output === "string"
+          ? parsed.output
+          : safeStringify(parsed.output ?? "");
+        toolCallsCount = Array.isArray(parsed.toolCalls)
+          ? parsed.toolCalls.length
+          : 0;
+        if (parsed.success === false || status === "failed") {
+          issues.push("child_reported_failure");
+          verdict = "retry";
+        }
+        if (status === "cancelled") {
+          issues.push("child_cancelled");
+          verdict = "fail";
+          retryable = false;
+        }
+        if (status === "delegation_fallback") {
+          issues.push("child_used_parent_fallback");
+          verdict = "fail";
+          retryable = false;
+        }
+      }
+    }
+
+    const trimmedOutput = output.trim();
+    if (trimmedOutput.length === 0) {
+      issues.push("empty_child_output");
+      verdict = moreSevereVerifierVerdict(verdict, "retry");
+    }
+
+    const expectsJson = step.inputContract.toLowerCase().includes("json");
+    if (expectsJson && trimmedOutput.length > 0) {
+      const parsedOutput = parseJsonObjectFromText(trimmedOutput);
+      if (!parsedOutput) {
+        issues.push("contract_violation_expected_json_output");
+        verdict = moreSevereVerifierVerdict(verdict, "retry");
+      }
+    }
+
+    const outputLower = trimmedOutput.toLowerCase();
+    const likelyEvidence =
+      /(line|file|log|trace|stderr|stdout|stack|error|\d)/.test(outputLower);
+    if (trimmedOutput.length > 0 && !likelyEvidence) {
+      issues.push("weak_evidence_density");
+    }
+
+    const expectationTokens = step.acceptanceCriteria
+      .flatMap((criterion) =>
+        extractVerifierTokens(criterion)
+      )
+      .slice(0, 24);
+    if (expectationTokens.length > 0 && trimmedOutput.length > 0) {
+      const matched = expectationTokens.some((token) =>
+        outputLower.includes(token)
+      );
+      if (!matched) {
+        issues.push("acceptance_criteria_not_evidenced");
+      }
+    }
+
+    if (
+      trimmedOutput.length > 0 &&
+      /(according to|as seen in|from the logs|based on)/.test(outputLower) &&
+      artifactText.length > 0 &&
+      !outputIntersectsArtifacts(outputLower, artifactText)
+    ) {
+      issues.push("hallucination_risk_artifact_mismatch");
+      verdict = moreSevereVerifierVerdict(verdict, "retry");
+    }
+
+    if (step.requiredToolCapabilities.length > 0 && toolCallsCount === 0) {
+      issues.push("missing_tool_result_consistency_signal");
+    }
+
+    const confidence = Math.max(0, 1 - Math.min(0.9, issues.length * 0.18));
+    if (verdict !== "pass" || confidence < DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE) {
+      unresolvedItems.push(
+        `${step.name}:${issues.length > 0 ? issues.join(",") : "low_confidence"}`,
+      );
+    }
+    stepAssessments.push({
+      name: step.name,
+      verdict,
+      confidence,
+      retryable,
+      issues,
+      summary:
+        issues.length > 0
+          ? issues.join("; ")
+          : "deterministic verifier checks passed",
+    });
+  }
+
+  const overall = resolveVerifierOverall(stepAssessments);
+  const confidence = stepAssessments.length > 0
+    ? Number(
+        (
+          stepAssessments.reduce((sum, step) => sum + step.confidence, 0) /
+          stepAssessments.length
+        ).toFixed(4),
+      )
+    : 1;
+  return {
+    overall,
+    confidence,
+    unresolvedItems,
+    steps: stepAssessments,
+    source: "deterministic",
+  };
+}
+
+export function buildSubagentVerifierMessages(
+  systemPrompt: string,
+  messageText: string,
+  plannerPlan: PlannerPlan,
+  subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
+  pipelineResult: PipelineResult,
+  plannerContext: PipelinePlannerContext,
+  deterministicDecision: SubagentVerifierDecision,
+): readonly LLMMessage[] {
+  const artifactBundle = collectVerifierArtifacts(
+    pipelineResult,
+    plannerContext,
+  );
+  const childBundle = subagentSteps.map((step) => ({
+    name: step.name,
+    objective: step.objective,
+    inputContract: step.inputContract,
+    acceptanceCriteria: step.acceptanceCriteria,
+    requiredToolCapabilities: step.requiredToolCapabilities,
+    rawResult: truncateText(
+      pipelineResult.context.results[step.name] ?? "missing",
+      MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS,
+    ),
+  }));
+  return [
+    { role: "system", content: systemPrompt },
+    {
+      role: "system",
+      content:
+        "You are a strict verifier for delegated child outputs. " +
+        "Assess contract adherence, evidence quality, hallucination risk against provided artifacts, and tool-result consistency. " +
+        "Return JSON only with schema: " +
+        '{"overall":"pass|retry|fail","confidence":0..1,"unresolved":[string],"steps":[{"name":string,"verdict":"pass|retry|fail","confidence":0..1,"retryable":boolean,"issues":[string],"summary":string}]}.',
+    },
+    {
+      role: "user",
+      content: safeStringify({
+        request: messageText,
+        plannerReason: plannerPlan.reason,
+        deterministicVerifier: deterministicDecision,
+        childBundle,
+        artifacts: artifactBundle.map((entry) =>
+          truncateText(entry, MAX_SUBAGENT_VERIFIER_ARTIFACT_CHARS)
+        ),
+      }),
+    },
+  ];
+}
+
+export function parseSubagentVerifierDecision(
+  content: string,
+  subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
+): SubagentVerifierDecision | undefined {
+  const parsed = parseJsonObjectFromText(content);
+  if (!parsed) return undefined;
+  const overallRaw = parsed.overall;
+  if (
+    overallRaw !== "pass" &&
+    overallRaw !== "retry" &&
+    overallRaw !== "fail"
+  ) {
+    return undefined;
+  }
+  const confidenceRaw = parsed.confidence;
+  const confidence = typeof confidenceRaw === "number" && Number.isFinite(confidenceRaw)
+    ? Math.max(0, Math.min(1, confidenceRaw))
+    : 0.5;
+  const unresolvedItems = Array.isArray(parsed.unresolved)
+    ? parsed.unresolved
+        .filter((entry): entry is string => typeof entry === "string")
+        .map((entry) => entry.trim())
+        .filter((entry) => entry.length > 0)
+    : [];
+  const stepsByName = new Map(subagentSteps.map((step) => [step.name, step]));
+  const parsedSteps = Array.isArray(parsed.steps) ? parsed.steps : [];
+  const assessments: SubagentVerifierStepAssessment[] = [];
+  for (const entry of parsedSteps) {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      Array.isArray(entry)
+    ) {
+      continue;
+    }
+    const obj = entry as Record<string, unknown>;
+    const name = parsePlannerRequiredString(obj.name);
+    if (!name || !stepsByName.has(name)) continue;
+    const verdictRaw = obj.verdict;
+    if (
+      verdictRaw !== "pass" &&
+      verdictRaw !== "retry" &&
+      verdictRaw !== "fail"
+    ) {
+      continue;
+    }
+    const stepConfidenceRaw = obj.confidence;
+    const stepConfidence =
+      typeof stepConfidenceRaw === "number" && Number.isFinite(stepConfidenceRaw)
+        ? Math.max(0, Math.min(1, stepConfidenceRaw))
+        : confidence;
+    const retryable =
+      typeof obj.retryable === "boolean" ? obj.retryable : true;
+    const issues = Array.isArray(obj.issues)
+      ? obj.issues
+          .filter((issue): issue is string => typeof issue === "string")
+          .map((issue) => issue.trim())
+          .filter((issue) => issue.length > 0)
+      : [];
+    const summary = parsePlannerOptionalString(obj.summary) ??
+      (issues.length > 0 ? issues.join("; ") : "verifier assessment");
+    assessments.push({
+      name,
+      verdict: verdictRaw,
+      confidence: stepConfidence,
+      retryable,
+      issues,
+      summary,
+    });
+  }
+  if (assessments.length === 0) return undefined;
+  return {
+    overall: overallRaw,
+    confidence,
+    unresolvedItems,
+    steps: assessments,
+    source: "model",
+  };
+}
+
+export function mergeSubagentVerifierDecisions(
+  deterministic: SubagentVerifierDecision,
+  model: SubagentVerifierDecision,
+): SubagentVerifierDecision {
+  const byName = new Map<string, SubagentVerifierStepAssessment>();
+  for (const step of deterministic.steps) {
+    byName.set(step.name, step);
+  }
+  for (const step of model.steps) {
+    const existing = byName.get(step.name);
+    if (!existing) {
+      byName.set(step.name, step);
+      continue;
+    }
+    const mergedVerdict = moreSevereVerifierVerdict(
+      existing.verdict,
+      step.verdict,
+    );
+    const mergedIssues = [...new Set([...existing.issues, ...step.issues])];
+    byName.set(step.name, {
+      name: step.name,
+      verdict: mergedVerdict,
+      confidence: Math.min(existing.confidence, step.confidence),
+      retryable: existing.retryable && step.retryable,
+      issues: mergedIssues,
+      summary:
+        mergedIssues.length > 0
+          ? mergedIssues.join("; ")
+          : "merged verifier checks passed",
+    });
+  }
+  const steps = [...byName.values()];
+  const overall = resolveVerifierOverall(steps);
+  const unresolvedItems = [
+    ...new Set([
+      ...deterministic.unresolvedItems,
+      ...model.unresolvedItems,
+      ...steps
+        .filter((step) => step.verdict !== "pass")
+        .map((step) => `${step.name}:${step.summary}`),
+    ]),
+  ];
+  return {
+    overall,
+    confidence: Math.min(deterministic.confidence, model.confidence),
+    unresolvedItems,
+    steps,
+    source: "merged",
+  };
+}
+
+export function resolveVerifierOverall(
+  steps: readonly SubagentVerifierStepAssessment[],
+): "pass" | "retry" | "fail" {
+  let overall: "pass" | "retry" | "fail" = "pass";
+  for (const step of steps) {
+    overall = moreSevereVerifierVerdict(overall, step.verdict);
+    if (overall === "fail") return "fail";
+  }
+  return overall;
+}
+
+export function moreSevereVerifierVerdict(
+  a: SubagentVerifierStepVerdict,
+  b: SubagentVerifierStepVerdict,
+): SubagentVerifierStepVerdict {
+  const weight: Record<SubagentVerifierStepVerdict, number> = {
+    pass: 0,
+    retry: 1,
+    fail: 2,
+  };
+  return weight[a] >= weight[b] ? a : b;
+}
+
+export function extractVerifierTokens(value: string): string[] {
+  const matches = value.toLowerCase().match(/[a-z0-9_.-]+/g) ?? [];
+  const deduped = new Set<string>();
+  for (const match of matches) {
+    if (match.length < 4) continue;
+    deduped.add(match);
+  }
+  return [...deduped];
+}
+
+export function collectVerifierArtifacts(
+  pipelineResult: PipelineResult,
+  plannerContext: PipelinePlannerContext,
+): readonly string[] {
+  const artifacts: string[] = [];
+  for (const item of plannerContext.toolOutputs ?? []) {
+    artifacts.push(item.content);
+  }
+  for (const item of plannerContext.memory ?? []) {
+    artifacts.push(item.content);
+  }
+  for (const item of Object.values(pipelineResult.context.results)) {
+    if (typeof item !== "string") continue;
+    artifacts.push(item);
+  }
+  return artifacts
+    .map((entry) => truncateText(entry, MAX_SUBAGENT_VERIFIER_ARTIFACT_CHARS))
+    .filter((entry) => entry.length > 0)
+    .slice(0, 24);
+}
+
+export function outputIntersectsArtifacts(
+  outputLower: string,
+  artifactLower: string,
+): boolean {
+  const tokens = extractVerifierTokens(outputLower).slice(0, 24);
+  return tokens.some((token) =>
+    token.length >= 5 && artifactLower.includes(token)
+  );
+}

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -9,17 +9,13 @@
  * @module
  */
 
-import type { GatewayMessage } from "../gateway/message.js";
 import type {
   LLMChatOptions,
   LLMProvider,
   LLMMessage,
-  LLMContentPart,
+  LLMToolCall,
   LLMResponse,
   LLMUsage,
-  LLMRequestMetrics,
-  LLMStatefulDiagnostics,
-  LLMStatefulFallbackReason,
   StreamProgressCallback,
   ToolHandler,
 } from "./types.js";
@@ -28,7 +24,6 @@ import {
   LLMRateLimitError,
   classifyLLMFailure,
 } from "./errors.js";
-import { RuntimeError, RuntimeErrorCodes } from "../types/errors.js";
 import { safeStringify } from "../tools/types.js";
 import {
   applyPromptBudget,
@@ -36,10 +31,7 @@ import {
   type PromptBudgetDiagnostics,
   type PromptBudgetSection,
 } from "./prompt-budget.js";
-import {
-  DEFAULT_LLM_RETRY_POLICY_MATRIX,
-  toPipelineStopReason,
-} from "./policy.js";
+import { toPipelineStopReason } from "./policy.js";
 import type {
   LLMFailureClass,
   LLMPipelineStopReason,
@@ -49,12 +41,9 @@ import type {
 import type {
   Pipeline,
   PipelinePlannerContext,
-  PipelinePlannerContextMemorySource,
   PipelinePlannerStep,
   PipelineResult,
-  PipelineStep,
 } from "../workflow/pipeline.js";
-import type { WorkflowGraphEdge } from "../workflow/types.js";
 import {
   assessDelegationDecision,
   resolveDelegationDecisionConfig,
@@ -68,778 +57,140 @@ import {
   DELEGATION_USEFULNESS_PROXY_VERSION,
   deriveDelegationContextClusterId,
   type DelegationBanditPolicyTuner,
-  type DelegationBanditSelection,
   type DelegationTrajectorySink,
 } from "./delegation-learning.js";
+// ---------------------------------------------------------------------------
+// Imports from extracted sibling modules
+// ---------------------------------------------------------------------------
 
-// ============================================================================
-// Error classes
-// ============================================================================
+import {
+  ChatBudgetExceededError,
+} from "./chat-executor-types.js";
+import type {
+  SkillInjector,
+  MemoryRetriever,
+  ToolCallRecord,
+  ChatExecuteParams,
+  ChatPromptShape,
+  ChatCallUsageRecord,
+  ChatPlannerSummary,
+  PlannerDiagnostic,
+  ChatExecutorResult,
+  DeterministicPipelineExecutor,
+  ChatExecutorConfig,
+  EvaluatorConfig,
+  CooldownEntry,
+  SessionToolFailurePattern,
+  SessionToolFailureCircuitState,
+  FallbackResult,
+  PlannerDeterministicToolStepIntent,
+  PlannerSubAgentTaskStepIntent,
+  PlannerPlan,
+  SubagentVerifierDecision,
+  ResolvedSubagentVerifierConfig,
+  PlannerPipelineVerifierLoopInput,
+  ToolLoopState,
+  ToolCallAction,
+  ExecutionContext,
+} from "./chat-executor-types.js";
+import {
+  MAX_CONSECUTIVE_IDENTICAL_FAILURES,
+  MAX_CONSECUTIVE_ALL_FAILED_ROUNDS,
+  RECOVERY_HINT_PREFIX,
+  MAX_EVAL_USER_CHARS,
+  MAX_EVAL_RESPONSE_CHARS,
+  MAX_CONTEXT_INJECTION_CHARS,
+  MAX_PROMPT_CHARS_BUDGET,
+  MAX_TOOL_IMAGE_CHARS_BUDGET,
+  DEFAULT_MAX_RUNTIME_SYSTEM_HINTS,
+  DEFAULT_PLANNER_MAX_TOKENS,
+  DEFAULT_TOOL_BUDGET_PER_REQUEST,
+  DEFAULT_MODEL_RECALLS_PER_REQUEST,
+  DEFAULT_FAILURE_BUDGET_PER_REQUEST,
+  DEFAULT_TOOL_CALL_TIMEOUT_MS,
+  DEFAULT_REQUEST_TIMEOUT_MS,
+  DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE,
+  DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS,
+  MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS,
+  DEFAULT_TOOL_FAILURE_BREAKER_THRESHOLD,
+  DEFAULT_TOOL_FAILURE_BREAKER_WINDOW_MS,
+  DEFAULT_TOOL_FAILURE_BREAKER_COOLDOWN_MS,
+  MACOS_SIDE_EFFECT_TOOLS,
+  DEFAULT_EVAL_RUBRIC,
+  MAX_COMPACT_INPUT,
+} from "./chat-executor-constants.js";
+import {
+  didToolCallFail,
+  extractToolFailureText,
+  resolveRetryPolicyMatrix,
+  hasExplicitIdempotencyKey,
+  isHighRiskToolCall,
+  isToolRetrySafe,
+  isLikelyToolTransportFailure,
+  enrichToolResultMetadata,
+} from "./chat-executor-tool-utils.js";
+import {
+  extractMessageText,
+  truncateText,
+  sanitizeFinalContent,
+  reconcileStructuredToolOutcome,
+  estimatePromptShape,
+  normalizeHistory,
+  sanitizeToolCallsForReplay,
+  buildPromptToolContent,
+  appendUserMessage,
+  generateFallbackContent,
+  summarizeToolCalls,
+} from "./chat-executor-text.js";
+import {
+  buildSemanticToolCallKey,
+  summarizeStateful,
+  buildRecoveryHints,
+} from "./chat-executor-recovery.js";
+import {
+  assessPlannerDecision,
+  buildPlannerMessages,
+  buildPlannerExecutionContext,
+  parsePlannerPlan,
+  validatePlannerGraph,
+  isHighRiskSubagentPlan,
+  computePlannerGraphDepth,
+  isPipelineStopReasonHint,
+  buildPlannerSynthesisMessages,
+  ensureSubagentProvenanceCitations,
+  pipelineResultToToolCalls,
+} from "./chat-executor-planner.js";
+import {
+  evaluateSubagentDeterministicChecks,
+  buildSubagentVerifierMessages,
+  parseSubagentVerifierDecision,
+  mergeSubagentVerifierDecisions,
+} from "./chat-executor-verifier.js";
+// ---------------------------------------------------------------------------
+// Re-exports — preserve backward-compatible import paths for consumers
+// ---------------------------------------------------------------------------
 
-/**
- * Error thrown when a session's token budget is exceeded.
- */
-export class ChatBudgetExceededError extends RuntimeError {
-  public readonly sessionId: string;
-  public readonly used: number;
-  public readonly limit: number;
+export { ChatBudgetExceededError } from "./chat-executor-types.js";
+export type {
+  SkillInjector,
+  MemoryRetriever,
+  ToolCallRecord,
+  ChatExecuteParams,
+  ChatPromptShape,
+  ChatCallUsageRecord,
+  ChatPlannerSummary,
+  PlannerDiagnostic,
+  ChatStatefulSummary,
+  ChatToolRoutingSummary,
+  ChatExecutorResult,
+  DeterministicPipelineExecutor,
+  LLMRetryPolicyOverrides,
+  ToolFailureCircuitBreakerConfig,
+  ChatExecutorConfig,
+  EvaluatorConfig,
+  EvaluationResult,
+} from "./chat-executor-types.js";
 
-  constructor(sessionId: string, used: number, limit: number) {
-    super(
-      `Token budget exceeded for session "${sessionId}": ${used}/${limit}`,
-      RuntimeErrorCodes.CHAT_BUDGET_EXCEEDED,
-    );
-    this.name = "ChatBudgetExceededError";
-    this.sessionId = sessionId;
-    this.used = used;
-    this.limit = limit;
-  }
-}
-
-// ============================================================================
-// Injection interfaces
-// ============================================================================
-
-/** Injects skill context into a conversation. */
-export interface SkillInjector {
-  inject(message: string, sessionId: string): Promise<string | undefined>;
-}
-
-/** Retrieves memory context for a conversation. */
-export interface MemoryRetriever {
-  retrieve(message: string, sessionId: string): Promise<string | undefined>;
-}
-
-// ============================================================================
-// Core types
-// ============================================================================
-
-/** Record of a single tool call execution. */
-export interface ToolCallRecord {
-  readonly name: string;
-  readonly args: Record<string, unknown>;
-  readonly result: string;
-  readonly isError: boolean;
-  readonly durationMs: number;
-}
-
-/** Parameters for a single ChatExecutor.execute() call. */
-export interface ChatExecuteParams {
-  readonly message: GatewayMessage;
-  readonly history: readonly LLMMessage[];
-  readonly systemPrompt: string;
-  readonly sessionId: string;
-  /** Per-call tool handler — overrides the constructor handler for this call. */
-  readonly toolHandler?: ToolHandler;
-  /** Per-call stream callback — overrides the constructor callback for this call. */
-  readonly onStreamChunk?: StreamProgressCallback;
-  /** Abort signal — when aborted, the executor stops after the current tool call. */
-  readonly signal?: AbortSignal;
-  /** Per-call tool round limit — overrides the constructor default. */
-  readonly maxToolRounds?: number;
-  /** Optional per-turn tool-routing subset and expansion policy. */
-  readonly toolRouting?: {
-    /** Initial routed subset for this turn. */
-    readonly routedToolNames?: readonly string[];
-    /** One-turn expanded subset used on suspected routing misses. */
-    readonly expandedToolNames?: readonly string[];
-    /** Enable one-turn expansion retry on routed-tool misses. */
-    readonly expandOnMiss?: boolean;
-  };
-}
-
-/** Estimated prompt-shape statistics for one provider call. */
-export interface ChatPromptShape {
-  readonly messageCount: number;
-  readonly systemMessages: number;
-  readonly userMessages: number;
-  readonly assistantMessages: number;
-  readonly toolMessages: number;
-  readonly estimatedChars: number;
-  readonly systemPromptChars: number;
-}
-
-/** Per-provider-call usage attribution for one ChatExecutor execution. */
-export interface ChatCallUsageRecord {
-  /** 1-based call index within a single execute() invocation. */
-  readonly callIndex: number;
-  readonly phase:
-    | "initial"
-    | "planner"
-    | "planner_verifier"
-    | "planner_synthesis"
-    | "tool_followup"
-    | "evaluator"
-    | "evaluator_retry";
-  readonly provider: string;
-  readonly model?: string;
-  readonly finishReason: LLMResponse["finishReason"];
-  readonly usage: LLMUsage;
-  readonly beforeBudget: ChatPromptShape;
-  readonly afterBudget: ChatPromptShape;
-  /** Provider-specific request metrics (e.g. toolSchemaChars for Grok). */
-  readonly providerRequestMetrics?: LLMRequestMetrics;
-  /** Prompt-budget diagnostics (sections dropped/truncated, caps, and totals). */
-  readonly budgetDiagnostics?: PromptBudgetDiagnostics;
-  /** Stateful continuation diagnostics for this provider call (when supported). */
-  readonly statefulDiagnostics?: LLMStatefulDiagnostics;
-}
-
-/** Planner-routing decision and ROI summary for one execute() invocation. */
-export interface ChatPlannerSummary {
-  readonly enabled: boolean;
-  readonly used: boolean;
-  readonly routeReason?: string;
-  readonly complexityScore: number;
-  readonly plannerCalls: number;
-  readonly plannedSteps: number;
-  readonly deterministicStepsExecuted: number;
-  /** Estimated downstream model recalls avoided by deterministic execution. */
-  readonly estimatedRecallsAvoided: number;
-  /** Structured planner parse/validation/policy diagnostics for this turn. */
-  readonly diagnostics?: readonly PlannerDiagnostic[];
-  /** Sub-agent delegation utility decision for planner-emitted subagent tasks. */
-  readonly delegationDecision?: DelegationDecision;
-  /** Sub-agent verification/critic pass summary. */
-  readonly subagentVerification?: {
-    readonly enabled: boolean;
-    readonly performed: boolean;
-    readonly rounds: number;
-    readonly overall: "pass" | "retry" | "fail" | "skipped";
-    readonly confidence: number;
-    readonly unresolvedItems: readonly string[];
-  };
-  /** Online policy tuning diagnostics for delegation arm selection. */
-  readonly delegationPolicyTuning?: {
-    readonly enabled: boolean;
-    readonly contextClusterId?: string;
-    readonly selectedArmId?: string;
-    readonly selectedArmReason?: string;
-    readonly tunedThreshold?: number;
-    readonly exploration: boolean;
-    readonly finalReward?: number;
-    readonly usefulDelegation?: boolean;
-    readonly usefulDelegationScore?: number;
-    readonly rewardProxyVersion?: string;
-  };
-}
-
-export interface PlannerDiagnostic {
-  readonly category: "parse" | "validation" | "policy";
-  readonly code: string;
-  readonly message: string;
-  readonly details?: Readonly<Record<string, string | number | boolean>>;
-}
-
-/** Aggregated stateful continuation counters for one execute() invocation. */
-export interface ChatStatefulSummary {
-  readonly enabled: boolean;
-  readonly attemptedCalls: number;
-  readonly continuedCalls: number;
-  readonly fallbackCalls: number;
-  readonly fallbackReasons: Readonly<Record<LLMStatefulFallbackReason, number>>;
-}
-
-/** Aggregated tool-routing diagnostics for one execute() invocation. */
-export interface ChatToolRoutingSummary {
-  readonly enabled: boolean;
-  readonly initialToolCount: number;
-  readonly finalToolCount: number;
-  readonly routeMisses: number;
-  readonly expanded: boolean;
-}
-
-/** Result returned from ChatExecutor.execute(). */
-export interface ChatExecutorResult {
-  readonly content: string;
-  readonly provider: string;
-  /** Actual model identifier returned by the provider for the final response. */
-  readonly model?: string;
-  readonly usedFallback: boolean;
-  readonly toolCalls: readonly ToolCallRecord[];
-  readonly tokenUsage: LLMUsage;
-  /** Per-call token and prompt-shape attribution for this execution. */
-  readonly callUsage: readonly ChatCallUsageRecord[];
-  readonly durationMs: number;
-  /** True if conversation history was compacted during this execution. */
-  readonly compacted: boolean;
-  /** Aggregated stateful continuation diagnostics for this execution. */
-  readonly statefulSummary?: ChatStatefulSummary;
-  /** Per-turn dynamic tool-routing diagnostics for this execution. */
-  readonly toolRoutingSummary?: ChatToolRoutingSummary;
-  /** Planner/executor routing summary and ROI diagnostics. */
-  readonly plannerSummary?: ChatPlannerSummary;
-  /** Canonical stop reason for this request execution. */
-  readonly stopReason: LLMPipelineStopReason;
-  /** Optional detail for non-completed stop reasons. */
-  readonly stopReasonDetail?: string;
-  /** Result of response evaluation, if evaluator is configured. */
-  readonly evaluation?: EvaluationResult;
-}
-
-/** Minimal pipeline executor interface required by ChatExecutor planner path. */
-export interface DeterministicPipelineExecutor {
-  execute(pipeline: Pipeline, startFrom?: number): Promise<PipelineResult>;
-}
-
-type LLMRetryPolicyOverrides = Partial<{
-  [K in LLMFailureClass]: Partial<LLMRetryPolicyRule>;
-}>;
-
-export interface ToolFailureCircuitBreakerConfig {
-  /** Enable per-session tool failure circuit breaker (default: true). */
-  readonly enabled?: boolean;
-  /** Repeated semantic failure threshold before opening breaker (default: 5). */
-  readonly threshold?: number;
-  /** Rolling window for counting repeated failures in ms (default: 300_000). */
-  readonly windowMs?: number;
-  /** Breaker open cooldown in ms (default: 120_000). */
-  readonly cooldownMs?: number;
-}
-
-/** Configuration for ChatExecutor construction. */
-export interface ChatExecutorConfig {
-  /** Ordered providers — first is primary, rest are fallbacks. */
-  readonly providers: readonly LLMProvider[];
-  readonly toolHandler?: ToolHandler;
-  readonly maxToolRounds?: number;
-  readonly onStreamChunk?: StreamProgressCallback;
-  readonly skillInjector?: SkillInjector;
-  readonly memoryRetriever?: MemoryRetriever;
-  readonly allowedTools?: readonly string[];
-  /**
-   * Maximum token budget per session. When cumulative usage meets or exceeds
-   * this value, the executor attempts to compact conversation history by
-   * summarizing older messages. If compaction fails, falls back to
-   * `ChatBudgetExceededError`.
-   */
-  readonly sessionTokenBudget?: number;
-  /** Callback when context compaction occurs (budget recovery). */
-  readonly onCompaction?: (sessionId: string, summary: string) => void;
-  /** Optional response evaluator/critic configuration. */
-  readonly evaluator?: EvaluatorConfig;
-  /** Optional provider that injects self-learning context per message. */
-  readonly learningProvider?: MemoryRetriever;
-  /** Optional provider that injects cross-session progress context per message. */
-  readonly progressProvider?: MemoryRetriever;
-  /** Prompt budget allocator configuration (Phase 2). */
-  readonly promptBudget?: PromptBudgetConfig;
-  /** Base cooldown period for failed providers in ms (default: 60_000). */
-  readonly providerCooldownMs?: number;
-  /** Maximum cooldown period in ms (default: 300_000). */
-  readonly maxCooldownMs?: number;
-  /** Maximum tracked sessions before eviction (default: 10_000). */
-  readonly maxTrackedSessions?: number;
-  /** Enable planner/executor split for high-complexity turns. */
-  readonly plannerEnabled?: boolean;
-  /** Max output tokens for the planner pass (bounded planning call). */
-  readonly plannerMaxTokens?: number;
-  /** Optional deterministic workflow executor used when planner emits executable steps. */
-  readonly pipelineExecutor?: DeterministicPipelineExecutor;
-  /** Delegation utility scoring controls for planner-emitted subagent tasks. */
-  readonly delegationDecision?: DelegationDecisionConfig;
-  /** Optional live resolver for delegation threshold overrides. */
-  readonly resolveDelegationScoreThreshold?: () => number | undefined;
-  /** Optional verifier/critic loop for planner-emitted subagent outputs. */
-  readonly subagentVerifier?: {
-    /** Enable verifier flow for planner-emitted subagent steps. */
-    readonly enabled?: boolean;
-    /** Enforce verification whenever subagent steps execute. */
-    readonly force?: boolean;
-    /** Minimum confidence required to accept child outputs. */
-    readonly minConfidence?: number;
-    /** Max verification rounds (initial verification included). */
-    readonly maxRounds?: number;
-  };
-  /** Optional delegation learning hooks (trajectory sink + online bandit tuner). */
-  readonly delegationLearning?: {
-    readonly trajectorySink?: DelegationTrajectorySink;
-    readonly banditTuner?: DelegationBanditPolicyTuner;
-    readonly defaultStrategyArmId?: string;
-  };
-  /** Maximum tool calls allowed for a single execute() invocation. */
-  readonly toolBudgetPerRequest?: number;
-  /** Maximum model recalls (calls after the first) for a single execute() invocation. */
-  readonly maxModelRecallsPerRequest?: number;
-  /** Maximum total failed tool calls allowed for a single execute() invocation. */
-  readonly maxFailureBudgetPerRequest?: number;
-  /** Timeout for a single tool execution call in milliseconds. */
-  readonly toolCallTimeoutMs?: number;
-  /** End-to-end timeout for one execute() invocation in milliseconds. */
-  readonly requestTimeoutMs?: number;
-  /** Failure-class retry policy overrides (merged with defaults). */
-  readonly retryPolicyMatrix?: LLMRetryPolicyOverrides;
-  /** Session-level breaker for repeated failing tool patterns. */
-  readonly toolFailureCircuitBreaker?: ToolFailureCircuitBreakerConfig;
-}
-
-// ============================================================================
-// Evaluator types
-// ============================================================================
-
-/** Configuration for optional response evaluation/critic. */
-export interface EvaluatorConfig {
-  readonly rubric?: string;
-  /** Minimum score (0.0–1.0) to accept the response. Default: 0.7. */
-  readonly minScore?: number;
-  /** Maximum retry attempts when score is below threshold. Default: 1. */
-  readonly maxRetries?: number;
-}
-
-/** Result of a response evaluation. */
-export interface EvaluationResult {
-  readonly score: number;
-  readonly feedback: string;
-  readonly passed: boolean;
-  readonly retryCount: number;
-}
-
-// ============================================================================
-// Internal types
-// ============================================================================
-
-interface CooldownEntry {
-  availableAt: number;
-  failures: number;
-}
-
-interface SessionToolFailurePattern {
-  count: number;
-  lastAt: number;
-}
-
-interface SessionToolFailureCircuitState {
-  openUntil: number;
-  reason?: string;
-  patterns: Map<string, SessionToolFailurePattern>;
-}
-
-interface FallbackResult {
-  response: LLMResponse;
-  providerName: string;
-  usedFallback: boolean;
-  beforeBudget: ChatPromptShape;
-  afterBudget: ChatPromptShape;
-  budgetDiagnostics: PromptBudgetDiagnostics;
-}
-
-interface RecoveryHint {
-  key: string;
-  message: string;
-}
-
-interface PlannerDecision {
-  score: number;
-  shouldPlan: boolean;
-  reason: string;
-}
-
-type PlannerStepType = "deterministic_tool" | "subagent_task" | "synthesis";
-
-interface PlannerStepBaseIntent {
-  name: string;
-  stepType: PlannerStepType;
-  dependsOn?: readonly string[];
-}
-
-interface PlannerDeterministicToolStepIntent extends PlannerStepBaseIntent {
-  stepType: "deterministic_tool";
-  tool: string;
-  args: Record<string, unknown>;
-  onError?: PipelineStep["onError"];
-  maxRetries?: number;
-}
-
-interface PlannerSubAgentTaskStepIntent extends PlannerStepBaseIntent {
-  stepType: "subagent_task";
-  objective: string;
-  inputContract: string;
-  acceptanceCriteria: readonly string[];
-  requiredToolCapabilities: readonly string[];
-  contextRequirements: readonly string[];
-  maxBudgetHint: string;
-  canRunParallel: boolean;
-}
-
-interface PlannerSynthesisStepIntent extends PlannerStepBaseIntent {
-  stepType: "synthesis";
-  objective?: string;
-}
-
-type PlannerStepIntent =
-  | PlannerDeterministicToolStepIntent
-  | PlannerSubAgentTaskStepIntent
-  | PlannerSynthesisStepIntent;
-
-interface PlannerPlan {
-  reason?: string;
-  requiresSynthesis?: boolean;
-  confidence?: number;
-  steps: PlannerStepIntent[];
-  edges: readonly WorkflowGraphEdge[];
-}
-
-interface PlannerParseResult {
-  readonly plan?: PlannerPlan;
-  readonly diagnostics: readonly PlannerDiagnostic[];
-}
-
-interface PlannerGraphValidationConfig {
-  readonly maxSubagentFanout: number;
-  readonly maxSubagentDepth: number;
-}
-
-type SubagentVerifierStepVerdict = "pass" | "retry" | "fail";
-
-interface SubagentVerifierStepAssessment {
-  readonly name: string;
-  readonly verdict: SubagentVerifierStepVerdict;
-  readonly confidence: number;
-  readonly retryable: boolean;
-  readonly issues: readonly string[];
-  readonly summary: string;
-}
-
-interface SubagentVerifierDecision {
-  readonly overall: "pass" | "retry" | "fail";
-  readonly confidence: number;
-  readonly unresolvedItems: readonly string[];
-  readonly steps: readonly SubagentVerifierStepAssessment[];
-  readonly source: "deterministic" | "model" | "merged";
-}
-
-interface ResolvedSubagentVerifierConfig {
-  readonly enabled: boolean;
-  readonly force: boolean;
-  readonly minConfidence: number;
-  readonly maxRounds: number;
-}
-
-interface MutablePlannerVerificationSummary {
-  enabled: boolean;
-  performed: boolean;
-  rounds: number;
-  overall: "pass" | "retry" | "fail" | "skipped";
-  confidence: number;
-  unresolvedItems: string[];
-}
-
-interface MutablePlannerSummaryState {
-  deterministicStepsExecuted: number;
-  diagnostics: PlannerDiagnostic[];
-  subagentVerification: MutablePlannerVerificationSummary;
-}
-
-interface PlannerPipelineVerifierLoopInput {
-  pipeline: Pipeline;
-  plannerPlan: PlannerPlan;
-  subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
-  deterministicSteps: readonly PlannerDeterministicToolStepIntent[];
-  plannerExecutionContext: PipelinePlannerContext;
-  shouldRunSubagentVerifier: boolean;
-  plannerSummaryState: MutablePlannerSummaryState;
-  checkRequestTimeout: (stage: string) => boolean;
-  runPipelineWithGlobalTimeout: (
-    pipeline: Pipeline,
-  ) => Promise<PipelineResult | undefined>;
-  runSubagentVerifierRound: (input: {
-    plannerPlan: PlannerPlan;
-    subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
-    pipelineResult: PipelineResult;
-    plannerContext: PipelinePlannerContext;
-    round: number;
-  }) => Promise<SubagentVerifierDecision>;
-  appendToolRecord: (record: ToolCallRecord) => void;
-  setStopReason: (reason: LLMPipelineStopReason, detail?: string) => void;
-}
-
-// ============================================================================
-// Constants
-// ============================================================================
-
-/** Max chars for URL preview in tool summaries. */
-const MAX_URL_PREVIEW_CHARS = 80;
-/** Max chars for bash output in tool summaries. */
-const MAX_BASH_OUTPUT_CHARS = 2000;
-/** Max chars for command preview in tool summaries. */
-const MAX_COMMAND_PREVIEW_CHARS = 60;
-/**
- * Max consecutive identical failing tool calls before the loop is broken.
- * When the LLM calls the same tool with the same arguments and gets an error
- * N times in a row, we inject a hint after (N-1) and break after N.
- */
-const MAX_CONSECUTIVE_IDENTICAL_FAILURES = 3;
-/** Break tool loop after N rounds where every tool call failed. */
-const MAX_CONSECUTIVE_ALL_FAILED_ROUNDS = 3;
-const RECOVERY_HINT_PREFIX = "Tool recovery hint:";
-const SHELL_BUILTIN_COMMANDS = new Set([
-  "set",
-  "cd",
-  "export",
-  "source",
-  "alias",
-  "unalias",
-  "unset",
-  "shopt",
-  "ulimit",
-  "umask",
-  "readonly",
-  "declare",
-  "typeset",
-  "builtin",
-]);
-/** Max chars for JSON result previews. */
-const MAX_RESULT_PREVIEW_CHARS = 500;
-/** Max chars for error message previews. */
-const MAX_ERROR_PREVIEW_CHARS = 300;
-/** Max chars of user message sent to the evaluator. */
-const MAX_EVAL_USER_CHARS = 500;
-/** Max chars of response sent to the evaluator. */
-const MAX_EVAL_RESPONSE_CHARS = 2000;
-/** Cap history depth sent to providers per request. */
-const MAX_HISTORY_MESSAGES = 20;
-/** Max chars retained per history message. */
-const MAX_HISTORY_MESSAGE_CHARS = 2_000;
-/** Max chars from a single injected system context block (skills/memory/progress). */
-const MAX_CONTEXT_INJECTION_CHARS = 12_000;
-/** Hard prompt-size guard (approx chars) to avoid provider context-length errors. */
-const MAX_PROMPT_CHARS_BUDGET = 100_000;
-/** Max chars kept from a tool result when feeding it back into the LLM. */
-const MAX_TOOL_RESULT_CHARS = 12_000;
-/** Max chars retained for any single string field inside JSON tool output. */
-const MAX_TOOL_RESULT_FIELD_CHARS = 2_000;
-/** Max array items retained in JSON tool output summaries. */
-const MAX_TOOL_RESULT_ARRAY_ITEMS = 40;
-/** Max object keys retained in JSON tool output summaries. */
-const MAX_TOOL_RESULT_OBJECT_KEYS = 48;
-const TOOL_RESULT_PRIORITY_KEYS = [
-  "error",
-  "stderr",
-  "stdout",
-  "exitcode",
-  "status",
-  "message",
-  "result",
-  "output",
-  "url",
-  "title",
-  "text",
-  "data",
-] as const;
-/** Global image-data budget (chars) for tool results in a single execution. */
-const MAX_TOOL_IMAGE_CHARS_BUDGET = 100_000;
-/** Max chars retained from a single user text message. */
-const MAX_USER_MESSAGE_CHARS = 8_000;
-/** Hard cap for final assistant response size (protects against runaway output). */
-const MAX_FINAL_RESPONSE_CHARS = 24_000;
-/** Minimum line count before repetitive-output suppression is evaluated. */
-const REPETITIVE_LINE_MIN_COUNT = 40;
-/** Dominant-line repetition threshold for runaway detection. */
-const REPETITIVE_LINE_MIN_REPEATS = 20;
-/** Unique-line ratio threshold for runaway detection. */
-const REPETITIVE_LINE_MAX_UNIQUE_RATIO = 0.35;
-/** Upper bound on additive runtime hint system messages per execution. */
-const DEFAULT_MAX_RUNTIME_SYSTEM_HINTS = 4;
-/** Default max planner output budget in tokens (soft, prompt-enforced). */
-const DEFAULT_PLANNER_MAX_TOKENS = 256;
-/** Maximum deterministic steps accepted from a planner pass. */
-const MAX_PLANNER_STEPS = 24;
-/** Parent history slice candidates retained for per-subagent curation. */
-const MAX_PLANNER_CONTEXT_HISTORY_CANDIDATES = 12;
-/** Max chars retained for one planner history candidate entry. */
-const MAX_PLANNER_CONTEXT_HISTORY_CHARS = 600;
-/** Max chars retained for one planner memory candidate entry. */
-const MAX_PLANNER_CONTEXT_MEMORY_CHARS = 1_200;
-/** Max chars retained for one planner tool-output candidate entry. */
-const MAX_PLANNER_CONTEXT_TOOL_OUTPUT_CHARS = 1_200;
-/** Default per-request tool-call budget. */
-const DEFAULT_TOOL_BUDGET_PER_REQUEST = 24;
-/** Default per-request model recall budget (calls after first). */
-const DEFAULT_MODEL_RECALLS_PER_REQUEST = 24;
-/** Default per-request failed-tool-call budget. */
-const DEFAULT_FAILURE_BUDGET_PER_REQUEST = 8;
-/** Default timeout for a single tool execution call in ms. */
-const DEFAULT_TOOL_CALL_TIMEOUT_MS = 180_000;
-/** Default end-to-end timeout for one execute() invocation in ms. */
-const DEFAULT_REQUEST_TIMEOUT_MS = 600_000;
-/** Default minimum verifier confidence for accepting subagent outputs. */
-const DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE = 0.65;
-/** Default max rounds for verifier/critique loops (initial round included). */
-const DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS = 2;
-/** Max chars retained from one subagent output in verifier prompts. */
-const MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS = 3_000;
-/** Max chars retained from one verifier artifact payload. */
-const MAX_SUBAGENT_VERIFIER_ARTIFACT_CHARS = 2_000;
-/** Break no-progress loops after repeated semantically equivalent rounds. */
-const MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS = 2;
-/** Default repeated-failure threshold before opening session breaker. */
-const DEFAULT_TOOL_FAILURE_BREAKER_THRESHOLD = 5;
-/** Default rolling window for repeated-failure breaker accounting. */
-const DEFAULT_TOOL_FAILURE_BREAKER_WINDOW_MS = 300_000;
-/** Default cooldown once repeated-failure breaker opens. */
-const DEFAULT_TOOL_FAILURE_BREAKER_COOLDOWN_MS = 120_000;
-/** Keep raw tool image payloads out of model replay by default. */
-const ENABLE_TOOL_IMAGE_REPLAY = false;
-/**
- * macOS native tools that cause visible side-effects (opening apps, running scripts).
- * Once any tool in this set executes, further calls to ANY tool in the set are
- * skipped for the remainder of the request. This prevents the model from e.g.
- * opening 3 YouTube tabs.
- *
- * NOTE: Desktop sandbox tools (`desktop.*`) are intentionally excluded — multi-step
- * desktop automation (click → type → screenshot → verify) needs repeated calls.
- */
-const MACOS_SIDE_EFFECT_TOOLS = new Set([
-  "system.open",
-  "system.applescript",
-  "system.notification",
-]);
-
-/**
- * High-risk side-effect tools MUST NOT be auto-retried unless an explicit
- * idempotency token is provided in tool args.
- */
-const HIGH_RISK_TOOL_PREFIXES = [
-  "agenc.",
-  "wallet.",
-  "solana.",
-  "desktop.",
-];
-const HIGH_RISK_TOOLS = new Set([
-  "system.bash",
-  "system.writeFile",
-  "system.delete",
-  "system.applescript",
-  "system.open",
-  "system.notification",
-  "system.execute",
-]);
-const SAFE_TOOL_RETRY_PREFIXES = [
-  "system.http",
-  "system.browse",
-  "system.extract",
-  "system.read",
-  "playwright.browser_",
-];
-const SAFE_TOOL_RETRY_TOOLS = new Set([
-  "system.listFiles",
-  "system.readFile",
-  "system.searchFiles",
-  "system.htmlToMarkdown",
-]);
-
-function didToolCallFail(isError: boolean, result: string): boolean {
-  if (isError) return true;
-  try {
-    const parsed = JSON.parse(result) as unknown;
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return false;
-    }
-    const obj = parsed as Record<string, unknown>;
-    if (typeof obj.error === "string" && obj.error.trim().length > 0) return true;
-    if (typeof obj.exitCode === "number" && obj.exitCode !== 0) return true;
-  } catch {
-    // Non-JSON tool output — treat as non-failure unless isError=true.
-  }
-  return false;
-}
-
-function parseToolResultObject(
-  result: string,
-): Record<string, unknown> | null {
-  try {
-    const parsed = JSON.parse(result) as unknown;
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return null;
-    }
-    return parsed as Record<string, unknown>;
-  } catch {
-    return null;
-  }
-}
-
-function extractToolFailureText(record: ToolCallRecord): string {
-  const parsed = parseToolResultObject(record.result);
-  if (!parsed) return record.result;
-
-  const pieces: string[] = [];
-  if (typeof parsed.error === "string" && parsed.error.trim().length > 0) {
-    pieces.push(parsed.error.trim());
-  }
-  if (typeof parsed.stderr === "string" && parsed.stderr.trim().length > 0) {
-    pieces.push(parsed.stderr.trim());
-  }
-  if (pieces.length > 0) return pieces.join("\n");
-  return record.result;
-}
-
-function resolveRetryPolicyMatrix(
-  overrides?: LLMRetryPolicyOverrides,
-): LLMRetryPolicyMatrix {
-  if (!overrides) return DEFAULT_LLM_RETRY_POLICY_MATRIX;
-  const merged = {
-    ...DEFAULT_LLM_RETRY_POLICY_MATRIX,
-  } as Record<LLMFailureClass, LLMRetryPolicyRule>;
-  for (const failureClass of Object.keys(
-    DEFAULT_LLM_RETRY_POLICY_MATRIX,
-  ) as LLMFailureClass[]) {
-    const baseRule = merged[failureClass];
-    const patch = overrides[failureClass];
-    if (!patch) continue;
-    merged[failureClass] = {
-      ...baseRule,
-      ...patch,
-    };
-  }
-  return merged;
-}
-
-function hasExplicitIdempotencyKey(args: Record<string, unknown>): boolean {
-  const value = args.idempotencyKey;
-  return typeof value === "string" && value.trim().length > 0;
-}
-
-function isHighRiskToolCall(
-  toolName: string,
-): boolean {
-  if (HIGH_RISK_TOOLS.has(toolName)) return true;
-  return HIGH_RISK_TOOL_PREFIXES.some((prefix) => toolName.startsWith(prefix));
-}
-
-function isToolRetrySafe(toolName: string): boolean {
-  if (SAFE_TOOL_RETRY_TOOLS.has(toolName)) return true;
-  return SAFE_TOOL_RETRY_PREFIXES.some((prefix) => toolName.startsWith(prefix));
-}
-
-function isLikelyToolTransportFailure(
-  errorText: string,
-): boolean {
-  const lower = errorText.toLowerCase();
-  return (
-    lower.includes("timed out") ||
-    lower.includes("timeout") ||
-    lower.includes("fetch failed") ||
-    lower.includes("connection refused") ||
-    lower.includes("econnrefused") ||
-    lower.includes("econnreset") ||
-    lower.includes("etimedout") ||
-    lower.includes("network") ||
-    lower.includes("transport") ||
-    lower.includes("bridge")
-  );
-}
-
-function enrichToolResultMetadata(
-  result: string,
-  metadata: Record<string, unknown>,
-): string {
-  const parsed = parseToolResultObject(result);
-  if (!parsed) return result;
-  return safeStringify({
-    ...parsed,
-    ...metadata,
-  });
-}
 
 // ============================================================================
 // ChatExecutor
@@ -1021,6 +372,285 @@ export class ChatExecutor {
   private async executeRequest(
     params: ChatExecuteParams,
   ): Promise<ChatExecutorResult> {
+    const ctx = await this.initializeExecutionContext(params);
+
+    // Planner path (complexity-based delegation)
+    if (
+      this.plannerEnabled &&
+      ctx.plannerDecision.shouldPlan &&
+      this.pipelineExecutor &&
+      ctx.activeToolHandler
+    ) {
+      await this.executePlannerPath(ctx);
+    }
+
+    // Direct path: initial LLM call + tool loop
+    if (!ctx.plannerHandled) {
+      await this.executeToolCallLoop(ctx);
+    }
+
+    this.checkRequestTimeout(ctx, "finalization");
+    this.trackTokenUsage(ctx.sessionId, ctx.cumulativeUsage.totalTokens);
+
+    // Optional response evaluation (critic)
+    if (this.evaluator && ctx.finalContent && ctx.stopReason === "completed") {
+      await this.evaluateAndRetryResponse(ctx);
+    }
+
+    // Finalization, trajectory recording, bandit outcome
+    const { plannerSummary, durationMs } = this.recordOutcomeAndFinalize(ctx);
+
+    // Sanitize + assemble result
+    ctx.finalContent = sanitizeFinalContent(ctx.finalContent);
+    ctx.finalContent = reconcileStructuredToolOutcome(
+      ctx.finalContent,
+      ctx.allToolCalls,
+    );
+
+    return {
+      content: ctx.finalContent,
+      provider: ctx.providerName,
+      model: ctx.responseModel,
+      usedFallback: ctx.usedFallback,
+      toolCalls: ctx.allToolCalls,
+      tokenUsage: ctx.cumulativeUsage,
+      callUsage: ctx.callUsage,
+      durationMs,
+      compacted: ctx.compacted,
+      statefulSummary: summarizeStateful(ctx.callUsage),
+      toolRoutingSummary: ctx.toolRouting
+        ? {
+          enabled: true,
+          initialToolCount: ctx.initialRoutedToolNames.length,
+          finalToolCount: ctx.activeRoutedToolNames.length,
+          routeMisses: ctx.routedToolMisses,
+          expanded: ctx.routedToolsExpanded,
+        }
+        : undefined,
+      plannerSummary,
+      stopReason: ctx.stopReason,
+      stopReasonDetail: ctx.stopReasonDetail,
+      evaluation: ctx.evaluation,
+    };
+  }
+
+  // ===========================================================================
+  // Utility helpers extracted from executeRequest() closures (Steps 2-6)
+  // ===========================================================================
+
+  private pushMessage(
+    ctx: ExecutionContext,
+    nextMessage: LLMMessage,
+    section: PromptBudgetSection,
+  ): void {
+    ctx.messages.push(nextMessage);
+    ctx.messageSections.push(section);
+  }
+
+  private setStopReason(
+    ctx: ExecutionContext,
+    reason: LLMPipelineStopReason,
+    detail?: string,
+  ): void {
+    if (ctx.stopReason === "completed") {
+      ctx.stopReason = reason;
+      ctx.stopReasonDetail = detail;
+    }
+  }
+
+  private timeoutDetail(stage: string): string {
+    return `Request exceeded end-to-end timeout (${this.requestTimeoutMs}ms) during ${stage}`;
+  }
+
+  private checkRequestTimeout(ctx: ExecutionContext, stage: string): boolean {
+    if (this.getRemainingRequestMs(ctx) > 0) return false;
+    this.setStopReason(ctx, "timeout", this.timeoutDetail(stage));
+    return true;
+  }
+
+  private appendToolRecord(ctx: ExecutionContext, record: ToolCallRecord): void {
+    ctx.allToolCalls.push(record);
+    if (didToolCallFail(record.isError, record.result)) {
+      ctx.failedToolCalls++;
+    }
+  }
+
+  private hasModelRecallBudget(ctx: ExecutionContext): boolean {
+    if (ctx.modelCalls === 0) return true;
+    return ctx.modelCalls - 1 < ctx.effectiveMaxModelRecalls;
+  }
+
+  private getRemainingRequestMs(ctx: ExecutionContext): number {
+    return ctx.requestDeadlineAt - Date.now();
+  }
+
+  private async callModelForPhase(
+    ctx: ExecutionContext,
+    input: {
+      phase: ChatCallUsageRecord["phase"];
+      callMessages: readonly LLMMessage[];
+      callSections?: readonly PromptBudgetSection[];
+      onStreamChunk?: StreamProgressCallback;
+      statefulSessionId?: string;
+      routedToolNames?: readonly string[];
+      budgetReason: string;
+    },
+  ): Promise<LLMResponse | undefined> {
+    if (!this.hasModelRecallBudget(ctx)) {
+      this.setStopReason(ctx, "budget_exceeded", input.budgetReason);
+      return undefined;
+    }
+    if (this.checkRequestTimeout(ctx, `${input.phase} model call`)) {
+      return undefined;
+    }
+    const effectiveRoutedToolNames = input.routedToolNames !== undefined
+      ? input.routedToolNames
+      : (ctx.toolRouting ? ctx.activeRoutedToolNames : undefined);
+    let next: FallbackResult;
+    try {
+      next = await this.callWithFallback(
+        input.callMessages,
+        input.onStreamChunk,
+        input.callSections,
+        {
+          ...(input.statefulSessionId
+            ? { statefulSessionId: input.statefulSessionId }
+            : {}),
+          ...(effectiveRoutedToolNames !== undefined
+            ? { routedToolNames: effectiveRoutedToolNames }
+            : {}),
+        },
+      );
+    } catch (error) {
+      const annotated = this.annotateFailureError(
+        error,
+        `${input.phase} model call`,
+      );
+      this.setStopReason(ctx, annotated.stopReason, annotated.stopReasonDetail);
+      throw annotated.error;
+    }
+    ctx.modelCalls++;
+    ctx.providerName = next.providerName;
+    ctx.responseModel = next.response.model;
+    if (next.usedFallback) ctx.usedFallback = true;
+    this.accumulateUsage(ctx.cumulativeUsage, next.response.usage);
+    ctx.callUsage.push(
+      this.createCallUsageRecord({
+        callIndex: ++ctx.callIndex,
+        phase: input.phase,
+        providerName: next.providerName,
+        response: next.response,
+        beforeBudget: next.beforeBudget,
+        afterBudget: next.afterBudget,
+        budgetDiagnostics: next.budgetDiagnostics,
+      }),
+    );
+    return next.response;
+  }
+
+  private async runPipelineWithTimeout(
+    ctx: ExecutionContext,
+    pipeline: Pipeline,
+  ): Promise<PipelineResult | undefined> {
+    const remainingMs = this.getRemainingRequestMs(ctx);
+    if (remainingMs <= 0) {
+      this.setStopReason(ctx, "timeout", this.timeoutDetail("planner pipeline execution"));
+      return undefined;
+    }
+    const timeoutMessage = `planner pipeline timed out after ${remainingMs}ms`;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new Error(timeoutMessage));
+      }, remainingMs);
+    });
+    try {
+      return await Promise.race([
+        this.pipelineExecutor!.execute(pipeline),
+        timeoutPromise,
+      ]);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (message === timeoutMessage) {
+        this.setStopReason(ctx, "timeout", this.timeoutDetail("planner pipeline execution"));
+        return undefined;
+      }
+      const annotated = this.annotateFailureError(
+        error,
+        "planner pipeline execution",
+      );
+      this.setStopReason(ctx, annotated.stopReason, annotated.stopReasonDetail);
+      throw annotated.error;
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
+  }
+
+  private async runSubagentVerifier(
+    ctx: ExecutionContext,
+    input: {
+      plannerPlan: PlannerPlan;
+      subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+      pipelineResult: PipelineResult;
+      plannerContext: PipelinePlannerContext;
+      round: number;
+    },
+  ): Promise<SubagentVerifierDecision> {
+    const deterministic = evaluateSubagentDeterministicChecks(
+      input.subagentSteps,
+      input.pipelineResult,
+      input.plannerContext,
+    );
+    const verifierMessages = buildSubagentVerifierMessages(
+      ctx.systemPrompt,
+      ctx.messageText,
+      input.plannerPlan,
+      input.subagentSteps,
+      input.pipelineResult,
+      input.plannerContext,
+      deterministic,
+    );
+    const verifierSections: PromptBudgetSection[] = [
+      "system_anchor",
+      "system_runtime",
+      "user",
+    ];
+    const verifierResponse = await this.callModelForPhase(ctx, {
+      phase: "planner_verifier",
+      callMessages: verifierMessages,
+      callSections: verifierSections,
+      statefulSessionId: ctx.sessionId,
+      budgetReason:
+        "Planner verifier blocked by max model recalls per request budget",
+    });
+    if (!verifierResponse) {
+      return deterministic;
+    }
+    const modelDecision = parseSubagentVerifierDecision(
+      verifierResponse.content,
+      input.subagentSteps,
+    );
+    if (!modelDecision) {
+      ctx.plannerSummaryState.diagnostics.push({
+        category: "parse",
+        code: "subagent_verifier_parse_failed",
+        message:
+          "Sub-agent verifier returned non-JSON or malformed schema; using deterministic verifier fallback",
+        details: {
+          round: input.round,
+        },
+      });
+      return deterministic;
+    }
+    return mergeSubagentVerifierDecisions(
+      deterministic,
+      modelDecision,
+    );
+  }
+
+  private async initializeExecutionContext(
+    params: ChatExecuteParams,
+  ): Promise<ExecutionContext> {
     const {
       message,
       systemPrompt,
@@ -1029,17 +659,22 @@ export class ChatExecutor {
       maxToolRounds: paramMaxToolRounds,
     } = params;
     let { history } = params;
-    const activeToolHandler = params.toolHandler ?? this.toolHandler;
-    const activeStreamCallback = params.onStreamChunk ?? this.onStreamChunk;
-    const effectiveMaxToolRounds = paramMaxToolRounds ?? this.maxToolRounds;
-    const effectiveToolBudget = this.toolBudgetPerRequest;
-    const effectiveMaxModelRecalls = this.maxModelRecallsPerRequest;
-    const effectiveFailureBudget = this.maxFailureBudgetPerRequest;
     const startTime = Date.now();
-    const parentTurnId = `parent:${sessionId}:${startTime}`;
-    const trajectoryTraceId = `trace:${sessionId}:${startTime}`;
-    const requestDeadlineAt = startTime + this.requestTimeoutMs;
-    const getRemainingRequestMs = (): number => requestDeadlineAt - Date.now();
+    const messageText = extractMessageText(message);
+    const hasHistory = history.length > 0;
+    const plannerDecision = assessPlannerDecision(this.plannerEnabled, messageText, history);
+    const initialRoutedToolNames = params.toolRouting?.routedToolNames
+      ? Array.from(new Set(params.toolRouting.routedToolNames))
+      : [];
+    const expandedRoutedToolNames = params.toolRouting?.expandedToolNames
+      ? Array.from(new Set(params.toolRouting.expandedToolNames))
+      : [];
+    const resolvedThresholdOverride = this.resolveDelegationScoreThreshold?.();
+    const baseDelegationThreshold =
+      typeof resolvedThresholdOverride === "number" &&
+        Number.isFinite(resolvedThresholdOverride)
+        ? Math.max(0, Math.min(1, resolvedThresholdOverride))
+        : this.delegationDecisionConfig.scoreThreshold;
 
     // Pre-check token budget — attempt compaction instead of hard fail
     let compacted = false;
@@ -1060,1408 +695,182 @@ export class ChatExecutor {
       }
     }
 
-    // Build messages array with explicit section tags for prompt budgeting.
-    const messages: LLMMessage[] = [];
-    const messageSections: PromptBudgetSection[] = [];
-    const pushMessage = (
-      nextMessage: LLMMessage,
-      section: PromptBudgetSection,
-    ): void => {
-      messages.push(nextMessage);
-      messageSections.push(section);
+    const ctx: ExecutionContext = {
+      // --- Immutable request params ---
+      message,
+      messageText,
+      systemPrompt,
+      sessionId,
+      signal,
+      activeToolHandler: params.toolHandler ?? this.toolHandler,
+      activeStreamCallback: params.onStreamChunk ?? this.onStreamChunk,
+      effectiveMaxToolRounds: paramMaxToolRounds ?? this.maxToolRounds,
+      effectiveToolBudget: this.toolBudgetPerRequest,
+      effectiveMaxModelRecalls: this.maxModelRecallsPerRequest,
+      effectiveFailureBudget: this.maxFailureBudgetPerRequest,
+      startTime,
+      requestDeadlineAt: startTime + this.requestTimeoutMs,
+      parentTurnId: `parent:${sessionId}:${startTime}`,
+      trajectoryTraceId: `trace:${sessionId}:${startTime}`,
+      initialRoutedToolNames,
+      expandedRoutedToolNames,
+      canExpandOnRoutingMiss: Boolean(
+        params.toolRouting?.expandOnMiss &&
+        expandedRoutedToolNames.length > 0,
+      ),
+      hasHistory,
+      plannerDecision,
+      baseDelegationThreshold,
+      toolRouting: params.toolRouting,
+
+      // --- Mutable accumulator state ---
+      history,
+      messages: [],
+      messageSections: [],
+      cumulativeUsage: {
+        promptTokens: 0,
+        completionTokens: 0,
+        totalTokens: 0,
+      },
+      callUsage: [],
+      callIndex: 0,
+      modelCalls: 0,
+      allToolCalls: [],
+      failedToolCalls: 0,
+      usedFallback: false,
+      providerName: this.providers[0]?.name ?? "unknown",
+      responseModel: undefined,
+      response: undefined,
+      evaluation: undefined,
+      finalContent: "",
+      compacted,
+      stopReason: "completed",
+      stopReasonDetail: undefined,
+      activeRoutedToolNames: initialRoutedToolNames,
+      routedToolsExpanded: false,
+      routedToolMisses: 0,
+      plannerHandled: false,
+      plannerSummaryState: {
+        enabled: this.plannerEnabled,
+        used: false,
+        routeReason: plannerDecision.reason,
+        complexityScore: plannerDecision.score,
+        plannerCalls: 0,
+        plannedSteps: 0,
+        deterministicStepsExecuted: 0,
+        estimatedRecallsAvoided: 0,
+        diagnostics: [] as PlannerDiagnostic[],
+        delegationDecision: undefined as DelegationDecision | undefined,
+        subagentVerification: {
+          enabled: this.subagentVerifierConfig.enabled,
+          performed: false,
+          rounds: 0,
+          overall: "skipped" as "pass" | "retry" | "fail" | "skipped",
+          confidence: 1,
+          unresolvedItems: [] as string[],
+        },
+        delegationPolicyTuning: {
+          enabled: Boolean(this.delegationBanditTuner),
+          contextClusterId: undefined as string | undefined,
+          selectedArmId: undefined as string | undefined,
+          selectedArmReason: undefined as string | undefined,
+          tunedThreshold: undefined as number | undefined,
+          exploration: false,
+          finalReward: undefined as number | undefined,
+          usefulDelegation: undefined as boolean | undefined,
+          usefulDelegationScore: undefined as number | undefined,
+          rewardProxyVersion: undefined as string | undefined,
+        },
+      },
+      trajectoryContextClusterId: deriveDelegationContextClusterId({
+        complexityScore: plannerDecision.score,
+        subagentStepCount: 0,
+        hasHistory,
+        highRiskPlan: false,
+      }),
+      selectedBanditArm: undefined,
+      tunedDelegationThreshold: baseDelegationThreshold,
+      plannedSubagentSteps: 0,
+      plannedDeterministicSteps: 0,
+      plannedSynthesisSteps: 0,
+      plannedDependencyDepth: 0,
+      plannedFanout: 0,
     };
-    pushMessage({ role: "system", content: systemPrompt }, "system_anchor");
+
+    // Build messages array with explicit section tags for prompt budgeting.
+    this.pushMessage(ctx, { role: "system", content: ctx.systemPrompt }, "system_anchor");
 
     // Context injection — skill, memory, and learning (all best-effort)
-    const messageText = ChatExecutor.extractMessageText(message);
-    const hasHistory = history.length > 0;
     await this.injectContext(
       this.skillInjector,
-      messageText,
-      sessionId,
-      messages,
-      messageSections,
+      ctx.messageText,
+      ctx.sessionId,
+      ctx.messages,
+      ctx.messageSections,
       "system_runtime",
     );
     // Session-scoped persistence should not bleed into truly fresh chats.
     // For the first turn, only inject static skill context.
-    if (hasHistory) {
+    if (ctx.hasHistory) {
       await this.injectContext(
         this.memoryRetriever,
-        messageText,
-        sessionId,
-        messages,
-        messageSections,
+        ctx.messageText,
+        ctx.sessionId,
+        ctx.messages,
+        ctx.messageSections,
         "memory_semantic",
       );
       await this.injectContext(
         this.learningProvider,
-        messageText,
-        sessionId,
-        messages,
-        messageSections,
+        ctx.messageText,
+        ctx.sessionId,
+        ctx.messages,
+        ctx.messageSections,
         "memory_episodic",
       );
       await this.injectContext(
         this.progressProvider,
-        messageText,
-        sessionId,
-        messages,
-        messageSections,
+        ctx.messageText,
+        ctx.sessionId,
+        ctx.messages,
+        ctx.messageSections,
         "memory_working",
       );
     }
 
     // Append history and user message
-    for (const historicalMessage of ChatExecutor.normalizeHistory(history)) {
-      pushMessage(historicalMessage, "history");
+    for (const historicalMessage of normalizeHistory(ctx.history)) {
+      this.pushMessage(ctx, historicalMessage, "history");
     }
 
-    ChatExecutor.appendUserMessage(messages, messageSections, message);
+    appendUserMessage(ctx.messages, ctx.messageSections, ctx.message);
 
-    // First LLM call
-    const cumulativeUsage: LLMUsage = {
-      promptTokens: 0,
-      completionTokens: 0,
-      totalTokens: 0,
-    };
-    const callUsage: ChatCallUsageRecord[] = [];
-    let callIndex = 0;
-    let modelCalls = 0;
-    const allToolCalls: ToolCallRecord[] = [];
-    let failedToolCalls = 0;
-    let usedFallback = false;
-    let providerName = this.providers[0]?.name ?? "unknown";
-    let responseModel: string | undefined;
-    let response: LLMResponse | undefined;
-    let evaluation: EvaluationResult | undefined;
-    let finalContent = "";
-    let stopReason: LLMPipelineStopReason = "completed";
-    let stopReasonDetail: string | undefined;
-    const initialRoutedToolNames = params.toolRouting?.routedToolNames
-      ? Array.from(new Set(params.toolRouting.routedToolNames))
-      : [];
-    const expandedRoutedToolNames = params.toolRouting?.expandedToolNames
-      ? Array.from(new Set(params.toolRouting.expandedToolNames))
-      : [];
-    const canExpandOnRoutingMiss = Boolean(
-      params.toolRouting?.expandOnMiss &&
-      expandedRoutedToolNames.length > 0,
-    );
-    let activeRoutedToolNames = initialRoutedToolNames;
-    let routedToolsExpanded = false;
-    let routedToolMisses = 0;
+    return ctx;
+  }
 
-    const plannerDecision = this.assessPlannerDecision(messageText, history);
-    let trajectoryContextClusterId = deriveDelegationContextClusterId({
-      complexityScore: plannerDecision.score,
-      subagentStepCount: 0,
-      hasHistory,
-      highRiskPlan: false,
-    });
-    let selectedBanditArm: DelegationBanditSelection | undefined;
-    const resolvedThresholdOverride = this.resolveDelegationScoreThreshold?.();
-    const baseDelegationThreshold =
-      typeof resolvedThresholdOverride === "number" &&
-        Number.isFinite(resolvedThresholdOverride)
-        ? Math.max(0, Math.min(1, resolvedThresholdOverride))
-        : this.delegationDecisionConfig.scoreThreshold;
-    let tunedDelegationThreshold = baseDelegationThreshold;
-    let plannedSubagentSteps = 0;
-    let plannedDeterministicSteps = 0;
-    let plannedSynthesisSteps = 0;
-    let plannedDependencyDepth = 0;
-    let plannedFanout = 0;
-    const plannerSummaryState = {
-      enabled: this.plannerEnabled,
-      used: false,
-      routeReason: plannerDecision.reason,
-      complexityScore: plannerDecision.score,
-      plannerCalls: 0,
-      plannedSteps: 0,
-      deterministicStepsExecuted: 0,
-      estimatedRecallsAvoided: 0,
-      diagnostics: [] as PlannerDiagnostic[],
-      delegationDecision: undefined as DelegationDecision | undefined,
-      subagentVerification: {
-        enabled: this.subagentVerifierConfig.enabled,
-        performed: false,
-        rounds: 0,
-        overall: "skipped" as "pass" | "retry" | "fail" | "skipped",
-        confidence: 1,
-        unresolvedItems: [] as string[],
-      },
-      delegationPolicyTuning: {
-        enabled: Boolean(this.delegationBanditTuner),
-        contextClusterId: undefined as string | undefined,
-        selectedArmId: undefined as string | undefined,
-        selectedArmReason: undefined as string | undefined,
-        tunedThreshold: undefined as number | undefined,
-        exploration: false,
-        finalReward: undefined as number | undefined,
-        usefulDelegation: undefined as boolean | undefined,
-        usefulDelegationScore: undefined as number | undefined,
-        rewardProxyVersion: undefined as string | undefined,
-      },
-    };
-
-    const setStopReason = (
-      reason: LLMPipelineStopReason,
-      detail?: string,
-    ): void => {
-      if (stopReason === "completed") {
-        stopReason = reason;
-        stopReasonDetail = detail;
-      }
-    };
-
-    const timeoutDetail = (stage: string): string =>
-      `Request exceeded end-to-end timeout (${this.requestTimeoutMs}ms) during ${stage}`;
-
-    const checkRequestTimeout = (stage: string): boolean => {
-      if (getRemainingRequestMs() > 0) return false;
-      setStopReason("timeout", timeoutDetail(stage));
-      return true;
-    };
-
-    const appendToolRecord = (record: ToolCallRecord): void => {
-      allToolCalls.push(record);
-      if (didToolCallFail(record.isError, record.result)) {
-        failedToolCalls++;
-      }
-    };
-
-    const hasModelRecallBudget = (): boolean => {
-      if (modelCalls === 0) return true; // first model call
-      return modelCalls - 1 < effectiveMaxModelRecalls;
-    };
-
-    const callModel = async (input: {
-      phase: ChatCallUsageRecord["phase"];
-      callMessages: readonly LLMMessage[];
-      callSections?: readonly PromptBudgetSection[];
-      onStreamChunk?: StreamProgressCallback;
-      statefulSessionId?: string;
-      routedToolNames?: readonly string[];
-      budgetReason: string;
-    }): Promise<LLMResponse | undefined> => {
-      if (!hasModelRecallBudget()) {
-        setStopReason("budget_exceeded", input.budgetReason);
-        return undefined;
-      }
-      if (checkRequestTimeout(`${input.phase} model call`)) {
-        return undefined;
-      }
-      const effectiveRoutedToolNames = input.routedToolNames !== undefined
-        ? input.routedToolNames
-        : (params.toolRouting ? activeRoutedToolNames : undefined);
-      let next: FallbackResult;
-      try {
-        next = await this.callWithFallback(
-          input.callMessages,
-          input.onStreamChunk,
-          input.callSections,
-          {
-            ...(input.statefulSessionId
-              ? { statefulSessionId: input.statefulSessionId }
-              : {}),
-            ...(effectiveRoutedToolNames !== undefined
-              ? { routedToolNames: effectiveRoutedToolNames }
-              : {}),
-          },
-        );
-      } catch (error) {
-        const annotated = this.annotateFailureError(
-          error,
-          `${input.phase} model call`,
-        );
-        setStopReason(annotated.stopReason, annotated.stopReasonDetail);
-        throw annotated.error;
-      }
-      modelCalls++;
-      providerName = next.providerName;
-      responseModel = next.response.model;
-      if (next.usedFallback) usedFallback = true;
-      this.accumulateUsage(cumulativeUsage, next.response.usage);
-      callUsage.push(
-        this.createCallUsageRecord({
-          callIndex: ++callIndex,
-          phase: input.phase,
-          providerName: next.providerName,
-          response: next.response,
-          beforeBudget: next.beforeBudget,
-          afterBudget: next.afterBudget,
-          budgetDiagnostics: next.budgetDiagnostics,
-        }),
-      );
-      return next.response;
-    };
-
-    const runPipelineWithGlobalTimeout = async (
-      pipeline: Pipeline,
-    ): Promise<PipelineResult | undefined> => {
-      const remainingMs = getRemainingRequestMs();
-      if (remainingMs <= 0) {
-        setStopReason("timeout", timeoutDetail("planner pipeline execution"));
-        return undefined;
-      }
-      const timeoutMessage = `planner pipeline timed out after ${remainingMs}ms`;
-      let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutHandle = setTimeout(() => {
-          reject(new Error(timeoutMessage));
-        }, remainingMs);
-      });
-      try {
-        return await Promise.race([
-          this.pipelineExecutor!.execute(pipeline),
-          timeoutPromise,
-        ]);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (message === timeoutMessage) {
-          setStopReason("timeout", timeoutDetail("planner pipeline execution"));
-          return undefined;
-        }
-        const annotated = this.annotateFailureError(
-          error,
-          "planner pipeline execution",
-        );
-        setStopReason(annotated.stopReason, annotated.stopReasonDetail);
-        throw annotated.error;
-      } finally {
-        if (timeoutHandle) clearTimeout(timeoutHandle);
-      }
-    };
-
-    const runSubagentVerifierRound = async (input: {
-      plannerPlan: PlannerPlan;
-      subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
-      pipelineResult: PipelineResult;
-      plannerContext: PipelinePlannerContext;
-      round: number;
-    }): Promise<SubagentVerifierDecision> => {
-      const deterministic = ChatExecutor.evaluateSubagentDeterministicChecks(
-        input.subagentSteps,
-        input.pipelineResult,
-        input.plannerContext,
-      );
-      const verifierMessages = ChatExecutor.buildSubagentVerifierMessages(
-        systemPrompt,
-        messageText,
-        input.plannerPlan,
-        input.subagentSteps,
-        input.pipelineResult,
-        input.plannerContext,
-        deterministic,
-      );
-      const verifierSections: PromptBudgetSection[] = [
-        "system_anchor",
-        "system_runtime",
-        "user",
-      ];
-      const verifierResponse = await callModel({
-        phase: "planner_verifier",
-        callMessages: verifierMessages,
-        callSections: verifierSections,
-        statefulSessionId: sessionId,
-        budgetReason:
-          "Planner verifier blocked by max model recalls per request budget",
-      });
-      if (!verifierResponse) {
-        return deterministic;
-      }
-      const modelDecision = ChatExecutor.parseSubagentVerifierDecision(
-        verifierResponse.content,
-        input.subagentSteps,
-      );
-      if (!modelDecision) {
-        plannerSummaryState.diagnostics.push({
-          category: "parse",
-          code: "subagent_verifier_parse_failed",
-          message:
-            "Sub-agent verifier returned non-JSON or malformed schema; using deterministic verifier fallback",
-          details: {
-            round: input.round,
-          },
-        });
-        return deterministic;
-      }
-      return ChatExecutor.mergeSubagentVerifierDecisions(
-        deterministic,
-        modelDecision,
-      );
-    };
-
-    let plannerHandled = false;
-    if (
-      this.plannerEnabled &&
-      plannerDecision.shouldPlan &&
-      this.pipelineExecutor &&
-      activeToolHandler
-    ) {
-      plannerSummaryState.used = true;
-      const plannerMessages = ChatExecutor.buildPlannerMessages(
-        messageText,
-        history,
-        this.plannerMaxTokens,
-      );
-      const plannerSections: PromptBudgetSection[] = [
-        "system_anchor",
-        "history",
-        "user",
-      ];
-      const plannerResponse = await callModel({
-        phase: "planner",
-        callMessages: plannerMessages,
-        callSections: plannerSections,
-        budgetReason:
-          "Planner pass blocked by max model recalls per request budget",
-      });
-
-      if (plannerResponse) {
-        plannerSummaryState.plannerCalls = 1;
-        const plannerParse = ChatExecutor.parsePlannerPlan(plannerResponse.content);
-        plannerSummaryState.diagnostics.push(...plannerParse.diagnostics);
-        const plannerPlan = plannerParse.plan;
-        if (plannerPlan) {
-          const graphDiagnostics = ChatExecutor.validatePlannerGraph(
-            plannerPlan,
-            {
-              maxSubagentFanout: this.delegationDecisionConfig.maxFanoutPerTurn,
-              maxSubagentDepth: this.delegationDecisionConfig.maxDepth,
-            },
-          );
-          if (graphDiagnostics.length > 0) {
-            plannerSummaryState.diagnostics.push(...graphDiagnostics);
-            plannerSummaryState.routeReason = "planner_validation_failed";
-          } else if (plannerPlan.reason) {
-            plannerSummaryState.routeReason = plannerPlan.reason;
-          }
-          plannerSummaryState.plannedSteps = plannerPlan.steps.length;
-          plannedSubagentSteps = plannerPlan.steps.filter(
-            (step) => step.stepType === "subagent_task",
-          ).length;
-          plannedDeterministicSteps = plannerPlan.steps.filter(
-            (step) => step.stepType === "deterministic_tool",
-          ).length;
-          plannedSynthesisSteps = plannerPlan.steps.filter(
-            (step) => step.stepType === "synthesis",
-          ).length;
-          plannedFanout = plannedSubagentSteps;
-          plannedDependencyDepth = ChatExecutor.computePlannerGraphDepth(
-            plannerPlan.steps.map((step) => step.name),
-            plannerPlan.edges,
-          ).maxDepth;
-          const subagentSteps = plannerPlan.steps.filter(
-            (step): step is PlannerSubAgentTaskStepIntent =>
-              step.stepType === "subagent_task",
-          );
-          if (subagentSteps.length > 0) {
-            const synthesisSteps = plannerPlan.steps.filter(
-              (step) => step.stepType === "synthesis",
-            ).length;
-            const highRiskPlan = ChatExecutor.isHighRiskSubagentPlan(
-              subagentSteps,
-            );
-            trajectoryContextClusterId = deriveDelegationContextClusterId({
-              complexityScore: plannerDecision.score,
-              subagentStepCount: subagentSteps.length,
-              hasHistory,
-              highRiskPlan,
-            });
-
-            if (this.delegationBanditTuner) {
-              selectedBanditArm = this.delegationBanditTuner.selectArm({
-                contextClusterId: trajectoryContextClusterId,
-                preferredArmId: this.delegationDefaultStrategyArmId,
-              });
-              tunedDelegationThreshold =
-                this.delegationBanditTuner.applyThresholdOffset(
-                  baseDelegationThreshold,
-                  selectedBanditArm.armId,
-                );
-              plannerSummaryState.delegationPolicyTuning = {
-                enabled: true,
-                contextClusterId: trajectoryContextClusterId,
-                selectedArmId: selectedBanditArm.armId,
-                selectedArmReason: selectedBanditArm.reason,
-                tunedThreshold: tunedDelegationThreshold,
-                exploration: selectedBanditArm.exploration,
-                finalReward: undefined,
-                usefulDelegation: undefined,
-                usefulDelegationScore: undefined,
-                rewardProxyVersion: undefined,
-              };
-            } else {
-              plannerSummaryState.delegationPolicyTuning = {
-                enabled: false,
-                contextClusterId: trajectoryContextClusterId,
-                selectedArmId: this.delegationDefaultStrategyArmId,
-                selectedArmReason: "fallback",
-                tunedThreshold: baseDelegationThreshold,
-                exploration: false,
-                finalReward: undefined,
-                usefulDelegation: undefined,
-                usefulDelegationScore: undefined,
-                rewardProxyVersion: undefined,
-              };
-            }
-
-            const tunedDecisionConfig: DelegationDecisionConfig = {
-              enabled: this.delegationDecisionConfig.enabled,
-              mode: this.delegationDecisionConfig.mode,
-              scoreThreshold: tunedDelegationThreshold,
-              maxFanoutPerTurn: this.delegationDecisionConfig.maxFanoutPerTurn,
-              maxDepth: this.delegationDecisionConfig.maxDepth,
-              handoffMinPlannerConfidence:
-                this.delegationDecisionConfig.handoffMinPlannerConfidence,
-              hardBlockedTaskClasses: [
-                ...this.delegationDecisionConfig.hardBlockedTaskClasses,
-              ],
-            };
-            const delegationDecision = assessDelegationDecision({
-              messageText,
-              plannerConfidence: plannerPlan.confidence,
-              complexityScore: plannerDecision.score,
-              totalSteps: plannerPlan.steps.length,
-              synthesisSteps,
-              edges: plannerPlan.edges,
-              subagentSteps: subagentSteps.map((step) => ({
-                name: step.name,
-                dependsOn: step.dependsOn,
-                acceptanceCriteria: step.acceptanceCriteria,
-                requiredToolCapabilities: step.requiredToolCapabilities,
-                contextRequirements: step.contextRequirements,
-                maxBudgetHint: step.maxBudgetHint,
-                canRunParallel: step.canRunParallel,
-              })),
-              config: tunedDecisionConfig,
-            });
-            plannerSummaryState.delegationDecision = delegationDecision;
-            if (!delegationDecision.shouldDelegate) {
-              plannerSummaryState.routeReason =
-                `delegation_veto_${delegationDecision.reason}`;
-              plannerSummaryState.diagnostics.push({
-                category: "policy",
-                code: "delegation_veto",
-                message:
-                  `Delegation vetoed by policy scorer: ${delegationDecision.reason}`,
-                details: {
-                  reason: delegationDecision.reason,
-                  threshold: delegationDecision.threshold,
-                  utilityScore: Number(
-                    delegationDecision.utilityScore.toFixed(4),
-                  ),
-                  safetyRisk: Number(delegationDecision.safetyRisk.toFixed(4)),
-                },
-              });
-            }
-          }
-          const deterministicSteps = plannerPlan.steps.filter(
-            (step): step is PlannerDeterministicToolStepIntent =>
-              step.stepType === "deterministic_tool",
-          );
-          const plannerPipelineSteps: PipelinePlannerStep[] = plannerPlan.steps.map(
-            (step) => {
-              if (step.stepType === "deterministic_tool") {
-                return {
-                  name: step.name,
-                  stepType: step.stepType,
-                  dependsOn: step.dependsOn,
-                  tool: step.tool,
-                  args: step.args,
-                  onError: step.onError,
-                  maxRetries: step.maxRetries,
-                };
-              }
-              if (step.stepType === "subagent_task") {
-                return {
-                  name: step.name,
-                  stepType: step.stepType,
-                  dependsOn: step.dependsOn,
-                  objective: step.objective,
-                  inputContract: step.inputContract,
-                  acceptanceCriteria: step.acceptanceCriteria,
-                  requiredToolCapabilities: step.requiredToolCapabilities,
-                  contextRequirements: step.contextRequirements,
-                  maxBudgetHint: step.maxBudgetHint,
-                  canRunParallel: step.canRunParallel,
-                };
-              }
-              return {
-                name: step.name,
-                stepType: step.stepType,
-                dependsOn: step.dependsOn,
-                objective: step.objective,
-              };
-            },
-          );
-          const plannerExecutionContext = ChatExecutor.buildPlannerExecutionContext(
-            messageText,
-            history,
-            messages,
-            messageSections,
-            activeRoutedToolNames.length > 0
-              ? activeRoutedToolNames
-              : (this.allowedTools ? [...this.allowedTools] : undefined),
-          );
-          const hasExecutablePlannerSteps =
-            deterministicSteps.length > 0 ||
-            (
-              subagentSteps.length > 0 &&
-              plannerSummaryState.delegationDecision?.shouldDelegate === true
-            );
-
-          if (
-            hasExecutablePlannerSteps &&
-            plannerSummaryState.routeReason !== "planner_validation_failed"
-          ) {
-            if (deterministicSteps.length > effectiveToolBudget) {
-              setStopReason(
-                "budget_exceeded",
-                `Planner produced ${deterministicSteps.length} deterministic steps but tool budget is ${effectiveToolBudget}`,
-              );
-              finalContent =
-                `Planned ${deterministicSteps.length} deterministic steps, ` +
-                `but request tool budget is ${effectiveToolBudget}.`;
-              plannerHandled = true;
-            } else {
-              const pipeline: Pipeline = {
-                id: `planner:${sessionId}:${Date.now()}`,
-                createdAt: Date.now(),
-                context: { results: {} },
-                steps: deterministicSteps.map((step) => ({
-                  name: step.name,
-                  tool: step.tool,
-                  args: step.args,
-                  onError: step.onError,
-                  maxRetries: step.maxRetries,
-                })),
-                plannerSteps: plannerPipelineSteps,
-                edges: plannerPlan.edges,
-                maxParallelism: this.delegationDecisionConfig.maxFanoutPerTurn,
-                plannerContext: plannerExecutionContext,
-              };
-
-              const shouldRunSubagentVerifier =
-                subagentSteps.length > 0 &&
-                plannerSummaryState.delegationDecision?.shouldDelegate === true &&
-                (
-                  this.subagentVerifierConfig.enabled ||
-                  this.subagentVerifierConfig.force
-                );
-              const {
-                verifierRounds,
-                verificationDecision,
-                pipelineResult,
-              } = await this.executePlannerPipelineWithVerifier({
-                pipeline,
-                plannerPlan,
-                subagentSteps,
-                deterministicSteps,
-                plannerExecutionContext,
-                shouldRunSubagentVerifier,
-                plannerSummaryState,
-                checkRequestTimeout,
-                runPipelineWithGlobalTimeout,
-                runSubagentVerifierRound,
-                appendToolRecord,
-                setStopReason,
-              });
-
-              if (
-                shouldRunSubagentVerifier &&
-                verifierRounds === 0 &&
-                !plannerSummaryState.subagentVerification.performed
-              ) {
-                plannerSummaryState.subagentVerification = {
-                  enabled: true,
-                  performed: false,
-                  rounds: 0,
-                  overall: "skipped",
-                  confidence: 1,
-                  unresolvedItems: [],
-                };
-              }
-
-              if (pipelineResult) {
-                if (pipelineResult.status === "failed") {
-                  const hintedStopReason = ChatExecutor.isPipelineStopReasonHint(
-                    pipelineResult.stopReasonHint,
-                  )
-                    ? pipelineResult.stopReasonHint
-                    : "tool_error";
-                  setStopReason(
-                    hintedStopReason,
-                    pipelineResult.error ??
-                      "Deterministic pipeline execution failed",
-                  );
-                } else if (pipelineResult.status === "halted") {
-                  setStopReason(
-                    "tool_calls",
-                    `Deterministic pipeline halted at step ${
-                      (pipelineResult.resumeFrom ?? 0) + 1
-                    } awaiting approval`,
-                  );
-                }
-              } else if (stopReason === "completed") {
-                setStopReason(
-                  "timeout",
-                  timeoutDetail("planner pipeline execution"),
-                );
-              }
-
-              if (failedToolCalls > effectiveFailureBudget) {
-                setStopReason(
-                  "tool_error",
-                  `Failure budget exceeded (${failedToolCalls}/${effectiveFailureBudget}) during deterministic pipeline execution`,
-                );
-              }
-
-              if (
-                pipelineResult &&
-                (plannerPlan.requiresSynthesis || stopReason !== "completed")
-              ) {
-                const synthesisMessages = ChatExecutor.buildPlannerSynthesisMessages(
-                  systemPrompt,
-                  messageText,
-                  plannerPlan,
-                  pipelineResult,
-                  verificationDecision,
-                );
-                const synthesisSections: PromptBudgetSection[] = [
-                  "system_anchor",
-                  "system_runtime",
-                  "user",
-                ];
-                const synthesisResponse = await callModel({
-                  phase: "planner_synthesis",
-                  callMessages: synthesisMessages,
-                  callSections: synthesisSections,
-                  onStreamChunk: activeStreamCallback,
-                  statefulSessionId: sessionId,
-                  budgetReason:
-                    "Planner synthesis blocked by max model recalls per request budget",
-                });
-                if (synthesisResponse) {
-                  response = synthesisResponse;
-                  finalContent = ChatExecutor.ensureSubagentProvenanceCitations(
-                    synthesisResponse.content,
-                    plannerPlan,
-                    pipelineResult,
-                  );
-                }
-              }
-
-              if (!finalContent) {
-                finalContent =
-                  ChatExecutor.generateFallbackContent(allToolCalls) ??
-                  ChatExecutor.summarizeToolCalls(
-                    allToolCalls.filter((call) => !call.isError),
-                  );
-              }
-              plannerHandled = true;
-            }
-          } else {
-            if (
-              !plannerSummaryState.delegationDecision ||
-              plannerSummaryState.delegationDecision.shouldDelegate
-            ) {
-              if (plannerSummaryState.routeReason !== "planner_validation_failed") {
-                plannerSummaryState.routeReason = "planner_no_deterministic_steps";
-              }
-            }
-          }
-        } else {
-          plannerSummaryState.routeReason = "planner_parse_failed";
-        }
-      }
-    }
-
-    if (!plannerHandled) {
-      response = await callModel({
-        phase: "initial",
-        callMessages: messages,
-        callSections: messageSections,
-        onStreamChunk: activeStreamCallback,
-        statefulSessionId: sessionId,
-        budgetReason:
-          "Initial completion blocked by max model recalls per request budget",
-      });
-
-      // Tool call loop — side-effect deduplication prevents the model from
-      // repeating desktop actions (e.g. opening 3 YouTube tabs). Once ANY
-      // side-effect tool executes, all others are skipped for this request.
-      let rounds = 0;
-      let sideEffectExecuted = false;
-      let remainingToolImageChars = MAX_TOOL_IMAGE_CHARS_BUDGET;
-      const emittedRecoveryHints = new Set<string>();
-      // Track consecutive identical failing calls to break stuck loops.
-      let lastFailKey = "";
-      let consecutiveFailCount = 0;
-      let consecutiveAllFailedRounds = 0;
-      let lastRoundSemanticKey = "";
-      let consecutiveSemanticDuplicateRounds = 0;
-
-      while (
-        response &&
-        response.finishReason === "tool_calls" &&
-        response.toolCalls.length > 0 &&
-        activeToolHandler &&
-        rounds < effectiveMaxToolRounds
-      ) {
-        // Check for cancellation before each round.
-        if (signal?.aborted) {
-          setStopReason("cancelled", "Execution cancelled by caller");
-          break;
-        }
-        if (checkRequestTimeout("tool loop")) {
-          break;
-        }
-        const activeCircuit = this.getActiveToolFailureCircuit(sessionId);
-        if (activeCircuit) {
-          setStopReason("no_progress", activeCircuit.reason);
-          break;
-        }
-
-        rounds++;
-        const roundToolCallStart = allToolCalls.length;
-        const activeRoutedToolSet = activeRoutedToolNames.length > 0
-          ? new Set(activeRoutedToolNames)
-          : null;
-        let expandAfterRound = false;
-
-        // Append the assistant message with tool calls.
-        pushMessage(
-          {
-            role: "assistant",
-            content: response.content,
-            toolCalls: response.toolCalls,
-          },
-          "assistant_runtime",
-        );
-
-        let abortRound = false;
-        for (const toolCall of response.toolCalls) {
-          if (checkRequestTimeout(`tool "${toolCall.name}" dispatch`)) {
-            abortRound = true;
-            break;
-          }
-          if (allToolCalls.length >= effectiveToolBudget) {
-            setStopReason(
-              "budget_exceeded",
-              `Tool budget exceeded (${effectiveToolBudget} per request)`,
-            );
-            abortRound = true;
-            break;
-          }
-
-          if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name) && sideEffectExecuted) {
-            const skipResult = safeStringify({
-              error: `Skipped "${toolCall.name}" — a desktop action was already performed. Combine actions into a single tool call.`,
-            });
-            pushMessage(
-              {
-                role: "tool",
-                content: skipResult,
-                toolCallId: toolCall.id,
-                toolName: toolCall.name,
-              },
-              "tools",
-            );
-            appendToolRecord({
-              name: toolCall.name,
-              args: {},
-              result: skipResult,
-              isError: true,
-              durationMs: 0,
-            });
-            continue;
-          }
-          if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name)) sideEffectExecuted = true;
-
-          // Global allowlist check.
-          if (this.allowedTools && !this.allowedTools.has(toolCall.name)) {
-            const errorResult = safeStringify({
-              error: `Tool "${toolCall.name}" is not permitted`,
-            });
-            pushMessage(
-              {
-                role: "tool",
-                content: errorResult,
-                toolCallId: toolCall.id,
-                toolName: toolCall.name,
-              },
-              "tools",
-            );
-            appendToolRecord({
-              name: toolCall.name,
-              args: {},
-              result: errorResult,
-              isError: true,
-              durationMs: 0,
-            });
-            continue;
-          }
-          // Dynamic routed subset check.
-          if (activeRoutedToolSet && !activeRoutedToolSet.has(toolCall.name)) {
-            routedToolMisses++;
-            const errorResult = safeStringify({
-              error:
-                `Tool "${toolCall.name}" was not available in the routed tool subset for this turn`,
-              routingMiss: true,
-            });
-            pushMessage(
-              {
-                role: "tool",
-                content: errorResult,
-                toolCallId: toolCall.id,
-                toolName: toolCall.name,
-              },
-              "tools",
-            );
-            appendToolRecord({
-              name: toolCall.name,
-              args: {},
-              result: errorResult,
-              isError: true,
-              durationMs: 0,
-            });
-            if (canExpandOnRoutingMiss && !routedToolsExpanded) {
-              expandAfterRound = true;
-            }
-            continue;
-          }
-
-          // Parse arguments.
-          let args: Record<string, unknown>;
-          try {
-            const parsed = JSON.parse(toolCall.arguments) as unknown;
-            if (
-              typeof parsed !== "object" ||
-              parsed === null ||
-              Array.isArray(parsed)
-            ) {
-              throw new Error("Tool arguments must be a JSON object");
-            }
-            args = parsed as Record<string, unknown>;
-          } catch (parseErr) {
-            const errorResult = safeStringify({
-              error: `Invalid tool arguments: ${(parseErr as Error).message}`,
-            });
-            pushMessage(
-              {
-                role: "tool",
-                content: errorResult,
-                toolCallId: toolCall.id,
-                toolName: toolCall.name,
-              },
-              "tools",
-            );
-            appendToolRecord({
-              name: toolCall.name,
-              args: {},
-              result: errorResult,
-              isError: true,
-              durationMs: 0,
-            });
-            continue;
-          }
-
-          // Execute tool.
-          const toolStart = Date.now();
-          let result = safeStringify({ error: "Tool execution failed" });
-          let isError = false;
-          let toolFailed = false;
-          let transportFailure = false;
-          let timedOut = false;
-          let finalToolTimeoutMs = this.toolCallTimeoutMs;
-          let retrySuppressedReason: string | undefined;
-          let retryCount = 0;
-          const maxToolRetries = Math.max(
-            0,
-            this.retryPolicyMatrix.tool_error.maxRetries,
-          );
-
-          for (let attempt = 0; attempt <= maxToolRetries; attempt++) {
-            const remainingRequestMs = getRemainingRequestMs();
-            const toolTimeoutMs = Math.min(
-              this.toolCallTimeoutMs,
-              Math.max(1, remainingRequestMs),
-            );
-            finalToolTimeoutMs = toolTimeoutMs;
-            let toolTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
-            const toolCallPromise = (async (): Promise<{
-              result: string;
-              isError: boolean;
-              timedOut: boolean;
-              threw: boolean;
-            }> => {
-              try {
-                const value = await activeToolHandler(toolCall.name, args);
-                return {
-                  result: value,
-                  isError: false,
-                  timedOut: false,
-                  threw: false,
-                };
-              } catch (toolErr) {
-                return {
-                  result: safeStringify({ error: (toolErr as Error).message }),
-                  isError: true,
-                  timedOut: false,
-                  threw: true,
-                };
-              }
-            })();
-            const timeoutPromise = new Promise<{
-              result: string;
-              isError: boolean;
-              timedOut: boolean;
-              threw: boolean;
-            }>((resolve) => {
-              toolTimeoutHandle = setTimeout(() => {
-                resolve({
-                  result: safeStringify({
-                    error: `Tool "${toolCall.name}" timed out after ${toolTimeoutMs}ms`,
-                  }),
-                  isError: true,
-                  timedOut: true,
-                  threw: false,
-                });
-              }, toolTimeoutMs);
-            });
-            const toolOutcome = await Promise.race([
-              toolCallPromise,
-              timeoutPromise,
-            ]);
-            if (toolTimeoutHandle !== undefined) {
-              clearTimeout(toolTimeoutHandle);
-            }
-
-            result = toolOutcome.result;
-            isError = toolOutcome.isError;
-            timedOut = toolOutcome.timedOut;
-
-            toolFailed = didToolCallFail(isError, result);
-            const failureText = toolFailed
-              ? extractToolFailureText({
-                name: toolCall.name,
-                args,
-                result,
-                isError: toolFailed,
-                durationMs: 0,
-              })
-              : "";
-            transportFailure =
-              timedOut ||
-              toolOutcome.threw ||
-              isLikelyToolTransportFailure(failureText);
-            if (!toolFailed) break;
-
-            const canRetryTransportFailure =
-              transportFailure &&
-              attempt < maxToolRetries &&
-              !signal?.aborted &&
-              getRemainingRequestMs() > 0;
-            if (!canRetryTransportFailure) break;
-
-            const highRiskTool = isHighRiskToolCall(toolCall.name);
-            const hasIdempotencyKey = hasExplicitIdempotencyKey(args);
-            const retrySafe = highRiskTool
-              ? hasIdempotencyKey
-              : isToolRetrySafe(toolCall.name);
-            if (!retrySafe) {
-              retrySuppressedReason = highRiskTool && !hasIdempotencyKey
-                ? `Suppressed auto-retry for high-risk tool "${toolCall.name}" without idempotencyKey`
-                : `Suppressed auto-retry for potentially side-effecting tool "${toolCall.name}"`;
-              break;
-            }
-
-            retryCount++;
-          }
-          const toolDuration = Date.now() - toolStart;
-          if (retryCount > 0) {
-            result = enrichToolResultMetadata(result, { retryAttempts: retryCount });
-          }
-          if (retrySuppressedReason) {
-            result = enrichToolResultMetadata(result, {
-              retrySuppressedReason,
-            });
-          }
-          if (timedOut && toolFailed) {
-            setStopReason(
-              "timeout",
-              `Tool "${toolCall.name}" timed out after ${finalToolTimeoutMs}ms`,
-            );
-            abortRound = true;
-          }
-
-          if (
-            this.toolFailureBreakerEnabled &&
-            toolFailed
-          ) {
-            const failKey = ChatExecutor.buildSemanticToolCallKey(toolCall.name, args);
-            const circuitReason = this.recordToolFailurePattern(
-              sessionId,
-              failKey,
-              toolCall.name,
-            );
-            if (circuitReason) {
-              setStopReason("no_progress", circuitReason);
-              abortRound = true;
-              result = enrichToolResultMetadata(result, {
-                circuitBreaker: "open",
-                circuitBreakerReason: circuitReason,
-              });
-            }
-          }
-
-          appendToolRecord({
-            name: toolCall.name,
-            args,
-            result,
-            isError: toolFailed,
-            durationMs: toolDuration,
-          });
-
-          if (failedToolCalls > effectiveFailureBudget) {
-            setStopReason(
-              "tool_error",
-              `Failure budget exceeded (${failedToolCalls}/${effectiveFailureBudget})`,
-            );
-            abortRound = true;
-          }
-
-          // Track consecutive semantic failures to detect stuck loops.
-          const failDetected = toolFailed;
-          const semanticToolKey = ChatExecutor.buildSemanticToolCallKey(
-            toolCall.name,
-            args,
-          );
-          const failKey = failDetected ? semanticToolKey : "";
-          if (!failDetected && this.toolFailureBreakerEnabled) {
-            this.clearToolFailurePattern(sessionId, semanticToolKey);
-          }
-          if (failDetected && failKey === lastFailKey) {
-            consecutiveFailCount++;
-          } else {
-            lastFailKey = failKey;
-            consecutiveFailCount = failDetected ? 1 : 0;
-          }
-
-          const promptToolContent = ChatExecutor.buildPromptToolContent(
-            result,
-            remainingToolImageChars,
-          );
-          remainingToolImageChars = promptToolContent.remainingImageBudget;
-          pushMessage(
-            {
-              role: "tool",
-              content: promptToolContent.content,
-              toolCallId: toolCall.id,
-              toolName: toolCall.name,
-            },
-            "tools",
-          );
-
-          if (abortRound) break;
-        }
-
-        // Check for cancellation before re-calling LLM.
-        if (signal?.aborted) {
-          setStopReason("cancelled", "Execution cancelled by caller");
-          break;
-        }
-        if (checkRequestTimeout("tool follow-up")) {
-          break;
-        }
-
-        const roundCalls = allToolCalls.slice(roundToolCallStart);
-        if (abortRound) break;
-
-        // Break stuck loops — if semantically equivalent failing call repeats
-        // too many times, stop and surface no-progress.
-        if (consecutiveFailCount >= MAX_CONSECUTIVE_IDENTICAL_FAILURES) {
-          setStopReason(
-            "no_progress",
-            "Detected repeated semantically-equivalent failing tool calls",
-          );
-          break;
-        }
-
-        // Break stuck loops — if all tool calls fail for multiple consecutive
-        // rounds, stop retrying and let the model respond with what it learned.
-        if (roundCalls.length > 0) {
-          const roundFailures = roundCalls.filter((call) =>
-            didToolCallFail(call.isError, call.result),
-          ).length;
-          if (roundFailures === roundCalls.length) {
-            consecutiveAllFailedRounds++;
-          } else {
-            consecutiveAllFailedRounds = 0;
-            consecutiveSemanticDuplicateRounds = 0;
-            lastRoundSemanticKey = "";
-          }
-          if (consecutiveAllFailedRounds >= MAX_CONSECUTIVE_ALL_FAILED_ROUNDS) {
-            setStopReason(
-              "no_progress",
-              `All tool calls failed for ${MAX_CONSECUTIVE_ALL_FAILED_ROUNDS} consecutive rounds`,
-            );
-            break;
-          }
-
-          if (roundFailures === roundCalls.length) {
-            const roundSemanticKey = roundCalls
-              .map((call) =>
-                ChatExecutor.buildSemanticToolCallKey(call.name, call.args),
-              )
-              .sort()
-              .join("|");
-            if (
-              roundSemanticKey.length > 0 &&
-              roundSemanticKey === lastRoundSemanticKey
-            ) {
-              consecutiveSemanticDuplicateRounds++;
-            } else {
-              consecutiveSemanticDuplicateRounds = 0;
-            }
-            lastRoundSemanticKey = roundSemanticKey;
-            if (
-              consecutiveSemanticDuplicateRounds >=
-              MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS
-            ) {
-              setStopReason(
-                "no_progress",
-                "Detected repeated semantically equivalent tool rounds with no material progress",
-              );
-              break;
-            }
-          }
-        }
-
-        const recoveryHints = ChatExecutor.buildRecoveryHints(
-          roundCalls,
-          emittedRecoveryHints,
-        );
-        for (const hint of recoveryHints) {
-          if (this.maxRuntimeSystemHints <= 0) break;
-          const runtimeHintCount = messageSections.filter(
-            (section) => section === "system_runtime",
-          ).length;
-          if (runtimeHintCount >= this.maxRuntimeSystemHints) break;
-          pushMessage(
-            {
-              role: "system",
-              content: `${RECOVERY_HINT_PREFIX} ${hint.message}`,
-            },
-            "system_runtime",
-          );
-        }
-
-        if (expandAfterRound && expandedRoutedToolNames.length > 0) {
-          routedToolsExpanded = true;
-          activeRoutedToolNames = expandedRoutedToolNames;
-          if (this.maxRuntimeSystemHints > 0) {
-            const runtimeHintCount = messageSections.filter(
-              (section) => section === "system_runtime",
-            ).length;
-            if (runtimeHintCount < this.maxRuntimeSystemHints) {
-              pushMessage(
-                {
-                  role: "system",
-                  content:
-                    `${RECOVERY_HINT_PREFIX} The previous tool request targeted a tool outside the routed subset. ` +
-                    "Tool availability has been expanded for one retry. Choose the best available tool and continue.",
-                },
-                "system_runtime",
-              );
-            }
-          }
-        }
-
-        // Re-call LLM.
-        const nextResponse = await callModel({
-          phase: "tool_followup",
-          callMessages: messages,
-          callSections: messageSections,
-          onStreamChunk: activeStreamCallback,
-          statefulSessionId: sessionId,
-          budgetReason:
-            "Max model recalls exceeded while following up after tool calls",
-        });
-        if (!nextResponse) break;
-        response = nextResponse;
-      }
-
-      if (signal?.aborted) {
-        setStopReason("cancelled", "Execution cancelled by caller");
-      } else if (
-        response &&
-        response.finishReason === "tool_calls" &&
-        rounds >= effectiveMaxToolRounds
-      ) {
-        setStopReason(
-          "tool_calls",
-          `Reached max tool rounds (${effectiveMaxToolRounds})`,
-        );
-      }
-
-      // If the LLM returned empty content after tool calls (common when maxToolRounds
-      // is hit while the LLM still wanted to make more calls), generate a fallback
-      // summary from the last successful tool result.
-      finalContent = response?.content ?? "";
-      if (!finalContent && allToolCalls.length > 0) {
-        finalContent =
-          ChatExecutor.generateFallbackContent(allToolCalls) ?? finalContent;
-      }
-      if (!finalContent && stopReason !== "completed" && stopReasonDetail) {
-        finalContent = stopReasonDetail;
-      }
-    }
-
-    checkRequestTimeout("finalization");
-
-    // Update session token budget with all model calls so far.
-    this.trackTokenUsage(sessionId, cumulativeUsage.totalTokens);
-
-    // Response evaluation (optional critic)
-    if (this.evaluator && finalContent && stopReason === "completed") {
-      const minScore = this.evaluator.minScore ?? 0.7;
-      const maxRetries = this.evaluator.maxRetries ?? 1;
-      let retryCount = 0;
-      let currentContent = finalContent;
-
-      while (retryCount <= maxRetries) {
-        if (checkRequestTimeout("response evaluation")) {
-          break;
-        }
-        // Skip evaluation if token budget would be exceeded.
-        if (this.sessionTokenBudget !== undefined) {
-          const used = this.sessionTokens.get(sessionId) ?? 0;
-          if (used >= this.sessionTokenBudget) break;
-        }
-        if (!hasModelRecallBudget()) {
-          setStopReason(
-            "budget_exceeded",
-            "Max model recalls exceeded during response evaluation",
-          );
-          break;
-        }
-
-        const evalResult = await this.evaluateResponse(currentContent, messageText);
-        modelCalls++;
-        if (evalResult.usedFallback) usedFallback = true;
-        this.accumulateUsage(cumulativeUsage, evalResult.response.usage);
-        this.trackTokenUsage(sessionId, evalResult.response.usage.totalTokens);
-        callUsage.push(
-          this.createCallUsageRecord({
-            callIndex: ++callIndex,
-            phase: "evaluator",
-            providerName: evalResult.providerName,
-            response: evalResult.response,
-            beforeBudget: evalResult.beforeBudget,
-            afterBudget: evalResult.afterBudget,
-            budgetDiagnostics: evalResult.budgetDiagnostics,
-          }),
-        );
-
-        if (evalResult.score >= minScore || retryCount === maxRetries) {
-          evaluation = {
-            score: evalResult.score,
-            feedback: evalResult.feedback,
-            passed: evalResult.score >= minScore,
-            retryCount,
-          };
-          finalContent = currentContent;
-          break;
-        }
-
-        retryCount++;
-        pushMessage(
-          { role: "assistant", content: currentContent },
-          "assistant_runtime",
-        );
-        pushMessage(
-          {
-            role: "system",
-            content: `Response scored ${evalResult.score.toFixed(2)}. Feedback: ${evalResult.feedback}\nPlease improve your response.`,
-          },
-          "system_runtime",
-        );
-
-        if (!hasModelRecallBudget()) {
-          setStopReason(
-            "budget_exceeded",
-            "Max model recalls exceeded during evaluator retry",
-          );
-          break;
-        }
-        if (checkRequestTimeout("evaluator retry")) {
-          break;
-        }
-        let retry: FallbackResult;
-        try {
-          retry = await this.callWithFallback(
-            messages,
-            activeStreamCallback,
-            messageSections,
-            {
-              statefulSessionId: sessionId,
-              ...(params.toolRouting
-                ? { routedToolNames: activeRoutedToolNames }
-                : {}),
-            },
-          );
-        } catch (error) {
-          const annotated = this.annotateFailureError(
-            error,
-            "evaluator retry",
-          );
-          setStopReason(annotated.stopReason, annotated.stopReasonDetail);
-          throw annotated.error;
-        }
-        modelCalls++;
-        this.accumulateUsage(cumulativeUsage, retry.response.usage);
-        this.trackTokenUsage(sessionId, retry.response.usage.totalTokens);
-        callUsage.push(
-          this.createCallUsageRecord({
-            callIndex: ++callIndex,
-            phase: "evaluator_retry",
-            providerName: retry.providerName,
-            response: retry.response,
-            beforeBudget: retry.beforeBudget,
-            afterBudget: retry.afterBudget,
-            budgetDiagnostics: retry.budgetDiagnostics,
-          }),
-        );
-        providerName = retry.providerName;
-        responseModel = retry.response.model;
-        if (retry.usedFallback) usedFallback = true;
-        currentContent = retry.response.content || currentContent;
-      }
-    }
-
-    const durationMs = Date.now() - startTime;
-    const stopReasonQualityBase = stopReason === "completed"
+  private recordOutcomeAndFinalize(ctx: ExecutionContext): {
+    plannerSummary: ChatPlannerSummary;
+    durationMs: number;
+  } {
+    const durationMs = Date.now() - ctx.startTime;
+    const stopReasonQualityBase = ctx.stopReason === "completed"
       ? 0.85
-      : stopReason === "tool_calls"
+      : ctx.stopReason === "tool_calls"
         ? 0.6
         : 0.25;
-    const verifierBonus = plannerSummaryState.subagentVerification.performed
+    const verifierBonus = ctx.plannerSummaryState.subagentVerification.performed
       ? (
-        plannerSummaryState.subagentVerification.overall === "pass"
+        ctx.plannerSummaryState.subagentVerification.overall === "pass"
           ? 0.1
-          : plannerSummaryState.subagentVerification.overall === "retry"
+          : ctx.plannerSummaryState.subagentVerification.overall === "retry"
             ? 0
             : -0.15
       )
       : 0;
-    const evaluatorBonus = evaluation
-      ? (evaluation.passed ? 0.1 : -0.1)
+    const evaluatorBonus = ctx.evaluation
+      ? (ctx.evaluation.passed ? 0.1 : -0.1)
       : 0;
-    const failurePenalty = Math.min(0.25, failedToolCalls * 0.05);
+    const failurePenalty = Math.min(0.25, ctx.failedToolCalls * 0.05);
     const qualityProxy = Math.max(
       0,
       Math.min(
@@ -2471,25 +880,25 @@ export class ChatExecutor {
     );
     const rewardSignal = computeDelegationFinalReward({
       qualityProxy,
-      tokenCost: cumulativeUsage.totalTokens,
+      tokenCost: ctx.cumulativeUsage.totalTokens,
       latencyMs: durationMs,
       errorCount:
-        failedToolCalls + (stopReason === "completed" ? 0 : 1),
+        ctx.failedToolCalls + (ctx.stopReason === "completed" ? 0 : 1),
     });
-    const estimatedRecallsAvoided = plannerSummaryState.used
+    const estimatedRecallsAvoided = ctx.plannerSummaryState.used
       ? Math.max(
           0,
-          plannerSummaryState.deterministicStepsExecuted -
-            Math.max(0, modelCalls - plannerSummaryState.plannerCalls),
+          ctx.plannerSummaryState.deterministicStepsExecuted -
+            Math.max(0, ctx.modelCalls - ctx.plannerSummaryState.plannerCalls),
         )
       : 0;
     const delegatedThisTurn =
-      plannerSummaryState.delegationDecision?.shouldDelegate === true;
-    const verifierSnapshot = plannerSummaryState.subagentVerification;
+      ctx.plannerSummaryState.delegationDecision?.shouldDelegate === true;
+    const verifierSnapshot = ctx.plannerSummaryState.subagentVerification;
     const usefulnessProxy = computeUsefulDelegationProxy({
       delegated: delegatedThisTurn,
-      stopReason,
-      failedToolCalls,
+      stopReason: ctx.stopReason,
+      failedToolCalls: ctx.failedToolCalls,
       estimatedRecallsAvoided,
       verifier: {
         performed: verifierSnapshot.performed,
@@ -2503,17 +912,17 @@ export class ChatExecutor {
       : 0;
 
     if (
-      selectedBanditArm &&
+      ctx.selectedBanditArm &&
       this.delegationBanditTuner &&
-      plannerSummaryState.delegationPolicyTuning.enabled
+      ctx.plannerSummaryState.delegationPolicyTuning.enabled
     ) {
       this.delegationBanditTuner.recordOutcome({
-        contextClusterId: trajectoryContextClusterId,
-        armId: selectedBanditArm.armId,
+        contextClusterId: ctx.trajectoryContextClusterId,
+        armId: ctx.selectedBanditArm.armId,
         reward: policyReward,
       });
-      plannerSummaryState.delegationPolicyTuning = {
-        ...plannerSummaryState.delegationPolicyTuning,
+      ctx.plannerSummaryState.delegationPolicyTuning = {
+        ...ctx.plannerSummaryState.delegationPolicyTuning,
         finalReward: policyReward,
         usefulDelegation: usefulnessProxy.useful,
         usefulDelegationScore: usefulnessProxy.score,
@@ -2522,32 +931,32 @@ export class ChatExecutor {
     }
 
     if (this.delegationTrajectorySink) {
-      const selectedTools = activeRoutedToolNames.length > 0
-        ? [...activeRoutedToolNames]
+      const selectedTools = ctx.activeRoutedToolNames.length > 0
+        ? [...ctx.activeRoutedToolNames]
         : (this.allowedTools ? [...this.allowedTools] : []);
       this.delegationTrajectorySink.record({
         schemaVersion: 1,
-        traceId: trajectoryTraceId,
-        turnId: parentTurnId,
+        traceId: ctx.trajectoryTraceId,
+        turnId: ctx.parentTurnId,
         turnType: "parent",
         timestampMs: Date.now(),
         stateFeatures: {
-          sessionId,
-          contextClusterId: trajectoryContextClusterId,
-          complexityScore: plannerDecision.score,
-          plannerStepCount: plannerSummaryState.plannedSteps,
-          subagentStepCount: plannedSubagentSteps,
-          deterministicStepCount: plannedDeterministicSteps,
-          synthesisStepCount: plannedSynthesisSteps,
-          dependencyDepth: plannedDependencyDepth,
-          fanout: plannedFanout,
+          sessionId: ctx.sessionId,
+          contextClusterId: ctx.trajectoryContextClusterId,
+          complexityScore: ctx.plannerDecision.score,
+          plannerStepCount: ctx.plannerSummaryState.plannedSteps,
+          subagentStepCount: ctx.plannedSubagentSteps,
+          deterministicStepCount: ctx.plannedDeterministicSteps,
+          synthesisStepCount: ctx.plannedSynthesisSteps,
+          dependencyDepth: ctx.plannedDependencyDepth,
+          fanout: ctx.plannedFanout,
         },
         action: {
           delegated:
-            plannerSummaryState.delegationDecision?.shouldDelegate === true,
+            ctx.plannerSummaryState.delegationDecision?.shouldDelegate === true,
           strategyArmId:
-            selectedBanditArm?.armId ?? this.delegationDefaultStrategyArmId,
-          threshold: tunedDelegationThreshold,
+            ctx.selectedBanditArm?.armId ?? this.delegationDefaultStrategyArmId,
+          threshold: ctx.tunedDelegationThreshold,
           selectedTools,
           childConfig: {
             maxDepth: this.delegationDecisionConfig.maxDepth,
@@ -2557,17 +966,17 @@ export class ChatExecutor {
         },
         immediateOutcome: {
           qualityProxy,
-          tokenCost: cumulativeUsage.totalTokens,
+          tokenCost: ctx.cumulativeUsage.totalTokens,
           latencyMs: durationMs,
           errorCount:
-            failedToolCalls + (stopReason === "completed" ? 0 : 1),
-          ...(stopReason !== "completed" ? { errorClass: stopReason } : {}),
+            ctx.failedToolCalls + (ctx.stopReason === "completed" ? 0 : 1),
+          ...(ctx.stopReason !== "completed" ? { errorClass: ctx.stopReason } : {}),
         },
         finalReward: rewardSignal,
         metadata: {
-          plannerUsed: plannerSummaryState.used,
-          routeReason: plannerSummaryState.routeReason ?? "none",
-          stopReason,
+          plannerUsed: ctx.plannerSummaryState.used,
+          routeReason: ctx.plannerSummaryState.routeReason ?? "none",
+          stopReason: ctx.stopReason,
           usefulDelegation: usefulnessProxy.useful,
           usefulDelegationScore: Number(usefulnessProxy.score.toFixed(4)),
           usefulDelegationProxyVersion: DELEGATION_USEFULNESS_PROXY_VERSION,
@@ -2576,61 +985,1111 @@ export class ChatExecutor {
     }
 
     const plannerSummary: ChatPlannerSummary = {
-      enabled: plannerSummaryState.enabled,
-      used: plannerSummaryState.used,
-      routeReason: plannerSummaryState.routeReason,
-      complexityScore: plannerSummaryState.complexityScore,
-      plannerCalls: plannerSummaryState.plannerCalls,
-      plannedSteps: plannerSummaryState.plannedSteps,
-      deterministicStepsExecuted: plannerSummaryState.deterministicStepsExecuted,
-      estimatedRecallsAvoided: plannerSummaryState.used
+      enabled: ctx.plannerSummaryState.enabled,
+      used: ctx.plannerSummaryState.used,
+      routeReason: ctx.plannerSummaryState.routeReason,
+      complexityScore: ctx.plannerSummaryState.complexityScore,
+      plannerCalls: ctx.plannerSummaryState.plannerCalls,
+      plannedSteps: ctx.plannerSummaryState.plannedSteps,
+      deterministicStepsExecuted: ctx.plannerSummaryState.deterministicStepsExecuted,
+      estimatedRecallsAvoided: ctx.plannerSummaryState.used
         ? estimatedRecallsAvoided
         : 0,
-      diagnostics: plannerSummaryState.diagnostics.length > 0
-        ? plannerSummaryState.diagnostics
+      diagnostics: ctx.plannerSummaryState.diagnostics.length > 0
+        ? ctx.plannerSummaryState.diagnostics
         : undefined,
-      delegationDecision: plannerSummaryState.delegationDecision,
-      subagentVerification: plannerSummaryState.subagentVerification.enabled
-        ? plannerSummaryState.subagentVerification
+      delegationDecision: ctx.plannerSummaryState.delegationDecision,
+      subagentVerification: ctx.plannerSummaryState.subagentVerification.enabled
+        ? ctx.plannerSummaryState.subagentVerification
         : undefined,
-      delegationPolicyTuning: plannerSummaryState.delegationPolicyTuning.enabled
-        ? plannerSummaryState.delegationPolicyTuning
+      delegationPolicyTuning: ctx.plannerSummaryState.delegationPolicyTuning.enabled
+        ? ctx.plannerSummaryState.delegationPolicyTuning
         : undefined,
     };
 
-    finalContent = ChatExecutor.sanitizeFinalContent(finalContent);
-    finalContent = ChatExecutor.reconcileStructuredToolOutcome(
-      finalContent,
-      allToolCalls,
-    );
-    const statefulSummary = ChatExecutor.summarizeStateful(callUsage);
-    const toolRoutingSummary = params.toolRouting
-      ? {
-        enabled: true,
-        initialToolCount: initialRoutedToolNames.length,
-        finalToolCount: activeRoutedToolNames.length,
-        routeMisses: routedToolMisses,
-        expanded: routedToolsExpanded,
+    return { plannerSummary, durationMs };
+  }
+
+  private async evaluateAndRetryResponse(ctx: ExecutionContext): Promise<void> {
+    const minScore = this.evaluator!.minScore ?? 0.7;
+    const maxRetries = this.evaluator!.maxRetries ?? 1;
+    let retryCount = 0;
+    let currentContent = ctx.finalContent;
+
+    while (retryCount <= maxRetries) {
+      if (this.checkRequestTimeout(ctx, "response evaluation")) {
+        break;
       }
-      : undefined;
+      // Skip evaluation if token budget would be exceeded.
+      if (this.sessionTokenBudget !== undefined) {
+        const used = this.sessionTokens.get(ctx.sessionId) ?? 0;
+        if (used >= this.sessionTokenBudget) break;
+      }
+      if (!this.hasModelRecallBudget(ctx)) {
+        this.setStopReason(
+          ctx,
+          "budget_exceeded",
+          "Max model recalls exceeded during response evaluation",
+        );
+        break;
+      }
 
-    return {
-      content: finalContent,
-      provider: providerName,
-      model: responseModel,
-      usedFallback,
-      toolCalls: allToolCalls,
-      tokenUsage: cumulativeUsage,
-      callUsage,
-      durationMs,
-      compacted,
-      statefulSummary,
-      toolRoutingSummary,
-      plannerSummary,
-      stopReason,
-      stopReasonDetail,
-      evaluation,
+      const evalResult = await this.evaluateResponse(currentContent, ctx.messageText);
+      ctx.modelCalls++;
+      if (evalResult.usedFallback) ctx.usedFallback = true;
+      this.accumulateUsage(ctx.cumulativeUsage, evalResult.response.usage);
+      this.trackTokenUsage(ctx.sessionId, evalResult.response.usage.totalTokens);
+      ctx.callUsage.push(
+        this.createCallUsageRecord({
+          callIndex: ++ctx.callIndex,
+          phase: "evaluator",
+          providerName: evalResult.providerName,
+          response: evalResult.response,
+          beforeBudget: evalResult.beforeBudget,
+          afterBudget: evalResult.afterBudget,
+          budgetDiagnostics: evalResult.budgetDiagnostics,
+        }),
+      );
+
+      if (evalResult.score >= minScore || retryCount === maxRetries) {
+        ctx.evaluation = {
+          score: evalResult.score,
+          feedback: evalResult.feedback,
+          passed: evalResult.score >= minScore,
+          retryCount,
+        };
+        ctx.finalContent = currentContent;
+        break;
+      }
+
+      retryCount++;
+      this.pushMessage(
+        ctx,
+        { role: "assistant", content: currentContent },
+        "assistant_runtime",
+      );
+      this.pushMessage(
+        ctx,
+        {
+          role: "system",
+          content: `Response scored ${evalResult.score.toFixed(2)}. Feedback: ${evalResult.feedback}\nPlease improve your response.`,
+        },
+        "system_runtime",
+      );
+
+      if (!this.hasModelRecallBudget(ctx)) {
+        this.setStopReason(
+          ctx,
+          "budget_exceeded",
+          "Max model recalls exceeded during evaluator retry",
+        );
+        break;
+      }
+      if (this.checkRequestTimeout(ctx, "evaluator retry")) {
+        break;
+      }
+      let retry: FallbackResult;
+      try {
+        retry = await this.callWithFallback(
+          ctx.messages,
+          ctx.activeStreamCallback,
+          ctx.messageSections,
+          {
+            statefulSessionId: ctx.sessionId,
+            ...(ctx.toolRouting
+              ? { routedToolNames: ctx.activeRoutedToolNames }
+              : {}),
+          },
+        );
+      } catch (error) {
+        const annotated = this.annotateFailureError(
+          error,
+          "evaluator retry",
+        );
+        this.setStopReason(ctx, annotated.stopReason, annotated.stopReasonDetail);
+        throw annotated.error;
+      }
+      ctx.modelCalls++;
+      this.accumulateUsage(ctx.cumulativeUsage, retry.response.usage);
+      this.trackTokenUsage(ctx.sessionId, retry.response.usage.totalTokens);
+      ctx.callUsage.push(
+        this.createCallUsageRecord({
+          callIndex: ++ctx.callIndex,
+          phase: "evaluator_retry",
+          providerName: retry.providerName,
+          response: retry.response,
+          beforeBudget: retry.beforeBudget,
+          afterBudget: retry.afterBudget,
+          budgetDiagnostics: retry.budgetDiagnostics,
+        }),
+      );
+      ctx.providerName = retry.providerName;
+      ctx.responseModel = retry.response.model;
+      if (retry.usedFallback) ctx.usedFallback = true;
+      currentContent = retry.response.content || currentContent;
+    }
+  }
+
+  private async executeToolCallLoop(ctx: ExecutionContext): Promise<void> {
+    ctx.response = await this.callModelForPhase(ctx, {
+      phase: "initial",
+      callMessages: ctx.messages,
+      callSections: ctx.messageSections,
+      onStreamChunk: ctx.activeStreamCallback,
+      statefulSessionId: ctx.sessionId,
+      budgetReason:
+        "Initial completion blocked by max model recalls per request budget",
+    });
+
+    // Tool call loop — side-effect deduplication prevents the model from
+    // repeating desktop actions (e.g. opening 3 YouTube tabs). Once ANY
+    // side-effect tool executes, all others are skipped for this request.
+    let rounds = 0;
+    const emittedRecoveryHints = new Set<string>();
+    // Track consecutive identical failing calls to break stuck loops.
+    let consecutiveAllFailedRounds = 0;
+    let lastRoundSemanticKey = "";
+    let consecutiveSemanticDuplicateRounds = 0;
+    const loopState: ToolLoopState = {
+      sideEffectExecuted: false,
+      remainingToolImageChars: MAX_TOOL_IMAGE_CHARS_BUDGET,
+      activeRoutedToolSet: null,
+      expandAfterRound: false,
+      lastFailKey: "",
+      consecutiveFailCount: 0,
     };
+
+    while (
+      ctx.response &&
+      ctx.response.finishReason === "tool_calls" &&
+      ctx.response.toolCalls.length > 0 &&
+      ctx.activeToolHandler &&
+      rounds < ctx.effectiveMaxToolRounds
+    ) {
+      // Check for cancellation before each round.
+      if (ctx.signal?.aborted) {
+        this.setStopReason(ctx, "cancelled", "Execution cancelled by caller");
+        break;
+      }
+      if (this.checkRequestTimeout(ctx, "tool loop")) {
+        break;
+      }
+      const activeCircuit = this.getActiveToolFailureCircuit(ctx.sessionId);
+      if (activeCircuit) {
+        this.setStopReason(ctx, "no_progress", activeCircuit.reason);
+        break;
+      }
+
+      rounds++;
+      const roundToolCallStart = ctx.allToolCalls.length;
+      loopState.activeRoutedToolSet = ctx.activeRoutedToolNames.length > 0
+        ? new Set(ctx.activeRoutedToolNames)
+        : null;
+      loopState.expandAfterRound = false;
+
+      // Append the assistant message with tool calls.
+      this.pushMessage(
+        ctx,
+        {
+          role: "assistant",
+          content: ctx.response.content,
+          toolCalls: sanitizeToolCallsForReplay(
+            ctx.response.toolCalls,
+          ),
+        },
+        "assistant_runtime",
+      );
+
+      let abortRound = false;
+      for (const toolCall of ctx.response.toolCalls) {
+        const action = await this.executeSingleToolCall(ctx, toolCall, loopState);
+        if (action === "abort_loop" || action === "abort_round") {
+          abortRound = true;
+          break;
+        }
+        // "skip" and "processed" both continue the loop
+      }
+
+      // Check for cancellation before re-calling LLM.
+      if (ctx.signal?.aborted) {
+        this.setStopReason(ctx, "cancelled", "Execution cancelled by caller");
+        break;
+      }
+      if (this.checkRequestTimeout(ctx, "tool follow-up")) {
+        break;
+      }
+
+      const roundCalls = ctx.allToolCalls.slice(roundToolCallStart);
+      if (abortRound) break;
+
+      // Break stuck loops — if semantically equivalent failing call repeats
+      // too many times, stop and surface no-progress.
+      if (loopState.consecutiveFailCount >= MAX_CONSECUTIVE_IDENTICAL_FAILURES) {
+        this.setStopReason(
+          ctx,
+          "no_progress",
+          "Detected repeated semantically-equivalent failing tool calls",
+        );
+        break;
+      }
+
+      // Break stuck loops — if all tool calls fail for multiple consecutive
+      // rounds, stop retrying and let the model respond with what it learned.
+      if (roundCalls.length > 0) {
+        const roundFailures = roundCalls.filter((call) =>
+          didToolCallFail(call.isError, call.result),
+        ).length;
+        if (roundFailures === roundCalls.length) {
+          consecutiveAllFailedRounds++;
+        } else {
+          consecutiveAllFailedRounds = 0;
+          consecutiveSemanticDuplicateRounds = 0;
+          lastRoundSemanticKey = "";
+        }
+        if (consecutiveAllFailedRounds >= MAX_CONSECUTIVE_ALL_FAILED_ROUNDS) {
+          this.setStopReason(
+            ctx,
+            "no_progress",
+            `All tool calls failed for ${MAX_CONSECUTIVE_ALL_FAILED_ROUNDS} consecutive rounds`,
+          );
+          break;
+        }
+
+        if (roundFailures === roundCalls.length) {
+          const roundSemanticKey = roundCalls
+            .map((call) =>
+              buildSemanticToolCallKey(call.name, call.args),
+            )
+            .sort()
+            .join("|");
+          if (
+            roundSemanticKey.length > 0 &&
+            roundSemanticKey === lastRoundSemanticKey
+          ) {
+            consecutiveSemanticDuplicateRounds++;
+          } else {
+            consecutiveSemanticDuplicateRounds = 0;
+          }
+          lastRoundSemanticKey = roundSemanticKey;
+          if (
+            consecutiveSemanticDuplicateRounds >=
+            MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS
+          ) {
+            this.setStopReason(
+              ctx,
+              "no_progress",
+              "Detected repeated semantically equivalent tool rounds with no material progress",
+            );
+            break;
+          }
+        }
+      }
+
+      const recoveryHints = buildRecoveryHints(
+        roundCalls,
+        emittedRecoveryHints,
+      );
+      for (const hint of recoveryHints) {
+        if (this.maxRuntimeSystemHints <= 0) break;
+        const runtimeHintCount = ctx.messageSections.filter(
+          (section) => section === "system_runtime",
+        ).length;
+        if (runtimeHintCount >= this.maxRuntimeSystemHints) break;
+        this.pushMessage(
+          ctx,
+          {
+            role: "system",
+            content: `${RECOVERY_HINT_PREFIX} ${hint.message}`,
+          },
+          "system_runtime",
+        );
+      }
+
+      if (loopState.expandAfterRound && ctx.expandedRoutedToolNames.length > 0) {
+        ctx.routedToolsExpanded = true;
+        ctx.activeRoutedToolNames = ctx.expandedRoutedToolNames;
+        if (this.maxRuntimeSystemHints > 0) {
+          const runtimeHintCount = ctx.messageSections.filter(
+            (section) => section === "system_runtime",
+          ).length;
+          if (runtimeHintCount < this.maxRuntimeSystemHints) {
+            this.pushMessage(
+              ctx,
+              {
+                role: "system",
+                content:
+                  `${RECOVERY_HINT_PREFIX} The previous tool request targeted a tool outside the routed subset. ` +
+                  "Tool availability has been expanded for one retry. Choose the best available tool and continue.",
+              },
+              "system_runtime",
+            );
+          }
+        }
+      }
+
+      // Re-call LLM.
+      const nextResponse = await this.callModelForPhase(ctx, {
+        phase: "tool_followup",
+        callMessages: ctx.messages,
+        callSections: ctx.messageSections,
+        onStreamChunk: ctx.activeStreamCallback,
+        statefulSessionId: ctx.sessionId,
+        budgetReason:
+          "Max model recalls exceeded while following up after tool calls",
+      });
+      if (!nextResponse) break;
+      ctx.response = nextResponse;
+    }
+
+    if (ctx.signal?.aborted) {
+      this.setStopReason(ctx, "cancelled", "Execution cancelled by caller");
+    } else if (
+      ctx.response &&
+      ctx.response.finishReason === "tool_calls" &&
+      rounds >= ctx.effectiveMaxToolRounds
+    ) {
+      this.setStopReason(
+        ctx,
+        "tool_calls",
+        `Reached max tool rounds (${ctx.effectiveMaxToolRounds})`,
+      );
+    }
+
+    // If the LLM returned empty content after tool calls (common when maxToolRounds
+    // is hit while the LLM still wanted to make more calls), generate a fallback
+    // summary from the last successful tool result.
+    ctx.finalContent = ctx.response?.content ?? "";
+    if (!ctx.finalContent && ctx.allToolCalls.length > 0) {
+      ctx.finalContent =
+        generateFallbackContent(ctx.allToolCalls) ?? ctx.finalContent;
+    }
+    if (!ctx.finalContent && ctx.stopReason !== "completed" && ctx.stopReasonDetail) {
+      ctx.finalContent = ctx.stopReasonDetail;
+    }
+  }
+
+  private async executeSingleToolCall(
+    ctx: ExecutionContext,
+    toolCall: LLMToolCall,
+    loopState: ToolLoopState,
+  ): Promise<ToolCallAction> {
+    if (this.checkRequestTimeout(ctx, `tool "${toolCall.name}" dispatch`)) {
+      return "abort_loop";
+    }
+    if (ctx.allToolCalls.length >= ctx.effectiveToolBudget) {
+      this.setStopReason(
+        ctx,
+        "budget_exceeded",
+        `Tool budget exceeded (${ctx.effectiveToolBudget} per request)`,
+      );
+      return "abort_loop";
+    }
+
+    if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name) && loopState.sideEffectExecuted) {
+      const skipResult = safeStringify({
+        error: `Skipped "${toolCall.name}" — a desktop action was already performed. Combine actions into a single tool call.`,
+      });
+      this.pushMessage(
+        ctx,
+        {
+          role: "tool",
+          content: skipResult,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        },
+        "tools",
+      );
+      this.appendToolRecord(ctx, {
+        name: toolCall.name,
+        args: {},
+        result: skipResult,
+        isError: true,
+        durationMs: 0,
+      });
+      return "skip";
+    }
+    if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name)) loopState.sideEffectExecuted = true;
+
+    // Global allowlist check.
+    if (this.allowedTools && !this.allowedTools.has(toolCall.name)) {
+      const errorResult = safeStringify({
+        error: `Tool "${toolCall.name}" is not permitted`,
+      });
+      this.pushMessage(
+        ctx,
+        {
+          role: "tool",
+          content: errorResult,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        },
+        "tools",
+      );
+      this.appendToolRecord(ctx, {
+        name: toolCall.name,
+        args: {},
+        result: errorResult,
+        isError: true,
+        durationMs: 0,
+      });
+      return "skip";
+    }
+    // Dynamic routed subset check.
+    if (loopState.activeRoutedToolSet && !loopState.activeRoutedToolSet.has(toolCall.name)) {
+      ctx.routedToolMisses++;
+      const errorResult = safeStringify({
+        error:
+          `Tool "${toolCall.name}" was not available in the routed tool subset for this turn`,
+        routingMiss: true,
+      });
+      this.pushMessage(
+        ctx,
+        {
+          role: "tool",
+          content: errorResult,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        },
+        "tools",
+      );
+      this.appendToolRecord(ctx, {
+        name: toolCall.name,
+        args: {},
+        result: errorResult,
+        isError: true,
+        durationMs: 0,
+      });
+      if (ctx.canExpandOnRoutingMiss && !ctx.routedToolsExpanded) {
+        loopState.expandAfterRound = true;
+      }
+      return "skip";
+    }
+
+    // Parse arguments.
+    let args: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(toolCall.arguments) as unknown;
+      if (
+        typeof parsed !== "object" ||
+        parsed === null ||
+        Array.isArray(parsed)
+      ) {
+        throw new Error("Tool arguments must be a JSON object");
+      }
+      args = parsed as Record<string, unknown>;
+    } catch (parseErr) {
+      const errorResult = safeStringify({
+        error: `Invalid tool arguments: ${(parseErr as Error).message}`,
+      });
+      this.pushMessage(
+        ctx,
+        {
+          role: "tool",
+          content: errorResult,
+          toolCallId: toolCall.id,
+          toolName: toolCall.name,
+        },
+        "tools",
+      );
+      this.appendToolRecord(ctx, {
+        name: toolCall.name,
+        args: {},
+        result: errorResult,
+        isError: true,
+        durationMs: 0,
+      });
+      return "skip";
+    }
+
+    // Execute tool.
+    const toolStart = Date.now();
+    let result = safeStringify({ error: "Tool execution failed" });
+    let isError = false;
+    let toolFailed = false;
+    let transportFailure = false;
+    let timedOut = false;
+    let finalToolTimeoutMs = this.toolCallTimeoutMs;
+    let retrySuppressedReason: string | undefined;
+    let retryCount = 0;
+    const maxToolRetries = Math.max(
+      0,
+      this.retryPolicyMatrix.tool_error.maxRetries,
+    );
+
+    for (let attempt = 0; attempt <= maxToolRetries; attempt++) {
+      const remainingRequestMs = this.getRemainingRequestMs(ctx);
+      const toolTimeoutMs = Math.min(
+        this.toolCallTimeoutMs,
+        Math.max(1, remainingRequestMs),
+      );
+      finalToolTimeoutMs = toolTimeoutMs;
+      let toolTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      const toolCallPromise = (async (): Promise<{
+        result: string;
+        isError: boolean;
+        timedOut: boolean;
+        threw: boolean;
+      }> => {
+        try {
+          const value = await ctx.activeToolHandler!(toolCall.name, args);
+          return {
+            result: value,
+            isError: false,
+            timedOut: false,
+            threw: false,
+          };
+        } catch (toolErr) {
+          return {
+            result: safeStringify({ error: (toolErr as Error).message }),
+            isError: true,
+            timedOut: false,
+            threw: true,
+          };
+        }
+      })();
+      const timeoutPromise = new Promise<{
+        result: string;
+        isError: boolean;
+        timedOut: boolean;
+        threw: boolean;
+      }>((resolve) => {
+        toolTimeoutHandle = setTimeout(() => {
+          resolve({
+            result: safeStringify({
+              error: `Tool "${toolCall.name}" timed out after ${toolTimeoutMs}ms`,
+            }),
+            isError: true,
+            timedOut: true,
+            threw: false,
+          });
+        }, toolTimeoutMs);
+      });
+      const toolOutcome = await Promise.race([
+        toolCallPromise,
+        timeoutPromise,
+      ]);
+      if (toolTimeoutHandle !== undefined) {
+        clearTimeout(toolTimeoutHandle);
+      }
+
+      result = toolOutcome.result;
+      isError = toolOutcome.isError;
+      timedOut = toolOutcome.timedOut;
+
+      toolFailed = didToolCallFail(isError, result);
+      const failureText = toolFailed
+        ? extractToolFailureText({
+          name: toolCall.name,
+          args,
+          result,
+          isError: toolFailed,
+          durationMs: 0,
+        })
+        : "";
+      transportFailure =
+        timedOut ||
+        toolOutcome.threw ||
+        isLikelyToolTransportFailure(failureText);
+      if (!toolFailed) break;
+
+      const canRetryTransportFailure =
+        transportFailure &&
+        attempt < maxToolRetries &&
+        !ctx.signal?.aborted &&
+        this.getRemainingRequestMs(ctx) > 0;
+      if (!canRetryTransportFailure) break;
+
+      const highRiskTool = isHighRiskToolCall(toolCall.name);
+      const hasIdempotencyKey = hasExplicitIdempotencyKey(args);
+      const retrySafe = highRiskTool
+        ? hasIdempotencyKey
+        : isToolRetrySafe(toolCall.name);
+      if (!retrySafe) {
+        retrySuppressedReason = highRiskTool && !hasIdempotencyKey
+          ? `Suppressed auto-retry for high-risk tool "${toolCall.name}" without idempotencyKey`
+          : `Suppressed auto-retry for potentially side-effecting tool "${toolCall.name}"`;
+        break;
+      }
+
+      retryCount++;
+    }
+    const toolDuration = Date.now() - toolStart;
+    if (retryCount > 0) {
+      result = enrichToolResultMetadata(result, { retryAttempts: retryCount });
+    }
+    if (retrySuppressedReason) {
+      result = enrichToolResultMetadata(result, {
+        retrySuppressedReason,
+      });
+    }
+
+    let abortRound = false;
+    if (timedOut && toolFailed) {
+      this.setStopReason(
+        ctx,
+        "timeout",
+        `Tool "${toolCall.name}" timed out after ${finalToolTimeoutMs}ms`,
+      );
+      abortRound = true;
+    }
+
+    if (
+      this.toolFailureBreakerEnabled &&
+      toolFailed
+    ) {
+      const failKey = buildSemanticToolCallKey(toolCall.name, args);
+      const circuitReason = this.recordToolFailurePattern(
+        ctx.sessionId,
+        failKey,
+        toolCall.name,
+      );
+      if (circuitReason) {
+        this.setStopReason(ctx, "no_progress", circuitReason);
+        abortRound = true;
+        result = enrichToolResultMetadata(result, {
+          circuitBreaker: "open",
+          circuitBreakerReason: circuitReason,
+        });
+      }
+    }
+
+    this.appendToolRecord(ctx, {
+      name: toolCall.name,
+      args,
+      result,
+      isError: toolFailed,
+      durationMs: toolDuration,
+    });
+
+    if (ctx.failedToolCalls > ctx.effectiveFailureBudget) {
+      this.setStopReason(
+        ctx,
+        "tool_error",
+        `Failure budget exceeded (${ctx.failedToolCalls}/${ctx.effectiveFailureBudget})`,
+      );
+      abortRound = true;
+    }
+
+    // Track consecutive semantic failures to detect stuck loops.
+    const failDetected = toolFailed;
+    const semanticToolKey = buildSemanticToolCallKey(
+      toolCall.name,
+      args,
+    );
+    const failKey = failDetected ? semanticToolKey : "";
+    if (!failDetected && this.toolFailureBreakerEnabled) {
+      this.clearToolFailurePattern(ctx.sessionId, semanticToolKey);
+    }
+    if (failDetected && failKey === loopState.lastFailKey) {
+      loopState.consecutiveFailCount++;
+    } else {
+      loopState.lastFailKey = failKey;
+      loopState.consecutiveFailCount = failDetected ? 1 : 0;
+    }
+
+    const promptToolContent = buildPromptToolContent(
+      result,
+      loopState.remainingToolImageChars,
+    );
+    loopState.remainingToolImageChars = promptToolContent.remainingImageBudget;
+    this.pushMessage(
+      ctx,
+      {
+        role: "tool",
+        content: promptToolContent.content,
+        toolCallId: toolCall.id,
+        toolName: toolCall.name,
+      },
+      "tools",
+    );
+
+    if (abortRound) return "abort_round";
+    return "processed";
+  }
+
+  private async executePlannerPath(ctx: ExecutionContext): Promise<void> {
+    ctx.plannerSummaryState.used = true;
+    const plannerMessages = buildPlannerMessages(
+      ctx.messageText,
+      ctx.history,
+      this.plannerMaxTokens,
+    );
+    const plannerSections: PromptBudgetSection[] = [
+      "system_anchor",
+      "history",
+      "user",
+    ];
+    const plannerResponse = await this.callModelForPhase(ctx, {
+      phase: "planner",
+      callMessages: plannerMessages,
+      callSections: plannerSections,
+      budgetReason:
+        "Planner pass blocked by max model recalls per request budget",
+    });
+
+    if (plannerResponse) {
+      ctx.plannerSummaryState.plannerCalls = 1;
+      const plannerParse = parsePlannerPlan(plannerResponse.content);
+      ctx.plannerSummaryState.diagnostics.push(...plannerParse.diagnostics);
+      const plannerPlan = plannerParse.plan;
+      if (plannerPlan) {
+        const graphDiagnostics = validatePlannerGraph(
+          plannerPlan,
+          {
+            maxSubagentFanout: this.delegationDecisionConfig.maxFanoutPerTurn,
+            maxSubagentDepth: this.delegationDecisionConfig.maxDepth,
+          },
+        );
+        if (graphDiagnostics.length > 0) {
+          ctx.plannerSummaryState.diagnostics.push(...graphDiagnostics);
+          ctx.plannerSummaryState.routeReason = "planner_validation_failed";
+        } else if (plannerPlan.reason) {
+          ctx.plannerSummaryState.routeReason = plannerPlan.reason;
+        }
+        ctx.plannerSummaryState.plannedSteps = plannerPlan.steps.length;
+        ctx.plannedSubagentSteps = plannerPlan.steps.filter(
+          (step) => step.stepType === "subagent_task",
+        ).length;
+        ctx.plannedDeterministicSteps = plannerPlan.steps.filter(
+          (step) => step.stepType === "deterministic_tool",
+        ).length;
+        ctx.plannedSynthesisSteps = plannerPlan.steps.filter(
+          (step) => step.stepType === "synthesis",
+        ).length;
+        ctx.plannedFanout = ctx.plannedSubagentSteps;
+        ctx.plannedDependencyDepth = computePlannerGraphDepth(
+          plannerPlan.steps.map((step) => step.name),
+          plannerPlan.edges,
+        ).maxDepth;
+        const subagentSteps = plannerPlan.steps.filter(
+          (step): step is PlannerSubAgentTaskStepIntent =>
+            step.stepType === "subagent_task",
+        );
+        if (subagentSteps.length > 0) {
+          const synthesisSteps = plannerPlan.steps.filter(
+            (step) => step.stepType === "synthesis",
+          ).length;
+          const highRiskPlan = isHighRiskSubagentPlan(
+            subagentSteps,
+          );
+          ctx.trajectoryContextClusterId = deriveDelegationContextClusterId({
+            complexityScore: ctx.plannerDecision.score,
+            subagentStepCount: subagentSteps.length,
+            hasHistory: ctx.hasHistory,
+            highRiskPlan,
+          });
+
+          if (this.delegationBanditTuner) {
+            ctx.selectedBanditArm = this.delegationBanditTuner.selectArm({
+              contextClusterId: ctx.trajectoryContextClusterId,
+              preferredArmId: this.delegationDefaultStrategyArmId,
+            });
+            ctx.tunedDelegationThreshold =
+              this.delegationBanditTuner.applyThresholdOffset(
+                ctx.baseDelegationThreshold,
+                ctx.selectedBanditArm.armId,
+              );
+            ctx.plannerSummaryState.delegationPolicyTuning = {
+              enabled: true,
+              contextClusterId: ctx.trajectoryContextClusterId,
+              selectedArmId: ctx.selectedBanditArm.armId,
+              selectedArmReason: ctx.selectedBanditArm.reason,
+              tunedThreshold: ctx.tunedDelegationThreshold,
+              exploration: ctx.selectedBanditArm.exploration,
+              finalReward: undefined,
+              usefulDelegation: undefined,
+              usefulDelegationScore: undefined,
+              rewardProxyVersion: undefined,
+            };
+          } else {
+            ctx.plannerSummaryState.delegationPolicyTuning = {
+              enabled: false,
+              contextClusterId: ctx.trajectoryContextClusterId,
+              selectedArmId: this.delegationDefaultStrategyArmId,
+              selectedArmReason: "fallback",
+              tunedThreshold: ctx.baseDelegationThreshold,
+              exploration: false,
+              finalReward: undefined,
+              usefulDelegation: undefined,
+              usefulDelegationScore: undefined,
+              rewardProxyVersion: undefined,
+            };
+          }
+
+          const tunedDecisionConfig: DelegationDecisionConfig = {
+            enabled: this.delegationDecisionConfig.enabled,
+            mode: this.delegationDecisionConfig.mode,
+            scoreThreshold: ctx.tunedDelegationThreshold,
+            maxFanoutPerTurn: this.delegationDecisionConfig.maxFanoutPerTurn,
+            maxDepth: this.delegationDecisionConfig.maxDepth,
+            handoffMinPlannerConfidence:
+              this.delegationDecisionConfig.handoffMinPlannerConfidence,
+            hardBlockedTaskClasses: [
+              ...this.delegationDecisionConfig.hardBlockedTaskClasses,
+            ],
+          };
+          const delegationDecision = assessDelegationDecision({
+            messageText: ctx.messageText,
+            plannerConfidence: plannerPlan.confidence,
+            complexityScore: ctx.plannerDecision.score,
+            totalSteps: plannerPlan.steps.length,
+            synthesisSteps,
+            edges: plannerPlan.edges,
+            subagentSteps: subagentSteps.map((step) => ({
+              name: step.name,
+              dependsOn: step.dependsOn,
+              acceptanceCriteria: step.acceptanceCriteria,
+              requiredToolCapabilities: step.requiredToolCapabilities,
+              contextRequirements: step.contextRequirements,
+              maxBudgetHint: step.maxBudgetHint,
+              canRunParallel: step.canRunParallel,
+            })),
+            config: tunedDecisionConfig,
+          });
+          ctx.plannerSummaryState.delegationDecision = delegationDecision;
+          if (!delegationDecision.shouldDelegate) {
+            ctx.plannerSummaryState.routeReason =
+              `delegation_veto_${delegationDecision.reason}`;
+            ctx.plannerSummaryState.diagnostics.push({
+              category: "policy",
+              code: "delegation_veto",
+              message:
+                `Delegation vetoed by policy scorer: ${delegationDecision.reason}`,
+              details: {
+                reason: delegationDecision.reason,
+                threshold: delegationDecision.threshold,
+                utilityScore: Number(
+                  delegationDecision.utilityScore.toFixed(4),
+                ),
+                safetyRisk: Number(delegationDecision.safetyRisk.toFixed(4)),
+              },
+            });
+          }
+        }
+        const deterministicSteps = plannerPlan.steps.filter(
+          (step): step is PlannerDeterministicToolStepIntent =>
+            step.stepType === "deterministic_tool",
+        );
+        const plannerPipelineSteps: PipelinePlannerStep[] = plannerPlan.steps.map(
+          (step) => {
+            if (step.stepType === "deterministic_tool") {
+              return {
+                name: step.name,
+                stepType: step.stepType,
+                dependsOn: step.dependsOn,
+                tool: step.tool,
+                args: step.args,
+                onError: step.onError,
+                maxRetries: step.maxRetries,
+              };
+            }
+            if (step.stepType === "subagent_task") {
+              return {
+                name: step.name,
+                stepType: step.stepType,
+                dependsOn: step.dependsOn,
+                objective: step.objective,
+                inputContract: step.inputContract,
+                acceptanceCriteria: step.acceptanceCriteria,
+                requiredToolCapabilities: step.requiredToolCapabilities,
+                contextRequirements: step.contextRequirements,
+                maxBudgetHint: step.maxBudgetHint,
+                canRunParallel: step.canRunParallel,
+              };
+            }
+            return {
+              name: step.name,
+              stepType: step.stepType,
+              dependsOn: step.dependsOn,
+              objective: step.objective,
+            };
+          },
+        );
+        const plannerExecutionContext = buildPlannerExecutionContext(
+          ctx.messageText,
+          ctx.history,
+          ctx.messages,
+          ctx.messageSections,
+          ctx.activeRoutedToolNames.length > 0
+            ? ctx.activeRoutedToolNames
+            : (this.allowedTools ? [...this.allowedTools] : undefined),
+        );
+        const hasExecutablePlannerSteps =
+          deterministicSteps.length > 0 ||
+          (
+            subagentSteps.length > 0 &&
+            ctx.plannerSummaryState.delegationDecision?.shouldDelegate === true
+          );
+
+        if (
+          hasExecutablePlannerSteps &&
+          ctx.plannerSummaryState.routeReason !== "planner_validation_failed"
+        ) {
+          if (deterministicSteps.length > ctx.effectiveToolBudget) {
+            this.setStopReason(
+              ctx,
+              "budget_exceeded",
+              `Planner produced ${deterministicSteps.length} deterministic steps but tool budget is ${ctx.effectiveToolBudget}`,
+            );
+            ctx.finalContent =
+              `Planned ${deterministicSteps.length} deterministic steps, ` +
+              `but request tool budget is ${ctx.effectiveToolBudget}.`;
+            ctx.plannerHandled = true;
+          } else {
+            const pipeline: Pipeline = {
+              id: `planner:${ctx.sessionId}:${Date.now()}`,
+              createdAt: Date.now(),
+              context: { results: {} },
+              steps: deterministicSteps.map((step) => ({
+                name: step.name,
+                tool: step.tool,
+                args: step.args,
+                onError: step.onError,
+                maxRetries: step.maxRetries,
+              })),
+              plannerSteps: plannerPipelineSteps,
+              edges: plannerPlan.edges,
+              maxParallelism: this.delegationDecisionConfig.maxFanoutPerTurn,
+              plannerContext: plannerExecutionContext,
+            };
+
+            const shouldRunSubagentVerifier =
+              subagentSteps.length > 0 &&
+              ctx.plannerSummaryState.delegationDecision?.shouldDelegate === true &&
+              (
+                this.subagentVerifierConfig.enabled ||
+                this.subagentVerifierConfig.force
+              );
+            const {
+              verifierRounds,
+              verificationDecision,
+              pipelineResult,
+            } = await this.executePlannerPipelineWithVerifier({
+              pipeline,
+              plannerPlan,
+              subagentSteps,
+              deterministicSteps,
+              plannerExecutionContext,
+              shouldRunSubagentVerifier,
+              plannerSummaryState: ctx.plannerSummaryState,
+              checkRequestTimeout: (stage: string) => this.checkRequestTimeout(ctx, stage),
+              runPipelineWithGlobalTimeout: (p: Pipeline) => this.runPipelineWithTimeout(ctx, p),
+              runSubagentVerifierRound: (input) => this.runSubagentVerifier(ctx, input),
+              appendToolRecord: (record: ToolCallRecord) => this.appendToolRecord(ctx, record),
+              setStopReason: (reason: LLMPipelineStopReason, detail?: string) => this.setStopReason(ctx, reason, detail),
+            });
+
+            if (
+              shouldRunSubagentVerifier &&
+              verifierRounds === 0 &&
+              !ctx.plannerSummaryState.subagentVerification.performed
+            ) {
+              ctx.plannerSummaryState.subagentVerification = {
+                enabled: true,
+                performed: false,
+                rounds: 0,
+                overall: "skipped",
+                confidence: 1,
+                unresolvedItems: [],
+              };
+            }
+
+            if (pipelineResult) {
+              if (pipelineResult.status === "failed") {
+                const hintedStopReason = isPipelineStopReasonHint(
+                  pipelineResult.stopReasonHint,
+                )
+                  ? pipelineResult.stopReasonHint
+                  : "tool_error";
+                this.setStopReason(
+                  ctx,
+                  hintedStopReason,
+                  pipelineResult.error ??
+                    "Deterministic pipeline execution failed",
+                );
+              } else if (pipelineResult.status === "halted") {
+                this.setStopReason(
+                  ctx,
+                  "tool_calls",
+                  `Deterministic pipeline halted at step ${
+                    (pipelineResult.resumeFrom ?? 0) + 1
+                  } awaiting approval`,
+                );
+              }
+            } else if (ctx.stopReason === "completed") {
+              this.setStopReason(
+                ctx,
+                "timeout",
+                this.timeoutDetail("planner pipeline execution"),
+              );
+            }
+
+            if (ctx.failedToolCalls > ctx.effectiveFailureBudget) {
+              this.setStopReason(
+                ctx,
+                "tool_error",
+                `Failure budget exceeded (${ctx.failedToolCalls}/${ctx.effectiveFailureBudget}) during deterministic pipeline execution`,
+              );
+            }
+
+            if (
+              pipelineResult &&
+              (plannerPlan.requiresSynthesis || ctx.stopReason !== "completed")
+            ) {
+              const synthesisMessages = buildPlannerSynthesisMessages(
+                ctx.systemPrompt,
+                ctx.messageText,
+                plannerPlan,
+                pipelineResult,
+                verificationDecision,
+              );
+              const synthesisSections: PromptBudgetSection[] = [
+                "system_anchor",
+                "system_runtime",
+                "user",
+              ];
+              const synthesisResponse = await this.callModelForPhase(ctx, {
+                phase: "planner_synthesis",
+                callMessages: synthesisMessages,
+                callSections: synthesisSections,
+                onStreamChunk: ctx.activeStreamCallback,
+                statefulSessionId: ctx.sessionId,
+                budgetReason:
+                  "Planner synthesis blocked by max model recalls per request budget",
+              });
+              if (synthesisResponse) {
+                ctx.response = synthesisResponse;
+                ctx.finalContent = ensureSubagentProvenanceCitations(
+                  synthesisResponse.content,
+                  plannerPlan,
+                  pipelineResult,
+                );
+              }
+            }
+
+            if (!ctx.finalContent) {
+              ctx.finalContent =
+                generateFallbackContent(ctx.allToolCalls) ??
+                summarizeToolCalls(
+                  ctx.allToolCalls.filter((call) => !call.isError),
+                );
+            }
+            ctx.plannerHandled = true;
+          }
+        } else {
+          if (
+            !ctx.plannerSummaryState.delegationDecision ||
+            ctx.plannerSummaryState.delegationDecision.shouldDelegate
+          ) {
+            if (ctx.plannerSummaryState.routeReason !== "planner_validation_failed") {
+              ctx.plannerSummaryState.routeReason = "planner_no_deterministic_steps";
+            }
+          }
+        }
+      } else {
+        ctx.plannerSummaryState.routeReason = "planner_parse_failed";
+      }
+    }
   }
 
   private async executePlannerPipelineWithVerifier(
@@ -2652,7 +2111,7 @@ export class ChatExecutor {
       if (!nextPipelineResult) break;
       pipelineResult = nextPipelineResult;
 
-      for (const record of ChatExecutor.pipelineResultToToolCalls(
+      for (const record of pipelineResultToToolCalls(
         input.plannerPlan.steps,
         nextPipelineResult,
       )) {
@@ -2782,7 +2241,7 @@ export class ChatExecutor {
       routedToolNames?: readonly string[];
     },
   ): Promise<FallbackResult> {
-    const beforeBudget = ChatExecutor.estimatePromptShape(messages);
+    const beforeBudget = estimatePromptShape(messages);
     const budgeted = applyPromptBudget(
       messages.map((message, index) => ({
         message,
@@ -2791,7 +2250,7 @@ export class ChatExecutor {
       this.promptBudget,
     );
     const boundedMessages = budgeted.messages;
-    const afterBudget = ChatExecutor.estimatePromptShape(boundedMessages);
+    const afterBudget = estimatePromptShape(boundedMessages);
     const budgetDiagnostics = budgeted.diagnostics;
     const hasStatefulSessionId = Boolean(options?.statefulSessionId);
     const hasRoutedToolNames = Boolean(
@@ -3074,2141 +2533,10 @@ export class ChatExecutor {
     }
   }
 
-  private assessPlannerDecision(
-    messageText: string,
-    history: readonly LLMMessage[],
-  ): PlannerDecision {
-    if (!this.plannerEnabled) {
-      return {
-        score: 0,
-        shouldPlan: false,
-        reason: "planner_disabled",
-      };
-    }
 
-    let score = 0;
-    const reasons: string[] = [];
-    const normalized = messageText.toLowerCase();
 
-    const hasMultiStepCue =
-      /\b(first|second|third|then|after that|next|finally|step\b|in order|checklist|pipeline)\b/i.test(
-        messageText,
-      ) ||
-      /\b1[\).:]\s+.+\b2[\).:]/s.test(messageText);
-    if (hasMultiStepCue) {
-      score += 3;
-      reasons.push("multi_step_cues");
-    }
-
-    const hasToolDiversityCue =
-      /\b(browser|http|curl|bash|command|container|playwright|open|navigate|teardown|verify)\b/i.test(
-        messageText,
-      );
-    if (hasToolDiversityCue) {
-      score += 1;
-      reasons.push("multi_tool_candidates");
-    }
-
-    const longTask = messageText.length >= 320 || messageText.split(/\n/).length >= 4;
-    if (longTask) {
-      score += 1;
-      reasons.push("long_or_structured_request");
-    }
-
-    const historyTail = history.slice(-10);
-    const priorToolMessages = historyTail.filter(
-      (entry) => entry.role === "tool",
-    ).length;
-    if (priorToolMessages >= 4) {
-      score += 2;
-      reasons.push("prior_tool_loop_activity");
-    }
-    if (historyTail.some((entry) => typeof entry.content === "string" && entry.content.includes(RECOVERY_HINT_PREFIX))) {
-      score += 2;
-      reasons.push("prior_no_progress_signal");
-    }
-
-    const directFastPath =
-      score < 3 ||
-      normalized.trim().length < 20 ||
-      /\b(hi|hello|thanks|thank you)\b/.test(normalized);
-
-    return {
-      score,
-      shouldPlan: !directFastPath,
-      reason: reasons.length > 0 ? reasons.join("+") : "direct_fast_path",
-    };
-  }
-
-  private static buildPlannerMessages(
-    messageText: string,
-    history: readonly LLMMessage[],
-    plannerMaxTokens: number,
-  ): readonly LLMMessage[] {
-    const historyPreview = history
-      .slice(-6)
-      .map((entry) => {
-        const raw =
-          typeof entry.content === "string"
-            ? entry.content
-            : entry.content
-                .filter((part) => part.type === "text")
-                .map((part) => part.text)
-                .join(" ");
-        return `[${entry.role}] ${ChatExecutor.truncateText(raw, 300)}`;
-      })
-      .join("\n");
-    const maxSteps = Math.min(
-      MAX_PLANNER_STEPS,
-      Math.max(1, Math.floor(plannerMaxTokens / 8)),
-    );
-
-    return [
-      {
-        role: "system",
-        content:
-          "Plan this request into executable intents. Respond with strict JSON only.\n" +
-          "Schema:\n" +
-          "{\n" +
-          '  "reason": "short routing reason",\n' +
-          '  "requiresSynthesis": boolean,\n' +
-          '  "steps": [\n' +
-          "    {\n" +
-          '      "name": "step_name",\n' +
-          '      "step_type": "deterministic_tool|subagent_task|synthesis",\n' +
-          '      "depends_on": ["step_name"],\n' +
-          '      "tool": "tool.name",\n' +
-          '      "args": { "key": "value" },\n' +
-          '      "onError": "abort|retry|skip",\n' +
-          '      "maxRetries": number,\n' +
-          '      "objective": "required for subagent_task",\n' +
-          '      "input_contract": "required for subagent_task",\n' +
-          '      "acceptance_criteria": ["required for subagent_task"],\n' +
-          '      "required_tool_capabilities": ["required for subagent_task"],\n' +
-          '      "context_requirements": ["required for subagent_task"],\n' +
-          '      "max_budget_hint": "required for subagent_task",\n' +
-          '      "can_run_parallel": true\n' +
-          "    }\n" +
-          "  ]\n" +
-          "}\n" +
-          "Rules:\n" +
-          "- deterministic_tool steps are executable by the deterministic pipeline.\n" +
-          "- subagent_task steps MUST include all subagent fields.\n" +
-          "- synthesis steps describe final merge/synthesis intent and do not call tools.\n" +
-          `Keep output concise and below approximately ${plannerMaxTokens} tokens. ` +
-          `Never emit more than ${maxSteps} steps.`,
-      },
-      {
-        role: "user",
-        content:
-          `User request:\n${messageText}\n\n` +
-          (historyPreview.length > 0
-            ? `Recent conversation context:\n${historyPreview}\n\n`
-            : "") +
-          "Return JSON only.",
-      },
-    ];
-  }
-
-  private static buildPlannerExecutionContext(
-    messageText: string,
-    history: readonly LLMMessage[],
-    messages: readonly LLMMessage[],
-    sections: readonly PromptBudgetSection[],
-    parentAllowedTools?: readonly string[],
-  ): PipelinePlannerContext {
-    const normalizedHistory = ChatExecutor.normalizeHistory(history);
-    const historySlice = normalizedHistory
-      .slice(-MAX_PLANNER_CONTEXT_HISTORY_CANDIDATES)
-      .map((entry) => ({
-        role: entry.role,
-        content: ChatExecutor.truncateText(
-          ChatExecutor.extractLLMMessageText(entry),
-          MAX_PLANNER_CONTEXT_HISTORY_CHARS,
-        ),
-        ...(entry.role === "tool" && entry.toolName
-          ? { toolName: entry.toolName }
-          : {}),
-      }))
-      .filter((entry) => entry.content.trim().length > 0);
-
-    const memory: Array<{
-      source: PipelinePlannerContextMemorySource;
-      content: string;
-    }> = [];
-    const bySection = (
-      section: PromptBudgetSection,
-    ): PipelinePlannerContextMemorySource | null => {
-      if (section === "memory_semantic") return "memory_semantic";
-      if (section === "memory_episodic") return "memory_episodic";
-      if (section === "memory_working") return "memory_working";
-      return null;
-    };
-    for (let i = 0; i < messages.length; i++) {
-      const source = bySection(sections[i] ?? "history");
-      if (!source) continue;
-      const message = messages[i];
-      if (!message || message.role !== "system") continue;
-      const content = ChatExecutor.truncateText(
-        ChatExecutor.extractLLMMessageText(message),
-        MAX_PLANNER_CONTEXT_MEMORY_CHARS,
-      );
-      if (content.trim().length === 0) continue;
-      memory.push({ source, content });
-    }
-
-    const toolOutputs = normalizedHistory
-      .filter((entry) => entry.role === "tool")
-      .map((entry) => ({
-        ...(entry.toolName ? { toolName: entry.toolName } : {}),
-        content: ChatExecutor.truncateText(
-          ChatExecutor.extractLLMMessageText(entry),
-          MAX_PLANNER_CONTEXT_TOOL_OUTPUT_CHARS,
-        ),
-      }))
-      .filter((entry) => entry.content.trim().length > 0);
-
-    return {
-      parentRequest: ChatExecutor.truncateText(
-        messageText,
-        MAX_USER_MESSAGE_CHARS,
-      ),
-      history: historySlice,
-      memory,
-      toolOutputs,
-      ...(parentAllowedTools && parentAllowedTools.length > 0
-        ? { parentAllowedTools: [...new Set(parentAllowedTools)] }
-        : {}),
-    };
-  }
-
-  private static parsePlannerPlan(content: string): PlannerParseResult {
-    const diagnostics: PlannerDiagnostic[] = [];
-    const parsed = ChatExecutor.parseJsonObjectFromText(content);
-    if (!parsed) {
-      diagnostics.push(
-        ChatExecutor.createPlannerDiagnostic(
-          "parse",
-          "invalid_json",
-          "Planner output is not parseable JSON object",
-        ),
-      );
-      return { diagnostics };
-    }
-    if (!Array.isArray(parsed.steps)) {
-      diagnostics.push(
-        ChatExecutor.createPlannerDiagnostic(
-          "parse",
-          "missing_steps_array",
-          'Planner output must include a "steps" array',
-        ),
-      );
-      return { diagnostics };
-    }
-
-    const steps: PlannerStepIntent[] = [];
-    const unresolvedDependencies = new Map<string, readonly string[]>();
-    const nameAliases = new Map<string, string>();
-    const usedStepNames = new Set<string>();
-    const maxSteps = Math.min(MAX_PLANNER_STEPS, parsed.steps.length);
-
-    for (const [index, rawStep] of parsed.steps.slice(0, maxSteps).entries()) {
-      if (
-        typeof rawStep !== "object" ||
-        rawStep === null ||
-        Array.isArray(rawStep)
-      ) {
-        diagnostics.push(
-          ChatExecutor.createPlannerDiagnostic(
-            "parse",
-            "invalid_step_object",
-            `Planner step at index ${index} must be an object`,
-            { stepIndex: index },
-          ),
-        );
-        return { diagnostics };
-      }
-      const step = rawStep as Record<string, unknown>;
-      const stepType = ChatExecutor.parsePlannerStepType(step.step_type);
-      if (!stepType) {
-        diagnostics.push(
-          ChatExecutor.createPlannerDiagnostic(
-            "parse",
-            "invalid_step_type",
-            `Planner step at index ${index} has invalid step_type`,
-            { stepIndex: index },
-          ),
-        );
-        return { diagnostics };
-      }
-
-      const rawName =
-        typeof step.name === "string" ? step.name.trim() : "";
-      const sanitizedName = ChatExecutor.sanitizePlannerStepName(
-        rawName.length > 0 ? rawName : `step_${steps.length + 1}`,
-      );
-      const safeName = ChatExecutor.dedupePlannerStepName(
-        sanitizedName,
-        usedStepNames,
-      );
-      usedStepNames.add(safeName);
-
-      if (rawName.length > 0) {
-        if (nameAliases.has(rawName)) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "duplicate_step_name",
-              `Planner step name "${rawName}" is duplicated`,
-              { stepIndex: index, stepName: rawName },
-            ),
-          );
-          return { diagnostics };
-        }
-        nameAliases.set(rawName, safeName);
-      }
-      nameAliases.set(safeName, safeName);
-
-      const dependsOn = ChatExecutor.parsePlannerDependsOn(step.depends_on);
-      if (!dependsOn) {
-        diagnostics.push(
-          ChatExecutor.createPlannerDiagnostic(
-            "parse",
-            "invalid_depends_on",
-            `Planner step "${safeName}" has invalid depends_on`,
-            { stepIndex: index, stepName: safeName },
-          ),
-        );
-        return { diagnostics };
-      }
-      unresolvedDependencies.set(safeName, dependsOn);
-
-      if (stepType === "deterministic_tool") {
-        if (typeof step.tool !== "string" || step.tool.trim().length === 0) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_tool_name",
-              `Deterministic planner step "${safeName}" must include a non-empty tool name`,
-              { stepIndex: index, stepName: safeName },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (
-          step.args !== undefined &&
-          (
-            typeof step.args !== "object" ||
-            step.args === null ||
-            Array.isArray(step.args)
-          )
-        ) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "invalid_tool_args",
-              `Planner step "${safeName}" has invalid args; expected JSON object`,
-              { stepIndex: index, stepName: safeName },
-            ),
-          );
-          return { diagnostics };
-        }
-        const args =
-          typeof step.args === "object" &&
-          step.args !== null &&
-          !Array.isArray(step.args)
-            ? (step.args as Record<string, unknown>)
-            : {};
-        const onError =
-          step.onError === "retry" ||
-          step.onError === "skip" ||
-          step.onError === "abort"
-            ? step.onError
-            : undefined;
-        const maxRetries =
-          typeof step.maxRetries === "number" && Number.isFinite(step.maxRetries)
-            ? Math.max(0, Math.min(5, Math.floor(step.maxRetries)))
-            : undefined;
-        steps.push({
-          name: safeName,
-          stepType,
-          tool: step.tool.trim(),
-          args,
-          onError,
-          maxRetries,
-        });
-        continue;
-      }
-
-      if (stepType === "subagent_task") {
-        const objective = ChatExecutor.parsePlannerRequiredString(step.objective);
-        const inputContract = ChatExecutor.parsePlannerRequiredString(
-          step.input_contract,
-        );
-        const acceptanceCriteria = ChatExecutor.parsePlannerStringArray(
-          step.acceptance_criteria,
-        );
-        const requiredToolCapabilities = ChatExecutor.parsePlannerStringArray(
-          step.required_tool_capabilities,
-        );
-        const contextRequirements = ChatExecutor.parsePlannerStringArray(
-          step.context_requirements,
-        );
-        const maxBudgetHint = ChatExecutor.parsePlannerRequiredString(
-          step.max_budget_hint,
-        );
-        const canRunParallel =
-          typeof step.can_run_parallel === "boolean"
-            ? step.can_run_parallel
-            : undefined;
-        if (!objective) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_subagent_field",
-              `Planner subagent step "${safeName}" is missing objective`,
-              { stepIndex: index, stepName: safeName, field: "objective" },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (!inputContract) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_subagent_field",
-              `Planner subagent step "${safeName}" is missing input_contract`,
-              { stepIndex: index, stepName: safeName, field: "input_contract" },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (!acceptanceCriteria || acceptanceCriteria.length === 0) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_subagent_field",
-              `Planner subagent step "${safeName}" is missing acceptance_criteria`,
-              {
-                stepIndex: index,
-                stepName: safeName,
-                field: "acceptance_criteria",
-              },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (!requiredToolCapabilities || requiredToolCapabilities.length === 0) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_subagent_field",
-              `Planner subagent step "${safeName}" is missing required_tool_capabilities`,
-              {
-                stepIndex: index,
-                stepName: safeName,
-                field: "required_tool_capabilities",
-              },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (!contextRequirements || contextRequirements.length === 0) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_subagent_field",
-              `Planner subagent step "${safeName}" is missing context_requirements`,
-              {
-                stepIndex: index,
-                stepName: safeName,
-                field: "context_requirements",
-              },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (!maxBudgetHint) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_subagent_field",
-              `Planner subagent step "${safeName}" is missing max_budget_hint`,
-              {
-                stepIndex: index,
-                stepName: safeName,
-                field: "max_budget_hint",
-              },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (canRunParallel === undefined) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "missing_subagent_field",
-              `Planner subagent step "${safeName}" is missing can_run_parallel`,
-              {
-                stepIndex: index,
-                stepName: safeName,
-                field: "can_run_parallel",
-              },
-            ),
-          );
-          return { diagnostics };
-        }
-
-        steps.push({
-          name: safeName,
-          stepType,
-          objective,
-          inputContract,
-          acceptanceCriteria,
-          requiredToolCapabilities,
-          contextRequirements,
-          maxBudgetHint,
-          canRunParallel,
-        });
-        continue;
-      }
-
-      const objective = ChatExecutor.parsePlannerOptionalString(step.objective);
-      steps.push({
-        name: safeName,
-        stepType,
-        ...(objective ? { objective } : {}),
-      });
-    }
-
-    const knownStepNames = new Set(steps.map((step) => step.name));
-    const edges: WorkflowGraphEdge[] = [];
-    for (const step of steps) {
-      const rawDepends = unresolvedDependencies.get(step.name) ?? [];
-      if (rawDepends.length === 0) continue;
-      const resolved = new Set<string>();
-      for (const dependencyName of rawDepends) {
-        const alias = nameAliases.get(dependencyName) ?? dependencyName;
-        if (!knownStepNames.has(alias)) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "unknown_dependency",
-              `Planner step "${step.name}" depends on unknown step "${dependencyName}"`,
-              { stepName: step.name, dependencyName },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (alias === step.name) {
-          diagnostics.push(
-            ChatExecutor.createPlannerDiagnostic(
-              "parse",
-              "self_dependency",
-              `Planner step "${step.name}" cannot depend on itself`,
-              { stepName: step.name },
-            ),
-          );
-          return { diagnostics };
-        }
-        if (resolved.has(alias)) continue;
-        resolved.add(alias);
-        edges.push({ from: alias, to: step.name });
-      }
-      if (resolved.size > 0) {
-        step.dependsOn = [...resolved];
-      }
-    }
-
-    const cyclePath = ChatExecutor.detectPlannerCycle(
-      steps.map((step) => step.name),
-      edges,
-    );
-    if (cyclePath) {
-      diagnostics.push(
-        ChatExecutor.createPlannerDiagnostic(
-          "validation",
-          "cyclic_dependency",
-          "Planner dependency graph contains a cycle",
-          {
-            cycle: cyclePath.join("->"),
-          },
-        ),
-      );
-      return { diagnostics };
-    }
-
-    const containsSynthesisStep = steps.some(
-      (step) => step.stepType === "synthesis",
-    );
-
-    return {
-      plan: {
-        reason: typeof parsed.reason === "string" ? parsed.reason : undefined,
-        confidence: ChatExecutor.parsePlannerConfidence(parsed.confidence),
-        requiresSynthesis:
-          typeof parsed.requiresSynthesis === "boolean"
-            ? parsed.requiresSynthesis || containsSynthesisStep
-            : containsSynthesisStep || undefined,
-        steps,
-        edges,
-      },
-      diagnostics,
-    };
-  }
-
-  private static validatePlannerGraph(
-    plannerPlan: PlannerPlan,
-    config: PlannerGraphValidationConfig,
-  ): readonly PlannerDiagnostic[] {
-    const diagnostics: PlannerDiagnostic[] = [];
-    const subagentSteps = plannerPlan.steps.filter(
-      (step): step is PlannerSubAgentTaskStepIntent =>
-        step.stepType === "subagent_task",
-    );
-    if (subagentSteps.length === 0) return diagnostics;
-
-    if (subagentSteps.length > config.maxSubagentFanout) {
-      diagnostics.push(
-        ChatExecutor.createPlannerDiagnostic(
-          "validation",
-          "subagent_fanout_exceeded",
-          `Planner emitted ${subagentSteps.length} subagent tasks but maxFanoutPerTurn is ${config.maxSubagentFanout}`,
-          {
-            subagentSteps: subagentSteps.length,
-            maxFanoutPerTurn: config.maxSubagentFanout,
-          },
-        ),
-      );
-    }
-
-    const subagentStepNames = new Set(subagentSteps.map((step) => step.name));
-    const subagentEdges = plannerPlan.edges.filter((edge) =>
-      subagentStepNames.has(edge.from) && subagentStepNames.has(edge.to)
-    );
-    const graphDepth = ChatExecutor.computePlannerGraphDepth(
-      [...subagentStepNames],
-      subagentEdges,
-    );
-    if (graphDepth.cyclic) {
-      diagnostics.push(
-        ChatExecutor.createPlannerDiagnostic(
-          "validation",
-          "cyclic_dependency",
-          "Planner dependency graph contains a cycle",
-        ),
-      );
-      return diagnostics;
-    }
-    if (graphDepth.maxDepth > config.maxSubagentDepth) {
-      diagnostics.push(
-        ChatExecutor.createPlannerDiagnostic(
-          "validation",
-          "subagent_depth_exceeded",
-          `Planner subagent dependency depth ${graphDepth.maxDepth} exceeds maxDepth ${config.maxSubagentDepth}`,
-          {
-            depth: graphDepth.maxDepth,
-            maxDepth: config.maxSubagentDepth,
-          },
-        ),
-      );
-    }
-
-    return diagnostics;
-  }
-
-  private static createPlannerDiagnostic(
-    category: PlannerDiagnostic["category"],
-    code: string,
-    message: string,
-    details?: Readonly<Record<string, string | number | boolean>>,
-  ): PlannerDiagnostic {
-    return { category, code, message, ...(details ? { details } : {}) };
-  }
-
-  private static isHighRiskSubagentPlan(
-    steps: readonly PlannerSubAgentTaskStepIntent[],
-  ): boolean {
-    for (const step of steps) {
-      for (const capability of step.requiredToolCapabilities) {
-        const normalized = capability.trim().toLowerCase();
-        if (!normalized) continue;
-        if (
-          normalized.startsWith("wallet.") ||
-          normalized.startsWith("solana.") ||
-          normalized.startsWith("agenc.") ||
-          normalized.startsWith("desktop.") ||
-          normalized === "system.delete" ||
-          normalized === "system.writefile" ||
-          normalized === "system.execute" ||
-          normalized === "system.open" ||
-          normalized === "system.applescript" ||
-          normalized === "system.notification"
-        ) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  private static detectPlannerCycle(
-    nodes: readonly string[],
-    edges: readonly WorkflowGraphEdge[],
-  ): string[] | null {
-    const adjacency = new Map<string, string[]>();
-    for (const node of nodes) {
-      adjacency.set(node, []);
-    }
-    for (const edge of edges) {
-      if (!adjacency.has(edge.from) || !adjacency.has(edge.to)) continue;
-      adjacency.get(edge.from)!.push(edge.to);
-    }
-    const visiting = new Set<string>();
-    const visited = new Set<string>();
-    const stack: string[] = [];
-
-    const walk = (node: string): string[] | null => {
-      if (visiting.has(node)) {
-        const loopStart = stack.indexOf(node);
-        return loopStart >= 0
-          ? [...stack.slice(loopStart), node]
-          : [node, node];
-      }
-      if (visited.has(node)) return null;
-      visiting.add(node);
-      stack.push(node);
-      for (const next of adjacency.get(node) ?? []) {
-        const cycle = walk(next);
-        if (cycle) return cycle;
-      }
-      stack.pop();
-      visiting.delete(node);
-      visited.add(node);
-      return null;
-    };
-
-    for (const node of nodes) {
-      const cycle = walk(node);
-      if (cycle) return cycle;
-    }
-    return null;
-  }
-
-  private static computePlannerGraphDepth(
-    nodes: readonly string[],
-    edges: readonly WorkflowGraphEdge[],
-  ): { maxDepth: number; cyclic: boolean } {
-    if (nodes.length === 0) return { maxDepth: 0, cyclic: false };
-    const inDegree = new Map<string, number>();
-    const outgoing = new Map<string, string[]>();
-    const depth = new Map<string, number>();
-
-    for (const node of nodes) {
-      inDegree.set(node, 0);
-      outgoing.set(node, []);
-      depth.set(node, 1);
-    }
-    for (const edge of edges) {
-      if (!inDegree.has(edge.from) || !inDegree.has(edge.to)) continue;
-      outgoing.get(edge.from)!.push(edge.to);
-      inDegree.set(edge.to, (inDegree.get(edge.to) ?? 0) + 1);
-    }
-
-    const queue: string[] = [];
-    for (const [node, nodeInDegree] of inDegree.entries()) {
-      if (nodeInDegree === 0) queue.push(node);
-    }
-
-    let visited = 0;
-    let maxDepth = 1;
-    while (queue.length > 0) {
-      const node = queue.shift()!;
-      visited++;
-      const nodeDepth = depth.get(node) ?? 1;
-      maxDepth = Math.max(maxDepth, nodeDepth);
-      for (const next of outgoing.get(node) ?? []) {
-        const nextDepth = Math.max(depth.get(next) ?? 1, nodeDepth + 1);
-        depth.set(next, nextDepth);
-        const nextInDegree = (inDegree.get(next) ?? 0) - 1;
-        inDegree.set(next, nextInDegree);
-        if (nextInDegree === 0) queue.push(next);
-      }
-    }
-
-    return {
-      maxDepth,
-      cyclic: visited !== nodes.length,
-    };
-  }
-
-  private static parsePlannerStepType(
-    value: unknown,
-  ): PlannerStepType | undefined {
-    return value === "deterministic_tool" ||
-      value === "subagent_task" ||
-      value === "synthesis"
-      ? value
-      : undefined;
-  }
-
-  private static parsePlannerRequiredString(
-    value: unknown,
-  ): string | undefined {
-    if (typeof value !== "string") return undefined;
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
-  }
-
-  private static parsePlannerOptionalString(
-    value: unknown,
-  ): string | undefined {
-    if (typeof value !== "string") return undefined;
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
-  }
-
-  private static parsePlannerStringArray(
-    value: unknown,
-  ): readonly string[] | undefined {
-    if (!Array.isArray(value)) return undefined;
-    const items: string[] = [];
-    for (const entry of value) {
-      if (typeof entry !== "string") return undefined;
-      const trimmed = entry.trim();
-      if (trimmed.length === 0) return undefined;
-      items.push(trimmed);
-    }
-    return items;
-  }
-
-  private static parsePlannerDependsOn(
-    value: unknown,
-  ): readonly string[] | undefined {
-    if (value === undefined) return [];
-    if (!Array.isArray(value)) return undefined;
-    const items: string[] = [];
-    for (const entry of value) {
-      if (typeof entry !== "string") return undefined;
-      const trimmed = entry.trim();
-      if (trimmed.length === 0) return undefined;
-      items.push(trimmed);
-    }
-    return items;
-  }
-
-  private static parsePlannerConfidence(
-    value: unknown,
-  ): number | undefined {
-    if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
-    if (value >= 0 && value <= 1) return value;
-    if (value >= 0 && value <= 100) return value / 100;
-    return undefined;
-  }
-
-  private static sanitizePlannerStepName(name: string): string {
-    const trimmed = name.trim();
-    const normalized = trimmed.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 48);
-    return normalized.length > 0 ? normalized : "step";
-  }
-
-  private static dedupePlannerStepName(
-    name: string,
-    used: ReadonlySet<string>,
-  ): string {
-    if (!used.has(name)) return name;
-    for (let i = 2; i <= 999; i++) {
-      const candidate = `${name}_${i}`;
-      if (!used.has(candidate)) return candidate;
-    }
-    return `${name}_${Date.now().toString(36)}`;
-  }
-
-  private static parseJsonObjectFromText(
-    content: string,
-  ): Record<string, unknown> | undefined {
-    const trimmed = content.trim();
-    const direct = ChatExecutor.tryParseObject(trimmed);
-    if (direct) return direct;
-
-    const start = trimmed.indexOf("{");
-    const end = trimmed.lastIndexOf("}");
-    if (start >= 0 && end > start) {
-      const candidate = trimmed.slice(start, end + 1);
-      return ChatExecutor.tryParseObject(candidate);
-    }
-    return undefined;
-  }
-
-  private static tryParseObject(
-    candidate: string,
-  ): Record<string, unknown> | undefined {
-    try {
-      const parsed = JSON.parse(candidate) as unknown;
-      if (
-        typeof parsed === "object" &&
-        parsed !== null &&
-        !Array.isArray(parsed)
-      ) {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      // fall through
-    }
-    return undefined;
-  }
-
-  private static isPipelineStopReasonHint(
-    value: unknown,
-  ): value is Exclude<LLMPipelineStopReason, "completed" | "tool_calls"> {
-    return (
-      value === "validation_error" ||
-      value === "provider_error" ||
-      value === "authentication_error" ||
-      value === "rate_limited" ||
-      value === "timeout" ||
-      value === "tool_error" ||
-      value === "budget_exceeded" ||
-      value === "no_progress" ||
-      value === "cancelled"
-    );
-  }
-
-  private static evaluateSubagentDeterministicChecks(
-    subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
-    pipelineResult: PipelineResult,
-    plannerContext: PipelinePlannerContext,
-  ): SubagentVerifierDecision {
-    const stepAssessments: SubagentVerifierStepAssessment[] = [];
-    const unresolvedItems: string[] = [];
-    const artifactCorpus = ChatExecutor.collectVerifierArtifacts(
-      pipelineResult,
-      plannerContext,
-    );
-    const artifactText = artifactCorpus.join(" ").toLowerCase();
-
-    for (const step of subagentSteps) {
-      const raw = pipelineResult.context.results[step.name];
-      const issues: string[] = [];
-      let verdict: SubagentVerifierStepVerdict = "pass";
-      let retryable = true;
-      let output = "";
-      let status = "unknown";
-      let toolCallsCount = 0;
-
-      if (typeof raw !== "string") {
-        issues.push("missing_subagent_result");
-        verdict = "retry";
-      } else {
-        const parsed = ChatExecutor.parseJsonObjectFromText(raw);
-        if (!parsed) {
-          issues.push("malformed_subagent_result_payload");
-          verdict = "retry";
-          output = raw;
-        } else {
-          status = typeof parsed.status === "string"
-            ? parsed.status.toLowerCase()
-            : "unknown";
-          output = typeof parsed.output === "string"
-            ? parsed.output
-            : safeStringify(parsed.output ?? "");
-          toolCallsCount = Array.isArray(parsed.toolCalls)
-            ? parsed.toolCalls.length
-            : 0;
-          if (parsed.success === false || status === "failed") {
-            issues.push("child_reported_failure");
-            verdict = "retry";
-          }
-          if (status === "cancelled") {
-            issues.push("child_cancelled");
-            verdict = "fail";
-            retryable = false;
-          }
-          if (status === "delegation_fallback") {
-            issues.push("child_used_parent_fallback");
-            verdict = "fail";
-            retryable = false;
-          }
-        }
-      }
-
-      const trimmedOutput = output.trim();
-      if (trimmedOutput.length === 0) {
-        issues.push("empty_child_output");
-        verdict = ChatExecutor.moreSevereVerifierVerdict(verdict, "retry");
-      }
-
-      const expectsJson = step.inputContract.toLowerCase().includes("json");
-      if (expectsJson && trimmedOutput.length > 0) {
-        const parsedOutput = ChatExecutor.parseJsonObjectFromText(trimmedOutput);
-        if (!parsedOutput) {
-          issues.push("contract_violation_expected_json_output");
-          verdict = ChatExecutor.moreSevereVerifierVerdict(verdict, "retry");
-        }
-      }
-
-      const outputLower = trimmedOutput.toLowerCase();
-      const likelyEvidence =
-        /(line|file|log|trace|stderr|stdout|stack|error|\d)/.test(outputLower);
-      if (trimmedOutput.length > 0 && !likelyEvidence) {
-        issues.push("weak_evidence_density");
-      }
-
-      const expectationTokens = step.acceptanceCriteria
-        .flatMap((criterion) =>
-          ChatExecutor.extractVerifierTokens(criterion)
-        )
-        .slice(0, 24);
-      if (expectationTokens.length > 0 && trimmedOutput.length > 0) {
-        const matched = expectationTokens.some((token) =>
-          outputLower.includes(token)
-        );
-        if (!matched) {
-          issues.push("acceptance_criteria_not_evidenced");
-        }
-      }
-
-      if (
-        trimmedOutput.length > 0 &&
-        /(according to|as seen in|from the logs|based on)/.test(outputLower) &&
-        artifactText.length > 0 &&
-        !ChatExecutor.outputIntersectsArtifacts(outputLower, artifactText)
-      ) {
-        issues.push("hallucination_risk_artifact_mismatch");
-        verdict = ChatExecutor.moreSevereVerifierVerdict(verdict, "retry");
-      }
-
-      if (step.requiredToolCapabilities.length > 0 && toolCallsCount === 0) {
-        issues.push("missing_tool_result_consistency_signal");
-      }
-
-      const confidence = Math.max(0, 1 - Math.min(0.9, issues.length * 0.18));
-      if (verdict !== "pass" || confidence < DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE) {
-        unresolvedItems.push(
-          `${step.name}:${issues.length > 0 ? issues.join(",") : "low_confidence"}`,
-        );
-      }
-      stepAssessments.push({
-        name: step.name,
-        verdict,
-        confidence,
-        retryable,
-        issues,
-        summary:
-          issues.length > 0
-            ? issues.join("; ")
-            : "deterministic verifier checks passed",
-      });
-    }
-
-    const overall = ChatExecutor.resolveVerifierOverall(stepAssessments);
-    const confidence = stepAssessments.length > 0
-      ? Number(
-          (
-            stepAssessments.reduce((sum, step) => sum + step.confidence, 0) /
-            stepAssessments.length
-          ).toFixed(4),
-        )
-      : 1;
-    return {
-      overall,
-      confidence,
-      unresolvedItems,
-      steps: stepAssessments,
-      source: "deterministic",
-    };
-  }
-
-  private static buildSubagentVerifierMessages(
-    systemPrompt: string,
-    messageText: string,
-    plannerPlan: PlannerPlan,
-    subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
-    pipelineResult: PipelineResult,
-    plannerContext: PipelinePlannerContext,
-    deterministicDecision: SubagentVerifierDecision,
-  ): readonly LLMMessage[] {
-    const artifactBundle = ChatExecutor.collectVerifierArtifacts(
-      pipelineResult,
-      plannerContext,
-    );
-    const childBundle = subagentSteps.map((step) => ({
-      name: step.name,
-      objective: step.objective,
-      inputContract: step.inputContract,
-      acceptanceCriteria: step.acceptanceCriteria,
-      requiredToolCapabilities: step.requiredToolCapabilities,
-      rawResult: ChatExecutor.truncateText(
-        pipelineResult.context.results[step.name] ?? "missing",
-        MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS,
-      ),
-    }));
-    return [
-      { role: "system", content: systemPrompt },
-      {
-        role: "system",
-        content:
-          "You are a strict verifier for delegated child outputs. " +
-          "Assess contract adherence, evidence quality, hallucination risk against provided artifacts, and tool-result consistency. " +
-          "Return JSON only with schema: " +
-          '{"overall":"pass|retry|fail","confidence":0..1,"unresolved":[string],"steps":[{"name":string,"verdict":"pass|retry|fail","confidence":0..1,"retryable":boolean,"issues":[string],"summary":string}]}.',
-      },
-      {
-        role: "user",
-        content: safeStringify({
-          request: messageText,
-          plannerReason: plannerPlan.reason,
-          deterministicVerifier: deterministicDecision,
-          childBundle,
-          artifacts: artifactBundle.map((entry) =>
-            ChatExecutor.truncateText(entry, MAX_SUBAGENT_VERIFIER_ARTIFACT_CHARS)
-          ),
-        }),
-      },
-    ];
-  }
-
-  private static parseSubagentVerifierDecision(
-    content: string,
-    subagentSteps: readonly PlannerSubAgentTaskStepIntent[],
-  ): SubagentVerifierDecision | undefined {
-    const parsed = ChatExecutor.parseJsonObjectFromText(content);
-    if (!parsed) return undefined;
-    const overallRaw = parsed.overall;
-    if (
-      overallRaw !== "pass" &&
-      overallRaw !== "retry" &&
-      overallRaw !== "fail"
-    ) {
-      return undefined;
-    }
-    const confidenceRaw = parsed.confidence;
-    const confidence = typeof confidenceRaw === "number" && Number.isFinite(confidenceRaw)
-      ? Math.max(0, Math.min(1, confidenceRaw))
-      : 0.5;
-    const unresolvedItems = Array.isArray(parsed.unresolved)
-      ? parsed.unresolved
-          .filter((entry): entry is string => typeof entry === "string")
-          .map((entry) => entry.trim())
-          .filter((entry) => entry.length > 0)
-      : [];
-    const stepsByName = new Map(subagentSteps.map((step) => [step.name, step]));
-    const parsedSteps = Array.isArray(parsed.steps) ? parsed.steps : [];
-    const assessments: SubagentVerifierStepAssessment[] = [];
-    for (const entry of parsedSteps) {
-      if (
-        typeof entry !== "object" ||
-        entry === null ||
-        Array.isArray(entry)
-      ) {
-        continue;
-      }
-      const obj = entry as Record<string, unknown>;
-      const name = ChatExecutor.parsePlannerRequiredString(obj.name);
-      if (!name || !stepsByName.has(name)) continue;
-      const verdictRaw = obj.verdict;
-      if (
-        verdictRaw !== "pass" &&
-        verdictRaw !== "retry" &&
-        verdictRaw !== "fail"
-      ) {
-        continue;
-      }
-      const stepConfidenceRaw = obj.confidence;
-      const stepConfidence =
-        typeof stepConfidenceRaw === "number" && Number.isFinite(stepConfidenceRaw)
-          ? Math.max(0, Math.min(1, stepConfidenceRaw))
-          : confidence;
-      const retryable =
-        typeof obj.retryable === "boolean" ? obj.retryable : true;
-      const issues = Array.isArray(obj.issues)
-        ? obj.issues
-            .filter((issue): issue is string => typeof issue === "string")
-            .map((issue) => issue.trim())
-            .filter((issue) => issue.length > 0)
-        : [];
-      const summary = ChatExecutor.parsePlannerOptionalString(obj.summary) ??
-        (issues.length > 0 ? issues.join("; ") : "verifier assessment");
-      assessments.push({
-        name,
-        verdict: verdictRaw,
-        confidence: stepConfidence,
-        retryable,
-        issues,
-        summary,
-      });
-    }
-    if (assessments.length === 0) return undefined;
-    return {
-      overall: overallRaw,
-      confidence,
-      unresolvedItems,
-      steps: assessments,
-      source: "model",
-    };
-  }
-
-  private static mergeSubagentVerifierDecisions(
-    deterministic: SubagentVerifierDecision,
-    model: SubagentVerifierDecision,
-  ): SubagentVerifierDecision {
-    const byName = new Map<string, SubagentVerifierStepAssessment>();
-    for (const step of deterministic.steps) {
-      byName.set(step.name, step);
-    }
-    for (const step of model.steps) {
-      const existing = byName.get(step.name);
-      if (!existing) {
-        byName.set(step.name, step);
-        continue;
-      }
-      const mergedVerdict = ChatExecutor.moreSevereVerifierVerdict(
-        existing.verdict,
-        step.verdict,
-      );
-      const mergedIssues = [...new Set([...existing.issues, ...step.issues])];
-      byName.set(step.name, {
-        name: step.name,
-        verdict: mergedVerdict,
-        confidence: Math.min(existing.confidence, step.confidence),
-        retryable: existing.retryable && step.retryable,
-        issues: mergedIssues,
-        summary:
-          mergedIssues.length > 0
-            ? mergedIssues.join("; ")
-            : "merged verifier checks passed",
-      });
-    }
-    const steps = [...byName.values()];
-    const overall = ChatExecutor.resolveVerifierOverall(steps);
-    const unresolvedItems = [
-      ...new Set([
-        ...deterministic.unresolvedItems,
-        ...model.unresolvedItems,
-        ...steps
-          .filter((step) => step.verdict !== "pass")
-          .map((step) => `${step.name}:${step.summary}`),
-      ]),
-    ];
-    return {
-      overall,
-      confidence: Math.min(deterministic.confidence, model.confidence),
-      unresolvedItems,
-      steps,
-      source: "merged",
-    };
-  }
-
-  private static resolveVerifierOverall(
-    steps: readonly SubagentVerifierStepAssessment[],
-  ): "pass" | "retry" | "fail" {
-    let overall: "pass" | "retry" | "fail" = "pass";
-    for (const step of steps) {
-      overall = ChatExecutor.moreSevereVerifierVerdict(overall, step.verdict);
-      if (overall === "fail") return "fail";
-    }
-    return overall;
-  }
-
-  private static moreSevereVerifierVerdict(
-    a: SubagentVerifierStepVerdict,
-    b: SubagentVerifierStepVerdict,
-  ): SubagentVerifierStepVerdict {
-    const weight: Record<SubagentVerifierStepVerdict, number> = {
-      pass: 0,
-      retry: 1,
-      fail: 2,
-    };
-    return weight[a] >= weight[b] ? a : b;
-  }
-
-  private static extractVerifierTokens(value: string): string[] {
-    const matches = value.toLowerCase().match(/[a-z0-9_.-]+/g) ?? [];
-    const deduped = new Set<string>();
-    for (const match of matches) {
-      if (match.length < 4) continue;
-      deduped.add(match);
-    }
-    return [...deduped];
-  }
-
-  private static collectVerifierArtifacts(
-    pipelineResult: PipelineResult,
-    plannerContext: PipelinePlannerContext,
-  ): readonly string[] {
-    const artifacts: string[] = [];
-    for (const item of plannerContext.toolOutputs ?? []) {
-      artifacts.push(item.content);
-    }
-    for (const item of plannerContext.memory ?? []) {
-      artifacts.push(item.content);
-    }
-    for (const item of Object.values(pipelineResult.context.results)) {
-      if (typeof item !== "string") continue;
-      artifacts.push(item);
-    }
-    return artifacts
-      .map((entry) => ChatExecutor.truncateText(entry, MAX_SUBAGENT_VERIFIER_ARTIFACT_CHARS))
-      .filter((entry) => entry.length > 0)
-      .slice(0, 24);
-  }
-
-  private static outputIntersectsArtifacts(
-    outputLower: string,
-    artifactLower: string,
-  ): boolean {
-    const tokens = ChatExecutor.extractVerifierTokens(outputLower).slice(0, 24);
-    return tokens.some((token) =>
-      token.length >= 5 && artifactLower.includes(token)
-    );
-  }
-
-  private static buildPlannerSynthesisMessages(
-    systemPrompt: string,
-    messageText: string,
-    plannerPlan: PlannerPlan,
-    pipelineResult: PipelineResult,
-    verificationDecision?: SubagentVerifierDecision,
-  ): readonly LLMMessage[] {
-    const plannerSteps = plannerPlan.steps.map((step) => {
-      if (step.stepType === "deterministic_tool") {
-        return {
-          name: step.name,
-          stepType: step.stepType,
-          tool: step.tool,
-          dependsOn: step.dependsOn,
-        };
-      }
-      if (step.stepType === "subagent_task") {
-        return {
-          name: step.name,
-          stepType: step.stepType,
-          objective: step.objective,
-          dependsOn: step.dependsOn,
-          canRunParallel: step.canRunParallel,
-        };
-      }
-      return {
-        name: step.name,
-        stepType: step.stepType,
-        objective: step.objective,
-        dependsOn: step.dependsOn,
-      };
-    });
-    const subagentStepMap = new Map<
-      string,
-      SubagentVerifierStepAssessment
-    >(
-      (verificationDecision?.steps ?? []).map((step) => [step.name, step]),
-    );
-    const childOutputs = plannerPlan.steps
-      .filter((step): step is PlannerSubAgentTaskStepIntent => step.stepType === "subagent_task")
-      .map((step) => {
-        const raw = pipelineResult.context.results[step.name];
-        const parsed = typeof raw === "string"
-          ? ChatExecutor.parseJsonObjectFromText(raw)
-          : undefined;
-        const status =
-          typeof parsed?.status === "string" ? parsed.status : "unknown";
-        const output = typeof parsed?.output === "string"
-          ? parsed.output
-          : (typeof raw === "string" ? raw : "");
-        const marker =
-          status === "failed" || status === "cancelled"
-            ? status
-            : (
-                status === "delegation_fallback" ? "unresolved" : "completed"
-              );
-        const verification = subagentStepMap.get(step.name);
-        return {
-          name: step.name,
-          objective: step.objective,
-          status,
-          marker,
-          confidence: verification?.confidence ?? null,
-          verifierVerdict: verification?.verdict ?? null,
-          unresolvedIssues: verification?.issues ?? [],
-          output: ChatExecutor.truncateText(
-            output,
-            MAX_SUBAGENT_VERIFIER_OUTPUT_CHARS,
-          ),
-          provenanceTag: `[source:${step.name}]`,
-        };
-      });
-    const unresolvedItems = [
-      ...(verificationDecision?.unresolvedItems ?? []),
-      ...childOutputs
-        .filter((child) => child.marker !== "completed")
-        .map((child) => `${child.name}:${child.marker}`),
-    ];
-    const renderedResults = safeStringify({
-      plannerReason: plannerPlan.reason,
-      status: pipelineResult.status,
-      completedSteps: pipelineResult.completedSteps,
-      totalSteps: pipelineResult.totalSteps,
-      resumeFrom: pipelineResult.resumeFrom,
-      error: pipelineResult.error,
-      plannerSteps,
-      plannerEdges: plannerPlan.edges,
-      results: pipelineResult.context.results,
-      childOutputs,
-      verifier: verificationDecision ?? null,
-      unresolvedItems,
-    });
-    return [
-      { role: "system", content: systemPrompt },
-      {
-        role: "system",
-        content:
-          "Synthesize the final user-facing answer from deterministic workflow and delegated child results. " +
-          "Do not invent unexecuted steps and do not call any tools. " +
-          "When a major claim is derived from child output, append provenance tags like [source:<step_name>]. " +
-          "Explicitly surface unresolved items or failed/cancelled child outputs.",
-      },
-      {
-        role: "user",
-        content:
-          `Original request:\n${messageText}\n\n` +
-          `Workflow execution bundle (with child confidence/provenance markers):\n${renderedResults}`,
-      },
-    ];
-  }
-
-  private static ensureSubagentProvenanceCitations(
-    content: string,
-    plannerPlan: PlannerPlan,
-    pipelineResult: PipelineResult,
-  ): string {
-    const trimmed = content.trim();
-    const subagentStepNames = plannerPlan.steps
-      .filter((step): step is PlannerSubAgentTaskStepIntent => step.stepType === "subagent_task")
-      .map((step) => step.name)
-      .filter((name) =>
-        typeof pipelineResult.context.results[name] === "string"
-      );
-    if (subagentStepNames.length === 0) return content;
-    if (/\[source:[^\]]+\]/.test(trimmed)) return content;
-    const citationLine = `Sources: ${subagentStepNames
-      .map((name) => `[source:${name}]`)
-      .join(" ")}`;
-    if (trimmed.length === 0) return citationLine;
-    return `${content}\n\n${citationLine}`;
-  }
-
-  private static pipelineResultToToolCalls(
-    steps: readonly PlannerStepIntent[],
-    pipelineResult: PipelineResult,
-  ): ToolCallRecord[] {
-    const records: ToolCallRecord[] = [];
-    for (const step of steps) {
-      const result = pipelineResult.context.results[step.name];
-      if (typeof result !== "string") continue;
-      if (step.stepType === "deterministic_tool") {
-        const inferredFailure =
-          result.startsWith("SKIPPED:") || didToolCallFail(false, result);
-        records.push({
-          name: step.tool,
-          args: step.args,
-          result,
-          isError: inferredFailure,
-          durationMs: 0,
-        });
-        continue;
-      }
-      if (step.stepType === "subagent_task") {
-        const inferredFailure = ChatExecutor.didSubagentStepFail(result);
-        records.push({
-          name: "execute_with_agent",
-          args: {
-            objective: step.objective,
-            requiredToolCapabilities: step.requiredToolCapabilities,
-            stepName: step.name,
-          },
-          result,
-          isError: inferredFailure,
-          durationMs: 0,
-        });
-      }
-    }
-    return records;
-  }
-
-  private static didSubagentStepFail(result: string): boolean {
-    if (result.startsWith("SKIPPED:")) return true;
-    try {
-      const parsed = JSON.parse(result) as unknown;
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        Array.isArray(parsed)
-      ) {
-        return didToolCallFail(false, result);
-      }
-      const obj = parsed as Record<string, unknown>;
-      if (obj.success === false) return true;
-      if (obj.status === "failed" || obj.status === "cancelled") return true;
-      if (typeof obj.error === "string" && obj.error.trim().length > 0) {
-        return true;
-      }
-      return false;
-    } catch {
-      return didToolCallFail(false, result);
-    }
-  }
-
-  private static buildSemanticToolCallKey(
-    name: string,
-    args: Record<string, unknown>,
-  ): string {
-    return `${name}:${ChatExecutor.normalizeSemanticValue(args)}`;
-  }
-
-  private static normalizeSemanticValue(value: unknown): string {
-    if (value === null || value === undefined) return "null";
-    if (typeof value === "string") {
-      return value.trim().replace(/\s+/g, " ").toLowerCase();
-    }
-    if (typeof value === "number" || typeof value === "boolean") {
-      return String(value);
-    }
-    if (Array.isArray(value)) {
-      return `[${value.map((item) => ChatExecutor.normalizeSemanticValue(item)).join(",")}]`;
-    }
-    if (typeof value === "object") {
-      const obj = value as Record<string, unknown>;
-      const keys = Object.keys(obj).sort();
-      return `{${keys
-        .map(
-          (key) =>
-            `${key}:${ChatExecutor.normalizeSemanticValue(obj[key])}`,
-        )
-        .join(",")}}`;
-    }
-    return String(value);
-  }
-
-  private static summarizeStateful(
-    callUsage: readonly ChatCallUsageRecord[],
-  ): ChatStatefulSummary | undefined {
-    const entries = callUsage
-      .map((entry) => entry.statefulDiagnostics)
-      .filter(
-        (entry): entry is LLMStatefulDiagnostics =>
-          entry !== undefined && entry.enabled,
-      );
-    if (entries.length === 0) return undefined;
-
-    const fallbackReasons: Record<LLMStatefulFallbackReason, number> = {
-      missing_previous_response_id: 0,
-      provider_retrieval_failure: 0,
-      state_reconciliation_mismatch: 0,
-    };
-    let attemptedCalls = 0;
-    let continuedCalls = 0;
-    let fallbackCalls = 0;
-
-    for (const entry of entries) {
-      if (entry.attempted) attemptedCalls++;
-      if (entry.continued) continuedCalls++;
-      if (entry.fallbackReason) {
-        fallbackCalls++;
-        fallbackReasons[entry.fallbackReason] += 1;
-      }
-    }
-
-    return {
-      enabled: true,
-      attemptedCalls,
-      continuedCalls,
-      fallbackCalls,
-      fallbackReasons,
-    };
-  }
-
-  private static buildRecoveryHints(
-    roundCalls: readonly ToolCallRecord[],
-    emittedHints: Set<string>,
-  ): RecoveryHint[] {
-    const hints: RecoveryHint[] = [];
-    for (const call of roundCalls) {
-      const hint = ChatExecutor.inferRecoveryHint(call);
-      if (!hint) continue;
-      if (emittedHints.has(hint.key)) continue;
-      emittedHints.add(hint.key);
-      hints.push(hint);
-    }
-    return hints;
-  }
-
-  private static inferRecoveryHint(
-    call: ToolCallRecord,
-  ): RecoveryHint | undefined {
-    if (!didToolCallFail(call.isError, call.result)) return undefined;
-
-    const failureText = extractToolFailureText(call);
-    const failureTextLower = failureText.toLowerCase();
-
-    if (call.name === "system.bash") {
-      const command = String(call.args?.command ?? "").trim().toLowerCase();
-      const isBuiltin = command.length > 0 && SHELL_BUILTIN_COMMANDS.has(command);
-      if (
-        isBuiltin ||
-        failureTextLower.includes("shell builtin") ||
-        /spawn\s+\S+\s+enoent/i.test(failureText)
-      ) {
-        return {
-          key: "system-bash-shell-builtin",
-          message:
-            "system.bash executes one real binary only. Shell builtins (for example `set`, `cd`, `export`) " +
-            "and script-style command chains do not work there. Use executable + args, or move multi-line/chained logic to `desktop.bash`.",
-        };
-      }
-      if (
-        failureTextLower.includes("one executable token") ||
-        failureTextLower.includes("shell operators/newlines")
-      ) {
-        return {
-          key: "system-bash-command-shape",
-          message:
-            "system.bash `command` must be a single executable token. Put flags/operands in `args`. " +
-            "For pipes/redirection/heredocs or multi-line shell scripts, use `desktop.bash`.",
-        };
-      }
-      if (failureTextLower.includes("nested shell invocation")) {
-        return {
-          key: "system-bash-shell-reinvocation",
-          message:
-            "system.bash already runs commands in a shell. Do NOT wrap with `bash -c` or `sh -c`. " +
-            "Pass the inner command directly as `command` (omit `args` for shell mode). " +
-            'Example: instead of command="bash -c \'curl http://...\'" use command="curl http://...".',
-        };
-      }
-    }
-
-    if (
-      call.name === "system.browse" ||
-      call.name === "system.httpGet" ||
-      call.name === "system.httpPost" ||
-      call.name === "system.httpFetch"
-    ) {
-      if (
-        failureTextLower.includes("private/loopback address blocked") ||
-        failureTextLower.includes("ssrf target blocked")
-      ) {
-        return {
-          key: "localhost-ssrf-blocked",
-          message:
-            "system.browse/system.http* block localhost/private/internal addresses by design. " +
-            "For local service checks on the HOST, use system.bash with curl (e.g. command=\"curl -sSf http://127.0.0.1:PORT\"). " +
-            "Desktop tools run inside Docker and CANNOT reach the host's localhost.",
-        };
-      }
-    }
-
-    return undefined;
-  }
 
   /** Extract plain-text content from a gateway message. */
-  private static extractMessageText(message: GatewayMessage): string {
-    return typeof message.content === "string" ? message.content : "";
-  }
-
-  /** Extract plain-text content from an LLM message. */
-  private static extractLLMMessageText(message: LLMMessage): string {
-    if (typeof message.content === "string") return message.content;
-    return message.content
-      .filter((part) => part.type === "text")
-      .map((part) => part.text)
-      .join(" ");
-  }
-
-  private static truncateText(value: string, maxChars: number): string {
-    if (value.length <= maxChars) return value;
-    if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
-    return value.slice(0, maxChars - 3) + "...";
-  }
-
-  private static sanitizeFinalContent(content: string): string {
-    if (!content) return content;
-    const collapsed = ChatExecutor.collapseRunawayRepetition(content);
-    if (collapsed.length <= MAX_FINAL_RESPONSE_CHARS) return collapsed;
-    return (
-      ChatExecutor.truncateText(collapsed, MAX_FINAL_RESPONSE_CHARS) +
-      "\n\n[response truncated: oversized model output suppressed]"
-    );
-  }
-
-  private static reconcileStructuredToolOutcome(
-    content: string,
-    toolCalls: readonly ToolCallRecord[],
-  ): string {
-    if (!content || toolCalls.length === 0) return content;
-    const trimmed = content.trim();
-    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return content;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed) as unknown;
-    } catch {
-      return content;
-    }
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return content;
-    }
-
-    const payload = parsed as Record<string, unknown>;
-    if (typeof payload.overall !== "string" || !Array.isArray(payload.steps)) {
-      return content;
-    }
-
-    const normalizedOverall = payload.overall.trim().toLowerCase();
-    if (normalizedOverall !== "pass") {
-      return content;
-    }
-
-    const hasToolFailure = toolCalls.some((toolCall) =>
-      didToolCallFail(toolCall.isError, toolCall.result),
-    );
-
-    const executedTools = new Set(
-      toolCalls
-        .map((toolCall) => toolCall.name?.trim())
-        .filter((name): name is string => Boolean(name)),
-    );
-    const claimedTools = new Set<string>();
-    for (const step of payload.steps) {
-      if (typeof step !== "object" || step === null || Array.isArray(step)) {
-        continue;
-      }
-      const toolName = (step as { tool?: unknown }).tool;
-      if (typeof toolName === "string" && toolName.trim().length > 0) {
-        claimedTools.add(toolName.trim());
-      }
-    }
-
-    const claimsUnexecutedTool = Array.from(claimedTools).some(
-      (toolName) => !executedTools.has(toolName),
-    );
-
-    if (!hasToolFailure && !claimsUnexecutedTool) {
-      return content;
-    }
-
-    payload.overall = "fail";
-    return safeStringify(payload);
-  }
-
-  private static collapseRunawayRepetition(content: string): string {
-    const lines = content.split(/\r?\n/);
-    if (lines.length < REPETITIVE_LINE_MIN_COUNT) return content;
-
-    const normalized = lines.map((line) =>
-      line.trim().replace(/\s+/g, " ").toLowerCase(),
-    );
-    const nonEmpty = normalized.filter((line) => line.length > 0);
-    if (nonEmpty.length < REPETITIVE_LINE_MIN_COUNT) return content;
-
-    const freq = new Map<string, number>();
-    for (const line of nonEmpty) {
-      if (line.length > 80) continue;
-      freq.set(line, (freq.get(line) ?? 0) + 1);
-    }
-
-    let topCount = 0;
-    for (const count of freq.values()) {
-      if (count > topCount) topCount = count;
-    }
-
-    const uniqueRatio = new Set(nonEmpty).size / nonEmpty.length;
-    if (
-      topCount < REPETITIVE_LINE_MIN_REPEATS ||
-      uniqueRatio > REPETITIVE_LINE_MAX_UNIQUE_RATIO
-    ) {
-      return content;
-    }
-
-    const preview = lines.slice(0, 24).join("\n");
-    return `${preview}\n\n[response truncated: repetitive model output suppressed]`;
-  }
-
-  private static isBase64Like(value: string): boolean {
-    if (value.length < 128) return false;
-    return /^[A-Za-z0-9+/=\r\n]+$/.test(value);
-  }
-
-  private static estimateContentChars(
-    content: string | LLMContentPart[],
-  ): number {
-    if (typeof content === "string") return content.length;
-    return content.reduce((sum, part) => {
-      if (part.type === "text") return sum + part.text.length;
-      return sum + part.image_url.url.length;
-    }, 0);
-  }
-
-  private static estimateMessageChars(message: LLMMessage): number {
-    // Small role/metadata overhead for rough token approximation.
-    return ChatExecutor.estimateContentChars(message.content) + 64;
-  }
-
-  private static estimatePromptShape(
-    messages: readonly LLMMessage[],
-  ): ChatPromptShape {
-    let systemMessages = 0;
-    let userMessages = 0;
-    let assistantMessages = 0;
-    let toolMessages = 0;
-    let estimatedChars = 0;
-    let systemPromptChars = 0;
-
-    for (const message of messages) {
-      estimatedChars += ChatExecutor.estimateMessageChars(message);
-      if (message.role === "system") {
-        systemMessages++;
-        systemPromptChars += ChatExecutor.estimateContentChars(message.content);
-      } else if (message.role === "user") {
-        userMessages++;
-      } else if (message.role === "assistant") {
-        assistantMessages++;
-      } else if (message.role === "tool") {
-        toolMessages++;
-      }
-    }
-
-    return {
-      messageCount: messages.length,
-      systemMessages,
-      userMessages,
-      assistantMessages,
-      toolMessages,
-      estimatedChars,
-      systemPromptChars,
-    };
-  }
-
-  private static normalizeHistory(history: readonly LLMMessage[]): LLMMessage[] {
-    const recent = history.slice(-MAX_HISTORY_MESSAGES);
-    return recent.map((entry) => {
-      if (typeof entry.content === "string") {
-        if (entry.role === "tool") {
-          const prepared = ChatExecutor.prepareToolResultForPrompt(entry.content);
-          return { ...entry, content: prepared.text };
-        }
-        return {
-          ...entry,
-          content: ChatExecutor.truncateText(
-            entry.content,
-            MAX_HISTORY_MESSAGE_CHARS,
-          ),
-        };
-      }
-
-      const parts: LLMContentPart[] = entry.content.map((part) => {
-        if (part.type === "text") {
-          return {
-            type: "text" as const,
-            text: ChatExecutor.truncateText(
-              part.text,
-              MAX_HISTORY_MESSAGE_CHARS,
-            ),
-          };
-        }
-        // Never replay historical inline images into future prompts.
-        return {
-          type: "text" as const,
-          text: "[prior image omitted]",
-        };
-      });
-      return { ...entry, content: parts };
-    });
-  }
-
-  private static sanitizeJsonForPrompt(
-    value: unknown,
-    captureDataUrl: (url: string) => void,
-  ): unknown {
-    const keyPriority = (key: string): number => {
-      const normalized = key.toLowerCase();
-      const idx = TOOL_RESULT_PRIORITY_KEYS.indexOf(
-        normalized as (typeof TOOL_RESULT_PRIORITY_KEYS)[number],
-      );
-      return idx >= 0 ? idx : TOOL_RESULT_PRIORITY_KEYS.length + 1;
-    };
-
-    if (typeof value === "string") {
-      if (value.startsWith("data:image/")) {
-        captureDataUrl(value);
-        return "(see image)";
-      }
-      if (ChatExecutor.isBase64Like(value)) {
-        return "(base64 omitted)";
-      }
-      return ChatExecutor.truncateText(value, MAX_TOOL_RESULT_FIELD_CHARS);
-    }
-    if (Array.isArray(value)) {
-      const sanitizedItems = value
-        .slice(0, MAX_TOOL_RESULT_ARRAY_ITEMS)
-        .map((item) => ChatExecutor.sanitizeJsonForPrompt(item, captureDataUrl));
-      const omitted = value.length - sanitizedItems.length;
-      if (omitted > 0) {
-        sanitizedItems.push(`[${omitted} items omitted]`);
-      }
-      return sanitizedItems;
-    }
-    if (value && typeof value === "object") {
-      const obj = value as Record<string, unknown>;
-      const out: Record<string, unknown> = {};
-      const orderedEntries = Object.entries(obj)
-        .sort(([a], [b]) => {
-          const priorityDelta = keyPriority(a) - keyPriority(b);
-          if (priorityDelta !== 0) return priorityDelta;
-          return a.localeCompare(b);
-        })
-        .slice(0, MAX_TOOL_RESULT_OBJECT_KEYS);
-      for (const [key, field] of orderedEntries) {
-        const keyLower = key.toLowerCase();
-        if (typeof field === "string") {
-          if (field.startsWith("data:image/")) {
-            captureDataUrl(field);
-            out[key] = "(see image)";
-            continue;
-          }
-          if (
-            keyLower === "image" ||
-            keyLower === "dataurl" ||
-            keyLower.endsWith("base64")
-          ) {
-            if (ChatExecutor.isBase64Like(field)) {
-              out[key] = "(base64 omitted)";
-              continue;
-            }
-          }
-          out[key] = ChatExecutor.truncateText(
-            field,
-            MAX_TOOL_RESULT_FIELD_CHARS,
-          );
-          continue;
-        }
-        out[key] = ChatExecutor.sanitizeJsonForPrompt(field, captureDataUrl);
-      }
-      const omittedKeys = Object.keys(obj).length - orderedEntries.length;
-      if (omittedKeys > 0) {
-        out.__truncatedKeys = omittedKeys;
-      }
-      return out;
-    }
-    return value;
-  }
-
-  private static prepareToolResultForPrompt(result: string): {
-    text: string;
-    dataUrl?: string;
-  } {
-    let capturedDataUrl: string | undefined;
-    const setDataUrl = (url: string): void => {
-      if (!capturedDataUrl) capturedDataUrl = url;
-    };
-
-    try {
-      const parsed = JSON.parse(result) as unknown;
-      const sanitized = ChatExecutor.sanitizeJsonForPrompt(parsed, setDataUrl);
-      return {
-        text: ChatExecutor.truncateText(
-          safeStringify(sanitized),
-          MAX_TOOL_RESULT_CHARS,
-        ),
-        ...(capturedDataUrl ? { dataUrl: capturedDataUrl } : {}),
-      };
-    } catch {
-      const dataUrlMatch = result.match(
-        /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/,
-      );
-      const text = result
-        .replace(
-          /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g,
-          "(see image)",
-        )
-        .replace(/"[Ii]mage"\s*:\s*"[A-Za-z0-9+/=\r\n]{128,}"/g, '"image":"(base64 omitted)"')
-        .trim();
-      return {
-        text: ChatExecutor.truncateText(text, MAX_TOOL_RESULT_CHARS),
-        ...(dataUrlMatch ? { dataUrl: dataUrlMatch[0] } : {}),
-      };
-    }
-  }
-
-  private static buildPromptToolContent(
-    result: string,
-    remainingImageBudget: number,
-  ): {
-    content: string | import("./types.js").LLMContentPart[];
-    remainingImageBudget: number;
-  } {
-    const prepared = ChatExecutor.prepareToolResultForPrompt(result);
-    if (!prepared.dataUrl) {
-      return { content: prepared.text, remainingImageBudget };
-    }
-
-    if (!ENABLE_TOOL_IMAGE_REPLAY) {
-      const note = ChatExecutor.truncateText(
-        `${prepared.text}\n\n[Image artifact kept out-of-band by default; prefer URL/DOM/text/process checks before visual verification.]`,
-        MAX_TOOL_RESULT_CHARS,
-      );
-      return { content: note, remainingImageBudget };
-    }
-
-    // Prevent huge inline screenshots from blowing up prompt size.
-    if (prepared.dataUrl.length > remainingImageBudget) {
-      const note =
-        prepared.text +
-        "\n\n[Screenshot omitted from prompt due image context budget]";
-      return {
-        content: ChatExecutor.truncateText(note, MAX_TOOL_RESULT_CHARS),
-        remainingImageBudget,
-      };
-    }
-
-    return {
-      content: [
-        { type: "image_url" as const, image_url: { url: prepared.dataUrl } },
-        { type: "text" as const, text: prepared.text },
-      ],
-      remainingImageBudget: remainingImageBudget - prepared.dataUrl.length,
-    };
-  }
-
-  /** Append a user message, handling multimodal (image) attachments. */
-  private static appendUserMessage(
-    messages: LLMMessage[],
-    sections: PromptBudgetSection[],
-    message: GatewayMessage,
-  ): void {
-    const imageAttachments = (message.attachments ?? []).filter(
-      (a) => a.data && a.mimeType.startsWith("image/"),
-    );
-    const trimmedUserText = ChatExecutor.truncateText(
-      message.content,
-      MAX_USER_MESSAGE_CHARS,
-    );
-    if (imageAttachments.length > 0) {
-      const contentParts: LLMContentPart[] = [];
-      if (trimmedUserText) {
-        contentParts.push({ type: "text", text: trimmedUserText });
-      }
-      for (const att of imageAttachments) {
-        const base64 = Buffer.from(att.data!).toString("base64");
-        contentParts.push({
-          type: "image_url",
-          image_url: { url: `data:${att.mimeType};base64,${base64}` },
-        });
-      }
-      messages.push({ role: "user", content: contentParts });
-      sections.push("user");
-    } else {
-      messages.push({ role: "user", content: trimmedUserText });
-      sections.push("user");
-    }
-  }
-
-  /**
-   * Build a human-readable fallback when the LLM returned empty content
-   * after tool calls (e.g. when maxToolRounds is hit mid-loop).
-   */
-  private static generateFallbackContent(
-    allToolCalls: readonly ToolCallRecord[],
-  ): string | undefined {
-    const successes = allToolCalls.filter((tc) => !tc.isError);
-    const lastSuccess = successes[successes.length - 1];
-    if (!lastSuccess) return undefined;
-
-    try {
-      const parsed = JSON.parse(lastSuccess.result);
-      if (parsed.taskPda) {
-        return `Task created successfully.\n\n**Task PDA:** ${parsed.taskPda}\n**Transaction:** ${parsed.transactionSignature ?? "confirmed"}`;
-      }
-      if (parsed.agentPda) {
-        return `Agent registered successfully.\n\n**Agent PDA:** ${parsed.agentPda}\n**Transaction:** ${parsed.transactionSignature ?? "confirmed"}`;
-      }
-      if (
-        parsed.success === true ||
-        parsed.exitCode === 0 ||
-        parsed.output !== undefined
-      ) {
-        return ChatExecutor.summarizeToolCalls(successes);
-      }
-      if (parsed.error) {
-        return `Something went wrong: ${String(parsed.error).slice(0, MAX_ERROR_PREVIEW_CHARS)}`;
-      }
-      if (parsed.exitCode != null && parsed.exitCode !== 0) {
-        const errOutput = parsed.stderr || parsed.stdout || "";
-        return errOutput.trim()
-          ? `Command failed: ${String(errOutput).slice(0, MAX_ERROR_PREVIEW_CHARS)}`
-          : "The command failed. Let me try a different approach.";
-      }
-      return `Operation completed. Result:\n\`\`\`json\n${lastSuccess.result.slice(0, MAX_RESULT_PREVIEW_CHARS)}\n\`\`\``;
-    } catch {
-      return `Operation completed. Result: ${lastSuccess.result.slice(0, MAX_RESULT_PREVIEW_CHARS)}`;
-    }
-  }
-
-  /** Build a human-readable summary from successful tool calls. */
-  private static summarizeToolCalls(
-    successes: readonly ToolCallRecord[],
-  ): string {
-    const summaries: string[] = [];
-    for (const tc of successes) {
-      if (tc.name === "system.open") {
-        const target = String(tc.args?.target ?? "");
-        if (target.includes("youtube.com/watch")) {
-          summaries.push("Opened YouTube video");
-        } else if (target.includes("youtube.com")) {
-          summaries.push("Opened YouTube");
-        } else if (target) {
-          summaries.push(
-            `Opened ${target.slice(0, MAX_URL_PREVIEW_CHARS)}`,
-          );
-        }
-      } else if (tc.name === "system.bash") {
-        try {
-          const bashResult = JSON.parse(tc.result);
-          const bashOutput = bashResult.stdout || bashResult.output || "";
-          if (bashOutput.trim()) {
-            summaries.push(
-              bashOutput.trim().slice(0, MAX_BASH_OUTPUT_CHARS),
-            );
-          } else {
-            const cmd = String(tc.args?.command ?? "").slice(
-              0,
-              MAX_COMMAND_PREVIEW_CHARS,
-            );
-            if (cmd) summaries.push(`Ran: ${cmd}`);
-          }
-        } catch {
-          const cmd = String(tc.args?.command ?? "").slice(
-            0,
-            MAX_COMMAND_PREVIEW_CHARS,
-          );
-          if (cmd) summaries.push(`Ran: ${cmd}`);
-        }
-      } else if (tc.name === "system.applescript") {
-        const script = String(tc.args?.script ?? "");
-        if (script.includes("do script")) {
-          summaries.push("Opened Terminal and ran the command");
-        } else if (script.includes("activate")) {
-          summaries.push("Brought app to front");
-        } else if (script.includes("quit")) {
-          summaries.push("Closed the app");
-        } else {
-          summaries.push("Done");
-        }
-      } else if (tc.name === "system.notification") {
-        summaries.push("Notification sent");
-      } else {
-        summaries.push("Done");
-      }
-    }
-    return summaries.length > 0 ? summaries.join("\n") : "Done!";
-  }
 
   /**
    * Best-effort context injection. Supports both SkillInjector (`.inject()`)
@@ -5232,7 +2560,7 @@ export class ChatExecutor {
         const sectionMaxChars = this.getContextSectionMaxChars(section);
         messages.push({
           role: "system",
-          content: ChatExecutor.truncateText(
+          content: truncateText(
             context,
             sectionMaxChars,
           ),
@@ -5317,10 +2645,6 @@ export class ChatExecutor {
   // Response evaluation
   // --------------------------------------------------------------------------
 
-  private static readonly DEFAULT_EVAL_RUBRIC =
-    "Rate this AI response 0.0-1.0. Consider accuracy, completeness, clarity, " +
-    "and appropriate use of tool results.\n" +
-    'Return ONLY JSON: {"score": 0.0-1.0, "feedback": "brief explanation"}';
 
   private async evaluateResponse(
     content: string,
@@ -5335,7 +2659,7 @@ export class ChatExecutor {
     afterBudget: ChatPromptShape;
     budgetDiagnostics: PromptBudgetDiagnostics;
   }> {
-    const rubric = this.evaluator?.rubric ?? ChatExecutor.DEFAULT_EVAL_RUBRIC;
+    const rubric = this.evaluator?.rubric ?? DEFAULT_EVAL_RUBRIC;
     let fallbackResult: FallbackResult;
     try {
       fallbackResult = await this.callWithFallback([
@@ -5394,7 +2718,6 @@ export class ChatExecutor {
   // --------------------------------------------------------------------------
 
   /** Max chars of history text sent to the summarization call. */
-  private static readonly MAX_COMPACT_INPUT = 20_000;
 
   private async compactHistory(
     history: readonly LLMMessage[],
@@ -5422,8 +2745,8 @@ export class ChatExecutor {
       })
       .join("\n");
 
-    if (historyText.length > ChatExecutor.MAX_COMPACT_INPUT) {
-      historyText = historyText.slice(-ChatExecutor.MAX_COMPACT_INPUT);
+    if (historyText.length > MAX_COMPACT_INPUT) {
+      historyText = historyText.slice(-MAX_COMPACT_INPUT);
     }
 
     let compactResponse: FallbackResult;


### PR DESCRIPTION
## Summary

- Decompose the 5,741-line `ChatExecutor` monolith into 8 responsibility-focused files (main file reduced to 2,788 lines — 51% reduction)
- All `private static` methods converted to standalone exported functions in dedicated modules: types, constants, tool-utils, text, recovery, planner, verifier
- Zero breaking changes — `llm/index.ts` and all 17 consumer files unchanged via re-exports from `chat-executor.ts`

## New file structure

| File | Lines | Content |
|------|-------|---------|
| `chat-executor.ts` | 2,788 | Class + instance methods + re-exports |
| `chat-executor-types.ts` | 620 | All types, interfaces, error class |
| `chat-executor-constants.ts` | 201 | All constants, tool classification sets |
| `chat-executor-tool-utils.ts` | 131 | 9 standalone tool helper functions |
| `chat-executor-text.ts` | 658 | 22 text processing functions |
| `chat-executor-recovery.ts` | 170 | 5 semantic/recovery functions |
| `chat-executor-planner.ts` | 1,155 | 22 planner parsing/validation functions |
| `chat-executor-verifier.ts` | 421 | 9 subagent verifier functions |

## Test plan

- [x] TypeScript typecheck passes clean
- [x] chat-executor.test.ts: 112/112 tests pass
- [x] Full runtime test suite: 5,297/5,297 tests pass (260 files)
- [x] Full build (sdk + runtime + mcp + docs-mcp) succeeds
- [x] No circular dependencies (all imports point "up" the dependency graph)