### PR TITLE
refactor(runtime): decompose ChatExecutor instance methods

### DIFF
--- a/runtime/src/desktop/manager.test.ts
+++ b/runtime/src/desktop/manager.test.ts
@@ -181,7 +181,7 @@ describe("DesktopSandboxManager", () => {
       const args = runCall![1] as string[];
       expect(args).toContain("--detach");
       expect(args).toContain("--pids-limit");
-      expect(args).toContain("256");
+      expect(args).toContain("1024");
       expect(args).toContain("agenc/desktop:latest");
     });
 

--- a/runtime/src/desktop/manager.ts
+++ b/runtime/src/desktop/manager.ts
@@ -41,8 +41,8 @@ const CONTAINER_API_PORT = 9990;
 const CONTAINER_VNC_PORT = 6080;
 /** Max subprocess output buffer (1 MB). */
 const MAX_EXEC_BUFFER = 1024 * 1024;
-/** Max PIDs per container — limits fork bombs. */
-const CONTAINER_PID_LIMIT = "256";
+/** Max PIDs per container — high enough for Chromium/Playwright worker bursts. */
+const CONTAINER_PID_LIMIT = "1024";
 /** Docker memory formats accepted by `docker run --memory` (e.g. 512m, 4g). */
 const MEMORY_LIMIT_RE = /^\d+(?:[bkmg])?$/i;
 /** Docker CPU formats accepted by `docker run --cpus` (e.g. 0.5, 2, 2.0). */

--- a/runtime/src/gateway/approvals.test.ts
+++ b/runtime/src/gateway/approvals.test.ts
@@ -133,16 +133,14 @@ describe('ApprovalEngine', () => {
       expect(rule!.tool).toBe('system.delete');
     });
 
-    it('requires approval for system.bash by default', () => {
+    it('does not require approval for system.bash by default', () => {
       const rule = engine.requiresApproval('system.bash', { command: 'npm' });
-      expect(rule).not.toBeNull();
-      expect(rule!.tool).toBe('system.bash');
+      expect(rule).toBeNull();
     });
 
-    it('requires approval for desktop.bash by default', () => {
+    it('does not require approval for desktop.bash by default', () => {
       const rule = engine.requiresApproval('desktop.bash', { command: 'whoami' });
-      expect(rule).not.toBeNull();
-      expect(rule!.tool).toBe('desktop.bash');
+      expect(rule).toBeNull();
     });
 
     it('returns null for unmatched tool', () => {
@@ -570,16 +568,16 @@ describe('ApprovalEngine', () => {
   // ============================================================================
 
   describe('DEFAULT_APPROVAL_RULES', () => {
-    it('has 12 rules', () => {
-      expect(DEFAULT_APPROVAL_RULES).toHaveLength(12);
+    it('has 10 rules', () => {
+      expect(DEFAULT_APPROVAL_RULES).toHaveLength(10);
     });
 
     it('covers system.delete and system.evaluateJs', () => {
       const tools = DEFAULT_APPROVAL_RULES.map((r) => r.tool);
       expect(tools).toContain('system.delete');
       expect(tools).toContain('system.evaluateJs');
-      expect(tools).toContain('system.bash');
-      expect(tools).toContain('desktop.bash');
+      expect(tools).not.toContain('system.bash');
+      expect(tools).not.toContain('desktop.bash');
     });
 
     it('covers wallet.sign, wallet.transfer, agenc.createTask, agenc.registerAgent', () => {

--- a/runtime/src/gateway/approvals.ts
+++ b/runtime/src/gateway/approvals.ts
@@ -152,8 +152,9 @@ export function extractAmount(
 /**
  * Built-in approval rules for common dangerous operations.
  *
- * Note: both `system.bash` and `desktop.bash` are included by default because
- * they are general-purpose execution surfaces.
+ * Note: `system.bash` and `desktop.bash` are intentionally NOT included by
+ * default to avoid blocking normal terminal workflows. Teams that require
+ * blanket shell approvals can add explicit rules via configuration.
  */
 export const DEFAULT_APPROVAL_RULES: readonly ApprovalRule[] = [
   {
@@ -163,14 +164,6 @@ export const DEFAULT_APPROVAL_RULES: readonly ApprovalRule[] = [
   {
     tool: "system.evaluateJs",
     description: "JavaScript evaluation",
-  },
-  {
-    tool: "system.bash",
-    description: "Shell command execution",
-  },
-  {
-    tool: "desktop.bash",
-    description: "Desktop sandbox shell command execution",
   },
   {
     tool: "wallet.sign",

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, readFile, writeFile, stat } from "node:fs/promises";
+import { mkdtemp, rm, readFile, writeFile, stat, mkdir, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -56,6 +56,7 @@ import {
   isProcessAlive,
   checkStalePid,
   isCommandUnavailableError,
+  sanitizeToolResultTextForTrace,
   resolveTraceLoggingConfig,
   summarizeToolFailureForLog,
   summarizeLLMFailureForSurface,
@@ -63,6 +64,7 @@ import {
   didEvalScriptPass,
   resolveBashToolEnv,
   resolveBashDenyExclusions,
+  ensureChromiumCompatShims,
   DaemonManager,
   generateSystemdUnit,
   generateLaunchdPlist,
@@ -92,6 +94,31 @@ describe("isCommandUnavailableError", () => {
 
   it("returns false for non-availability errors", () => {
     expect(isCommandUnavailableError(new Error("HTTP 500"))).toBe(false);
+  });
+});
+
+describe("sanitizeToolResultTextForTrace", () => {
+  it("scrubs embedded base64 blobs from mixed markdown tool output", () => {
+    const hugeBase64 = "A".repeat(30_000);
+    const raw = [
+      "### Result",
+      '- [Screenshot of viewport](../../tmp/screenshot.png)',
+      `{"type":"image","data":"${hugeBase64}"}`,
+    ].join("\n");
+
+    const sanitized = sanitizeToolResultTextForTrace(raw);
+
+    expect(sanitized).toContain('"data":"(base64 omitted)"');
+    expect(sanitized).not.toContain(hugeBase64.slice(0, 256));
+    expect(sanitized.length).toBeLessThan(raw.length);
+  });
+
+  it("scrubs inline data:image URLs", () => {
+    const raw = `result data:image/png;base64,${"B".repeat(1024)}`;
+    const sanitized = sanitizeToolResultTextForTrace(raw);
+
+    expect(sanitized).toContain("(see image)");
+    expect(sanitized).not.toContain("data:image/png;base64,");
   });
 });
 
@@ -326,7 +353,7 @@ describe("resolveBashDenyExclusions", () => {
       { desktop: { enabled: true } },
       "linux",
     );
-    expect(exclusions).toEqual(["killall", "pkill"]);
+    expect(exclusions).toEqual(["killall", "pkill", "gdb"]);
   });
 
   it("keeps desktop-only exclusions off for non-desktop Linux", () => {
@@ -343,6 +370,70 @@ describe("resolveBashDenyExclusions", () => {
       "darwin",
     );
     expect(exclusions).toEqual(["killall", "pkill", "curl", "wget"]);
+  });
+});
+
+describe("ensureChromiumCompatShims", () => {
+  it("creates chromium and chromium-browser shims when only google-chrome exists", async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), "agenc-chromium-shim-"));
+    try {
+      const fakeBin = join(tempHome, "fake-bin");
+      await mkdir(fakeBin, { recursive: true });
+
+      const chromePath = join(fakeBin, "google-chrome");
+      await writeFile(
+        chromePath,
+        "#!/usr/bin/env bash\nexit 0\n",
+        "utf-8",
+      );
+      await chmod(chromePath, 0o755);
+
+      const shimDir = await ensureChromiumCompatShims(
+        { desktop: { enabled: true } },
+        fakeBin,
+        undefined,
+        "linux",
+        tempHome,
+      );
+
+      expect(shimDir).toBe(join(tempHome, ".agenc", "bin"));
+
+      const chromiumShim = await readFile(join(shimDir!, "chromium"), "utf-8");
+      const chromiumBrowserShim = await readFile(
+        join(shimDir!, "chromium-browser"),
+        "utf-8",
+      );
+
+      expect(chromiumShim).toContain(`exec "${chromePath}" "$@"`);
+      expect(chromiumBrowserShim).toContain(`exec "${chromePath}" "$@"`);
+    } finally {
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("does not create shims when chromium commands already exist", async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), "agenc-chromium-shim-"));
+    try {
+      const fakeBin = join(tempHome, "fake-bin");
+      await mkdir(fakeBin, { recursive: true });
+
+      for (const cmd of ["chromium", "chromium-browser"]) {
+        const cmdPath = join(fakeBin, cmd);
+        await writeFile(cmdPath, "#!/usr/bin/env bash\nexit 0\n", "utf-8");
+        await chmod(cmdPath, 0o755);
+      }
+
+      const shimDir = await ensureChromiumCompatShims(
+        { desktop: { enabled: true } },
+        fakeBin,
+        undefined,
+        "linux",
+        tempHome,
+      );
+      expect(shimDir).toBeUndefined();
+    } finally {
+      await rm(tempHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -8,9 +8,9 @@
  * @module
  */
 
-import { mkdir, readFile, unlink, writeFile, access } from 'node:fs/promises';
+import { mkdir, readFile, unlink, writeFile, access, chmod } from 'node:fs/promises';
 import { constants } from 'node:fs';
-import { dirname, join, resolve as resolvePath } from 'node:path';
+import { delimiter, dirname, join, resolve as resolvePath } from 'node:path';
 import { homedir } from 'node:os';
 import { createHash, randomUUID } from 'node:crypto';
 import { spawn } from 'node:child_process';
@@ -220,7 +220,14 @@ const DEFAULT_HARD_BLOCKED_TASK_CLASSES: readonly DelegationHardBlockedTaskClass
 const BASH_SAFE_ENV_KEYS = ['PATH', 'HOME', 'USER', 'SHELL', 'LANG', 'TERM', 'SOLANA_RPC_URL'] as const;
 const BASH_DESKTOP_ENV_KEYS = ['DOCKER_HOST', 'CARGO_HOME', 'GOPATH', 'DISPLAY'] as const;
 const MAC_DESKTOP_BASH_DENY_EXCLUSIONS = ['killall', 'pkill', 'curl', 'wget'] as const;
-const LINUX_DESKTOP_BASH_DENY_EXCLUSIONS = ['killall', 'pkill'] as const;
+const LINUX_DESKTOP_BASH_DENY_EXCLUSIONS = ['killall', 'pkill', 'gdb'] as const;
+const CHROMIUM_COMPAT_COMMANDS = ['chromium', 'chromium-browser'] as const;
+const CHROMIUM_HOST_CHROME_CANDIDATES = [
+  'google-chrome',
+  '/usr/bin/google-chrome',
+  '/opt/google/chrome/chrome',
+] as const;
+const CHROMIUM_SHIM_DIR_SEGMENTS = ['.agenc', 'bin'] as const;
 
 /**
  * Build a minimal environment for system.bash.
@@ -259,6 +266,116 @@ export function resolveBashDenyExclusions(
     return [...LINUX_DESKTOP_BASH_DENY_EXCLUSIONS];
   }
   return undefined;
+}
+
+function splitPathEntries(pathValue: string | undefined): string[] {
+  if (!pathValue) return [];
+  return pathValue.split(delimiter).map((entry) => entry.trim()).filter((entry) => entry.length > 0);
+}
+
+async function isExecutablePath(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveExecutablePath(
+  command: string,
+  envPath: string | undefined,
+): Promise<string | undefined> {
+  if (command.includes('/')) {
+    return (await isExecutablePath(command)) ? command : undefined;
+  }
+
+  const searchDirs = splitPathEntries(envPath);
+  for (const dir of searchDirs) {
+    const candidate = join(dir, command);
+    if (await isExecutablePath(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function prependPathEntry(
+  pathValue: string | undefined,
+  entry: string,
+): string {
+  const entries = splitPathEntries(pathValue);
+  if (entries.includes(entry)) {
+    return entries.join(delimiter);
+  }
+  return [entry, ...entries].join(delimiter);
+}
+
+function buildChromiumShimScript(targetExecutable: string): string {
+  return [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    `exec ${JSON.stringify(targetExecutable)} "$@"`,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Ensure host-level Chromium compatibility commands exist for system.bash checks.
+ *
+ * Some Linux hosts only install Google Chrome. When desktop mode is enabled we
+ * provide user-scoped shim binaries (`chromium`, `chromium-browser`) that
+ * forward to Chrome, then prepend that shim directory to system.bash PATH.
+ */
+export async function ensureChromiumCompatShims(
+  config: Pick<GatewayConfig, 'desktop'>,
+  envPath: string | undefined,
+  logger: Logger | undefined = silentLogger,
+  platform: NodeJS.Platform = process.platform,
+  homeDir: string = homedir(),
+): Promise<string | undefined> {
+  if (!config.desktop?.enabled || platform !== 'linux') {
+    return undefined;
+  }
+
+  const existingChromium = await resolveExecutablePath('chromium', envPath);
+  const existingChromiumBrowser = await resolveExecutablePath('chromium-browser', envPath);
+  if (existingChromium && existingChromiumBrowser) {
+    return undefined;
+  }
+
+  let chromeTarget: string | undefined;
+  for (const candidate of CHROMIUM_HOST_CHROME_CANDIDATES) {
+    chromeTarget = await resolveExecutablePath(candidate, envPath);
+    if (chromeTarget) break;
+  }
+  if (!chromeTarget) {
+    return undefined;
+  }
+
+  const shimDir = join(homeDir, ...CHROMIUM_SHIM_DIR_SEGMENTS);
+  await mkdir(shimDir, { recursive: true });
+
+  const createdShims: string[] = [];
+  for (const name of CHROMIUM_COMPAT_COMMANDS) {
+    const existing = name === 'chromium'
+      ? existingChromium
+      : existingChromiumBrowser;
+    if (existing) continue;
+
+    const shimPath = join(shimDir, name);
+    await writeFile(shimPath, buildChromiumShimScript(chromeTarget), 'utf-8');
+    await chmod(shimPath, 0o755);
+    createdShims.push(name);
+  }
+
+  if (createdShims.length > 0) {
+    (logger ?? silentLogger).info(
+      `Installed host Chromium compatibility shim(s): ${createdShims.join(', ')} -> ${chromeTarget}`,
+    );
+  }
+
+  return shimDir;
 }
 
 interface ResolvedSubAgentRuntimeConfig {
@@ -535,6 +652,24 @@ function truncateToolLogText(value: string, maxChars = TOOL_LOG_SNIPPET_MAX_CHAR
   if (value.length <= maxChars) return value;
   if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
   return value.slice(0, maxChars - 3) + "...";
+}
+
+const TRACE_DATA_IMAGE_URL_PATTERN =
+  /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g;
+const TRACE_JSON_BINARY_FIELD_PATTERN =
+  /"([A-Za-z0-9_.-]*(?:image|dataurl|data|base64)[A-Za-z0-9_.-]*)"\s*:\s*"([A-Za-z0-9+/=\r\n]{128,})"/gi;
+const TRACE_QUOTED_BASE64_BLOB_PATTERN = /"([A-Za-z0-9+/=\r\n]{512,})"/g;
+const TRACE_RAW_BASE64_BLOB_PATTERN = /[A-Za-z0-9+/=\r\n]{2048,}/g;
+
+export function sanitizeToolResultTextForTrace(rawResult: string): string {
+  return rawResult
+    .replace(TRACE_DATA_IMAGE_URL_PATTERN, "(see image)")
+    .replace(
+      TRACE_JSON_BINARY_FIELD_PATTERN,
+      (_match: string, key: string) => `"${key}":"(base64 omitted)"`,
+    )
+    .replace(TRACE_QUOTED_BASE64_BLOB_PATTERN, '"(base64 omitted)"')
+    .replace(TRACE_RAW_BASE64_BLOB_PATTERN, "(base64 omitted)");
 }
 
 function summarizeArtifactText(value: string, maxChars: number): unknown {
@@ -1123,7 +1258,10 @@ function summarizeToolResultForTrace(rawResult: string, maxChars: number): unkno
     const parsed = JSON.parse(rawResult) as unknown;
     return summarizeTraceValue(parsed, maxChars);
   } catch {
-    return truncateToolLogText(rawResult, maxChars);
+    return truncateToolLogText(
+      sanitizeToolResultTextForTrace(rawResult),
+      maxChars,
+    );
   }
 }
 
@@ -3803,6 +3941,14 @@ export class DaemonManager {
     // Security: Only expose a minimal host env to system.bash.
     // Token-like secrets are intentionally excluded by default.
     const safeEnv = resolveBashToolEnv(config);
+    const chromiumShimDir = await ensureChromiumCompatShims(
+      config,
+      safeEnv.PATH,
+      this.logger,
+    );
+    if (chromiumShimDir) {
+      safeEnv.PATH = prependPathEntry(safeEnv.PATH, chromiumShimDir);
+    }
 
     // Security: Do NOT use unrestricted mode — the default deny list prevents
     // dangerous commands (rm -rf, curl for exfiltration, etc.) from being

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -11,6 +11,7 @@
 import type { DeterministicPipelineExecutor } from "../llm/chat-executor.js";
 import type {
   Pipeline,
+  PipelineExecutionOptions,
   PipelinePlannerContextHistoryEntry,
   PipelinePlannerContextMemorySource,
   PipelinePlannerContextMemoryEntry,
@@ -375,10 +376,14 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     this.fallbackBehavior = config.fallbackBehavior ?? DEFAULT_FALLBACK_BEHAVIOR;
   }
 
-  async execute(pipeline: Pipeline, startFrom = 0): Promise<PipelineResult> {
+  async execute(
+    pipeline: Pipeline,
+    startFrom = 0,
+    options?: PipelineExecutionOptions,
+  ): Promise<PipelineResult> {
     const plannerSteps = pipeline.plannerSteps;
     if (!plannerSteps || plannerSteps.length === 0) {
-      return this.fallbackExecutor.execute(pipeline, startFrom);
+      return this.fallbackExecutor.execute(pipeline, startFrom, options);
     }
 
     if (startFrom > 0) {
@@ -457,6 +462,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           pipeline,
           mutableResults,
           budgetTracker,
+          options,
         );
         running.set(node.step.name, { promise, exclusive: exclusiveNode });
         pending.delete(node.step.name);
@@ -722,9 +728,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     pipeline: Pipeline,
     results: Record<string, string>,
     budgetTracker: RequestTreeBudgetTracker,
+    options?: PipelineExecutionOptions,
   ): Promise<NodeExecutionOutcome> {
     if (step.stepType === "deterministic_tool") {
-      return this.executeDeterministicStep(step, pipeline, results);
+      return this.executeDeterministicStep(step, pipeline, results, options);
     }
     if (step.stepType === "subagent_task") {
       return this.executeSubagentStep(step, pipeline, results, budgetTracker);
@@ -744,6 +751,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     step: PipelinePlannerDeterministicStep,
     pipeline: Pipeline,
     results: Record<string, string>,
+    options?: PipelineExecutionOptions,
   ): Promise<NodeExecutionOutcome> {
     const singleStep: PipelineStep = {
       name: step.name,
@@ -758,7 +766,11 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       context: { results: { ...results } },
       steps: [singleStep],
     };
-    const outcome = await this.fallbackExecutor.execute(stepPipeline);
+    const outcome = await this.fallbackExecutor.execute(
+      stepPipeline,
+      0,
+      options,
+    );
     if (outcome.status === "halted") {
       return {
         status: "halted",

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -118,7 +118,7 @@ describe("createSessionToolHandler", () => {
     );
   });
 
-  it("emits approval.request for system.bash under default approval rules", async () => {
+  it("does not emit approval.request for system.bash under default approval rules", async () => {
     const sentMessages: ControlResponse[] = [];
     const send = vi.fn((msg: ControlResponse): void => {
       sentMessages.push(msg);
@@ -134,36 +134,17 @@ describe("createSessionToolHandler", () => {
       approvalEngine,
     });
 
-    const resultPromise = handler("system.bash", {
+    const result = await handler("system.bash", {
       command: "npm",
       args: ["run", "build"],
     });
-
-    let requestId: string | undefined;
-    for (let i = 0; i < 20; i += 1) {
-      const approvalRequest = sentMessages.find(
-        (msg) => msg.type === "approval.request",
-      );
-      if (approvalRequest) {
-        requestId = (approvalRequest.payload as { requestId?: string }).requestId;
-        if (requestId) break;
-      }
-      await new Promise((resolve) => setTimeout(resolve, 5));
-    }
-    expect(requestId).toBeDefined();
-    approvalEngine.resolve(requestId!, {
-      requestId: requestId!,
-      disposition: "yes",
-    });
-
-    const result = await resultPromise;
 
     expect(result).toBe("build-complete");
     expect(baseHandler).toHaveBeenCalledWith("system.bash", {
       command: "npm",
       args: ["run", "build"],
     });
-    expect(sentMessages.some((msg) => msg.type === "approval.request")).toBe(true);
+    expect(sentMessages.some((msg) => msg.type === "approval.request")).toBe(false);
   });
 
   it("includes parent subagent context in approval prompts for delegated sessions", async () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -12,6 +12,7 @@ import type { LLMPipelineStopReason } from "./policy.js";
 import type {
   PipelinePlannerContext,
   PipelinePlannerContextMemorySource,
+  PipelinePlannerStep,
   PipelineResult,
 } from "../workflow/pipeline.js";
 import type { WorkflowGraphEdge } from "../workflow/types.js";
@@ -24,10 +25,21 @@ import type {
   PlannerParseResult,
   PlannerDiagnostic,
   PlannerGraphValidationConfig,
+  FullPlannerSummaryState,
   SubagentVerifierDecision,
   SubagentVerifierStepAssessment,
   ToolCallRecord,
 } from "./chat-executor-types.js";
+import {
+  assessDelegationDecision,
+  type DelegationDecisionConfig,
+  type DelegationDecision,
+  type DelegationHardBlockedTaskClass,
+} from "./delegation-decision.js";
+import type {
+  DelegationBanditPolicyTuner,
+  DelegationBanditSelection,
+} from "./delegation-learning.js";
 import {
   MAX_PLANNER_STEPS,
   MAX_PLANNER_CONTEXT_HISTORY_CANDIDATES,
@@ -1129,6 +1141,205 @@ export function pipelineResultToToolCalls(
     }
   }
   return records;
+}
+
+// ============================================================================
+// Extracted from executePlannerPath — delegation bandit arm resolution
+// ============================================================================
+
+/** Result of bandit arm resolution for delegation policy tuning. */
+export interface BanditArmResolution {
+  readonly selectedArm: DelegationBanditSelection | undefined;
+  readonly tunedThreshold: number;
+  readonly policyTuning: FullPlannerSummaryState["delegationPolicyTuning"];
+}
+
+/**
+ * Resolve the delegation bandit arm selection, returning the selected arm,
+ * tuned threshold, and delegation policy tuning record.
+ */
+export function resolveDelegationBanditArm(
+  banditTuner: DelegationBanditPolicyTuner | undefined,
+  trajectoryContextClusterId: string,
+  defaultArmId: string,
+  baseDelegationThreshold: number,
+): BanditArmResolution {
+  if (banditTuner) {
+    const selectedArm = banditTuner.selectArm({
+      contextClusterId: trajectoryContextClusterId,
+      preferredArmId: defaultArmId,
+    });
+    const tunedThreshold = banditTuner.applyThresholdOffset(
+      baseDelegationThreshold,
+      selectedArm.armId,
+    );
+    return {
+      selectedArm,
+      tunedThreshold,
+      policyTuning: {
+        enabled: true,
+        contextClusterId: trajectoryContextClusterId,
+        selectedArmId: selectedArm.armId,
+        selectedArmReason: selectedArm.reason,
+        tunedThreshold,
+        exploration: selectedArm.exploration,
+        finalReward: undefined,
+        usefulDelegation: undefined,
+        usefulDelegationScore: undefined,
+        rewardProxyVersion: undefined,
+      },
+    };
+  }
+
+  return {
+    selectedArm: undefined,
+    tunedThreshold: baseDelegationThreshold,
+    policyTuning: {
+      enabled: false,
+      contextClusterId: trajectoryContextClusterId,
+      selectedArmId: defaultArmId,
+      selectedArmReason: "fallback",
+      tunedThreshold: baseDelegationThreshold,
+      exploration: false,
+      finalReward: undefined,
+      usefulDelegation: undefined,
+      usefulDelegationScore: undefined,
+      rewardProxyVersion: undefined,
+    },
+  };
+}
+
+// ============================================================================
+// Extracted from executePlannerPath — delegation decision assessment
+// ============================================================================
+
+/** Input for assessing and recording a delegation decision. */
+export interface DelegationAssessmentInput {
+  readonly messageText: string;
+  readonly plannerPlan: PlannerPlan;
+  readonly subagentSteps: readonly PlannerSubAgentTaskStepIntent[];
+  readonly complexityScore: number;
+  readonly tunedThreshold: number;
+  readonly delegationConfig: {
+    readonly enabled: boolean;
+    readonly mode: string;
+    readonly maxFanoutPerTurn: number;
+    readonly maxDepth: number;
+    readonly handoffMinPlannerConfidence: number;
+    readonly hardBlockedTaskClasses: Iterable<DelegationHardBlockedTaskClass>;
+  };
+}
+
+/**
+ * Assess whether to delegate and record the decision + any veto diagnostic
+ * on the planner summary state. Returns the delegation decision.
+ */
+export function assessAndRecordDelegationDecision(
+  input: DelegationAssessmentInput,
+  summaryState: FullPlannerSummaryState,
+): DelegationDecision {
+  const synthesisSteps = input.plannerPlan.steps.filter(
+    (step) => step.stepType === "synthesis",
+  ).length;
+
+  const tunedDecisionConfig: DelegationDecisionConfig = {
+    enabled: input.delegationConfig.enabled,
+    mode: input.delegationConfig.mode as DelegationDecisionConfig["mode"],
+    scoreThreshold: input.tunedThreshold,
+    maxFanoutPerTurn: input.delegationConfig.maxFanoutPerTurn,
+    maxDepth: input.delegationConfig.maxDepth,
+    handoffMinPlannerConfidence:
+      input.delegationConfig.handoffMinPlannerConfidence,
+    hardBlockedTaskClasses: [
+      ...input.delegationConfig.hardBlockedTaskClasses,
+    ],
+  };
+
+  const delegationDecision = assessDelegationDecision({
+    messageText: input.messageText,
+    plannerConfidence: input.plannerPlan.confidence,
+    complexityScore: input.complexityScore,
+    totalSteps: input.plannerPlan.steps.length,
+    synthesisSteps,
+    edges: input.plannerPlan.edges,
+    subagentSteps: input.subagentSteps.map((step) => ({
+      name: step.name,
+      dependsOn: step.dependsOn,
+      acceptanceCriteria: step.acceptanceCriteria,
+      requiredToolCapabilities: step.requiredToolCapabilities,
+      contextRequirements: step.contextRequirements,
+      maxBudgetHint: step.maxBudgetHint,
+      canRunParallel: step.canRunParallel,
+    })),
+    config: tunedDecisionConfig,
+  });
+
+  summaryState.delegationDecision = delegationDecision;
+  if (!delegationDecision.shouldDelegate) {
+    summaryState.routeReason =
+      `delegation_veto_${delegationDecision.reason}`;
+    summaryState.diagnostics.push({
+      category: "policy",
+      code: "delegation_veto",
+      message:
+        `Delegation vetoed by policy scorer: ${delegationDecision.reason}`,
+      details: {
+        reason: delegationDecision.reason,
+        threshold: delegationDecision.threshold,
+        utilityScore: Number(
+          delegationDecision.utilityScore.toFixed(4),
+        ),
+        safetyRisk: Number(delegationDecision.safetyRisk.toFixed(4)),
+      },
+    });
+  }
+
+  return delegationDecision;
+}
+
+// ============================================================================
+// Extracted from executePlannerPath — pipeline step mapping
+// ============================================================================
+
+/**
+ * Map PlannerStepIntent[] to PipelinePlannerStep[] for the pipeline executor.
+ */
+export function mapPlannerStepsToPipelineSteps(
+  steps: readonly PlannerStepIntent[],
+): PipelinePlannerStep[] {
+  return steps.map((step) => {
+    if (step.stepType === "deterministic_tool") {
+      return {
+        name: step.name,
+        stepType: step.stepType,
+        dependsOn: step.dependsOn,
+        tool: step.tool,
+        args: step.args,
+        onError: step.onError,
+        maxRetries: step.maxRetries,
+      };
+    }
+    if (step.stepType === "subagent_task") {
+      return {
+        name: step.name,
+        stepType: step.stepType,
+        dependsOn: step.dependsOn,
+        objective: step.objective,
+        inputContract: step.inputContract,
+        acceptanceCriteria: step.acceptanceCriteria,
+        requiredToolCapabilities: step.requiredToolCapabilities,
+        contextRequirements: step.contextRequirements,
+        maxBudgetHint: step.maxBudgetHint,
+        canRunParallel: step.canRunParallel,
+      };
+    }
+    return {
+      name: step.name,
+      stepType: step.stepType,
+      dependsOn: step.dependsOn,
+      objective: step.objective,
+    };
+  });
 }
 
 export function didSubagentStepFail(result: string): boolean {

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -9,13 +9,52 @@ import type {
   RecoveryHint,
   ChatCallUsageRecord,
   ChatStatefulSummary,
+  ChatPlannerSummary,
+  EvaluationResult,
+  ExecutionContext,
+  FullPlannerSummaryState,
 } from "./chat-executor-types.js";
 import type { LLMStatefulDiagnostics, LLMStatefulFallbackReason } from "./types.js";
+import type { LLMPipelineStopReason } from "./policy.js";
+import type {
+  DelegationTrajectoryFinalReward,
+  DelegationTrajectoryRecord,
+} from "./delegation-learning.js";
 import { SHELL_BUILTIN_COMMANDS } from "./chat-executor-constants.js";
 import {
   didToolCallFail,
   extractToolFailureText,
 } from "./chat-executor-tool-utils.js";
+
+const DESKTOP_BIASED_SYSTEM_COMMANDS = new Set([
+  "chromium",
+  "chromium-browser",
+  "google-chrome",
+  "google-chrome-stable",
+  "playwright",
+  "gdb",
+]);
+
+function isDesktopSessionUnavailable(failureTextLower: string): boolean {
+  return (
+    failureTextLower.includes("requires desktop session") ||
+    failureTextLower.includes('tool not found: "desktop.bash"') ||
+    failureTextLower.includes("tool not found: 'desktop.bash'")
+  );
+}
+
+function isDesktopBiasedSystemCommandFailure(
+  command: string,
+  failureTextLower: string,
+): boolean {
+  if (!DESKTOP_BIASED_SYSTEM_COMMANDS.has(command)) return false;
+  return (
+    failureTextLower.includes("enoent") ||
+    failureTextLower.includes("command not found") ||
+    failureTextLower.includes("is denied") ||
+    failureTextLower.includes("not found")
+  );
+}
 
 export function buildSemanticToolCallKey(
   name: string,
@@ -108,9 +147,30 @@ export function inferRecoveryHint(
 
   const failureText = extractToolFailureText(call);
   const failureTextLower = failureText.toLowerCase();
+  if (
+    isDesktopSessionUnavailable(failureTextLower) &&
+    (call.name === "desktop.bash" ||
+      call.name.startsWith("playwright.") ||
+      call.name.startsWith("mcp."))
+  ) {
+    return {
+      key: "desktop-session-unavailable",
+      message:
+        "Desktop/container tools are unavailable in this chat session. Attach a desktop session first (`/desktop attach`), " +
+        "then retry with `desktop.bash` or the required `playwright.*`/`mcp.*` tool.",
+    };
+  }
 
   if (call.name === "system.bash") {
     const command = String(call.args?.command ?? "").trim().toLowerCase();
+    if (isDesktopBiasedSystemCommandFailure(command, failureTextLower)) {
+      return {
+        key: "system-bash-host-desktop-mismatch",
+        message:
+          "This command failed on `system.bash` (host shell) but appears to target desktop/container tooling. " +
+          "Attach desktop (`/desktop attach`) and run it with `desktop.bash` (or `playwright.*` for browser actions).",
+      };
+    }
     const isBuiltin = command.length > 0 && SHELL_BUILTIN_COMMANDS.has(command);
     if (
       isBuiltin ||
@@ -167,4 +227,141 @@ export function inferRecoveryHint(
   }
 
   return undefined;
+}
+
+// ============================================================================
+// Quality & trajectory helpers (extracted from recordOutcomeAndFinalize)
+// ============================================================================
+
+/** Input for computing quality proxy score. */
+export interface QualityProxyInput {
+  readonly stopReason: LLMPipelineStopReason;
+  readonly verifierPerformed: boolean;
+  readonly verifierOverall: "pass" | "retry" | "fail" | "skipped";
+  readonly evaluation?: EvaluationResult;
+  readonly failedToolCalls: number;
+}
+
+/** Compute a 0–1 quality proxy score from execution outcome signals. */
+export function computeQualityProxy(input: QualityProxyInput): number {
+  const stopReasonQualityBase = input.stopReason === "completed"
+    ? 0.85
+    : input.stopReason === "tool_calls"
+      ? 0.6
+      : 0.25;
+  const verifierBonus = input.verifierPerformed
+    ? (
+      input.verifierOverall === "pass"
+        ? 0.1
+        : input.verifierOverall === "retry"
+          ? 0
+          : -0.15
+    )
+    : 0;
+  const evaluatorBonus = input.evaluation
+    ? (input.evaluation.passed ? 0.1 : -0.1)
+    : 0;
+  const failurePenalty = Math.min(0.25, input.failedToolCalls * 0.05);
+  return Math.max(
+    0,
+    Math.min(
+      1,
+      stopReasonQualityBase + verifierBonus + evaluatorBonus - failurePenalty,
+    ),
+  );
+}
+
+/** Input for building a delegation trajectory record. */
+export interface DelegationTrajectoryInput {
+  readonly ctx: ExecutionContext;
+  readonly qualityProxy: number;
+  readonly durationMs: number;
+  readonly rewardSignal: DelegationTrajectoryFinalReward;
+  readonly usefulnessProxy: { readonly useful: boolean; readonly score: number };
+  readonly selectedTools: readonly string[];
+  readonly defaultStrategyArmId: string;
+  readonly delegationMaxDepth: number;
+  readonly delegationMaxFanoutPerTurn: number;
+  readonly requestTimeoutMs: number;
+  readonly usefulDelegationProxyVersion: string;
+}
+
+/** Build a trajectory sink record object from execution context. */
+export function buildDelegationTrajectoryEntry(input: DelegationTrajectoryInput): DelegationTrajectoryRecord {
+  const { ctx } = input;
+  return {
+    schemaVersion: 1,
+    traceId: ctx.trajectoryTraceId,
+    turnId: ctx.parentTurnId,
+    turnType: "parent",
+    timestampMs: Date.now(),
+    stateFeatures: {
+      sessionId: ctx.sessionId,
+      contextClusterId: ctx.trajectoryContextClusterId,
+      complexityScore: ctx.plannerDecision.score,
+      plannerStepCount: ctx.plannerSummaryState.plannedSteps,
+      subagentStepCount: ctx.plannedSubagentSteps,
+      deterministicStepCount: ctx.plannedDeterministicSteps,
+      synthesisStepCount: ctx.plannedSynthesisSteps,
+      dependencyDepth: ctx.plannedDependencyDepth,
+      fanout: ctx.plannedFanout,
+    },
+    action: {
+      delegated:
+        ctx.plannerSummaryState.delegationDecision?.shouldDelegate === true,
+      strategyArmId:
+        ctx.selectedBanditArm?.armId ?? input.defaultStrategyArmId,
+      threshold: ctx.tunedDelegationThreshold,
+      selectedTools: [...input.selectedTools],
+      childConfig: {
+        maxDepth: input.delegationMaxDepth,
+        maxFanoutPerTurn: input.delegationMaxFanoutPerTurn,
+        timeoutMs: input.requestTimeoutMs,
+      },
+    },
+    immediateOutcome: {
+      qualityProxy: input.qualityProxy,
+      tokenCost: ctx.cumulativeUsage.totalTokens,
+      latencyMs: input.durationMs,
+      errorCount:
+        ctx.failedToolCalls + (ctx.stopReason === "completed" ? 0 : 1),
+      ...(ctx.stopReason !== "completed" ? { errorClass: ctx.stopReason } : {}),
+    },
+    finalReward: input.rewardSignal,
+    metadata: {
+      plannerUsed: ctx.plannerSummaryState.used,
+      routeReason: ctx.plannerSummaryState.routeReason ?? "none",
+      stopReason: ctx.stopReason,
+      usefulDelegation: input.usefulnessProxy.useful,
+      usefulDelegationScore: Number(input.usefulnessProxy.score.toFixed(4)),
+      usefulDelegationProxyVersion: input.usefulDelegationProxyVersion,
+    },
+  };
+}
+
+/** Build the final ChatPlannerSummary from mutable summary state. */
+export function buildPlannerSummary(
+  state: FullPlannerSummaryState,
+  estimatedRecallsAvoided: number,
+): ChatPlannerSummary {
+  return {
+    enabled: state.enabled,
+    used: state.used,
+    routeReason: state.routeReason,
+    complexityScore: state.complexityScore,
+    plannerCalls: state.plannerCalls,
+    plannedSteps: state.plannedSteps,
+    deterministicStepsExecuted: state.deterministicStepsExecuted,
+    estimatedRecallsAvoided: state.used ? estimatedRecallsAvoided : 0,
+    diagnostics: state.diagnostics.length > 0
+      ? state.diagnostics
+      : undefined,
+    delegationDecision: state.delegationDecision,
+    subagentVerification: state.subagentVerification.enabled
+      ? state.subagentVerification
+      : undefined,
+    delegationPolicyTuning: state.delegationPolicyTuning.enabled
+      ? state.delegationPolicyTuning
+      : undefined,
+  };
 }

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -213,6 +213,27 @@ export function isBase64Like(value: string): boolean {
   return /^[A-Za-z0-9+/=\r\n]+$/.test(value);
 }
 
+const DATA_IMAGE_URL_PATTERN =
+  /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/;
+const DATA_IMAGE_URL_GLOBAL_PATTERN =
+  /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g;
+const JSON_BINARY_FIELD_PATTERN =
+  /"([A-Za-z0-9_.-]*(?:image|dataurl|data|base64)[A-Za-z0-9_.-]*)"\s*:\s*"([A-Za-z0-9+/=\r\n]{128,})"/gi;
+const QUOTED_BASE64_BLOB_PATTERN = /"([A-Za-z0-9+/=\r\n]{512,})"/g;
+const RAW_BASE64_BLOB_PATTERN = /[A-Za-z0-9+/=\r\n]{2048,}/g;
+
+function sanitizeRawToolResultText(value: string): string {
+  return value
+    .replace(DATA_IMAGE_URL_GLOBAL_PATTERN, "(see image)")
+    .replace(
+      JSON_BINARY_FIELD_PATTERN,
+      (_match: string, key: string) => `"${key}":"(base64 omitted)"`,
+    )
+    .replace(QUOTED_BASE64_BLOB_PATTERN, '"(base64 omitted)"')
+    .replace(RAW_BASE64_BLOB_PATTERN, "(base64 omitted)")
+    .trim();
+}
+
 // ============================================================================
 // Prompt shape estimation
 // ============================================================================
@@ -415,12 +436,17 @@ export function sanitizeJsonForPrompt(
         if (
           keyLower === "image" ||
           keyLower === "dataurl" ||
+          keyLower === "data" ||
           keyLower.endsWith("base64")
         ) {
           if (isBase64Like(field)) {
             out[key] = "(base64 omitted)";
             continue;
           }
+        }
+        if (isBase64Like(field)) {
+          out[key] = "(base64 omitted)";
+          continue;
         }
         out[key] = truncateText(
           field,
@@ -459,16 +485,8 @@ export function prepareToolResultForPrompt(result: string): {
       ...(capturedDataUrl ? { dataUrl: capturedDataUrl } : {}),
     };
   } catch {
-    const dataUrlMatch = result.match(
-      /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/,
-    );
-    const text = result
-      .replace(
-        /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g,
-        "(see image)",
-      )
-      .replace(/"[Ii]mage"\s*:\s*"[A-Za-z0-9+/=\r\n]{128,}"/g, '"image":"(base64 omitted)"')
-      .trim();
+    const dataUrlMatch = result.match(DATA_IMAGE_URL_PATTERN);
+    const text = sanitizeRawToolResultText(result);
     return {
       text: truncateText(text, MAX_TOOL_RESULT_CHARS),
       ...(dataUrlMatch ? { dataUrl: dataUrlMatch[0] } : {}),

--- a/runtime/src/llm/chat-executor-tool-utils.test.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.test.ts
@@ -33,6 +33,16 @@ describe("chat-executor-tool-utils", () => {
       ).toBe(true);
     });
 
+    it("returns true for plain-text tool-not-found failures", () => {
+      expect(didToolCallFail(false, 'Tool not found: "desktop.bash"')).toBe(true);
+    });
+
+    it("returns true for desktop-session requirement failures", () => {
+      expect(
+        didToolCallFail(false, "Container MCP tool — requires desktop session"),
+      ).toBe(true);
+    });
+
     it("returns false for normal non-JSON output", () => {
       expect(didToolCallFail(false, "all good")).toBe(false);
     });

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -4,22 +4,29 @@
  * @module
  */
 
-import type { ToolCallRecord } from "./chat-executor-types.js";
+import type { LLMToolCall, LLMMessage, ToolHandler } from "./types.js";
+import type { ToolCallRecord, ToolCallAction, ToolLoopState, RecoveryHint, LLMRetryPolicyOverrides } from "./chat-executor-types.js";
 import type { LLMRetryPolicyMatrix } from "./policy.js";
 import { DEFAULT_LLM_RETRY_POLICY_MATRIX } from "./policy.js";
 import type { LLMFailureClass, LLMRetryPolicyRule } from "./policy.js";
-import type { LLMRetryPolicyOverrides } from "./chat-executor-types.js";
 import {
   HIGH_RISK_TOOLS,
   HIGH_RISK_TOOL_PREFIXES,
   SAFE_TOOL_RETRY_TOOLS,
   SAFE_TOOL_RETRY_PREFIXES,
+  MACOS_SIDE_EFFECT_TOOLS,
+  MAX_CONSECUTIVE_IDENTICAL_FAILURES,
+  MAX_CONSECUTIVE_ALL_FAILED_ROUNDS,
+  MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS,
+  RECOVERY_HINT_PREFIX,
 } from "./chat-executor-constants.js";
+import { buildSemanticToolCallKey } from "./chat-executor-recovery.js";
 import { safeStringify } from "../tools/types.js";
 
 const NON_JSON_FAILURE_PREFIXES = [
   "mcp tool \"",
   "error executing tool",
+  "tool not found:",
 ];
 
 export function didToolCallFail(isError: boolean, result: string): boolean {
@@ -140,5 +147,379 @@ function isLikelyFailureText(result: string): boolean {
   const text = result.trim().toLowerCase();
   if (text.length === 0) return false;
   if (text.startsWith("mcp tool \"") && text.includes("\" failed:")) return true;
+  if (text.includes("requires desktop session")) return true;
   return NON_JSON_FAILURE_PREFIXES.some((prefix) => text.startsWith(prefix));
+}
+
+// ============================================================================
+// Permission / argument / retry helpers (extracted from executeSingleToolCall)
+// ============================================================================
+
+/** Result of checking whether a tool call is permitted. */
+export interface ToolCallPermissionResult {
+  readonly action: ToolCallAction;
+  readonly errorResult?: string;
+  readonly expandAfterRound?: boolean;
+  readonly routingMiss?: boolean;
+}
+
+/** Check side-effect dedup, global allowlist, and routed subset for a tool call. */
+export function checkToolCallPermission(
+  toolCall: LLMToolCall,
+  allowedTools: Set<string> | null,
+  routedToolSet: Set<string> | null,
+  canExpandOnRoutingMiss: boolean,
+  routedToolsExpanded: boolean,
+  sideEffectExecuted: boolean,
+): ToolCallPermissionResult {
+  // Side-effect dedup check.
+  if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name) && sideEffectExecuted) {
+    return {
+      action: "skip",
+      errorResult: safeStringify({
+        error: `Skipped "${toolCall.name}" — a desktop action was already performed. Combine actions into a single tool call.`,
+      }),
+    };
+  }
+
+  // Global allowlist check.
+  if (allowedTools && !allowedTools.has(toolCall.name)) {
+    return {
+      action: "skip",
+      errorResult: safeStringify({
+        error: `Tool "${toolCall.name}" is not permitted`,
+      }),
+    };
+  }
+
+  // Dynamic routed subset check.
+  if (routedToolSet && !routedToolSet.has(toolCall.name)) {
+    return {
+      action: "skip",
+      errorResult: safeStringify({
+        error:
+          `Tool "${toolCall.name}" was not available in the routed tool subset for this turn`,
+        routingMiss: true,
+      }),
+      expandAfterRound: canExpandOnRoutingMiss && !routedToolsExpanded,
+      routingMiss: true,
+    };
+  }
+
+  return { action: "processed" };
+}
+
+/** Result of parsing tool call arguments. */
+export type ParseToolCallArgsResult =
+  | { readonly ok: true; readonly args: Record<string, unknown> }
+  | { readonly ok: false; readonly error: string };
+
+/** Parse and validate tool call JSON arguments. */
+export function parseToolCallArguments(
+  toolCall: LLMToolCall,
+): ParseToolCallArgsResult {
+  try {
+    const parsed = JSON.parse(toolCall.arguments) as unknown;
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      throw new Error("Tool arguments must be a JSON object");
+    }
+    return { ok: true, args: parsed as Record<string, unknown> };
+  } catch (parseErr) {
+    return {
+      ok: false,
+      error: safeStringify({
+        error: `Invalid tool arguments: ${(parseErr as Error).message}`,
+      }),
+    };
+  }
+}
+
+/** Configuration for tool execution with retry. */
+export interface ToolExecutionConfig {
+  readonly toolCallTimeoutMs: number;
+  readonly retryPolicyMatrix: LLMRetryPolicyMatrix;
+  readonly signal?: AbortSignal;
+  readonly requestDeadlineAt: number;
+}
+
+/** Result of executing a tool with retry logic. */
+export interface ToolExecutionResult {
+  result: string;
+  isError: boolean;
+  toolFailed: boolean;
+  timedOut: boolean;
+  retryCount: number;
+  retrySuppressedReason?: string;
+  durationMs: number;
+  finalToolTimeoutMs: number;
+}
+
+/** Execute a tool call with timeout racing and transport-failure retry. */
+export async function executeToolWithRetry(
+  toolCall: LLMToolCall,
+  args: Record<string, unknown>,
+  handler: ToolHandler,
+  config: ToolExecutionConfig,
+): Promise<ToolExecutionResult> {
+  const toolStart = Date.now();
+  let result = safeStringify({ error: "Tool execution failed" });
+  let isError = false;
+  let toolFailed = false;
+  let timedOut = false;
+  let finalToolTimeoutMs = config.toolCallTimeoutMs;
+  let retrySuppressedReason: string | undefined;
+  let retryCount = 0;
+  const maxToolRetries = Math.max(
+    0,
+    config.retryPolicyMatrix.tool_error.maxRetries,
+  );
+
+  for (let attempt = 0; attempt <= maxToolRetries; attempt++) {
+    const remainingRequestMs = config.requestDeadlineAt - Date.now();
+    const toolTimeoutMs = Math.min(
+      config.toolCallTimeoutMs,
+      Math.max(1, remainingRequestMs),
+    );
+    finalToolTimeoutMs = toolTimeoutMs;
+    let toolTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const toolCallPromise = (async (): Promise<{
+      result: string;
+      isError: boolean;
+      timedOut: boolean;
+      threw: boolean;
+    }> => {
+      try {
+        const value = await handler(toolCall.name, args);
+        return {
+          result: value,
+          isError: false,
+          timedOut: false,
+          threw: false,
+        };
+      } catch (toolErr) {
+        return {
+          result: safeStringify({ error: (toolErr as Error).message }),
+          isError: true,
+          timedOut: false,
+          threw: true,
+        };
+      }
+    })();
+    const timeoutPromise = new Promise<{
+      result: string;
+      isError: boolean;
+      timedOut: boolean;
+      threw: boolean;
+    }>((resolve) => {
+      toolTimeoutHandle = setTimeout(() => {
+        resolve({
+          result: safeStringify({
+            error: `Tool "${toolCall.name}" timed out after ${toolTimeoutMs}ms`,
+          }),
+          isError: true,
+          timedOut: true,
+          threw: false,
+        });
+      }, toolTimeoutMs);
+    });
+    const toolOutcome = await Promise.race([
+      toolCallPromise,
+      timeoutPromise,
+    ]);
+    if (toolTimeoutHandle !== undefined) {
+      clearTimeout(toolTimeoutHandle);
+    }
+
+    result = toolOutcome.result;
+    isError = toolOutcome.isError;
+    timedOut = toolOutcome.timedOut;
+
+    toolFailed = didToolCallFail(isError, result);
+    const failureText = toolFailed
+      ? extractToolFailureText({
+        name: toolCall.name,
+        args,
+        result,
+        isError: toolFailed,
+        durationMs: 0,
+      })
+      : "";
+    const transportFailure =
+      timedOut ||
+      toolOutcome.threw ||
+      isLikelyToolTransportFailure(failureText);
+    if (!toolFailed) break;
+
+    const canRetryTransportFailure =
+      transportFailure &&
+      attempt < maxToolRetries &&
+      !config.signal?.aborted &&
+      (config.requestDeadlineAt - Date.now()) > 0;
+    if (!canRetryTransportFailure) break;
+
+    const highRiskTool = isHighRiskToolCall(toolCall.name);
+    const hasIdempotency = hasExplicitIdempotencyKey(args);
+    const retrySafe = highRiskTool
+      ? hasIdempotency
+      : isToolRetrySafe(toolCall.name);
+    if (!retrySafe) {
+      retrySuppressedReason = highRiskTool && !hasIdempotency
+        ? `Suppressed auto-retry for high-risk tool "${toolCall.name}" without idempotencyKey`
+        : `Suppressed auto-retry for potentially side-effecting tool "${toolCall.name}"`;
+      break;
+    }
+
+    retryCount++;
+  }
+  const durationMs = Date.now() - toolStart;
+  if (retryCount > 0) {
+    result = enrichToolResultMetadata(result, { retryAttempts: retryCount });
+  }
+  if (retrySuppressedReason) {
+    result = enrichToolResultMetadata(result, { retrySuppressedReason });
+  }
+
+  return {
+    result,
+    isError,
+    toolFailed,
+    timedOut,
+    retryCount,
+    retrySuppressedReason,
+    durationMs,
+    finalToolTimeoutMs,
+  };
+}
+
+/** Update loop-state consecutive failure tracking. */
+export function trackToolCallFailureState(
+  toolFailed: boolean,
+  semanticToolKey: string,
+  loopState: ToolLoopState,
+): void {
+  const failKey = toolFailed ? semanticToolKey : "";
+  if (toolFailed && failKey === loopState.lastFailKey) {
+    loopState.consecutiveFailCount++;
+  } else {
+    loopState.lastFailKey = failKey;
+    loopState.consecutiveFailCount = toolFailed ? 1 : 0;
+  }
+}
+
+// ============================================================================
+// Stuck-loop detection (extracted from executeToolCallLoop)
+// ============================================================================
+
+/** Mutable counters for cross-round stuck detection. */
+export interface RoundStuckState {
+  consecutiveAllFailedRounds: number;
+  lastRoundSemanticKey: string;
+  consecutiveSemanticDuplicateRounds: number;
+}
+
+/** Result of stuck-loop detection check. */
+export interface StuckDetectionResult {
+  readonly shouldBreak: boolean;
+  readonly reason?: string;
+}
+
+/** Check for stuck tool loop patterns across rounds. */
+export function checkToolLoopStuckDetection(
+  roundCalls: readonly ToolCallRecord[],
+  loopState: ToolLoopState,
+  stuckState: RoundStuckState,
+): StuckDetectionResult {
+  // Per-call consecutive identical failure check.
+  if (loopState.consecutiveFailCount >= MAX_CONSECUTIVE_IDENTICAL_FAILURES) {
+    return {
+      shouldBreak: true,
+      reason: "Detected repeated semantically-equivalent failing tool calls",
+    };
+  }
+
+  if (roundCalls.length === 0) return { shouldBreak: false };
+
+  const roundFailures = roundCalls.filter((call) =>
+    didToolCallFail(call.isError, call.result),
+  ).length;
+  if (roundFailures === roundCalls.length) {
+    stuckState.consecutiveAllFailedRounds++;
+  } else {
+    stuckState.consecutiveAllFailedRounds = 0;
+    stuckState.consecutiveSemanticDuplicateRounds = 0;
+    stuckState.lastRoundSemanticKey = "";
+  }
+  if (stuckState.consecutiveAllFailedRounds >= MAX_CONSECUTIVE_ALL_FAILED_ROUNDS) {
+    return {
+      shouldBreak: true,
+      reason: `All tool calls failed for ${MAX_CONSECUTIVE_ALL_FAILED_ROUNDS} consecutive rounds`,
+    };
+  }
+
+  if (roundFailures === roundCalls.length) {
+    const roundSemanticKey = roundCalls
+      .map((call) => buildSemanticToolCallKey(call.name, call.args))
+      .sort()
+      .join("|");
+    if (
+      roundSemanticKey.length > 0 &&
+      roundSemanticKey === stuckState.lastRoundSemanticKey
+    ) {
+      stuckState.consecutiveSemanticDuplicateRounds++;
+    } else {
+      stuckState.consecutiveSemanticDuplicateRounds = 0;
+    }
+    stuckState.lastRoundSemanticKey = roundSemanticKey;
+    if (
+      stuckState.consecutiveSemanticDuplicateRounds >=
+      MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS
+    ) {
+      return {
+        shouldBreak: true,
+        reason:
+          "Detected repeated semantically equivalent tool rounds with no material progress",
+      };
+    }
+  }
+
+  return { shouldBreak: false };
+}
+
+/** Build recovery hint messages for injection after a tool round. */
+export function buildToolLoopRecoveryMessages(
+  recoveryHints: readonly RecoveryHint[],
+  maxRuntimeSystemHints: number,
+  currentRuntimeHintCount: number,
+): LLMMessage[] {
+  const messages: LLMMessage[] = [];
+  if (maxRuntimeSystemHints <= 0) return messages;
+  let hintCount = currentRuntimeHintCount;
+  for (const hint of recoveryHints) {
+    if (hintCount >= maxRuntimeSystemHints) break;
+    messages.push({
+      role: "system",
+      content: `${RECOVERY_HINT_PREFIX} ${hint.message}`,
+    });
+    hintCount++;
+  }
+  return messages;
+}
+
+/** Build a routing expansion hint message when tool routing misses are detected. */
+export function buildRoutingExpansionMessage(
+  maxRuntimeSystemHints: number,
+  currentRuntimeHintCount: number,
+): LLMMessage | null {
+  if (maxRuntimeSystemHints <= 0) return null;
+  if (currentRuntimeHintCount >= maxRuntimeSystemHints) return null;
+  return {
+    role: "system",
+    content:
+      `${RECOVERY_HINT_PREFIX} The previous tool request targeted a tool outside the routed subset. ` +
+      "Tool availability has been expanded for one retry. Choose the best available tool and continue.",
+  };
 }

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -28,6 +28,7 @@ import type {
 } from "./policy.js";
 import type {
   Pipeline,
+  PipelineExecutionOptions,
   PipelinePlannerContext,
   PipelineResult,
   PipelineStep,
@@ -39,6 +40,7 @@ import type {
   DelegationBanditSelection,
   DelegationTrajectorySink,
 } from "./delegation-learning.js";
+import { deriveDelegationContextClusterId } from "./delegation-learning.js";
 import { RuntimeError, RuntimeErrorCodes } from "../types/errors.js";
 
 // ============================================================================
@@ -248,7 +250,11 @@ export interface ChatExecutorResult {
 
 /** Minimal pipeline executor interface required by ChatExecutor planner path. */
 export interface DeterministicPipelineExecutor {
-  execute(pipeline: Pipeline, startFrom?: number): Promise<PipelineResult>;
+  execute(
+    pipeline: Pipeline,
+    startFrom?: number,
+    options?: PipelineExecutionOptions,
+  ): Promise<PipelineResult>;
 }
 
 export type LLMRetryPolicyOverrides = Partial<{
@@ -617,4 +623,150 @@ export interface ExecutionContext {
   plannedSynthesisSteps: number;
   plannedDependencyDepth: number;
   plannedFanout: number;
+}
+
+// ============================================================================
+// ExecutionContext builder (extracted from initializeExecutionContext)
+// ============================================================================
+
+/** Parameters for building the default ExecutionContext object. */
+export interface BuildExecutionContextParams {
+  readonly message: GatewayMessage;
+  readonly messageText: string;
+  readonly systemPrompt: string;
+  readonly sessionId: string;
+  readonly signal?: AbortSignal;
+  readonly history: readonly LLMMessage[];
+  readonly plannerDecision: PlannerDecision;
+  readonly compacted: boolean;
+  readonly toolHandler?: ToolHandler;
+  readonly streamCallback?: StreamProgressCallback;
+  readonly toolRouting?: ChatExecuteParams["toolRouting"];
+  readonly initialRoutedToolNames: readonly string[];
+  readonly expandedRoutedToolNames: readonly string[];
+  readonly baseDelegationThreshold: number;
+}
+
+/** Configuration values from ChatExecutor instance needed for context building. */
+export interface BuildExecutionContextConfig {
+  readonly maxToolRounds: number;
+  readonly toolBudgetPerRequest: number;
+  readonly maxModelRecallsPerRequest: number;
+  readonly maxFailureBudgetPerRequest: number;
+  readonly requestTimeoutMs: number;
+  readonly providerName: string;
+  readonly plannerEnabled: boolean;
+  readonly subagentVerifierEnabled: boolean;
+  readonly delegationBanditTunerEnabled: boolean;
+  readonly delegationScoreThreshold: number;
+}
+
+/** Build the default ExecutionContext object with all mutable state initialized. */
+export function buildDefaultExecutionContext(
+  params: BuildExecutionContextParams,
+  config: BuildExecutionContextConfig,
+): ExecutionContext {
+  const startTime = Date.now();
+  const hasHistory = params.history.length > 0;
+  return {
+    // --- Immutable request params ---
+    message: params.message,
+    messageText: params.messageText,
+    systemPrompt: params.systemPrompt,
+    sessionId: params.sessionId,
+    signal: params.signal,
+    activeToolHandler: params.toolHandler,
+    activeStreamCallback: params.streamCallback,
+    effectiveMaxToolRounds: config.maxToolRounds,
+    effectiveToolBudget: config.toolBudgetPerRequest,
+    effectiveMaxModelRecalls: config.maxModelRecallsPerRequest,
+    effectiveFailureBudget: config.maxFailureBudgetPerRequest,
+    startTime,
+    requestDeadlineAt: startTime + config.requestTimeoutMs,
+    parentTurnId: `parent:${params.sessionId}:${startTime}`,
+    trajectoryTraceId: `trace:${params.sessionId}:${startTime}`,
+    initialRoutedToolNames: params.initialRoutedToolNames,
+    expandedRoutedToolNames: params.expandedRoutedToolNames,
+    canExpandOnRoutingMiss: Boolean(
+      params.toolRouting?.expandOnMiss &&
+      params.expandedRoutedToolNames.length > 0,
+    ),
+    hasHistory,
+    plannerDecision: params.plannerDecision,
+    baseDelegationThreshold: params.baseDelegationThreshold,
+    toolRouting: params.toolRouting,
+
+    // --- Mutable accumulator state ---
+    history: params.history,
+    messages: [],
+    messageSections: [],
+    cumulativeUsage: {
+      promptTokens: 0,
+      completionTokens: 0,
+      totalTokens: 0,
+    },
+    callUsage: [],
+    callIndex: 0,
+    modelCalls: 0,
+    allToolCalls: [],
+    failedToolCalls: 0,
+    usedFallback: false,
+    providerName: config.providerName,
+    responseModel: undefined,
+    response: undefined,
+    evaluation: undefined,
+    finalContent: "",
+    compacted: params.compacted,
+    stopReason: "completed",
+    stopReasonDetail: undefined,
+    activeRoutedToolNames: params.initialRoutedToolNames,
+    routedToolsExpanded: false,
+    routedToolMisses: 0,
+    plannerHandled: false,
+    plannerSummaryState: {
+      enabled: config.plannerEnabled,
+      used: false,
+      routeReason: params.plannerDecision.reason,
+      complexityScore: params.plannerDecision.score,
+      plannerCalls: 0,
+      plannedSteps: 0,
+      deterministicStepsExecuted: 0,
+      estimatedRecallsAvoided: 0,
+      diagnostics: [] as PlannerDiagnostic[],
+      delegationDecision: undefined as DelegationDecision | undefined,
+      subagentVerification: {
+        enabled: config.subagentVerifierEnabled,
+        performed: false,
+        rounds: 0,
+        overall: "skipped" as "pass" | "retry" | "fail" | "skipped",
+        confidence: 1,
+        unresolvedItems: [] as string[],
+      },
+      delegationPolicyTuning: {
+        enabled: config.delegationBanditTunerEnabled,
+        contextClusterId: undefined as string | undefined,
+        selectedArmId: undefined as string | undefined,
+        selectedArmReason: undefined as string | undefined,
+        tunedThreshold: undefined as number | undefined,
+        exploration: false,
+        finalReward: undefined as number | undefined,
+        usefulDelegation: undefined as boolean | undefined,
+        usefulDelegationScore: undefined as number | undefined,
+        rewardProxyVersion: undefined as string | undefined,
+      },
+    },
+    trajectoryContextClusterId: deriveDelegationContextClusterId({
+      complexityScore: params.plannerDecision.score,
+      subagentStepCount: 0,
+      hasHistory,
+      highRiskPlan: false,
+    }),
+    selectedBanditArm: undefined,
+    tunedDelegationThreshold: params.baseDelegationThreshold,
+    plannedSubagentSteps: 0,
+    plannedDeterministicSteps: 0,
+    plannedSynthesisSteps: 0,
+    plannedDependencyDepth: 0,
+    plannedFanout: 0,
+  };
 }

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -647,6 +647,46 @@ describe("ChatExecutor", () => {
       }
     });
 
+    it("sanitizes mixed markdown + embedded JSON base64 screenshot blobs", async () => {
+      const hugeBase64 = "C".repeat(95_000);
+      const toolHandler = vi.fn().mockResolvedValue(
+        [
+          "### Result",
+          '- [Screenshot of viewport](../../tmp/screenshot.png)',
+          '{"type":"image","data":"' + hugeBase64 + '"}',
+        ].join("\n"),
+      );
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                { id: "tc-1", name: "mcp.browser.browser_take_screenshot", arguments: "{}" },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "done" })),
+      });
+
+      const executor = new ChatExecutor({ providers: [provider], toolHandler });
+      await executor.execute(createParams());
+
+      const followupMessages = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1][0] as LLMMessage[];
+      const toolMessage = followupMessages.find(
+        (m) => m.role === "tool" && m.toolCallId === "tc-1",
+      );
+      expect(toolMessage).toBeDefined();
+      expect(typeof toolMessage?.content).toBe("string");
+      const text = String(toolMessage?.content);
+      expect(text).toContain('"data":"(base64 omitted)"');
+      expect(text).not.toContain(hugeBase64.slice(0, 256));
+      expect(text.length).toBeLessThan(13_000);
+    });
+
     it("multi-round tool calls chain with context", async () => {
       const toolHandler = vi
         .fn()
@@ -1011,6 +1051,135 @@ describe("ChatExecutor", () => {
       expect(injectedHint).toBeDefined();
       expect(String(injectedHint?.content)).toContain("system.bash");
       expect(String(injectedHint?.content)).toContain("CANNOT reach");
+    });
+
+    it("injects a recovery hint when desktop.bash is unavailable", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue('{"error":"Tool not found: \\"desktop.bash\\""}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "desktop.bash",
+                  arguments: '{"command":"ls"}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("Desktop/container tools are unavailable"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("/desktop attach");
+      expect(String(injectedHint?.content)).toContain("desktop.bash");
+    });
+
+    it("injects a recovery hint when container MCP tools require desktop session", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue("Container MCP tool — requires desktop session");
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "mcp.kitty.launch",
+                  arguments: '{"instance":"terminal1"}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("Desktop/container tools are unavailable"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("/desktop attach");
+      expect(String(injectedHint?.content)).toContain("mcp.*");
+    });
+
+    it("injects a recovery hint when desktop-targeted command fails on system.bash", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue('{"error":"Command \\"gdb\\" is denied"}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "system.bash",
+                  arguments: '{"command":"gdb","args":["--version"]}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("host shell"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("/desktop attach");
+      expect(String(injectedHint?.content)).toContain("desktop.bash");
     });
 
     it("does not break loop when tool calls differ", async () => {
@@ -2046,6 +2215,81 @@ describe("ChatExecutor", () => {
       expect(result.content.toLowerCase()).toContain("hi");
     });
 
+    it("passes the active session tool handler into deterministic pipeline execution", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "multi_step_cues",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "step_1",
+                  step_type: "deterministic_tool",
+                  tool: "desktop.bash",
+                  args: { command: "echo", args: ["session"] },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockImplementation(
+          async (
+            _pipeline: unknown,
+            _startFrom?: number,
+            options?: { toolHandler?: (name: string, args: Record<string, unknown>) => Promise<string> },
+          ) => {
+            if (!options?.toolHandler) {
+              throw new Error("missing per-session tool handler");
+            }
+            const stepResult = await options.toolHandler("desktop.bash", {
+              command: "echo",
+              args: ["session"],
+            });
+            return {
+              status: "completed",
+              context: { results: { step_1: stepResult } },
+              completedSteps: 1,
+              totalSteps: 1,
+            };
+          },
+        ),
+      };
+      const defaultToolHandler = vi.fn().mockResolvedValue("default-handler-result");
+      const sessionToolHandler = vi
+        .fn()
+        .mockResolvedValue('{"stdout":"session-handler-result","exitCode":0}');
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: defaultToolHandler,
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "First run a desktop command, then summarize the outcome.",
+          ),
+          toolHandler: sessionToolHandler,
+        }),
+      );
+
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      const pipelineCallArgs = (pipelineExecutor.execute as ReturnType<typeof vi.fn>)
+        .mock.calls[0];
+      expect(pipelineCallArgs[2]).toBeDefined();
+      expect(pipelineCallArgs[2].toolHandler).toBe(sessionToolHandler);
+      expect(sessionToolHandler).toHaveBeenCalledWith("desktop.bash", {
+        command: "echo",
+        args: ["session"],
+      });
+      expect(defaultToolHandler).not.toHaveBeenCalled();
+      expect(result.stopReason).toBe("completed");
+    });
+
     it("applies bandit arm tuning and records parent trajectory rewards", async () => {
       const { DelegationBanditPolicyTuner, InMemoryDelegationTrajectorySink } =
         await import("./delegation-learning.js");
@@ -2260,6 +2504,10 @@ describe("ChatExecutor", () => {
               tool: "system.bash",
             }),
           ],
+        }),
+        0,
+        expect.objectContaining({
+          toolHandler: expect.any(Function),
         }),
       );
       expect(result.content).toBe("final synthesized answer");

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -24,7 +24,6 @@ import {
   LLMRateLimitError,
   classifyLLMFailure,
 } from "./errors.js";
-import { safeStringify } from "../tools/types.js";
 import {
   applyPromptBudget,
   type PromptBudgetConfig,
@@ -41,14 +40,10 @@ import type {
 import type {
   Pipeline,
   PipelinePlannerContext,
-  PipelinePlannerStep,
   PipelineResult,
 } from "../workflow/pipeline.js";
 import {
-  assessDelegationDecision,
   resolveDelegationDecisionConfig,
-  type DelegationDecision,
-  type DelegationDecisionConfig,
   type ResolvedDelegationDecisionConfig,
 } from "./delegation-decision.js";
 import {
@@ -65,6 +60,7 @@ import {
 
 import {
   ChatBudgetExceededError,
+  buildDefaultExecutionContext,
 } from "./chat-executor-types.js";
 import type {
   SkillInjector,
@@ -74,7 +70,6 @@ import type {
   ChatPromptShape,
   ChatCallUsageRecord,
   ChatPlannerSummary,
-  PlannerDiagnostic,
   ChatExecutorResult,
   DeterministicPipelineExecutor,
   ChatExecutorConfig,
@@ -94,9 +89,6 @@ import type {
   ExecutionContext,
 } from "./chat-executor-types.js";
 import {
-  MAX_CONSECUTIVE_IDENTICAL_FAILURES,
-  MAX_CONSECUTIVE_ALL_FAILED_ROUNDS,
-  RECOVERY_HINT_PREFIX,
   MAX_EVAL_USER_CHARS,
   MAX_EVAL_RESPONSE_CHARS,
   MAX_CONTEXT_INJECTION_CHARS,
@@ -111,7 +103,6 @@ import {
   DEFAULT_REQUEST_TIMEOUT_MS,
   DEFAULT_SUBAGENT_VERIFIER_MIN_CONFIDENCE,
   DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS,
-  MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS,
   DEFAULT_TOOL_FAILURE_BREAKER_THRESHOLD,
   DEFAULT_TOOL_FAILURE_BREAKER_WINDOW_MS,
   DEFAULT_TOOL_FAILURE_BREAKER_COOLDOWN_MS,
@@ -121,14 +112,17 @@ import {
 } from "./chat-executor-constants.js";
 import {
   didToolCallFail,
-  extractToolFailureText,
   resolveRetryPolicyMatrix,
-  hasExplicitIdempotencyKey,
-  isHighRiskToolCall,
-  isToolRetrySafe,
-  isLikelyToolTransportFailure,
   enrichToolResultMetadata,
+  checkToolCallPermission,
+  parseToolCallArguments,
+  executeToolWithRetry,
+  trackToolCallFailureState,
+  checkToolLoopStuckDetection,
+  buildToolLoopRecoveryMessages,
+  buildRoutingExpansionMessage,
 } from "./chat-executor-tool-utils.js";
+import type { RoundStuckState } from "./chat-executor-tool-utils.js";
 import {
   extractMessageText,
   truncateText,
@@ -146,6 +140,9 @@ import {
   buildSemanticToolCallKey,
   summarizeStateful,
   buildRecoveryHints,
+  computeQualityProxy,
+  buildDelegationTrajectoryEntry,
+  buildPlannerSummary,
 } from "./chat-executor-recovery.js";
 import {
   assessPlannerDecision,
@@ -159,6 +156,9 @@ import {
   buildPlannerSynthesisMessages,
   ensureSubagentProvenanceCitations,
   pipelineResultToToolCalls,
+  resolveDelegationBanditArm,
+  assessAndRecordDelegationDecision,
+  mapPlannerStepsToPipelineSteps,
 } from "./chat-executor-planner.js";
 import {
   evaluateSubagentDeterministicChecks,
@@ -566,7 +566,13 @@ export class ChatExecutor {
     });
     try {
       return await Promise.race([
-        this.pipelineExecutor!.execute(pipeline),
+        this.pipelineExecutor!.execute(
+          pipeline,
+          0,
+          ctx.activeToolHandler
+            ? { toolHandler: ctx.activeToolHandler }
+            : undefined,
+        ),
         timeoutPromise,
       ]);
     } catch (error) {
@@ -651,17 +657,9 @@ export class ChatExecutor {
   private async initializeExecutionContext(
     params: ChatExecuteParams,
   ): Promise<ExecutionContext> {
-    const {
-      message,
-      systemPrompt,
-      sessionId,
-      signal,
-      maxToolRounds: paramMaxToolRounds,
-    } = params;
+    const { message, systemPrompt, sessionId, signal } = params;
     let { history } = params;
-    const startTime = Date.now();
     const messageText = extractMessageText(message);
-    const hasHistory = history.length > 0;
     const plannerDecision = assessPlannerDecision(this.plannerEnabled, messageText, history);
     const initialRoutedToolNames = params.toolRouting?.routedToolNames
       ? Array.from(new Set(params.toolRouting.routedToolNames))
@@ -695,107 +693,36 @@ export class ChatExecutor {
       }
     }
 
-    const ctx: ExecutionContext = {
-      // --- Immutable request params ---
-      message,
-      messageText,
-      systemPrompt,
-      sessionId,
-      signal,
-      activeToolHandler: params.toolHandler ?? this.toolHandler,
-      activeStreamCallback: params.onStreamChunk ?? this.onStreamChunk,
-      effectiveMaxToolRounds: paramMaxToolRounds ?? this.maxToolRounds,
-      effectiveToolBudget: this.toolBudgetPerRequest,
-      effectiveMaxModelRecalls: this.maxModelRecallsPerRequest,
-      effectiveFailureBudget: this.maxFailureBudgetPerRequest,
-      startTime,
-      requestDeadlineAt: startTime + this.requestTimeoutMs,
-      parentTurnId: `parent:${sessionId}:${startTime}`,
-      trajectoryTraceId: `trace:${sessionId}:${startTime}`,
-      initialRoutedToolNames,
-      expandedRoutedToolNames,
-      canExpandOnRoutingMiss: Boolean(
-        params.toolRouting?.expandOnMiss &&
-        expandedRoutedToolNames.length > 0,
-      ),
-      hasHistory,
-      plannerDecision,
-      baseDelegationThreshold,
-      toolRouting: params.toolRouting,
-
-      // --- Mutable accumulator state ---
-      history,
-      messages: [],
-      messageSections: [],
-      cumulativeUsage: {
-        promptTokens: 0,
-        completionTokens: 0,
-        totalTokens: 0,
+    const ctx = buildDefaultExecutionContext(
+      {
+        message,
+        messageText,
+        systemPrompt,
+        sessionId,
+        signal,
+        history,
+        plannerDecision,
+        compacted,
+        toolHandler: params.toolHandler ?? this.toolHandler,
+        streamCallback: params.onStreamChunk ?? this.onStreamChunk,
+        toolRouting: params.toolRouting,
+        initialRoutedToolNames,
+        expandedRoutedToolNames,
+        baseDelegationThreshold,
       },
-      callUsage: [],
-      callIndex: 0,
-      modelCalls: 0,
-      allToolCalls: [],
-      failedToolCalls: 0,
-      usedFallback: false,
-      providerName: this.providers[0]?.name ?? "unknown",
-      responseModel: undefined,
-      response: undefined,
-      evaluation: undefined,
-      finalContent: "",
-      compacted,
-      stopReason: "completed",
-      stopReasonDetail: undefined,
-      activeRoutedToolNames: initialRoutedToolNames,
-      routedToolsExpanded: false,
-      routedToolMisses: 0,
-      plannerHandled: false,
-      plannerSummaryState: {
-        enabled: this.plannerEnabled,
-        used: false,
-        routeReason: plannerDecision.reason,
-        complexityScore: plannerDecision.score,
-        plannerCalls: 0,
-        plannedSteps: 0,
-        deterministicStepsExecuted: 0,
-        estimatedRecallsAvoided: 0,
-        diagnostics: [] as PlannerDiagnostic[],
-        delegationDecision: undefined as DelegationDecision | undefined,
-        subagentVerification: {
-          enabled: this.subagentVerifierConfig.enabled,
-          performed: false,
-          rounds: 0,
-          overall: "skipped" as "pass" | "retry" | "fail" | "skipped",
-          confidence: 1,
-          unresolvedItems: [] as string[],
-        },
-        delegationPolicyTuning: {
-          enabled: Boolean(this.delegationBanditTuner),
-          contextClusterId: undefined as string | undefined,
-          selectedArmId: undefined as string | undefined,
-          selectedArmReason: undefined as string | undefined,
-          tunedThreshold: undefined as number | undefined,
-          exploration: false,
-          finalReward: undefined as number | undefined,
-          usefulDelegation: undefined as boolean | undefined,
-          usefulDelegationScore: undefined as number | undefined,
-          rewardProxyVersion: undefined as string | undefined,
-        },
+      {
+        maxToolRounds: params.maxToolRounds ?? this.maxToolRounds,
+        toolBudgetPerRequest: this.toolBudgetPerRequest,
+        maxModelRecallsPerRequest: this.maxModelRecallsPerRequest,
+        maxFailureBudgetPerRequest: this.maxFailureBudgetPerRequest,
+        requestTimeoutMs: this.requestTimeoutMs,
+        providerName: this.providers[0]?.name ?? "unknown",
+        plannerEnabled: this.plannerEnabled,
+        subagentVerifierEnabled: this.subagentVerifierConfig.enabled,
+        delegationBanditTunerEnabled: Boolean(this.delegationBanditTuner),
+        delegationScoreThreshold: this.delegationDecisionConfig.scoreThreshold,
       },
-      trajectoryContextClusterId: deriveDelegationContextClusterId({
-        complexityScore: plannerDecision.score,
-        subagentStepCount: 0,
-        hasHistory,
-        highRiskPlan: false,
-      }),
-      selectedBanditArm: undefined,
-      tunedDelegationThreshold: baseDelegationThreshold,
-      plannedSubagentSteps: 0,
-      plannedDeterministicSteps: 0,
-      plannedSynthesisSteps: 0,
-      plannedDependencyDepth: 0,
-      plannedFanout: 0,
-    };
+    );
 
     // Build messages array with explicit section tags for prompt budgeting.
     this.pushMessage(ctx, { role: "system", content: ctx.systemPrompt }, "system_anchor");
@@ -853,31 +780,14 @@ export class ChatExecutor {
     durationMs: number;
   } {
     const durationMs = Date.now() - ctx.startTime;
-    const stopReasonQualityBase = ctx.stopReason === "completed"
-      ? 0.85
-      : ctx.stopReason === "tool_calls"
-        ? 0.6
-        : 0.25;
-    const verifierBonus = ctx.plannerSummaryState.subagentVerification.performed
-      ? (
-        ctx.plannerSummaryState.subagentVerification.overall === "pass"
-          ? 0.1
-          : ctx.plannerSummaryState.subagentVerification.overall === "retry"
-            ? 0
-            : -0.15
-      )
-      : 0;
-    const evaluatorBonus = ctx.evaluation
-      ? (ctx.evaluation.passed ? 0.1 : -0.1)
-      : 0;
-    const failurePenalty = Math.min(0.25, ctx.failedToolCalls * 0.05);
-    const qualityProxy = Math.max(
-      0,
-      Math.min(
-        1,
-        stopReasonQualityBase + verifierBonus + evaluatorBonus - failurePenalty,
-      ),
-    );
+    const verifierSnapshot = ctx.plannerSummaryState.subagentVerification;
+    const qualityProxy = computeQualityProxy({
+      stopReason: ctx.stopReason,
+      verifierPerformed: verifierSnapshot.performed,
+      verifierOverall: verifierSnapshot.overall,
+      evaluation: ctx.evaluation,
+      failedToolCalls: ctx.failedToolCalls,
+    });
     const rewardSignal = computeDelegationFinalReward({
       qualityProxy,
       tokenCost: ctx.cumulativeUsage.totalTokens,
@@ -894,7 +804,6 @@ export class ChatExecutor {
       : 0;
     const delegatedThisTurn =
       ctx.plannerSummaryState.delegationDecision?.shouldDelegate === true;
-    const verifierSnapshot = ctx.plannerSummaryState.subagentVerification;
     const usefulnessProxy = computeUsefulDelegationProxy({
       delegated: delegatedThisTurn,
       stopReason: ctx.stopReason,
@@ -934,78 +843,27 @@ export class ChatExecutor {
       const selectedTools = ctx.activeRoutedToolNames.length > 0
         ? [...ctx.activeRoutedToolNames]
         : (this.allowedTools ? [...this.allowedTools] : []);
-      this.delegationTrajectorySink.record({
-        schemaVersion: 1,
-        traceId: ctx.trajectoryTraceId,
-        turnId: ctx.parentTurnId,
-        turnType: "parent",
-        timestampMs: Date.now(),
-        stateFeatures: {
-          sessionId: ctx.sessionId,
-          contextClusterId: ctx.trajectoryContextClusterId,
-          complexityScore: ctx.plannerDecision.score,
-          plannerStepCount: ctx.plannerSummaryState.plannedSteps,
-          subagentStepCount: ctx.plannedSubagentSteps,
-          deterministicStepCount: ctx.plannedDeterministicSteps,
-          synthesisStepCount: ctx.plannedSynthesisSteps,
-          dependencyDepth: ctx.plannedDependencyDepth,
-          fanout: ctx.plannedFanout,
-        },
-        action: {
-          delegated:
-            ctx.plannerSummaryState.delegationDecision?.shouldDelegate === true,
-          strategyArmId:
-            ctx.selectedBanditArm?.armId ?? this.delegationDefaultStrategyArmId,
-          threshold: ctx.tunedDelegationThreshold,
-          selectedTools,
-          childConfig: {
-            maxDepth: this.delegationDecisionConfig.maxDepth,
-            maxFanoutPerTurn: this.delegationDecisionConfig.maxFanoutPerTurn,
-            timeoutMs: this.requestTimeoutMs,
-          },
-        },
-        immediateOutcome: {
+      this.delegationTrajectorySink.record(
+        buildDelegationTrajectoryEntry({
+          ctx,
           qualityProxy,
-          tokenCost: ctx.cumulativeUsage.totalTokens,
-          latencyMs: durationMs,
-          errorCount:
-            ctx.failedToolCalls + (ctx.stopReason === "completed" ? 0 : 1),
-          ...(ctx.stopReason !== "completed" ? { errorClass: ctx.stopReason } : {}),
-        },
-        finalReward: rewardSignal,
-        metadata: {
-          plannerUsed: ctx.plannerSummaryState.used,
-          routeReason: ctx.plannerSummaryState.routeReason ?? "none",
-          stopReason: ctx.stopReason,
-          usefulDelegation: usefulnessProxy.useful,
-          usefulDelegationScore: Number(usefulnessProxy.score.toFixed(4)),
+          durationMs,
+          rewardSignal,
+          usefulnessProxy,
+          selectedTools,
+          defaultStrategyArmId: this.delegationDefaultStrategyArmId,
+          delegationMaxDepth: this.delegationDecisionConfig.maxDepth,
+          delegationMaxFanoutPerTurn: this.delegationDecisionConfig.maxFanoutPerTurn,
+          requestTimeoutMs: this.requestTimeoutMs,
           usefulDelegationProxyVersion: DELEGATION_USEFULNESS_PROXY_VERSION,
-        },
-      });
+        }),
+      );
     }
 
-    const plannerSummary: ChatPlannerSummary = {
-      enabled: ctx.plannerSummaryState.enabled,
-      used: ctx.plannerSummaryState.used,
-      routeReason: ctx.plannerSummaryState.routeReason,
-      complexityScore: ctx.plannerSummaryState.complexityScore,
-      plannerCalls: ctx.plannerSummaryState.plannerCalls,
-      plannedSteps: ctx.plannerSummaryState.plannedSteps,
-      deterministicStepsExecuted: ctx.plannerSummaryState.deterministicStepsExecuted,
-      estimatedRecallsAvoided: ctx.plannerSummaryState.used
-        ? estimatedRecallsAvoided
-        : 0,
-      diagnostics: ctx.plannerSummaryState.diagnostics.length > 0
-        ? ctx.plannerSummaryState.diagnostics
-        : undefined,
-      delegationDecision: ctx.plannerSummaryState.delegationDecision,
-      subagentVerification: ctx.plannerSummaryState.subagentVerification.enabled
-        ? ctx.plannerSummaryState.subagentVerification
-        : undefined,
-      delegationPolicyTuning: ctx.plannerSummaryState.delegationPolicyTuning.enabled
-        ? ctx.plannerSummaryState.delegationPolicyTuning
-        : undefined,
-    };
+    const plannerSummary = buildPlannerSummary(
+      ctx.plannerSummaryState,
+      estimatedRecallsAvoided,
+    );
 
     return { plannerSummary, durationMs };
   }
@@ -1141,15 +999,13 @@ export class ChatExecutor {
         "Initial completion blocked by max model recalls per request budget",
     });
 
-    // Tool call loop — side-effect deduplication prevents the model from
-    // repeating desktop actions (e.g. opening 3 YouTube tabs). Once ANY
-    // side-effect tool executes, all others are skipped for this request.
     let rounds = 0;
     const emittedRecoveryHints = new Set<string>();
-    // Track consecutive identical failing calls to break stuck loops.
-    let consecutiveAllFailedRounds = 0;
-    let lastRoundSemanticKey = "";
-    let consecutiveSemanticDuplicateRounds = 0;
+    const stuckState: RoundStuckState = {
+      consecutiveAllFailedRounds: 0,
+      lastRoundSemanticKey: "",
+      consecutiveSemanticDuplicateRounds: 0,
+    };
     const loopState: ToolLoopState = {
       sideEffectExecuted: false,
       remainingToolImageChars: MAX_TOOL_IMAGE_CHARS_BUDGET,
@@ -1166,14 +1022,11 @@ export class ChatExecutor {
       ctx.activeToolHandler &&
       rounds < ctx.effectiveMaxToolRounds
     ) {
-      // Check for cancellation before each round.
       if (ctx.signal?.aborted) {
         this.setStopReason(ctx, "cancelled", "Execution cancelled by caller");
         break;
       }
-      if (this.checkRequestTimeout(ctx, "tool loop")) {
-        break;
-      }
+      if (this.checkRequestTimeout(ctx, "tool loop")) break;
       const activeCircuit = this.getActiveToolFailureCircuit(ctx.sessionId);
       if (activeCircuit) {
         this.setStopReason(ctx, "no_progress", activeCircuit.reason);
@@ -1187,15 +1040,12 @@ export class ChatExecutor {
         : null;
       loopState.expandAfterRound = false;
 
-      // Append the assistant message with tool calls.
       this.pushMessage(
         ctx,
         {
           role: "assistant",
           content: ctx.response.content,
-          toolCalls: sanitizeToolCallsForReplay(
-            ctx.response.toolCalls,
-          ),
+          toolCalls: sanitizeToolCallsForReplay(ctx.response.toolCalls),
         },
         "assistant_runtime",
       );
@@ -1207,123 +1057,50 @@ export class ChatExecutor {
           abortRound = true;
           break;
         }
-        // "skip" and "processed" both continue the loop
       }
 
-      // Check for cancellation before re-calling LLM.
       if (ctx.signal?.aborted) {
         this.setStopReason(ctx, "cancelled", "Execution cancelled by caller");
         break;
       }
-      if (this.checkRequestTimeout(ctx, "tool follow-up")) {
-        break;
-      }
+      if (this.checkRequestTimeout(ctx, "tool follow-up")) break;
 
       const roundCalls = ctx.allToolCalls.slice(roundToolCallStart);
       if (abortRound) break;
 
-      // Break stuck loops — if semantically equivalent failing call repeats
-      // too many times, stop and surface no-progress.
-      if (loopState.consecutiveFailCount >= MAX_CONSECUTIVE_IDENTICAL_FAILURES) {
-        this.setStopReason(
-          ctx,
-          "no_progress",
-          "Detected repeated semantically-equivalent failing tool calls",
-        );
+      // Stuck-loop detection (consecutive failures, semantic duplicates).
+      const stuckResult = checkToolLoopStuckDetection(roundCalls, loopState, stuckState);
+      if (stuckResult.shouldBreak) {
+        this.setStopReason(ctx, "no_progress", stuckResult.reason);
         break;
       }
 
-      // Break stuck loops — if all tool calls fail for multiple consecutive
-      // rounds, stop retrying and let the model respond with what it learned.
-      if (roundCalls.length > 0) {
-        const roundFailures = roundCalls.filter((call) =>
-          didToolCallFail(call.isError, call.result),
-        ).length;
-        if (roundFailures === roundCalls.length) {
-          consecutiveAllFailedRounds++;
-        } else {
-          consecutiveAllFailedRounds = 0;
-          consecutiveSemanticDuplicateRounds = 0;
-          lastRoundSemanticKey = "";
-        }
-        if (consecutiveAllFailedRounds >= MAX_CONSECUTIVE_ALL_FAILED_ROUNDS) {
-          this.setStopReason(
-            ctx,
-            "no_progress",
-            `All tool calls failed for ${MAX_CONSECUTIVE_ALL_FAILED_ROUNDS} consecutive rounds`,
-          );
-          break;
-        }
-
-        if (roundFailures === roundCalls.length) {
-          const roundSemanticKey = roundCalls
-            .map((call) =>
-              buildSemanticToolCallKey(call.name, call.args),
-            )
-            .sort()
-            .join("|");
-          if (
-            roundSemanticKey.length > 0 &&
-            roundSemanticKey === lastRoundSemanticKey
-          ) {
-            consecutiveSemanticDuplicateRounds++;
-          } else {
-            consecutiveSemanticDuplicateRounds = 0;
-          }
-          lastRoundSemanticKey = roundSemanticKey;
-          if (
-            consecutiveSemanticDuplicateRounds >=
-            MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS
-          ) {
-            this.setStopReason(
-              ctx,
-              "no_progress",
-              "Detected repeated semantically equivalent tool rounds with no material progress",
-            );
-            break;
-          }
-        }
+      // Recovery hints.
+      const recoveryHints = buildRecoveryHints(roundCalls, emittedRecoveryHints);
+      const runtimeHintCount = ctx.messageSections.filter(
+        (s) => s === "system_runtime",
+      ).length;
+      for (const msg of buildToolLoopRecoveryMessages(
+        recoveryHints,
+        this.maxRuntimeSystemHints,
+        runtimeHintCount,
+      )) {
+        this.pushMessage(ctx, msg, "system_runtime");
       }
 
-      const recoveryHints = buildRecoveryHints(
-        roundCalls,
-        emittedRecoveryHints,
-      );
-      for (const hint of recoveryHints) {
-        if (this.maxRuntimeSystemHints <= 0) break;
-        const runtimeHintCount = ctx.messageSections.filter(
-          (section) => section === "system_runtime",
-        ).length;
-        if (runtimeHintCount >= this.maxRuntimeSystemHints) break;
-        this.pushMessage(
-          ctx,
-          {
-            role: "system",
-            content: `${RECOVERY_HINT_PREFIX} ${hint.message}`,
-          },
-          "system_runtime",
-        );
-      }
-
+      // Routing expansion on miss.
       if (loopState.expandAfterRound && ctx.expandedRoutedToolNames.length > 0) {
         ctx.routedToolsExpanded = true;
         ctx.activeRoutedToolNames = ctx.expandedRoutedToolNames;
-        if (this.maxRuntimeSystemHints > 0) {
-          const runtimeHintCount = ctx.messageSections.filter(
-            (section) => section === "system_runtime",
-          ).length;
-          if (runtimeHintCount < this.maxRuntimeSystemHints) {
-            this.pushMessage(
-              ctx,
-              {
-                role: "system",
-                content:
-                  `${RECOVERY_HINT_PREFIX} The previous tool request targeted a tool outside the routed subset. ` +
-                  "Tool availability has been expanded for one retry. Choose the best available tool and continue.",
-              },
-              "system_runtime",
-            );
-          }
+        const updatedHintCount = ctx.messageSections.filter(
+          (s) => s === "system_runtime",
+        ).length;
+        const expansionMsg = buildRoutingExpansionMessage(
+          this.maxRuntimeSystemHints,
+          updatedHintCount,
+        );
+        if (expansionMsg) {
+          this.pushMessage(ctx, expansionMsg, "system_runtime");
         }
       }
 
@@ -1355,9 +1132,6 @@ export class ChatExecutor {
       );
     }
 
-    // If the LLM returned empty content after tool calls (common when maxToolRounds
-    // is hit while the LLM still wanted to make more calls), generate a fallback
-    // summary from the last successful tool result.
     ctx.finalContent = ctx.response?.content ?? "";
     if (!ctx.finalContent && ctx.allToolCalls.length > 0) {
       ctx.finalContent =
@@ -1385,15 +1159,22 @@ export class ChatExecutor {
       return "abort_loop";
     }
 
-    if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name) && loopState.sideEffectExecuted) {
-      const skipResult = safeStringify({
-        error: `Skipped "${toolCall.name}" — a desktop action was already performed. Combine actions into a single tool call.`,
-      });
+    // Permission check (side-effect dedup, allowlist, routed subset).
+    const permission = checkToolCallPermission(
+      toolCall,
+      this.allowedTools,
+      loopState.activeRoutedToolSet,
+      ctx.canExpandOnRoutingMiss,
+      ctx.routedToolsExpanded,
+      loopState.sideEffectExecuted,
+    );
+    if (permission.errorResult) {
+      if (permission.routingMiss) ctx.routedToolMisses++;
       this.pushMessage(
         ctx,
         {
           role: "tool",
-          content: skipResult,
+          content: permission.errorResult,
           toolCallId: toolCall.id,
           toolName: toolCall.name,
         },
@@ -1402,90 +1183,23 @@ export class ChatExecutor {
       this.appendToolRecord(ctx, {
         name: toolCall.name,
         args: {},
-        result: skipResult,
+        result: permission.errorResult,
         isError: true,
         durationMs: 0,
       });
+      if (permission.expandAfterRound) loopState.expandAfterRound = true;
       return "skip";
     }
     if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name)) loopState.sideEffectExecuted = true;
 
-    // Global allowlist check.
-    if (this.allowedTools && !this.allowedTools.has(toolCall.name)) {
-      const errorResult = safeStringify({
-        error: `Tool "${toolCall.name}" is not permitted`,
-      });
-      this.pushMessage(
-        ctx,
-        {
-          role: "tool",
-          content: errorResult,
-          toolCallId: toolCall.id,
-          toolName: toolCall.name,
-        },
-        "tools",
-      );
-      this.appendToolRecord(ctx, {
-        name: toolCall.name,
-        args: {},
-        result: errorResult,
-        isError: true,
-        durationMs: 0,
-      });
-      return "skip";
-    }
-    // Dynamic routed subset check.
-    if (loopState.activeRoutedToolSet && !loopState.activeRoutedToolSet.has(toolCall.name)) {
-      ctx.routedToolMisses++;
-      const errorResult = safeStringify({
-        error:
-          `Tool "${toolCall.name}" was not available in the routed tool subset for this turn`,
-        routingMiss: true,
-      });
-      this.pushMessage(
-        ctx,
-        {
-          role: "tool",
-          content: errorResult,
-          toolCallId: toolCall.id,
-          toolName: toolCall.name,
-        },
-        "tools",
-      );
-      this.appendToolRecord(ctx, {
-        name: toolCall.name,
-        args: {},
-        result: errorResult,
-        isError: true,
-        durationMs: 0,
-      });
-      if (ctx.canExpandOnRoutingMiss && !ctx.routedToolsExpanded) {
-        loopState.expandAfterRound = true;
-      }
-      return "skip";
-    }
-
     // Parse arguments.
-    let args: Record<string, unknown>;
-    try {
-      const parsed = JSON.parse(toolCall.arguments) as unknown;
-      if (
-        typeof parsed !== "object" ||
-        parsed === null ||
-        Array.isArray(parsed)
-      ) {
-        throw new Error("Tool arguments must be a JSON object");
-      }
-      args = parsed as Record<string, unknown>;
-    } catch (parseErr) {
-      const errorResult = safeStringify({
-        error: `Invalid tool arguments: ${(parseErr as Error).message}`,
-      });
+    const parseResult = parseToolCallArguments(toolCall);
+    if (!parseResult.ok) {
       this.pushMessage(
         ctx,
         {
           role: "tool",
-          content: errorResult,
+          content: parseResult.error,
           toolCallId: toolCall.id,
           toolName: toolCall.name,
         },
@@ -1494,149 +1208,39 @@ export class ChatExecutor {
       this.appendToolRecord(ctx, {
         name: toolCall.name,
         args: {},
-        result: errorResult,
+        result: parseResult.error,
         isError: true,
         durationMs: 0,
       });
       return "skip";
     }
+    const args = parseResult.args;
 
-    // Execute tool.
-    const toolStart = Date.now();
-    let result = safeStringify({ error: "Tool execution failed" });
-    let isError = false;
-    let toolFailed = false;
-    let transportFailure = false;
-    let timedOut = false;
-    let finalToolTimeoutMs = this.toolCallTimeoutMs;
-    let retrySuppressedReason: string | undefined;
-    let retryCount = 0;
-    const maxToolRetries = Math.max(
-      0,
-      this.retryPolicyMatrix.tool_error.maxRetries,
+    // Execute tool with retry.
+    const exec = await executeToolWithRetry(
+      toolCall,
+      args,
+      ctx.activeToolHandler!,
+      {
+        toolCallTimeoutMs: this.toolCallTimeoutMs,
+        retryPolicyMatrix: this.retryPolicyMatrix,
+        signal: ctx.signal,
+        requestDeadlineAt: ctx.requestDeadlineAt,
+      },
     );
 
-    for (let attempt = 0; attempt <= maxToolRetries; attempt++) {
-      const remainingRequestMs = this.getRemainingRequestMs(ctx);
-      const toolTimeoutMs = Math.min(
-        this.toolCallTimeoutMs,
-        Math.max(1, remainingRequestMs),
-      );
-      finalToolTimeoutMs = toolTimeoutMs;
-      let toolTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
-      const toolCallPromise = (async (): Promise<{
-        result: string;
-        isError: boolean;
-        timedOut: boolean;
-        threw: boolean;
-      }> => {
-        try {
-          const value = await ctx.activeToolHandler!(toolCall.name, args);
-          return {
-            result: value,
-            isError: false,
-            timedOut: false,
-            threw: false,
-          };
-        } catch (toolErr) {
-          return {
-            result: safeStringify({ error: (toolErr as Error).message }),
-            isError: true,
-            timedOut: false,
-            threw: true,
-          };
-        }
-      })();
-      const timeoutPromise = new Promise<{
-        result: string;
-        isError: boolean;
-        timedOut: boolean;
-        threw: boolean;
-      }>((resolve) => {
-        toolTimeoutHandle = setTimeout(() => {
-          resolve({
-            result: safeStringify({
-              error: `Tool "${toolCall.name}" timed out after ${toolTimeoutMs}ms`,
-            }),
-            isError: true,
-            timedOut: true,
-            threw: false,
-          });
-        }, toolTimeoutMs);
-      });
-      const toolOutcome = await Promise.race([
-        toolCallPromise,
-        timeoutPromise,
-      ]);
-      if (toolTimeoutHandle !== undefined) {
-        clearTimeout(toolTimeoutHandle);
-      }
-
-      result = toolOutcome.result;
-      isError = toolOutcome.isError;
-      timedOut = toolOutcome.timedOut;
-
-      toolFailed = didToolCallFail(isError, result);
-      const failureText = toolFailed
-        ? extractToolFailureText({
-          name: toolCall.name,
-          args,
-          result,
-          isError: toolFailed,
-          durationMs: 0,
-        })
-        : "";
-      transportFailure =
-        timedOut ||
-        toolOutcome.threw ||
-        isLikelyToolTransportFailure(failureText);
-      if (!toolFailed) break;
-
-      const canRetryTransportFailure =
-        transportFailure &&
-        attempt < maxToolRetries &&
-        !ctx.signal?.aborted &&
-        this.getRemainingRequestMs(ctx) > 0;
-      if (!canRetryTransportFailure) break;
-
-      const highRiskTool = isHighRiskToolCall(toolCall.name);
-      const hasIdempotencyKey = hasExplicitIdempotencyKey(args);
-      const retrySafe = highRiskTool
-        ? hasIdempotencyKey
-        : isToolRetrySafe(toolCall.name);
-      if (!retrySafe) {
-        retrySuppressedReason = highRiskTool && !hasIdempotencyKey
-          ? `Suppressed auto-retry for high-risk tool "${toolCall.name}" without idempotencyKey`
-          : `Suppressed auto-retry for potentially side-effecting tool "${toolCall.name}"`;
-        break;
-      }
-
-      retryCount++;
-    }
-    const toolDuration = Date.now() - toolStart;
-    if (retryCount > 0) {
-      result = enrichToolResultMetadata(result, { retryAttempts: retryCount });
-    }
-    if (retrySuppressedReason) {
-      result = enrichToolResultMetadata(result, {
-        retrySuppressedReason,
-      });
-    }
-
+    let { result } = exec;
     let abortRound = false;
-    if (timedOut && toolFailed) {
+    if (exec.timedOut && exec.toolFailed) {
       this.setStopReason(
         ctx,
         "timeout",
-        `Tool "${toolCall.name}" timed out after ${finalToolTimeoutMs}ms`,
+        `Tool "${toolCall.name}" timed out after ${exec.finalToolTimeoutMs}ms`,
       );
       abortRound = true;
     }
 
-    if (
-      this.toolFailureBreakerEnabled &&
-      toolFailed
-    ) {
+    if (this.toolFailureBreakerEnabled && exec.toolFailed) {
       const failKey = buildSemanticToolCallKey(toolCall.name, args);
       const circuitReason = this.recordToolFailurePattern(
         ctx.sessionId,
@@ -1657,8 +1261,8 @@ export class ChatExecutor {
       name: toolCall.name,
       args,
       result,
-      isError: toolFailed,
-      durationMs: toolDuration,
+      isError: exec.toolFailed,
+      durationMs: exec.durationMs,
     });
 
     if (ctx.failedToolCalls > ctx.effectiveFailureBudget) {
@@ -1671,21 +1275,11 @@ export class ChatExecutor {
     }
 
     // Track consecutive semantic failures to detect stuck loops.
-    const failDetected = toolFailed;
-    const semanticToolKey = buildSemanticToolCallKey(
-      toolCall.name,
-      args,
-    );
-    const failKey = failDetected ? semanticToolKey : "";
-    if (!failDetected && this.toolFailureBreakerEnabled) {
+    const semanticToolKey = buildSemanticToolCallKey(toolCall.name, args);
+    if (!exec.toolFailed && this.toolFailureBreakerEnabled) {
       this.clearToolFailurePattern(ctx.sessionId, semanticToolKey);
     }
-    if (failDetected && failKey === loopState.lastFailKey) {
-      loopState.consecutiveFailCount++;
-    } else {
-      loopState.lastFailKey = failKey;
-      loopState.consecutiveFailCount = failDetected ? 1 : 0;
-    }
+    trackToolCallFailureState(exec.toolFailed, semanticToolKey, loopState);
 
     const promptToolContent = buildPromptToolContent(
       result,
@@ -1766,12 +1360,7 @@ export class ChatExecutor {
             step.stepType === "subagent_task",
         );
         if (subagentSteps.length > 0) {
-          const synthesisSteps = plannerPlan.steps.filter(
-            (step) => step.stepType === "synthesis",
-          ).length;
-          const highRiskPlan = isHighRiskSubagentPlan(
-            subagentSteps,
-          );
+          const highRiskPlan = isHighRiskSubagentPlan(subagentSteps);
           ctx.trajectoryContextClusterId = deriveDelegationContextClusterId({
             complexityScore: ctx.plannerDecision.score,
             subagentStepCount: subagentSteps.length,
@@ -1779,131 +1368,34 @@ export class ChatExecutor {
             highRiskPlan,
           });
 
-          if (this.delegationBanditTuner) {
-            ctx.selectedBanditArm = this.delegationBanditTuner.selectArm({
-              contextClusterId: ctx.trajectoryContextClusterId,
-              preferredArmId: this.delegationDefaultStrategyArmId,
-            });
-            ctx.tunedDelegationThreshold =
-              this.delegationBanditTuner.applyThresholdOffset(
-                ctx.baseDelegationThreshold,
-                ctx.selectedBanditArm.armId,
-              );
-            ctx.plannerSummaryState.delegationPolicyTuning = {
-              enabled: true,
-              contextClusterId: ctx.trajectoryContextClusterId,
-              selectedArmId: ctx.selectedBanditArm.armId,
-              selectedArmReason: ctx.selectedBanditArm.reason,
-              tunedThreshold: ctx.tunedDelegationThreshold,
-              exploration: ctx.selectedBanditArm.exploration,
-              finalReward: undefined,
-              usefulDelegation: undefined,
-              usefulDelegationScore: undefined,
-              rewardProxyVersion: undefined,
-            };
-          } else {
-            ctx.plannerSummaryState.delegationPolicyTuning = {
-              enabled: false,
-              contextClusterId: ctx.trajectoryContextClusterId,
-              selectedArmId: this.delegationDefaultStrategyArmId,
-              selectedArmReason: "fallback",
-              tunedThreshold: ctx.baseDelegationThreshold,
-              exploration: false,
-              finalReward: undefined,
-              usefulDelegation: undefined,
-              usefulDelegationScore: undefined,
-              rewardProxyVersion: undefined,
-            };
-          }
+          const banditResult = resolveDelegationBanditArm(
+            this.delegationBanditTuner,
+            ctx.trajectoryContextClusterId,
+            this.delegationDefaultStrategyArmId,
+            ctx.baseDelegationThreshold,
+          );
+          ctx.selectedBanditArm = banditResult.selectedArm;
+          ctx.tunedDelegationThreshold = banditResult.tunedThreshold;
+          ctx.plannerSummaryState.delegationPolicyTuning = banditResult.policyTuning;
 
-          const tunedDecisionConfig: DelegationDecisionConfig = {
-            enabled: this.delegationDecisionConfig.enabled,
-            mode: this.delegationDecisionConfig.mode,
-            scoreThreshold: ctx.tunedDelegationThreshold,
-            maxFanoutPerTurn: this.delegationDecisionConfig.maxFanoutPerTurn,
-            maxDepth: this.delegationDecisionConfig.maxDepth,
-            handoffMinPlannerConfidence:
-              this.delegationDecisionConfig.handoffMinPlannerConfidence,
-            hardBlockedTaskClasses: [
-              ...this.delegationDecisionConfig.hardBlockedTaskClasses,
-            ],
-          };
-          const delegationDecision = assessDelegationDecision({
-            messageText: ctx.messageText,
-            plannerConfidence: plannerPlan.confidence,
-            complexityScore: ctx.plannerDecision.score,
-            totalSteps: plannerPlan.steps.length,
-            synthesisSteps,
-            edges: plannerPlan.edges,
-            subagentSteps: subagentSteps.map((step) => ({
-              name: step.name,
-              dependsOn: step.dependsOn,
-              acceptanceCriteria: step.acceptanceCriteria,
-              requiredToolCapabilities: step.requiredToolCapabilities,
-              contextRequirements: step.contextRequirements,
-              maxBudgetHint: step.maxBudgetHint,
-              canRunParallel: step.canRunParallel,
-            })),
-            config: tunedDecisionConfig,
-          });
-          ctx.plannerSummaryState.delegationDecision = delegationDecision;
-          if (!delegationDecision.shouldDelegate) {
-            ctx.plannerSummaryState.routeReason =
-              `delegation_veto_${delegationDecision.reason}`;
-            ctx.plannerSummaryState.diagnostics.push({
-              category: "policy",
-              code: "delegation_veto",
-              message:
-                `Delegation vetoed by policy scorer: ${delegationDecision.reason}`,
-              details: {
-                reason: delegationDecision.reason,
-                threshold: delegationDecision.threshold,
-                utilityScore: Number(
-                  delegationDecision.utilityScore.toFixed(4),
-                ),
-                safetyRisk: Number(delegationDecision.safetyRisk.toFixed(4)),
-              },
-            });
-          }
+          assessAndRecordDelegationDecision(
+            {
+              messageText: ctx.messageText,
+              plannerPlan,
+              subagentSteps,
+              complexityScore: ctx.plannerDecision.score,
+              tunedThreshold: ctx.tunedDelegationThreshold,
+              delegationConfig: this.delegationDecisionConfig,
+            },
+            ctx.plannerSummaryState,
+          );
         }
         const deterministicSteps = plannerPlan.steps.filter(
           (step): step is PlannerDeterministicToolStepIntent =>
             step.stepType === "deterministic_tool",
         );
-        const plannerPipelineSteps: PipelinePlannerStep[] = plannerPlan.steps.map(
-          (step) => {
-            if (step.stepType === "deterministic_tool") {
-              return {
-                name: step.name,
-                stepType: step.stepType,
-                dependsOn: step.dependsOn,
-                tool: step.tool,
-                args: step.args,
-                onError: step.onError,
-                maxRetries: step.maxRetries,
-              };
-            }
-            if (step.stepType === "subagent_task") {
-              return {
-                name: step.name,
-                stepType: step.stepType,
-                dependsOn: step.dependsOn,
-                objective: step.objective,
-                inputContract: step.inputContract,
-                acceptanceCriteria: step.acceptanceCriteria,
-                requiredToolCapabilities: step.requiredToolCapabilities,
-                contextRequirements: step.contextRequirements,
-                maxBudgetHint: step.maxBudgetHint,
-                canRunParallel: step.canRunParallel,
-              };
-            }
-            return {
-              name: step.name,
-              stepType: step.stepType,
-              dependsOn: step.dependsOn,
-              objective: step.objective,
-            };
-          },
+        const plannerPipelineSteps = mapPlannerStepsToPipelineSteps(
+          plannerPlan.steps,
         );
         const plannerExecutionContext = buildPlannerExecutionContext(
           ctx.messageText,

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -515,6 +515,47 @@ describe("GrokProvider", () => {
     });
   });
 
+  it("stops on response.completed even if trailing stream noise follows", async () => {
+    mockCreate.mockResolvedValueOnce(
+      (async function* () {
+        yield {
+          type: "response.completed",
+          response: makeCompletion({
+            output_text: "done",
+            output: [
+              {
+                type: "message",
+                content: [{ type: "output_text", text: "done" }],
+              },
+            ],
+          }),
+        };
+        // Provider-side trailing noise should be ignored after completion.
+        yield {
+          type: "response.output_text.delta",
+          delta: "ignored",
+        };
+        await new Promise(() => undefined);
+      })(),
+    );
+
+    const provider = new GrokProvider({ apiKey: "test-key", timeoutMs: 20 });
+    const onChunk = vi.fn();
+    const response = await provider.chatStream(
+      [{ role: "user", content: "test" }],
+      onChunk,
+    );
+
+    expect(response.finishReason).toBe("stop");
+    expect(response.error).toBeUndefined();
+    expect(response.content).toBe("done");
+    expect(onChunk).toHaveBeenCalledWith({
+      content: "",
+      done: true,
+      toolCalls: [],
+    });
+  });
+
   it("times out stalled streaming responses and returns partial output", async () => {
     mockCreate.mockResolvedValueOnce(
       (async function* () {
@@ -543,6 +584,25 @@ describe("GrokProvider", () => {
       done: true,
       toolCalls: [],
     });
+  });
+
+  it("enforces an absolute stream timeout even when chunks keep arriving", async () => {
+    mockCreate.mockResolvedValueOnce(
+      (async function* () {
+        while (true) {
+          yield {
+            type: "response.output_text.delta",
+            delta: "",
+          };
+          await new Promise((resolve) => setTimeout(resolve, 5));
+        }
+      })(),
+    );
+
+    const provider = new GrokProvider({ apiKey: "test-key", timeoutMs: 35 });
+    await expect(
+      provider.chatStream([{ role: "user", content: "test" }], () => undefined),
+    ).rejects.toThrow(LLMTimeoutError);
   });
 
   it("throws when stream fails before any content is received", async () => {

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -658,6 +658,8 @@ export class GrokProvider implements LLMProvider {
     let usage: LLMUsage = { promptTokens: 0, completionTokens: 0, totalTokens: 0 };
     const toolCallAccum = new Map<string, LLMToolCall>();
     let streamIterator: AsyncIterator<any> | null = null;
+    const streamTimeoutMs = normalizeTimeoutMs(this.config.timeoutMs);
+    const streamDeadlineAt = Date.now() + streamTimeoutMs;
 
     try {
       let stream: AsyncIterable<any>;
@@ -692,9 +694,13 @@ export class GrokProvider implements LLMProvider {
       streamIterator = stream[Symbol.asyncIterator]();
 
       while (true) {
+        const remainingStreamMs = streamDeadlineAt - Date.now();
+        if (remainingStreamMs <= 0) {
+          throw createStreamTimeoutError(this.name, streamTimeoutMs);
+        }
         const iterResult = await nextStreamChunkWithTimeout(
           streamIterator,
-          this.config.timeoutMs,
+          remainingStreamMs,
           this.name,
         );
         if (iterResult.done) break;
@@ -738,7 +744,7 @@ export class GrokProvider implements LLMProvider {
                 typeof response.id === "string" ? String(response.id) : undefined,
             };
           }
-          continue;
+          break;
         }
 
         if (event.type === "response.failed") {
@@ -750,7 +756,7 @@ export class GrokProvider implements LLMProvider {
           responseError =
             this.extractResponseError(failedResponse, "error") ??
             new LLMProviderError(this.name, "Provider returned status failed");
-          continue;
+          break;
         }
       }
 
@@ -772,13 +778,6 @@ export class GrokProvider implements LLMProvider {
       this.persistStatefulAnchor(plan, parsed);
       return parsed;
     } catch (err: unknown) {
-      if (streamIterator && typeof streamIterator.return === "function") {
-        try {
-          void streamIterator.return();
-        } catch {
-          // best-effort stream cleanup
-        }
-      }
       const mappedError = this.mapError(err);
       this.logPromptOverflowDiagnostics(mappedError, params);
       if (content.length > 0) {
@@ -798,6 +797,14 @@ export class GrokProvider implements LLMProvider {
         };
       }
       throw mappedError;
+    } finally {
+      if (streamIterator && typeof streamIterator.return === "function") {
+        try {
+          void streamIterator.return();
+        } catch {
+          // best-effort stream cleanup
+        }
+      }
     }
   }
 

--- a/runtime/src/workflow/pipeline.test.ts
+++ b/runtime/src/workflow/pipeline.test.ts
@@ -72,6 +72,26 @@ describe("PipelineExecutor", () => {
       expect(result.context.results["fetch"]).toBe('{"ok":true}');
     });
 
+    it("uses per-execution tool handler override when provided", async () => {
+      const baseHandler = createMockToolHandler({ "tool.a": "base-result" });
+      const overrideHandler = vi
+        .fn()
+        .mockResolvedValue("override-result");
+      const executor = createExecutor({ toolHandler: baseHandler });
+      const pipeline = createPipeline([
+        { name: "step-a", tool: "tool.a", args: {} },
+      ]);
+
+      const result = await executor.execute(pipeline, 0, {
+        toolHandler: overrideHandler,
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.context.results["step-a"]).toBe("override-result");
+      expect(overrideHandler).toHaveBeenCalledWith("tool.a", {});
+      expect(baseHandler).not.toHaveBeenCalled();
+    });
+
     it("returns failed on tool error with abort policy", async () => {
       const handler = createMockToolHandler(
         {},
@@ -307,6 +327,42 @@ describe("PipelineExecutor", () => {
       await expect(executor.resume("nonexistent")).rejects.toThrow(
         /No checkpoint found/,
       );
+    });
+
+    it("uses per-execution tool handler override during resume", async () => {
+      const backend = createMockMemoryBackend();
+      const baseHandler = createMockToolHandler({ "tool.b": "base-b" });
+      const overrideHandler = vi.fn().mockResolvedValue("override-b");
+      const executor = createExecutor({
+        toolHandler: baseHandler,
+        memoryBackend: backend,
+      });
+
+      await backend.set("pipeline:p2", {
+        pipelineId: "p2",
+        pipeline: {
+          id: "p2",
+          steps: [
+            { name: "a", tool: "tool.a", args: {} },
+            { name: "b", tool: "tool.b", args: {} },
+          ],
+          context: { results: {} },
+          createdAt: Date.now(),
+        },
+        stepIndex: 1,
+        context: { results: { a: "old-a" } },
+        status: "halted",
+        updatedAt: Date.now(),
+      });
+
+      const result = await executor.resume("p2", {
+        toolHandler: overrideHandler,
+      });
+
+      expect(result.status).toBe("completed");
+      expect(result.context.results["b"]).toBe("override-b");
+      expect(overrideHandler).toHaveBeenCalledWith("tool.b", {});
+      expect(baseHandler).not.toHaveBeenCalled();
     });
   });
 

--- a/runtime/src/workflow/pipeline.ts
+++ b/runtime/src/workflow/pipeline.ts
@@ -171,6 +171,14 @@ export interface PipelineExecutorConfig {
   readonly checkpointTtlMs?: number;
 }
 
+export interface PipelineExecutionOptions {
+  /**
+   * Optional per-execution tool handler override.
+   * Use this to run pipelines with session-scoped routing (for example desktop-aware handlers).
+   */
+  readonly toolHandler?: ToolHandler;
+}
+
 // ============================================================================
 // Helpers
 // ============================================================================
@@ -207,7 +215,11 @@ export class PipelineExecutor {
    * Execute a pipeline from a given step index.
    * Returns the result including status and resume info if halted.
    */
-  async execute(pipeline: Pipeline, startFrom = 0): Promise<PipelineResult> {
+  async execute(
+    pipeline: Pipeline,
+    startFrom = 0,
+    options?: PipelineExecutionOptions,
+  ): Promise<PipelineResult> {
     if (this.active.has(pipeline.id)) {
       return {
         status: "failed",
@@ -219,6 +231,7 @@ export class PipelineExecutor {
     }
 
     this.active.add(pipeline.id);
+    const executionToolHandler = options?.toolHandler ?? this.toolHandler;
     const mutableResults: Record<string, string> = { ...pipeline.context.results };
     let completedSteps = startFrom;
 
@@ -259,10 +272,15 @@ export class PipelineExecutor {
         }
 
         // Execute the tool and handle errors per step policy
-        const stepResult = await this.executeStep(step);
+        const stepResult = await this.executeStep(step, executionToolHandler);
 
         if (stepResult.error) {
-          const recovery = await this.handleStepError(pipeline.id, step, stepResult.error);
+          const recovery = await this.handleStepError(
+            pipeline.id,
+            step,
+            stepResult.error,
+            executionToolHandler,
+          );
           if (recovery.terminal) {
             this.active.delete(pipeline.id);
             return {
@@ -304,7 +322,10 @@ export class PipelineExecutor {
   }
 
   /** Resume a halted or interrupted pipeline from its checkpoint. */
-  async resume(pipelineId: string): Promise<PipelineResult> {
+  async resume(
+    pipelineId: string,
+    options?: PipelineExecutionOptions,
+  ): Promise<PipelineResult> {
     const checkpoint = await this.backend.get<PipelineCheckpoint>(
       checkpointKey(pipelineId),
     );
@@ -320,7 +341,7 @@ export class PipelineExecutor {
       context: checkpoint.context,
     };
 
-    return this.execute(pipeline, checkpoint.stepIndex);
+    return this.execute(pipeline, checkpoint.stepIndex, options);
   }
 
   /** List active pipeline IDs with their checkpoint status. */
@@ -353,6 +374,7 @@ export class PipelineExecutor {
     pipelineId: string,
     step: PipelineStep,
     error: string,
+    toolHandler: ToolHandler,
   ): Promise<{ terminal: true; error: string } | { terminal: false; result: string }> {
     const policy = step.onError ?? "abort";
 
@@ -364,7 +386,7 @@ export class PipelineExecutor {
     if (policy === "retry") {
       const maxRetries = step.maxRetries ?? 0;
       for (let attempt = 1; attempt <= maxRetries; attempt++) {
-        const retryResult = await this.executeStep(step);
+        const retryResult = await this.executeStep(step, toolHandler);
         if (!retryResult.error) {
           return { terminal: false, result: retryResult.result };
         }
@@ -381,9 +403,10 @@ export class PipelineExecutor {
 
   private async executeStep(
     step: PipelineStep,
+    toolHandler: ToolHandler,
   ): Promise<{ result: string; error?: string }> {
     try {
-      const result = await this.toolHandler(step.tool, step.args);
+      const result = await toolHandler(step.tool, step.args);
       return { result };
     } catch (err) {
       return { result: "", error: toErrorMessage(err) };

--- a/web/src/components/chat/ChatInput.test.tsx
+++ b/web/src/components/chat/ChatInput.test.tsx
@@ -42,6 +42,45 @@ describe('ChatInput', () => {
     expect(onSend).toHaveBeenCalledWith('line one', undefined);
   });
 
+  it('keeps textarea focused after sending on Enter', () => {
+    const onSend = vi.fn();
+    const { container } = render(<ChatInput onSend={onSend} />);
+
+    const input = container.querySelector(
+      'textarea[placeholder="Enter command..."]',
+    ) as HTMLTextAreaElement;
+    input.focus();
+    fireEvent.change(input, { target: { value: 'sticky focus' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter', shiftKey: false });
+
+    expect(onSend).toHaveBeenCalledWith('sticky focus', undefined);
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('keeps textarea focused after selecting a slash command with Enter', () => {
+    const onSend = vi.fn();
+    const { container } = render(<ChatInput onSend={onSend} />);
+
+    const input = container.querySelector(
+      'textarea[placeholder="Enter command..."]',
+    ) as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: '/res' } });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+
+    expect(input.value).toBe('/reset ');
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('focuses textarea on mount when nothing else is focused', () => {
+    const onSend = vi.fn();
+    const { container } = render(<ChatInput onSend={onSend} />);
+    const input = container.querySelector(
+      'textarea[placeholder="Enter command..."]',
+    ) as HTMLTextAreaElement;
+
+    expect(document.activeElement).toBe(input);
+  });
+
   it('attaches files and sends them with the message', async () => {
     const onSend = vi.fn();
     const { container } = render(<ChatInput onSend={onSend} />);

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -80,12 +80,38 @@ export function ChatInput({
     setActiveCommandIndex(0);
   }, [slashQuery]);
 
+  const focusComposer = useCallback(() => {
+    const focus = () => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      const cursor = el.value.length;
+      el.setSelectionRange(cursor, cursor);
+    };
+    focus();
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(focus);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (disabled) return;
+    const active = document.activeElement;
+    const activeIsTextInput =
+      active instanceof HTMLInputElement ||
+      active instanceof HTMLTextAreaElement ||
+      active instanceof HTMLSelectElement ||
+      (active instanceof HTMLElement && active.isContentEditable);
+    if (activeIsTextInput && active !== textareaRef.current) return;
+    focusComposer();
+  }, [disabled, focusComposer]);
+
   const applyCommand = useCallback((cmd: SlashCommandOption) => {
     const nextValue = `/${cmd.name} `;
     setValue(nextValue);
     setActiveCommandIndex(0);
-    textareaRef.current?.focus();
-  }, []);
+    focusComposer();
+  }, [focusComposer]);
 
   const handleSubmit = useCallback(() => {
     const trimmed = value.trim();
@@ -98,7 +124,8 @@ export function ChatInput({
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [value, disabled, onSend, attachments]);
+    focusComposer();
+  }, [attachments, disabled, focusComposer, onSend, value]);
 
   const handleFileSelect = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;

--- a/web/src/components/chat/ChatMessage.test.tsx
+++ b/web/src/components/chat/ChatMessage.test.tsx
@@ -75,4 +75,26 @@ describe('ChatMessage', () => {
     fireEvent.click(screen.getByRole('button', { name: /show tools/i }));
     expect(screen.getByText('desktop.bash')).toBeDefined();
   });
+
+  it('renders tool-result screenshots from non-desktop screenshot tools', () => {
+    const message: ChatMessageType = {
+      id: '4',
+      sender: 'agent',
+      content: 'Captured screenshot.',
+      timestamp: Date.now(),
+      toolCalls: [
+        {
+          toolName: 'mcp.browser.browser_take_screenshot',
+          status: 'completed',
+          args: { type: 'png' },
+          result: '### Result\n{"type":"image","data":"aGVsbG8=","mimeType":"image/png"}',
+        },
+      ],
+    };
+
+    render(<ChatMessage message={message} />);
+
+    const image = screen.getByAltText('Desktop screenshot') as HTMLImageElement;
+    expect(image.src).toContain('data:image/png;base64,aGVsbG8=');
+  });
 });

--- a/web/src/components/chat/ChatMessage.tsx
+++ b/web/src/components/chat/ChatMessage.tsx
@@ -4,6 +4,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { ChatMessage as ChatMessageType, SubagentTimelineItem, ToolCall } from '../../types';
 import { ToolCallCard } from './ToolCallCard';
+import { parseToolResultMedia } from './toolResultMedia';
 
 /** Allow data: URLs (for inline screenshots) in addition to the default safe protocols. */
 function urlTransform(url: string): string {
@@ -29,18 +30,11 @@ function extractScreenshotsFromToolCalls(toolCalls: ToolCall[] | undefined): str
   if (!toolCalls) return [];
   const urls: string[] = [];
   for (const tc of toolCalls) {
-    if (tc.toolName !== 'desktop.screenshot' || !tc.result) continue;
-    try {
-      let obj = JSON.parse(tc.result) as Record<string, unknown>;
-      if (typeof obj.content === 'string') {
-        try { obj = JSON.parse(obj.content) as Record<string, unknown>; } catch { /* */ }
-      }
-      if (typeof obj.dataUrl === 'string' && obj.dataUrl.startsWith('data:image/')) {
-        urls.push(obj.dataUrl);
-      } else if (typeof obj.image === 'string' && obj.image.length > 100) {
-        urls.push(`data:image/png;base64,${obj.image}`);
-      }
-    } catch { /* not JSON */ }
+    if (!tc.result) continue;
+    const parsed = parseToolResultMedia(tc.result);
+    for (const imageUrl of parsed.imageUrls) {
+      if (!urls.includes(imageUrl)) urls.push(imageUrl);
+    }
   }
   return urls;
 }

--- a/web/src/components/chat/ChatView.test.tsx
+++ b/web/src/components/chat/ChatView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { ChatView } from './ChatView';
 
@@ -123,5 +123,43 @@ describe('ChatView delegation summary', () => {
     );
 
     expect(screen.getAllByText(/4 agents: 2 running/).length).toBeGreaterThan(0);
+  });
+
+  it('opens the context panel above the bar on the left side', () => {
+    const { container } = render(
+      <ChatView
+        messages={[
+          {
+            id: 'agent-ctx',
+            sender: 'agent',
+            content: 'Context check',
+            timestamp: Date.now(),
+          },
+        ]}
+        isTyping={false}
+        onSend={vi.fn()}
+        connected
+        tokenUsage={{
+          totalTokens: 1200,
+          budget: 4000,
+          contextWindowTokens: 8000,
+          promptTokens: 1200,
+          compacted: false,
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /CONTEXT/i }));
+    const heading = screen.getByText('Model Context Window');
+    let panel: HTMLElement | null = heading as HTMLElement;
+    while (panel && !panel.className.includes('bottom-[40px]')) {
+      panel = panel.parentElement;
+    }
+
+    expect(panel).toBeTruthy();
+    expect(panel?.className).toContain('left-4');
+    expect(panel?.className).not.toContain('right-4');
+    expect(panel?.className).toContain('bottom-[40px]');
+    expect(container).toBeDefined();
   });
 });

--- a/web/src/components/chat/ChatView.tsx
+++ b/web/src/components/chat/ChatView.tsx
@@ -371,7 +371,7 @@ export function ChatView({
           </div>
 
           {contextPanelOpen && (
-            <div className="absolute bottom-[40px] right-4 z-20 w-[min(420px,calc(100vw-2rem))] border border-bbs-border bg-bbs-dark p-3">
+            <div className="absolute bottom-[40px] left-4 z-20 w-[min(420px,calc(100vw-2rem))] border border-bbs-border bg-bbs-dark p-3">
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="text-xs font-bold text-bbs-white">

--- a/web/src/components/chat/ToolCallCard.test.tsx
+++ b/web/src/components/chat/ToolCallCard.test.tsx
@@ -26,4 +26,24 @@ describe('ToolCallCard', () => {
     expect(screen.getByText(/"status":\s*"open"/)).toBeDefined();
     expect(screen.getByText(/"resultCount":\s*1/)).toBeDefined();
   });
+
+  it('renders embedded image results and redacts base64 payload text', () => {
+    const embedded = '### Result\n{"type":"image","data":"aGVsbG8=","mimeType":"image/png"}';
+
+    render(
+      <ToolCallCard
+        toolCall={{
+          toolName: 'mcp.browser.browser_take_screenshot',
+          args: { type: 'png' },
+          result: embedded,
+          status: 'completed',
+        }}
+      />,
+    );
+
+    const image = screen.getByAltText('Tool result image') as HTMLImageElement;
+    expect(image.src).toContain('data:image/png;base64,aGVsbG8=');
+    expect(screen.getByText(/\(base64 omitted\)/)).toBeDefined();
+    expect(screen.queryByText(/aGVsbG8=/)).toBeNull();
+  });
 });

--- a/web/src/components/chat/ToolCallCard.tsx
+++ b/web/src/components/chat/ToolCallCard.tsx
@@ -1,49 +1,9 @@
 import { useMemo, useState } from 'react';
 import type { ToolCall } from '../../types';
+import { parseToolResultMedia } from './toolResultMedia';
 
 interface ToolCallCardProps {
   toolCall: ToolCall;
-}
-
-function extractScreenshot(result: string | undefined): string | null {
-  if (!result) return null;
-  try {
-    let obj = JSON.parse(result) as Record<string, unknown>;
-    if (typeof obj.content === 'string') {
-      try {
-        obj = JSON.parse(obj.content) as Record<string, unknown>;
-      } catch { /* */ }
-    }
-    if (typeof obj.dataUrl === 'string' && obj.dataUrl.startsWith('data:image/')) {
-      return obj.dataUrl;
-    }
-    if (typeof obj.image === 'string' && obj.image.length > 100) {
-      return `data:image/png;base64,${obj.image}`;
-    }
-  } catch { /* */ }
-  return null;
-}
-
-function summarizeResult(result: string): string {
-  try {
-    let parsed = JSON.parse(result) as Record<string, unknown>;
-    if (typeof parsed.content === 'string') {
-      try {
-        parsed = JSON.parse(parsed.content) as Record<string, unknown>;
-      } catch { /* */ }
-    }
-    const summary: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      if ((key === 'image' || key === 'dataUrl') && typeof value === 'string' && value.length > 200) {
-        summary[key] = `<${Math.round(value.length / 1024)}KB base64>`;
-      } else {
-        summary[key] = value;
-      }
-    }
-    return JSON.stringify(summary, null, 2);
-  } catch {
-    return result;
-  }
 }
 
 function formatDuration(durationMs: number | undefined): string | null {
@@ -64,17 +24,17 @@ function statusLabel(toolCall: ToolCall): { text: string; color: string } {
 
 export function ToolCallCard({ toolCall }: ToolCallCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const isScreenshot = toolCall.toolName === 'desktop.screenshot';
   const badge = statusLabel(toolCall);
   const durationLabel = formatDuration(toolCall.durationMs);
   const argCount = Object.keys(toolCall.args).length;
 
-  const screenshotUrl = useMemo(
-    () => (isScreenshot ? extractScreenshot(toolCall.result) : null),
-    [isScreenshot, toolCall.result],
+  const media = useMemo(
+    () => parseToolResultMedia(toolCall.result),
+    [toolCall.result],
   );
+  const hasImages = media.imageUrls.length > 0;
 
-  const showContent = expanded || (isScreenshot && screenshotUrl !== null);
+  const showContent = expanded || hasImages;
 
   return (
     <div className="mt-1">
@@ -107,13 +67,14 @@ export function ToolCallCard({ toolCall }: ToolCallCardProps) {
             </div>
           )}
 
-          {screenshotUrl && (
+          {media.imageUrls.map((imageUrl, idx) => (
             <img
-              src={screenshotUrl}
-              alt="Desktop screenshot"
+              key={`tool-result-image-${idx}`}
+              src={imageUrl}
+              alt="Tool result image"
               className="max-w-full border border-bbs-border"
             />
-          )}
+          ))}
 
           {toolCall.result && (
             <div>
@@ -127,7 +88,7 @@ export function ToolCallCard({ toolCall }: ToolCallCardProps) {
                     : 'border-bbs-border bg-bbs-dark text-bbs-lightgray'
                 }`}
               >
-                {screenshotUrl ? summarizeResult(toolCall.result) : toolCall.result}
+                {media.redactedText || toolCall.result}
               </pre>
             </div>
           )}

--- a/web/src/components/chat/toolResultMedia.ts
+++ b/web/src/components/chat/toolResultMedia.ts
@@ -1,0 +1,131 @@
+export interface ParsedToolResultMedia {
+  imageUrls: string[];
+  redactedText: string;
+}
+
+function safeJsonParse(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function toDataUrl(mimeType: string | undefined, base64: string): string {
+  const mime = mimeType && mimeType.startsWith('image/') ? mimeType : 'image/png';
+  return `data:${mime};base64,${base64}`;
+}
+
+function addImageUrl(imageUrls: string[], candidate: string | undefined): void {
+  if (!candidate) return;
+  if (!candidate.startsWith('data:image/')) return;
+  if (!imageUrls.includes(candidate)) imageUrls.push(candidate);
+}
+
+function addBase64Image(
+  imageUrls: string[],
+  base64: string | undefined,
+  mimeType?: string,
+): void {
+  if (!base64 || base64.length < 8) return;
+  const dataUrl = toDataUrl(mimeType, base64);
+  if (!imageUrls.includes(dataUrl)) imageUrls.push(dataUrl);
+}
+
+function isBase64Like(value: string): boolean {
+  if (value.length < 128) return false;
+  return /^[A-Za-z0-9+/=\r\n]+$/.test(value);
+}
+
+function redactParsedBinary(value: unknown, keyHint?: string): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactParsedBinary(entry));
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = redactParsedBinary(entry, key.toLowerCase());
+    }
+    return out;
+  }
+  if (typeof value !== 'string') return value;
+
+  if (value.startsWith('data:image/')) {
+    return '(image data url omitted)';
+  }
+  if (
+    keyHint &&
+    /(image|dataurl|data|base64)/.test(keyHint) &&
+    isBase64Like(value)
+  ) {
+    return '(base64 omitted)';
+  }
+  if (value.length >= 2048 && isBase64Like(value)) {
+    return '(base64 omitted)';
+  }
+  return value;
+}
+
+function extractFromObject(value: unknown, imageUrls: string[]): void {
+  if (!value || typeof value !== 'object') return;
+  const obj = value as Record<string, unknown>;
+
+  const dataUrl = typeof obj.dataUrl === 'string' ? obj.dataUrl : undefined;
+  addImageUrl(imageUrls, dataUrl);
+
+  const imageMimeType =
+    typeof obj.imageMimeType === 'string'
+      ? obj.imageMimeType
+      : typeof obj.mimeType === 'string'
+        ? obj.mimeType
+        : undefined;
+  const image = typeof obj.image === 'string' ? obj.image : undefined;
+  addBase64Image(imageUrls, image, imageMimeType);
+
+  const type = typeof obj.type === 'string' ? obj.type : undefined;
+  const data = typeof obj.data === 'string' ? obj.data : undefined;
+  if (type === 'image') {
+    addBase64Image(imageUrls, data, imageMimeType);
+  }
+}
+
+export function parseToolResultMedia(result: string | undefined): ParsedToolResultMedia {
+  if (!result) return { imageUrls: [], redactedText: '' };
+
+  const imageUrls: string[] = [];
+  let redactedText = result;
+
+  const parsed = safeJsonParse(result);
+  if (parsed && typeof parsed === 'object') {
+    extractFromObject(parsed, imageUrls);
+    redactedText = JSON.stringify(redactParsedBinary(parsed), null, 2);
+    const parsedContent =
+      (parsed as Record<string, unknown>).content &&
+      typeof (parsed as Record<string, unknown>).content === 'string'
+        ? safeJsonParse((parsed as Record<string, unknown>).content as string)
+        : null;
+    if (parsedContent) extractFromObject(parsedContent, imageUrls);
+  }
+
+  // Matches: {"type":"image","data":"...","mimeType":"image/png"}
+  const imageJsonPattern =
+    /\{\s*"type"\s*:\s*"image"\s*,\s*"data"\s*:\s*"([A-Za-z0-9+/=\r\n]+)"\s*,\s*"mimeType"\s*:\s*"([^"]+)"\s*\}/g;
+  redactedText = redactedText.replace(
+    imageJsonPattern,
+    (_match: string, data: string, mimeType: string) => {
+      addBase64Image(imageUrls, data, mimeType);
+      return `{"type":"image","data":"(base64 omitted)","mimeType":"${mimeType}"}`;
+    },
+  );
+
+  const dataUrlPattern = /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\r\n]+/g;
+  redactedText = redactedText.replace(dataUrlPattern, (match: string) => {
+    addImageUrl(imageUrls, match);
+    return '(image data url omitted)';
+  });
+
+  // Large standalone base64 blobs still sneak in occasionally.
+  redactedText = redactedText.replace(/[A-Za-z0-9+/=\r\n]{2048,}/g, '(base64 omitted)');
+
+  return { imageUrls, redactedText: redactedText.trim() };
+}


### PR DESCRIPTION
## Summary

- Extract 14 pure-computation functions from 5 large ChatExecutor instance methods into existing sibling modules (`chat-executor-recovery.ts`, `chat-executor-types.ts`, `chat-executor-tool-utils.ts`, `chat-executor-planner.ts`)
- Reduce largest methods from 338-384 lines to 130-230 lines while keeping orchestration/control flow in the class
- Add typed input/result interfaces (`QualityProxyInput`, `DelegationTrajectoryInput`, `ToolCallPermissionResult`, `ToolExecutionConfig`, `RoundStuckState`, `BanditArmResolution`, `DelegationAssessmentInput`, etc.)
- Include gateway, workflow, web UI, and Grok adapter changes from prior sessions

## Test plan

- [x] `npx vitest run src/llm/chat-executor.test.ts` — 117 tests pass
- [x] `npx vitest run src/llm/chat-executor-tool-utils.test.ts` — 8 tests pass
- [x] `npm --prefix runtime run typecheck` — clean
- [x] `npm run test` — 5,320 tests pass across 261 files
- [x] `npm run build` — all packages build successfully