### PR TITLE
docs(security): align audit artifacts with actual review scope

### DIFF
--- a/audit/security-audit-2026-02-19.md
+++ b/audit/security-audit-2026-02-19.md
@@ -284,6 +284,11 @@ RISC Zero integration must be completed before mainnet.
 
 ## Unaudited Modules (Next Pass)
 
+Project-wide security-readiness remains blocked while any externally reachable
+or privilege-bearing surface below is still unaudited. This report should be
+read as a scoped artifact, not as full-product signoff. Use together with
+`docs/SECURITY_SCOPE_MATRIX.md` and `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md`.
+
 - `runtime/src/autonomous/` — risk scoring, arbitration logic
 - `runtime/src/gateway/` — WebSocket control plane, session security
 - `runtime/src/tools/` — bash tool execution security

--- a/docs/MAINNET_DEPLOYMENT.md
+++ b/docs/MAINNET_DEPLOYMENT.md
@@ -68,9 +68,12 @@ Complete all items before proceeding with mainnet deployment:
 
 ### Security Requirements
 - [ ] External security audit complete (see `docs/SECURITY_AUDIT_MAINNET.md`)
+- [ ] `docs/SECURITY_SCOPE_MATRIX.md` reviewed and updated for the release commit
+- [ ] `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` complete for runtime / desktop / webchat surfaces
 - [ ] All Critical severity findings fixed and verified
 - [ ] All High severity findings fixed and verified
 - [ ] Medium/Low findings addressed or documented with accepted risk
+- [ ] Security-owner signoff recorded that no externally reachable surface remains outside the declared audit scope
 
 ### Testing Requirements
 - [ ] All unit tests passing (`anchor test`)

--- a/docs/RUNTIME_PRE_AUDIT_CHECKLIST.md
+++ b/docs/RUNTIME_PRE_AUDIT_CHECKLIST.md
@@ -1,0 +1,70 @@
+# Runtime / Desktop / WebChat Pre-Audit Checklist
+
+Use this checklist before making any project-wide security-readiness claim or
+before handing AgenC to an external auditor as more than an on-chain review.
+
+If any item below is incomplete, the correct status is "scoped review only".
+
+## 1. Scope Declaration
+
+- [ ] The release commit is frozen and recorded.
+- [ ] The declared runtime review scope names the exact modules being reviewed.
+- [ ] Out-of-scope surfaces are listed explicitly.
+- [ ] `docs/SECURITY_SCOPE_MATRIX.md` is updated for the release commit.
+
+Minimum modules to classify before signoff:
+
+- `runtime/src/gateway/`
+- `runtime/src/tools/`
+- `runtime/src/channels/webchat/`
+- `runtime/src/desktop/`
+- `containers/desktop/server/`
+- any exposed browser / desktop control-plane bridge
+
+## 2. Review Coverage
+
+- [ ] Threat modeling covers externally reachable and privilege-bearing runtime
+      surfaces.
+- [ ] Session ownership boundaries are reviewed for create / attach / cancel
+      flows.
+- [ ] Desktop control-plane authentication and published-port assumptions are
+      reviewed.
+- [ ] File-containment and path-normalization behavior is tested directly in
+      the desktop server layer.
+- [ ] Shell and system tool restrictions are reviewed for bypasses, chaining,
+      and command-construction edge cases.
+- [ ] HTTP / browser networking paths are reviewed for SSRF, redirect abuse,
+      and local-network reachability.
+- [ ] Tool routing, approvals, and privileged fallbacks are reviewed for scope
+      drift.
+
+## 3. Findings Gate
+
+- [ ] No open Critical findings remain in the declared runtime scope.
+- [ ] No open High findings remain in the declared runtime scope.
+- [ ] Medium findings are either fixed or documented with named acceptance.
+- [ ] Scoped documents do not claim project-wide readiness while any surface is
+      still unaudited.
+
+## 4. Operational Gate
+
+- [ ] Published ports, auth requirements, and CORS / origin assumptions are
+      documented.
+- [ ] Every externally reachable surface has a named owner.
+- [ ] No externally reachable or privilege-bearing surface remains outside the
+      declared audit scope without explicit signoff.
+- [ ] Blocking issues are listed in the release record.
+
+## 5. Security Owner Signoff
+
+Record before any project-wide readiness statement:
+
+- Security owner:
+- Release owner:
+- Release commit:
+- Date:
+- Open exceptions:
+- Signoff statement:
+  - "I confirm that the declared review scope matches the externally reachable
+    AgenC surfaces for this milestone, and that any remaining exclusions are
+    explicitly documented."

--- a/docs/SECURITY_AUDIT_DEVNET.md
+++ b/docs/SECURITY_AUDIT_DEVNET.md
@@ -1,16 +1,39 @@
-# Devnet Security Audit Package
+# Devnet On-Chain Security Package
 
 ## Executive Summary
 
-This document provides an audit-ready security package for the AgenC Solana coordination program deployed to Solana Devnet. The scope includes the on-chain program, its Devnet deployment, and the smoke test validation run. No Critical, High, Medium, or Low findings were identified in this package; informational notes are listed where applicable.
+This document provides a scoped security package for the AgenC Solana
+coordination program deployed to Solana Devnet. The scope includes only the
+on-chain program, its Devnet deployment, and the smoke test validation run.
+
+This document does not cover runtime gateway security, desktop sandbox control
+plane security, webchat/session security, MCP tool authorization, or frontend
+surfaces. See `docs/SECURITY_SCOPE_MATRIX.md` and
+`docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` for the cross-surface scope boundary.
+
+No Critical, High, Medium, or Low findings were identified within this
+declared on-chain scope; informational notes are listed where applicable.
 
 ## Scope
+
+### In Scope
 
 - Program: `programs/agenc-coordination`
 - Cluster: Solana Devnet
 - Commit: `c53771ddbb4097f45c08fe339a924bb348c33aab`
 - Program ID: `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 - Anchor Version: `0.32.1`
+
+### Explicitly Out of Scope
+
+- `runtime/src/gateway/`
+- `runtime/src/tools/`
+- `runtime/src/channels/webchat/`
+- `runtime/src/desktop/`
+- `containers/desktop/`
+- `mcp/src/tools/`
+- `web/`
+- `demo-app/`
 
 ## Threat Model
 
@@ -84,4 +107,9 @@ The protocol invariants below are enforced by program constraints and are used f
 
 ## Conclusion
 
-The Devnet deployment is stable under the current scope and threat model. The smoke test suite exercises core lifecycle paths without identifying logic errors; remaining failures are limited to Devnet funding rate limits. This package is suitable as an audit-ready Devnet security artifact.
+The Devnet deployment is stable under the current on-chain scope and threat
+model. The smoke test suite exercises core lifecycle paths without identifying
+logic errors; remaining failures are limited to Devnet funding rate limits.
+
+This package is suitable as a scoped Devnet / on-chain security artifact. It
+is not a project-wide security-readiness statement for AgenC.

--- a/docs/SECURITY_AUDIT_MAINNET.md
+++ b/docs/SECURITY_AUDIT_MAINNET.md
@@ -5,6 +5,17 @@
 **Program ID:** `5j9ZbT3mnPX5QjWVMrDaWFuaGf8ddji6LW1HVJw6kUE7`
 **Framework:** Anchor (Solana)
 
+## Scope Boundary
+
+This RFP covers the on-chain coordination program. It is not, by itself, a
+project-wide security-readiness statement for AgenC runtime, desktop, webchat,
+MCP, or frontend surfaces.
+
+Use this document together with:
+
+- `docs/SECURITY_SCOPE_MATRIX.md`
+- `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md`
+
 ## 1. Audit Scope
 
 ### 1.1 Instructions
@@ -232,13 +243,17 @@ Before engaging auditors, complete the following:
 - [ ] Known issues documented (if any)
 - [ ] Deployment configuration finalized (devnet/mainnet parameters)
 - [ ] Access credentials prepared for auditor communication channel
+- [ ] `docs/SECURITY_SCOPE_MATRIX.md` updated for the release commit
+- [ ] `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` completed for runtime, desktop, webchat, and tool surfaces
+- [ ] No open Critical or High findings remain on externally reachable runtime / desktop / webchat surfaces
+- [ ] Security-owner signoff recorded that no externally reachable surface remains outside the declared audit scope
 
 ## 7. Contact and Submission
 
 **Project:** AgenC Coordination Protocol
 **Repository:** [Provide repository URL]
 **Primary Contact:** [Provide contact email]
-**Expected Audit Start:** [TBD after pre-audit checklist complete]
+**Expected Audit Start:** [TBD after pre-audit checklist complete and security-owner signoff is recorded]
 
 ---
 

--- a/docs/SECURITY_SCOPE_MATRIX.md
+++ b/docs/SECURITY_SCOPE_MATRIX.md
@@ -1,0 +1,44 @@
+# Security Review Scope Matrix
+
+This matrix prevents scoped audit artifacts from being read as project-wide
+security signoff. Every security package, audit report, and readiness claim
+must map to a specific surface and evidence set.
+
+If a surface below is not marked reviewed, the correct claim is "scoped
+review only", not "AgenC is audit-ready" or "the product is fully
+security-reviewed".
+
+## Current Scope Status
+
+| Surface | Reachability / Privilege | Current Review Status | Evidence | Project-wide readiness claim allowed? |
+| --- | --- | --- | --- | --- |
+| On-chain coordination program | Escrow, reward distribution, dispute resolution, protocol authority | Scoped review completed for current Devnet / on-chain package | `docs/SECURITY_AUDIT_DEVNET.md`, `audit/security-audit-2026-02-19.md` | No, on-chain only |
+| Runtime gateway and session control | WebSocket control plane, session ownership, tool routing | Not fully reviewed in a completed security package | `audit/security-audit-2026-02-19.md` (`Unaudited Modules`), `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` | No |
+| Runtime system tools | Shell, HTTP, browser, file editing, network reachability | Partially hardened, not fully reviewed in a completed security package | `audit/security-audit-2026-02-19.md` (`Unaudited Modules`), runtime issue / PR history | No |
+| Desktop sandbox control plane | Desktop REST bridge, VNC/noVNC exposure, sandbox auth, file containment | Review incomplete; open blocker(s) remain | Open issue tracker, `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` | No |
+| WebChat ownership and desktop session binding | Session mapping, desktop attach/create authorization, cancellation semantics | Partially reviewed through targeted fixes, not fully signed off as a surface | Runtime issue / PR history, `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` | No |
+| MCP tools and authorization | Tool exposure, permission boundaries, external capability routing | Unaudited in the current package | `audit/security-audit-2026-02-19.md` (`Unaudited Modules`) | No |
+| Web frontend and demo surfaces | Browser UI, demo app, human-facing web surfaces | Unaudited in the current package | `audit/security-audit-2026-02-19.md` (`Unaudited Modules`) | No |
+
+## Allowed Claims
+
+- Allowed: "The Solana coordination program has no findings within the current
+  Devnet / on-chain review scope."
+- Allowed: "This artifact covers the on-chain program only."
+- Not allowed: "AgenC is audit-ready" unless every externally reachable or
+  privilege-bearing surface in this matrix is either reviewed or explicitly
+  signed off as deferred risk for the stated milestone.
+- Not allowed: reusing an on-chain-only artifact as evidence that runtime,
+  desktop, webchat, MCP, or frontend surfaces are security-reviewed.
+
+## Release Gate
+
+Before any project-wide security-readiness claim, release note, or auditor
+handoff:
+
+- Update this matrix for the intended release commit.
+- List any remaining out-of-scope surfaces explicitly.
+- Confirm the runtime / desktop / webchat checklist in
+  `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` is complete.
+- Record the blocking issues or accepted exceptions.
+- Obtain named security-owner signoff.

--- a/docs/audit/AUDIT_ROADMAP.md
+++ b/docs/audit/AUDIT_ROADMAP.md
@@ -1,10 +1,18 @@
 # SOLANA AUDIT ROADMAP
 
-This document defines the pre audit and pre hardening roadmap for the AgenC Solana on chain coordination program. This is the phase where development pauses and the protocol is treated as critical infrastructure.
+This document defines the pre audit and pre hardening roadmap for the AgenC
+Solana on chain coordination program. This is the phase where development
+pauses and the protocol is treated as critical infrastructure.
+
+This roadmap applies only to the on-chain coordination program. It does not
+establish project-wide security readiness for runtime, desktop, webchat, MCP,
+or frontend surfaces. Track those separately in `docs/SECURITY_SCOPE_MATRIX.md`
+and `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md`.
 
 This program is the trust layer for AgenC. It holds funds in escrow, distributes rewards, resolves disputes, and tracks agent reputation and stake. A single vulnerability at this layer would compromise funds and permanently damage trust in the system.
 
-The goal of this roadmap is to make the program correct, predictable, and audit ready before mainnet deployment or SDK integration.
+The goal of this roadmap is to make the program correct, predictable, and
+ready for an on-chain audit before mainnet deployment or SDK integration.
 
 
 ## Guiding principle
@@ -88,4 +96,3 @@ These events form the basis for monitoring, analytics, and future SDK integratio
 ## Exit criteria
 
 This roadmap phase is complete when all tests pass, all invariants are enforced, static analysis is clean, and any external audit feedback is resolved. Only after this point should SDK integration or new feature development resume.
-


### PR DESCRIPTION
## Summary

Closes #1380.

This PR removes the misleading project-wide readiness signal from the current security package and replaces it with explicit scope and gate documents.

What changed:
- rewrites `docs/SECURITY_AUDIT_DEVNET.md` as a scoped on-chain / Devnet artifact instead of a broad "audit-ready" package
- adds `docs/SECURITY_SCOPE_MATRIX.md` to separate on-chain, runtime, desktop, webchat, MCP, and frontend review status
- adds `docs/RUNTIME_PRE_AUDIT_CHECKLIST.md` as the dedicated runtime / desktop / webchat pre-audit gate
- updates `docs/SECURITY_AUDIT_MAINNET.md`, `docs/MAINNET_DEPLOYMENT.md`, `audit/security-audit-2026-02-19.md`, and `docs/audit/AUDIT_ROADMAP.md` to link the new scope controls and require blocker/signoff rules before any project-wide readiness claim

## Why

The repo already had scoped on-chain audit artifacts, but the wording and layout could still be read as if AgenC as a whole had been security-reviewed. That was no longer defensible once runtime / desktop issues were found outside the reviewed scope.

This PR does not claim those runtime surfaces are now audited. It makes the opposite explicit:
- scoped artifacts stay scoped
- project-wide readiness requires cross-surface scope review
- unresolved runtime / desktop blockers prevent broader readiness claims

## Testing

- `git diff --check`
- `rg -n "audit-ready|audit ready" docs audit`

## Notes

The remaining `audit-ready` wording is now only used inside `docs/SECURITY_SCOPE_MATRIX.md` as an example of a disallowed claim.
