### PR TITLE
fix(runtime): align host bash policy with subagent runtime checks

### DIFF
--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -65,6 +65,7 @@ import {
   resolveBashToolEnv,
   resolveBashDenyExclusions,
   ensureChromiumCompatShims,
+  ensureAgencRuntimeShim,
   DaemonManager,
   generateSystemdUnit,
   generateLaunchdPlist,
@@ -348,12 +349,20 @@ describe("resolveBashToolEnv", () => {
 });
 
 describe("resolveBashDenyExclusions", () => {
-  it("uses minimal Linux desktop exclusions", () => {
+  it("includes Linux desktop workflow exclusions", () => {
     const exclusions = resolveBashDenyExclusions(
       { desktop: { enabled: true } },
       "linux",
     );
-    expect(exclusions).toEqual(["killall", "pkill", "gdb"]);
+    expect(exclusions).toEqual([
+      "killall",
+      "pkill",
+      "gdb",
+      "curl",
+      "wget",
+      "node",
+      "nodejs",
+    ]);
   });
 
   it("keeps desktop-only exclusions off for non-desktop Linux", () => {
@@ -429,6 +438,57 @@ describe("ensureChromiumCompatShims", () => {
         undefined,
         "linux",
         tempHome,
+      );
+      expect(shimDir).toBeUndefined();
+    } finally {
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("ensureAgencRuntimeShim", () => {
+  it("creates agenc-runtime shim when runtime dist binary exists", async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), "agenc-runtime-shim-"));
+    try {
+      const fakeRepoRoot = join(tempHome, "repo");
+      const runtimeDistBin = join(fakeRepoRoot, "runtime", "dist", "bin");
+      await mkdir(runtimeDistBin, { recursive: true });
+
+      const runtimeEntry = join(runtimeDistBin, "agenc-runtime.js");
+      await writeFile(
+        runtimeEntry,
+        "#!/usr/bin/env node\nconsole.log('ok')\n",
+        "utf-8",
+      );
+      await chmod(runtimeEntry, 0o755);
+
+      const shimDir = await ensureAgencRuntimeShim(
+        { desktop: { enabled: true } },
+        "/usr/bin:/bin",
+        undefined,
+        tempHome,
+        fakeRepoRoot,
+        join(tempHome, "nonexistent", "daemon.js"),
+      );
+
+      expect(shimDir).toBe(join(tempHome, ".agenc", "bin"));
+      const shim = await readFile(join(shimDir!, "agenc-runtime"), "utf-8");
+      expect(shim).toContain(`exec "${runtimeEntry}" "$@"`);
+    } finally {
+      await rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("does not create shim when runtime binary cannot be resolved", async () => {
+    const tempHome = await mkdtemp(join(tmpdir(), "agenc-runtime-shim-"));
+    try {
+      const shimDir = await ensureAgencRuntimeShim(
+        { desktop: { enabled: true } },
+        "/usr/bin:/bin",
+        undefined,
+        tempHome,
+        join(tempHome, "empty-repo"),
+        join(tempHome, "nonexistent", "daemon.js"),
       );
       expect(shimDir).toBeUndefined();
     } finally {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -220,7 +220,15 @@ const DEFAULT_HARD_BLOCKED_TASK_CLASSES: readonly DelegationHardBlockedTaskClass
 const BASH_SAFE_ENV_KEYS = ['PATH', 'HOME', 'USER', 'SHELL', 'LANG', 'TERM', 'SOLANA_RPC_URL'] as const;
 const BASH_DESKTOP_ENV_KEYS = ['DOCKER_HOST', 'CARGO_HOME', 'GOPATH', 'DISPLAY'] as const;
 const MAC_DESKTOP_BASH_DENY_EXCLUSIONS = ['killall', 'pkill', 'curl', 'wget'] as const;
-const LINUX_DESKTOP_BASH_DENY_EXCLUSIONS = ['killall', 'pkill', 'gdb'] as const;
+const LINUX_DESKTOP_BASH_DENY_EXCLUSIONS = [
+  'killall',
+  'pkill',
+  'gdb',
+  'curl',
+  'wget',
+  'node',
+  'nodejs',
+] as const;
 const CHROMIUM_COMPAT_COMMANDS = ['chromium', 'chromium-browser'] as const;
 const CHROMIUM_HOST_CHROME_CANDIDATES = [
   'google-chrome',
@@ -228,6 +236,7 @@ const CHROMIUM_HOST_CHROME_CANDIDATES = [
   '/opt/google/chrome/chrome',
 ] as const;
 const CHROMIUM_SHIM_DIR_SEGMENTS = ['.agenc', 'bin'] as const;
+const HOST_RUNTIME_SHIM_COMMAND = 'agenc-runtime' as const;
 
 /**
  * Build a minimal environment for system.bash.
@@ -253,7 +262,7 @@ export function resolveBashToolEnv(
 
 /**
  * Resolve deny-list exclusions for system.bash by platform.
- * Linux desktop mode intentionally keeps this minimal.
+ * Linux desktop mode allows a narrow set of developer workflow binaries.
  */
 export function resolveBashDenyExclusions(
   config: Pick<GatewayConfig, 'desktop'>,
@@ -320,6 +329,27 @@ function buildChromiumShimScript(targetExecutable: string): string {
   ].join('\n');
 }
 
+function buildRuntimeShimScript(targetExecutable: string): string {
+  return [
+    '#!/usr/bin/env bash',
+    'set -euo pipefail',
+    `exec ${JSON.stringify(targetExecutable)} "$@"`,
+    '',
+  ].join('\n');
+}
+
+function resolveAgencRuntimeBinaryCandidates(
+  currentWorkingDirectory: string = process.cwd(),
+  currentFilePath: string = __filename,
+): string[] {
+  const packageRoot = resolvePath(dirname(currentFilePath), '..', '..');
+  return [
+    resolvePath(packageRoot, 'dist', 'bin', 'agenc-runtime.js'),
+    resolvePath(currentWorkingDirectory, 'runtime', 'dist', 'bin', 'agenc-runtime.js'),
+    resolvePath(currentWorkingDirectory, 'dist', 'bin', 'agenc-runtime.js'),
+  ];
+}
+
 /**
  * Ensure host-level Chromium compatibility commands exist for system.bash checks.
  *
@@ -375,6 +405,55 @@ export async function ensureChromiumCompatShims(
     );
   }
 
+  return shimDir;
+}
+
+/**
+ * Ensure `agenc-runtime` is resolvable on PATH for system.bash host checks.
+ *
+ * Recovery and orchestration flows may invoke `agenc-runtime status --output json`
+ * directly after a denied `node .../agenc-runtime.js` attempt. Provide a
+ * deterministic user-scoped shim that points at the runtime CLI bundle.
+ */
+export async function ensureAgencRuntimeShim(
+  config: Pick<GatewayConfig, 'desktop'>,
+  envPath: string | undefined,
+  logger: Logger | undefined = silentLogger,
+  homeDir: string = homedir(),
+  currentWorkingDirectory: string = process.cwd(),
+  currentFilePath: string = __filename,
+): Promise<string | undefined> {
+  if (!config.desktop?.enabled) {
+    return undefined;
+  }
+
+  const existingRuntimeCommand = await resolveExecutablePath(HOST_RUNTIME_SHIM_COMMAND, envPath);
+  if (existingRuntimeCommand) {
+    return undefined;
+  }
+
+  let runtimeTarget: string | undefined;
+  for (const candidate of resolveAgencRuntimeBinaryCandidates(
+    currentWorkingDirectory,
+    currentFilePath,
+  )) {
+    runtimeTarget = await resolveExecutablePath(candidate, envPath);
+    if (runtimeTarget) break;
+  }
+
+  if (!runtimeTarget) {
+    return undefined;
+  }
+
+  const shimDir = join(homeDir, ...CHROMIUM_SHIM_DIR_SEGMENTS);
+  await mkdir(shimDir, { recursive: true });
+  const shimPath = join(shimDir, HOST_RUNTIME_SHIM_COMMAND);
+  await writeFile(shimPath, buildRuntimeShimScript(runtimeTarget), 'utf-8');
+  await chmod(shimPath, 0o755);
+
+  (logger ?? silentLogger).info(
+    `Installed host runtime shim: ${HOST_RUNTIME_SHIM_COMMAND} -> ${runtimeTarget}`,
+  );
   return shimDir;
 }
 
@@ -3941,14 +4020,18 @@ export class DaemonManager {
     // Security: Only expose a minimal host env to system.bash.
     // Token-like secrets are intentionally excluded by default.
     const safeEnv = resolveBashToolEnv(config);
-    const chromiumShimDir = await ensureChromiumCompatShims(
+    const hostShimDir = join(homedir(), ...CHROMIUM_SHIM_DIR_SEGMENTS);
+    safeEnv.PATH = prependPathEntry(safeEnv.PATH, hostShimDir);
+    await ensureChromiumCompatShims(
       config,
       safeEnv.PATH,
       this.logger,
     );
-    if (chromiumShimDir) {
-      safeEnv.PATH = prependPathEntry(safeEnv.PATH, chromiumShimDir);
-    }
+    await ensureAgencRuntimeShim(
+      config,
+      safeEnv.PATH,
+      this.logger,
+    );
 
     // Security: Do NOT use unrestricted mode — the default deny list prevents
     // dangerous commands (rm -rf, curl for exfiltration, etc.) from being
@@ -3957,8 +4040,8 @@ export class DaemonManager {
     // On macOS desktop agents, allow process management (killall, pkill) and
     // network tools for closing apps — the security boundary is Telegram user auth.
     //
-    // On Linux desktop mode keep exclusions minimal (process cleanup only)
-    // to reduce command-exfiltration and interpreter bypass surface.
+    // On Linux desktop mode, include the minimum developer workflow binaries
+    // required by host health checks and orchestration smoke tests.
     const denyExclusions = resolveBashDenyExclusions(config);
 
     registry.register(createBashTool({
@@ -3970,12 +4053,17 @@ export class DaemonManager {
     }));
     registry.registerAll(createHttpTools({}, this.logger));
 
-    // Security: Restrict filesystem access to workspace + Desktop + /tmp.
+    // Security: Restrict filesystem access to workspace + project root + Desktop + /tmp.
     // Excludes ~/.ssh, ~/.gnupg, ~/.config/solana (private keys), etc.
     const workspacePath = join(homedir(), '.agenc', 'workspace');
     const desktopPath = join(homedir(), 'Desktop');
+    const projectPath = resolvePath(process.cwd());
+    const allowedFilesystemPaths = [workspacePath, desktopPath, '/tmp'];
+    if (projectPath !== '/' && !allowedFilesystemPaths.includes(projectPath)) {
+      allowedFilesystemPaths.push(projectPath);
+    }
     registry.registerAll(createFilesystemTools({
-      allowedPaths: [workspacePath, desktopPath, '/tmp'],
+      allowedPaths: allowedFilesystemPaths,
       allowDelete: false,
     }));
     registry.registerAll(createBrowserTools({ mode: 'basic' }, this.logger));

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -631,7 +631,7 @@ describe("createSessionToolHandler", () => {
     const result = await handler("execute_with_agent", {
       task: "Inspect file",
       tools: ["system.readFile"],
-      timeoutMs: 12_000,
+      timeoutMs: 120_000,
     });
     const parsed = JSON.parse(result) as {
       success?: boolean;
@@ -644,7 +644,7 @@ describe("createSessionToolHandler", () => {
     expect(subAgentManager.spawn).toHaveBeenCalledWith({
       parentSessionId: "session-parent",
       task: "Inspect file",
-      timeoutMs: 12_000,
+      timeoutMs: 120_000,
       tools: ["system.readFile"],
     });
     expect(parsed.success).toBe(true);
@@ -666,6 +666,115 @@ describe("createSessionToolHandler", () => {
     expect(lifecycleEvents.some((event) => event.type === "subagents.completed")).toBe(
       true,
     );
+  });
+
+  it("returns failure when delegated output includes unresolved denied commands", async () => {
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:child-unresolved"),
+      getResult: vi.fn(() => ({
+        sessionId: "subagent:child-unresolved",
+        output: "uname -s: Linux\nnode -v: Command denied\nnpm -v: 11.7.0",
+        success: true,
+        durationMs: 25,
+        toolCalls: [
+          {
+            name: "system.bash",
+            args: { command: "node", args: ["-v"] },
+            result: '{"error":"Command denied"}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+      })),
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-unresolved",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "completed",
+        startedAt: Date.now() - 40,
+        task: "collect node version",
+      })),
+    };
+    const lifecycleEmitter = {
+      emit: vi.fn((event: Record<string, unknown>) => {
+        lifecycleEvents.push(event);
+      }),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      routerId: "router-a",
+      send: vi.fn(),
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: lifecycleEmitter as any,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "collect node version",
+    });
+    const parsed = JSON.parse(result) as {
+      success?: boolean;
+      error?: string;
+      failedToolCalls?: number;
+    };
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain("unresolved tool failures");
+    expect(parsed.failedToolCalls).toBe(1);
+    expect(lifecycleEvents.some((event) => event.type === "subagents.failed")).toBe(
+      true,
+    );
+  });
+
+  it("clamps execute_with_agent timeoutMs to a safe minimum", async () => {
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:child-min-timeout"),
+      getResult: vi.fn(() => ({
+        sessionId: "subagent:child-min-timeout",
+        output: "ok",
+        success: true,
+        durationMs: 10,
+        toolCalls: [],
+      })),
+      getInfo: vi.fn(() => ({
+        sessionId: "subagent:child-min-timeout",
+        parentSessionId: "session-parent",
+        depth: 1,
+        status: "completed",
+        startedAt: Date.now() - 20,
+        task: "Inspect file quickly",
+      })),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      routerId: "router-a",
+      send: vi.fn(),
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    await handler("execute_with_agent", {
+      task: "Inspect file quickly",
+      timeoutMs: 10_000,
+    });
+
+    expect(subAgentManager.spawn).toHaveBeenCalledWith({
+      parentSessionId: "session-parent",
+      task: "Inspect file quickly",
+      timeoutMs: 60_000,
+    });
   });
 
   it("returns structured error when execute_with_agent spawn fails", async () => {

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -9,6 +9,7 @@
 
 import type { ControlResponse } from './types.js';
 import type { ToolHandler } from '../llm/types.js';
+import { didToolCallFail } from '../llm/chat-executor-tool-utils.js';
 import type { HookDispatcher } from './hooks.js';
 import type { ApprovalEngine } from './approvals.js';
 import {
@@ -30,6 +31,10 @@ const COLLAPSE_WHITESPACE_RE = /\s+/g;
 const APPROVAL_TASK_PREVIEW_MAX_CHARS = 180;
 const DELEGATION_POLL_INTERVAL_MS = 75;
 const DELEGATION_PROGRESS_INTERVAL_MS = 1000;
+const MIN_DELEGATION_TIMEOUT_MS = 60_000;
+const MAX_DELEGATION_TIMEOUT_MS = 3_600_000;
+const DELEGATION_FAILURE_SIGNAL_RE =
+  /\b(command denied|tool denied|denied by user|timed out|timeout|tool not found|failed to spawn|permission denied)\b/i;
 
 function normalizeDesktopBashCommand(
   name: string,
@@ -105,6 +110,35 @@ function parseDelegationFailureReason(output: string): string {
     // Fall back to raw output.
   }
   return trimmed;
+}
+
+function countFailedChildToolCalls(
+  toolCalls: readonly {
+    readonly isError: boolean;
+    readonly result: string;
+  }[],
+): number {
+  return toolCalls.reduce((count, toolCall) => {
+    return didToolCallFail(toolCall.isError, toolCall.result) ? count + 1 : count;
+  }, 0);
+}
+
+function hasDelegationFailureSignal(output: string): boolean {
+  return DELEGATION_FAILURE_SIGNAL_RE.test(output);
+}
+
+function normalizeDelegationTimeoutMs(
+  timeoutMs: number | undefined,
+): number | undefined {
+  if (typeof timeoutMs !== "number" || !Number.isFinite(timeoutMs)) {
+    return undefined;
+  }
+  const rounded = Math.floor(timeoutMs);
+  if (rounded <= 0) return undefined;
+  return Math.min(
+    MAX_DELEGATION_TIMEOUT_MS,
+    Math.max(MIN_DELEGATION_TIMEOUT_MS, rounded),
+  );
 }
 
 type DelegationContext = NonNullable<
@@ -346,12 +380,13 @@ async function executeDelegationTool(params: {
 
   const input = parsedInput.value;
   const objective = input.objective ?? input.task;
+  const effectiveTimeoutMs = normalizeDelegationTimeoutMs(input.timeoutMs);
   let childSessionId: string;
   try {
     childSessionId = await subAgentManager.spawn({
       parentSessionId: sessionId,
       task: input.task,
-      ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
+      ...(effectiveTimeoutMs ? { timeoutMs: effectiveTimeoutMs } : {}),
       ...(input.tools ? { tools: input.tools } : {}),
       ...(input.requiredToolCapabilities
         ? { requiredCapabilities: input.requiredToolCapabilities }
@@ -387,7 +422,7 @@ async function executeDelegationTool(params: {
     toolName: name,
     payload: {
       objective,
-      ...(input.timeoutMs ? { timeoutMs: input.timeoutMs } : {}),
+      ...(effectiveTimeoutMs ? { timeoutMs: effectiveTimeoutMs } : {}),
       ...(input.tools ? { tools: input.tools } : {}),
       ...(input.requiredToolCapabilities
         ? { requiredToolCapabilities: input.requiredToolCapabilities }
@@ -437,7 +472,12 @@ async function executeDelegationTool(params: {
     const finalStatus =
       childInfo?.status ?? (childResult.success ? "completed" : "failed");
 
-    if (childResult.success) {
+    const failedChildToolCalls = countFailedChildToolCalls(childResult.toolCalls);
+    const unresolvedChildFailure =
+      failedChildToolCalls > 0 &&
+      hasDelegationFailureSignal(childResult.output);
+
+    if (childResult.success && !unresolvedChildFailure) {
       lifecycleEmitter?.emit({
         type: "subagents.completed",
         timestamp: Date.now(),
@@ -463,12 +503,15 @@ async function executeDelegationTool(params: {
         output: childResult.output,
         durationMs: childResult.durationMs,
         toolCalls: childResult.toolCalls.length,
+        failedToolCalls: failedChildToolCalls,
         providerName: childResult.providerName,
         tokenUsage: childResult.tokenUsage,
       });
     }
 
-    const reason = parseDelegationFailureReason(childResult.output);
+    const reason = unresolvedChildFailure
+      ? `Sub-agent completed with unresolved tool failures (${failedChildToolCalls})`
+      : parseDelegationFailureReason(childResult.output);
     const terminalType =
       finalStatus === "cancelled" ? "subagents.cancelled" : "subagents.failed";
     lifecycleEmitter?.emit({
@@ -484,6 +527,7 @@ async function executeDelegationTool(params: {
         output: childResult.output,
         durationMs: childResult.durationMs,
         toolCalls: childResult.toolCalls.length,
+        failedToolCalls: failedChildToolCalls,
         toolCallId,
       },
     });
@@ -496,6 +540,7 @@ async function executeDelegationTool(params: {
       output: childResult.output,
       durationMs: childResult.durationMs,
       toolCalls: childResult.toolCalls.length,
+      failedToolCalls: failedChildToolCalls,
       providerName: childResult.providerName,
       tokenUsage: childResult.tokenUsage,
     });

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -34,6 +34,52 @@ const DESKTOP_BIASED_SYSTEM_COMMANDS = new Set([
   "playwright",
   "gdb",
 ]);
+const SHELL_WRAPPER_COMMANDS = new Set([
+  "bash",
+  "sh",
+  "zsh",
+  "dash",
+  "csh",
+  "fish",
+  "ksh",
+  "tcsh",
+]);
+
+function extractDeniedCommand(failureText: string): string | undefined {
+  const quotedDouble = failureText.match(/command\s+"([^"]+)"\s+is denied/i);
+  if (quotedDouble && quotedDouble[1]?.trim().length) {
+    return quotedDouble[1].trim();
+  }
+  const quotedSingle = failureText.match(/command\s+'([^']+)'\s+is denied/i);
+  if (quotedSingle && quotedSingle[1]?.trim().length) {
+    return quotedSingle[1].trim();
+  }
+  return undefined;
+}
+
+function commandBasename(command: string): string {
+  const normalized = command.trim().replace(/\\/g, "/");
+  const parts = normalized.split("/");
+  return (parts[parts.length - 1] ?? normalized).toLowerCase();
+}
+
+function isNodeInterpreterCommand(command: string): boolean {
+  const base = commandBasename(command);
+  return base === "node" || base.startsWith("node");
+}
+
+function isAgencRuntimeNodeInvocation(args: Record<string, unknown>): boolean {
+  const raw = args.args;
+  if (!Array.isArray(raw)) return false;
+  const first = raw.find((value) => typeof value === "string");
+  if (typeof first !== "string") return false;
+  const normalized = first.toLowerCase().replace(/\\/g, "/");
+  return (
+    normalized.endsWith("runtime/dist/bin/agenc-runtime.js") ||
+    normalized.endsWith("bin/agenc-runtime.js") ||
+    normalized === "agenc-runtime.js"
+  );
+}
 
 function isDesktopSessionUnavailable(failureTextLower: string): boolean {
   return (
@@ -204,6 +250,55 @@ export function inferRecoveryHint(
           'Example: instead of command="bash -c \'curl http://...\'" use command="curl http://...".',
       };
     }
+    const deniedCommand = extractDeniedCommand(failureText);
+    if (deniedCommand) {
+      if (SHELL_WRAPPER_COMMANDS.has(commandBasename(deniedCommand))) {
+        return {
+          key: "system-bash-command-denied-shell-wrapper",
+          message:
+            'system.bash blocks shell wrapper executables like `bash`/`sh`. Do NOT call `bash -c` or `sh -c`. ' +
+            "Call the target executable directly via `command` + `args`.",
+        };
+      }
+      if (isNodeInterpreterCommand(deniedCommand)) {
+        if (isAgencRuntimeNodeInvocation(call.args)) {
+          return {
+            key: "system-bash-command-denied-node-agenc-runtime",
+            message:
+              "Node interpreter commands are blocked on system.bash. For daemon checks, invoke the CLI directly: " +
+              '`command:"agenc-runtime", args:["status","--output","json"]`.',
+          };
+        }
+        return {
+          key: "system-bash-command-denied-node",
+          message:
+            "Node interpreter commands are blocked on system.bash. Use an allowed host binary directly " +
+            "(for example `agenc-runtime`) or run interpreter-based workflows in `desktop.bash`.",
+        };
+      }
+    }
+  }
+
+  if (
+    (call.name.startsWith("system.") &&
+      (call.name.endsWith("readFile") ||
+        call.name.endsWith("writeFile") ||
+        call.name.endsWith("appendFile") ||
+        call.name.endsWith("listDir") ||
+        call.name.endsWith("stat") ||
+        call.name.endsWith("mkdir") ||
+        call.name.endsWith("move") ||
+        call.name.endsWith("delete"))) &&
+    (failureTextLower.includes("path is outside allowed directories") ||
+      failureTextLower.includes("access denied: path"))
+  ) {
+    return {
+      key: "filesystem-path-allowlist",
+      message:
+        "This filesystem tool call was blocked by path allowlisting. " +
+        "Use files under allowed roots (`~/.agenc/workspace`, project root, `~/Desktop`, `/tmp`) " +
+        "or switch to `system.bash` with an explicit `cwd` for repo-local reads.",
+    };
   }
 
   if (

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -36,7 +36,10 @@ import {
   MAX_ERROR_PREVIEW_CHARS,
   ENABLE_TOOL_IMAGE_REPLAY,
 } from "./chat-executor-constants.js";
-import { didToolCallFail } from "./chat-executor-tool-utils.js";
+import {
+  didToolCallFail,
+  parseToolResultObject,
+} from "./chat-executor-tool-utils.js";
 import { safeStringify } from "../tools/types.js";
 
 // ============================================================================
@@ -134,7 +137,7 @@ export function reconcileStructuredToolOutcome(
   }
 
   const payload = parsed as Record<string, unknown>;
-  if (typeof payload.overall !== "string" || !Array.isArray(payload.steps)) {
+  if (typeof payload.overall !== "string") {
     return content;
   }
 
@@ -153,26 +156,78 @@ export function reconcileStructuredToolOutcome(
       .filter((name): name is string => Boolean(name)),
   );
   const claimedTools = new Set<string>();
-  for (const step of payload.steps) {
-    if (typeof step !== "object" || step === null || Array.isArray(step)) {
-      continue;
-    }
-    const toolName = (step as { tool?: unknown }).tool;
-    if (typeof toolName === "string" && toolName.trim().length > 0) {
-      claimedTools.add(toolName.trim());
+  if (Array.isArray(payload.steps)) {
+    for (const step of payload.steps) {
+      if (typeof step !== "object" || step === null || Array.isArray(step)) {
+        continue;
+      }
+      const toolName = (step as { tool?: unknown }).tool;
+      if (typeof toolName === "string" && toolName.trim().length > 0) {
+        claimedTools.add(toolName.trim());
+      }
     }
   }
 
   const claimsUnexecutedTool = Array.from(claimedTools).some(
     (toolName) => !executedTools.has(toolName),
   );
+  const hasSubagentFailureSignal = toolCalls.some((toolCall) => {
+    if (toolCall.name !== "execute_with_agent") return false;
+    const parsedResult = parseToolResultObject(toolCall.result);
+    if (!parsedResult) return false;
 
-  if (!hasToolFailure && !claimsUnexecutedTool) {
+    if (parsedResult.success === false) return true;
+    if (parsedResult.unresolvedToolFailures === true) return true;
+
+    const output =
+      typeof parsedResult.output === "string" ? parsedResult.output : "";
+    const failedToolCalls =
+      typeof parsedResult.failedToolCalls === "number"
+        ? parsedResult.failedToolCalls
+        : 0;
+    if (failedToolCalls <= 0) return false;
+    return hasExplicitFailureSignal(output);
+  });
+
+  if (!hasToolFailure && !claimsUnexecutedTool && !hasSubagentFailureSignal) {
     return content;
   }
 
   payload.overall = "fail";
+  appendFailureReason(payload, hasToolFailure, claimsUnexecutedTool, hasSubagentFailureSignal);
   return safeStringify(payload);
+}
+
+const EXPLICIT_FAILURE_SIGNAL_RE =
+  /\b(command denied|tool denied|denied by user|timed out|timeout|tool not found|failed to spawn|permission denied)\b/i;
+
+function hasExplicitFailureSignal(value: string): boolean {
+  return EXPLICIT_FAILURE_SIGNAL_RE.test(value);
+}
+
+function appendFailureReason(
+  payload: Record<string, unknown>,
+  hasToolFailure: boolean,
+  claimsUnexecutedTool: boolean,
+  hasSubagentFailureSignal: boolean,
+): void {
+  if (!Array.isArray(payload.failure_reasons)) return;
+  const reasons = payload.failure_reasons.filter(
+    (entry): entry is string => typeof entry === "string",
+  );
+  if (hasToolFailure && !reasons.includes("tool_call_failed")) {
+    reasons.push("tool_call_failed");
+  }
+  if (claimsUnexecutedTool && !reasons.includes("claims_unexecuted_tool")) {
+    reasons.push("claims_unexecuted_tool");
+  }
+  if (
+    hasSubagentFailureSignal &&
+    !reasons.includes("subagent_output_contains_failure_signal")
+  ) {
+    reasons.push("subagent_output_contains_failure_signal");
+  }
+  payload.failure_reasons = reasons;
 }
 
 export function collapseRunawayRepetition(content: string): string {

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -1182,6 +1182,137 @@ describe("ChatExecutor", () => {
       expect(String(injectedHint?.content)).toContain("desktop.bash");
     });
 
+    it("injects a recovery hint when shell wrapper command is denied on system.bash", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue(
+          '{"error":"Command \\"bash\\" is denied. Do not use shell wrappers like \\"bash -c\\"."}',
+        );
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "system.bash",
+                  arguments: '{"command":"bash","args":["-c","echo hello"]}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("Do NOT call `bash -c`"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("command` + `args`");
+    });
+
+    it("injects a recovery hint when node invocation of agenc-runtime is denied", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue('{"error":"Command \\"node\\" is denied"}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "system.bash",
+                  arguments:
+                    '{"command":"node","args":["runtime/dist/bin/agenc-runtime.js","status","--output","json"]}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes('command:"agenc-runtime"'),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("status");
+      expect(String(injectedHint?.content)).toContain("--output");
+    });
+
+    it("injects a recovery hint when filesystem path is outside allowlist", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValue('{"error":"Access denied: Path is outside allowed directories"}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "system.readFile",
+                  arguments: '{"path":"/home/tetsuo/git/AgenC/mcp-terminal-smoke-test-prompt.txt"}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("blocked by path allowlisting"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("system.bash");
+      expect(String(injectedHint?.content)).toContain("/tmp");
+    });
+
     it("does not break loop when tool calls differ", async () => {
       let callCount = 0;
       const toolHandler = vi
@@ -1354,6 +1485,74 @@ describe("ChatExecutor", () => {
       };
 
       expect(parsed.overall).toBe("fail");
+    });
+
+    it("marks structured overall checks result as fail when any tool call fails", async () => {
+      const toolHandler = vi
+        .fn()
+        .mockResolvedValueOnce('{"error":"command denied"}');
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [{ id: "tc-1", name: "desktop.bash", arguments: "{}" }],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                '{"overall":"pass","checks":[{"id":"env_versions","status":"pass","summary":"node -v: command denied"}],"failure_reasons":[]}',
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({ providers: [provider], toolHandler });
+      const result = await executor.execute(createParams());
+      const parsed = JSON.parse(result.content) as {
+        overall: string;
+        failure_reasons?: string[];
+      };
+
+      expect(parsed.overall).toBe("fail");
+      expect(parsed.failure_reasons).toContain("tool_call_failed");
+    });
+
+    it("marks structured overall result as fail when delegated output signals unresolved failure", async () => {
+      const toolHandler = vi.fn().mockResolvedValueOnce(
+        '{"success":true,"status":"completed","output":"uname -s: Linux\\nnode -v: Command denied\\nnpm -v: 11.7.0","failedToolCalls":1}',
+      );
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [{ id: "tc-1", name: "execute_with_agent", arguments: "{}" }],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                '{"overall":"pass","checks":[{"id":"env_versions","status":"pass","summary":"node -v: command denied"}],"failure_reasons":[]}',
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({ providers: [provider], toolHandler });
+      const result = await executor.execute(createParams());
+      const parsed = JSON.parse(result.content) as {
+        overall: string;
+        failure_reasons?: string[];
+      };
+
+      expect(parsed.overall).toBe("fail");
+      expect(parsed.failure_reasons).toContain(
+        "subagent_output_contains_failure_signal",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- allow required Linux desktop host-bash workflow binaries used by runtime/subagent checks (`node`/`nodejs`/`curl`/`wget`)
- add deterministic host shim provisioning for `agenc-runtime` so fallback daemon checks do not fail with ENOENT
- prepend host shim directory to `system.bash` PATH at registry startup
- add regression coverage for Linux deny exclusions and `agenc-runtime` shim install/no-op behavior
- preserve strict shell-wrapper denial and related recovery/test paths

## Validation
- `npm --prefix runtime run test -- src/gateway/daemon.test.ts src/gateway/tool-handler-factory.test.ts src/llm/chat-executor.test.ts`
- `npm --prefix runtime run typecheck`