### PR TITLE
fix(web): preserve composer focus and scroll state

### DIFF
--- a/.claude/notes/gotchas.md
+++ b/.claude/notes/gotchas.md
@@ -124,3 +124,7 @@
 - Keep provider-native search heuristics narrow. Broad words like `current` or `recent` will route `web_search` into normal shell/status turns and trigger provider 400s or unnecessary search costs.
 - Treat terminal open and terminal close as separate routed intents. Reusing a cached "open terminal" cluster for "close the terminal" causes the model to loop on `desktop.window_list` instead of using direct tools like `mcp.kitty.close`.
 - If `mcp.kitty.launch` / `mcp.kitty.close` is available, prompt and routing should prefer those direct tools over GUI-guessing fallbacks. Use `desktop.window_focus` + `desktop.keyboard_key` only when the direct close path is unavailable.
+
+## Web Vitest Invocation Gotcha (2026-03-06)
+
+- Run web package tests from `web/` or explicitly pass `--config web/vitest.config.ts`. Invoking `vitest` from the repo root skips the package `jsdom` config and produces false `document is not defined` / `Element is not defined` failures in React component tests.

--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -53,3 +53,10 @@
 - **What worked:** The runtime now suppresses xAI `web_search` on unsupported Grok models instead of trusting a config flag, narrows research routing so generic `current` turns stop triggering provider search, and routes terminal close intent toward `mcp.kitty.close` with cache invalidation when users switch from opening to closing a terminal.
 - **What didn't:** Terminal close still depends on the direct kitty tool being present in the session. When it is absent, the fallback remains GUI window focus plus `alt+F4`, so that path still deserves incident coverage.
 - **Rule added to CLAUDE.md:** yes, `Grok Server-Side Tools: Gate provider-native search on actual model support` and `Terminal Routing: Treat open/close as separate intents`
+
+## PR [pending]: web preserve composer focus and respect manual scroll state
+- **Date:** 2026-03-06
+- **Files changed:** `web/src/App.tsx`, `web/src/App.integration.test.tsx`, `web/src/components/chat/ChatInput.tsx`, `web/src/components/chat/MessageList.tsx`, `web/src/components/chat/MessageList.test.tsx`, `web/src/components/activity/ActivityFeedView.tsx`, `web/src/components/activity/ActivityFeedView.test.tsx`, `web/src/components/chat/DesktopPanel.tsx`, `web/src/components/chat/ChatMessage.tsx`, `web/vite.config.ts`
+- **What worked:** The chat composer now keeps focus when the desktop panel auto-opens during voice use, both message and activity feeds stop yanking the user back to the bottom after manual scroll-up, and the markdown/syntax-highlighter vendor code is split out of the main web bundle. The web package tests and build passed from the package directory.
+- **What didn't:** Running Vitest from the repo root produced false DOM-environment failures because it skipped `web/vitest.config.ts`. That is a command-shape gotcha, not a product bug, and it is now documented.
+- **Rule added to CLAUDE.md:** no

--- a/.claude/notes/techdebt-2026-03-06-web-chat-focus-scroll-bundle.md
+++ b/.claude/notes/techdebt-2026-03-06-web-chat-focus-scroll-bundle.md
@@ -1,0 +1,27 @@
+## Tech Debt Report - 2026-03-06
+
+### Critical (Fix Now)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| None | — | — | — |
+
+### High (Fix This Sprint)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| None | — | — | — |
+
+### Medium (Backlog)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| Auto-scroll stickiness logic now exists in both chat and activity feeds | `web/src/components/chat/MessageList.tsx`, `web/src/components/activity/ActivityFeedView.tsx` | Future threshold or scroll-follow changes could drift between the two surfaces | Extract a shared scroll-follow hook if either component changes again |
+| The composer-focus restore helper lives in `App.tsx` rather than a reusable UI utility | `web/src/App.tsx` | If other overlays start auto-opening, focus restoration logic may get copied instead of reused | Extract a small focus-preservation helper if another auto-open/focus case appears |
+
+### Duplications Found
+| Pattern | Locations | Lines | Refactor To |
+|---------|-----------|-------|-------------|
+| Near-identical stick-to-bottom scroll logic | `web/src/components/chat/MessageList.tsx`, `web/src/components/activity/ActivityFeedView.tsx` | component-local scroll handler/effect blocks | Shared `useStickToBottom` hook |
+
+### Summary
+- Total issues: 2
+- Estimated cleanup: 3 files
+- Recommended priority: Extract a shared scroll-follow hook if either feed changes again

--- a/web/src/App.integration.test.tsx
+++ b/web/src/App.integration.test.tsx
@@ -1,11 +1,14 @@
-import { act, render } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WSMessage } from './types';
+import { WS_DESKTOP_LIST } from './constants';
 import App from './App';
 
 let capturedOnMessage: ((msg: WSMessage) => void) | null = null;
 let chatMessages: MockChatViewMessage[] = [];
 let chatIsTyping = false;
+let chatDesktopOpen = false;
+let mockVoiceActive = false;
 
 interface MockChatViewMessage {
   id: string;
@@ -27,7 +30,7 @@ vi.mock('./hooks/useWebSocket', () => ({
 
 vi.mock('./hooks/useVoice', () => ({
   useVoice: () => ({
-    isVoiceActive: false,
+    isVoiceActive: mockVoiceActive,
     isRecording: false,
     isSpeaking: false,
     voiceState: 'inactive',
@@ -44,11 +47,22 @@ vi.mock('./hooks/useVoice', () => ({
 }));
 
 vi.mock('./components/chat/ChatView', () => ({
-  ChatView: ({ messages, isTyping }: { messages: MockChatViewMessage[]; isTyping: boolean }) => {
+  ChatView: ({
+    messages,
+    isTyping,
+    desktopOpen,
+  }: {
+    messages: MockChatViewMessage[];
+    isTyping: boolean;
+    desktopOpen?: boolean;
+  }) => {
     chatMessages = messages;
     chatIsTyping = isTyping;
+    chatDesktopOpen = Boolean(desktopOpen);
     return (
       <div>
+        <textarea data-chat-composer="true" defaultValue="" />
+        <div data-testid="desktop-open">{desktopOpen ? 'open' : 'closed'}</div>
         <div data-testid="chat-messages">{JSON.stringify(messages)}</div>
       </div>
     );
@@ -59,6 +73,12 @@ beforeEach(() => {
   capturedOnMessage = null;
   chatMessages = [];
   chatIsTyping = false;
+  chatDesktopOpen = false;
+  mockVoiceActive = false;
+});
+
+afterEach(() => {
+  cleanup();
 });
 
 describe('App websocket integration', () => {
@@ -184,5 +204,48 @@ describe('App websocket integration', () => {
     expect(
       chatMessages.some((m) => m.content === 'delegated response should suppress'),
     ).toBe(false);
+  });
+
+  it('restores composer focus when a desktop auto-opens while the user is typing', async () => {
+    mockVoiceActive = true;
+    const view = render(<App />);
+
+    const composer = view.container.querySelector('textarea[data-chat-composer="true"]') as HTMLTextAreaElement | null;
+    expect(composer).toBeTruthy();
+    if (!composer) {
+      throw new Error('Expected chat composer textarea');
+    }
+    fireEvent.change(composer, { target: { value: 'typing now' } });
+    composer.focus();
+    composer.setSelectionRange(6, 6);
+
+    expect(document.activeElement).toBe(composer);
+    expect(screen.getByTestId('desktop-open').textContent).toBe('closed');
+
+    act(() => {
+      capturedOnMessage?.({
+        type: WS_DESKTOP_LIST,
+        payload: [
+          {
+            containerId: 'desktop-1',
+            sessionId: 'other-session',
+            status: 'ready',
+            createdAt: 0,
+            lastActivityAt: 0,
+            vncUrl: 'http://desktop.local',
+            uptimeMs: 0,
+          },
+        ],
+      });
+    });
+
+    await waitFor(() => {
+      expect(chatDesktopOpen).toBe(true);
+      expect(screen.getByTestId('desktop-open').textContent).toBe('open');
+      expect(document.activeElement).toBe(composer);
+    });
+
+    expect(composer.selectionStart).toBe(6);
+    expect(composer.selectionEnd).toBe(6);
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,58 @@ import { SettingsView } from './components/settings/SettingsView';
 import { PaymentView } from './components/payment/PaymentView';
 import { DesktopView } from './components/desktop/DesktopView';
 
+const CHAT_COMPOSER_SELECTOR = 'textarea[data-chat-composer="true"]';
+
+interface ComposerFocusSnapshot {
+  element: HTMLTextAreaElement;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+function captureFocusedComposer(): ComposerFocusSnapshot | null {
+  if (typeof document === 'undefined') return null;
+  const active = document.activeElement;
+  if (!(active instanceof HTMLTextAreaElement)) return null;
+  if (active.dataset.chatComposer !== 'true') return null;
+
+  return {
+    element: active,
+    selectionStart: active.selectionStart ?? active.value.length,
+    selectionEnd: active.selectionEnd ?? active.value.length,
+  };
+}
+
+function restoreComposerFocus(snapshot: ComposerFocusSnapshot) {
+  const restore = () => {
+    if (typeof document === 'undefined') return;
+    const active = document.activeElement;
+    const target = document.body.contains(snapshot.element)
+      ? snapshot.element
+      : document.querySelector(CHAT_COMPOSER_SELECTOR);
+    if (!(target instanceof HTMLTextAreaElement)) return;
+
+    const activeIsNeutral =
+      active === null
+      || active === document.body
+      || active === target
+      || active instanceof HTMLIFrameElement;
+
+    if (!activeIsNeutral) return;
+
+    target.focus();
+    const start = Math.min(snapshot.selectionStart, target.value.length);
+    const end = Math.min(snapshot.selectionEnd, target.value.length);
+    target.setSelectionRange(start, end);
+  };
+
+  if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+    window.requestAnimationFrame(() => window.requestAnimationFrame(restore));
+    return;
+  }
+
+  setTimeout(restore, 0);
+}
+
 export default function App() {
   const [currentView, setCurrentView] = useState<ViewId>('chat');
   const [selectedApproval, setSelectedApproval] = useState<ApprovalRequest | null>(null);
@@ -86,7 +138,11 @@ export default function App() {
   // Auto-open desktop panel when a sandbox becomes ready
   useEffect(() => {
     if (sessionDesktopUrl && !prevVncUrl.current) {
+      const focusedComposer = captureFocusedComposer();
       setDesktopPanelOpen(true);
+      if (focusedComposer) {
+        restoreComposerFocus(focusedComposer);
+      }
     }
     prevVncUrl.current = sessionDesktopUrl;
   }, [sessionDesktopUrl]);

--- a/web/src/components/activity/ActivityFeedView.test.tsx
+++ b/web/src/components/activity/ActivityFeedView.test.tsx
@@ -1,0 +1,65 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ActivityFeedView } from './ActivityFeedView';
+import type { ActivityEvent } from '../../types';
+
+describe('ActivityFeedView', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the empty state when there are no events', () => {
+    render(<ActivityFeedView events={[]} onClear={vi.fn()} />);
+
+    expect(screen.getByText('No events yet')).toBeDefined();
+  });
+
+  it('keeps following new events when the user is already near the bottom', () => {
+    const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+    const initialEvents: ActivityEvent[] = [
+      { eventType: 'chat.inbound', data: { description: 'first' }, timestamp: 1 },
+    ];
+    const nextEvents: ActivityEvent[] = [
+      ...initialEvents,
+      { eventType: 'chat.response', data: { description: 'second' }, timestamp: 2 },
+    ];
+
+    const view = render(<ActivityFeedView events={initialEvents} onClear={vi.fn()} />);
+    const container = view.getByTestId('activity-feed-scroll-container');
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(container, 'clientHeight', { configurable: true, value: 300 });
+    Object.defineProperty(container, 'scrollTop', { configurable: true, value: 640 });
+
+    scrollSpy.mockClear();
+    fireEvent.scroll(container);
+    view.rerender(<ActivityFeedView events={nextEvents} onClear={vi.fn()} />);
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not yank the user back down when they have scrolled up', () => {
+    const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+    const initialEvents: ActivityEvent[] = [
+      { eventType: 'chat.inbound', data: { description: 'first' }, timestamp: 1 },
+    ];
+    const nextEvents: ActivityEvent[] = [
+      ...initialEvents,
+      { eventType: 'chat.response', data: { description: 'second' }, timestamp: 2 },
+    ];
+
+    const view = render(<ActivityFeedView events={initialEvents} onClear={vi.fn()} />);
+    const container = view.getByTestId('activity-feed-scroll-container');
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(container, 'clientHeight', { configurable: true, value: 300 });
+    Object.defineProperty(container, 'scrollTop', { configurable: true, value: 120 });
+
+    scrollSpy.mockClear();
+    fireEvent.scroll(container);
+    view.rerender(<ActivityFeedView events={nextEvents} onClear={vi.fn()} />);
+
+    expect(scrollSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/activity/ActivityFeedView.tsx
+++ b/web/src/components/activity/ActivityFeedView.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import type { ActivityEvent } from '../../types';
 import { EventCard } from './EventCard';
+
+const AUTO_SCROLL_THRESHOLD_PX = 96;
 
 interface ActivityFeedViewProps {
   events: ActivityEvent[];
@@ -8,9 +10,24 @@ interface ActivityFeedViewProps {
 }
 
 export function ActivityFeedView({ events, onClear }: ActivityFeedViewProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
+
+  const updateStickToBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    stickToBottomRef.current = distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX;
+  }, []);
 
   useEffect(() => {
+    updateStickToBottom();
+  }, [updateStickToBottom]);
+
+  useEffect(() => {
+    if (!stickToBottomRef.current) return;
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [events]);
 
@@ -48,24 +65,31 @@ export function ActivityFeedView({ events, onClear }: ActivityFeedViewProps) {
       </div>
 
       {/* Events */}
-      <div className="flex-1 overflow-y-auto p-6"><div className="max-w-2xl mx-auto space-y-2">
-        {events.length === 0 ? (
-          <div className="flex flex-col items-center gap-3 py-12">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" className="text-tetsuo-200" strokeWidth="1.5" strokeLinecap="round">
-              <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
-            </svg>
-            <span className="text-sm text-tetsuo-400">No events yet</span>
-            <span className="text-xs text-tetsuo-300">Activity will appear here in real-time</span>
-          </div>
-        ) : (
-          events.map((event, i) => (
-            <div key={i} className="animate-list-item" style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}>
-              <EventCard event={event} />
+      <div
+        ref={scrollContainerRef}
+        data-testid="activity-feed-scroll-container"
+        className="flex-1 overflow-y-auto p-6"
+        onScroll={updateStickToBottom}
+      >
+        <div className="max-w-2xl mx-auto space-y-2">
+          {events.length === 0 ? (
+            <div className="flex flex-col items-center gap-3 py-12">
+              <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" className="text-tetsuo-200" strokeWidth="1.5" strokeLinecap="round">
+                <path d="M22 12h-4l-3 9L9 3l-3 9H2" />
+              </svg>
+              <span className="text-sm text-tetsuo-400">No events yet</span>
+              <span className="text-xs text-tetsuo-300">Activity will appear here in real-time</span>
             </div>
-          ))
-        )}
-        <div ref={endRef} />
-      </div></div>
+          ) : (
+            events.map((event, i) => (
+              <div key={i} className="animate-list-item" style={{ animationDelay: `${Math.min(i, 10) * 30}ms` }}>
+                <EventCard event={event} />
+              </div>
+            ))
+          )}
+          <div ref={endRef} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -213,6 +213,7 @@ export function ChatInput({
           <span className="text-bbs-purple font-bold shrink-0 mt-0.5">{'>'}</span>
           <textarea
             ref={textareaRef}
+            data-chat-composer="true"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={handleKeyDown}

--- a/web/src/components/chat/ChatMessage.tsx
+++ b/web/src/components/chat/ChatMessage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { PrismAsyncLight as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { ChatMessage as ChatMessageType, SubagentTimelineItem, ToolCall } from '../../types';
 import { ToolCallCard } from './ToolCallCard';

--- a/web/src/components/chat/DesktopPanel.tsx
+++ b/web/src/components/chat/DesktopPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const DESKTOP_IFRAME_LOAD_TIMEOUT_MS = 8_000;
 
@@ -9,17 +9,12 @@ interface DesktopPanelProps {
 
 export function DesktopPanel({ vncUrl, onClose }: DesktopPanelProps) {
   const [loading, setLoading] = useState(true);
-  const iframeRef = useRef<HTMLIFrameElement>(null);
 
   const iframeSrc = `${vncUrl}?autoconnect=true&resize=scale&view_only=false&show_dot=true`;
 
   const openFullscreen = useCallback(() => {
     window.open(vncUrl, '_blank', 'noopener');
   }, [vncUrl]);
-
-  const handleContainerClick = useCallback(() => {
-    iframeRef.current?.focus();
-  }, []);
 
   useEffect(() => {
     const timer = setTimeout(() => setLoading(false), DESKTOP_IFRAME_LOAD_TIMEOUT_MS);
@@ -53,18 +48,18 @@ export function DesktopPanel({ vncUrl, onClose }: DesktopPanelProps) {
       </div>
 
       {/* iframe container */}
-      <div className="relative flex-1 min-h-0" onClick={handleContainerClick}>
+      <div className="relative flex-1 min-h-0">
         {loading && (
           <div className="absolute inset-0 z-10 flex items-center justify-center bg-bbs-black pointer-events-none">
             <span className="text-xs text-bbs-gray animate-pulse">Connecting to desktop...</span>
           </div>
         )}
         <iframe
-          ref={iframeRef}
           src={iframeSrc}
           className="w-full h-full border-0"
           onLoad={() => setLoading(false)}
           allow="clipboard-read; clipboard-write"
+          tabIndex={-1}
           title="Desktop Viewer"
         />
       </div>

--- a/web/src/components/chat/MessageList.test.tsx
+++ b/web/src/components/chat/MessageList.test.tsx
@@ -1,9 +1,14 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MessageList } from './MessageList';
 import type { ChatMessage } from '../../types';
 
 describe('MessageList', () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
   it('shows empty state when there are no messages', () => {
     render(<MessageList messages={[]} isTyping={false} />);
 
@@ -31,5 +36,53 @@ describe('MessageList', () => {
 
     expect(screen.getByText('beta')).toBeDefined();
     expect(screen.queryByText('alpha')).toBeNull();
+  });
+
+  it('keeps following the latest messages when the user is already near the bottom', () => {
+    const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+    const initialMessages: ChatMessage[] = [
+      { id: '1', sender: 'user', content: 'alpha', timestamp: 1 },
+    ];
+    const nextMessages: ChatMessage[] = [
+      ...initialMessages,
+      { id: '2', sender: 'agent', content: 'beta', timestamp: 2 },
+    ];
+
+    const view = render(<MessageList messages={initialMessages} isTyping={false} />);
+    const container = view.getByTestId('message-list-scroll-container');
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(container, 'clientHeight', { configurable: true, value: 300 });
+    Object.defineProperty(container, 'scrollTop', { configurable: true, value: 640 });
+
+    scrollSpy.mockClear();
+    fireEvent.scroll(container);
+    view.rerender(<MessageList messages={nextMessages} isTyping={false} />);
+
+    expect(scrollSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not yank the user back to the bottom when they scrolled up', () => {
+    const scrollSpy = vi.spyOn(Element.prototype, 'scrollIntoView').mockImplementation(() => {});
+    const initialMessages: ChatMessage[] = [
+      { id: '1', sender: 'user', content: 'alpha', timestamp: 1 },
+    ];
+    const nextMessages: ChatMessage[] = [
+      ...initialMessages,
+      { id: '2', sender: 'agent', content: 'beta', timestamp: 2 },
+    ];
+
+    const view = render(<MessageList messages={initialMessages} isTyping={false} />);
+    const container = view.getByTestId('message-list-scroll-container');
+
+    Object.defineProperty(container, 'scrollHeight', { configurable: true, value: 1000 });
+    Object.defineProperty(container, 'clientHeight', { configurable: true, value: 300 });
+    Object.defineProperty(container, 'scrollTop', { configurable: true, value: 120 });
+
+    scrollSpy.mockClear();
+    fireEvent.scroll(container);
+    view.rerender(<MessageList messages={nextMessages} isTyping={false} />);
+
+    expect(scrollSpy).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/chat/MessageList.tsx
+++ b/web/src/components/chat/MessageList.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { ChatMessage as ChatMessageType } from '../../types';
 import { ChatMessage } from './ChatMessage';
+
+const AUTO_SCROLL_THRESHOLD_PX = 96;
 
 interface MessageListProps {
   messages: ChatMessageType[];
@@ -10,7 +12,9 @@ interface MessageListProps {
 }
 
 export function MessageList({ messages, isTyping, theme = 'dark', searchQuery = '' }: MessageListProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const endRef = useRef<HTMLDivElement>(null);
+  const stickToBottomRef = useRef(true);
   const query = searchQuery.trim().toLowerCase();
 
   const filtered = useMemo(
@@ -18,12 +22,30 @@ export function MessageList({ messages, isTyping, theme = 'dark', searchQuery = 
     [messages, query],
   );
 
+  const updateStickToBottom = useCallback(() => {
+    const container = scrollContainerRef.current;
+    if (!container) return;
+    const distanceFromBottom =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    stickToBottomRef.current = distanceFromBottom <= AUTO_SCROLL_THRESHOLD_PX;
+  }, []);
+
   useEffect(() => {
-    if (!query) endRef.current?.scrollIntoView({ behavior: 'smooth' });
+    updateStickToBottom();
+  }, [updateStickToBottom]);
+
+  useEffect(() => {
+    if (query || !stickToBottomRef.current) return;
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isTyping, query]);
 
   return (
-    <div className="flex-1 overflow-y-auto px-4 py-4 md:px-6 md:py-6">
+    <div
+      ref={scrollContainerRef}
+      data-testid="message-list-scroll-container"
+      className="flex-1 overflow-y-auto px-4 py-4 md:px-6 md:py-6"
+      onScroll={updateStickToBottom}
+    >
       <div className="space-y-3">
         {filtered.length === 0 && !query && (
           <div className="flex items-center justify-center h-full text-bbs-gray text-xs">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,9 +1,55 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const REACT_VENDOR_MATCHERS = [
+  '/react/',
+  'react-dom',
+  'scheduler',
+];
+
+const MARKDOWN_VENDOR_MATCHERS = [
+  'react-markdown',
+  'remark-',
+  'rehype-',
+  'micromark',
+  'mdast-',
+  'hast-',
+  'unist-',
+  'vfile',
+  'property-information',
+  'html-url-attributes',
+  'space-separated-tokens',
+  'comma-separated-tokens',
+  'style-to-object',
+  'style-to-js',
+  'trim-lines',
+  'bail',
+  'trough',
+  'devlop',
+  'is-plain-obj',
+];
+
+function matchesAny(id: string, matchers: string[]): boolean {
+  return matchers.some((matcher) => id.includes(matcher));
+}
+
+function manualChunks(id: string): string | undefined {
+  if (!id.includes('node_modules')) return undefined;
+  if (matchesAny(id, REACT_VENDOR_MATCHERS)) return 'react-vendor';
+  if (matchesAny(id, MARKDOWN_VENDOR_MATCHERS)) return 'markdown-vendor';
+  return undefined;
+}
+
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 5173,
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks,
+      },
+    },
   },
 });


### PR DESCRIPTION
# Summary
- preserve chat composer focus and cursor position when the desktop panel auto-opens
- stop chat and activity feeds from force-scrolling users back to the bottom after manual scroll-up
- reduce initial web bundle pressure by splitting markdown/react vendor chunks and using async Prism loading

# Changes
- add focus capture/restore in `web/src/App.tsx` and mark the chat composer explicitly in `web/src/components/chat/ChatInput.tsx`
- make message/activity auto-scroll conditional on the user still being near the bottom, with regression tests for both views
- simplify `DesktopPanel`, switch `ChatMessage` to `PrismAsyncLight`, and add manual chunking in `web/vite.config.ts`
- record the scoped tech-debt note and the web-package Vitest invocation gotcha

# Testing
- [x] (from `web/`) `npx vitest run src/App.integration.test.tsx src/components/chat/MessageList.test.tsx src/components/activity/ActivityFeedView.test.tsx`
- [x] (from `web/`) `npm test`
- [x] (from `web/`) `npm run build`
- [ ] `anchor test` (N/A)
- [ ] `cargo fmt --check` (N/A)
- [ ] `cargo clippy` (N/A)
- [ ] `cargo test` (N/A)

# Security / Risk
- [x] PDA seeds/constraints reviewed (if applicable)
- [x] No authority bypass introduced
- [x] Escrow/funds safety considered (if applicable)

# Checklist
- [x] Tests added/updated (or N/A)
- [x] Docs updated (if needed)

# Issue link(s)
- Fixes #1397
