### PR TITLE
fix(sonar): add explicit comparators for string sorts

### DIFF
--- a/mcp/src/tools/replay.ts
+++ b/mcp/src/tools/replay.ts
@@ -833,8 +833,8 @@ function summarizeReplayIncident(
     dispute_pda_filters: [filters.disputePda ?? null],
     from_slot: filters.fromSlot,
     to_slot: filters.toSlot,
-    unique_task_ids: [...taskIds].sort(),
-    unique_dispute_ids: [...disputeIds].sort(),
+    unique_task_ids: [...taskIds].sort((a, b) => a.localeCompare(b)),
+    unique_dispute_ids: [...disputeIds].sort((a, b) => a.localeCompare(b)),
     source_event_type_counts: sourceEventTypeCounts,
     source_event_name_counts: sourceEventNameCounts,
     trace_id_counts: traceIdCounts,
@@ -888,11 +888,11 @@ function validateReplayIncident(
   const result = {
     strict_mode: strictMode,
     event_validation: {
-      errors: [...replay.errors].sort(),
-      warnings: [...replay.warnings].sort(),
+      errors: [...replay.errors].sort((a, b) => a.localeCompare(b)),
+      warnings: [...replay.warnings].sort((a, b) => a.localeCompare(b)),
       replay_task_count: replayTaskCount,
     },
-    anomaly_ids: [...anomalyIds].sort(),
+    anomaly_ids: [...anomalyIds].sort((a, b) => a.localeCompare(b)),
   };
 
   const deterministicHash = createHash("sha256")
@@ -925,15 +925,15 @@ function buildIncidentNarrative(
   });
 
   const validationLines = [
-    ...validation.event_validation.errors.sort(),
-    ...validation.event_validation.warnings.sort(),
+    ...validation.event_validation.errors.sort((a, b) => a.localeCompare(b)),
+    ...validation.event_validation.warnings.sort((a, b) => a.localeCompare(b)),
   ].map((line) => `validation:${line}`);
 
   const lines = [...anomalyLines, ...validationLines];
   const anomaly_ids = sortedEvents
     .map((entry) => entry.anomaly_id)
     .filter((entry) => entry.length > 0)
-    .sort();
+    .sort((a, b) => a.localeCompare(b));
 
   const deterministicHash = createHash("sha256")
     .update(stableStringifyJson(lines as unknown as JsonValue))

--- a/mcp/src/tools/testing.ts
+++ b/mcp/src/tools/testing.ts
@@ -672,7 +672,9 @@ export function registerTestingTools(server: McpServer): void {
     {},
     withToolErrorResponse(async () => {
       const entries = await readdir(TESTS_DIR);
-      const testFiles = entries.filter((e) => e.endsWith(".ts")).sort();
+      const testFiles = entries
+        .filter((e) => e.endsWith(".ts"))
+        .sort((a, b) => a.localeCompare(b));
 
       const descriptions: Record<string, string> = {
         "test_1.ts": "Main integration test suite",

--- a/mcp/src/utils/schema-hash.ts
+++ b/mcp/src/utils/schema-hash.ts
@@ -27,7 +27,7 @@ function normalizeLiteral(value: unknown): JsonLike {
   if (typeof value === "object") {
     const record = value as Record<string, unknown>;
     const out: Record<string, JsonLike> = {};
-    for (const key of Object.keys(record).sort()) {
+    for (const key of Object.keys(record).sort((a, b) => a.localeCompare(b))) {
       out[key] = normalizeLiteral(record[key]);
     }
     return out;
@@ -66,7 +66,7 @@ function extractSchemaDescription(schema: ZodTypeAny): unknown {
         | undefined;
       const shape = shapeFn ? shapeFn() : {};
       const fields: Record<string, unknown> = {};
-      for (const key of Object.keys(shape).sort()) {
+      for (const key of Object.keys(shape).sort((a, b) => a.localeCompare(b))) {
         fields[key] = extractSchemaDescription(shape[key]);
       }
       return {

--- a/runtime/src/autonomous/arbitration.ts
+++ b/runtime/src/autonomous/arbitration.ts
@@ -93,7 +93,7 @@ function collectReasonCodes(
       seen.add(reason.code);
     }
   }
-  return [...seen].sort();
+  return [...seen].sort((a, b) => a.localeCompare(b));
 }
 
 /**

--- a/runtime/src/cli/replay.ts
+++ b/runtime/src/cli/replay.ts
@@ -299,7 +299,7 @@ function sortRecordByKey(
   record: Record<string, number>,
 ): Record<string, number> {
   const sorted: Record<string, number> = {};
-  for (const key of Object.keys(record).sort()) {
+  for (const key of Object.keys(record).sort((a, b) => a.localeCompare(b))) {
     sorted[key] = record[key]!;
   }
   return sorted;
@@ -385,8 +385,8 @@ export function summarizeReplayIncidentRecords(
     };
   });
 
-  const uniqueTaskIds = [...taskIds].sort();
-  const uniqueDisputeIds = [...disputeIds].sort();
+  const uniqueTaskIds = [...taskIds].sort((a, b) => a.localeCompare(b));
+  const uniqueDisputeIds = [...disputeIds].sort((a, b) => a.localeCompare(b));
   const sortedEventTypeCounts = sortRecordByKey(sourceEventTypeCounts);
   const sortedEventNameCounts = sortRecordByKey(sourceEventNameCounts);
   const sortedTraceIdCounts = sortRecordByKey(traceIdCounts);

--- a/runtime/src/eval/incident-case.ts
+++ b/runtime/src/eval/incident-case.ts
@@ -168,7 +168,7 @@ export function buildIncidentCase(input: BuildIncidentCaseInput): IncidentCase {
             typeof entry === "string" && entry.length > 0,
         ),
     ),
-  ].sort();
+  ].sort((a, b) => a.localeCompare(b));
 
   const disputeIds = collectDisputeIds(windowedEvents);
   const caseId = computeCaseId(traceWindow, taskIds, disputeIds);
@@ -407,7 +407,7 @@ function collectDisputeIds(
     const disputePda = extractDisputePda(event);
     if (disputePda) disputeIds.add(disputePda);
   }
-  return [...disputeIds].sort();
+  return [...disputeIds].sort((a, b) => a.localeCompare(b));
 }
 
 function extractDisputePda(event: ProjectedTimelineEvent): string | undefined {

--- a/runtime/src/eval/query-dsl.ts
+++ b/runtime/src/eval/query-dsl.ts
@@ -273,7 +273,7 @@ export function parseQueryDSL(input: string): QueryDSL {
         }
 
         if (invalid.length === 0) {
-          dsl.walletSet = [...wallets].sort();
+          dsl.walletSet = [...wallets].sort((a, b) => a.localeCompare(b));
         } else {
           dsl.walletSet = wallets;
         }
@@ -307,8 +307,8 @@ export function normalizeQuery(dsl: QueryDSL): CanonicalQuery {
       from: dsl.slotRange?.from ?? null,
       to: dsl.slotRange?.to ?? null,
     },
-    walletSet: [...(dsl.walletSet ?? [])].sort(),
-    anomalyCodes: [...(dsl.anomalyCodes ?? [])].sort(),
+    walletSet: [...(dsl.walletSet ?? [])].sort((a, b) => a.localeCompare(b)),
+    anomalyCodes: [...(dsl.anomalyCodes ?? [])].sort((a, b) => a.localeCompare(b)),
   };
 
   const canonical = stableStringifyJson(normalized as unknown as JsonValue);

--- a/runtime/src/eval/replay-comparison.ts
+++ b/runtime/src/eval/replay-comparison.ts
@@ -899,8 +899,8 @@ export class ReplayComparisonService {
     }
 
     return {
-      taskIds: [...taskIds].sort(),
-      disputeIds: [...disputeIds].sort(),
+      taskIds: [...taskIds].sort((a, b) => a.localeCompare(b)),
+      disputeIds: [...disputeIds].sort((a, b) => a.localeCompare(b)),
     };
   }
 }

--- a/runtime/src/eval/types.ts
+++ b/runtime/src/eval/types.ts
@@ -290,7 +290,7 @@ function canonicalizeJson(value: JsonValue): JsonValue {
 
   if (isPlainObject(value)) {
     const output: JsonObject = {};
-    for (const key of Object.keys(value).sort()) {
+    for (const key of Object.keys(value).sort((a, b) => a.localeCompare(b))) {
       output[key] = canonicalizeJson(value[key] as JsonValue);
     }
     return output;

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -520,7 +520,7 @@ export class ToolRouter {
       break;
     }
 
-    return Array.from(terms).sort();
+    return Array.from(terms).sort((a, b) => a.localeCompare(b));
   }
 
   private scoreTools(intentTerms: readonly string[]): Array<{ tool: IndexedTool; score: number }> {

--- a/runtime/src/gateway/workspace.ts
+++ b/runtime/src/gateway/workspace.ts
@@ -330,7 +330,7 @@ export class WorkspaceManager {
       }
     }
 
-    return results.sort();
+    return results.sort((a, b) => a.localeCompare(b));
   }
 
   async createWorkspace(

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -122,7 +122,7 @@ export function normalizeSemanticValue(value: unknown): string {
   }
   if (typeof value === "object") {
     const obj = value as Record<string, unknown>;
-    const keys = Object.keys(obj).sort();
+    const keys = Object.keys(obj).sort((a, b) => a.localeCompare(b));
     return `{${keys
       .map(
         (key) =>

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -463,7 +463,7 @@ export function checkToolLoopStuckDetection(
   if (roundFailures === roundCalls.length) {
     const roundSemanticKey = roundCalls
       .map((call) => buildSemanticToolCallKey(call.name, call.args))
-      .sort()
+      .sort((a, b) => a.localeCompare(b))
       .join("|");
     if (
       roundSemanticKey.length > 0 &&

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -262,7 +262,7 @@ function stableStringify(value: unknown): string {
     return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
   }
   const record = value as Record<string, unknown>;
-  const keys = Object.keys(record).sort();
+  const keys = Object.keys(record).sort((a, b) => a.localeCompare(b));
   const entries = keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
   return `{${entries.join(",")}}`;
 }

--- a/runtime/src/memory/structured.ts
+++ b/runtime/src/memory/structured.ts
@@ -126,7 +126,7 @@ export class DailyLogManager {
       return files
         .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
         .map((f) => basename(f, ".md"))
-        .sort();
+        .sort((a, b) => a.localeCompare(b));
     } catch (err) {
       if (isEnoent(err)) return [];
       throw err;

--- a/runtime/src/replay/alerting.ts
+++ b/runtime/src/replay/alerting.ts
@@ -490,7 +490,9 @@ export function validateAlertSchema(
 export function computeAnomalySetHash(
   alerts: ReadonlyArray<ReplayAnomalyAlert>,
 ): string {
-  const sortedIds = alerts.map((alert) => alert.id).sort();
+  const sortedIds = alerts
+    .map((alert) => alert.id)
+    .sort((a, b) => a.localeCompare(b));
   const payload = stableStringifyJson(sortedIds as JsonValue);
   return createHash("sha256").update(payload).digest("hex");
 }
@@ -507,7 +509,7 @@ export function computeAnomalySetHashFromContexts(
       const base = buildAlertPayload(ctx);
       return makeAlertId(base);
     })
-    .sort();
+    .sort((a, b) => a.localeCompare(b));
   return createHash("sha256")
     .update(stableStringifyJson(ids as JsonValue))
     .digest("hex");

--- a/runtime/src/replay/backfill.ts
+++ b/runtime/src/replay/backfill.ts
@@ -235,7 +235,10 @@ export class ReplayBackfillService {
               cursor,
               duplicateReport:
                 duplicateKeys.length > 0
-                  ? { count: duplicates, keys: [...duplicateKeys].sort() }
+                  ? {
+                      count: duplicates,
+                      keys: [...duplicateKeys].sort((a, b) => a.localeCompare(b)),
+                    }
                   : undefined,
             };
           }
@@ -311,7 +314,10 @@ export class ReplayBackfillService {
           cursor,
           duplicateReport:
             duplicateKeys.length > 0
-              ? { count: duplicates, keys: [...duplicateKeys].sort() }
+              ? {
+                  count: duplicates,
+                  keys: [...duplicateKeys].sort((a, b) => a.localeCompare(b)),
+                }
               : undefined,
         };
       }
@@ -324,7 +330,10 @@ export class ReplayBackfillService {
           cursor,
           duplicateReport:
             duplicateKeys.length > 0
-              ? { count: duplicates, keys: [...duplicateKeys].sort() }
+              ? {
+                  count: duplicates,
+                  keys: [...duplicateKeys].sort((a, b) => a.localeCompare(b)),
+                }
               : undefined,
         };
       }

--- a/runtime/src/telemetry/collector.ts
+++ b/runtime/src/telemetry/collector.ts
@@ -34,7 +34,7 @@ export function buildKey(
   labels?: Record<string, string>,
 ): string {
   if (!labels || Object.keys(labels).length === 0) return name;
-  const sorted = Object.keys(labels).sort();
+  const sorted = Object.keys(labels).sort((a, b) => a.localeCompare(b));
   const parts = sorted.map((k) => `${k}=${labels[k]}`);
   return `${name}|${parts.join("|")}`;
 }

--- a/runtime/src/tools/x/tools.ts
+++ b/runtime/src/tools/x/tools.ts
@@ -44,7 +44,7 @@ function buildOAuthHeader(
   };
 
   const allParams = { ...params, ...oauthParams };
-  const sortedKeys = Object.keys(allParams).sort();
+  const sortedKeys = Object.keys(allParams).sort((a, b) => a.localeCompare(b));
   const paramString = sortedKeys.map((k) => `${percentEncode(k)}=${percentEncode(allParams[k])}`).join('&');
 
   const signatureBase = `${method.toUpperCase()}&${percentEncode(url)}&${percentEncode(paramString)}`;
@@ -54,7 +54,7 @@ function buildOAuthHeader(
   oauthParams.oauth_signature = signature;
 
   const headerParts = Object.keys(oauthParams)
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .map((k) => `${percentEncode(k)}="${percentEncode(oauthParams[k])}"`)
     .join(', ');
 

--- a/runtime/src/types/config-migration.ts
+++ b/runtime/src/types/config-migration.ts
@@ -274,7 +274,7 @@ export function buildConfigSchemaSnapshot(
   version: ConfigVersion,
   profile: string,
 ): ConfigSchemaSnapshot {
-  const keys = [...KNOWN_CONFIG_KEYS].sort();
+  const keys = [...KNOWN_CONFIG_KEYS].sort((a, b) => a.localeCompare(b));
   const sha256 = createHash("sha256").update(keys.join("\n")).digest("hex");
 
   return { version, profile, keys, sha256 };

--- a/runtime/src/workflow/feature-extractor.ts
+++ b/runtime/src/workflow/feature-extractor.ts
@@ -71,7 +71,7 @@ function sumMatchingMetrics(
   workflowId: string,
 ): number {
   let total = 0;
-  const keys = Object.keys(values).sort();
+  const keys = Object.keys(values).sort((a, b) => a.localeCompare(b));
 
   for (const key of keys) {
     const parsed = parseCompositeMetricKey(key);
@@ -134,7 +134,7 @@ function computeDepthByNode(state: WorkflowState): Map<string, number> {
 
 function orderedRecord(map: Map<string, number>): Record<string, number> {
   const out: Record<string, number> = {};
-  for (const key of [...map.keys()].sort()) {
+  for (const key of [...map.keys()].sort((a, b) => a.localeCompare(b))) {
     out[key] = map.get(key) ?? 0;
   }
   return out;
@@ -217,7 +217,7 @@ function buildMetadata(
   const out = new Map<string, string>();
 
   if (base) {
-    for (const key of Object.keys(base).sort()) {
+    for (const key of Object.keys(base).sort((a, b) => a.localeCompare(b))) {
       out.set(key, base[key]);
     }
   }
@@ -232,7 +232,7 @@ function buildMetadata(
 
     if (roleCounts.size > 0) {
       out.set("workflow_source", "team_adapter");
-      for (const role of [...roleCounts.keys()].sort()) {
+      for (const role of [...roleCounts.keys()].sort((a, b) => a.localeCompare(b))) {
         out.set(`role_count.${role}`, String(roleCounts.get(role) ?? 0));
       }
     }
@@ -243,7 +243,7 @@ function buildMetadata(
   if (out.size === 0) return undefined;
 
   const object: Record<string, string> = {};
-  for (const key of [...out.keys()].sort()) {
+  for (const key of [...out.keys()].sort((a, b) => a.localeCompare(b))) {
     object[key] = out.get(key) ?? "";
   }
   return object;

--- a/runtime/src/workflow/mutations.ts
+++ b/runtime/src/workflow/mutations.ts
@@ -195,7 +195,9 @@ function mutateEdgeRewire(
   baseline: WorkflowDefinition,
   rng: () => number,
 ): MutationAttemptResult | null {
-  const names = baseline.tasks.map((task) => task.name).sort();
+  const names = baseline.tasks
+    .map((task) => task.name)
+    .sort((a, b) => a.localeCompare(b));
   if (names.length < 2) return null;
 
   const edgeByChild = new Map(baseline.edges.map((edge) => [edge.to, edge]));

--- a/runtime/src/workflow/optimizer.ts
+++ b/runtime/src/workflow/optimizer.ts
@@ -281,7 +281,7 @@ function summarizeOperators(
   }
 
   const output: Record<string, number> = {};
-  for (const key of [...counts.keys()].sort()) {
+  for (const key of [...counts.keys()].sort((a, b) => a.localeCompare(b))) {
     output[key] = counts.get(key) ?? 0;
   }
   return output;


### PR DESCRIPTION
## Summary
- replace bare string sort/toSorted calls in production runtime and MCP code with explicit `localeCompare` comparators
- cover remaining production string sort sites in MCP testing and structured memory utilities
- keep deterministic hashing, snapshot, replay, workflow, and telemetry ordering explicit

Closes #1369

## Testing
- `npm --prefix runtime run typecheck`
- `npm --prefix runtime run test -- src/eval/query-dsl.test.ts src/eval/incident-case.test.ts src/eval/replay-comparison.test.ts src/cli/replay.test.ts src/gateway/tool-routing.test.ts src/gateway/workspace.test.ts src/gateway/workspace-files.test.ts src/replay/replay-storage.test.ts tests/cli-replay-commands.test.ts`
- `cd mcp && node --import tsx --test src/prompts/prompts.test.ts src/tools/human-facing.test.ts src/tools/replay-policy-controls.test.ts src/tools/replay-schema-stability.test.ts src/tools/replay-changelog-lint.test.ts`

## Notes
- `npm --prefix mcp run test` is not green in this environment because several existing suites depend on unresolved `@agenc/runtime` imports and missing replay fixtures unrelated to this change.
- `npm --prefix mcp run typecheck` also fails in this environment for existing `@agenc/runtime` resolution issues unrelated to this change.