### PR TITLE
fix(sdk): clean up code quality issues from IDE inspections

### DIFF
--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -47,12 +47,12 @@ export interface PrivacyClientConfig {
 }
 
 export class PrivacyClient {
-  private connection: Connection;
+  private readonly connection: Connection;
   private program: Program | null = null;
   private config: PrivacyClientConfig;
   private wallet: Keypair | null = null;
-  private agentId: Uint8Array | number[] | null = null;
-  private proverConfig: ProverConfig | null = null;
+  private readonly agentId: Uint8Array | number[] | null = null;
+  private readonly proverConfig: ProverConfig | null = null;
   private logger: Logger;
 
   constructor(config: PrivacyClientConfig = {}) {
@@ -62,16 +62,16 @@ export class PrivacyClient {
 
     // Validate RPC URL format if provided
     if (config.rpcUrl !== undefined) {
+      let url: URL;
       try {
-        const url = new URL(config.rpcUrl);
-        if (url.protocol !== "http:" && url.protocol !== "https:") {
-          throw new Error("RPC URL must use http or https protocol");
-        }
-      } catch (e) {
-        if ((e as Error).message.includes("http or https")) {
-          throw new Error(`Invalid RPC URL: ${(e as Error).message}`);
-        }
+        url = new URL(config.rpcUrl);
+      } catch {
         throw new Error(`Invalid RPC URL: ${config.rpcUrl}`);
+      }
+      if (url.protocol !== "http:" && url.protocol !== "https:") {
+        throw new Error(
+          `Invalid RPC URL: RPC URL must use http or https protocol`,
+        );
       }
     }
 
@@ -224,7 +224,7 @@ export class PrivacyClient {
     this.logger.debug(`Proof generated in ${proofResult.generationTime}ms`);
 
     // Submit private completion on-chain
-    const result = await submitCompleteTaskPrivate(
+    return await submitCompleteTaskPrivate(
       this.connection,
       this.program,
       this.wallet,
@@ -238,8 +238,6 @@ export class PrivacyClient {
         nullifierSeed: proofResult.nullifierSeed,
       },
     );
-
-    return result;
   }
 
   /**

--- a/sdk/src/proofs.ts
+++ b/sdk/src/proofs.ts
@@ -14,12 +14,8 @@ import type { ProverConfig } from "./prover.js";
 import {
   HASH_SIZE,
   OUTPUT_FIELD_COUNT,
-  RISC0_IMAGE_ID_LEN,
   RISC0_JOURNAL_LEN,
-  RISC0_SEAL_BORSH_LEN,
   RISC0_SELECTOR_LEN,
-  TRUSTED_RISC0_IMAGE_ID,
-  TRUSTED_RISC0_SELECTOR,
 } from "./constants";
 
 /** BN254 scalar field modulus */

--- a/sdk/src/queries.ts
+++ b/sdk/src/queries.ts
@@ -10,7 +10,7 @@ import {
   GetProgramAccountsFilter,
 } from "@solana/web3.js";
 import type { Program } from "@coral-xyz/anchor";
-import { PROGRAM_ID, DISCRIMINATOR_SIZE } from "./constants";
+import { PROGRAM_ID } from "./constants";
 import { getAccount } from "./anchor-utils";
 import { getSdkLogger } from "./logger";
 

--- a/sdk/src/state.ts
+++ b/sdk/src/state.ts
@@ -1,6 +1,6 @@
 import { Connection, Keypair, PublicKey, SystemProgram } from "@solana/web3.js";
 import anchor, { type Program } from "@coral-xyz/anchor";
-import { PROGRAM_ID, SEEDS } from "./constants";
+import { PROGRAM_ID } from "./constants";
 import { getAccount } from "./anchor-utils";
 import { deriveProtocolPda } from "./protocol";
 import { toBigInt, toNumber } from "./utils/numeric";

--- a/sdk/src/tasks.ts
+++ b/sdk/src/tasks.ts
@@ -1028,6 +1028,52 @@ export async function cancelTask(
 }
 
 // ============================================================================
+// Internal helpers
+// ============================================================================
+
+interface TaskAccountData {
+  taskId?: number[] | Uint8Array;
+  status?: { [key: string]: Record<string, never> } | number;
+  creator?: PublicKey;
+  rewardAmount?: { toString: () => string };
+  deadline?: { toNumber: () => number };
+  constraintHash?: number[] | Uint8Array | null;
+  currentWorkers?: number;
+  maxWorkers?: number;
+  completedAt?: { toNumber: () => number } | null;
+  rewardMint?: PublicKey | null;
+}
+
+function parseTaskAccountData(data: TaskAccountData): TaskStatus | null {
+  if (data.creator === undefined || data.status === undefined) {
+    return null;
+  }
+
+  const state = parseTaskState(data.status);
+
+  let constraintHash: Uint8Array | null = null;
+  if (data.constraintHash) {
+    const bytes = new Uint8Array(data.constraintHash);
+    if (bytes.some((b) => b !== 0)) {
+      constraintHash = bytes;
+    }
+  }
+
+  return {
+    taskId: data.taskId ? new Uint8Array(data.taskId) : new Uint8Array(32),
+    state,
+    creator: data.creator,
+    rewardAmount: BigInt(data.rewardAmount?.toString() ?? "0"),
+    deadline: data.deadline?.toNumber() ?? 0,
+    constraintHash,
+    currentWorkers: data.currentWorkers ?? 0,
+    maxWorkers: data.maxWorkers ?? 1,
+    completedAt: data.completedAt?.toNumber() ?? null,
+    rewardMint: data.rewardMint ?? null,
+  };
+}
+
+// ============================================================================
 // Query Functions
 // ============================================================================
 
@@ -1040,51 +1086,15 @@ export async function getTask(
 ): Promise<TaskStatus | null> {
   try {
     const task = await getAccount(program, "task").fetch(taskPda);
-
-    interface TaskAccountData {
-      taskId?: number[] | Uint8Array;
-      status?: { [key: string]: Record<string, never> } | number;
-      creator?: PublicKey;
-      rewardAmount?: { toString: () => string };
-      deadline?: { toNumber: () => number };
-      constraintHash?: number[] | Uint8Array | null;
-      currentWorkers?: number;
-      maxWorkers?: number;
-      completedAt?: { toNumber: () => number } | null;
-      rewardMint?: PublicKey | null;
-    }
-
     const data = task as TaskAccountData;
+    const parsed = parseTaskAccountData(data);
 
-    if (data.creator === undefined || data.status === undefined) {
+    if (!parsed) {
       getSdkLogger().warn("Task account data missing required fields");
       return null;
     }
 
-    // Parse Anchor enum status (e.g. { open: {} } → 0)
-    const state = parseTaskState(data.status);
-
-    // Parse constraint hash — check if all zeros (means no constraint)
-    let constraintHash: Uint8Array | null = null;
-    if (data.constraintHash) {
-      const bytes = new Uint8Array(data.constraintHash);
-      if (bytes.some((b) => b !== 0)) {
-        constraintHash = bytes;
-      }
-    }
-
-    return {
-      taskId: data.taskId ? new Uint8Array(data.taskId) : new Uint8Array(32),
-      state,
-      creator: data.creator,
-      rewardAmount: BigInt(data.rewardAmount?.toString() ?? "0"),
-      deadline: data.deadline?.toNumber() ?? 0,
-      constraintHash,
-      currentWorkers: data.currentWorkers ?? 0,
-      maxWorkers: data.maxWorkers ?? 1,
-      completedAt: data.completedAt?.toNumber() ?? null,
-      rewardMint: data.rewardMint ?? null,
-    };
+    return parsed;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     if (
@@ -1113,54 +1123,21 @@ export async function getTasksByCreator(
     },
   ]);
 
-  interface TaskAccountData {
-    taskId?: number[] | Uint8Array;
-    status?: { [key: string]: Record<string, never> } | number;
-    creator?: PublicKey;
-    rewardAmount?: { toString: () => string };
-    deadline?: { toNumber: () => number };
-    constraintHash?: number[] | Uint8Array | null;
-    currentWorkers?: number;
-    maxWorkers?: number;
-    completedAt?: { toNumber: () => number } | null;
-    rewardMint?: PublicKey | null;
-  }
-
   const result: TaskStatus[] = [];
 
   for (let idx = 0; idx < tasks.length; idx++) {
     const t = tasks[idx];
     const data = t.account as TaskAccountData;
+    const parsed = parseTaskAccountData(data);
 
-    if (data.creator === undefined || data.status === undefined) {
+    if (!parsed) {
       getSdkLogger().warn(
         `Task at index ${idx} missing required fields, skipping`,
       );
       continue;
     }
 
-    const state = parseTaskState(data.status);
-
-    let constraintHash: Uint8Array | null = null;
-    if (data.constraintHash) {
-      const bytes = new Uint8Array(data.constraintHash);
-      if (bytes.some((b) => b !== 0)) {
-        constraintHash = bytes;
-      }
-    }
-
-    result.push({
-      taskId: data.taskId ? new Uint8Array(data.taskId) : new Uint8Array(32),
-      state,
-      creator: data.creator,
-      rewardAmount: BigInt(data.rewardAmount?.toString() ?? "0"),
-      deadline: data.deadline?.toNumber() ?? 0,
-      constraintHash,
-      currentWorkers: data.currentWorkers ?? 0,
-      maxWorkers: data.maxWorkers ?? 1,
-      completedAt: data.completedAt?.toNumber() ?? null,
-      rewardMint: data.rewardMint ?? null,
-    });
+    result.push(parsed);
   }
 
   return result;


### PR DESCRIPTION
## Summary

Addresses code quality issues identified by RustRover IDE inspections (IntelliJ + SonarLint) across the SDK module. All changes are non-breaking and backward-compatible.

## Changes

### Unused Imports Removed (6 imports across 3 files)
- **`sdk/src/proofs.ts`**: Removed `RISC0_IMAGE_ID_LEN`, `RISC0_SEAL_BORSH_LEN`, `TRUSTED_RISC0_IMAGE_ID`, `TRUSTED_RISC0_SELECTOR` — these constants were imported but never referenced in the file
- **`sdk/src/state.ts`**: Removed `SEEDS` — imported from `./constants` but unused
- **`sdk/src/queries.ts`**: Removed `DISCRIMINATOR_SIZE` — imported from `./constants` but unused (the constant is still used in `tasks.ts` which imports it separately)

### Throw-Catch Antipattern Refactored (`sdk/src/client.ts`)
- **Before**: RPC URL validation threw an error inside a try block, then caught it in the same catch to re-throw with a different message — unnecessary indirection
- **After**: Separated URL parsing (try/catch) from protocol validation (direct throw), eliminating the self-catch pattern

### Redundant Variable Eliminated (`sdk/src/client.ts`)
- `const result = await submitCompleteTaskPrivate(...)` followed by `return result` → simplified to direct `return await submitCompleteTaskPrivate(...)`

### Fields Marked as `readonly` (`sdk/src/client.ts`)
- `connection`, `agentId`, and `proverConfig` are assigned only in the constructor and never reassigned — marked `readonly` to enforce immutability

### Duplicated Code Extracted (`sdk/src/tasks.ts`)
- Two identical 12-line blocks in `getTask()` and `getTasksByCreator()` that parsed `TaskAccountData` into `TaskStatus` objects
- Extracted into a shared `parseTaskAccountData()` helper function, reducing duplication from 24 lines to a single function call in each location
- The `TaskAccountData` interface was also duplicated — now defined once at module scope

## Issues NOT Fixed (Intentional)
- **35 "Import can be shortened"** warnings in `runtime/src/runtime.ts` and `runtime/src/builder.ts` — these use explicit `.js` extensions required for ESM module resolution
- **14 "Deprecated symbol used"** warnings — these are backward-compatibility aliases intentionally exported with `@deprecated` JSDoc tags (e.g., `ProofPreconditionResult` → `ProofSubmissionPreflightResult`)
- **2 throw-catch patterns** in `tasks.ts` and `prover.ts` — valid cleanup/rollback patterns (nullifier cache rollback on failure, prover error re-throw)
- **1 duplicated code fragment** (9 lines) in `proofs.ts` — `hashFieldElements` vs `computeNullifierFromAgentSecret` have different semantics despite structural similarity

## Test Results

| Suite | Result |
|-------|--------|
| SDK | **259/259 tests passed** (1 suite skipped — missing Anchor IDL artifact, pre-existing) |
| Runtime | **5291/5291 tests passed** (4 suites skipped — missing Anchor `.so` build, pre-existing) |

## Test Plan
- [x] All SDK unit tests pass (`yarn test` in `sdk/`)
- [x] All runtime unit tests pass (`yarn test` in `runtime/`)
- [x] SDK builds successfully (`yarn build` in `sdk/`)
- [x] Runtime builds successfully (`yarn build` in `runtime/`)
- [x] Re-ran IDE inspections on all modified files — confirmed fixed issues no longer appear