### PR TITLE
ci: add SonarCloud analysis on PRs and main pushes

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,24 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sonarcloud:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,19 @@
+# SonarCloud Configuration for AgenC
+sonar.projectKey=tetsuo-ai_AgenC
+sonar.organization=tetsuo-ai
+
+# Sources
+sonar.sources=sdk/src,runtime/src,mcp/src,web/src,programs/agenc-coordination/src
+
+# Tests
+sonar.tests=sdk/src/__tests__,runtime/tests,runtime/src,mcp/tests,web/tests
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts
+
+# Exclusions
+sonar.exclusions=**/node_modules/**,**/dist/**,**/target/**,**/*.lock,**/coverage/**,**/benchmarks/artifacts/**,**/.idea/**,**/demo/**,**/demo-app/**,**/examples/**,**/docs/**
+
+# TypeScript / JavaScript
+sonar.typescript.lcov.reportPaths=sdk/coverage/lcov.info,runtime/coverage/lcov.info
+
+# Encoding
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary

Integrates SonarCloud automated code analysis into the CI pipeline. Every PR and push to `main` will now trigger a SonarCloud scan that reports code smells, bugs, vulnerabilities, and security hotspots.

## Changes

- **`.github/workflows/sonarcloud.yml`** — New workflow using `SonarSource/sonarqube-scan-action@v5`, triggered on PR open/sync/reopen and push to `main`
- **`sonar-project.properties`** — Project configuration:
  - Sources: `sdk/src`, `runtime/src`, `mcp/src`, `web/src`, `programs/agenc-coordination/src`
  - Tests: `sdk/src/__tests__`, `runtime/tests`, `mcp/tests`, `web/tests`
  - Exclusions: `node_modules`, `dist`, `target`, lock files, benchmarks, docs, demo apps
- **`SONAR_TOKEN`** secret already added to repo settings

## How it works

1. Developer opens a PR → SonarCloud Action runs automatically
2. SonarCloud posts a **check status** (pass/fail) on the PR
3. SonarCloud posts a **comment** with new issues found in the PR code
4. Full dashboard available at https://sonarcloud.io/project/overview?id=tetsuo-ai_AgenC

## Current baseline (first scan)

| Metric | Count |
|--------|-------|
| Total issues | 2,346 |
| Blockers | 6 |
| Critical | 349 |
| Major | 554 |
| Minor | 1,437 |
| Bugs | 94 |
| Vulnerabilities | 4 |
| Code Smells | 2,248 |

## Test plan
- [x] SONAR_TOKEN secret configured in GitHub repo settings
- [x] SonarCloud project `tetsuo-ai_AgenC` verified via API
- [ ] Verify SonarCloud scan runs on this PR (will trigger automatically)
- [ ] Verify PR decoration (check status + comment) appears