### PR TITLE
fix(runtime): require pinned config for private proof generation

### DIFF
--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -152,12 +152,16 @@ await monitor.stop();
 import { ProofEngine } from '@agenc/runtime';
 
 const engine = new ProofEngine({
+  proverBackend: {
+    kind: 'local-binary',
+    binaryPath: '/usr/local/bin/agenc-zkvm-host',
+  },
   methodId: trustedImageIdBytes,
   routerConfig: {
-    routerProgram,
-    router,
-    verifierEntry,
-    verifierProgram,
+    routerProgramId,
+    routerPda,
+    verifierEntryPda,
+    verifierProgramId,
   },
   verifyAfterGeneration: false,
   cache: { ttlMs: 300_000, maxEntries: 100 },
@@ -167,9 +171,15 @@ const result = await engine.generate({
   taskPda, agentPubkey,
   output: [1n, 2n, 3n, 4n],
   salt: engine.generateSalt(),
+  agentSecret,
 });
-// result.fromCache, result.verified, result.proof, result.proofHash
+// result.fromCache, result.verified, result.sealBytes, result.imageId
 ```
+
+Private proof generation fails closed unless `methodId` and the full
+`routerConfig` are pinned. The only bypass is
+`unsafeAllowUnpinnedPrivateProofs: true`, which should be used only for local
+development.
 
 ### Dispute Operations
 
@@ -316,11 +326,15 @@ Provider-specific additions:
 
 | Field | Type | Required | Default |
 |-------|------|----------|---------|
-| `methodId` | `Uint8Array` | Yes | Trusted image ID bytes |
-| `routerConfig.routerProgram` | `PublicKey` | Yes | Trusted router program |
-| `routerConfig.router` | `PublicKey` | Yes | Router PDA |
-| `routerConfig.verifierEntry` | `PublicKey` | Yes | Verifier-entry PDA |
-| `routerConfig.verifierProgram` | `PublicKey` | Yes | Trusted verifier program |
+| `proverBackend.kind` | `"local-binary" \| "remote"` | Yes | — |
+| `proverBackend.binaryPath` | `string` | If `kind="local-binary"` | — |
+| `proverBackend.endpoint` | `string` | If `kind="remote"` | — |
+| `methodId` | `Uint8Array` | Required for private proving | — |
+| `routerConfig.routerProgramId` | `PublicKey` | Required for private proving | — |
+| `routerConfig.routerPda` | `PublicKey` | Required for private proving | — |
+| `routerConfig.verifierEntryPda` | `PublicKey` | Required for private proving | — |
+| `routerConfig.verifierProgramId` | `PublicKey` | Required for private proving | — |
+| `unsafeAllowUnpinnedPrivateProofs` | `boolean` | No | `false` (development only) |
 | `verifyAfterGeneration` | `boolean` | No | `false` |
 | `cache.ttlMs` | `number` | No | `300_000` |
 | `cache.maxEntries` | `number` | No | `100` |

--- a/runtime/src/proof/engine.test.ts
+++ b/runtime/src/proof/engine.test.ts
@@ -80,7 +80,17 @@ import {
   ProofCacheError,
 } from "./errors.js";
 import { RuntimeErrorCodes, RuntimeError } from "../types/errors.js";
-import type { ProofInputs, EngineProofResult } from "./types.js";
+import type {
+  EngineProofResult,
+  ProofEngineConfig,
+  ProofInputs,
+} from "./types.js";
+
+const DEFAULT_LOCAL_BINARY_BACKEND = {
+  kind: "local-binary" as const,
+  binaryPath: "/usr/bin/agenc-zkvm-host",
+};
+const MOCK_PINNED_METHOD_ID = new Uint8Array(32).fill(0xef);
 
 function makeInputs(): ProofInputs {
   return {
@@ -88,6 +98,27 @@ function makeInputs(): ProofInputs {
     agentPubkey: Keypair.generate().publicKey,
     output: [1n, 2n, 3n, 4n],
     salt: 12345n,
+    agentSecret: 67890n,
+  };
+}
+
+function makeRouterConfig() {
+  return {
+    routerProgramId: Keypair.generate().publicKey,
+    routerPda: Keypair.generate().publicKey,
+    verifierEntryPda: Keypair.generate().publicKey,
+    verifierProgramId: Keypair.generate().publicKey,
+  };
+}
+
+function makePinnedProofConfig(
+  overrides: Partial<ProofEngineConfig> = {},
+): ProofEngineConfig {
+  return {
+    methodId: new Uint8Array(MOCK_PINNED_METHOD_ID),
+    routerConfig: makeRouterConfig(),
+    proverBackend: { ...DEFAULT_LOCAL_BINARY_BACKEND },
+    ...overrides,
   };
 }
 
@@ -145,12 +176,7 @@ describe("ProofEngine", () => {
     });
 
     it("calls SDK generateProof and returns EngineProofResult", async () => {
-      const engine = new ProofEngine({
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(makePinnedProofConfig());
       const inputs = makeInputs();
       const result = await engine.generate(inputs);
 
@@ -173,16 +199,64 @@ describe("ProofEngine", () => {
 
     it("enforces configured methodId against generated imageId", async () => {
       const pinnedMethodId = new Uint8Array(32).fill(0x7f);
-      const engine = new ProofEngine({
-        methodId: pinnedMethodId,
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(
+        makePinnedProofConfig({ methodId: pinnedMethodId }),
+      );
 
       await expect(engine.generate(makeInputs())).rejects.toThrow(
         "Generated imageId does not match configured methodId",
+      );
+    });
+
+    it("rejects private proving when methodId and routerConfig are not pinned", async () => {
+      const engine = new ProofEngine({
+        proverBackend: { ...DEFAULT_LOCAL_BINARY_BACKEND },
+      });
+
+      await expect(engine.generate(makeInputs())).rejects.toThrow(
+        "Private proof generation requires pinned methodId and complete routerConfig",
+      );
+      await expect(engine.generate(makeInputs())).rejects.toThrow("methodId");
+      await expect(engine.generate(makeInputs())).rejects.toThrow(
+        "routerConfig.routerProgramId",
+      );
+    });
+
+    it("rejects private proving when routerConfig is only partially pinned", async () => {
+      const engine = new ProofEngine({
+        methodId: new Uint8Array(MOCK_PINNED_METHOD_ID),
+        routerConfig: {
+          routerProgramId: Keypair.generate().publicKey,
+          routerPda: Keypair.generate().publicKey,
+        },
+        proverBackend: { ...DEFAULT_LOCAL_BINARY_BACKEND },
+      });
+
+      await expect(engine.generate(makeInputs())).rejects.toThrow(
+        "routerConfig.verifierEntryPda, routerConfig.verifierProgramId",
+      );
+    });
+
+    it("allows unpinned private proving only with the explicit unsafe override", async () => {
+      const warnFn = vi.fn();
+      const engine = new ProofEngine({
+        proverBackend: { ...DEFAULT_LOCAL_BINARY_BACKEND },
+        unsafeAllowUnpinnedPrivateProofs: true,
+        logger: {
+          debug: vi.fn(),
+          info: vi.fn(),
+          warn: warnFn,
+          error: vi.fn(),
+          setLevel: vi.fn(),
+        },
+      });
+
+      await expect(engine.generate(makeInputs())).resolves.toMatchObject({
+        fromCache: false,
+        verified: false,
+      });
+      expect(warnFn).toHaveBeenCalledWith(
+        expect.stringContaining("unsafeAllowUnpinnedPrivateProofs=true"),
       );
     });
 
@@ -190,12 +264,7 @@ describe("ProofEngine", () => {
       vi.mocked(mockGenerateProof).mockRejectedValueOnce(
         new Error("proof backend boom"),
       );
-      const engine = new ProofEngine({
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(makePinnedProofConfig());
 
       await expect(engine.generate(makeInputs())).rejects.toThrow(
         ProofGenerationError,
@@ -206,12 +275,7 @@ describe("ProofEngine", () => {
       vi.mocked(mockGenerateProof).mockRejectedValueOnce(
         new Error("proof backend boom"),
       );
-      const engine = new ProofEngine({
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(makePinnedProofConfig());
 
       await expect(engine.generate(makeInputs())).rejects.toThrow(
         "proof backend boom",
@@ -220,12 +284,7 @@ describe("ProofEngine", () => {
 
     it("wraps non-Error SDK throws in ProofGenerationError", async () => {
       vi.mocked(mockGenerateProof).mockRejectedValueOnce("string error");
-      const engine = new ProofEngine({
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(makePinnedProofConfig());
 
       await expect(engine.generate(makeInputs())).rejects.toThrow(
         ProofGenerationError,
@@ -238,13 +297,9 @@ describe("ProofEngine", () => {
   // ==========================================================================
 
   describe("generate with cache", () => {
-    const cacheEngineConfig = {
+    const cacheEngineConfig = makePinnedProofConfig({
       cache: { ttlMs: 60_000 },
-      proverBackend: {
-        kind: "local-binary" as const,
-        binaryPath: "/usr/bin/agenc-zkvm-host",
-      },
-    };
+    });
 
     it("stores result in cache on miss", async () => {
       const engine = new ProofEngine(cacheEngineConfig);
@@ -273,13 +328,11 @@ describe("ProofEngine", () => {
 
     it("respects cache TTL expiry", async () => {
       vi.useFakeTimers();
-      const engine = new ProofEngine({
-        cache: { ttlMs: 1000 },
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(
+        makePinnedProofConfig({
+          cache: { ttlMs: 1000 },
+        }),
+      );
       const inputs = makeInputs();
 
       await engine.generate(inputs);
@@ -294,13 +347,11 @@ describe("ProofEngine", () => {
     });
 
     it("evicts oldest entry when cache is full", async () => {
-      const engine = new ProofEngine({
-        cache: { ttlMs: 60_000, maxEntries: 2 },
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(
+        makePinnedProofConfig({
+          cache: { ttlMs: 60_000, maxEntries: 2 },
+        }),
+      );
 
       const inputs1 = makeInputs();
       const inputs2 = makeInputs();
@@ -342,11 +393,8 @@ describe("ProofEngine", () => {
     it("logs a warning when verifyAfterGeneration is set", async () => {
       const warnFn = vi.fn();
       const engine = new ProofEngine({
+        ...makePinnedProofConfig(),
         verifyAfterGeneration: true,
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
         logger: {
           debug: vi.fn(),
           info: vi.fn(),
@@ -377,7 +425,7 @@ describe("ProofEngine", () => {
         inputs.agentPubkey,
         inputs.output,
         inputs.salt,
-        undefined,
+        inputs.agentSecret,
       );
       expect(result.constraintHash).toBe(123n);
       expect(result.outputCommitment).toBe(456n);
@@ -415,13 +463,8 @@ describe("ProofEngine", () => {
 
     it("marks methodId and router as pinned when configured", () => {
       const engine = new ProofEngine({
+        ...makePinnedProofConfig(),
         methodId: new Uint8Array(32).fill(7),
-        routerConfig: {
-          routerProgramId: Keypair.generate().publicKey,
-          routerPda: Keypair.generate().publicKey,
-          verifierEntryPda: Keypair.generate().publicKey,
-          verifierProgramId: Keypair.generate().publicKey,
-        },
       });
       const status = engine.checkTools();
       expect(status.methodIdPinned).toBe(true);
@@ -449,12 +492,7 @@ describe("ProofEngine", () => {
     });
 
     it("tracks generation stats", async () => {
-      const engine = new ProofEngine({
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(makePinnedProofConfig());
 
       await engine.generate(makeInputs());
       await engine.generate(makeInputs());
@@ -466,13 +504,11 @@ describe("ProofEngine", () => {
     });
 
     it("tracks cache hit/miss stats", async () => {
-      const engine = new ProofEngine({
-        cache: { ttlMs: 60_000 },
-        proverBackend: {
-          kind: "local-binary",
-          binaryPath: "/usr/bin/agenc-zkvm-host",
-        },
-      });
+      const engine = new ProofEngine(
+        makePinnedProofConfig({
+          cache: { ttlMs: 60_000 },
+        }),
+      );
       const inputs = makeInputs();
 
       await engine.generate(inputs); // miss
@@ -591,25 +627,22 @@ describe("ProofEngine with local-binary backend", () => {
   });
 
   it("calls SDK generateProof with prover config", async () => {
-    const engine = new ProofEngine({
-      proverBackend: {
-        kind: "local-binary",
-        binaryPath: "/usr/bin/agenc-zkvm-host",
-      },
-    });
+    const engine = new ProofEngine(makePinnedProofConfig());
     await engine.generate(makeInputs());
 
     expect(mockGenerateProof).toHaveBeenCalledOnce();
   });
 
   it("passes correct prover config to SDK", async () => {
-    const engine = new ProofEngine({
-      proverBackend: {
-        kind: "local-binary",
-        binaryPath: "/usr/bin/agenc-zkvm-host",
-        timeoutMs: 60_000,
-      },
-    });
+    const engine = new ProofEngine(
+      makePinnedProofConfig({
+        proverBackend: {
+          kind: "local-binary",
+          binaryPath: "/usr/bin/agenc-zkvm-host",
+          timeoutMs: 60_000,
+        },
+      }),
+    );
     await engine.generate(makeInputs());
 
     const args = vi.mocked(mockGenerateProof).mock.calls[0];
@@ -621,9 +654,11 @@ describe("ProofEngine with local-binary backend", () => {
   });
 
   it("throws ProofGenerationError when binaryPath is missing", async () => {
-    const engine = new ProofEngine({
-      proverBackend: { kind: "local-binary" },
-    });
+    const engine = new ProofEngine(
+      makePinnedProofConfig({
+        proverBackend: { kind: "local-binary" },
+      }),
+    );
 
     await expect(engine.generate(makeInputs())).rejects.toThrow(
       ProofGenerationError,
@@ -640,13 +675,15 @@ describe("ProofEngine with remote backend", () => {
   });
 
   it("calls SDK generateProof with remote config", async () => {
-    const engine = new ProofEngine({
-      proverBackend: {
-        kind: "remote",
-        endpoint: "https://prover.example.com",
-        headers: { Authorization: "Bearer abc" },
-      },
-    });
+    const engine = new ProofEngine(
+      makePinnedProofConfig({
+        proverBackend: {
+          kind: "remote",
+          endpoint: "https://prover.example.com",
+          headers: { Authorization: "Bearer abc" },
+        },
+      }),
+    );
     await engine.generate(makeInputs());
 
     expect(mockGenerateProof).toHaveBeenCalledOnce();
@@ -661,9 +698,11 @@ describe("ProofEngine with remote backend", () => {
   });
 
   it("throws ProofGenerationError when endpoint is missing", async () => {
-    const engine = new ProofEngine({
-      proverBackend: { kind: "remote" },
-    });
+    const engine = new ProofEngine(
+      makePinnedProofConfig({
+        proverBackend: { kind: "remote" },
+      }),
+    );
 
     await expect(engine.generate(makeInputs())).rejects.toThrow(
       ProofGenerationError,
@@ -753,6 +792,7 @@ describe("deriveCacheKey", () => {
       agentPubkey,
       output: [1n, 2n, 3n, 4n],
       salt: 12345n,
+      agentSecret: 67890n,
     };
 
     const key1 = deriveCacheKey(inputs);

--- a/runtime/src/proof/engine.ts
+++ b/runtime/src/proof/engine.ts
@@ -37,6 +37,12 @@ import type {
 import { ProofCache } from "./cache.js";
 import { ProofGenerationError } from "./errors.js";
 const METHOD_ID_LEN = 32;
+const ROUTER_CONFIG_FIELDS = [
+  "routerProgramId",
+  "routerPda",
+  "verifierEntryPda",
+  "verifierProgramId",
+] as const;
 
 /**
  * Map runtime ProverBackendConfig to SDK's ProverConfig for real prover backends.
@@ -93,6 +99,17 @@ export function buildSdkProverConfig(
  * @example
  * ```typescript
  * const engine = new ProofEngine({
+ *   proverBackend: {
+ *     kind: "local-binary",
+ *     binaryPath: "/usr/local/bin/agenc-zkvm-host",
+ *   },
+ *   methodId: trustedImageIdBytes,
+ *   routerConfig: {
+ *     routerProgramId,
+ *     routerPda,
+ *     verifierEntryPda,
+ *     verifierProgramId,
+ *   },
  *   cache: { ttlMs: 300_000, maxEntries: 100 },
  *   verifyAfterGeneration: false,
  * });
@@ -102,6 +119,7 @@ export function buildSdkProverConfig(
  *   agentPubkey,
  *   output: [1n, 2n, 3n, 4n],
  *   salt: engine.generateSalt(),
+ *   agentSecret,
  * });
  * ```
  */
@@ -110,6 +128,7 @@ export class ProofEngine implements ProofGenerator {
   private readonly routerConfig: RouterConfig | null;
   private readonly proverBackend: ProverBackend;
   private readonly proverBackendConfig: ProverBackendConfig | undefined;
+  private readonly unsafeAllowUnpinnedPrivateProofs: boolean;
   private readonly verifyAfterGeneration: boolean;
   private readonly cache: ProofCache | null;
   private readonly logger: Logger;
@@ -132,6 +151,8 @@ export class ProofEngine implements ProofGenerator {
     this.routerConfig = config?.routerConfig ?? null;
     this.proverBackendConfig = config?.proverBackend;
     this.proverBackend = config?.proverBackend?.kind ?? "local-binary";
+    this.unsafeAllowUnpinnedPrivateProofs =
+      config?.unsafeAllowUnpinnedPrivateProofs ?? false;
     this.verifyAfterGeneration = config?.verifyAfterGeneration ?? false;
     this.cache = config?.cache ? new ProofCache(config.cache) : null;
     this.logger = config?.logger ?? silentLogger;
@@ -151,6 +172,11 @@ export class ProofEngine implements ProofGenerator {
         'endpoint is set but prover backend kind is not "remote" — endpoint will be ignored',
       );
     }
+    if (this.unsafeAllowUnpinnedPrivateProofs) {
+      this.logger.warn(
+        "unsafeAllowUnpinnedPrivateProofs=true disables methodId/router pinning and should only be used for local development",
+      );
+    }
   }
 
   /**
@@ -161,6 +187,8 @@ export class ProofEngine implements ProofGenerator {
    */
   async generate(inputs: ProofInputs): Promise<EngineProofResult> {
     this._totalRequests++;
+    const proverBackendConfig = this.requireProverBackendConfig();
+    this.requirePinnedPrivateProofConfig();
 
     // Check cache
     if (this.cache) {
@@ -177,14 +205,9 @@ export class ProofEngine implements ProofGenerator {
 
     // Generate proof via SDK
     const startTime = Date.now();
-    if (!this.proverBackendConfig) {
-      throw new ProofGenerationError(
-        "ProofEngine requires an explicit proverBackend configuration (local-binary or remote)",
-      );
-    }
     let sdkResult;
     try {
-      const sdkProverConfig = buildSdkProverConfig(this.proverBackendConfig);
+      const sdkProverConfig = buildSdkProverConfig(proverBackendConfig);
       sdkResult = await sdkGenerateProof(
         {
           taskPda: inputs.taskPda,
@@ -298,16 +321,49 @@ export class ProofEngine implements ProofGenerator {
     };
   }
 
-  private isRouterPinned(): boolean {
-    if (!this.routerConfig) {
-      return false;
+  private requireProverBackendConfig(): ProverBackendConfig {
+    if (!this.proverBackendConfig) {
+      throw new ProofGenerationError(
+        "ProofEngine requires an explicit proverBackend configuration (local-binary or remote)",
+      );
     }
-    return Boolean(
-      this.routerConfig.routerProgramId &&
-      this.routerConfig.routerPda &&
-      this.routerConfig.verifierEntryPda &&
-      this.routerConfig.verifierProgramId,
+    return this.proverBackendConfig;
+  }
+
+  private requirePinnedPrivateProofConfig(): void {
+    if (this.unsafeAllowUnpinnedPrivateProofs) {
+      return;
+    }
+
+    const missingFields = [
+      ...(this.methodId ? [] : ["methodId"]),
+      ...this.getMissingRouterConfigFields(),
+    ];
+    if (missingFields.length === 0) {
+      return;
+    }
+
+    throw new ProofGenerationError(
+      `Private proof generation requires pinned methodId and complete routerConfig; missing ${missingFields.join(", ")}. Set unsafeAllowUnpinnedPrivateProofs=true only for local development.`,
     );
+  }
+
+  private getMissingRouterConfigFields(): string[] {
+    if (!this.routerConfig) {
+      return ROUTER_CONFIG_FIELDS.map((field) => `routerConfig.${field}`);
+    }
+
+    const missingFields: string[] = [];
+    for (const field of ROUTER_CONFIG_FIELDS) {
+      if (!this.routerConfig[field]) {
+        missingFields.push(`routerConfig.${field}`);
+      }
+    }
+    return missingFields;
+  }
+
+  private isRouterPinned(): boolean {
+    return this.getMissingRouterConfigFields().length === 0;
   }
 
   /**

--- a/runtime/src/proof/types.ts
+++ b/runtime/src/proof/types.ts
@@ -62,12 +62,19 @@ export interface ProofCacheConfig {
  * Configuration for the ProofEngine.
  */
 export interface ProofEngineConfig {
-  /** Optional pinned RISC0 method id (image id, 32 bytes) */
+  /** Pinned RISC0 method id (image id, 32 bytes) for private proof generation */
   methodId?: Uint8Array;
-  /** Optional trusted router/verifier account config */
+  /** Trusted router/verifier account config for private proof generation */
   routerConfig?: RouterConfig;
   /** Optional prover backend config */
   proverBackend?: ProverBackendConfig;
+  /**
+   * Allow private proof generation without pinned method/router config.
+   *
+   * SECURITY: Development-only escape hatch. Production private proving should
+   * fail closed unless methodId and routerConfig are both pinned.
+   */
+  unsafeAllowUnpinnedPrivateProofs?: boolean;
   /** Whether to verify proofs after generation. Default: false */
   verifyAfterGeneration?: boolean;
   /** Cache configuration. Omit to disable caching. */


### PR DESCRIPTION
## Summary
- fail closed in `ProofEngine.generate()` unless private proof generation has a pinned `methodId` and complete `routerConfig`
- add an explicit `unsafeAllowUnpinnedPrivateProofs` escape hatch for local development and warn when it is enabled
- cover pinned, unpinned, partial-router, and unsafe-override flows in `engine.test.ts`, and document the minimal pinned config in `docs/RUNTIME_API.md`

Closes #1382

## Testing
- `npm --prefix runtime run test -- src/proof/engine.test.ts`
- `npm --prefix runtime run typecheck`
