### PR TITLE
fix(runtime): harden kitty/tmux tool routing and failure handling

### DIFF
--- a/containers/desktop/Dockerfile
+++ b/containers/desktop/Dockerfile
@@ -225,6 +225,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && python3 -m pip install --break-system-packages --ignore-installed --no-cache-dir --upgrade pip wheel==0.46.2 jaraco.context==6.1.0 \
     && git clone https://github.com/den-tanui/kitty-mcp.git /tmp/kitty-mcp \
     && sed -i '30,34d' /tmp/kitty-mcp/pyproject.toml \
+    && sed -i 's/--app-id=/--class=/g' /tmp/kitty-mcp/src/kitty_mcp/kitty.py \
     && /home/agenc/.local/bin/uv tool install /tmp/kitty-mcp \
     && UV_PYTHON_BIN="$(find /home/agenc/.local/share/uv/python -path '*/bin/python' 2>/dev/null | head -n1 || true)" \
     && if [ -n "$UV_PYTHON_BIN" ]; then \

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -34,6 +34,14 @@ const TOOLS: LLMTool[] = [
   makeTool("agenc.getTask", "Read task details"),
 ];
 
+const MCP_TERMINAL_TOOLS: LLMTool[] = [
+  ...TOOLS,
+  makeTool("mcp.kitty.launch", "Launch kitty terminal window"),
+  makeTool("mcp.kitty.send_text", "Send text to a kitty instance"),
+  makeTool("mcp.tmux.execute-command", "Execute command in tmux session"),
+  makeTool("mcp.tmux.list-sessions", "List tmux sessions"),
+];
+
 describe("ToolRouter", () => {
   it("returns full toolset when disabled", () => {
     const router = new ToolRouter(TOOLS, { enabled: false });
@@ -114,6 +122,31 @@ describe("ToolRouter", () => {
 
     expect(next.diagnostics.cacheHit).toBe(false);
     expect(next.diagnostics.invalidatedReason).toBe("explicit_redirect");
+  });
+
+  it("invalidates cached route when explicit tmux intent needs mcp.tmux family", () => {
+    const router = new ToolRouter(MCP_TERMINAL_TOOLS, {
+      maxToolsPerTurn: 8,
+      minCacheConfidence: 0,
+    });
+
+    const first = router.route({
+      sessionId: "s-tmux",
+      messageText: "open a kitty terminal and keep using it",
+      history: [],
+    });
+    expect(first.routedToolNames.some((name) => name.startsWith("mcp.kitty."))).toBe(true);
+    expect(first.routedToolNames.some((name) => name.startsWith("mcp.tmux."))).toBe(false);
+
+    const second = router.route({
+      sessionId: "s-tmux",
+      messageText: "in that same terminal start tmux",
+      history: [{ role: "user", content: "open a kitty terminal", toolCalls: undefined }],
+    });
+
+    expect(second.diagnostics.cacheHit).toBe(false);
+    expect(second.diagnostics.invalidatedReason).toBe("missing_required_family");
+    expect(second.routedToolNames.some((name) => name.startsWith("mcp.tmux."))).toBe(true);
   });
 
   it("invalidates cache after repeated routing misses", () => {

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -133,6 +133,14 @@ const MCP_TERMS = new Set([
   "window",
 ]);
 
+const REQUIRED_MCP_FAMILY_BY_TERM: Record<string, string> = {
+  kitty: "mcp.kitty",
+  tmux: "mcp.tmux",
+  neovim: "mcp.neovim",
+  nvim: "mcp.neovim",
+  vim: "mcp.neovim",
+};
+
 interface NormalizedRoutingConfig {
   enabled: boolean;
   minToolsPerTurn: number;
@@ -245,6 +253,19 @@ function familyFromToolName(name: string): string {
     }
   }
   return prefix;
+}
+
+function requiredFamiliesForTerms(terms: readonly string[]): Set<string> {
+  const required = new Set<string>();
+  for (const term of terms) {
+    const family = REQUIRED_MCP_FAMILY_BY_TERM[term];
+    if (family) required.add(family);
+  }
+  return required;
+}
+
+function hasAnyToolInFamily(toolNames: readonly string[], family: string): boolean {
+  return toolNames.some((name) => familyFromToolName(name) === family);
 }
 
 function normalizeConfig(config: ToolRoutingConfig | undefined): NormalizedRoutingConfig {
@@ -377,6 +398,7 @@ export class ToolRouter {
     const clusterKey = intentTerms.slice(0, 6).join("|") || "general";
     const now = Date.now();
     const cached = this.cache.get(params.sessionId);
+    const requiredFamilies = requiredFamiliesForTerms(intentTerms);
 
     let invalidatedReason: string | undefined;
     if (cached) {
@@ -386,6 +408,12 @@ export class ToolRouter {
         invalidatedReason = "ttl_expired";
       } else if (EXPLICIT_PIVOT_RE.test(params.messageText)) {
         invalidatedReason = "explicit_redirect";
+      } else if (
+        Array.from(requiredFamilies).some(
+          (family) => !hasAnyToolInFamily(cached.routedToolNames, family),
+        )
+      ) {
+        invalidatedReason = "missing_required_family";
       } else {
         const similarity = jaccardSimilarity(intentTerms, cached.terms);
         if (intentTerms.length > 0 && similarity < this.config.pivotSimilarityThreshold) {
@@ -410,7 +438,7 @@ export class ToolRouter {
     }
 
     const scored = this.scoreTools(intentTerms);
-    const routedToolNames = this.selectRoutedTools(scored);
+    const routedToolNames = this.selectRoutedTools(scored, requiredFamilies);
     const expandedToolNames = this.selectExpandedTools(scored, routedToolNames);
     const confidence = this.estimateConfidence(scored, intentTerms, routedToolNames);
 
@@ -501,6 +529,7 @@ export class ToolRouter {
     const hasFileIntent = intentTerms.some((term) => FILE_TERMS.has(term));
     const hasNetworkIntent = intentTerms.some((term) => NETWORK_TERMS.has(term));
     const hasMCPIntent = intentTerms.some((term) => MCP_TERMS.has(term));
+    const requiredFamilies = requiredFamiliesForTerms(intentTerms);
 
     const scored = this.indexedTools.map((tool) => {
       let score = 0;
@@ -525,6 +554,9 @@ export class ToolRouter {
       }
       if (hasMCPIntent && tool.family.startsWith("mcp.")) {
         score += 3;
+      }
+      if (requiredFamilies.has(tool.family)) {
+        score += 6;
       }
       if (hasFileIntent && tool.family === "system") {
         if (
@@ -558,6 +590,7 @@ export class ToolRouter {
 
   private selectRoutedTools(
     scored: ReadonlyArray<{ tool: IndexedTool; score: number }>,
+    requiredFamilies: ReadonlySet<string>,
   ): string[] {
     const selected = new Set<string>();
     const familyCounts = new Map<string, number>();
@@ -585,6 +618,12 @@ export class ToolRouter {
       selected.add(candidate.name);
       familyCounts.set(candidate.family, usedInFamily + 1);
     };
+
+    for (const requiredFamily of requiredFamilies) {
+      const bestRequired = scored.find((entry) => entry.tool.family === requiredFamily);
+      if (!bestRequired) continue;
+      tryAdd(bestRequired.tool);
+    }
 
     for (const entry of scored) {
       if (entry.score <= 0 && selected.size >= minTools) break;

--- a/runtime/src/llm/chat-executor-tool-utils.test.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { didToolCallFail } from "./chat-executor-tool-utils.js";
+
+describe("chat-executor-tool-utils", () => {
+  describe("didToolCallFail", () => {
+    it("returns true when execution is marked isError", () => {
+      expect(didToolCallFail(true, "ok")).toBe(true);
+    });
+
+    it("returns true for JSON error payloads", () => {
+      expect(didToolCallFail(false, '{"error":"boom"}')).toBe(true);
+    });
+
+    it("returns true for non-zero JSON exitCode", () => {
+      expect(didToolCallFail(false, '{"exitCode":1}')).toBe(true);
+    });
+
+    it("returns true for MCP plain-text failure signatures", () => {
+      expect(
+        didToolCallFail(
+          false,
+          'MCP tool "launch" failed: MCP tool "launch" callTool timed out after 30000ms',
+        ),
+      ).toBe(true);
+    });
+
+    it("returns true for plain-text tool execution errors", () => {
+      expect(
+        didToolCallFail(
+          false,
+          "Error executing tool send_text: Instance 'terminal1' not found",
+        ),
+      ).toBe(true);
+    });
+
+    it("returns false for normal non-JSON output", () => {
+      expect(didToolCallFail(false, "all good")).toBe(false);
+    });
+  });
+});

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -17,18 +17,24 @@ import {
 } from "./chat-executor-constants.js";
 import { safeStringify } from "../tools/types.js";
 
+const NON_JSON_FAILURE_PREFIXES = [
+  "mcp tool \"",
+  "error executing tool",
+];
+
 export function didToolCallFail(isError: boolean, result: string): boolean {
   if (isError) return true;
   try {
     const parsed = JSON.parse(result) as unknown;
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      return false;
+      return isLikelyFailureText(result);
     }
     const obj = parsed as Record<string, unknown>;
     if (typeof obj.error === "string" && obj.error.trim().length > 0) return true;
     if (typeof obj.exitCode === "number" && obj.exitCode !== 0) return true;
   } catch {
-    // Non-JSON tool output — treat as non-failure unless isError=true.
+    // Non-JSON tool output — detect known tool-wrapper failure signatures.
+    return isLikelyFailureText(result);
   }
   return false;
 }
@@ -128,4 +134,11 @@ export function enrichToolResultMetadata(
     ...parsed,
     ...metadata,
   });
+}
+
+function isLikelyFailureText(result: string): boolean {
+  const text = result.trim().toLowerCase();
+  if (text.length === 0) return false;
+  if (text.startsWith("mcp tool \"") && text.includes("\" failed:")) return true;
+  return NON_JSON_FAILURE_PREFIXES.some((prefix) => text.startsWith(prefix));
 }

--- a/runtime/src/tools/registry.test.ts
+++ b/runtime/src/tools/registry.test.ts
@@ -181,6 +181,25 @@ describe("ToolRegistry", () => {
     expect(result).toBe('{"error":"invalid input"}');
   });
 
+  it("createToolHandler wraps plain-text tool errors as JSON", async () => {
+    const registry = new ToolRegistry();
+    registry.register(
+      makeTool("test.soft-fail-text", {
+        execute: async (): Promise<ToolResult> => ({
+          content: 'MCP tool "launch" failed: timed out',
+          isError: true,
+        }),
+      }),
+    );
+
+    const handler = registry.createToolHandler();
+    const result = await handler("test.soft-fail-text", {});
+
+    expect(JSON.parse(result)).toEqual({
+      error: 'MCP tool "launch" failed: timed out',
+    });
+  });
+
   it("createToolHandler blocks denied tools via policy engine", async () => {
     const policyEngine = new PolicyEngine({
       policy: {

--- a/runtime/src/tools/registry.ts
+++ b/runtime/src/tools/registry.ts
@@ -183,6 +183,7 @@ export class ToolRegistry {
         const result = await tool.execute(args);
         if (result.isError) {
           this.logger.warn(`Tool "${name}" returned error: ${result.content}`);
+          return normalizeToolErrorContent(result.content);
         }
         return result.content;
       } catch (err) {
@@ -203,4 +204,20 @@ function inferToolAccess(toolName: string): "read" | "write" {
   const readPrefixes = ["get", "list", "query", "inspect", "read"];
   if (readPrefixes.some((p) => action.startsWith(p))) return "read";
   return "write";
+}
+
+function normalizeToolErrorContent(content: string): string {
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return content;
+    }
+  } catch {
+    // Non-JSON error payloads are wrapped below.
+  }
+
+  const message = content.trim();
+  return safeStringify({
+    error: message.length > 0 ? message : "Tool execution failed",
+  });
 }


### PR DESCRIPTION
## Summary\n- fix kitty MCP launch compatibility in desktop image by aligning launch flag with installed kitty build\n- harden tool routing cache invalidation so explicit tmux intent includes the mcp.tmux family\n- normalize plain-text tool errors and classify known non-JSON MCP failures as failed calls\n\n## Testing\n- npm --prefix runtime run test -- src/gateway/tool-routing.test.ts src/tools/registry.test.ts src/llm/chat-executor-tool-utils.test.ts\n- npm --prefix runtime run typecheck\n