### PR TITLE
feat(runtime): add durable background task runtime

### DIFF
--- a/.claude/notes/gotchas.md
+++ b/.claude/notes/gotchas.md
@@ -172,3 +172,35 @@
 
 - Doom MCP `start_game` defaults are not safe for user-facing launch prompts: omitted args fall back to headless, HUD-off, `RES_320X240`. Normalize `mcp.doom.start_game` in the runtime so visible launches force a real window, HUD, and a sane resolution before the call leaves the executor.
 - Explicit "stop Doom" webchat requests should be runtime-owned, not model-owned. The model will often reach for `desktop.process_stop`, `kill`, or `sudo pkill`, but the game is owned by the Doom MCP. For webchat, short-circuit those requests to `mcp.doom.stop_game` directly.
+
+## Durable Webchat Session Recovery Gotchas (2026-03-06)
+
+- WebSocket `clientId` is not a durable session identity. If webchat resume/list behavior needs to survive reconnects or daemon restarts, the browser must supply a stable client-owned key and the runtime must persist session ownership/index metadata against that key.
+- Rebinding a resumed webchat session to the socket is not sufficient on its own. After daemon restart, the foreground `SessionManager` history must be rehydrated from persisted memory before the next user turn, or the model will answer from a blank local session despite the runtime having durable thread history.
+- Runtime-owned background updates should still advance durable session metadata even while no browser socket is attached. Otherwise recovered background work continues in memory, but `chat.sessions` / `chat.resume` metadata lags behind the real task progress after restart.
+
+## Durable Background Run Context Gotchas (2026-03-06)
+
+- Restart durability alone is not enough for a real supervisor loop. If active runs only keep a rolling `slice(-N)` transcript, long-lived work will still lose the operator’s intent and verified state even though the run itself survives.
+- Treat follow-up user messages during an active background run as runtime signals, not as an automatic cancel-and-replace. Cancelling on every operator intervention collapses the task runtime back into a bounded chat model.
+- Carry-forward state must stay compact and explicit: summary, verified facts, open loops, and next focus. Dumping raw prior history back into the actor prompt defeats the point of durable supervision and recreates long-context drift.
+
+## Background Run Signal-Tail Gotchas (2026-03-06)
+
+- Do not flip a background run from `running` to `working` until the cycle tail is actually done. If the state changes early, a late signal can schedule overlapping cycles or skip the current cycle's deterministic completion path.
+- Carry-forward compaction must only consume the signal snapshot it actually summarized. Clearing the whole `pendingSignals` array drops late-arriving process/operator events and forces a timer fallback even when the runtime already has decisive evidence.
+- If a fresh external signal is still pending at the end of a working cycle, do not publish the stale working update first. Re-wake immediately on the pending signal or finish deterministically from the verified runtime event.
+
+## Background Run Control Plane Gotchas (2026-03-06)
+
+- Bare session-control messages like `status`, `stop`, `pause`, and `resume` must be runtime-owned. Do not let them fall through to the model when the session is in or near a background-run workflow, or the model will reinterpret them as general tool-use prompts and do something unrelated.
+- Keep a persisted recent-run snapshot per session even after terminal completion. Without that, runtime-owned `status` after completion regresses to `No active run` with no operator context, and bare control messages lose the last known task state after the active in-memory run is deleted.
+- `pause` is not `stop`. Treating `pause` as a stop-regex alias silently destroys durable work instead of preserving it for later resume.
+- Queued operator instructions while paused should stay queued but must not wake the run until an explicit resume. Otherwise paused state is only cosmetic and the runtime keeps acting behind the operator’s back.
+
+## Desktop Restart Recovery Gotchas (2026-03-07)
+
+- A durable background supervisor is not actually durable if daemon restart destroys the tool environment it depends on. For desktop-managed processes, `DesktopSandboxManager.stop()` must preserve live containers and `start()` must recover them from Docker inspect data instead of blindly deleting every labeled container as an “orphan.”
+- Recovered desktop sandboxes need more than a container ID. The runtime must rebuild session mapping, auth token, port bindings, resolution, and resource metadata before follow-up `desktop.process_status` calls can reattach to the same workload.
+- Live websocket resume tests must use a stable `clientKey`. `chat.resume` is owner-scoped by design, so reconnect tests with a throwaway websocket client and no durable client key will fail even if the runtime recovery path is correct.
+- Once outbound messages are persisted to history/session metadata before socket delivery, “no client mapping” during daemon restart is expected. Keep that path at debug level; warn-level logs turn normal reconnect windows into incident noise.

--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -1,3 +1,24 @@
+## PR [pending]: durable task runtime operator-signal and carry-forward hardening
+- **Date:** 2026-03-06
+- **Files changed:** `runtime/src/gateway/background-run-store.ts`, `runtime/src/gateway/background-run-store.test.ts`, `runtime/src/gateway/background-run-supervisor.ts`, `runtime/src/gateway/background-run-supervisor.test.ts`, `runtime/src/gateway/daemon.ts`, `runtime/src/utils/keyed-async-queue.ts`, `runtime/src/utils/keyed-async-queue.test.ts`, `.claude/notes/gotchas.md`, `.claude/notes/pr-log.md`, `.claude/notes/techdebt-2026-03-06-durable-task-runtime-phase3.md`
+- **What worked:** Active background runs now accept persisted operator signals instead of being cancelled by every follow-up user message, and the supervisor carries a compact durable state snapshot across cycles so long-running work no longer depends only on a short rolling transcript. The focused unit suite passed, and a live websocket smoke confirmed a real daemon session queued a follow-up instruction into the active run instead of tearing it down.
+- **What didn't:** The current operator-signal routing is session-exclusive while a background run is active. That is correct for task-runtime semantics, but it means foreground unrelated questions in the same session now need an explicit pause/new-session story instead of piggybacking on the old cancel-and-replace behavior.
+- **Rule added to CLAUDE.md:** no
+
+## PR [pending]: background run control-plane hardening
+- **Date:** 2026-03-06
+- **Files changed:** `runtime/src/gateway/background-run-control.ts`, `runtime/src/gateway/background-run-control.test.ts`, `runtime/src/gateway/background-run-store.ts`, `runtime/src/gateway/background-run-store.test.ts`, `runtime/src/gateway/background-run-supervisor.ts`, `runtime/src/gateway/background-run-supervisor.test.ts`, `runtime/src/gateway/daemon.ts`, `.claude/notes/gotchas.md`, `.claude/notes/pr-log.md`, `.claude/notes/techdebt-2026-03-06-background-run-control-plane.md`
+- **What worked:** Session-level `status` and `stop` are now runtime-owned even after a run completes, because the supervisor persists a recent-run snapshot per session. The runtime also has real `pause`/`resume` semantics now, including queued operator instructions that remain queued while paused and resume cleanly later. Focused tests passed, and live websocket probes verified active control, terminal-status lookup, running-state recovery across daemon restart, and paused-state recovery across daemon restart.
+- **What didn't:** The control plane still lives in a large webchat branch inside `runtime/src/gateway/daemon.ts`, and `BackgroundRunSupervisor.executeCycle()` is still the dominant hot path. Both are correct, but they are the next extraction targets if the supervisor keeps growing.
+- **Rule added to CLAUDE.md:** no
+
+## PR [pending]: durable task runtime session recovery hardening
+- **Date:** 2026-03-06
+- **Files changed:** `runtime/src/gateway/background-run-store.ts`, `runtime/src/gateway/background-run-store.test.ts`, `runtime/src/gateway/background-run-supervisor.ts`, `runtime/src/gateway/background-run-supervisor.test.ts`, `runtime/src/gateway/daemon.ts`, `runtime/src/gateway/session.ts`, `runtime/src/channels/webchat/plugin.ts`, `runtime/src/channels/webchat/plugin.test.ts`, `runtime/src/channels/webchat/session-store.ts`, `runtime/src/channels/webchat/session-store.test.ts`, `runtime/src/channels/webchat/types.ts`, `web/src/hooks/useChat.ts`, `web/src/hooks/useChat.test.ts`
+- **What worked:** Background runs now persist/recover across daemon restarts, the web client can rediscover/resume prior sessions with a stable browser key, resumed foreground sessions rehydrate recent context from memory, and `until_stopped` runs are no longer forced to fail because of generic runtime/cycle caps.
+- **What didn't:** The new durable session store and the existing background run store both carry near-identical keyed async write-serialization logic. That duplication is acceptable for this phase, but it should be extracted before another durable store is added.
+- **Rule added to CLAUDE.md:** no
+
 ## PR [pending]: desktop doom image contract hardening
 - **Date:** 2026-03-06
 - **Files changed:** `containers/desktop/Dockerfile`, `containers/desktop/install-secure-path-launchers.sh`, `containers/desktop/secure-path-launchers.txt`, `scripts/check-desktop-image-hardening.mjs`, `scripts/check-desktop-image-hardening.test.mjs`, `scripts/smoke-desktop-doom-image.mjs`, `package.json`, `.github/workflows/ci.yml`, `README.md`, `docs/security/mcp-security-stack.md`, `.claude/notes/gotchas.md`, `.claude/notes/pr-log.md`, `.claude/notes/techdebt-2026-03-06-doom-desktop-image-regression.md`
@@ -101,4 +122,18 @@
 - **Files changed:** `runtime/src/llm/chat-executor-tool-utils.ts`, `runtime/src/llm/chat-executor-tool-utils.test.ts`, `runtime/src/gateway/tool-handler-factory.ts`, `runtime/src/gateway/tool-handler-factory.test.ts`, `runtime/src/llm/chat-executor-recovery.ts`, `runtime/src/llm/chat-executor-recovery.test.ts`, `runtime/src/gateway/tool-routing.ts`, `runtime/src/gateway/tool-routing.test.ts`, `runtime/src/gateway/doom-stop-guard.ts`, `runtime/src/gateway/doom-stop-guard.test.ts`, `runtime/src/gateway/daemon.ts`
 - **What worked:** Minimal Doom launch prompts now normalize to a visible HUD-on `1280x720` window, duplicate same-turn `mcp.doom.start_game` calls are blocked, and explicit webchat stop requests bypass model improvisation and call `mcp.doom.stop_game` directly. Live websocket smoke confirmed both the rewritten launch args and the deterministic stop path.
 - **What didn't:** The deterministic Doom stop flow currently duplicates some of the normal webchat final-response/session-memory bookkeeping in `daemon.ts`. If more runtime-owned fast paths are added, extract that shared response path instead of cloning it again.
+- **Rule added to CLAUDE.md:** no
+
+## PR [pending]: runtime background-run signal-tail hardening
+- **Date:** 2026-03-06
+- **Files changed:** `runtime/src/gateway/background-run-supervisor.ts`, `runtime/src/gateway/background-run-supervisor.test.ts`
+- **What worked:** Late process and external signals no longer get lost in the cycle tail. The supervisor now keeps the cycle `running` until tail work finishes, preserves only the consumed signal snapshot during carry-forward compaction, suppresses stale working updates when fresh signals are pending, and completes on verified `process_exit` without falling into a second timer-driven cycle. Focused runtime tests and a live websocket smoke against the daemon both passed.
+- **What didn't:** `executeCycle()` is still a very large hot-path method, and deterministic terminal completion still relies on regex/classifier heuristics rather than typed tool-domain completion contracts.
+- **Rule added to CLAUDE.md:** no
+
+## PR [pending]: runtime desktop restart recovery for durable background runs
+- **Date:** 2026-03-07
+- **Files changed:** `runtime/src/desktop/manager.ts`, `runtime/src/desktop/manager.test.ts`, `runtime/src/channels/webchat/plugin.ts`, `runtime/src/gateway/daemon.ts`
+- **What worked:** Desktop sandboxes now survive daemon restart and reattach from Docker inspect data, so managed-process background runs can recover the same container and continue native `desktop.process_status` verification instead of probing a fresh empty sandbox. Live websocket restart recovery passed end to end with a real `/bin/sleep` managed process, and the completion update was still persisted to session history while the client was disconnected.
+- **What didn't:** Sandbox preservation is now runtime-safe, but daemon shutdown still preserves every tracked desktop container. That is correct for restart durability, but it needs a future operator mode split if we want a clean distinction between “restart/suspend” and “fully tear down desktops.”
 - **Rule added to CLAUDE.md:** no

--- a/containers/desktop/server/dist/server.js
+++ b/containers/desktop/server/dist/server.js
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import { TOOL_DEFINITIONS, executeTool } from "./tools.js";
+import { TOOL_DEFINITIONS, executeTool, subscribeDesktopToolEvents, } from "./tools.js";
 import { isAuthorizedRequest, resolveAllowedOrigin } from "./auth.js";
 function json(res, status, data) {
     const body = JSON.stringify(data);
@@ -76,6 +76,39 @@ function handleToolsListRequest(req, res, path) {
     json(res, 200, TOOL_DEFINITIONS);
     return true;
 }
+function writeSseEvent(res, event) {
+    res.write(`event: ${event.type}\n`);
+    res.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+function handleEventStreamRequest(req, res, path) {
+    if (req.method !== "GET" || path !== "/events") {
+        return false;
+    }
+    res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+    });
+    res.write(": connected\n\n");
+    const unsubscribe = subscribeDesktopToolEvents((event) => {
+        if (!res.destroyed && !res.writableEnded) {
+            writeSseEvent(res, event);
+        }
+    });
+    const heartbeat = setInterval(() => {
+        if (!res.destroyed && !res.writableEnded) {
+            res.write(": ping\n\n");
+        }
+    }, 15_000);
+    const cleanup = () => {
+        clearInterval(heartbeat);
+        unsubscribe();
+    };
+    req.on("close", cleanup);
+    req.on("aborted", cleanup);
+    res.on("close", cleanup);
+    return true;
+}
 function extractToolName(path) {
     const match = /^\/tools\/([a-z_]+)$/.exec(path);
     return match?.[1];
@@ -132,6 +165,9 @@ async function handleRequest(req, res, authToken, startTime) {
         return;
     }
     if (handleHealthRequest(req, res, path, startTime)) {
+        return;
+    }
+    if (handleEventStreamRequest(req, res, path)) {
         return;
     }
     if (handleToolsListRequest(req, res, path)) {

--- a/containers/desktop/server/dist/server.test.js
+++ b/containers/desktop/server/dist/server.test.js
@@ -62,3 +62,47 @@ test("rejects non-loopback CORS preflight requests", async () => {
         assert.equal(res.status, 403);
     });
 });
+test("streams managed process exit events over /events", async () => {
+    await withServer(async (baseUrl) => {
+        const eventsResponse = await fetch(`${baseUrl}/events`, {
+            headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+        });
+        assert.equal(eventsResponse.status, 200);
+        assert.equal(eventsResponse.headers.get("content-type"), "text/event-stream");
+        assert.ok(eventsResponse.body, "expected event stream body");
+        const reader = eventsResponse.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        const eventPromise = (async () => {
+            while (true) {
+                const { value, done } = await reader.read();
+                if (done) {
+                    throw new Error("event stream ended before managed process exit");
+                }
+                buffer += decoder.decode(value, { stream: true });
+                const dataMatch = buffer.match(/event:\s+managed_process\.exited[\s\S]*?data:\s+(\{.*\})\n\n/);
+                if (dataMatch?.[1]) {
+                    return JSON.parse(dataMatch[1]);
+                }
+            }
+        })();
+        const startResponse = await fetch(`${baseUrl}/tools/process_start`, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${AUTH_TOKEN}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                command: "/bin/sleep",
+                args: ["1"],
+                label: "event-stream-test",
+            }),
+        });
+        assert.equal(startResponse.status, 200);
+        const event = await eventPromise;
+        assert.equal(event.type, "managed_process.exited");
+        assert.equal(event.payload.state, "exited");
+        assert.match(String(event.payload.processId ?? ""), /^proc_/);
+        await reader.cancel();
+    });
+});

--- a/containers/desktop/server/dist/tools.js
+++ b/containers/desktop/server/dist/tools.js
@@ -61,6 +61,23 @@ const CHROMIUM_DETERMINISTIC_FLAGS = [
 let managedProcessesLoaded = false;
 const managedProcesses = new Map();
 let managedProcessRegistryPersistChain = Promise.resolve();
+const desktopToolEventListeners = new Set();
+export function subscribeDesktopToolEvents(listener) {
+    desktopToolEventListeners.add(listener);
+    return () => {
+        desktopToolEventListeners.delete(listener);
+    };
+}
+function emitDesktopToolEvent(event) {
+    for (const listener of [...desktopToolEventListeners]) {
+        try {
+            listener(event);
+        }
+        catch (error) {
+            warnBestEffort("desktop tool event listener failed", error);
+        }
+    }
+}
 function exec(cmd, args, timeoutMs = EXEC_TIMEOUT_MS) {
     return new Promise((resolve, reject) => {
         execFile(cmd, args, {
@@ -489,14 +506,40 @@ async function finalizeManagedProcessExit(processId, exitCode, signal) {
     const record = managedProcesses.get(processId);
     if (!record)
         return;
-    managedProcesses.set(processId, {
+    if (record.state === "exited" && typeof record.endedAt === "number") {
+        return;
+    }
+    const exitedRecord = {
         ...record,
         state: "exited",
         endedAt: record.endedAt ?? Date.now(),
         exitCode,
         signal,
-    });
+    };
+    managedProcesses.set(processId, exitedRecord);
     await persistManagedProcessRegistry();
+    emitDesktopToolEvent({
+        type: "managed_process.exited",
+        timestamp: exitedRecord.endedAt ?? Date.now(),
+        payload: {
+            processId: exitedRecord.processId,
+            ...(exitedRecord.label ? { label: exitedRecord.label } : {}),
+            pid: exitedRecord.pid,
+            pgid: exitedRecord.pgid,
+            state: exitedRecord.state,
+            startedAt: exitedRecord.startedAt,
+            ...(typeof exitedRecord.endedAt === "number"
+                ? { endedAt: exitedRecord.endedAt }
+                : {}),
+            ...(exitedRecord.exitCode !== undefined
+                ? { exitCode: exitedRecord.exitCode }
+                : {}),
+            ...(exitedRecord.signal !== undefined
+                ? { signal: exitedRecord.signal }
+                : {}),
+            logPath: exitedRecord.logPath,
+        },
+    });
 }
 function buildManagedProcessResponse(record, recentOutput, extra) {
     return {

--- a/containers/desktop/server/src/server.test.ts
+++ b/containers/desktop/server/src/server.test.ts
@@ -78,3 +78,57 @@ test("rejects non-loopback CORS preflight requests", async () => {
     assert.equal(res.status, 403);
   });
 });
+
+test("streams managed process exit events over /events", async () => {
+  await withServer(async (baseUrl) => {
+    const eventsResponse = await fetch(`${baseUrl}/events`, {
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}` },
+    });
+    assert.equal(eventsResponse.status, 200);
+    assert.equal(eventsResponse.headers.get("content-type"), "text/event-stream");
+    assert.ok(eventsResponse.body, "expected event stream body");
+
+    const reader = eventsResponse.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    const eventPromise = (async () => {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) {
+          throw new Error("event stream ended before managed process exit");
+        }
+        buffer += decoder.decode(value, { stream: true });
+        const dataMatch = buffer.match(
+          /event:\s+managed_process\.exited[\s\S]*?data:\s+(\{.*\})\n\n/,
+        );
+        if (dataMatch?.[1]) {
+          return JSON.parse(dataMatch[1]) as {
+            type: string;
+            payload: { processId?: string; state?: string };
+          };
+        }
+      }
+    })();
+
+    const startResponse = await fetch(`${baseUrl}/tools/process_start`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        command: "/bin/sleep",
+        args: ["1"],
+        label: "event-stream-test",
+      }),
+    });
+    assert.equal(startResponse.status, 200);
+
+    const event = await eventPromise;
+    assert.equal(event.type, "managed_process.exited");
+    assert.equal(event.payload.state, "exited");
+    assert.match(String(event.payload.processId ?? ""), /^proc_/);
+
+    await reader.cancel();
+  });
+});

--- a/containers/desktop/server/src/server.ts
+++ b/containers/desktop/server/src/server.ts
@@ -1,5 +1,10 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
-import { TOOL_DEFINITIONS, executeTool } from "./tools.js";
+import {
+  TOOL_DEFINITIONS,
+  executeTool,
+  subscribeDesktopToolEvents,
+  type DesktopToolEvent,
+} from "./tools.js";
 import type { HealthResponse } from "./types.js";
 import { isAuthorizedRequest, resolveAllowedOrigin } from "./auth.js";
 
@@ -108,6 +113,51 @@ function handleToolsListRequest(
   return true;
 }
 
+function writeSseEvent(res: ServerResponse, event: DesktopToolEvent): void {
+  res.write(`event: ${event.type}\n`);
+  res.write(`data: ${JSON.stringify(event)}\n\n`);
+}
+
+function handleEventStreamRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  path: string,
+): boolean {
+  if (req.method !== "GET" || path !== "/events") {
+    return false;
+  }
+
+  res.writeHead(200, {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache, no-transform",
+    Connection: "keep-alive",
+  });
+  res.write(": connected\n\n");
+
+  const unsubscribe = subscribeDesktopToolEvents((event) => {
+    if (!res.destroyed && !res.writableEnded) {
+      writeSseEvent(res, event);
+    }
+  });
+
+  const heartbeat = setInterval(() => {
+    if (!res.destroyed && !res.writableEnded) {
+      res.write(": ping\n\n");
+    }
+  }, 15_000);
+
+  const cleanup = (): void => {
+    clearInterval(heartbeat);
+    unsubscribe();
+  };
+
+  req.on("close", cleanup);
+  req.on("aborted", cleanup);
+  res.on("close", cleanup);
+
+  return true;
+}
+
 function extractToolName(path: string): string | undefined {
   const match = /^\/tools\/([a-z_]+)$/.exec(path);
   return match?.[1];
@@ -183,6 +233,10 @@ async function handleRequest(
   }
 
   if (handleHealthRequest(req, res, path, startTime)) {
+    return;
+  }
+
+  if (handleEventStreamRequest(req, res, path)) {
     return;
   }
 

--- a/containers/desktop/server/src/tools.ts
+++ b/containers/desktop/server/src/tools.ts
@@ -99,9 +99,48 @@ interface ManagedProcessRecord {
   envKeys?: string[];
 }
 
+export interface DesktopToolEvent {
+  readonly type: "managed_process.exited";
+  readonly timestamp: number;
+  readonly payload: {
+    readonly processId: string;
+    readonly label?: string;
+    readonly pid: number;
+    readonly pgid: number;
+    readonly state: ManagedProcessState;
+    readonly startedAt: number;
+    readonly endedAt?: number;
+    readonly exitCode?: number | null;
+    readonly signal?: string | null;
+    readonly logPath: string;
+  };
+}
+
+type DesktopToolEventListener = (event: DesktopToolEvent) => void;
+
 let managedProcessesLoaded = false;
 const managedProcesses = new Map<string, ManagedProcessRecord>();
 let managedProcessRegistryPersistChain: Promise<void> = Promise.resolve();
+const desktopToolEventListeners = new Set<DesktopToolEventListener>();
+
+export function subscribeDesktopToolEvents(
+  listener: DesktopToolEventListener,
+): () => void {
+  desktopToolEventListeners.add(listener);
+  return () => {
+    desktopToolEventListeners.delete(listener);
+  };
+}
+
+function emitDesktopToolEvent(event: DesktopToolEvent): void {
+  for (const listener of [...desktopToolEventListeners]) {
+    try {
+      listener(event);
+    } catch (error) {
+      warnBestEffort("desktop tool event listener failed", error);
+    }
+  }
+}
 
 function exec(
   cmd: string,
@@ -628,14 +667,40 @@ async function finalizeManagedProcessExit(
   await ensureManagedProcessRegistryLoaded();
   const record = managedProcesses.get(processId);
   if (!record) return;
-  managedProcesses.set(processId, {
+  if (record.state === "exited" && typeof record.endedAt === "number") {
+    return;
+  }
+  const exitedRecord: ManagedProcessRecord = {
     ...record,
     state: "exited",
     endedAt: record.endedAt ?? Date.now(),
     exitCode,
     signal,
-  });
+  };
+  managedProcesses.set(processId, exitedRecord);
   await persistManagedProcessRegistry();
+  emitDesktopToolEvent({
+    type: "managed_process.exited",
+    timestamp: exitedRecord.endedAt ?? Date.now(),
+    payload: {
+      processId: exitedRecord.processId,
+      ...(exitedRecord.label ? { label: exitedRecord.label } : {}),
+      pid: exitedRecord.pid,
+      pgid: exitedRecord.pgid,
+      state: exitedRecord.state,
+      startedAt: exitedRecord.startedAt,
+      ...(typeof exitedRecord.endedAt === "number"
+        ? { endedAt: exitedRecord.endedAt }
+        : {}),
+      ...(exitedRecord.exitCode !== undefined
+        ? { exitCode: exitedRecord.exitCode }
+        : {}),
+      ...(exitedRecord.signal !== undefined
+        ? { signal: exitedRecord.signal }
+        : {}),
+      logPath: exitedRecord.logPath,
+    },
+  });
 }
 
 function buildManagedProcessResponse(

--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -11,6 +11,7 @@ import type { WebChatDeps } from "./types.js";
 import type { ChannelContext } from "../../gateway/channel.js";
 import type { ControlMessage, ControlResponse } from "../../gateway/types.js";
 import { silentLogger } from "../../utils/logger.js";
+import { InMemoryBackend } from "../../memory/in-memory/backend.js";
 
 // ============================================================================
 // Test helpers
@@ -498,6 +499,7 @@ describe("WebChatChannel", () => {
         msg("chat.history", { limit: 10 }, "req-2"),
         send,
       );
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       // Find the history response
       const historyCall = send.mock.calls.find(
@@ -529,7 +531,7 @@ describe("WebChatChannel", () => {
       );
     });
 
-    it("should reject unknown session", () => {
+    it("should reject unknown session", async () => {
       const send = vi.fn<(response: ControlResponse) => void>();
 
       channel.handleMessage(
@@ -538,13 +540,14 @@ describe("WebChatChannel", () => {
         msg("chat.resume", { sessionId: "nonexistent" }),
         send,
       );
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(send).toHaveBeenCalledWith(
         expect.objectContaining({ type: "error" }),
       );
     });
 
-    it("should resume an existing session by same client", () => {
+    it("should resume an existing session by same client", async () => {
       const send1 = vi.fn<(response: ControlResponse) => void>();
 
       // Client 1 creates a session with a message
@@ -566,6 +569,7 @@ describe("WebChatChannel", () => {
         msg("chat.resume", { sessionId }, "req-3"),
         send2,
       );
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       const resumeCall = send2.mock.calls.find(
         (call) =>
@@ -578,7 +582,7 @@ describe("WebChatChannel", () => {
       );
     });
 
-    it("should reject resume from different client (session hijacking prevention)", () => {
+    it("should reject resume from different client (session hijacking prevention)", async () => {
       const send1 = vi.fn<(response: ControlResponse) => void>();
 
       // Client 1 creates a session
@@ -600,14 +604,113 @@ describe("WebChatChannel", () => {
         msg("chat.resume", { sessionId }, "req-3"),
         send2,
       );
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       const errorCall = send2.mock.calls.find(
         (call) => (call[0] as ControlResponse).error !== undefined,
       );
       expect(errorCall).toBeDefined();
-      expect((errorCall![0] as ControlResponse).error).toContain(
-        "Not authorized",
+      expect((errorCall![0] as ControlResponse).error).toContain("Session");
+    });
+
+    it("lists and resumes durable sessions across plugin restart with a stable client key", async () => {
+      const memoryBackend = new InMemoryBackend();
+      const send1 = vi.fn<(response: ControlResponse) => void>();
+      deps = createDeps({ memoryBackend });
+      context = createContext();
+      channel = new WebChatChannel(deps);
+      await channel.initialize(context);
+      await channel.start();
+
+      channel.handleMessage(
+        "client_1",
+        "chat.message",
+        msg("chat.message", { content: "Hello", clientKey: "browser-1" }),
+        send1,
       );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const gatewayMsg = vi.mocked(context.onMessage).mock.calls[0][0];
+      const sessionId = gatewayMsg.sessionId;
+      await memoryBackend.addEntry({
+        sessionId,
+        role: "user",
+        content: "Hello",
+      });
+      await memoryBackend.addEntry({
+        sessionId,
+        role: "assistant",
+        content: "I am still working.",
+      });
+
+      await channel.stop();
+
+      const hydrateSessionContext = vi.fn().mockResolvedValue(undefined);
+      const send2 = vi.fn<(response: ControlResponse) => void>();
+      const channel2 = new WebChatChannel(
+        createDeps({ memoryBackend, hydrateSessionContext }),
+      );
+      const context2 = createContext();
+      await channel2.initialize(context2);
+      await channel2.start();
+
+      channel2.handleMessage(
+        "client_2",
+        "chat.sessions",
+        msg("chat.sessions", { clientKey: "browser-1" }, "req-sessions"),
+        send2,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const sessionsCall = send2.mock.calls.find(
+        (call) => (call[0] as ControlResponse).type === "chat.sessions",
+      );
+      expect(sessionsCall).toBeDefined();
+      expect((sessionsCall![0] as ControlResponse).payload).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ sessionId, messageCount: 1 }),
+        ]),
+      );
+
+      channel2.handleMessage(
+        "client_2",
+        "chat.resume",
+        msg(
+          "chat.resume",
+          { sessionId, clientKey: "browser-1" },
+          "req-resume",
+        ),
+        send2,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(hydrateSessionContext).toHaveBeenCalledWith(sessionId);
+      const resumedCall = send2.mock.calls.find(
+        (call) => (call[0] as ControlResponse).type === "chat.resumed",
+      );
+      expect(resumedCall).toBeDefined();
+
+      channel2.handleMessage(
+        "client_2",
+        "chat.history",
+        msg("chat.history", { clientKey: "browser-1" }, "req-history"),
+        send2,
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const historyCall = send2.mock.calls.find(
+        (call) =>
+          (call[0] as ControlResponse).type === "chat.history" &&
+          (call[0] as ControlResponse).id === "req-history",
+      );
+      expect(historyCall).toBeDefined();
+      expect((historyCall![0] as ControlResponse).payload).toEqual([
+        expect.objectContaining({ content: "Hello", sender: "user" }),
+        expect.objectContaining({
+          content: "I am still working.",
+          sender: "agent",
+        }),
+      ]);
     });
   });
 

--- a/runtime/src/channels/webchat/plugin.ts
+++ b/runtime/src/channels/webchat/plugin.ts
@@ -29,6 +29,7 @@ import { HANDLER_MAP } from "./handlers.js";
 import type { SendFn } from "./handlers.js";
 import type { HandlerRequestContext } from "./handlers.js";
 import { matchesEventFilters } from "./protocol.js";
+import { WebChatSessionStore } from "./session-store.js";
 
 const MESSAGE_ID_TTL_MS = 5 * 60_000;
 const MAX_TRACKED_MESSAGE_IDS = 5_000;
@@ -60,9 +61,11 @@ export class WebChatChannel
   private readonly clientSessions = new Map<string, string>();
   // sessionId → clientId reverse mapping (for send())
   private readonly sessionClients = new Map<string, string>();
+  // clientId → durable browser owner key, when provided by the web client
+  private readonly clientOwnerKeys = new Map<string, string>();
   // clientId → send function (for pushing messages to specific clients)
   private readonly clientSenders = new Map<string, SendFn>();
-  // Security: sessionId → creator clientId (prevents session hijacking)
+  // Security: sessionId → durable owner key (or volatile client fallback)
   private readonly sessionOwners = new Map<string, string>();
   // sessionId → chat history for resume support
   private readonly sessionHistory = new Map<
@@ -75,12 +78,16 @@ export class WebChatChannel
   private readonly sessionAbortControllers = new Map<string, AbortController>();
   // Dedup replayed chat.message envelopes (e.g. reconnect flush/retry)
   private readonly seenMessageIds = new Map<string, number>();
+  private readonly sessionStore?: WebChatSessionStore;
 
   private healthy = true;
 
   constructor(deps: WebChatDeps, _config?: WebChatChannelConfig) {
     super();
     this.deps = deps;
+    this.sessionStore = deps.memoryBackend
+      ? new WebChatSessionStore({ memoryBackend: deps.memoryBackend })
+      : undefined;
   }
 
   /** Create and track an AbortController for a session's in-flight execution. */
@@ -131,6 +138,7 @@ export class WebChatChannel
   override async stop(): Promise<void> {
     this.clientSessions.clear();
     this.sessionClients.clear();
+    this.clientOwnerKeys.clear();
     this.clientSenders.clear();
     this.sessionOwners.clear();
     this.sessionHistory.clear();
@@ -165,22 +173,6 @@ export class WebChatChannel
   // --------------------------------------------------------------------------
 
   override async send(message: OutboundMessage): Promise<void> {
-    const clientId = this.sessionClients.get(message.sessionId);
-    if (!clientId) {
-      this.context.logger.warn?.(
-        `WebChat: no client mapping for session "${message.sessionId}"`,
-      );
-      return;
-    }
-
-    const sendFn = this.clientSenders.get(clientId);
-    if (!sendFn) {
-      this.context.logger.warn?.(
-        `WebChat: no send function for client "${clientId}"`,
-      );
-      return;
-    }
-
     const timestamp = Date.now();
 
     // Store in history for resume
@@ -189,6 +181,27 @@ export class WebChatChannel
       sender: "agent",
       timestamp,
     });
+    await this.persistSessionActivity(message.sessionId, {
+      content: message.content,
+      sender: "agent",
+      timestamp,
+    });
+
+    const clientId = this.sessionClients.get(message.sessionId);
+    if (!clientId) {
+      this.context.logger.debug?.(
+        `WebChat: no client mapping for session "${message.sessionId}"`,
+      );
+      return;
+    }
+
+    const sendFn = this.clientSenders.get(clientId);
+    if (!sendFn) {
+      this.context.logger.debug?.(
+        `WebChat: no send function for client "${clientId}"`,
+      );
+      return;
+    }
 
     sendFn({
       type: "chat.message",
@@ -215,6 +228,7 @@ export class WebChatChannel
 
     const id = typeof msg.id === "string" ? msg.id : undefined;
     let payload = msg.payload as Record<string, unknown> | undefined;
+    this.captureClientOwnerKey(clientId, payload);
 
     // Voice messages are routed to the voice bridge
     if (type.startsWith("voice.")) {
@@ -256,7 +270,7 @@ export class WebChatChannel
     }
 
     if (type === "chat.new") {
-      this.handleChatNew(clientId, id, send);
+      this.handleChatNew(clientId, payload, id, send);
       return;
     }
 
@@ -271,7 +285,7 @@ export class WebChatChannel
     }
 
     if (type === "chat.sessions") {
-      this.handleChatSessions(clientId, id, send);
+      this.handleChatSessions(clientId, payload, id, send);
       return;
     }
 
@@ -284,7 +298,10 @@ export class WebChatChannel
         typeof normalizedPayload.sessionId !== "string" ||
         normalizedPayload.sessionId.length === 0
       ) {
-        const sessionId = this.ensureSession(clientId);
+        const sessionId = this.ensureSession(
+          clientId,
+          this.currentOwnerKey(clientId),
+        );
         normalizedPayload.sessionId = sessionId;
         send({ type: "chat.session", payload: { sessionId } });
       }
@@ -299,7 +316,7 @@ export class WebChatChannel
         activeSessionId: this.clientSessions.get(clientId),
         listOwnedSessionIds: () => this.listOwnedSessionIds(clientId),
         isSessionOwned: (sessionId: string) =>
-          this.sessionOwners.get(sessionId) === clientId,
+          this.sessionOwners.get(sessionId) === this.currentOwnerKey(clientId),
       };
       const result = handler(this.deps, payload, id, send, requestContext);
       if (result instanceof Promise) {
@@ -345,7 +362,10 @@ export class WebChatChannel
     switch (type) {
       case "voice.start": {
         // Pass the client's current sessionId so voice and text share history
-        const voiceSessionId = this.ensureSession(clientId);
+        const voiceSessionId = this.ensureSession(
+          clientId,
+          this.currentOwnerKey(clientId),
+        );
         void bridge.startSession(clientId, send, voiceSessionId).catch((error) => {
           this.context.logger?.warn?.("Failed to start voice session:", error);
           send({
@@ -425,8 +445,9 @@ export class WebChatChannel
       return;
     }
 
-    // Ensure session mapping
-    const sessionId = this.ensureSession(clientId);
+    const ownerKey = this.resolveOwnerKey(clientId, payload);
+    const timestamp = Date.now();
+    const sessionId = this.ensureSession(clientId, ownerKey);
 
     // Notify the client of its session ID (needed for desktop viewer matching)
     send({ type: 'chat.session', payload: { sessionId } });
@@ -435,7 +456,12 @@ export class WebChatChannel
     this.appendHistory(sessionId, {
       content: content as string,
       sender: "user",
-      timestamp: Date.now(),
+      timestamp,
+    });
+    void this.persistSessionActivity(sessionId, {
+      content: content as string,
+      sender: "user",
+      timestamp,
     });
 
     // Convert base64 attachments from the WebSocket payload to MessageAttachment[]
@@ -500,6 +526,7 @@ export class WebChatChannel
 
   private handleChatNew(
     clientId: string,
+    payload: Record<string, unknown> | undefined,
     id: string | undefined,
     send: SendFn,
   ): void {
@@ -515,7 +542,8 @@ export class WebChatChannel
       );
     }
 
-    const sessionId = this.ensureSession(clientId, { forceNew: true });
+    const ownerKey = this.resolveOwnerKey(clientId, payload);
+    const sessionId = this.ensureSession(clientId, ownerKey, { forceNew: true });
     send({ type: "chat.session", payload: { sessionId }, id });
     send({ type: "chat.history", payload: [], id });
   }
@@ -526,17 +554,13 @@ export class WebChatChannel
     id: string | undefined,
     send: SendFn,
   ): void {
-    const sessionId = this.clientSessions.get(clientId);
-    if (!sessionId) {
-      send({ type: "chat.history", payload: [], id });
-      return;
-    }
-
-    const limit = typeof payload?.limit === "number" ? payload.limit : 50;
-    const history = this.sessionHistory.get(sessionId) ?? [];
-    const messages = history.slice(-limit);
-
-    send({ type: "chat.history", payload: messages, id });
+    void this.handleChatHistoryAsync(clientId, payload, id, send).catch((error) => {
+      send({
+        type: "error",
+        error: `Failed to load chat history: ${(error as Error).message}`,
+        id,
+      });
+    });
   }
 
   private handleChatResume(
@@ -545,15 +569,77 @@ export class WebChatChannel
     id: string | undefined,
     send: SendFn,
   ): void {
-    const targetSessionId = (payload as Record<string, unknown> | undefined)
-      ?.sessionId;
+    void this.handleChatResumeAsync(clientId, payload, id, send).catch((error) => {
+      send({
+        type: "error",
+        error: `Failed to resume chat session: ${(error as Error).message}`,
+        id,
+      });
+    });
+  }
+
+  private handleChatSessions(
+    clientId: string,
+    payload: Record<string, unknown> | undefined,
+    id: string | undefined,
+    send: SendFn,
+  ): void {
+    void this.handleChatSessionsAsync(clientId, payload, id, send).catch((error) => {
+      send({
+        type: "error",
+        error: `Failed to list chat sessions: ${(error as Error).message}`,
+        id,
+      });
+    });
+  }
+
+  private async handleChatHistoryAsync(
+    clientId: string,
+    payload: Record<string, unknown> | undefined,
+    id: string | undefined,
+    send: SendFn,
+  ): Promise<void> {
+    const sessionId = this.clientSessions.get(clientId);
+    if (!sessionId) {
+      send({ type: "chat.history", payload: [], id });
+      return;
+    }
+
+    const ownerKey = this.resolveOwnerKey(clientId, payload);
+    const authorized = await this.isAuthorizedSession(
+      sessionId,
+      ownerKey,
+      clientId,
+    );
+    if (!authorized) {
+      send({ type: "error", error: "Not authorized to access this session", id });
+      return;
+    }
+
+    const limit = typeof payload?.limit === "number" ? payload.limit : 50;
+    const history = await this.loadSessionHistory(sessionId, limit);
+    send({ type: "chat.history", payload: history, id });
+  }
+
+  private async handleChatResumeAsync(
+    clientId: string,
+    payload: Record<string, unknown> | undefined,
+    id: string | undefined,
+    send: SendFn,
+  ): Promise<void> {
+    const targetSessionId = payload?.sessionId;
     if (!targetSessionId || typeof targetSessionId !== "string") {
       send({ type: "error", error: "Missing sessionId in chat.resume", id });
       return;
     }
 
-    const history = this.sessionHistory.get(targetSessionId);
-    if (!history) {
+    const ownerKey = this.resolveOwnerKey(clientId, payload);
+    const authorized = await this.isAuthorizedSession(
+      targetSessionId,
+      ownerKey,
+      clientId,
+    );
+    if (!authorized) {
       send({
         type: "error",
         error: `Session "${targetSessionId}" not found`,
@@ -562,27 +648,17 @@ export class WebChatChannel
       return;
     }
 
-    // Security: Verify session ownership to prevent session hijacking.
-    // Only the client that created a session can resume it.
-    const owner = this.sessionOwners.get(targetSessionId);
-    if (owner && owner !== clientId) {
-      send({
-        type: "error",
-        error: "Not authorized to resume this session",
-        id,
-      });
-      return;
-    }
-
-    // Remove old mapping if exists
     const oldSession = this.clientSessions.get(clientId);
     if (oldSession) {
       this.sessionClients.delete(oldSession);
     }
 
-    // Map client to the resumed session
     this.clientSessions.set(clientId, targetSessionId);
     this.sessionClients.set(targetSessionId, clientId);
+    this.sessionOwners.set(targetSessionId, ownerKey);
+
+    await Promise.resolve(this.deps.hydrateSessionContext?.(targetSessionId));
+    const history = await this.loadSessionHistory(targetSessionId);
 
     send({
       type: "chat.resumed",
@@ -594,11 +670,31 @@ export class WebChatChannel
     });
   }
 
-  private handleChatSessions(
+  private async handleChatSessionsAsync(
     clientId: string,
+    payload: Record<string, unknown> | undefined,
     id: string | undefined,
     send: SendFn,
-  ): void {
+  ): Promise<void> {
+    const ownerKey = this.resolveOwnerKey(clientId, payload);
+    if (this.sessionStore && this.isDurableOwnerKey(ownerKey)) {
+      const persistedSessions = await this.sessionStore.listSessionsForOwner(ownerKey);
+      const sessions = persistedSessions
+        .filter((session) => session.messageCount > 0)
+        .map((session) => {
+          this.sessionOwners.set(session.sessionId, session.ownerKey);
+          return {
+            sessionId: session.sessionId,
+            label: session.label,
+            messageCount: session.messageCount,
+            lastActiveAt: session.lastActiveAt,
+          };
+        })
+        .sort((a, b) => b.lastActiveAt - a.lastActiveAt);
+      send({ type: "chat.sessions", payload: sessions, id });
+      return;
+    }
+
     const sessions: Array<{
       sessionId: string;
       label: string;
@@ -610,7 +706,7 @@ export class WebChatChannel
       if (history.length === 0) continue;
       // Security: Only show sessions owned by this client
       const owner = this.sessionOwners.get(sessionId);
-      if (owner && owner !== clientId) continue;
+      if (owner && owner !== ownerKey) continue;
       const firstUserMsg = history.find((m) => m.sender === "user");
       const label = firstUserMsg
         ? firstUserMsg.content.slice(0, 80)
@@ -719,6 +815,7 @@ export class WebChatChannel
 
   private ensureSession(
     clientId: string,
+    ownerKey: string,
     options?: { forceNew?: boolean },
   ): string {
     const existing = this.clientSessions.get(clientId);
@@ -743,9 +840,9 @@ export class WebChatChannel
 
     this.clientSessions.set(clientId, sessionId);
     this.sessionClients.set(sessionId, clientId);
-    // Track session creator for ownership verification on resume
-    if (!this.sessionOwners.has(sessionId)) {
-      this.sessionOwners.set(sessionId, clientId);
+    this.sessionOwners.set(sessionId, ownerKey);
+    if (this.isDurableOwnerKey(ownerKey)) {
+      void this.sessionStore?.ensureSession({ sessionId, ownerKey });
     }
 
     return sessionId;
@@ -788,12 +885,108 @@ export class WebChatChannel
 
   private listOwnedSessionIds(clientId: string): string[] {
     const owned: string[] = [];
+    const ownerKey = this.currentOwnerKey(clientId);
     for (const [sessionId, ownerId] of this.sessionOwners) {
-      if (ownerId === clientId) {
+      if (ownerId === ownerKey) {
         owned.push(sessionId);
       }
     }
     return owned;
+  }
+
+  private captureClientOwnerKey(
+    clientId: string,
+    payload: Record<string, unknown> | undefined,
+  ): void {
+    const clientKey =
+      typeof payload?.clientKey === "string" ? payload.clientKey.trim() : "";
+    if (clientKey.length === 0) return;
+    this.clientOwnerKeys.set(clientId, `web:${clientKey}`);
+  }
+
+  private currentOwnerKey(clientId: string): string {
+    return this.clientOwnerKeys.get(clientId) ?? `volatile:${clientId}`;
+  }
+
+  private resolveOwnerKey(
+    clientId: string,
+    payload: Record<string, unknown> | undefined,
+  ): string {
+    this.captureClientOwnerKey(clientId, payload);
+    return this.currentOwnerKey(clientId);
+  }
+
+  private isDurableOwnerKey(ownerKey: string): boolean {
+    return !ownerKey.startsWith("volatile:");
+  }
+
+  private async persistSessionActivity(
+    sessionId: string,
+    entry: { content: string; sender: "user" | "agent"; timestamp: number },
+  ): Promise<void> {
+    if (!this.sessionStore) {
+      return;
+    }
+    const ownerKey =
+      this.sessionOwners.get(sessionId) ??
+      (await this.sessionStore.loadSession(sessionId))?.ownerKey;
+    if (!ownerKey || !this.isDurableOwnerKey(ownerKey)) {
+      return;
+    }
+    this.sessionOwners.set(sessionId, ownerKey);
+    try {
+      await this.sessionStore.recordActivity({
+        sessionId,
+        ownerKey,
+        sender: entry.sender,
+        content: entry.content,
+        timestamp: entry.timestamp,
+      });
+    } catch (error) {
+      this.context.logger.debug("Failed to persist webchat session activity", {
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  private async isAuthorizedSession(
+    sessionId: string,
+    ownerKey: string,
+    clientId: string,
+  ): Promise<boolean> {
+    const cachedOwner = this.sessionOwners.get(sessionId);
+    if (cachedOwner) {
+      return cachedOwner === ownerKey || cachedOwner === `volatile:${clientId}`;
+    }
+    const persisted = await this.sessionStore?.loadSession(sessionId);
+    if (!persisted) {
+      return this.sessionHistory.has(sessionId);
+    }
+    this.sessionOwners.set(sessionId, persisted.ownerKey);
+    return persisted.ownerKey === ownerKey;
+  }
+
+  private async loadSessionHistory(
+    sessionId: string,
+    limit?: number,
+  ): Promise<Array<{ content: string; sender: "user" | "agent"; timestamp: number }>> {
+    if (this.deps.memoryBackend) {
+      const entries = await this.deps.memoryBackend.getThread(sessionId, limit);
+      const history = entries
+        .filter((entry) => entry.role === "user" || entry.role === "assistant")
+        .map((entry): { content: string; sender: "user" | "agent"; timestamp: number } => ({
+          content: entry.content,
+          sender: entry.role === "assistant" ? "agent" : "user",
+          timestamp: entry.timestamp,
+        }));
+      if (history.length > 0) {
+        this.sessionHistory.set(sessionId, history);
+        return history;
+      }
+    }
+    const history = this.sessionHistory.get(sessionId) ?? [];
+    return typeof limit === "number" && limit > 0 ? history.slice(-limit) : history;
   }
 
   // --------------------------------------------------------------------------
@@ -819,6 +1012,7 @@ export class WebChatChannel
       // Note: we keep sessionHistory for resume support
     }
     this.clientSessions.delete(clientId);
+    this.clientOwnerKeys.delete(clientId);
     this.clientSenders.delete(clientId);
   }
 }

--- a/runtime/src/channels/webchat/session-store.test.ts
+++ b/runtime/src/channels/webchat/session-store.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryBackend } from "../../memory/in-memory/backend.js";
+import { WebChatSessionStore } from "./session-store.js";
+
+describe("WebChatSessionStore", () => {
+  it("creates a durable session record and indexes it by owner", async () => {
+    const backend = new InMemoryBackend();
+    const store = new WebChatSessionStore({ memoryBackend: backend });
+
+    await store.ensureSession({
+      sessionId: "session-1",
+      ownerKey: "web:browser-1",
+      createdAt: 100,
+    });
+
+    expect(await store.loadSession("session-1")).toMatchObject({
+      sessionId: "session-1",
+      ownerKey: "web:browser-1",
+      label: "New conversation",
+      messageCount: 0,
+    });
+    expect(await store.listSessionsForOwner("web:browser-1")).toHaveLength(1);
+  });
+
+  it("tracks label, activity time, and message count across user/agent turns", async () => {
+    const backend = new InMemoryBackend();
+    const store = new WebChatSessionStore({ memoryBackend: backend });
+
+    await store.recordActivity({
+      sessionId: "session-2",
+      ownerKey: "web:browser-2",
+      sender: "user",
+      content: "Check the deployment logs for errors",
+      timestamp: 200,
+    });
+    await store.recordActivity({
+      sessionId: "session-2",
+      ownerKey: "web:browser-2",
+      sender: "agent",
+      content: "Still checking in the background.",
+      timestamp: 250,
+    });
+
+    expect(await store.loadSession("session-2")).toMatchObject({
+      label: "Check the deployment logs for errors",
+      messageCount: 2,
+      lastActiveAt: 250,
+    });
+  });
+});

--- a/runtime/src/channels/webchat/session-store.ts
+++ b/runtime/src/channels/webchat/session-store.ts
@@ -1,0 +1,198 @@
+import { createHash } from "node:crypto";
+import type { MemoryBackend } from "../../memory/types.js";
+import type { Logger } from "../../utils/logger.js";
+import { silentLogger } from "../../utils/logger.js";
+import { KeyedAsyncQueue } from "../../utils/keyed-async-queue.js";
+
+const WEBCHAT_SESSION_KEY_PREFIX = "webchat:session:";
+const WEBCHAT_OWNER_INDEX_KEY_PREFIX = "webchat:owner:";
+
+export interface PersistedWebChatSession {
+  readonly version: 1;
+  readonly sessionId: string;
+  readonly ownerKey: string;
+  readonly label: string;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly lastActiveAt: number;
+  readonly messageCount: number;
+}
+
+export interface WebChatSessionStoreConfig {
+  readonly memoryBackend: MemoryBackend;
+  readonly logger?: Logger;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function sessionKey(sessionId: string): string {
+  return `${WEBCHAT_SESSION_KEY_PREFIX}${sessionId}`;
+}
+
+function ownerIndexKey(ownerKey: string): string {
+  const ownerHash = createHash("sha256").update(ownerKey).digest("hex");
+  return `${WEBCHAT_OWNER_INDEX_KEY_PREFIX}${ownerHash}`;
+}
+
+function coerceSession(value: unknown): PersistedWebChatSession | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  if (
+    raw.version !== 1 ||
+    typeof raw.sessionId !== "string" ||
+    typeof raw.ownerKey !== "string" ||
+    typeof raw.label !== "string" ||
+    typeof raw.createdAt !== "number" ||
+    typeof raw.updatedAt !== "number" ||
+    typeof raw.lastActiveAt !== "number" ||
+    typeof raw.messageCount !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    sessionId: raw.sessionId,
+    ownerKey: raw.ownerKey,
+    label: raw.label,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+    lastActiveAt: raw.lastActiveAt,
+    messageCount: raw.messageCount,
+  };
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function buildLabel(
+  current: PersistedWebChatSession | undefined,
+  sender: "user" | "agent",
+  content: string,
+): string {
+  if (current && current.label.trim().length > 0) {
+    return current.label;
+  }
+  if (sender !== "user") {
+    return "New conversation";
+  }
+  const compact = content.replace(/\s+/g, " ").trim();
+  return compact.length > 0 ? compact.slice(0, 80) : "New conversation";
+}
+
+export class WebChatSessionStore {
+  private readonly memoryBackend: MemoryBackend;
+  private readonly logger: Logger;
+  private readonly queue: KeyedAsyncQueue;
+
+  constructor(config: WebChatSessionStoreConfig) {
+    this.memoryBackend = config.memoryBackend;
+    this.logger = config.logger ?? silentLogger;
+    this.queue = new KeyedAsyncQueue({
+      logger: this.logger,
+      label: "WebChat session store",
+    });
+  }
+
+  async loadSession(
+    sessionId: string,
+  ): Promise<PersistedWebChatSession | undefined> {
+    const value = await this.memoryBackend.get(sessionKey(sessionId));
+    return coerceSession(value);
+  }
+
+  async ensureSession(params: {
+    sessionId: string;
+    ownerKey: string;
+    createdAt?: number;
+  }): Promise<PersistedWebChatSession> {
+    const createdAt = params.createdAt ?? Date.now();
+    return this.queue.run(params.sessionId, async () => {
+      const existing = await this.loadSession(params.sessionId);
+      if (existing) {
+        if (existing.ownerKey !== params.ownerKey) {
+          throw new Error("Session owner mismatch");
+        }
+        return existing;
+      }
+
+      const next: PersistedWebChatSession = {
+        version: 1,
+        sessionId: params.sessionId,
+        ownerKey: params.ownerKey,
+        label: "New conversation",
+        createdAt,
+        updatedAt: createdAt,
+        lastActiveAt: createdAt,
+        messageCount: 0,
+      };
+
+      await this.writeSession(next);
+      await this.addOwnerIndex(params.ownerKey, params.sessionId);
+      return next;
+    });
+  }
+
+  async recordActivity(params: {
+    sessionId: string;
+    ownerKey: string;
+    sender: "user" | "agent";
+    content: string;
+    timestamp?: number;
+  }): Promise<PersistedWebChatSession> {
+    const timestamp = params.timestamp ?? Date.now();
+    return this.queue.run(params.sessionId, async () => {
+      const current = await this.loadSession(params.sessionId);
+      const ownerKey = current?.ownerKey ?? params.ownerKey;
+      if (current && current.ownerKey !== params.ownerKey) {
+        throw new Error("Session owner mismatch");
+      }
+
+      const next: PersistedWebChatSession = {
+        version: 1,
+        sessionId: params.sessionId,
+        ownerKey,
+        label: buildLabel(current, params.sender, params.content),
+        createdAt: current?.createdAt ?? timestamp,
+        updatedAt: timestamp,
+        lastActiveAt: timestamp,
+        messageCount: (current?.messageCount ?? 0) + 1,
+      };
+
+      await this.writeSession(next);
+      await this.addOwnerIndex(ownerKey, params.sessionId);
+      return next;
+    });
+  }
+
+  async listSessionsForOwner(
+    ownerKey: string,
+  ): Promise<readonly PersistedWebChatSession[]> {
+    const ids = normalizeStringArray(
+      await this.memoryBackend.get(ownerIndexKey(ownerKey)),
+    );
+    const sessions = await Promise.all(ids.map((id) => this.loadSession(id)));
+    return sessions.filter(
+      (session): session is PersistedWebChatSession =>
+        session !== undefined && session.ownerKey === ownerKey,
+    );
+  }
+
+  private async writeSession(session: PersistedWebChatSession): Promise<void> {
+    await this.memoryBackend.set(sessionKey(session.sessionId), cloneJson(session));
+  }
+
+  private async addOwnerIndex(
+    ownerKey: string,
+    sessionId: string,
+  ): Promise<void> {
+    const key = ownerIndexKey(ownerKey);
+    const current = normalizeStringArray(await this.memoryBackend.get(key));
+    if (current.includes(sessionId)) return;
+    current.push(sessionId);
+    await this.memoryBackend.set(key, current);
+  }
+}

--- a/runtime/src/channels/webchat/types.ts
+++ b/runtime/src/channels/webchat/types.ts
@@ -69,6 +69,8 @@ export interface WebChatDeps {
   onDesktopSessionRebound?: (sessionId: string) => void;
   /** Optional callback to fully reset backend context for a web session. */
   resetSessionContext?: (sessionId: string) => Promise<void> | void;
+  /** Optional callback to rehydrate backend context for a resumed web session. */
+  hydrateSessionContext?: (sessionId: string) => Promise<void> | void;
   /** Optional callback to cancel a daemon-owned background run for a session. */
   cancelBackgroundRun?: (sessionId: string) => Promise<boolean> | boolean;
 }
@@ -90,6 +92,7 @@ export interface ChatMessageRequest {
   type: "chat.message";
   payload: {
     content: string;
+    clientKey?: string;
     attachments?: Array<{ type: string; url?: string; mimeType: string }>;
   };
   id?: string;
@@ -103,28 +106,31 @@ export interface ChatTypingRequest {
 
 export interface ChatHistoryRequest {
   type: "chat.history";
-  payload?: { limit?: number };
+  payload?: { limit?: number; clientKey?: string };
   id?: string;
 }
 
 export interface ChatResumeRequest {
   type: "chat.resume";
-  payload: { sessionId: string };
+  payload: { sessionId: string; clientKey?: string };
   id?: string;
 }
 
 export interface ChatNewRequest {
   type: "chat.new";
+  payload?: { clientKey?: string };
   id?: string;
 }
 
 export interface ChatSessionsRequest {
   type: "chat.sessions";
+  payload?: { clientKey?: string };
   id?: string;
 }
 
 export interface ChatCancelRequest {
   type: "chat.cancel";
+  payload?: { clientKey?: string };
   id?: string;
 }
 

--- a/runtime/src/desktop/manager.test.ts
+++ b/runtime/src/desktop/manager.test.ts
@@ -60,12 +60,55 @@ function mockDockerSuccess(
         return;
       }
       if (subCommand === "inspect") {
+        const formatArgIndex = args.indexOf("--format");
+        if (formatArgIndex !== -1) {
+          const port1 = 32768 + containerIdCounter * 2;
+          const port2 = port1 + 1;
+          cb(
+            null,
+            responses.inspect ??
+              `{"6080/tcp":[{"HostIp":"127.0.0.1","HostPort":"${port1}"}],"9990/tcp":[{"HostIp":"127.0.0.1","HostPort":"${port2}"}]}`,
+            "",
+          );
+          return;
+        }
         const port1 = 32768 + containerIdCounter * 2;
         const port2 = port1 + 1;
         cb(
           null,
-          responses.inspect ??
-            `{"6080/tcp":[{"HostIp":"127.0.0.1","HostPort":"${port1}"}],"9990/tcp":[{"HostIp":"127.0.0.1","HostPort":"${port2}"}]}`,
+          responses.inspectFull ??
+            JSON.stringify([
+              {
+                Id: args[1] ?? `ctr${String(containerIdCounter).padStart(9, "0")}ff`,
+                Name: "/agenc-desktop-sess1",
+                Created: "2026-03-07T07:00:00.000Z",
+                Config: {
+                  Env: [
+                    "DISPLAY_WIDTH=1280",
+                    "DISPLAY_HEIGHT=1024",
+                    "DESKTOP_AUTH_TOKEN=recoveredtoken",
+                  ],
+                  Labels: {
+                    "session-id": "sess1",
+                    "agenc.desktop.resolution": "1280x1024",
+                    "agenc.desktop.max-memory": "4g",
+                    "agenc.desktop.max-cpu": "2.0",
+                    "agenc.desktop.created-at": "1772866800000",
+                  },
+                },
+                State: {
+                  Running: true,
+                  Status: "running",
+                  StartedAt: "2026-03-07T07:00:01.000Z",
+                },
+                NetworkSettings: {
+                  Ports: {
+                    "6080/tcp": [{ HostIp: "127.0.0.1", HostPort: `${port1}` }],
+                    "9990/tcp": [{ HostIp: "127.0.0.1", HostPort: `${port2}` }],
+                  },
+                },
+              },
+            ]),
           "",
         );
         return;
@@ -133,12 +176,12 @@ describe("DesktopSandboxManager", () => {
   });
 
   describe("start()", () => {
-    it("cleans up orphan containers on start", async () => {
-      mockDockerSuccess({ ps: "deadbeef1234\noldcontainer1\n" });
+    it("recovers live managed containers on start", async () => {
+      mockDockerSuccess({ ps: "deadbeef1234\n" });
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({ status: "ok" }) });
       manager = new DesktopSandboxManager(makeConfig());
       await manager.start();
 
-      // Should have called docker ps with our label filter
       const psCalls = mockExecFile.mock.calls.filter(
         (c: unknown[]) => (c[1] as string[])[0] === "ps",
       );
@@ -147,12 +190,48 @@ describe("DesktopSandboxManager", () => {
         "managed-by=agenc-desktop",
       );
 
-      // Should have rm -f each orphan
+      expect(manager.activeCount).toBe(1);
+      const recovered = manager.getHandleBySession("sess1");
+      expect(recovered?.containerId).toBe("deadbeef1234");
+      expect(recovered?.status).toBe("ready");
+      expect(recovered?.apiHostPort).toBeGreaterThan(0);
+      expect(recovered?.vncHostPort).toBeGreaterThan(0);
+
       const rmCalls = mockExecFile.mock.calls.filter(
         (c: unknown[]) =>
           (c[1] as string[])[0] === "rm" && (c[1] as string[])[1] === "-f",
       );
-      expect(rmCalls.length).toBe(2);
+      expect(rmCalls.length).toBe(0);
+    });
+
+    it("removes dead managed containers it cannot recover", async () => {
+      mockDockerSuccess({
+        ps: "deadbeef1234\n",
+        inspectFull: JSON.stringify([
+          {
+            Id: "deadbeef1234",
+            Name: "/agenc-desktop-sess1",
+            Config: {
+              Env: ["DESKTOP_AUTH_TOKEN=recoveredtoken"],
+              Labels: { "session-id": "sess1" },
+            },
+            State: {
+              Running: false,
+              Status: "exited",
+            },
+            NetworkSettings: { Ports: {} },
+          },
+        ]),
+      });
+      manager = new DesktopSandboxManager(makeConfig());
+      await manager.start();
+
+      expect(manager.activeCount).toBe(0);
+      const rmCalls = mockExecFile.mock.calls.filter(
+        (c: unknown[]) =>
+          (c[1] as string[])[0] === "rm" && (c[1] as string[])[1] === "-f",
+      );
+      expect(rmCalls.length).toBe(1);
     });
   });
 
@@ -521,6 +600,26 @@ describe("DesktopSandboxManager", () => {
 
       await manager.destroyAll();
       expect(manager.activeCount).toBe(0);
+    });
+
+    it("stop preserves tracked containers for daemon recovery", async () => {
+      manager = new DesktopSandboxManager(makeConfig());
+      await manager.start();
+      const handle = await manager.create({ sessionId: "sess1" });
+      const rmCallsBeforeStop = mockExecFile.mock.calls.filter(
+        (c: unknown[]) =>
+          (c[1] as string[])[0] === "rm" && (c[1] as string[])[1] === "-f",
+      ).length;
+
+      await manager.stop();
+
+      expect(manager.activeCount).toBe(0);
+      expect(manager.getHandle(handle.containerId)).toBeUndefined();
+      const rmCalls = mockExecFile.mock.calls.filter(
+        (c: unknown[]) =>
+          (c[1] as string[])[0] === "rm" && (c[1] as string[])[1] === "-f",
+      );
+      expect(rmCalls.length).toBe(rmCallsBeforeStop);
     });
   });
 

--- a/runtime/src/desktop/manager.ts
+++ b/runtime/src/desktop/manager.ts
@@ -35,6 +35,11 @@ import {
 
 const CONTAINER_PREFIX = "agenc-desktop";
 const MANAGED_BY_LABEL = "managed-by=agenc-desktop";
+const SESSION_LABEL_KEY = "session-id";
+const RESOLUTION_LABEL_KEY = "agenc.desktop.resolution";
+const MAX_MEMORY_LABEL_KEY = "agenc.desktop.max-memory";
+const MAX_CPU_LABEL_KEY = "agenc.desktop.max-cpu";
+const CREATED_AT_LABEL_KEY = "agenc.desktop.created-at";
 const DOCKER_TIMEOUT_MS = 30_000;
 const READY_POLL_INTERVAL_MS = 1_000;
 const READY_TIMEOUT_MS = 60_000;
@@ -101,6 +106,31 @@ interface DockerRunOptions {
   sandboxOptions: CreateDesktopSandboxOptions;
 }
 
+interface DockerInspectRecord {
+  readonly Id?: string;
+  readonly Name?: string;
+  readonly Created?: string;
+  readonly Config?: {
+    readonly Env?: readonly string[];
+    readonly Labels?: Record<string, string>;
+  };
+  readonly State?: {
+    readonly Running?: boolean;
+    readonly Status?: string;
+    readonly StartedAt?: string;
+  };
+  readonly HostConfig?: {
+    readonly Memory?: number;
+    readonly NanoCpus?: number;
+  };
+  readonly NetworkSettings?: {
+    readonly Ports?: Record<
+      string,
+      Array<{ HostIp?: string; HostPort?: string }> | null
+    >;
+  };
+}
+
 function parsePortMappings(inspectJson: string): PortMapping {
   // docker inspect --format '{{json .NetworkSettings.Ports}}'
   // Returns: {"6080/tcp":[{"HostIp":"127.0.0.1","HostPort":"32768"}],"9990/tcp":[...]}
@@ -162,6 +192,67 @@ function validateCpuLimit(value: string): void {
       `Invalid CPU limit "${value}". Value must be greater than 0.`,
     );
   }
+}
+
+function parseInspectJson(stdout: string): DockerInspectRecord {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    throw new Error(`Invalid docker inspect JSON: ${toErrorMessage(err)}`);
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error("docker inspect returned no records");
+  }
+  const [record] = parsed;
+  if (!record || typeof record !== "object") {
+    throw new Error("docker inspect returned an invalid record");
+  }
+  return record as DockerInspectRecord;
+}
+
+function parseTimestamp(value: string | undefined): number | undefined {
+  if (!value || value.startsWith("0001-01-01")) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function findEnvValue(
+  env: readonly string[] | undefined,
+  key: string,
+): string | undefined {
+  const prefix = `${key}=`;
+  const entry = env?.find((value) => value.startsWith(prefix));
+  return entry ? entry.slice(prefix.length) : undefined;
+}
+
+function parseResolutionLabel(
+  value: string | undefined,
+): { width: number; height: number } | undefined {
+  if (!value) return undefined;
+  const match = /^(\d+)x(\d+)$/.exec(value.trim());
+  if (!match) return undefined;
+  const width = Number.parseInt(match[1]!, 10);
+  const height = Number.parseInt(match[2]!, 10);
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return undefined;
+  }
+  return { width, height };
+}
+
+function normalizeRecoveredMemoryLimit(
+  value: string | undefined,
+  fallback: string,
+): string {
+  return value && value.trim().length > 0 ? value.trim() : fallback;
+}
+
+function normalizeRecoveredCpuLimit(
+  value: string | undefined,
+  fallback: string,
+): string {
+  return value && value.trim().length > 0 ? value.trim() : fallback;
 }
 
 // ============================================================================
@@ -264,13 +355,20 @@ export class DesktopSandboxManager {
       this.logger.warn("Docker not available — desktop sandbox disabled");
       return;
     }
-    await this.cleanupOrphans();
+    await this.recoverExistingContainers();
     this.logger.info("Desktop sandbox manager started");
   }
 
-  /** Stop the manager: destroy all containers, clear all timers. */
+  /** Stop the manager: preserve live containers for daemon recovery and clear local state. */
   async stop(): Promise<void> {
-    await this.destroyAll();
+    const preservedContainerIds = [...this.handles.keys()];
+    for (const containerId of preservedContainerIds) {
+      this.clearTimers(containerId);
+    }
+    this.handles.clear();
+    this.sessionMap.clear();
+    this.authTokens.clear();
+    this.dockerAvailable = null;
     this.logger.info("Desktop sandbox manager stopped");
   }
 
@@ -531,7 +629,11 @@ export class DesktopSandboxManager {
 
     args.push(
       "--label", MANAGED_BY_LABEL,
-      "--label", `session-id=${sessionId}`,
+      "--label", `${SESSION_LABEL_KEY}=${sessionId}`,
+      "--label", `${RESOLUTION_LABEL_KEY}=${resolution.width}x${resolution.height}`,
+      "--label", `${MAX_MEMORY_LABEL_KEY}=${maxMemory}`,
+      "--label", `${MAX_CPU_LABEL_KEY}=${maxCpu}`,
+      "--label", `${CREATED_AT_LABEL_KEY}=${Date.now()}`,
       "--publish", `127.0.0.1::${CONTAINER_API_PORT}`,
       "--publish", `127.0.0.1::${CONTAINER_VNC_PORT}`,
       "--network", this.config.networkMode === "none" ? "none" : "bridge",
@@ -689,8 +791,8 @@ export class DesktopSandboxManager {
     );
   }
 
-  /** Remove stale orphan containers with our management label. */
-  private async cleanupOrphans(): Promise<void> {
+  /** Reattach any live managed containers and clean up dead ones. */
+  private async recoverExistingContainers(): Promise<void> {
     try {
       const { stdout } = await execFileAsync("docker", [
         "ps",
@@ -702,12 +804,127 @@ export class DesktopSandboxManager {
       ]);
       const ids = stdout.trim().split("\n").filter(Boolean);
       for (const id of ids) {
-        this.logger.info(`Cleaning up orphan desktop container ${id}`);
-        await this.forceRemove(id);
+        const recovered = await this.recoverContainer(id);
+        if (!recovered) {
+          this.logger.info(`Cleaning up unrecoverable desktop container ${id}`);
+          await this.forceRemove(id);
+        }
       }
     } catch {
       // Intentional: Docker may not be available — logged by caller
     }
+  }
+
+  private async recoverContainer(containerId: string): Promise<boolean> {
+    let inspect: DockerInspectRecord;
+    try {
+      const { stdout } = await execFileAsync("docker", ["inspect", containerId]);
+      inspect = parseInspectJson(stdout);
+    } catch (err) {
+      this.logger.debug("Failed to inspect recoverable desktop container", {
+        containerId,
+        error: toErrorMessage(err),
+      });
+      return false;
+    }
+
+    const labels = inspect.Config?.Labels ?? {};
+    const sessionId = labels[SESSION_LABEL_KEY];
+    if (!sessionId) {
+      return false;
+    }
+
+    const authToken = findEnvValue(inspect.Config?.Env, DESKTOP_AUTH_ENV_KEY);
+    if (!authToken) {
+      this.logger.debug("Desktop container missing auth token during recovery", {
+        containerId,
+        sessionId,
+      });
+      return false;
+    }
+
+    if (inspect.State?.Running !== true) {
+      return false;
+    }
+
+    let ports: PortMapping;
+    try {
+      ports = parsePortMappings(
+        JSON.stringify(inspect.NetworkSettings?.Ports ?? {}),
+      );
+    } catch (err) {
+      this.logger.debug("Desktop container missing port mappings during recovery", {
+        containerId,
+        sessionId,
+        error: toErrorMessage(err),
+      });
+      return false;
+    }
+
+    const resolution =
+      parseResolutionLabel(labels[RESOLUTION_LABEL_KEY]) ??
+      (() => {
+        const width = Number.parseInt(
+          findEnvValue(inspect.Config?.Env, "DISPLAY_WIDTH") ?? "",
+          10,
+        );
+        const height = Number.parseInt(
+          findEnvValue(inspect.Config?.Env, "DISPLAY_HEIGHT") ?? "",
+          10,
+        );
+        if (Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0) {
+          return { width, height };
+        }
+        return this.config.resolution;
+      })();
+
+    const createdAt =
+      Number.parseInt(labels[CREATED_AT_LABEL_KEY] ?? "", 10) ||
+      parseTimestamp(inspect.State?.StartedAt) ||
+      parseTimestamp(inspect.Created) ||
+      Date.now();
+
+    const handle: DesktopSandboxHandle = {
+      containerId,
+      containerName: inspect.Name?.replace(/^\//, "") || containerId,
+      sessionId,
+      status: "starting",
+      createdAt,
+      lastActivityAt: Date.now(),
+      apiHostPort: ports.apiHostPort,
+      vncHostPort: ports.vncHostPort,
+      resolution,
+      maxMemory: normalizeRecoveredMemoryLimit(
+        labels[MAX_MEMORY_LABEL_KEY],
+        this.config.maxMemory,
+      ),
+      maxCpu: normalizeRecoveredCpuLimit(
+        labels[MAX_CPU_LABEL_KEY],
+        this.config.maxCpu,
+      ),
+    };
+
+    try {
+      await this.waitForReady(handle, authToken);
+      handle.status = "ready";
+    } catch (err) {
+      this.logger.debug("Desktop container health check failed during recovery", {
+        containerId,
+        sessionId,
+        error: toErrorMessage(err),
+      });
+      return false;
+    }
+
+    this.handles.set(containerId, handle);
+    this.sessionMap.set(sessionId, containerId);
+    this.authTokens.set(containerId, authToken);
+    this.resetIdleTimer(containerId);
+    this.startLifetimeTimer(containerId);
+    this.logger.info(
+      `Recovered desktop sandbox ${containerId} for session ${sessionId} (API: ${ports.apiHostPort}, VNC: ${ports.vncHostPort})`,
+    );
+    return true;
   }
 
   /** Force-remove a container by name or ID. Idempotent. */
@@ -765,6 +982,12 @@ export class DesktopSandboxManager {
 
   /** Start the max lifetime timer for a container. */
   private startLifetimeTimer(containerId: string): void {
+    const handle = this.handles.get(containerId);
+    if (!handle) {
+      return;
+    }
+    const elapsedMs = Math.max(0, Date.now() - handle.createdAt);
+    const remainingMs = Math.max(0, this.config.maxLifetimeMs - elapsedMs);
     const timer = setTimeout(() => {
       this.logger.info(
         `Desktop sandbox ${containerId} max lifetime reached — destroying`,
@@ -774,7 +997,7 @@ export class DesktopSandboxManager {
           `Failed to destroy expired container ${containerId}: ${toErrorMessage(err)}`,
         );
       });
-    }, this.config.maxLifetimeMs);
+    }, remainingMs);
 
     timer.unref();
     this.lifetimeTimers.set(containerId, timer);

--- a/runtime/src/desktop/rest-bridge.test.ts
+++ b/runtime/src/desktop/rest-bridge.test.ts
@@ -108,6 +108,54 @@ describe("DesktopRESTBridge", () => {
         DesktopSandboxConnectionError,
       );
     });
+
+    it("subscribes to the desktop event stream and forwards parsed events", async () => {
+      const onEvent = vi.fn(async () => undefined);
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            new TextEncoder().encode(
+              [
+                "event: managed_process.exited",
+                'data: {"type":"managed_process.exited","timestamp":123,"payload":{"processId":"proc_123","state":"exited"}}',
+                "",
+                "",
+              ].join("\n"),
+            ),
+          );
+          controller.close();
+        },
+      });
+
+      bridge = new DesktopRESTBridge({
+        apiHostPort: 32769,
+        containerId: "abc123",
+        authToken: "test-token",
+        onEvent,
+      });
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes("/health")) {
+          return { ok: true, json: async () => ({ status: "ok" }) };
+        }
+        if (url.endsWith("/tools") && !url.includes("/tools/")) {
+          return { ok: true, json: async () => TOOL_DEFS };
+        }
+        if (url.endsWith("/events")) {
+          return { ok: true, body: stream };
+        }
+        return { ok: false, status: 404, json: async () => ({ error: "not found" }) };
+      });
+
+      await bridge.connect();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(onEvent).toHaveBeenCalledWith({
+        type: "managed_process.exited",
+        timestamp: 123,
+        payload: { processId: "proc_123", state: "exited" },
+      });
+      bridge.disconnect();
+    });
   });
 
   describe("disconnect()", () => {

--- a/runtime/src/desktop/rest-bridge.ts
+++ b/runtime/src/desktop/rest-bridge.ts
@@ -25,6 +25,8 @@ const CONNECT_TIMEOUT_MS = 5_000;
 const DEFAULT_TOOL_EXECUTION_TIMEOUT_MS = 180_000;
 /** Hard cap for individual tool execution calls (matches container bash upper bound + slack). */
 const MAX_TOOL_EXECUTION_TIMEOUT_MS = 660_000;
+const EVENT_STREAM_RETRY_INITIAL_MS = 500;
+const EVENT_STREAM_RETRY_MAX_MS = 5_000;
 
 // ============================================================================
 // Types for REST API responses
@@ -34,6 +36,12 @@ interface RESTToolDefinition {
   name: string;
   description: string;
   inputSchema: Record<string, unknown>;
+}
+
+export interface DesktopBridgeEvent {
+  readonly type: string;
+  readonly timestamp: number;
+  readonly payload: Record<string, unknown>;
 }
 
 function resolveToolExecutionTimeoutMs(args: Record<string, unknown>): number {
@@ -58,6 +66,7 @@ export interface DesktopRESTBridgeOptions {
   containerId: string;
   authToken: string;
   logger?: Logger;
+  onEvent?: (event: DesktopBridgeEvent) => void | Promise<void>;
 }
 
 export class DesktopRESTBridge {
@@ -65,14 +74,18 @@ export class DesktopRESTBridge {
   private readonly containerId: string;
   private readonly authToken: string;
   private readonly logger: Logger;
+  private readonly onEvent?: (event: DesktopBridgeEvent) => void | Promise<void>;
   private connected = false;
   private tools: Tool[] = [];
+  private eventStreamAbort: AbortController | null = null;
+  private eventStreamLoop: Promise<void> | null = null;
 
   constructor(options: DesktopRESTBridgeOptions) {
     this.baseUrl = `http://localhost:${options.apiHostPort}`;
     this.containerId = options.containerId;
     this.authToken = options.authToken;
     this.logger = options.logger ?? silentLogger;
+    this.onEvent = options.onEvent;
   }
 
   /** Fetch tool definitions from the container and create bridged Tool objects. */
@@ -89,6 +102,7 @@ export class DesktopRESTBridge {
 
     this.tools = definitions.map((def) => this.createBridgedTool(def));
     this.connected = true;
+    this.startEventStream();
 
     this.logger.info(
       `Desktop REST bridge connected to ${this.containerId} (${this.tools.length} tools)`,
@@ -99,6 +113,7 @@ export class DesktopRESTBridge {
   disconnect(): void {
     this.connected = false;
     this.tools = [];
+    this.stopEventStream();
   }
 
   /** Whether the bridge is currently connected. */
@@ -205,6 +220,7 @@ export class DesktopRESTBridge {
           // Network-level failures usually mean the container API is unhealthy.
           // Mark disconnected so callers can recycle/reconnect the bridge.
           bridgeRef.connected = false;
+          bridgeRef.stopEventStream();
           logger.error(
             `Desktop tool ${name} failed [${containerId}]: ${toErrorMessage(err)}`,
           );
@@ -217,5 +233,166 @@ export class DesktopRESTBridge {
         }
       },
     };
+  }
+
+  private startEventStream(): void {
+    if (!this.onEvent || this.eventStreamLoop || !this.connected) {
+      return;
+    }
+
+    const controller = new AbortController();
+    this.eventStreamAbort = controller;
+    this.eventStreamLoop = this.runEventStreamLoop(controller).finally(() => {
+      if (this.eventStreamAbort === controller) {
+        this.eventStreamAbort = null;
+      }
+      if (this.eventStreamLoop !== null) {
+        this.eventStreamLoop = null;
+      }
+    });
+  }
+
+  private stopEventStream(): void {
+    this.eventStreamAbort?.abort();
+    this.eventStreamAbort = null;
+    this.eventStreamLoop = null;
+  }
+
+  private async runEventStreamLoop(controller: AbortController): Promise<void> {
+    let retryDelayMs = EVENT_STREAM_RETRY_INITIAL_MS;
+    while (this.connected && !controller.signal.aborted) {
+      try {
+        const res = await fetch(`${this.baseUrl}/events`, {
+          headers: createDesktopAuthHeaders(this.authToken),
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        if (!res.body) {
+          throw new Error("Event stream body missing");
+        }
+
+        retryDelayMs = EVENT_STREAM_RETRY_INITIAL_MS;
+        await this.consumeEventStream(res.body, controller.signal);
+      } catch (error) {
+        if (controller.signal.aborted || !this.connected) {
+          return;
+        }
+        this.logger.debug("Desktop event stream disconnected", {
+          containerId: this.containerId,
+          error: toErrorMessage(error),
+        });
+        await this.sleepWithAbort(retryDelayMs, controller.signal);
+        retryDelayMs = Math.min(
+          EVENT_STREAM_RETRY_MAX_MS,
+          retryDelayMs * 2,
+        );
+      }
+    }
+  }
+
+  private async consumeEventStream(
+    stream: ReadableStream<Uint8Array>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    try {
+      while (!signal.aborted) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        ({ buffer } = await this.drainEventBuffer(buffer));
+      }
+      buffer += decoder.decode();
+      await this.drainEventBuffer(buffer, true);
+    } finally {
+      void reader.cancel().catch(() => undefined);
+    }
+  }
+
+  private async drainEventBuffer(
+    buffer: string,
+    flushRemainder = false,
+  ): Promise<{ buffer: string }> {
+    let nextBuffer = buffer;
+    while (true) {
+      const separatorIndex = nextBuffer.indexOf("\n\n");
+      if (separatorIndex < 0) {
+        if (flushRemainder && nextBuffer.trim().length > 0) {
+          await this.handleEventChunk(nextBuffer);
+          nextBuffer = "";
+        }
+        return { buffer: nextBuffer };
+      }
+      const chunk = nextBuffer.slice(0, separatorIndex);
+      nextBuffer = nextBuffer.slice(separatorIndex + 2);
+      await this.handleEventChunk(chunk);
+    }
+  }
+
+  private async handleEventChunk(chunk: string): Promise<void> {
+    const lines = chunk
+      .split(/\r?\n/)
+      .map((line) => line.trimEnd())
+      .filter((line) => line.length > 0 && !line.startsWith(":"));
+    if (lines.length === 0) return;
+
+    let eventType = "message";
+    const dataLines: string[] = [];
+    for (const line of lines) {
+      if (line.startsWith("event:")) {
+        eventType = line.slice("event:".length).trim();
+        continue;
+      }
+      if (line.startsWith("data:")) {
+        dataLines.push(line.slice("data:".length).trim());
+      }
+    }
+    if (dataLines.length === 0 || !this.onEvent) {
+      return;
+    }
+
+    try {
+      const parsed = JSON.parse(dataLines.join("\n")) as Record<string, unknown>;
+      const timestamp =
+        typeof parsed.timestamp === "number" ? parsed.timestamp : Date.now();
+      const payload =
+        parsed.payload && typeof parsed.payload === "object" && !Array.isArray(parsed.payload)
+          ? parsed.payload as Record<string, unknown>
+          : {};
+      await this.onEvent({
+        type:
+          typeof parsed.type === "string" && parsed.type.trim().length > 0
+            ? parsed.type
+            : eventType,
+        timestamp,
+        payload,
+      });
+    } catch (error) {
+      this.logger.debug("Failed to parse desktop event stream payload", {
+        containerId: this.containerId,
+        error: toErrorMessage(error),
+        chunk,
+      });
+    }
+  }
+
+  private async sleepWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+    if (signal.aborted || ms <= 0) return;
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      }, ms);
+      const onAbort = (): void => {
+        clearTimeout(timer);
+        signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
   }
 }

--- a/runtime/src/desktop/session-router.test.ts
+++ b/runtime/src/desktop/session-router.test.ts
@@ -117,6 +117,24 @@ describe("createDesktopAwareToolHandler", () => {
     expect(result).toContain("clicked");
   });
 
+  it("passes desktop event callbacks through to the bridge", async () => {
+    const manager = mockManager();
+    const onDesktopEvent = vi.fn();
+    const handler = createDesktopAwareToolHandler(baseHandler, "sess1", {
+      desktopManager: manager,
+      bridges,
+      onDesktopEvent,
+    });
+
+    await handler("desktop.mouse_click", { x: 100, y: 200 });
+
+    expect(DesktopRESTBridge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onEvent: onDesktopEvent,
+      }),
+    );
+  });
+
   it("creates sandbox lazily on first desktop tool call", async () => {
     const manager = mockManager();
     const handler = createDesktopAwareToolHandler(baseHandler, "sess1", {

--- a/runtime/src/desktop/session-router.ts
+++ b/runtime/src/desktop/session-router.ts
@@ -14,7 +14,10 @@ import { silentLogger } from "../utils/logger.js";
 import { toErrorMessage } from "../utils/async.js";
 import type { DesktopSandboxManager } from "./manager.js";
 import { DesktopSandboxPoolExhaustedError } from "./errors.js";
-import { DesktopRESTBridge } from "./rest-bridge.js";
+import {
+  DesktopRESTBridge,
+  type DesktopBridgeEvent,
+} from "./rest-bridge.js";
 import type { MCPServerConfig, MCPToolBridge } from "../mcp-client/types.js";
 import { ResilientMCPBridge } from "../mcp-client/resilient-bridge.js";
 
@@ -458,6 +461,8 @@ export interface DesktopRouterOptions {
   containerMCPBridges?: Map<string, MCPToolBridge[]>;
   /** Optional per-session tool allowlist for least-privilege desktop routing. */
   allowedToolNames?: readonly string[];
+  /** Optional callback for runtime-owned desktop lifecycle events. */
+  onDesktopEvent?: (event: DesktopBridgeEvent) => void | Promise<void>;
   logger?: Logger;
   /** Deprecated no-op. Auto-screenshot capture is disabled. */
   autoScreenshot?: boolean;
@@ -511,6 +516,7 @@ export function createDesktopAwareToolHandler(
     containerMCPConfigs,
     containerMCPBridges,
     allowedToolNames,
+    onDesktopEvent,
     logger: log = silentLogger,
     autoScreenshot: _autoScreenshot = false,
   } = options;
@@ -545,6 +551,7 @@ export function createDesktopAwareToolHandler(
         desktopManager,
         bridges,
         playwrightBridges,
+        onDesktopEvent,
         log,
       );
     }
@@ -566,6 +573,7 @@ export function createDesktopAwareToolHandler(
           bridges,
           scopedContainerMCPConfigs,
           containerMCPBridges,
+          onDesktopEvent,
           log,
         );
       }
@@ -583,7 +591,13 @@ export function createDesktopAwareToolHandler(
     // Ensure bridge is connected for this session
     let bridge = bridges.get(sessionId);
     if (!bridge || !bridge.isConnected()) {
-      bridge = await ensureBridge(sessionId, desktopManager, bridges, log);
+      bridge = await ensureBridge(
+        sessionId,
+        desktopManager,
+        bridges,
+        onDesktopEvent,
+        log,
+      );
       if (!bridge) {
         return safeStringify({ error: "Desktop sandbox unavailable" });
       }
@@ -662,7 +676,13 @@ export function createDesktopAwareToolHandler(
         containerMCPBridges,
         log,
       );
-      const recovered = await ensureBridge(sessionId, desktopManager, bridges, log);
+      const recovered = await ensureBridge(
+        sessionId,
+        desktopManager,
+        bridges,
+        onDesktopEvent,
+        log,
+      );
       if (recovered) {
         const retryTool = recovered.getTools().find((t) => t.name === `desktop.${toolName}`);
         if (retryTool) {
@@ -765,12 +785,19 @@ async function handlePlaywrightCall(
   desktopManager: DesktopSandboxManager,
   bridges: Map<string, DesktopRESTBridge>,
   playwrightBridges: Map<string, MCPToolBridge>,
+  onDesktopEvent: ((event: DesktopBridgeEvent) => void | Promise<void>) | undefined,
   log: Logger,
 ): Promise<string> {
   // Ensure desktop bridge exists first (Playwright needs a running container)
   let bridge = bridges.get(sessionId);
   if (!bridge || !bridge.isConnected()) {
-    bridge = await ensureBridge(sessionId, desktopManager, bridges, log);
+    bridge = await ensureBridge(
+      sessionId,
+      desktopManager,
+      bridges,
+      onDesktopEvent,
+      log,
+    );
     if (!bridge) {
       return safeStringify({ error: "Desktop sandbox unavailable" });
     }
@@ -805,6 +832,7 @@ async function ensureBridge(
   sessionId: string,
   desktopManager: DesktopSandboxManager,
   bridges: Map<string, DesktopRESTBridge>,
+  onDesktopEvent: ((event: DesktopBridgeEvent) => void | Promise<void>) | undefined,
   log: Logger,
 ): Promise<DesktopRESTBridge | undefined> {
   const connectBridge = async (): Promise<DesktopRESTBridge> => {
@@ -820,6 +848,7 @@ async function ensureBridge(
       containerId: handle.containerId,
       authToken,
       logger: log,
+      onEvent: onDesktopEvent,
     });
     await bridge.connect();
     bridges.set(sessionId, bridge);
@@ -985,12 +1014,19 @@ async function handleContainerMCPCall(
   bridges: Map<string, DesktopRESTBridge>,
   containerMCPConfigs: readonly MCPServerConfig[],
   containerMCPBridges: Map<string, MCPToolBridge[]>,
+  onDesktopEvent: ((event: DesktopBridgeEvent) => void | Promise<void>) | undefined,
   log: Logger,
 ): Promise<string> {
   // Ensure desktop bridge exists first (container MCP needs a running container)
   let bridge = bridges.get(sessionId);
   if (!bridge || !bridge.isConnected()) {
-    bridge = await ensureBridge(sessionId, desktopManager, bridges, log);
+    bridge = await ensureBridge(
+      sessionId,
+      desktopManager,
+      bridges,
+      onDesktopEvent,
+      log,
+    );
     if (!bridge) {
       return safeStringify({ error: "Desktop sandbox unavailable" });
     }

--- a/runtime/src/gateway/background-run-control.test.ts
+++ b/runtime/src/gateway/background-run-control.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatBackgroundRunStatus,
+  formatInactiveBackgroundRunStatus,
+  formatInactiveBackgroundRunStop,
+} from "./background-run-control.js";
+import type { BackgroundRunRecentSnapshot } from "./background-run-store.js";
+import type { BackgroundRunStatusSnapshot } from "./background-run-supervisor.js";
+
+function makeActiveSnapshot(
+  overrides: Partial<BackgroundRunStatusSnapshot> = {},
+): BackgroundRunStatusSnapshot {
+  return {
+    id: "bg_123",
+    sessionId: "session-1",
+    objective: "Monitor the process.",
+    state: "working",
+    cycleCount: 3,
+    createdAt: 1_000,
+    updatedAt: 11_000,
+    lastVerifiedAt: 9_000,
+    nextCheckAt: 15_000,
+    nextHeartbeatAt: 13_000,
+    lastUserUpdate: "Process is still running.",
+    lastWakeReason: "timer",
+    pendingSignals: 1,
+    carryForwardSummary: "Waiting for exit.",
+    ...overrides,
+  };
+}
+
+function makeRecentSnapshot(
+  overrides: Partial<BackgroundRunRecentSnapshot> = {},
+): BackgroundRunRecentSnapshot {
+  return {
+    version: 1,
+    runId: "bg_123",
+    sessionId: "session-1",
+    objective: "Monitor the process.",
+    state: "completed",
+    contractKind: "until_condition",
+    requiresUserStop: false,
+    cycleCount: 4,
+    createdAt: 1_000,
+    updatedAt: 12_000,
+    lastVerifiedAt: 11_000,
+    nextCheckAt: undefined,
+    nextHeartbeatAt: undefined,
+    lastUserUpdate: "Process exited cleanly.",
+    lastToolEvidence: "desktop.process_status [ok] exited",
+    lastWakeReason: "process_exit",
+    pendingSignals: 0,
+    carryForwardSummary: "Process observed exited.",
+    ...overrides,
+  };
+}
+
+describe("background-run-control", () => {
+  it("formats active background run status deterministically", () => {
+    const message = formatBackgroundRunStatus(makeActiveSnapshot(), 12_000);
+
+    expect(message).toContain("Background run: working");
+    expect(message).toContain("Objective: Monitor the process.");
+    expect(message).toContain("Cycles: 3");
+    expect(message).toContain("Last verified: ~3s ago");
+    expect(message).toContain("Latest update: Process is still running.");
+    expect(message).toContain("Pending signals: 1");
+    expect(message).toContain("Next heartbeat: ~1s");
+    expect(message).toContain("Next check: ~3s");
+  });
+
+  it("formats inactive status replies from the recent snapshot", () => {
+    const message = formatInactiveBackgroundRunStatus(makeRecentSnapshot(), 15_000);
+
+    expect(message).toContain("No active background run for this session.");
+    expect(message).toContain("Last run: completed");
+    expect(message).toContain("Objective: Monitor the process.");
+    expect(message).toContain("Last changed: ~3s ago");
+    expect(message).toContain("Latest update: Process exited cleanly.");
+  });
+
+  it("formats inactive stop replies without invoking the model", () => {
+    expect(formatInactiveBackgroundRunStop(undefined)).toBe(
+      "No active background run to stop.",
+    );
+
+    const message = formatInactiveBackgroundRunStop(
+      makeRecentSnapshot({ state: "failed" }),
+      16_000,
+    );
+    expect(message).toContain("No active background run to stop.");
+    expect(message).toContain("Last run: failed");
+    expect(message).toContain("Last changed: ~4s ago");
+  });
+});

--- a/runtime/src/gateway/background-run-control.ts
+++ b/runtime/src/gateway/background-run-control.ts
@@ -1,0 +1,78 @@
+import type { BackgroundRunRecentSnapshot } from "./background-run-store.js";
+import type { BackgroundRunStatusSnapshot } from "./background-run-supervisor.js";
+
+type BackgroundRunSnapshotLike =
+  | BackgroundRunStatusSnapshot
+  | BackgroundRunRecentSnapshot;
+
+function formatRelativeAge(
+  timestamp: number | undefined,
+  now: number,
+): string | undefined {
+  if (timestamp === undefined) return undefined;
+  return `~${Math.max(1, Math.ceil(Math.max(0, now - timestamp) / 1000))}s ago`;
+}
+
+function formatRelativeDelay(
+  timestamp: number | undefined,
+  now: number,
+): string | undefined {
+  if (timestamp === undefined) return undefined;
+  return `~${Math.max(0, Math.ceil(Math.max(0, timestamp - now) / 1000))}s`;
+}
+
+export function formatBackgroundRunStatus(
+  snapshot: BackgroundRunSnapshotLike,
+  now = Date.now(),
+): string {
+  const nextCheck = formatRelativeDelay(snapshot.nextCheckAt, now);
+  const nextHeartbeat = formatRelativeDelay(snapshot.nextHeartbeatAt, now);
+  const lastVerified = formatRelativeAge(snapshot.lastVerifiedAt, now);
+  const lines = [
+    `Background run: ${snapshot.state}`,
+    `Objective: ${snapshot.objective}`,
+    `Cycles: ${snapshot.cycleCount}`,
+  ];
+  if (lastVerified) lines.push(`Last verified: ${lastVerified}`);
+  if (snapshot.lastUserUpdate) lines.push(`Latest update: ${snapshot.lastUserUpdate}`);
+  if (snapshot.pendingSignals > 0) lines.push(`Pending signals: ${snapshot.pendingSignals}`);
+  if (nextHeartbeat) lines.push(`Next heartbeat: ${nextHeartbeat}`);
+  if (nextCheck) lines.push(`Next check: ${nextCheck}`);
+  if (!nextCheck && snapshot.state === "working") lines.push("Next check: pending");
+  return lines.join("\n");
+}
+
+export function formatInactiveBackgroundRunStatus(
+  snapshot: BackgroundRunRecentSnapshot | undefined,
+  now = Date.now(),
+): string {
+  if (!snapshot) {
+    return "No active background run for this session.";
+  }
+  const lastChanged = formatRelativeAge(snapshot.updatedAt, now);
+  const lines = [
+    "No active background run for this session.",
+    `Last run: ${snapshot.state}`,
+    `Objective: ${snapshot.objective}`,
+  ];
+  if (lastChanged) lines.push(`Last changed: ${lastChanged}`);
+  if (snapshot.lastUserUpdate) lines.push(`Latest update: ${snapshot.lastUserUpdate}`);
+  return lines.join("\n");
+}
+
+export function formatInactiveBackgroundRunStop(
+  snapshot: BackgroundRunRecentSnapshot | undefined,
+  now = Date.now(),
+): string {
+  if (!snapshot) {
+    return "No active background run to stop.";
+  }
+  const lastChanged = formatRelativeAge(snapshot.updatedAt, now);
+  const lines = [
+    "No active background run to stop.",
+    `Last run: ${snapshot.state}`,
+    `Objective: ${snapshot.objective}`,
+  ];
+  if (lastChanged) lines.push(`Last changed: ${lastChanged}`);
+  return lines.join("\n");
+}

--- a/runtime/src/gateway/background-run-store.test.ts
+++ b/runtime/src/gateway/background-run-store.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { InMemoryBackend } from "../memory/in-memory/backend.js";
+import {
+  BackgroundRunStore,
+  type PersistedBackgroundRun,
+} from "./background-run-store.js";
+
+function makeRun(
+  overrides: Partial<PersistedBackgroundRun> = {},
+): PersistedBackgroundRun {
+  return {
+    version: 1,
+    id: "bg-test",
+    sessionId: "session-1",
+    objective: "Monitor a process until it completes.",
+    contract: {
+      kind: "until_condition",
+      successCriteria: ["Verify the process is still running."],
+      completionCriteria: ["Observe the terminal process state."],
+      blockedCriteria: ["Missing process controls."],
+      nextCheckMs: 4_000,
+      heartbeatMs: 12_000,
+      requiresUserStop: false,
+      managedProcessPolicy: {
+        mode: "until_exit",
+        maxRestarts: 3,
+        restartBackoffMs: 2_000,
+      },
+    },
+    state: "working",
+    createdAt: 1,
+    updatedAt: 1,
+    cycleCount: 1,
+    stableWorkingCycles: 0,
+    consecutiveErrorCycles: 0,
+    nextCheckAt: 5_000,
+    nextHeartbeatAt: 3_000,
+    lastVerifiedAt: 1,
+    lastUserUpdate: "Process is running.",
+    lastToolEvidence: "desktop.process_status [ok] running",
+    lastHeartbeatContent: undefined,
+    lastWakeReason: "timer",
+    carryForward: {
+      summary: "Watcher is running and still requires supervision.",
+      verifiedFacts: ["Watcher process is running."],
+      openLoops: ["Wait for the terminal process state."],
+      nextFocus: "Check process state again.",
+      lastCompactedAt: 1,
+    },
+    pendingSignals: [],
+    observedTargets: [
+      {
+        kind: "managed_process",
+        processId: "proc_watcher",
+        label: "watcher",
+        pid: 42,
+        pgid: 42,
+        desiredState: "exited",
+        exitPolicy: "until_exit",
+        currentState: "running",
+        lastObservedAt: 1,
+        launchSpec: {
+          command: "/bin/sleep",
+          args: ["2"],
+          cwd: "/tmp",
+          label: "watcher",
+          logPath: "/tmp/agenc-processes/proc_watcher.log",
+        },
+        restartCount: 1,
+        lastRestartAt: 2,
+      },
+    ],
+    internalHistory: [],
+    leaseOwnerId: "instance-a",
+    leaseExpiresAt: 10_000,
+    ...overrides,
+  };
+}
+
+describe("BackgroundRunStore", () => {
+  it("saves, lists, and deletes persisted runs", async () => {
+    const backend = new InMemoryBackend();
+    const store = new BackgroundRunStore({ memoryBackend: backend });
+    const run = makeRun();
+
+    await store.saveRun(run);
+
+    expect(await store.loadRun(run.sessionId)).toEqual(run);
+    expect(await store.listRuns()).toEqual([run]);
+
+    await store.deleteRun(run.sessionId);
+
+    expect(await store.loadRun(run.sessionId)).toBeUndefined();
+    expect(await store.listRuns()).toEqual([]);
+  });
+
+  it("enforces lease ownership until the lease expires", async () => {
+    const backend = new InMemoryBackend();
+    const store = new BackgroundRunStore({ memoryBackend: backend });
+    const run = makeRun();
+
+    await store.saveRun(run);
+
+    const foreignClaim = await store.claimLease(run.sessionId, "instance-b", 5_000);
+    expect(foreignClaim.claimed).toBe(false);
+    expect(foreignClaim.run?.leaseOwnerId).toBe("instance-a");
+
+    const expiredClaim = await store.claimLease(run.sessionId, "instance-b", 11_000);
+    expect(expiredClaim.claimed).toBe(true);
+    expect(expiredClaim.run?.leaseOwnerId).toBe("instance-b");
+
+    const released = await store.releaseLease(run.sessionId, "instance-b", 12_000, {
+      ...expiredClaim.run!,
+      state: "working",
+      nextCheckAt: 15_000,
+    });
+    expect(released?.leaseOwnerId).toBeUndefined();
+    expect(released?.nextCheckAt).toBe(15_000);
+  });
+
+  it("stores append-only run events in a dedicated thread", async () => {
+    const backend = new InMemoryBackend();
+    const store = new BackgroundRunStore({ memoryBackend: backend });
+    const run = makeRun();
+
+    await store.saveRun(run);
+    await store.appendEvent(run, {
+      type: "run_started",
+      summary: "Background run started.",
+      timestamp: 1,
+      data: { phase: "start" },
+    });
+    await store.appendEvent(run, {
+      type: "cycle_started",
+      summary: "Cycle 1 started.",
+      timestamp: 2,
+      data: { cycle: 1 },
+    });
+
+    const events = await store.listEvents(run.id);
+    expect(events).toHaveLength(2);
+    expect(events[0]?.content).toBe("Background run started.");
+    expect(events[0]?.metadata).toMatchObject({
+      backgroundRunId: run.id,
+      eventType: "run_started",
+      phase: "start",
+    });
+    expect(events[1]?.metadata).toMatchObject({
+      eventType: "cycle_started",
+      cycle: 1,
+    });
+  });
+
+  it("stores and reloads the latest recent snapshot for a session", async () => {
+    const backend = new InMemoryBackend();
+    const store = new BackgroundRunStore({ memoryBackend: backend });
+
+    await store.saveRecentSnapshot({
+      version: 1,
+      runId: "bg-test",
+      sessionId: "session-1",
+      objective: "Monitor the process until it exits.",
+      state: "completed",
+      contractKind: "until_condition",
+      requiresUserStop: false,
+      cycleCount: 2,
+      createdAt: 1,
+      updatedAt: 20,
+      lastVerifiedAt: 18,
+      nextCheckAt: undefined,
+      nextHeartbeatAt: undefined,
+      lastUserUpdate: "Process exited cleanly.",
+      lastToolEvidence: "desktop.process_status [ok] exited",
+      lastWakeReason: "process_exit",
+      pendingSignals: 0,
+      carryForwardSummary: "Observed terminal process exit.",
+    });
+
+    expect(await store.loadRecentSnapshot("session-1")).toEqual({
+      version: 1,
+      runId: "bg-test",
+      sessionId: "session-1",
+      objective: "Monitor the process until it exits.",
+      state: "completed",
+      contractKind: "until_condition",
+      requiresUserStop: false,
+      cycleCount: 2,
+      createdAt: 1,
+      updatedAt: 20,
+      lastVerifiedAt: 18,
+      nextCheckAt: undefined,
+      nextHeartbeatAt: undefined,
+      lastUserUpdate: "Process exited cleanly.",
+      lastToolEvidence: "desktop.process_status [ok] exited",
+      lastWakeReason: "process_exit",
+      pendingSignals: 0,
+      carryForwardSummary: "Observed terminal process exit.",
+    });
+  });
+});

--- a/runtime/src/gateway/background-run-store.ts
+++ b/runtime/src/gateway/background-run-store.ts
@@ -1,0 +1,675 @@
+import type { LLMMessage } from "../llm/types.js";
+import type { MemoryBackend, MemoryEntry } from "../memory/types.js";
+import type { Logger } from "../utils/logger.js";
+import { silentLogger } from "../utils/logger.js";
+import { KeyedAsyncQueue } from "../utils/keyed-async-queue.js";
+
+const BACKGROUND_RUN_KEY_PREFIX = "background-run:session:";
+const BACKGROUND_RUN_RECENT_KEY_PREFIX = "background-run:recent:session:";
+const BACKGROUND_RUN_EVENT_SESSION_PREFIX = "background-run:";
+const DEFAULT_LEASE_DURATION_MS = 45_000;
+
+export type BackgroundRunKind =
+  | "finite"
+  | "until_condition"
+  | "until_stopped";
+
+export type BackgroundRunState =
+  | "pending"
+  | "running"
+  | "working"
+  | "paused"
+  | "completed"
+  | "blocked"
+  | "failed"
+  | "cancelled";
+
+export interface BackgroundRunContract {
+  readonly kind: BackgroundRunKind;
+  readonly successCriteria: readonly string[];
+  readonly completionCriteria: readonly string[];
+  readonly blockedCriteria: readonly string[];
+  readonly nextCheckMs: number;
+  readonly heartbeatMs?: number;
+  readonly requiresUserStop: boolean;
+  readonly managedProcessPolicy?: BackgroundRunManagedProcessPolicy;
+}
+
+export interface BackgroundRunManagedProcessPolicy {
+  readonly mode: "none" | "until_exit" | "keep_running" | "restart_on_exit";
+  readonly maxRestarts?: number;
+  readonly restartBackoffMs?: number;
+}
+
+export interface BackgroundRunManagedProcessLaunchSpec {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly cwd?: string;
+  readonly label?: string;
+  readonly logPath?: string;
+}
+
+export type BackgroundRunWakeReason =
+  | "start"
+  | "timer"
+  | "busy_retry"
+  | "recovery"
+  | "user_input"
+  | "external_event"
+  | "tool_result"
+  | "process_exit"
+  | "webhook"
+  | "daemon_shutdown";
+
+export interface BackgroundRunSignal {
+  readonly id: string;
+  readonly type: Exclude<
+    BackgroundRunWakeReason,
+    "start" | "timer" | "busy_retry" | "recovery" | "daemon_shutdown"
+  >;
+  readonly content: string;
+  readonly timestamp: number;
+  readonly data?: Record<string, unknown>;
+}
+
+export interface BackgroundRunObservedManagedProcessTarget {
+  readonly kind: "managed_process";
+  readonly processId: string;
+  readonly label?: string;
+  readonly pid?: number;
+  readonly pgid?: number;
+  readonly desiredState: "running" | "exited";
+  readonly exitPolicy: "until_exit" | "keep_running" | "restart_on_exit";
+  readonly currentState: "running" | "exited";
+  readonly lastObservedAt: number;
+  readonly exitCode?: number | null;
+  readonly signal?: string | null;
+  readonly launchSpec?: BackgroundRunManagedProcessLaunchSpec;
+  readonly restartCount?: number;
+  readonly lastRestartAt?: number;
+}
+
+export type BackgroundRunObservedTarget =
+  | BackgroundRunObservedManagedProcessTarget;
+
+export interface BackgroundRunCarryForwardState {
+  readonly summary: string;
+  readonly verifiedFacts: readonly string[];
+  readonly openLoops: readonly string[];
+  readonly nextFocus?: string;
+  readonly lastCompactedAt: number;
+}
+
+export interface BackgroundRunRecentSnapshot {
+  readonly version: 1;
+  readonly runId: string;
+  readonly sessionId: string;
+  readonly objective: string;
+  readonly state: BackgroundRunState;
+  readonly contractKind: BackgroundRunKind;
+  readonly requiresUserStop: boolean;
+  readonly cycleCount: number;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly lastVerifiedAt?: number;
+  readonly nextCheckAt?: number;
+  readonly nextHeartbeatAt?: number;
+  readonly lastUserUpdate?: string;
+  readonly lastToolEvidence?: string;
+  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly pendingSignals: number;
+  readonly carryForwardSummary?: string;
+}
+
+export interface PersistedBackgroundRun {
+  readonly version: 1;
+  readonly id: string;
+  readonly sessionId: string;
+  readonly objective: string;
+  readonly contract: BackgroundRunContract;
+  readonly state: BackgroundRunState;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly cycleCount: number;
+  readonly stableWorkingCycles: number;
+  readonly consecutiveErrorCycles: number;
+  readonly nextCheckAt?: number;
+  readonly nextHeartbeatAt?: number;
+  readonly lastVerifiedAt?: number;
+  readonly lastUserUpdate?: string;
+  readonly lastToolEvidence?: string;
+  readonly lastHeartbeatContent?: string;
+  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly carryForward?: BackgroundRunCarryForwardState;
+  readonly pendingSignals: readonly BackgroundRunSignal[];
+  readonly observedTargets: readonly BackgroundRunObservedTarget[];
+  readonly internalHistory: readonly LLMMessage[];
+  readonly leaseOwnerId?: string;
+  readonly leaseExpiresAt?: number;
+}
+
+export interface BackgroundRunEvent {
+  readonly type: string;
+  readonly summary: string;
+  readonly timestamp: number;
+  readonly data?: Record<string, unknown>;
+}
+
+export interface BackgroundRunLeaseResult {
+  readonly claimed: boolean;
+  readonly run?: PersistedBackgroundRun;
+}
+
+export interface BackgroundRunStoreConfig {
+  readonly memoryBackend: MemoryBackend;
+  readonly logger?: Logger;
+  readonly leaseDurationMs?: number;
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function backgroundRunKey(sessionId: string): string {
+  return `${BACKGROUND_RUN_KEY_PREFIX}${sessionId}`;
+}
+
+function backgroundRunRecentKey(sessionId: string): string {
+  return `${BACKGROUND_RUN_RECENT_KEY_PREFIX}${sessionId}`;
+}
+
+function backgroundRunEventSessionId(runId: string): string {
+  return `${BACKGROUND_RUN_EVENT_SESSION_PREFIX}${runId}`;
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function coercePositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function coerceNonNegativeInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const normalized = Math.floor(value);
+  return normalized >= 0 ? normalized : undefined;
+}
+
+function coerceLaunchSpec(
+  value: unknown,
+): BackgroundRunManagedProcessLaunchSpec | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  if (typeof raw.command !== "string" || raw.command.trim().length === 0) {
+    return undefined;
+  }
+  const args = normalizeStringArray(raw.args);
+  return {
+    command: raw.command,
+    args,
+    cwd: typeof raw.cwd === "string" ? raw.cwd : undefined,
+    label: typeof raw.label === "string" ? raw.label : undefined,
+    logPath: typeof raw.logPath === "string" ? raw.logPath : undefined,
+  };
+}
+
+function coerceSignal(value: unknown): BackgroundRunSignal | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const type = raw.type;
+  if (
+    type !== "user_input" &&
+    type !== "external_event" &&
+    type !== "tool_result" &&
+    type !== "process_exit" &&
+    type !== "webhook"
+  ) {
+    return undefined;
+  }
+  if (
+    typeof raw.id !== "string" ||
+    typeof raw.content !== "string" ||
+    typeof raw.timestamp !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    id: raw.id,
+    type,
+    content: raw.content,
+    timestamp: raw.timestamp,
+    data:
+      raw.data && typeof raw.data === "object" && !Array.isArray(raw.data)
+        ? cloneJson(raw.data as Record<string, unknown>)
+        : undefined,
+  };
+}
+
+function coerceObservedTarget(
+  value: unknown,
+): BackgroundRunObservedTarget | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  if (raw.kind !== "managed_process") return undefined;
+  if (
+    typeof raw.processId !== "string" ||
+    (raw.desiredState !== "running" && raw.desiredState !== "exited") ||
+    (
+      raw.exitPolicy !== "until_exit" &&
+      raw.exitPolicy !== "keep_running" &&
+      raw.exitPolicy !== "restart_on_exit"
+    ) ||
+    (raw.currentState !== "running" && raw.currentState !== "exited") ||
+    typeof raw.lastObservedAt !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    kind: "managed_process",
+    processId: raw.processId,
+    label: typeof raw.label === "string" ? raw.label : undefined,
+    pid: typeof raw.pid === "number" ? raw.pid : undefined,
+    pgid: typeof raw.pgid === "number" ? raw.pgid : undefined,
+    desiredState: raw.desiredState,
+    exitPolicy: raw.exitPolicy,
+    currentState: raw.currentState,
+    lastObservedAt: raw.lastObservedAt,
+    exitCode:
+      raw.exitCode === null || typeof raw.exitCode === "number"
+        ? raw.exitCode
+        : undefined,
+    signal:
+      raw.signal === null || typeof raw.signal === "string"
+        ? raw.signal
+        : undefined,
+    launchSpec: coerceLaunchSpec(raw.launchSpec),
+    restartCount: coerceNonNegativeInteger(raw.restartCount),
+    lastRestartAt:
+      typeof raw.lastRestartAt === "number" ? raw.lastRestartAt : undefined,
+  };
+}
+
+function coerceCarryForward(
+  value: unknown,
+): BackgroundRunCarryForwardState | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  if (
+    typeof raw.summary !== "string" ||
+    typeof raw.lastCompactedAt !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    summary: raw.summary,
+    verifiedFacts: normalizeStringArray(raw.verifiedFacts),
+    openLoops: normalizeStringArray(raw.openLoops),
+    nextFocus:
+      typeof raw.nextFocus === "string" ? raw.nextFocus : undefined,
+    lastCompactedAt: raw.lastCompactedAt,
+  };
+}
+
+function coerceRecentSnapshot(
+  value: unknown,
+): BackgroundRunRecentSnapshot | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const state = raw.state;
+  const contractKind = raw.contractKind;
+  const lastWakeReason = raw.lastWakeReason;
+  if (
+    raw.version !== 1 ||
+    typeof raw.runId !== "string" ||
+    typeof raw.sessionId !== "string" ||
+    typeof raw.objective !== "string" ||
+    typeof raw.requiresUserStop !== "boolean" ||
+    typeof raw.cycleCount !== "number" ||
+    typeof raw.createdAt !== "number" ||
+    typeof raw.updatedAt !== "number" ||
+    typeof raw.pendingSignals !== "number" ||
+    (
+      state !== "pending" &&
+      state !== "running" &&
+      state !== "working" &&
+      state !== "paused" &&
+      state !== "completed" &&
+      state !== "blocked" &&
+      state !== "failed" &&
+      state !== "cancelled"
+    ) ||
+    (
+      contractKind !== "finite" &&
+      contractKind !== "until_condition" &&
+      contractKind !== "until_stopped"
+    )
+  ) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    runId: raw.runId,
+    sessionId: raw.sessionId,
+    objective: raw.objective,
+    state,
+    contractKind,
+    requiresUserStop: raw.requiresUserStop,
+    cycleCount: raw.cycleCount,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+    lastVerifiedAt:
+      typeof raw.lastVerifiedAt === "number" ? raw.lastVerifiedAt : undefined,
+    nextCheckAt:
+      typeof raw.nextCheckAt === "number" ? raw.nextCheckAt : undefined,
+    nextHeartbeatAt:
+      typeof raw.nextHeartbeatAt === "number" ? raw.nextHeartbeatAt : undefined,
+    lastUserUpdate:
+      typeof raw.lastUserUpdate === "string" ? raw.lastUserUpdate : undefined,
+    lastToolEvidence:
+      typeof raw.lastToolEvidence === "string"
+        ? raw.lastToolEvidence
+        : undefined,
+    lastWakeReason:
+      typeof lastWakeReason === "string"
+        ? lastWakeReason as BackgroundRunWakeReason
+        : undefined,
+    pendingSignals: raw.pendingSignals,
+    carryForwardSummary:
+      typeof raw.carryForwardSummary === "string"
+        ? raw.carryForwardSummary
+        : undefined,
+  };
+}
+
+function coerceContract(value: unknown): BackgroundRunContract | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const kind = raw.kind;
+  if (
+    kind !== "finite" &&
+    kind !== "until_condition" &&
+    kind !== "until_stopped"
+  ) {
+    return undefined;
+  }
+  const nextCheckMs =
+    typeof raw.nextCheckMs === "number" && Number.isFinite(raw.nextCheckMs)
+      ? raw.nextCheckMs
+      : 8_000;
+  const heartbeatMs =
+    typeof raw.heartbeatMs === "number" && Number.isFinite(raw.heartbeatMs)
+      ? raw.heartbeatMs
+      : undefined;
+  const managedProcessPolicy =
+    raw.managedProcessPolicy &&
+    typeof raw.managedProcessPolicy === "object" &&
+    !Array.isArray(raw.managedProcessPolicy)
+      ? raw.managedProcessPolicy as Record<string, unknown>
+      : undefined;
+  const managedProcessMode = managedProcessPolicy?.mode;
+  return {
+    kind,
+    successCriteria: normalizeStringArray(raw.successCriteria),
+    completionCriteria: normalizeStringArray(raw.completionCriteria),
+    blockedCriteria: normalizeStringArray(raw.blockedCriteria),
+    nextCheckMs,
+    heartbeatMs,
+    requiresUserStop: Boolean(raw.requiresUserStop),
+    managedProcessPolicy:
+      managedProcessMode === "none" ||
+      managedProcessMode === "until_exit" ||
+      managedProcessMode === "keep_running" ||
+      managedProcessMode === "restart_on_exit"
+        ? {
+            mode: managedProcessMode,
+            maxRestarts: coercePositiveInteger(managedProcessPolicy?.maxRestarts),
+            restartBackoffMs: coercePositiveInteger(
+              managedProcessPolicy?.restartBackoffMs,
+            ),
+          }
+        : undefined,
+  };
+}
+
+function coerceRun(value: unknown): PersistedBackgroundRun | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const raw = value as Record<string, unknown>;
+  const state = raw.state;
+  if (
+    state !== "pending" &&
+    state !== "running" &&
+    state !== "working" &&
+    state !== "paused" &&
+    state !== "completed" &&
+    state !== "blocked" &&
+    state !== "failed" &&
+    state !== "cancelled"
+  ) {
+    return undefined;
+  }
+  const contract = coerceContract(raw.contract);
+  const carryForward = coerceCarryForward(raw.carryForward);
+  const pendingSignals = Array.isArray(raw.pendingSignals)
+    ? raw.pendingSignals
+      .map((item) => coerceSignal(item))
+      .filter((item): item is BackgroundRunSignal => item !== undefined)
+    : [];
+  const observedTargets = Array.isArray(raw.observedTargets)
+    ? raw.observedTargets
+      .map((item) => coerceObservedTarget(item))
+      .filter((item): item is BackgroundRunObservedTarget => item !== undefined)
+    : [];
+  if (!contract) return undefined;
+  if (
+    raw.version !== 1 ||
+    typeof raw.id !== "string" ||
+    typeof raw.sessionId !== "string" ||
+    typeof raw.objective !== "string" ||
+    typeof raw.createdAt !== "number" ||
+    typeof raw.updatedAt !== "number" ||
+    typeof raw.cycleCount !== "number" ||
+    typeof raw.stableWorkingCycles !== "number" ||
+    typeof raw.consecutiveErrorCycles !== "number" ||
+    !Array.isArray(raw.internalHistory)
+  ) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    id: raw.id,
+    sessionId: raw.sessionId,
+    objective: raw.objective,
+    contract,
+    state,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+    cycleCount: raw.cycleCount,
+    stableWorkingCycles: raw.stableWorkingCycles,
+    consecutiveErrorCycles: raw.consecutiveErrorCycles,
+    nextCheckAt:
+      typeof raw.nextCheckAt === "number" ? raw.nextCheckAt : undefined,
+    nextHeartbeatAt:
+      typeof raw.nextHeartbeatAt === "number" ? raw.nextHeartbeatAt : undefined,
+    lastVerifiedAt:
+      typeof raw.lastVerifiedAt === "number" ? raw.lastVerifiedAt : undefined,
+    lastUserUpdate:
+      typeof raw.lastUserUpdate === "string" ? raw.lastUserUpdate : undefined,
+    lastToolEvidence:
+      typeof raw.lastToolEvidence === "string"
+        ? raw.lastToolEvidence
+        : undefined,
+    lastHeartbeatContent:
+      typeof raw.lastHeartbeatContent === "string"
+        ? raw.lastHeartbeatContent
+        : undefined,
+    lastWakeReason:
+      typeof raw.lastWakeReason === "string"
+        ? (raw.lastWakeReason as BackgroundRunWakeReason)
+        : undefined,
+    carryForward,
+    pendingSignals,
+    observedTargets,
+    internalHistory: cloneJson(raw.internalHistory as readonly LLMMessage[]),
+    leaseOwnerId:
+      typeof raw.leaseOwnerId === "string" ? raw.leaseOwnerId : undefined,
+    leaseExpiresAt:
+      typeof raw.leaseExpiresAt === "number" ? raw.leaseExpiresAt : undefined,
+  };
+}
+
+export class BackgroundRunStore {
+  private readonly memoryBackend: MemoryBackend;
+  private readonly logger: Logger;
+  private readonly leaseDurationMs: number;
+  private readonly queue: KeyedAsyncQueue;
+
+  constructor(config: BackgroundRunStoreConfig) {
+    this.memoryBackend = config.memoryBackend;
+    this.logger = config.logger ?? silentLogger;
+    this.leaseDurationMs = config.leaseDurationMs ?? DEFAULT_LEASE_DURATION_MS;
+    this.queue = new KeyedAsyncQueue({
+      logger: this.logger,
+      label: "Background run store",
+    });
+  }
+
+  async saveRun(run: PersistedBackgroundRun): Promise<void> {
+    await this.queue.run(run.sessionId, async () => {
+      await this.memoryBackend.set(backgroundRunKey(run.sessionId), cloneJson(run));
+    });
+  }
+
+  async loadRun(sessionId: string): Promise<PersistedBackgroundRun | undefined> {
+    const value = await this.memoryBackend.get(backgroundRunKey(sessionId));
+    return coerceRun(value);
+  }
+
+  async deleteRun(sessionId: string): Promise<void> {
+    await this.queue.run(sessionId, async () => {
+      await this.memoryBackend.delete(backgroundRunKey(sessionId));
+    });
+  }
+
+  async saveRecentSnapshot(snapshot: BackgroundRunRecentSnapshot): Promise<void> {
+    await this.queue.run(snapshot.sessionId, async () => {
+      await this.memoryBackend.set(
+        backgroundRunRecentKey(snapshot.sessionId),
+        cloneJson(snapshot),
+      );
+    });
+  }
+
+  async loadRecentSnapshot(
+    sessionId: string,
+  ): Promise<BackgroundRunRecentSnapshot | undefined> {
+    const value = await this.memoryBackend.get(backgroundRunRecentKey(sessionId));
+    return coerceRecentSnapshot(value);
+  }
+
+  async listRuns(): Promise<readonly PersistedBackgroundRun[]> {
+    const keys = await this.memoryBackend.listKeys(BACKGROUND_RUN_KEY_PREFIX);
+    const runs = await Promise.all(
+      keys.map(async (key) => {
+        const sessionId = key.slice(BACKGROUND_RUN_KEY_PREFIX.length);
+        return this.loadRun(sessionId);
+      }),
+    );
+    return runs.filter(
+      (run): run is PersistedBackgroundRun => run !== undefined,
+    );
+  }
+
+  async listEvents(runId: string, limit?: number): Promise<readonly MemoryEntry[]> {
+    return this.memoryBackend.getThread(backgroundRunEventSessionId(runId), limit);
+  }
+
+  async appendEvent(
+    run: Pick<PersistedBackgroundRun, "id" | "sessionId">,
+    event: BackgroundRunEvent,
+  ): Promise<void> {
+    await this.queue.run(run.sessionId, async () => {
+      await this.memoryBackend.addEntry({
+        sessionId: backgroundRunEventSessionId(run.id),
+        role: "system",
+        content: event.summary,
+        metadata: {
+          backgroundRunSessionId: run.sessionId,
+          backgroundRunId: run.id,
+          eventType: event.type,
+          ...event.data,
+        },
+      });
+    });
+  }
+
+  async claimLease(
+    sessionId: string,
+    instanceId: string,
+    now = Date.now(),
+  ): Promise<BackgroundRunLeaseResult> {
+    return this.queue.run(sessionId, async () => {
+      const current = await this.loadRun(sessionId);
+      if (!current) return { claimed: false };
+      const leaseIsActive =
+        current.leaseOwnerId &&
+        current.leaseOwnerId !== instanceId &&
+        typeof current.leaseExpiresAt === "number" &&
+        current.leaseExpiresAt > now;
+      if (leaseIsActive) {
+        return { claimed: false, run: current };
+      }
+      const claimed: PersistedBackgroundRun = {
+        ...current,
+        updatedAt: now,
+        leaseOwnerId: instanceId,
+        leaseExpiresAt: now + this.leaseDurationMs,
+      };
+      await this.memoryBackend.set(
+        backgroundRunKey(sessionId),
+        cloneJson(claimed),
+      );
+      return { claimed: true, run: claimed };
+    });
+  }
+
+  async renewLease(
+    run: PersistedBackgroundRun,
+    instanceId: string,
+    now = Date.now(),
+  ): Promise<PersistedBackgroundRun | undefined> {
+    const result = await this.claimLease(run.sessionId, instanceId, now);
+    return result.claimed ? result.run : undefined;
+  }
+
+  async releaseLease(
+    sessionId: string,
+    instanceId: string,
+    now = Date.now(),
+    updates?: Partial<PersistedBackgroundRun>,
+  ): Promise<PersistedBackgroundRun | undefined> {
+    return this.queue.run(sessionId, async () => {
+      const current = await this.loadRun(sessionId);
+      if (!current) return undefined;
+      if (current.leaseOwnerId && current.leaseOwnerId !== instanceId) {
+        return current;
+      }
+      const next: PersistedBackgroundRun = {
+        ...current,
+        ...updates,
+        updatedAt: now,
+        leaseOwnerId: undefined,
+        leaseExpiresAt: undefined,
+      };
+      await this.memoryBackend.set(backgroundRunKey(sessionId), cloneJson(next));
+      return next;
+    });
+  }
+}

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import type { ChatExecutorResult } from "../llm/chat-executor.js";
 import type { LLMProvider, ToolHandler } from "../llm/types.js";
+import { InMemoryBackend } from "../memory/in-memory/backend.js";
+import { SqliteBackend } from "../memory/sqlite/backend.js";
 import {
   BackgroundRunSupervisor,
   inferBackgroundRunIntent,
+  isBackgroundRunPauseRequest,
+  isBackgroundRunResumeRequest,
   isBackgroundRunStatusRequest,
   isBackgroundRunStopRequest,
 } from "./background-run-supervisor.js";
+import { BackgroundRunStore } from "./background-run-store.js";
 
 function makeResult(
   overrides: Partial<ChatExecutorResult> = {},
@@ -23,6 +31,107 @@ function makeResult(
     compacted: false,
     stopReason: "completed",
     ...overrides,
+  };
+}
+
+function createRunStore() {
+  return new BackgroundRunStore({
+    memoryBackend: new InMemoryBackend(),
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function eventually(assertion: () => void, attempts = 10): Promise<void> {
+  let lastError: unknown;
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    }
+  }
+  throw lastError;
+}
+
+function createManagedProcessToolHandler(params?: {
+  readonly initialProcessId?: string;
+  readonly label?: string;
+  readonly command?: string;
+  readonly args?: readonly string[];
+  readonly cwd?: string;
+}) {
+  const state = {
+    processId: params?.initialProcessId ?? "proc_watcher",
+    label: params?.label ?? "watcher",
+    command: params?.command ?? "/bin/sleep",
+    args: [...(params?.args ?? ["2"])],
+    cwd: params?.cwd ?? "/tmp",
+    currentState: "running" as "running" | "exited",
+    exitCode: 0 as number | null,
+    restartCount: 0,
+  };
+
+  const handler = vi.fn<ToolHandler>(async (name, args) => {
+    if (name === "desktop.process_status") {
+      return JSON.stringify({
+        processId: state.processId,
+        label: state.label,
+        command: state.command,
+        args: state.args,
+        cwd: state.cwd,
+        state: state.currentState,
+        exitCode: state.currentState === "exited" ? state.exitCode : undefined,
+      });
+    }
+    if (name === "desktop.process_start") {
+      state.restartCount += 1;
+      state.processId =
+        state.restartCount === 1
+          ? "proc_watcher_2"
+          : `proc_watcher_${state.restartCount + 1}`;
+      state.currentState = "running";
+      state.exitCode = 0;
+      state.command =
+        typeof args.command === "string" ? args.command : state.command;
+      state.args = Array.isArray(args.args)
+        ? args.args.map((value) => String(value))
+        : state.args;
+      state.cwd = typeof args.cwd === "string" ? args.cwd : state.cwd;
+      state.label = typeof args.label === "string" ? args.label : state.label;
+      return JSON.stringify({
+        processId: state.processId,
+        label: state.label,
+        command: state.command,
+        args: state.args,
+        cwd: state.cwd,
+        state: "running",
+        started: true,
+      });
+    }
+    throw new Error(`unexpected tool ${name}`);
+  });
+
+  return {
+    handler,
+    markExited(exitCode = 0) {
+      state.currentState = "exited";
+      state.exitCode = exitCode;
+    },
+    snapshot() {
+      return { ...state, args: [...state.args] };
+    },
   };
 }
 
@@ -44,6 +153,9 @@ describe("background-run-supervisor", () => {
     ).toBe(true);
     expect(inferBackgroundRunIntent("What is 2+2?")).toBe(false);
     expect(isBackgroundRunStopRequest("stop")).toBe(true);
+    expect(isBackgroundRunStopRequest("pause")).toBe(false);
+    expect(isBackgroundRunPauseRequest("pause")).toBe(true);
+    expect(isBackgroundRunResumeRequest("resume")).toBe(true);
     expect(isBackgroundRunStatusRequest("status")).toBe(true);
   });
 
@@ -81,6 +193,7 @@ describe("background-run-supervisor", () => {
       chatExecutor: { execute } as any,
       supervisorLlm,
       getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
       createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
       publishUpdate,
     });
@@ -152,6 +265,7 @@ describe("background-run-supervisor", () => {
         healthCheck: vi.fn(async () => true),
       },
       getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
       createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
       publishUpdate,
     });
@@ -160,7 +274,7 @@ describe("background-run-supervisor", () => {
       sessionId: "session-grounded",
       objective: "Play Doom until I say stop and keep me updated.",
     });
-    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(0);
 
     expect(publishUpdate).toHaveBeenNthCalledWith(
       2,
@@ -205,6 +319,7 @@ describe("background-run-supervisor", () => {
         healthCheck: vi.fn(async () => true),
       },
       getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
       createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
       publishUpdate,
     });
@@ -257,6 +372,7 @@ describe("background-run-supervisor", () => {
         healthCheck: vi.fn(async () => true),
       },
       getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
       createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
       publishUpdate,
     });
@@ -272,6 +388,60 @@ describe("background-run-supervisor", () => {
       "session-2",
       "Background task completed successfully.",
     );
+  });
+
+  it("keeps a recent terminal snapshot after completion for runtime-owned control replies", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: {
+        execute: vi.fn(async () =>
+          makeResult({
+            content: "Task finished.",
+            toolCalls: [
+              {
+                name: "desktop.process_status",
+                args: { processId: "proc_1" },
+                result: '{"state":"exited"}',
+                isError: false,
+                durationMs: 5,
+              },
+            ],
+          }),
+        ),
+      } as any,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi.fn(async () => ({
+          content:
+            '{"state":"completed","userUpdate":"Process finished successfully.","internalSummary":"finished","shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-terminal-snapshot",
+      objective: "Watch the process until it exits.",
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(supervisor.getStatusSnapshot("session-terminal-snapshot")).toBeUndefined();
+    await expect(
+      supervisor.getRecentSnapshot("session-terminal-snapshot"),
+    ).resolves.toMatchObject({
+      sessionId: "session-terminal-snapshot",
+      state: "completed",
+      lastUserUpdate: "Process finished successfully.",
+    });
   });
 
   it("cancels an active run", async () => {
@@ -294,6 +464,7 @@ describe("background-run-supervisor", () => {
         healthCheck: vi.fn(async () => true),
       },
       getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
       createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
       publishUpdate,
     });
@@ -307,6 +478,127 @@ describe("background-run-supervisor", () => {
     expect(cancelled).toBe(true);
     expect(supervisor.hasActiveRun("session-3")).toBe(false);
     expect(publishUpdate).toHaveBeenLastCalledWith("session-3", "Stopped by user.");
+  });
+
+  it("pauses a run, queues signals without waking it, and resumes cleanly", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResult({
+          content: "Watcher started.",
+          toolCalls: [
+            {
+              name: "desktop.process_start",
+              args: { command: "/bin/sleep", args: ["30"] },
+              result: '{"state":"running"}',
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResult({
+          content: "Watcher resumed with the queued instruction applied.",
+          toolCalls: [
+            {
+              name: "desktop.process_status",
+              args: { processId: "proc_1" },
+              result: '{"state":"running"}',
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        }),
+      );
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce({
+            content:
+              '{"kind":"until_stopped","successCriteria":["keep watcher running"],"completionCriteria":["user explicitly stops it"],"blockedCriteria":["missing process controls"],"nextCheckMs":4000,"heartbeatMs":12000,"requiresUserStop":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"running","nextCheckMs":4000,"shouldNotifyUser":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"summary":"Watcher is running.","verifiedFacts":["Watcher is running."],"openLoops":["Apply queued resume instruction."],"nextFocus":"Resume and continue monitoring."}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"state":"working","userUpdate":"Watcher resumed successfully.","internalSummary":"resumed","nextCheckMs":4000,"shouldNotifyUser":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"summary":"Watcher resumed and is still running.","verifiedFacts":["Watcher is running."],"openLoops":["Continue monitoring."],"nextFocus":"Continue supervision."}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-pause-resume",
+      objective: "Keep monitoring the watcher until I tell you to stop.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(supervisor.getStatusSnapshot("session-pause-resume")?.state).toBe("working");
+
+    await supervisor.pauseRun("session-pause-resume");
+    expect(supervisor.getStatusSnapshot("session-pause-resume")?.state).toBe("paused");
+
+    await supervisor.signalRun({
+      sessionId: "session-pause-resume",
+      content: "If it fails, restart it instead of stopping.",
+      type: "user_input",
+    });
+    expect(supervisor.getStatusSnapshot("session-pause-resume")?.pendingSignals).toBe(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    await supervisor.resumeRun("session-pause-resume");
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(supervisor.getStatusSnapshot("session-pause-resume")?.state).toBe("working");
+    expect(publishUpdate).toHaveBeenCalledWith(
+      "session-pause-resume",
+      "Paused the active background run for this session.",
+    );
+    expect(publishUpdate).toHaveBeenCalledWith(
+      "session-pause-resume",
+      "Resumed the background run for this session.",
+    );
   });
 
   it("publishes a runtime heartbeat while a stable background run waits for the next verification", async () => {
@@ -348,6 +640,14 @@ describe("background-run-supervisor", () => {
         .fn()
         .mockResolvedValueOnce({
           content:
+            '{"kind":"until_condition","successCriteria":["verify the file state"],"completionCriteria":["file appears"],"blockedCriteria":["missing filesystem access"],"nextCheckMs":30000,"heartbeatMs":12000,"requiresUserStop":false}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
             '{"state":"working","userUpdate":"File does not exist yet.","internalSummary":"waiting for file","nextCheckMs":30000,"shouldNotifyUser":true}',
           toolCalls: [],
           usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
@@ -355,6 +655,14 @@ describe("background-run-supervisor", () => {
           finishReason: "stop",
         })
         .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"File does not exist yet.","internalSummary":"waiting for file","nextCheckMs":30000,"shouldNotifyUser":false}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValue({
           content:
             '{"state":"working","userUpdate":"File does not exist yet.","internalSummary":"waiting for file","nextCheckMs":30000,"shouldNotifyUser":false}',
           toolCalls: [],
@@ -370,6 +678,7 @@ describe("background-run-supervisor", () => {
       chatExecutor: { execute } as any,
       supervisorLlm,
       getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
       createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
       publishUpdate,
     });
@@ -420,6 +729,7 @@ describe("background-run-supervisor", () => {
         healthCheck: vi.fn(async () => true),
       },
       getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
       createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
       publishUpdate,
     });
@@ -444,5 +754,993 @@ describe("background-run-supervisor", () => {
       }),
     );
     await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it("keeps until-stopped runs working even when the supervisor suggests completion", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: {
+        execute: vi.fn(async () =>
+          makeResult({
+            content: "Doom is launched and verified.",
+            toolCalls: [
+              {
+                name: "mcp.doom.start_game",
+                args: { async_player: true },
+                result: '{"status":"running"}',
+                isError: false,
+                durationMs: 5,
+              },
+            ],
+          }),
+        ),
+      } as any,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce({
+            content:
+              '{"kind":"until_stopped","successCriteria":["keep task running"],"completionCriteria":["user explicitly stops it"],"blockedCriteria":["missing tooling"],"nextCheckMs":4000,"heartbeatMs":12000,"requiresUserStop":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"state":"completed","userUpdate":"Doom setup complete.","internalSummary":"done","shouldNotifyUser":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-until-stop",
+      objective: "Keep playing Doom until I tell you to stop.",
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(supervisor.getStatusSnapshot("session-until-stop")?.state).toBe("working");
+  });
+
+  it("does not expire an until-stopped run just because it exceeds the runtime cap", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: {
+        execute: vi.fn(async () =>
+          makeResult({
+            content: "Process is still running.",
+            toolCalls: [
+              {
+                name: "desktop.process_status",
+                args: { processId: "proc_1" },
+                result: '{"state":"running"}',
+                isError: false,
+                durationMs: 5,
+              },
+            ],
+          }),
+        ),
+      } as any,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce({
+            content:
+              '{"kind":"until_stopped","successCriteria":["keep task running"],"completionCriteria":["user explicitly stops it"],"blockedCriteria":["missing tooling"],"nextCheckMs":4000,"heartbeatMs":12000,"requiresUserStop":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"state":"working","userUpdate":"Still running.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+      now: () => Date.now(),
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-until-stop-runtime-cap",
+      objective: "Keep monitoring until I tell you to stop.",
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    const activeRun = (supervisor as any).activeRuns.get(
+      "session-until-stop-runtime-cap",
+    );
+    activeRun.createdAt = Date.now() - (8 * 24 * 60 * 60_000);
+
+    await (supervisor as any).executeCycle("session-until-stop-runtime-cap");
+
+    expect(
+      supervisor.getStatusSnapshot("session-until-stop-runtime-cap")?.state,
+    ).toBe("working");
+  });
+
+  it("does not expire an until-stopped run just because it exceeds the cycle cap", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: {
+        execute: vi.fn(async () =>
+          makeResult({
+            content: "Process is still running.",
+            toolCalls: [
+              {
+                name: "desktop.process_status",
+                args: { processId: "proc_2" },
+                result: '{"state":"running"}',
+                isError: false,
+                durationMs: 5,
+              },
+            ],
+          }),
+        ),
+      } as any,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce({
+            content:
+              '{"kind":"until_stopped","successCriteria":["keep task running"],"completionCriteria":["user explicitly stops it"],"blockedCriteria":["missing tooling"],"nextCheckMs":4000,"heartbeatMs":12000,"requiresUserStop":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"state":"working","userUpdate":"Still running.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-until-stop-cycle-cap",
+      objective: "Keep monitoring until I tell you to stop.",
+    });
+    await vi.runOnlyPendingTimersAsync();
+
+    const activeRun = (supervisor as any).activeRuns.get(
+      "session-until-stop-cycle-cap",
+    );
+    activeRun.cycleCount = 512;
+
+    await (supervisor as any).executeCycle("session-until-stop-cycle-cap");
+
+    expect(
+      supervisor.getStatusSnapshot("session-until-stop-cycle-cap")?.state,
+    ).toBe("working");
+  });
+
+  it("recovers persisted runs after restart with sqlite durability", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "agenc-bg-run-"));
+    const dbPath = join(tempDir, "memory.sqlite");
+
+    try {
+      const backend1 = new SqliteBackend({ dbPath });
+      const runStore1 = new BackgroundRunStore({ memoryBackend: backend1 });
+      const publishUpdate1 = vi.fn(async () => undefined);
+      const execute1 = vi
+        .fn()
+        .mockResolvedValueOnce(
+          makeResult({
+            content: "Watcher started.",
+            toolCalls: [
+              {
+                name: "desktop.process_start",
+                args: { label: "watcher" },
+                result: '{"state":"running"}',
+                isError: false,
+                durationMs: 4,
+              },
+            ],
+          }),
+        );
+      const supervisorLlm1: LLMProvider = {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce({
+            content:
+              '{"kind":"until_condition","successCriteria":["verify the watcher"],"completionCriteria":["condition becomes true"],"blockedCriteria":["missing process tooling"],"nextCheckMs":4000,"heartbeatMs":12000,"requiresUserStop":false}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      };
+      const supervisor1 = new BackgroundRunSupervisor({
+        chatExecutor: { execute: execute1 } as any,
+        supervisorLlm: supervisorLlm1,
+        getSystemPrompt: () => "base system prompt",
+        runStore: runStore1,
+        createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+        publishUpdate: publishUpdate1,
+      });
+
+      await supervisor1.startRun({
+        sessionId: "session-recover",
+        objective: "Monitor the watcher in the background and keep me updated.",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(supervisor1.getStatusSnapshot("session-recover")?.state).toBe("working");
+      expect((await runStore1.listRuns()).length).toBe(1);
+      await supervisor1.shutdown();
+      expect((await runStore1.listRuns()).length).toBe(1);
+      await backend1.close();
+
+      const backend2 = new SqliteBackend({ dbPath });
+      const runStore2 = new BackgroundRunStore({ memoryBackend: backend2 });
+      const publishUpdate2 = vi.fn(async () => undefined);
+      const execute2 = vi.fn(async () =>
+        makeResult({
+          content: "Watcher still running.",
+          toolCalls: [
+            {
+              name: "desktop.process_status",
+              args: { processId: "watcher" },
+              result: '{"state":"running"}',
+              isError: false,
+              durationMs: 3,
+            },
+          ],
+        }),
+      );
+      const supervisorLlm2: LLMProvider = {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValue({
+            content:
+              '{"state":"working","userUpdate":"Watcher is still running.","internalSummary":"verified after restart","nextCheckMs":4000,"shouldNotifyUser":true}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      };
+      const supervisor2 = new BackgroundRunSupervisor({
+        chatExecutor: { execute: execute2 } as any,
+        supervisorLlm: supervisorLlm2,
+        getSystemPrompt: () => "base system prompt",
+        runStore: runStore2,
+        createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+        publishUpdate: publishUpdate2,
+      });
+
+      expect((await runStore2.listRuns()).length).toBe(1);
+      const recovered = await supervisor2.recoverRuns();
+      expect(recovered).toBe(1);
+      expect(supervisor2.getStatusSnapshot("session-recover")?.state).toBe("working");
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(execute2).toHaveBeenCalledTimes(1);
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(execute2).toHaveBeenCalledTimes(2);
+      await backend2.close();
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("queues user signals for an active run and carries forward compact state into the next cycle", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResult({
+          content: "Watcher started and verified.",
+          toolCalls: [
+            {
+              name: "desktop.process_start",
+              args: { label: "watcher" },
+              result: '{"state":"running"}',
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResult({
+          content: "Watcher is still running and will now restart if it crashes.",
+          toolCalls: [
+            {
+              name: "desktop.process_status",
+              args: { processId: "watcher" },
+              result: '{"state":"running"}',
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        }),
+      );
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content:
+            '{"kind":"until_condition","successCriteria":["watch the process"],"completionCriteria":["observe the terminal state"],"blockedCriteria":["missing process tooling"],"nextCheckMs":4000,"heartbeatMs":12000,"requiresUserStop":false}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher is running and needs supervision.","verifiedFacts":["Watcher is running."],"openLoops":["Restart watcher if it crashes."],"nextFocus":"Monitor for process exit."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Watcher is still running and the crash-restart policy is active.","internalSummary":"updated from user signal","nextCheckMs":4000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher is running with a crash-restart instruction queued and applied.","verifiedFacts":["Watcher is running."],"openLoops":["Monitor for process exit and restart if needed."],"nextFocus":"Continue process supervision."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-signals",
+      objective: "Monitor this process in the background and keep me updated.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(supervisor.getStatusSnapshot("session-signals")?.carryForwardSummary).toBe(
+      "Watcher is running and needs supervision.",
+    );
+
+    await supervisor.signalRun({
+      sessionId: "session-signals",
+      content: "If it crashes, restart it and keep monitoring.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    const secondPrompt = execute.mock.calls[1]?.[0].message.content ?? "";
+    expect(secondPrompt).toContain("Carry-forward state:");
+    expect(secondPrompt).toContain("Watcher is running and needs supervision.");
+    expect(secondPrompt).toContain("Pending external signals:");
+    expect(secondPrompt).toContain("If it crashes, restart it and keep monitoring.");
+    expect(supervisor.getStatusSnapshot("session-signals")?.pendingSignals).toBe(0);
+    expect(supervisor.getStatusSnapshot("session-signals")?.carryForwardSummary).toContain(
+      "crash-restart instruction queued and applied",
+    );
+  });
+
+  it("completes deterministically from a verified process_exit signal when the objective is satisfied", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi.fn().mockResolvedValue(
+      makeResult({
+        content: "Watcher started.",
+        toolCalls: [
+          {
+            name: "desktop.process_start",
+            args: { label: "watcher" },
+            result: '{"processId":"proc_watcher","state":"running"}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+      }),
+    );
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content:
+            '{"kind":"until_condition","successCriteria":["watch the process until it exits"],"completionCriteria":["observe the process exit"],"blockedCriteria":["missing process tooling"],"nextCheckMs":60000,"heartbeatMs":15000,"requiresUserStop":false}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"verified running","nextCheckMs":60000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher is running until exit is observed.","verifiedFacts":["Watcher is running."],"openLoops":["Wait for process exit."],"nextFocus":"Observe exit state."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-process-complete",
+      objective: "Monitor this process in the background until it exits.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(supervisor.getStatusSnapshot("session-process-complete")?.state).toBe("working");
+
+    await supervisor.signalRun({
+      sessionId: "session-process-complete",
+      type: "process_exit",
+      content: 'Managed process "watcher" (proc_watcher) exited (exitCode=0).',
+    });
+
+    expect(supervisor.getStatusSnapshot("session-process-complete")).toBeUndefined();
+    expect(publishUpdate).toHaveBeenLastCalledWith(
+      "session-process-complete",
+      'Managed process "watcher" (proc_watcher) exited (exitCode=0). Objective satisfied.',
+    );
+  });
+
+  it("wakes immediately on process_exit signals and restarts a managed process natively", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi.fn().mockResolvedValueOnce(
+      makeResult({
+        content: "Watcher started.",
+        toolCalls: [
+          {
+            name: "desktop.process_start",
+            args: {
+              command: "/bin/sleep",
+              args: ["2"],
+              cwd: "/tmp",
+              label: "watcher",
+            },
+            result:
+              '{"processId":"proc_watcher","label":"watcher","command":"/bin/sleep","args":["2"],"cwd":"/tmp","state":"running"}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+      }),
+    );
+    const nativeTools = createManagedProcessToolHandler();
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content:
+            '{"kind":"until_condition","successCriteria":["watch the process"],"completionCriteria":["observe the terminal state"],"blockedCriteria":["missing process tooling"],"nextCheckMs":60000,"heartbeatMs":15000,"requiresUserStop":false,"managedProcessPolicy":{"mode":"restart_on_exit","maxRestarts":3,"restartBackoffMs":2000}}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"verified running","nextCheckMs":60000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher is running.","verifiedFacts":["Watcher is running."],"openLoops":["Monitor for process exit."],"nextFocus":"Wait for process events."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher exited once and was restarted by the runtime.","verifiedFacts":["Watcher exited.","Watcher restarted successfully."],"openLoops":["Verify the restarted watcher stays up."],"nextFocus":"Confirm the restarted process is healthy."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => nativeTools.handler,
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-process-exit",
+      objective: "Monitor this process in the background and recover on exit.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    nativeTools.markExited(0);
+
+    await supervisor.signalRun({
+      sessionId: "session-process-exit",
+      type: "process_exit",
+      content: 'Managed process "watcher" (proc_watcher) exited (exitCode=0).',
+      data: { processId: "proc_watcher", exitCode: 0 },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(nativeTools.handler).toHaveBeenNthCalledWith(
+      1,
+      "desktop.process_status",
+      { label: "watcher" },
+    );
+    expect(nativeTools.handler).toHaveBeenNthCalledWith(
+      2,
+      "desktop.process_start",
+      {
+        command: "/bin/sleep",
+        args: ["2"],
+        cwd: "/tmp",
+        label: "watcher",
+      },
+    );
+
+    const snapshot = supervisor.getStatusSnapshot("session-process-exit");
+    expect(snapshot?.state).toBe("working");
+    expect(snapshot?.lastUserUpdate).toContain("Restarted");
+    expect(snapshot?.lastUserUpdate).toContain("proc_watcher_2");
+  });
+
+  it("uses native managed-process verification on timer wakes after the initial actor cycle", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi.fn().mockResolvedValueOnce(
+      makeResult({
+        content: "Sleep watcher started.",
+        toolCalls: [
+          {
+            name: "desktop.process_start",
+            args: {
+              command: "/bin/sleep",
+              args: ["2"],
+              cwd: "/tmp",
+              label: "watcher",
+            },
+            result:
+              '{"processId":"proc_watcher","label":"watcher","command":"/bin/sleep","args":["2"],"cwd":"/tmp","state":"running"}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+      }),
+    );
+    const nativeTools = createManagedProcessToolHandler();
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content:
+            '{"kind":"until_condition","successCriteria":["watch the process until it exits"],"completionCriteria":["observe the process exit"],"blockedCriteria":["missing process tooling"],"nextCheckMs":4000,"heartbeatMs":15000,"requiresUserStop":false,"managedProcessPolicy":{"mode":"until_exit"}}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"verified running","nextCheckMs":4000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher started successfully.","verifiedFacts":["Watcher is running."],"openLoops":["Wait for process exit."],"nextFocus":"Verify the process stays up."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher is still running after native verification.","verifiedFacts":["Watcher is still running."],"openLoops":["Wait for process exit."],"nextFocus":"Run another status probe later."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => nativeTools.handler,
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-native-probe",
+      objective: "Monitor this process in the background until it exits.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(4_000);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(nativeTools.handler).toHaveBeenCalledWith(
+      "desktop.process_status",
+      { label: "watcher" },
+    );
+
+    const snapshot = supervisor.getStatusSnapshot("session-native-probe");
+    expect(snapshot?.state).toBe("working");
+    expect(snapshot?.lastUserUpdate).toContain("still running");
+  });
+
+  it("completes deterministically from managed process status without waiting for an exit event", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi.fn().mockResolvedValue(
+      makeResult({
+        content: "Watcher reached its terminal state.",
+        toolCalls: [
+          {
+            name: "desktop.process_status",
+            args: { processId: "proc_watcher" },
+            result: '{"processId":"proc_watcher","label":"watcher","state":"exited","exitCode":0}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+      }),
+    );
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content:
+            '{"kind":"until_condition","successCriteria":["watch the process until it exits"],"completionCriteria":["observe the process exit"],"blockedCriteria":["missing process tooling"],"nextCheckMs":60000,"heartbeatMs":15000,"requiresUserStop":false,"managedProcessPolicy":{"mode":"until_exit"}}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher reached exited state.","verifiedFacts":["Watcher exited."],"openLoops":[],"nextFocus":"None."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-status-terminal",
+      objective: "Monitor this process in the background until it exits.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(supervisor.getStatusSnapshot("session-status-terminal")).toBeUndefined();
+    expect(publishUpdate).toHaveBeenLastCalledWith(
+      "session-status-terminal",
+      'Managed process "watcher" (proc_watcher) exited. Objective satisfied.',
+    );
+  });
+
+  it("completes from a process_exit signal that arrives during carry-forward refresh", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const carryForwardReply = deferred<{
+      content: string;
+      toolCalls: never[];
+      usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+      model: string;
+      finishReason: "stop";
+    }>();
+    const execute = vi.fn().mockResolvedValue(
+      makeResult({
+        content: "Watcher started.",
+        toolCalls: [
+          {
+            name: "desktop.process_start",
+            args: { label: "watcher" },
+            result: '{"processId":"proc_watcher","state":"running"}',
+            isError: false,
+            durationMs: 5,
+          },
+        ],
+      }),
+    );
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content:
+            '{"kind":"until_condition","successCriteria":["watch the process until it exits"],"completionCriteria":["observe the process exit"],"blockedCriteria":["missing process tooling"],"nextCheckMs":60000,"heartbeatMs":15000,"requiresUserStop":false}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"verified running","nextCheckMs":60000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockImplementationOnce(() => carryForwardReply.promise),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-process-tail-exit",
+      objective: "Monitor this process in the background until it exits.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(supervisor.getStatusSnapshot("session-process-tail-exit")?.state).toBe("running");
+
+    await supervisor.signalRun({
+      sessionId: "session-process-tail-exit",
+      type: "process_exit",
+      content: 'Managed process "watcher" (proc_watcher) exited (exitCode=0).',
+    });
+
+    carryForwardReply.resolve({
+      content:
+        '{"summary":"Watcher launch verified.","verifiedFacts":["Watcher started."],"openLoops":["Wait for process exit."],"nextFocus":"Observe exit."}',
+      toolCalls: [],
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      model: "supervisor-model",
+      finishReason: "stop",
+    });
+    await eventually(() => {
+      expect(supervisor.getStatusSnapshot("session-process-tail-exit")).toBeUndefined();
+      expect(execute).toHaveBeenCalledTimes(1);
+      expect(publishUpdate).toHaveBeenCalledWith(
+        "session-process-tail-exit",
+        'Managed process "watcher" (proc_watcher) exited (exitCode=0). Objective satisfied.',
+      );
+    });
+  });
+
+  it("preserves late external signals that arrive during carry-forward refresh", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const carryForwardReply = deferred<{
+      content: string;
+      toolCalls: never[];
+      usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+      model: string;
+      finishReason: "stop";
+    }>();
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce(
+        makeResult({
+          content: "Watcher started.",
+          toolCalls: [
+            {
+              name: "desktop.process_start",
+              args: { label: "watcher" },
+              result: '{"processId":"proc_watcher","state":"running"}',
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeResult({
+          content: "Observed the new external signal and captured it.",
+          toolCalls: [
+            {
+              name: "desktop.process_status",
+              args: { processId: "proc_watcher" },
+              result: '{"processId":"proc_watcher","state":"running"}',
+              isError: false,
+              durationMs: 5,
+            },
+          ],
+        }),
+      );
+    const supervisorLlm: LLMProvider = {
+      name: "supervisor",
+      chat: vi
+        .fn()
+        .mockResolvedValueOnce({
+          content:
+            '{"kind":"until_condition","successCriteria":["monitor the process and react to external events"],"completionCriteria":["observe the requested terminal state"],"blockedCriteria":["missing process tooling"],"nextCheckMs":60000,"heartbeatMs":15000,"requiresUserStop":false}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Watcher is running.","internalSummary":"verified running","nextCheckMs":60000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockImplementationOnce(() => carryForwardReply.promise)
+        .mockResolvedValueOnce({
+          content:
+            '{"state":"working","userUpdate":"Captured the external signal and will keep monitoring.","internalSummary":"reacted to external signal","nextCheckMs":60000,"shouldNotifyUser":true}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content:
+            '{"summary":"Watcher is running and the external signal was handled.","verifiedFacts":["Watcher is running.","External warning captured."],"openLoops":["Continue monitoring watcher health."],"nextFocus":"Wait for the next external event."}',
+          toolCalls: [],
+          usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+          model: "supervisor-model",
+          finishReason: "stop",
+        }),
+      chatStream: vi.fn(),
+      healthCheck: vi.fn(async () => true),
+    };
+
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm,
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => vi.fn(async () => "ok"),
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-late-external-signal",
+      objective: "Monitor this process in the background and react to external signals.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await supervisor.signalRun({
+      sessionId: "session-late-external-signal",
+      type: "external_event",
+      content: "A webhook reported a warning from the watcher process.",
+    });
+
+    carryForwardReply.resolve({
+      content:
+        '{"summary":"Watcher launch verified.","verifiedFacts":["Watcher started."],"openLoops":["Monitor for process health changes."],"nextFocus":"Wait for external events."}',
+      toolCalls: [],
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      model: "supervisor-model",
+      finishReason: "stop",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await eventually(() => {
+      expect(execute).toHaveBeenCalledTimes(2);
+    });
+    expect(execute.mock.calls[1]?.[0].message.content).toContain(
+      "A webhook reported a warning from the watcher process.",
+    );
+    expect(publishUpdate).not.toHaveBeenCalledWith(
+      "session-late-external-signal",
+      "Watcher is running.",
+    );
   });
 });

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -18,6 +18,24 @@ import { silentLogger } from "../utils/logger.js";
 import { toErrorMessage } from "../utils/async.js";
 import type { ToolRoutingDecision } from "./tool-routing.js";
 import type { ProgressTracker } from "./progress.js";
+import {
+  BackgroundRunStore,
+  type BackgroundRunCarryForwardState,
+  type BackgroundRunContract,
+  type BackgroundRunManagedProcessLaunchSpec,
+  type BackgroundRunManagedProcessPolicy,
+  type BackgroundRunObservedTarget,
+  type BackgroundRunRecentSnapshot,
+  type BackgroundRunSignal,
+  type BackgroundRunState,
+  type BackgroundRunWakeReason,
+  type PersistedBackgroundRun,
+} from "./background-run-store.js";
+import {
+  didToolCallFail,
+  extractToolFailureText,
+  parseToolResultObject,
+} from "../llm/chat-executor-tool-utils.js";
 
 const DEFAULT_POLL_INTERVAL_MS = 8_000;
 const BUSY_RETRY_INTERVAL_MS = 1_500;
@@ -29,14 +47,19 @@ const ACTIVE_CYCLE_HEARTBEAT_INITIAL_MS = 8_000;
 const ACTIVE_CYCLE_HEARTBEAT_REPEAT_MS = 15_000;
 const HEARTBEAT_MIN_DELAY_MS = 10_000;
 const HEARTBEAT_MAX_DELAY_MS = 20_000;
-const MAX_BACKGROUND_CYCLES = 64;
-const MAX_BACKGROUND_RUNTIME_MS = 30 * 60_000;
+const MAX_BACKGROUND_CYCLES = 512;
+const MAX_BACKGROUND_RUNTIME_MS = 7 * 24 * 60 * 60_000;
 const MAX_RUN_HISTORY_MESSAGES = 12;
+const HISTORY_COMPACTION_THRESHOLD = 10;
+const MIN_CARRY_FORWARD_REFRESH_MS = 60_000;
 const MAX_TOOL_RESULT_PREVIEW_CHARS = 240;
 const MAX_USER_UPDATE_CHARS = 240;
 const BACKGROUND_RUN_MAX_TOOL_ROUNDS = 1;
 const BACKGROUND_RUN_MAX_TOOL_BUDGET = 4;
 const BACKGROUND_RUN_MAX_MODEL_RECALLS = 0;
+const MAX_CONSECUTIVE_ERROR_CYCLES = 3;
+const DEFAULT_MANAGED_PROCESS_MAX_RESTARTS = 5;
+const DEFAULT_MANAGED_PROCESS_RESTART_BACKOFF_MS = 5_000;
 
 const UNTIL_STOP_RE =
   /\buntil\s+(?:i|you)\s+(?:say|tell)\s+(?:me\s+)?(?:to\s+)?stop\b/i;
@@ -47,7 +70,11 @@ const BACKGROUND_RE =
 const CONTINUOUS_RE =
   /\b(?:keep\s+(?:running|playing|watching|monitoring|checking|tracking)|stay\s+running|monitor(?:ing)?|watch(?:ing)?\s+for|poll(?:ing)?|continu(?:ous|ously))\b/i;
 const STOP_REQUEST_RE =
-  /^\s*(?:stop|cancel|halt|pause|end(?:\s+it|\s+that|\s+the\s+run)?|stop\s+that|stop\s+it)\b/i;
+  /^\s*(?:stop|cancel|halt|end(?:\s+it|\s+that|\s+the\s+run)?|stop\s+that|stop\s+it)\b/i;
+const PAUSE_REQUEST_RE =
+  /^\s*(?:pause|hold|wait|pause\s+that|pause\s+it)\b/i;
+const RESUME_REQUEST_RE =
+  /^\s*(?:resume|continue|continue\s+it|continue\s+that|unpause|restart\s+the\s+run)\b/i;
 const STATUS_REQUEST_RE =
   /^\s*(?:status|update|progress|how(?:'s|\s+is)\s+it\s+going|what(?:'s|\s+is)\s+the\s+status)\b/i;
 
@@ -65,14 +92,14 @@ const DECISION_SYSTEM_PROMPT =
   "You are a runtime supervisor deciding whether a background task should keep running. " +
   "Return JSON only with no markdown.";
 
-export type BackgroundRunState =
-  | "pending"
-  | "running"
-  | "working"
-  | "completed"
-  | "blocked"
-  | "failed"
-  | "cancelled";
+const CONTRACT_SYSTEM_PROMPT =
+  "You are a runtime planner for durable long-running task supervision. " +
+  "Return JSON only with no markdown.";
+
+const CARRY_FORWARD_SYSTEM_PROMPT =
+  "You maintain durable runtime state for a long-running task. " +
+  "Compress only the task-relevant context into concise JSON for the next cycle. " +
+  "Return JSON only with no markdown.";
 
 export interface BackgroundRunStatusSnapshot {
   readonly id: string;
@@ -86,6 +113,9 @@ export interface BackgroundRunStatusSnapshot {
   readonly nextCheckAt?: number;
   readonly nextHeartbeatAt?: number;
   readonly lastUserUpdate?: string;
+  readonly lastWakeReason?: BackgroundRunWakeReason;
+  readonly pendingSignals: number;
+  readonly carryForwardSummary?: string;
 }
 
 interface BackgroundRunDecision {
@@ -97,21 +127,30 @@ interface BackgroundRunDecision {
 }
 
 interface ActiveBackgroundRun {
+  version: 1;
   id: string;
   sessionId: string;
   objective: string;
+  contract: BackgroundRunContract;
   state: BackgroundRunState;
   createdAt: number;
   updatedAt: number;
   cycleCount: number;
   stableWorkingCycles: number;
+  consecutiveErrorCycles: number;
   nextCheckAt?: number;
   nextHeartbeatAt?: number;
   lastVerifiedAt?: number;
   lastUserUpdate?: string;
   lastToolEvidence?: string;
   lastHeartbeatContent?: string;
+  lastWakeReason?: BackgroundRunWakeReason;
+  carryForward?: BackgroundRunCarryForwardState;
+  pendingSignals: BackgroundRunSignal[];
+  observedTargets: BackgroundRunObservedTarget[];
   internalHistory: LLMMessage[];
+  leaseOwnerId?: string;
+  leaseExpiresAt?: number;
   timer: ReturnType<typeof setTimeout> | null;
   heartbeatTimer: ReturnType<typeof setTimeout> | null;
   abortController: AbortController | null;
@@ -139,7 +178,10 @@ export interface BackgroundRunSupervisorConfig {
   ) => void;
   readonly publishUpdate: (sessionId: string, content: string) => Promise<void>;
   readonly progressTracker?: ProgressTracker;
+  readonly runStore: BackgroundRunStore;
   readonly logger?: Logger;
+  readonly instanceId?: string;
+  readonly now?: () => number;
 }
 
 interface StartBackgroundRunParams {
@@ -178,6 +220,85 @@ function trimHistory(history: LLMMessage[]): LLMMessage[] {
   return history.slice(history.length - MAX_RUN_HISTORY_MESSAGES);
 }
 
+function truncateList(
+  values: readonly string[],
+  maxItems: number,
+  maxChars = 100,
+): string[] {
+  return values.slice(0, maxItems).map((value) => truncate(value, maxChars));
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function normalizeManagedProcessPolicyMode(
+  value: unknown,
+): "none" | "until_exit" | "keep_running" | "restart_on_exit" {
+  if (
+    value === "none" ||
+    value === "until_exit" ||
+    value === "keep_running" ||
+    value === "restart_on_exit"
+  ) {
+    return value;
+  }
+  return "none";
+}
+
+function normalizePositiveInteger(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : undefined;
+}
+
+function getManagedProcessPolicy(
+  run: ActiveBackgroundRun,
+): BackgroundRunManagedProcessPolicy {
+  const mode = normalizeManagedProcessPolicyMode(
+    run.contract.managedProcessPolicy?.mode ??
+      inferManagedProcessPolicyMode(run.objective),
+  );
+  return {
+    mode,
+    maxRestarts:
+      mode === "restart_on_exit"
+        ? normalizePositiveInteger(run.contract.managedProcessPolicy?.maxRestarts) ??
+          DEFAULT_MANAGED_PROCESS_MAX_RESTARTS
+        : undefined,
+    restartBackoffMs:
+      mode === "restart_on_exit"
+        ? normalizePositiveInteger(
+            run.contract.managedProcessPolicy?.restartBackoffMs,
+          ) ?? DEFAULT_MANAGED_PROCESS_RESTART_BACKOFF_MS
+        : undefined,
+  };
+}
+
+function inferManagedProcessPolicyMode(objective: string): "none" | "until_exit" | "keep_running" | "restart_on_exit" {
+  const text = objective.toLowerCase();
+  if (/\b(restart|recover|relaunch|respawn)\b/.test(text)) {
+    return "restart_on_exit";
+  }
+  if (/\buntil\b.*\b(exit|exits|exited|stop|stops|stopped|finish|finished|terminate|terminated)\b/.test(text)) {
+    return "until_exit";
+  }
+  if (
+    /\bkeep\b.*\b(running|alive|up)\b/.test(text) ||
+    /\b(stay up|ensure .* running|monitor .* running)\b/.test(text)
+  ) {
+    return "keep_running";
+  }
+  return "none";
+}
+
+function getManagedProcessPolicyMode(run: ActiveBackgroundRun): "none" | "until_exit" | "keep_running" | "restart_on_exit" {
+  return getManagedProcessPolicy(run).mode;
+}
+
 function summarizeToolCalls(toolCalls: readonly ChatExecutorResult["toolCalls"][number][]): string {
   if (toolCalls.length === 0) return "No tool calls executed in this cycle.";
   return toolCalls
@@ -189,6 +310,72 @@ function summarizeToolCalls(toolCalls: readonly ChatExecutorResult["toolCalls"][
     .join("\n");
 }
 
+function formatCarryForwardState(
+  carryForward: BackgroundRunCarryForwardState | undefined,
+): string | undefined {
+  if (!carryForward) return undefined;
+  const parts = [`Summary: ${truncate(carryForward.summary, 240)}`];
+  if (carryForward.verifiedFacts.length > 0) {
+    parts.push(
+      `Verified facts: ${truncateList(carryForward.verifiedFacts, 4).join(" | ")}`,
+    );
+  }
+  if (carryForward.openLoops.length > 0) {
+    parts.push(
+      `Open loops: ${truncateList(carryForward.openLoops, 4).join(" | ")}`,
+    );
+  }
+  if (carryForward.nextFocus) {
+    parts.push(`Next focus: ${truncate(carryForward.nextFocus, 120)}`);
+  }
+  return parts.join("\n");
+}
+
+function formatSignals(signals: readonly BackgroundRunSignal[]): string | undefined {
+  if (signals.length === 0) return undefined;
+  return signals
+    .map((signal) =>
+      `- [${signal.type}] ${truncate(signal.content, 180)}`,
+    )
+    .join("\n");
+}
+
+function formatObservedTargets(
+  observedTargets: readonly BackgroundRunObservedTarget[],
+): string | undefined {
+  if (observedTargets.length === 0) return undefined;
+  return observedTargets
+    .map((target) => {
+      if (target.kind !== "managed_process") {
+        return `- [unknown] ${truncate(JSON.stringify(target), 160)}`;
+      }
+      const label = target.label ? `"${target.label}" ` : "";
+      return (
+        `- [managed_process] ${label}(${target.processId}) ` +
+        `current=${target.currentState} desired=${target.desiredState} policy=${target.exitPolicy}`
+      );
+    })
+    .join("\n");
+}
+
+function cloneSignals(
+  signals: readonly BackgroundRunSignal[],
+): BackgroundRunSignal[] {
+  return signals.map((signal) => ({
+    ...signal,
+    data: signal.data ? { ...signal.data } : undefined,
+  }));
+}
+
+function removeConsumedSignals(
+  signals: readonly BackgroundRunSignal[],
+  consumedSignals: readonly BackgroundRunSignal[],
+): BackgroundRunSignal[] {
+  if (signals.length === 0 || consumedSignals.length === 0) return [...signals];
+  const consumedIds = new Set(consumedSignals.map((signal) => signal.id));
+  return signals.filter((signal) => !consumedIds.has(signal.id));
+}
+
 function buildActorPrompt(run: ActiveBackgroundRun): string {
   const recentHistory = run.lastUserUpdate
     ? `Latest published status: ${run.lastUserUpdate}\n`
@@ -196,12 +383,30 @@ function buildActorPrompt(run: ActiveBackgroundRun): string {
   const recentToolEvidence = run.lastToolEvidence
     ? `Latest tool evidence:\n${run.lastToolEvidence}\n`
     : "";
+  const carryForward = formatCarryForwardState(run.carryForward);
+  const carryForwardSection = carryForward
+    ? `Carry-forward state:\n${carryForward}\n`
+    : "";
+  const pendingSignals = formatSignals(run.pendingSignals);
+  const signalSection = pendingSignals
+    ? `Pending external signals:\n${pendingSignals}\n`
+    : "";
+  const observedTargets = formatObservedTargets(run.observedTargets);
+  const observedTargetSection = observedTargets
+    ? `Runtime observed targets:\n${observedTargets}\n`
+    : "";
+  const contractSummary =
+    `Run contract:\n${JSON.stringify(run.contract, null, 2)}\n`;
   const firstCycleGuidance = run.cycleCount === 1
     ? "This is the first cycle. Establish the baseline and start any required long-running process before relying on status checks alone.\n"
     : "";
   return (
     `Background objective:\n${run.objective}\n\n` +
     `Cycle: ${run.cycleCount}\n` +
+    contractSummary +
+    carryForwardSection +
+    signalSection +
+    observedTargetSection +
     recentHistory +
     recentToolEvidence +
     firstCycleGuidance +
@@ -251,13 +456,15 @@ function buildActiveCycleHeartbeatMessage(run: ActiveBackgroundRun): string {
 }
 
 function buildDecisionPrompt(params: {
+  contract: BackgroundRunContract;
   objective: string;
   actorResult: ChatExecutorResult;
   previousUpdate?: string;
 }): string {
-  const { objective, actorResult, previousUpdate } = params;
+  const { contract, objective, actorResult, previousUpdate } = params;
   return (
     `Objective:\n${objective}\n\n` +
+    `Run contract:\n${JSON.stringify(contract, null, 2)}\n\n` +
     (previousUpdate ? `Previous published update:\n${previousUpdate}\n\n` : "") +
     `Actor stop reason: ${actorResult.stopReason}\n` +
     `Actor stop detail: ${actorResult.stopReasonDetail ?? "none"}\n\n` +
@@ -273,6 +480,74 @@ function buildDecisionPrompt(params: {
     "- If a process or monitor was started and verified but should continue in the background, prefer `working`.\n" +
     "- If the actor hit a bounded cycle budget after successful tool calls, prefer `working` over `failed`.\n" +
     `- Keep userUpdate under ${MAX_USER_UPDATE_CHARS} chars.\n`
+  );
+}
+
+function buildContractPrompt(objective: string): string {
+  return (
+    `User objective:\n${objective}\n\n` +
+    "Return JSON only in this shape:\n" +
+    '{"kind":"finite|until_condition|until_stopped","successCriteria":["..."],"completionCriteria":["..."],"blockedCriteria":["..."],"nextCheckMs":8000,"heartbeatMs":15000,"requiresUserStop":false,"managedProcessPolicy":{"mode":"none|until_exit|keep_running|restart_on_exit","maxRestarts":5,"restartBackoffMs":5000}}\n\n' +
+    "Rules:\n" +
+    "- Use until_stopped only when the user explicitly says the task should continue until they stop it.\n" +
+    "- Use until_condition when the task should keep running until some external condition is observed.\n" +
+    "- Use finite for bounded tasks that should complete on their own.\n" +
+    "- Use managedProcessPolicy.mode = until_exit when the task is specifically to watch a managed process until it exits.\n" +
+    "- Use managedProcessPolicy.mode = keep_running when the task is to keep a managed process/server/app running and alert on exits.\n" +
+    "- Use managedProcessPolicy.mode = restart_on_exit when the task is to recover or restart a managed process after exit.\n" +
+    "- When mode = restart_on_exit, set a bounded restart budget and backoff to avoid flapping loops.\n" +
+    "- Use managedProcessPolicy.mode = none when the task is not centered on a managed process lifecycle.\n" +
+    "- nextCheckMs should be a practical verification cadence in milliseconds.\n" +
+    "- heartbeatMs is optional and should be omitted when no proactive heartbeat is useful.\n"
+  );
+}
+
+function buildCarryForwardPrompt(params: {
+  objective: string;
+  contract: BackgroundRunContract;
+  previous?: BackgroundRunCarryForwardState;
+  actorResult?: ChatExecutorResult;
+  latestUpdate?: string;
+  latestToolEvidence?: string;
+  pendingSignals: readonly BackgroundRunSignal[];
+  observedTargets: readonly BackgroundRunObservedTarget[];
+}): string {
+  const {
+    objective,
+    contract,
+    previous,
+    actorResult,
+    latestUpdate,
+    latestToolEvidence,
+    pendingSignals,
+    observedTargets,
+  } = params;
+  return (
+    `Objective:\n${objective}\n\n` +
+    `Run contract:\n${JSON.stringify(contract, null, 2)}\n\n` +
+    (previous
+      ? `Previous carry-forward state:\n${JSON.stringify(previous, null, 2)}\n\n`
+      : "") +
+    (latestUpdate ? `Latest published update:\n${latestUpdate}\n\n` : "") +
+    (latestToolEvidence ? `Latest tool evidence:\n${latestToolEvidence}\n\n` : "") +
+    (observedTargets.length > 0
+      ? `Runtime observed targets:\n${JSON.stringify(observedTargets, null, 2)}\n\n`
+      : "") +
+    (pendingSignals.length > 0
+      ? `Pending external signals:\n${JSON.stringify(pendingSignals, null, 2)}\n\n`
+      : "") +
+    (actorResult
+      ? `Latest actor response:\n${actorResult.content || "(empty)"}\n\n` +
+        `Latest cycle tool evidence:\n${summarizeToolCalls(actorResult.toolCalls)}\n\n`
+      : "") +
+    "Return JSON only in this shape:\n" +
+    '{"summary":"...","verifiedFacts":["..."],"openLoops":["..."],"nextFocus":"..."}\n\n' +
+    "Rules:\n" +
+    "- Keep only durable task-relevant context that the next cycle actually needs.\n" +
+    "- Prefer verified facts over guesses.\n" +
+    "- Include open loops that still require supervision.\n" +
+    "- Include operator/user signals when they change the next step.\n" +
+    "- Keep summary under 240 chars and each list item under 120 chars.\n"
   );
 }
 
@@ -318,6 +593,19 @@ function extractJsonObject(text: string): string | undefined {
   return undefined;
 }
 
+function parseJsonRecord(text: string): Record<string, unknown> | undefined {
+  const raw = extractJsonObject(text);
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function parseDecision(text: string): BackgroundRunDecision | undefined {
   const raw = extractJsonObject(text);
   if (!raw) return undefined;
@@ -355,6 +643,179 @@ function parseDecision(text: string): BackgroundRunDecision | undefined {
   } catch {
     return undefined;
   }
+}
+
+function parseContract(text: string): BackgroundRunContract | undefined {
+  const raw = extractJsonObject(text);
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const kind = parsed.kind;
+    if (
+      kind !== "finite" &&
+      kind !== "until_condition" &&
+      kind !== "until_stopped"
+    ) {
+      return undefined;
+    }
+    const nextCheckMs = clampPollIntervalMs(
+      typeof parsed.nextCheckMs === "number" ? parsed.nextCheckMs : undefined,
+    );
+    const heartbeatMs =
+      typeof parsed.heartbeatMs === "number" && Number.isFinite(parsed.heartbeatMs)
+        ? clampPollIntervalMs(parsed.heartbeatMs)
+        : undefined;
+    const managedProcessPolicy =
+      parsed.managedProcessPolicy &&
+      typeof parsed.managedProcessPolicy === "object" &&
+      !Array.isArray(parsed.managedProcessPolicy)
+        ? parsed.managedProcessPolicy as Record<string, unknown>
+        : undefined;
+    const normalizeList = (value: unknown, fallback: string): string[] => {
+      if (!Array.isArray(value)) return [fallback];
+      const list = value.filter((item): item is string => typeof item === "string");
+      return list.length > 0 ? list : [fallback];
+    };
+    return {
+      kind,
+      successCriteria: normalizeList(
+        parsed.successCriteria,
+        "Make forward progress on the objective with verified evidence.",
+      ),
+      completionCriteria: normalizeList(
+        parsed.completionCriteria,
+        "Only complete once the environment confirms the objective is satisfied.",
+      ),
+      blockedCriteria: normalizeList(
+        parsed.blockedCriteria,
+        "Block when required tools, permissions, or external preconditions are missing.",
+      ),
+      nextCheckMs,
+      heartbeatMs,
+      requiresUserStop:
+        typeof parsed.requiresUserStop === "boolean"
+          ? parsed.requiresUserStop
+          : kind === "until_stopped",
+      managedProcessPolicy:
+        managedProcessPolicy !== undefined
+          ? {
+              mode: normalizeManagedProcessPolicyMode(managedProcessPolicy.mode),
+              maxRestarts: normalizePositiveInteger(
+                managedProcessPolicy.maxRestarts,
+              ),
+              restartBackoffMs: normalizePositiveInteger(
+                managedProcessPolicy.restartBackoffMs,
+              ),
+            }
+          : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function parseCarryForwardState(
+  text: string,
+  now: number,
+): BackgroundRunCarryForwardState | undefined {
+  const raw = extractJsonObject(text);
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    if (typeof parsed.summary !== "string") return undefined;
+    const verifiedFacts = normalizeStringArray(parsed.verifiedFacts)
+      .slice(0, 6)
+      .map((item) => truncate(item, 120));
+    const openLoops = normalizeStringArray(parsed.openLoops)
+      .slice(0, 6)
+      .map((item) => truncate(item, 120));
+    return {
+      summary: truncate(parsed.summary, 240),
+      verifiedFacts,
+      openLoops,
+      nextFocus:
+        typeof parsed.nextFocus === "string"
+          ? truncate(parsed.nextFocus, 120)
+          : undefined,
+      lastCompactedAt: now,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function buildFallbackCarryForwardState(params: {
+  previous?: BackgroundRunCarryForwardState;
+  latestUpdate?: string;
+  latestToolEvidence?: string;
+  pendingSignals: readonly BackgroundRunSignal[];
+  now: number;
+}): BackgroundRunCarryForwardState {
+  const { previous, latestUpdate, latestToolEvidence, pendingSignals, now } = params;
+  const verifiedFacts = [
+    ...truncateList(previous?.verifiedFacts ?? [], 3, 120),
+    ...(latestToolEvidence ? [truncate(latestToolEvidence, 120)] : []),
+  ].slice(0, 4);
+  const openLoops = [
+    ...truncateList(previous?.openLoops ?? [], 3, 120),
+    ...pendingSignals.slice(0, 2).map((signal) => truncate(signal.content, 120)),
+  ].slice(0, 4);
+  return {
+    summary: truncate(
+      latestUpdate ??
+        previous?.summary ??
+        "Task remains active and requires continued supervision.",
+      240,
+    ),
+    verifiedFacts,
+    openLoops,
+    nextFocus:
+      pendingSignals[0]?.content
+        ? truncate(pendingSignals[0].content, 120)
+        : previous?.nextFocus,
+    lastCompactedAt: now,
+  };
+}
+
+function buildFallbackContract(objective: string): BackgroundRunContract {
+  const untilStopped = UNTIL_STOP_RE.test(objective);
+  const continuous = CONTINUOUS_RE.test(objective) || BACKGROUND_RE.test(objective);
+  const managedProcessPolicyMode = inferManagedProcessPolicyMode(objective);
+  return {
+    kind: untilStopped
+      ? "until_stopped"
+      : continuous
+        ? "until_condition"
+        : "finite",
+    successCriteria: [
+      "Use tools to make measurable progress and verify the result.",
+    ],
+    completionCriteria: [
+      untilStopped
+        ? "Do not complete until the user explicitly stops the run."
+        : "Only complete once tool evidence shows the objective is satisfied.",
+    ],
+    blockedCriteria: [
+      "Block when required approvals, credentials, or external preconditions are missing.",
+    ],
+    nextCheckMs: DEFAULT_POLL_INTERVAL_MS,
+    heartbeatMs: continuous ? HEARTBEAT_MIN_DELAY_MS : undefined,
+    requiresUserStop: untilStopped,
+    managedProcessPolicy:
+      managedProcessPolicyMode !== "none"
+        ? {
+            mode: managedProcessPolicyMode,
+            maxRestarts:
+              managedProcessPolicyMode === "restart_on_exit"
+                ? DEFAULT_MANAGED_PROCESS_MAX_RESTARTS
+                : undefined,
+            restartBackoffMs:
+              managedProcessPolicyMode === "restart_on_exit"
+                ? DEFAULT_MANAGED_PROCESS_RESTART_BACKOFF_MS
+                : undefined,
+          }
+        : undefined,
+  };
 }
 
 function buildFallbackDecision(run: ActiveBackgroundRun, actorResult: ChatExecutorResult): BackgroundRunDecision {
@@ -407,6 +868,7 @@ function buildFallbackDecision(run: ActiveBackgroundRun, actorResult: ChatExecut
 }
 
 function groundDecision(
+  run: ActiveBackgroundRun,
   actorResult: ChatExecutorResult,
   decision: BackgroundRunDecision,
 ): BackgroundRunDecision {
@@ -434,7 +896,845 @@ function groundDecision(
     };
   }
 
+  if (
+    decision.state === "completed" &&
+    run.contract.requiresUserStop
+  ) {
+    return {
+      state: "working",
+      userUpdate: truncate(
+        decision.userUpdate || "Task is still running until you tell me to stop.",
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary:
+        "Rejected premature completion because the run contract requires an explicit user stop.",
+      nextCheckMs: clampPollIntervalMs(run.contract.nextCheckMs),
+      shouldNotifyUser: decision.shouldNotifyUser,
+    };
+  }
+
+  if (
+    decision.state === "completed" &&
+    successfulToolCalls.length === 0 &&
+    !run.lastToolEvidence
+  ) {
+    return {
+      state: "blocked",
+      userUpdate: truncate(
+        "Background run cannot mark itself complete without verified tool evidence.",
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary:
+        "Rejected completion because there is no verified tool evidence in the current or previous cycle.",
+      shouldNotifyUser: true,
+    };
+  }
+
   return decision;
+}
+
+function computeConsecutiveErrorCycles(
+  run: ActiveBackgroundRun,
+  actorResult: ChatExecutorResult,
+): number {
+  if (actorResult.toolCalls.length === 0) return 0;
+  const allFailed = actorResult.toolCalls.every((toolCall) => toolCall.isError);
+  return allFailed ? run.consecutiveErrorCycles + 1 : 0;
+}
+
+function applyRepeatedErrorGuard(
+  decision: BackgroundRunDecision,
+  consecutiveErrorCycles: number,
+): BackgroundRunDecision {
+  if (consecutiveErrorCycles < MAX_CONSECUTIVE_ERROR_CYCLES) return decision;
+  if (decision.state !== "working") return decision;
+  return {
+    state: "blocked",
+    userUpdate: truncate(
+      "Background run is stuck on repeated tool errors and needs intervention or a different plan.",
+      MAX_USER_UPDATE_CHARS,
+    ),
+    internalSummary:
+      `Escalated after ${consecutiveErrorCycles} consecutive all-error cycles.`,
+    shouldNotifyUser: true,
+  };
+}
+
+function parseManagedProcessState(value: unknown): "running" | "exited" | undefined {
+  if (value === "running" || value === "exited") {
+    return value;
+  }
+  return undefined;
+}
+
+function parseManagedProcessLaunchSpec(
+  payload: Record<string, unknown>,
+): BackgroundRunManagedProcessLaunchSpec | undefined {
+  if (typeof payload.command !== "string" || payload.command.trim().length === 0) {
+    return undefined;
+  }
+  return {
+    command: payload.command,
+    args: normalizeStringArray(payload.args),
+    cwd: typeof payload.cwd === "string" ? payload.cwd : undefined,
+    label: typeof payload.label === "string" ? payload.label : undefined,
+    logPath: typeof payload.logPath === "string" ? payload.logPath : undefined,
+  };
+}
+
+function findManagedProcessTarget(
+  observedTargets: readonly BackgroundRunObservedTarget[],
+  processId: string | undefined,
+  label: string | undefined,
+): Extract<BackgroundRunObservedTarget, { kind: "managed_process" }> | undefined {
+  if (processId) {
+    const match = [...observedTargets]
+      .reverse()
+      .find((target) =>
+        target.kind === "managed_process" && target.processId === processId,
+      );
+    if (match?.kind === "managed_process") {
+      return match;
+    }
+  }
+  if (label) {
+    const match = [...observedTargets]
+      .reverse()
+      .find((target) =>
+        target.kind === "managed_process" && target.label === label,
+      );
+    if (match?.kind === "managed_process") {
+      return match;
+    }
+  }
+  return [...observedTargets]
+    .reverse()
+    .find((target): target is Extract<BackgroundRunObservedTarget, { kind: "managed_process" }> =>
+      target.kind === "managed_process",
+    );
+}
+
+function findLatestManagedProcessTarget(
+  observedTargets: readonly BackgroundRunObservedTarget[],
+): Extract<BackgroundRunObservedTarget, { kind: "managed_process" }> | undefined {
+  return [...observedTargets]
+    .reverse()
+    .find((target): target is Extract<BackgroundRunObservedTarget, { kind: "managed_process" }> =>
+      target.kind === "managed_process",
+    );
+}
+
+function shouldKeepRunningAfterProcessExit(run: ActiveBackgroundRun): boolean {
+  const policyMode = getManagedProcessPolicyMode(run);
+  if (policyMode === "keep_running" || policyMode === "restart_on_exit") {
+    return true;
+  }
+  const corpus = [
+    run.objective,
+    ...run.contract.successCriteria,
+    ...run.contract.completionCriteria,
+    ...run.contract.blockedCriteria,
+    run.carryForward?.summary,
+    ...(run.carryForward?.openLoops ?? []),
+    run.carryForward?.nextFocus,
+  ]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  return /\b(restart|recover|relaunch|respawn|replace|resume|keep running|stay running|continue monitoring|continue supervising)\b/.test(
+    corpus,
+  );
+}
+
+function allowsHeuristicProcessExitCompletion(run: ActiveBackgroundRun): boolean {
+  if (run.contract.requiresUserStop || run.contract.kind === "until_stopped") {
+    return false;
+  }
+  if (shouldKeepRunningAfterProcessExit(run)) {
+    return false;
+  }
+
+  const corpus = [
+    run.objective,
+    ...run.contract.successCriteria,
+    ...run.contract.completionCriteria,
+    run.carryForward?.summary,
+    ...(run.carryForward?.verifiedFacts ?? []),
+  ]
+    .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    .join(" ")
+    .toLowerCase();
+
+  return /\b(exit|exits|exited|stop|stops|stopped|terminate|terminated|finish|finished|complete|completed|terminal state)\b/.test(
+    corpus,
+  );
+}
+
+function extractManagedProcessObservation(
+  toolCall: ChatExecutorResult["toolCalls"][number],
+  observedAt: number,
+  existingTarget?: Extract<BackgroundRunObservedTarget, { kind: "managed_process" }>,
+): BackgroundRunObservedTarget | undefined {
+  if (
+    toolCall.isError ||
+    (
+      toolCall.name !== "desktop.process_start" &&
+      toolCall.name !== "desktop.process_status" &&
+      toolCall.name !== "desktop.process_stop"
+    )
+  ) {
+    return undefined;
+  }
+  const payload = parseJsonRecord(toolCall.result);
+  if (!payload) return undefined;
+  const processId =
+    typeof payload.processId === "string" && payload.processId.trim().length > 0
+      ? payload.processId.trim()
+      : undefined;
+  const currentState = parseManagedProcessState(payload.state);
+  if (!processId || !currentState) return undefined;
+  return {
+    kind: "managed_process",
+    processId,
+    label:
+      typeof payload.label === "string" && payload.label.trim().length > 0
+        ? payload.label.trim()
+        : undefined,
+    pid: typeof payload.pid === "number" ? payload.pid : undefined,
+    pgid: typeof payload.pgid === "number" ? payload.pgid : undefined,
+    desiredState: "running",
+    exitPolicy: "keep_running",
+    currentState,
+    lastObservedAt: observedAt,
+    exitCode:
+      payload.exitCode === null || typeof payload.exitCode === "number"
+        ? payload.exitCode
+        : undefined,
+    signal:
+      payload.signal === null || typeof payload.signal === "string"
+        ? payload.signal
+        : undefined,
+    launchSpec:
+      parseManagedProcessLaunchSpec(payload) ??
+      existingTarget?.launchSpec,
+    restartCount: existingTarget?.restartCount,
+    lastRestartAt: existingTarget?.lastRestartAt,
+  };
+}
+
+function upsertObservedTarget(
+  observedTargets: readonly BackgroundRunObservedTarget[],
+  nextTarget: BackgroundRunObservedTarget,
+): BackgroundRunObservedTarget[] {
+  const next = [...observedTargets];
+  const index = next.findIndex((target) =>
+    target.kind === nextTarget.kind &&
+    target.processId === nextTarget.processId,
+  );
+  if (index >= 0) {
+    next[index] = nextTarget;
+    return next;
+  }
+  next.push(nextTarget);
+  return next;
+}
+
+function observeManagedProcessTargets(
+  run: ActiveBackgroundRun,
+  actorResult: ChatExecutorResult,
+  now: number,
+): void {
+  const policyMode = getManagedProcessPolicyMode(run);
+  for (const toolCall of actorResult.toolCalls) {
+    const payload = parseJsonRecord(toolCall.result);
+    const processId =
+      payload && typeof payload.processId === "string"
+        ? payload.processId
+        : undefined;
+    const label =
+      payload && typeof payload.label === "string"
+        ? payload.label
+        : undefined;
+    const existingTarget = findManagedProcessTarget(
+      run.observedTargets,
+      processId,
+      label,
+    );
+    const observation = extractManagedProcessObservation(
+      toolCall,
+      now,
+      existingTarget,
+    );
+    if (!observation) continue;
+    const desiredState = policyMode === "until_exit" ? "exited" : "running";
+    const exitPolicy =
+      policyMode === "restart_on_exit"
+        ? "restart_on_exit"
+        : policyMode === "until_exit"
+          ? "until_exit"
+          : "keep_running";
+    run.observedTargets = upsertObservedTarget(run.observedTargets, {
+      ...observation,
+      desiredState,
+      exitPolicy,
+    });
+  }
+}
+
+function parseProcessExitSignalProcessId(signal: BackgroundRunSignal): string | undefined {
+  const processId =
+    signal.data && typeof signal.data === "object"
+      ? signal.data.processId
+      : undefined;
+  if (typeof processId === "string" && processId.trim().length > 0) {
+    return processId.trim();
+  }
+  return undefined;
+}
+
+function observeManagedProcessExitSignal(run: ActiveBackgroundRun): void {
+  const processExitSignal = [...run.pendingSignals]
+    .reverse()
+    .find((signal) => signal.type === "process_exit");
+  if (!processExitSignal) return;
+  const processId = parseProcessExitSignalProcessId(processExitSignal);
+  if (!processId) return;
+  const existing = run.observedTargets.find((target) =>
+    target.kind === "managed_process" && target.processId === processId,
+  );
+  if (!existing || existing.kind !== "managed_process") return;
+  run.observedTargets = upsertObservedTarget(run.observedTargets, {
+    ...existing,
+    currentState: "exited",
+    lastObservedAt: processExitSignal.timestamp,
+    exitCode:
+      processExitSignal.data?.exitCode === null ||
+      typeof processExitSignal.data?.exitCode === "number"
+        ? processExitSignal.data?.exitCode as number | null | undefined
+        : existing.exitCode,
+    signal:
+      processExitSignal.data?.signal === null ||
+      typeof processExitSignal.data?.signal === "string"
+        ? processExitSignal.data?.signal as string | null | undefined
+        : existing.signal,
+  });
+}
+
+function buildManagedProcessCompletionDecision(
+  run: ActiveBackgroundRun,
+): BackgroundRunDecision | undefined {
+  if (run.contract.requiresUserStop || run.contract.kind === "until_stopped") {
+    return undefined;
+  }
+  const target = [...run.observedTargets]
+    .reverse()
+    .find((candidate) =>
+      candidate.kind === "managed_process" &&
+      candidate.exitPolicy === "until_exit" &&
+      candidate.currentState === "exited" &&
+      candidate.desiredState === "exited",
+    );
+  if (!target || target.kind !== "managed_process") {
+    return undefined;
+  }
+  const matchingExitSignal = [...run.pendingSignals]
+    .reverse()
+    .find((signal) =>
+      signal.type === "process_exit" &&
+      parseProcessExitSignalProcessId(signal) === target.processId,
+    );
+  const targetLabel = target.label ? `"${target.label}" ` : "";
+  const detail =
+    matchingExitSignal?.content ??
+    `Managed process ${targetLabel}(${target.processId}) exited.`;
+  return {
+    state: "completed",
+    userUpdate: truncate(
+      `${detail} Objective satisfied.`,
+      MAX_USER_UPDATE_CHARS,
+    ),
+    internalSummary:
+      "Completed deterministically from managed-process lifecycle target.",
+    shouldNotifyUser: true,
+  };
+}
+
+function buildHeuristicProcessExitCompletionDecision(
+  run: ActiveBackgroundRun,
+): BackgroundRunDecision | undefined {
+  const processExitSignal = [...run.pendingSignals]
+    .reverse()
+    .find((signal) => signal.type === "process_exit");
+  if (!processExitSignal) return undefined;
+  if (!allowsHeuristicProcessExitCompletion(run)) return undefined;
+
+  const detail = (processExitSignal.content ?? "").toLowerCase();
+  const satisfiedByExit =
+    detail.includes("exited") ||
+    detail.includes("terminated") ||
+    detail.includes("finished");
+  if (!satisfiedByExit) {
+    return undefined;
+  }
+
+  return {
+    state: "completed",
+    userUpdate: truncate(
+      `${processExitSignal.content} Objective satisfied.`,
+      MAX_USER_UPDATE_CHARS,
+    ),
+    internalSummary:
+      "Completed deterministically from heuristic process_exit signal without waiting for another model cycle.",
+    shouldNotifyUser: true,
+  };
+}
+
+function buildDeterministicCompletionDecision(
+  run: ActiveBackgroundRun,
+): BackgroundRunDecision | undefined {
+  return (
+    buildManagedProcessCompletionDecision(run) ??
+    buildHeuristicProcessExitCompletionDecision(run)
+  );
+}
+
+interface NativeManagedProcessCycleResult {
+  readonly actorResult: ChatExecutorResult;
+  readonly decision: BackgroundRunDecision;
+}
+
+function hasOnlyNativeManagedProcessSignals(
+  run: ActiveBackgroundRun,
+): boolean {
+  return run.pendingSignals.every((signal) => signal.type === "process_exit");
+}
+
+function shouldUseManagedProcessNativeCycle(
+  run: ActiveBackgroundRun,
+): boolean {
+  if (getManagedProcessPolicyMode(run) === "none") return false;
+  if (!findLatestManagedProcessTarget(run.observedTargets)) return false;
+  if (run.pendingSignals.length === 0) return true;
+  return hasOnlyNativeManagedProcessSignals(run);
+}
+
+function buildManagedProcessIdentity(
+  target: Extract<BackgroundRunObservedTarget, { kind: "managed_process" }>,
+): string {
+  return `${target.label ? `"${target.label}" ` : ""}(${target.processId})`;
+}
+
+function buildManagedProcessExitDetail(
+  run: ActiveBackgroundRun,
+  target: Extract<BackgroundRunObservedTarget, { kind: "managed_process" }>,
+): string {
+  const matchingExitSignal = [...run.pendingSignals]
+    .reverse()
+    .find((signal) =>
+      signal.type === "process_exit" &&
+      parseProcessExitSignalProcessId(signal) === target.processId,
+    );
+  if (matchingExitSignal?.content) {
+    return matchingExitSignal.content;
+  }
+  const statusBits = [
+    target.exitCode !== undefined && target.exitCode !== null
+      ? `exitCode=${target.exitCode}`
+      : undefined,
+    target.signal ? `signal=${target.signal}` : undefined,
+  ].filter(Boolean);
+  return (
+    `Managed process ${buildManagedProcessIdentity(target)} exited` +
+    (statusBits.length > 0 ? ` (${statusBits.join(", ")}).` : ".")
+  );
+}
+
+async function executeNativeToolCall(
+  toolHandler: ToolHandler,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<ChatExecutorResult["toolCalls"][number]> {
+  const startedAt = Date.now();
+  try {
+    const result = await toolHandler(name, args);
+    return {
+      name,
+      args,
+      result,
+      isError: didToolCallFail(false, result),
+      durationMs: Math.max(0, Date.now() - startedAt),
+    };
+  } catch (error) {
+    const result = JSON.stringify({ error: toErrorMessage(error) });
+    return {
+      name,
+      args,
+      result,
+      isError: true,
+      durationMs: Math.max(0, Date.now() - startedAt),
+    };
+  }
+}
+
+function buildNativeActorResult(
+  toolCalls: readonly ChatExecutorResult["toolCalls"][number][],
+  content: string,
+): ChatExecutorResult {
+  const durationMs = toolCalls.reduce((total, toolCall) => total + toolCall.durationMs, 0);
+  return {
+    content,
+    provider: "runtime-native",
+    model: "managed-process-supervisor",
+    usedFallback: false,
+    toolCalls,
+    tokenUsage: { promptTokens: 0, completionTokens: 0, totalTokens: 0 },
+    callUsage: [],
+    durationMs,
+    compacted: false,
+    stopReason: "completed",
+  };
+}
+
+function markManagedProcessRestart(
+  run: ActiveBackgroundRun,
+  previousTarget: Extract<BackgroundRunObservedTarget, { kind: "managed_process" }>,
+  now: number,
+): void {
+  const nextTarget = findManagedProcessTarget(
+    run.observedTargets,
+    undefined,
+    previousTarget.label,
+  ) ?? findLatestManagedProcessTarget(run.observedTargets);
+  if (!nextTarget) return;
+  run.observedTargets = upsertObservedTarget(run.observedTargets, {
+    ...nextTarget,
+    restartCount: (previousTarget.restartCount ?? 0) + 1,
+    lastRestartAt: now,
+  });
+}
+
+async function executeManagedProcessNativeCycle(params: {
+  run: ActiveBackgroundRun;
+  toolHandler: ToolHandler;
+  now: number;
+}): Promise<NativeManagedProcessCycleResult | undefined> {
+  const { run, toolHandler, now } = params;
+  if (!shouldUseManagedProcessNativeCycle(run)) {
+    return undefined;
+  }
+
+  const target = findLatestManagedProcessTarget(run.observedTargets);
+  if (!target) {
+    return undefined;
+  }
+
+  const policy = getManagedProcessPolicy(run);
+  const statusArgs = target.label ? { label: target.label } : { processId: target.processId };
+  const statusCall = await executeNativeToolCall(
+    toolHandler,
+    "desktop.process_status",
+    statusArgs,
+  );
+  const toolCalls: ChatExecutorResult["toolCalls"][number][] = [statusCall];
+  const actorResult = buildNativeActorResult(
+    toolCalls,
+    `Verified managed process ${buildManagedProcessIdentity(target)}.`,
+  );
+
+  observeManagedProcessTargets(run, actorResult, now);
+  run.lastVerifiedAt = now;
+  run.lastToolEvidence = summarizeToolCalls(toolCalls);
+
+  const refreshedTarget =
+    findManagedProcessTarget(run.observedTargets, target.processId, target.label) ??
+    findLatestManagedProcessTarget(run.observedTargets);
+
+  if (!refreshedTarget) {
+    return {
+      actorResult,
+      decision: {
+        state: "working",
+        userUpdate: truncate(
+          "Managed process verification returned no usable state and will retry shortly.",
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary: "Native managed-process verification produced no observable target.",
+        nextCheckMs: MIN_POLL_INTERVAL_MS,
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  if (statusCall.isError) {
+    return {
+      actorResult,
+      decision: {
+        state: "working",
+        userUpdate: truncate(
+          `Managed process verification failed and will retry: ${extractToolFailureText(statusCall)}`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary: `Native managed-process status probe failed: ${extractToolFailureText(statusCall)}`,
+        nextCheckMs: MIN_POLL_INTERVAL_MS,
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  if (refreshedTarget.currentState === "running") {
+    return {
+      actorResult,
+      decision: {
+        state: "working",
+        userUpdate: truncate(
+          `Managed process ${buildManagedProcessIdentity(refreshedTarget)} is still running.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary: "Native managed-process verifier confirmed the process is still running.",
+        nextCheckMs: clampPollIntervalMs(run.contract.nextCheckMs),
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  if (policy.mode === "until_exit") {
+    return {
+      actorResult,
+      decision:
+        buildManagedProcessCompletionDecision(run) ?? {
+          state: "completed",
+          userUpdate: truncate(
+            `${buildManagedProcessExitDetail(run, refreshedTarget)} Objective satisfied.`,
+            MAX_USER_UPDATE_CHARS,
+          ),
+          internalSummary: "Completed from native managed-process status verification.",
+          shouldNotifyUser: true,
+        },
+    };
+  }
+
+  if (policy.mode === "keep_running") {
+    return {
+      actorResult,
+      decision: {
+        state: "blocked",
+        userUpdate: truncate(
+          `${buildManagedProcessExitDetail(run, refreshedTarget)} Restart is not configured, so the run is blocked until you give a new instruction.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          "Managed process exited under keep_running policy without auto-restart.",
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  if (policy.mode !== "restart_on_exit") {
+    return undefined;
+  }
+
+  const launchSpec = refreshedTarget.launchSpec;
+  if (!launchSpec) {
+    return {
+      actorResult,
+      decision: {
+        state: "blocked",
+        userUpdate: truncate(
+          `${buildManagedProcessExitDetail(run, refreshedTarget)} Restart is configured but the runtime has no launch spec to use.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          "Managed process restart policy could not execute because no launch spec was persisted.",
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  const restartCount = refreshedTarget.restartCount ?? 0;
+  if (
+    policy.maxRestarts !== undefined &&
+    restartCount >= policy.maxRestarts
+  ) {
+    return {
+      actorResult,
+      decision: {
+        state: "blocked",
+        userUpdate: truncate(
+          `${buildManagedProcessExitDetail(run, refreshedTarget)} Restart budget exhausted after ${restartCount} attempts.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          `Managed process restart budget exhausted at ${restartCount} attempts.`,
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  const restartBackoffMs = policy.restartBackoffMs ?? DEFAULT_MANAGED_PROCESS_RESTART_BACKOFF_MS;
+  if (
+    refreshedTarget.lastRestartAt !== undefined &&
+    refreshedTarget.lastRestartAt + restartBackoffMs > now
+  ) {
+    const remainingMs = refreshedTarget.lastRestartAt + restartBackoffMs - now;
+    return {
+      actorResult,
+      decision: {
+        state: "working",
+        userUpdate: truncate(
+          `${buildManagedProcessExitDetail(run, refreshedTarget)} Waiting ${Math.ceil(remainingMs / 1000)}s before restart.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          "Managed process restart deferred to honor restart backoff.",
+        nextCheckMs: Math.max(MIN_POLL_INTERVAL_MS, remainingMs),
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  const restartArgs: Record<string, unknown> = {
+    command: launchSpec.command,
+    args: [...launchSpec.args],
+  };
+  if (launchSpec.cwd) restartArgs.cwd = launchSpec.cwd;
+  if (launchSpec.label) restartArgs.label = launchSpec.label;
+  if (launchSpec.logPath) restartArgs.logPath = launchSpec.logPath;
+  const restartCall = await executeNativeToolCall(
+    toolHandler,
+    "desktop.process_start",
+    restartArgs,
+  );
+  toolCalls.push(restartCall);
+  const restartActorResult = buildNativeActorResult(
+    toolCalls,
+    `Recovered managed process ${buildManagedProcessIdentity(refreshedTarget)}.`,
+  );
+  observeManagedProcessTargets(run, restartActorResult, now);
+  run.lastVerifiedAt = now;
+  run.lastToolEvidence = summarizeToolCalls(toolCalls);
+
+  if (restartCall.isError) {
+    return {
+      actorResult: restartActorResult,
+      decision: {
+        state: "blocked",
+        userUpdate: truncate(
+          `${buildManagedProcessExitDetail(run, refreshedTarget)} Restart failed: ${extractToolFailureText(restartCall)}`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary: `Managed process restart failed: ${extractToolFailureText(restartCall)}`,
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  markManagedProcessRestart(run, refreshedTarget, now);
+  const restartedTarget =
+    findManagedProcessTarget(
+      run.observedTargets,
+      parseToolResultObject(restartCall.result)?.processId as string | undefined,
+      launchSpec.label,
+    ) ?? findLatestManagedProcessTarget(run.observedTargets);
+
+  return {
+    actorResult: restartActorResult,
+    decision: {
+      state: "working",
+      userUpdate: truncate(
+        `${buildManagedProcessExitDetail(run, refreshedTarget)} Restarted ${restartedTarget ? buildManagedProcessIdentity(restartedTarget) : "the managed process"} and will keep monitoring.`,
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary:
+        "Managed process exited and was restarted by the native runtime verifier.",
+      nextCheckMs: FAST_FOLLOWUP_POLL_INTERVAL_MS,
+      shouldNotifyUser: true,
+    },
+  };
+}
+
+function toPersistedRun(run: ActiveBackgroundRun): PersistedBackgroundRun {
+  return {
+    version: 1,
+    id: run.id,
+    sessionId: run.sessionId,
+    objective: run.objective,
+    contract: run.contract,
+    state: run.state,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    cycleCount: run.cycleCount,
+    stableWorkingCycles: run.stableWorkingCycles,
+    consecutiveErrorCycles: run.consecutiveErrorCycles,
+    nextCheckAt: run.nextCheckAt,
+    nextHeartbeatAt: run.nextHeartbeatAt,
+    lastVerifiedAt: run.lastVerifiedAt,
+    lastUserUpdate: run.lastUserUpdate,
+    lastToolEvidence: run.lastToolEvidence,
+    lastHeartbeatContent: run.lastHeartbeatContent,
+    lastWakeReason: run.lastWakeReason,
+    carryForward: run.carryForward,
+    pendingSignals: cloneSignals(run.pendingSignals),
+    observedTargets: [...run.observedTargets],
+    internalHistory: trimHistory([...run.internalHistory]),
+    leaseOwnerId: run.leaseOwnerId,
+    leaseExpiresAt: run.leaseExpiresAt,
+  };
+}
+
+function toRecentSnapshot(run: ActiveBackgroundRun): BackgroundRunRecentSnapshot {
+  return {
+    version: 1,
+    runId: run.id,
+    sessionId: run.sessionId,
+    objective: run.objective,
+    state: run.state,
+    contractKind: run.contract.kind,
+    requiresUserStop: run.contract.requiresUserStop,
+    cycleCount: run.cycleCount,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    lastVerifiedAt: run.lastVerifiedAt,
+    nextCheckAt: run.nextCheckAt,
+    nextHeartbeatAt: run.nextHeartbeatAt,
+    lastUserUpdate: run.lastUserUpdate,
+    lastToolEvidence: run.lastToolEvidence,
+    lastWakeReason: run.lastWakeReason,
+    pendingSignals: run.pendingSignals.length,
+    carryForwardSummary: run.carryForward?.summary,
+  };
+}
+
+function toActiveRun(run: PersistedBackgroundRun): ActiveBackgroundRun {
+  return {
+    version: 1,
+    id: run.id,
+    sessionId: run.sessionId,
+    objective: run.objective,
+    contract: run.contract,
+    state: run.state,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+    cycleCount: run.cycleCount,
+    stableWorkingCycles: run.stableWorkingCycles,
+    consecutiveErrorCycles: run.consecutiveErrorCycles,
+    nextCheckAt: run.nextCheckAt,
+    nextHeartbeatAt: run.nextHeartbeatAt,
+    lastVerifiedAt: run.lastVerifiedAt,
+    lastUserUpdate: run.lastUserUpdate,
+    lastToolEvidence: run.lastToolEvidence,
+    lastHeartbeatContent: run.lastHeartbeatContent,
+    lastWakeReason: run.lastWakeReason,
+    carryForward: run.carryForward,
+    pendingSignals: cloneSignals(run.pendingSignals),
+    observedTargets: [...run.observedTargets],
+    internalHistory: [...run.internalHistory],
+    leaseOwnerId: run.leaseOwnerId,
+    leaseExpiresAt: run.leaseExpiresAt,
+    timer: null,
+    heartbeatTimer: null,
+    abortController: null,
+  };
 }
 
 function chooseNextCheckMs(params: {
@@ -510,6 +1810,14 @@ export function isBackgroundRunStopRequest(message: string): boolean {
   return STOP_REQUEST_RE.test(message.trim());
 }
 
+export function isBackgroundRunPauseRequest(message: string): boolean {
+  return PAUSE_REQUEST_RE.test(message.trim());
+}
+
+export function isBackgroundRunResumeRequest(message: string): boolean {
+  return RESUME_REQUEST_RE.test(message.trim());
+}
+
 export function isBackgroundRunStatusRequest(message: string): boolean {
   return STATUS_REQUEST_RE.test(message.trim());
 }
@@ -525,7 +1833,10 @@ export class BackgroundRunSupervisor {
   private readonly onStatus?: BackgroundRunSupervisorConfig["onStatus"];
   private readonly publishUpdate: BackgroundRunSupervisorConfig["publishUpdate"];
   private readonly progressTracker?: ProgressTracker;
+  private readonly runStore: BackgroundRunStore;
   private readonly logger: Logger;
+  private readonly instanceId: string;
+  private readonly now: () => number;
   private readonly activeRuns = new Map<string, ActiveBackgroundRun>();
 
   constructor(config: BackgroundRunSupervisorConfig) {
@@ -539,7 +1850,12 @@ export class BackgroundRunSupervisor {
     this.onStatus = config.onStatus;
     this.publishUpdate = config.publishUpdate;
     this.progressTracker = config.progressTracker;
+    this.runStore = config.runStore;
     this.logger = config.logger ?? silentLogger;
+    this.instanceId =
+      config.instanceId ??
+      `background-supervisor-${Math.random().toString(36).slice(2, 10)}`;
+    this.now = config.now ?? (() => Date.now());
   }
 
   hasActiveRun(sessionId: string): boolean {
@@ -561,37 +1877,125 @@ export class BackgroundRunSupervisor {
       nextCheckAt: run.nextCheckAt,
       nextHeartbeatAt: run.nextHeartbeatAt,
       lastUserUpdate: run.lastUserUpdate,
+      lastWakeReason: run.lastWakeReason,
+      pendingSignals: run.pendingSignals.length,
+      carryForwardSummary: run.carryForward?.summary,
     };
+  }
+
+  async getRecentSnapshot(
+    sessionId: string,
+  ): Promise<BackgroundRunRecentSnapshot | undefined> {
+    const active = this.activeRuns.get(sessionId);
+    if (active) return toRecentSnapshot(active);
+    return this.runStore.loadRecentSnapshot(sessionId);
+  }
+
+  private isActiveRun(run: ActiveBackgroundRun): boolean {
+    return this.activeRuns.get(run.sessionId) === run;
+  }
+
+  async recoverRuns(): Promise<number> {
+    const persistedRuns = await this.runStore.listRuns();
+    let recovered = 0;
+    for (const persistedRun of persistedRuns) {
+      if (
+        persistedRun.state === "completed" ||
+        persistedRun.state === "failed" ||
+        persistedRun.state === "blocked" ||
+        persistedRun.state === "cancelled"
+      ) {
+        await this.runStore.deleteRun(persistedRun.sessionId);
+        continue;
+      }
+      const lease = await this.runStore.claimLease(
+        persistedRun.sessionId,
+        this.instanceId,
+        this.now(),
+      );
+      if (!lease.claimed || !lease.run) continue;
+      const run = toActiveRun(lease.run);
+      if (run.state === "running") {
+        run.state = "working";
+        run.updatedAt = this.now();
+        run.nextCheckAt = this.now();
+        run.nextHeartbeatAt = undefined;
+        run.lastWakeReason = "recovery";
+      }
+      this.activeRuns.set(run.sessionId, run);
+      await this.persistRun(run, {
+        type: "run_recovered",
+        summary: `Recovered background run: ${truncate(run.objective, 200)}`,
+        timestamp: this.now(),
+        data: { previousState: lease.run.state },
+      });
+      if (run.state === "paused") {
+        recovered += 1;
+        continue;
+      }
+      const nextDelay =
+        run.pendingSignals.length > 0
+          ? 0
+          : run.nextCheckAt !== undefined
+          ? Math.max(0, run.nextCheckAt - this.now())
+          : 0;
+      this.schedule(run, nextDelay, "recovery");
+      if (run.state === "working" && run.nextHeartbeatAt !== undefined) {
+        const heartbeatDelay = Math.max(0, run.nextHeartbeatAt - this.now());
+        this.scheduleHeartbeat(run, heartbeatDelay);
+      }
+      recovered += 1;
+    }
+    return recovered;
   }
 
   async startRun(params: StartBackgroundRunParams): Promise<BackgroundRunStatusSnapshot> {
     await this.cancelRun(params.sessionId, "Replaced by a new background run.");
 
-    const now = Date.now();
+    const now = this.now();
+    const contract = await this.planRunContract(params.objective);
     const run: ActiveBackgroundRun = {
+      version: 1,
       id: `bg-${now.toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
       sessionId: params.sessionId,
       objective: params.objective.trim(),
+      contract,
       state: "pending",
       createdAt: now,
       updatedAt: now,
       cycleCount: 0,
       stableWorkingCycles: 0,
+      consecutiveErrorCycles: 0,
       lastVerifiedAt: undefined,
       lastUserUpdate: undefined,
       lastToolEvidence: undefined,
       lastHeartbeatContent: undefined,
+      lastWakeReason: "start",
+      carryForward: undefined,
+      pendingSignals: [],
+      observedTargets: [],
       nextCheckAt: undefined,
       nextHeartbeatAt: undefined,
       internalHistory: [
         ...(this.seedHistoryForSession?.(params.sessionId)?.slice(-6) ?? []),
       ],
+      leaseOwnerId: this.instanceId,
+      leaseExpiresAt: now + 45_000,
       timer: null,
       heartbeatTimer: null,
       abortController: null,
     };
 
     this.activeRuns.set(params.sessionId, run);
+    await this.persistRun(run, {
+      type: "run_started",
+      summary: `Background run started: ${truncate(run.objective, 200)}`,
+      timestamp: now,
+      data: {
+        contractKind: run.contract.kind,
+        nextCheckMs: run.contract.nextCheckMs,
+      },
+    });
     await this.progressTracker?.append({
       sessionId: params.sessionId,
       type: "task_started",
@@ -602,8 +2006,116 @@ export class BackgroundRunSupervisor {
       params.sessionId,
       "Started a background run for this session. I’ll keep working and send updates here until it completes or you tell me to stop.",
     );
-    this.schedule(run, 0);
+    this.schedule(run, 0, "start");
     return this.getStatusSnapshot(params.sessionId)!;
+  }
+
+  async signalRun(params: {
+    sessionId: string;
+    content: string;
+    type?: Exclude<
+      BackgroundRunWakeReason,
+      "start" | "timer" | "busy_retry" | "recovery" | "daemon_shutdown"
+    >;
+    data?: Record<string, unknown>;
+  }): Promise<boolean> {
+    const run = this.activeRuns.get(params.sessionId);
+    if (!run) return false;
+
+    const content = params.content.trim();
+    if (!content) return false;
+
+    const signal: BackgroundRunSignal = {
+      id: `signal-${this.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+      type: params.type ?? "user_input",
+      content,
+      timestamp: this.now(),
+      data: params.data ? { ...params.data } : undefined,
+    };
+    run.pendingSignals.push(signal);
+    if (signal.type === "process_exit") {
+      observeManagedProcessExitSignal(run);
+    }
+    run.updatedAt = this.now();
+    run.lastWakeReason = signal.type;
+    await this.persistRun(run, {
+      type: "run_signalled",
+      summary: truncate(`Background run signalled: ${content}`, 200),
+      timestamp: this.now(),
+      data: { signalType: signal.type },
+    });
+
+    if (run.state === "paused") {
+      return true;
+    }
+
+    if (run.state !== "running") {
+      const completionDecision = buildDeterministicCompletionDecision(run);
+      if (completionDecision) {
+        await this.finishRun(run, completionDecision);
+        return true;
+      }
+      this.schedule(run, 0, signal.type);
+    }
+    return true;
+  }
+
+  async pauseRun(
+    sessionId: string,
+    reason = "Paused the active background run for this session.",
+  ): Promise<boolean> {
+    const run = this.activeRuns.get(sessionId);
+    if (!run) return false;
+    if (run.state === "paused") return true;
+
+    this.clearRunTimers(run);
+    run.abortController?.abort();
+    run.abortController = null;
+    run.state = "paused";
+    run.updatedAt = this.now();
+    run.lastWakeReason = "user_input";
+    run.lastUserUpdate = truncate(reason, MAX_USER_UPDATE_CHARS);
+
+    await this.progressTracker?.append({
+      sessionId,
+      type: "decision",
+      summary: truncate(`Background run paused: ${reason}`, 200),
+    });
+    await this.persistRun(run, {
+      type: "run_paused",
+      summary: truncate(`Background run paused: ${reason}`, 200),
+      timestamp: this.now(),
+    });
+    await this.publishUpdate(sessionId, run.lastUserUpdate);
+    return true;
+  }
+
+  async resumeRun(
+    sessionId: string,
+    reason = "Resumed the background run for this session.",
+  ): Promise<boolean> {
+    const run = this.activeRuns.get(sessionId);
+    if (!run || run.state !== "paused") return false;
+
+    run.state = "working";
+    run.updatedAt = this.now();
+    run.lastWakeReason = "user_input";
+    run.lastUserUpdate = truncate(reason, MAX_USER_UPDATE_CHARS);
+    run.lastHeartbeatContent = undefined;
+
+    await this.progressTracker?.append({
+      sessionId,
+      type: "decision",
+      summary: truncate(`Background run resumed: ${reason}`, 200),
+    });
+    await this.persistRun(run, {
+      type: "run_resumed",
+      summary: truncate(`Background run resumed: ${reason}`, 200),
+      timestamp: this.now(),
+    });
+    await this.publishUpdate(sessionId, run.lastUserUpdate);
+    this.schedule(run, 0, run.pendingSignals[0]?.type ?? "user_input");
+    return true;
   }
 
   async cancelRun(sessionId: string, reason = "Stopped by user."): Promise<boolean> {
@@ -614,9 +2126,17 @@ export class BackgroundRunSupervisor {
     run.abortController?.abort();
     run.abortController = null;
     run.state = "cancelled";
-    run.updatedAt = Date.now();
+    run.updatedAt = this.now();
+    run.lastUserUpdate = truncate(reason, MAX_USER_UPDATE_CHARS);
     this.activeRuns.delete(sessionId);
+    await this.runStore.saveRecentSnapshot(toRecentSnapshot(run));
 
+    await this.runStore.appendEvent(toPersistedRun(run), {
+      type: "run_cancelled",
+      summary: truncate(`Background run cancelled: ${reason}`, 200),
+      timestamp: this.now(),
+    });
+    await this.runStore.deleteRun(sessionId);
     await this.progressTracker?.append({
       sessionId,
       type: "task_completed",
@@ -627,16 +2147,54 @@ export class BackgroundRunSupervisor {
   }
 
   async shutdown(): Promise<void> {
-    const sessionIds = [...this.activeRuns.keys()];
-    for (const sessionId of sessionIds) {
-      await this.cancelRun(sessionId, "Background run stopped because the daemon is shutting down.");
+    const runs = [...this.activeRuns.values()];
+    for (const run of runs) {
+      this.clearRunTimers(run);
+      run.abortController?.abort();
+      run.abortController = null;
+      if (run.state === "running") {
+        run.state = "working";
+        run.nextCheckAt = this.now();
+        run.nextHeartbeatAt = undefined;
+        run.lastWakeReason = "recovery";
+      }
+      await this.runStore.releaseLease(
+        run.sessionId,
+        this.instanceId,
+        this.now(),
+        {
+          ...toPersistedRun(run),
+          state: run.state,
+          nextCheckAt: run.nextCheckAt,
+          nextHeartbeatAt: run.nextHeartbeatAt,
+          lastWakeReason: "daemon_shutdown",
+        },
+      );
+      await this.runStore.appendEvent(toPersistedRun(run), {
+        type: "run_suspended",
+        summary: "Background run suspended for daemon shutdown and will recover on next boot.",
+        timestamp: this.now(),
+      });
+      await this.runStore.saveRecentSnapshot(toRecentSnapshot(run));
+      this.activeRuns.delete(run.sessionId);
     }
   }
 
-  private schedule(run: ActiveBackgroundRun, delayMs: number): void {
+  private schedule(
+    run: ActiveBackgroundRun,
+    delayMs: number,
+    wakeReason: BackgroundRunWakeReason = "timer",
+  ): void {
     if (this.activeRuns.get(run.sessionId) !== run) return;
     if (run.timer) clearTimeout(run.timer);
-    run.nextCheckAt = Date.now() + delayMs;
+    run.nextCheckAt = this.now() + delayMs;
+    run.lastWakeReason = wakeReason;
+    void this.persistRun(run).catch((error) => {
+      this.logger.debug("Failed to persist scheduled background run", {
+        sessionId: run.sessionId,
+        error: toErrorMessage(error),
+      });
+    });
     run.timer = setTimeout(() => {
       void this.executeCycle(run.sessionId);
     }, Math.max(0, delayMs));
@@ -663,7 +2221,13 @@ export class BackgroundRunSupervisor {
     }
     run.nextHeartbeatAt = undefined;
     if (delayMs === undefined || delayMs <= 0) return;
-    run.nextHeartbeatAt = Date.now() + delayMs;
+    run.nextHeartbeatAt = this.now() + delayMs;
+    void this.persistRun(run).catch((error) => {
+      this.logger.debug("Failed to persist background heartbeat schedule", {
+        sessionId: run.sessionId,
+        error: toErrorMessage(error),
+      });
+    });
     run.heartbeatTimer = setTimeout(() => {
       void this.emitHeartbeat(run.sessionId);
     }, delayMs);
@@ -699,23 +2263,40 @@ export class BackgroundRunSupervisor {
     run.lastHeartbeatContent = content;
     run.nextHeartbeatAt = undefined;
     this.onStatus?.(sessionId, {
-      phase: "background_wait",
-      detail:
-        run.nextCheckAt !== undefined
-          ? `Next verification in ~${Math.max(1, Math.ceil((run.nextCheckAt - Date.now()) / 1000))}s`
-          : "Background run waiting for next verification",
-    });
+        phase: "background_wait",
+        detail:
+          run.nextCheckAt !== undefined
+            ? `Next verification in ~${Math.max(1, Math.ceil((run.nextCheckAt - this.now()) / 1000))}s`
+            : "Background run waiting for next verification",
+      });
     await this.publishUpdate(sessionId, content);
+    await this.persistRun(run);
   }
 
   private async executeCycle(sessionId: string): Promise<void> {
     const run = this.activeRuns.get(sessionId);
     if (!run) return;
-    if (this.isSessionBusy?.(sessionId)) {
-      this.schedule(run, BUSY_RETRY_INTERVAL_MS);
+    if (run.state === "paused") return;
+    const leasedRun = await this.runStore.renewLease(
+      toPersistedRun(run),
+      this.instanceId,
+      this.now(),
+    );
+    if (!leasedRun) {
+      this.clearRunTimers(run);
+      this.activeRuns.delete(sessionId);
       return;
     }
-    if (Date.now() - run.createdAt > MAX_BACKGROUND_RUNTIME_MS) {
+    run.leaseOwnerId = leasedRun.leaseOwnerId;
+    run.leaseExpiresAt = leasedRun.leaseExpiresAt;
+    if (this.isSessionBusy?.(sessionId)) {
+      this.schedule(run, BUSY_RETRY_INTERVAL_MS, "busy_retry");
+      return;
+    }
+    if (
+      !run.contract.requiresUserStop &&
+      this.now() - run.createdAt > MAX_BACKGROUND_RUNTIME_MS
+    ) {
       await this.finishRun(run, {
         state: "failed",
         userUpdate: "Background run timed out before the objective was completed.",
@@ -724,7 +2305,7 @@ export class BackgroundRunSupervisor {
       });
       return;
     }
-    if (run.cycleCount >= MAX_BACKGROUND_CYCLES) {
+    if (!run.contract.requiresUserStop && run.cycleCount >= MAX_BACKGROUND_CYCLES) {
       await this.finishRun(run, {
         state: "failed",
         userUpdate: "Background run hit its cycle budget before completing.",
@@ -735,7 +2316,7 @@ export class BackgroundRunSupervisor {
     }
 
     run.state = "running";
-    run.updatedAt = Date.now();
+    run.updatedAt = this.now();
     run.cycleCount += 1;
     run.nextHeartbeatAt = undefined;
     if (run.heartbeatTimer) {
@@ -747,55 +2328,77 @@ export class BackgroundRunSupervisor {
       phase: "background_run",
       detail: `Background run cycle ${run.cycleCount}`,
     });
+    await this.persistRun(run, {
+      type: "cycle_started",
+      summary: `Background run cycle ${run.cycleCount} started.`,
+      timestamp: this.now(),
+    });
     this.scheduleHeartbeat(run, ACTIVE_CYCLE_HEARTBEAT_INITIAL_MS);
 
+    const cycleToolHandler = this.createToolHandler({
+      sessionId,
+      runId: run.id,
+      cycleIndex: run.cycleCount,
+    });
     const actorPrompt = buildActorPrompt(run);
     const actorSystemPrompt = `${this.getSystemPrompt()}\n\n${BACKGROUND_ACTOR_SECTION}`;
     let actorResult: ChatExecutorResult | undefined;
     let decision: BackgroundRunDecision;
     let heartbeatMs: number | undefined;
+    let consecutiveErrorCycles = run.consecutiveErrorCycles;
     try {
       const previousToolEvidence = run.lastToolEvidence;
-      const toolRoutingDecision = this.buildToolRoutingDecision?.(
-        sessionId,
-        actorPrompt,
-        run.internalHistory,
-      );
-      actorResult = await this.chatExecutor.execute({
-        message: toRunMessage(actorPrompt, sessionId, run.id, run.cycleCount),
-        history: run.internalHistory,
-        systemPrompt: actorSystemPrompt,
-        sessionId,
-        toolHandler: this.createToolHandler({
-          sessionId,
-          runId: run.id,
-          cycleIndex: run.cycleCount,
-        }),
-        signal: run.abortController.signal,
-        maxToolRounds: BACKGROUND_RUN_MAX_TOOL_ROUNDS,
-        toolBudgetPerRequest: BACKGROUND_RUN_MAX_TOOL_BUDGET,
-        maxModelRecallsPerRequest: BACKGROUND_RUN_MAX_MODEL_RECALLS,
-        toolRouting: toolRoutingDecision
-          ? {
-            routedToolNames: toolRoutingDecision.routedToolNames,
-            expandedToolNames: toolRoutingDecision.expandedToolNames,
-            expandOnMiss: true,
-          }
-          : undefined,
+      const nativeCycle = await executeManagedProcessNativeCycle({
+        run,
+        toolHandler: cycleToolHandler,
+        now: this.now(),
       });
+      if (nativeCycle) {
+        actorResult = nativeCycle.actorResult;
+        decision = nativeCycle.decision;
+      } else {
+        const toolRoutingDecision = this.buildToolRoutingDecision?.(
+          sessionId,
+          actorPrompt,
+          run.internalHistory,
+        );
+        actorResult = await this.chatExecutor.execute({
+          message: toRunMessage(actorPrompt, sessionId, run.id, run.cycleCount),
+          history: run.internalHistory,
+          systemPrompt: actorSystemPrompt,
+          sessionId,
+          toolHandler: cycleToolHandler,
+          signal: run.abortController.signal,
+          maxToolRounds: BACKGROUND_RUN_MAX_TOOL_ROUNDS,
+          toolBudgetPerRequest: BACKGROUND_RUN_MAX_TOOL_BUDGET,
+          maxModelRecallsPerRequest: BACKGROUND_RUN_MAX_MODEL_RECALLS,
+          toolRouting: toolRoutingDecision
+            ? {
+              routedToolNames: toolRoutingDecision.routedToolNames,
+              expandedToolNames: toolRoutingDecision.expandedToolNames,
+              expandOnMiss: true,
+            }
+            : undefined,
+        });
 
-      run.internalHistory = trimHistory([
-        ...run.internalHistory,
-        { role: "user", content: actorPrompt },
-        { role: "assistant", content: actorResult.content },
-      ]);
-      run.lastVerifiedAt = Date.now();
-      run.lastToolEvidence = summarizeToolCalls(actorResult.toolCalls);
+        run.internalHistory = trimHistory([
+          ...run.internalHistory,
+          { role: "user", content: actorPrompt },
+          { role: "assistant", content: actorResult.content },
+        ]);
+        run.lastVerifiedAt = this.now();
+        run.lastToolEvidence = summarizeToolCalls(actorResult.toolCalls);
+        observeManagedProcessTargets(run, actorResult, run.lastVerifiedAt);
+        decision =
+          buildDeterministicCompletionDecision(run) ??
+          (await this.evaluateDecision(run, actorResult)) ??
+          buildFallbackDecision(run, actorResult);
+      }
 
-      decision =
-        (await this.evaluateDecision(run, actorResult)) ??
-        buildFallbackDecision(run, actorResult);
-      decision = groundDecision(actorResult, decision);
+      consecutiveErrorCycles = computeConsecutiveErrorCycles(run, actorResult);
+      run.consecutiveErrorCycles = consecutiveErrorCycles;
+      decision = groundDecision(run, actorResult, decision);
+      decision = applyRepeatedErrorGuard(decision, consecutiveErrorCycles);
       if (decision.state === "working") {
         const cadence = chooseNextCheckMs({
           run,
@@ -816,22 +2419,57 @@ export class BackgroundRunSupervisor {
       if (run.abortController?.signal.aborted) {
         return;
       }
+      run.consecutiveErrorCycles += 1;
       decision = {
-        state: "failed",
+        state:
+          run.consecutiveErrorCycles >= MAX_CONSECUTIVE_ERROR_CYCLES
+            ? "failed"
+            : "working",
         userUpdate: truncate(
           `Background run failed: ${toErrorMessage(error)}`,
           MAX_USER_UPDATE_CHARS,
         ),
         internalSummary: toErrorMessage(error),
+        nextCheckMs:
+          run.consecutiveErrorCycles >= MAX_CONSECUTIVE_ERROR_CYCLES
+            ? undefined
+            : MIN_POLL_INTERVAL_MS,
         shouldNotifyUser: true,
       };
     } finally {
       run.abortController = null;
     }
 
+    const signalDrivenCompletion = buildDeterministicCompletionDecision(run);
+    if (signalDrivenCompletion) {
+      decision = signalDrivenCompletion;
+    }
+
     if (decision.state === "working") {
+      const carryForwardSignalSnapshot = cloneSignals(run.pendingSignals);
+      await this.refreshCarryForwardState({
+        run,
+        actorResult,
+        signalSnapshot: carryForwardSignalSnapshot,
+      });
+      if (!this.isActiveRun(run)) {
+        return;
+      }
+      const postRefreshSignalDrivenCompletion = buildDeterministicCompletionDecision(run);
+      if (postRefreshSignalDrivenCompletion) {
+        await this.finishRun(run, postRefreshSignalDrivenCompletion);
+        return;
+      }
+
+      const pendingSignalWake = run.pendingSignals[0];
+      const hasPendingSignals = pendingSignalWake !== undefined;
+      const nextWakeReason = pendingSignalWake?.type ?? "timer";
+      const nextCheckMs = hasPendingSignals
+        ? 0
+        : clampPollIntervalMs(decision.nextCheckMs);
+
       run.state = "working";
-      run.updatedAt = Date.now();
+      run.updatedAt = this.now();
       await this.progressTracker?.append({
         sessionId,
         type: "decision",
@@ -840,18 +2478,45 @@ export class BackgroundRunSupervisor {
           200,
         ),
       });
-      if (decision.shouldNotifyUser) {
+      if (decision.shouldNotifyUser && !hasPendingSignals) {
         await this.publishUpdateIfChanged(run, decision.userUpdate);
       }
-      this.scheduleHeartbeat(run, heartbeatMs);
+      if (!this.isActiveRun(run)) {
+        return;
+      }
+      if (!hasPendingSignals) {
+        this.scheduleHeartbeat(run, heartbeatMs);
+      }
       this.onStatus?.(sessionId, {
         phase: "background_wait",
-        detail: `Next verification in ~${Math.max(1, Math.ceil((decision.nextCheckMs ?? DEFAULT_POLL_INTERVAL_MS) / 1000))}s`,
+        detail: hasPendingSignals
+          ? "Processing newly arrived external signals"
+          : `Next verification in ~${Math.max(1, Math.ceil(nextCheckMs / 1000))}s`,
       });
-      this.schedule(run, clampPollIntervalMs(decision.nextCheckMs));
+      await this.persistRun(run, {
+        type: "cycle_working",
+        summary: truncate(
+          `Background run working: ${decision.internalSummary}`,
+          200,
+        ),
+        timestamp: this.now(),
+        data: {
+          nextCheckMs,
+          consecutiveErrorCycles: run.consecutiveErrorCycles,
+          pendingSignals: run.pendingSignals.length,
+        },
+      });
+      if (!this.isActiveRun(run)) {
+        return;
+      }
+      this.schedule(run, nextCheckMs, nextWakeReason);
       return;
     }
 
+    await this.refreshCarryForwardState({ run, actorResult, force: true });
+    if (!this.isActiveRun(run)) {
+      return;
+    }
     await this.finishRun(run, decision);
   }
 
@@ -865,6 +2530,7 @@ export class BackgroundRunSupervisor {
         {
           role: "user",
           content: buildDecisionPrompt({
+            contract: run.contract,
             objective: run.objective,
             actorResult,
             previousUpdate: run.lastUserUpdate,
@@ -884,6 +2550,114 @@ export class BackgroundRunSupervisor {
     }
   }
 
+  private async refreshCarryForwardState(params: {
+    run: ActiveBackgroundRun;
+    actorResult?: ChatExecutorResult;
+    force?: boolean;
+    signalSnapshot?: readonly BackgroundRunSignal[];
+  }): Promise<void> {
+    const { run, actorResult, force, signalSnapshot } = params;
+    const pendingSignals = signalSnapshot ?? run.pendingSignals;
+    const hasSuccessfulToolCalls =
+      actorResult?.toolCalls.some((toolCall) => !toolCall.isError) ?? false;
+    const carryForwardAgeMs =
+      run.carryForward !== undefined
+        ? this.now() - run.carryForward.lastCompactedAt
+        : undefined;
+    const shouldRefresh =
+      force === true ||
+      !run.carryForward ||
+      pendingSignals.length > 0 ||
+      run.internalHistory.length >= HISTORY_COMPACTION_THRESHOLD ||
+      (
+        hasSuccessfulToolCalls &&
+        (carryForwardAgeMs === undefined ||
+          carryForwardAgeMs >= MIN_CARRY_FORWARD_REFRESH_MS)
+      );
+    if (!shouldRefresh) return;
+
+    try {
+      const response = await this.supervisorLlm.chat([
+        { role: "system", content: CARRY_FORWARD_SYSTEM_PROMPT },
+        {
+          role: "user",
+          content: buildCarryForwardPrompt({
+            objective: run.objective,
+            contract: run.contract,
+            previous: run.carryForward,
+            actorResult,
+            latestUpdate: run.lastUserUpdate,
+            latestToolEvidence: run.lastToolEvidence,
+            pendingSignals,
+            observedTargets: run.observedTargets,
+          }),
+        },
+      ], {
+        toolChoice: "none",
+      });
+      run.carryForward =
+        parseCarryForwardState(response.content, this.now()) ??
+        buildFallbackCarryForwardState({
+          previous: run.carryForward,
+          latestUpdate: run.lastUserUpdate,
+          latestToolEvidence: run.lastToolEvidence,
+          pendingSignals,
+          now: this.now(),
+        });
+    } catch (error) {
+      this.logger.debug("Background run carry-forward refresh failed", {
+        sessionId: run.sessionId,
+        runId: run.id,
+        error: toErrorMessage(error),
+      });
+      run.carryForward = buildFallbackCarryForwardState({
+        previous: run.carryForward,
+        latestUpdate: run.lastUserUpdate,
+        latestToolEvidence: run.lastToolEvidence,
+        pendingSignals,
+        now: this.now(),
+      });
+    }
+
+    if (pendingSignals.length > 0) {
+      run.pendingSignals = removeConsumedSignals(run.pendingSignals, pendingSignals);
+    }
+  }
+
+  private async planRunContract(objective: string): Promise<BackgroundRunContract> {
+    try {
+      const response = await this.supervisorLlm.chat([
+        { role: "system", content: CONTRACT_SYSTEM_PROMPT },
+        { role: "user", content: buildContractPrompt(objective) },
+      ], {
+        toolChoice: "none",
+      });
+      return parseContract(response.content) ?? buildFallbackContract(objective);
+    } catch (error) {
+      this.logger.debug("Background run contract planning failed", {
+        objective: truncate(objective, 120),
+        error: toErrorMessage(error),
+      });
+      return buildFallbackContract(objective);
+    }
+  }
+
+  private async persistRun(
+    run: ActiveBackgroundRun,
+    event?: {
+      type: string;
+      summary: string;
+      timestamp: number;
+      data?: Record<string, unknown>;
+    },
+  ): Promise<void> {
+    await this.runStore.saveRun(toPersistedRun(run));
+    await this.runStore.saveRecentSnapshot(toRecentSnapshot(run));
+    if (event) {
+      await this.runStore.appendEvent(toPersistedRun(run), event);
+    }
+  }
+
   private async publishUpdateIfChanged(
     run: ActiveBackgroundRun,
     content: string,
@@ -898,6 +2672,11 @@ export class BackgroundRunSupervisor {
       run.nextHeartbeatAt = undefined;
     }
     await this.publishUpdate(run.sessionId, next);
+    await this.persistRun(run, {
+      type: "user_update",
+      summary: next,
+      timestamp: this.now(),
+    });
   }
 
   private async finishRun(
@@ -908,8 +2687,12 @@ export class BackgroundRunSupervisor {
     run.abortController?.abort();
     run.abortController = null;
     run.state = decision.state;
-    run.updatedAt = Date.now();
+    run.updatedAt = this.now();
+    if (decision.shouldNotifyUser) {
+      run.lastUserUpdate = truncate(decision.userUpdate, MAX_USER_UPDATE_CHARS);
+    }
     this.activeRuns.delete(run.sessionId);
+    await this.runStore.saveRecentSnapshot(toRecentSnapshot(run));
 
     const progressType = decision.state === "completed"
       ? "task_completed"
@@ -922,6 +2705,15 @@ export class BackgroundRunSupervisor {
         200,
       ),
     });
+    await this.runStore.appendEvent(toPersistedRun(run), {
+      type: `run_${decision.state}`,
+      summary: truncate(
+        `Background run ${decision.state}: ${decision.internalSummary}`,
+        200,
+      ),
+      timestamp: this.now(),
+    });
+    await this.runStore.deleteRun(run.sessionId);
 
     if (decision.shouldNotifyUser) {
       await this.publishUpdate(run.sessionId, truncate(decision.userUpdate, MAX_USER_UPDATE_CHARS));

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -95,9 +95,11 @@ import { SkillDiscovery } from '../skills/markdown/discovery.js';
 import type { DiscoveredSkill } from '../skills/markdown/discovery.js';
 import { VoiceBridge } from './voice-bridge.js';
 import { createSessionToolHandler } from './tool-handler-factory.js';
+import type { DesktopBridgeEvent } from '../desktop/rest-bridge.js';
 import { InMemoryBackend } from '../memory/in-memory/backend.js';
 import { ApprovalEngine } from './approvals.js';
 import type { MemoryBackend } from '../memory/types.js';
+import { entryToMessage } from '../memory/types.js';
 import { createEmbeddingProvider } from '../memory/embeddings.js';
 import { InMemoryVectorStore } from '../memory/vector-store.js';
 import { SemanticMemoryRetriever } from '../memory/retriever.js';
@@ -136,9 +138,17 @@ import { SubAgentOrchestrator } from './subagent-orchestrator.js';
 import {
   BackgroundRunSupervisor,
   inferBackgroundRunIntent,
+  isBackgroundRunPauseRequest,
+  isBackgroundRunResumeRequest,
   isBackgroundRunStatusRequest,
   isBackgroundRunStopRequest,
 } from './background-run-supervisor.js';
+import { BackgroundRunStore } from './background-run-store.js';
+import {
+  formatBackgroundRunStatus,
+  formatInactiveBackgroundRunStatus,
+  formatInactiveBackgroundRunStop,
+} from './background-run-control.js';
 import { inferDoomTurnContract } from '../llm/chat-executor-doom.js';
 import {
   blockUntilDoomStopTool,
@@ -161,6 +171,67 @@ function chooseDoomResolutionForDisplay(
   if (width >= 1024 && height >= 768) return 'RES_1024X768';
   if (width >= 800 && height >= 600) return 'RES_800X600';
   return 'RES_640X480';
+}
+
+function mapDesktopBridgeEventTypeToWebChatEvent(type: string): string {
+  if (type === 'managed_process.exited') {
+    return 'desktop.process.exited';
+  }
+  return `desktop.${type.replace(/_/g, '.')}`;
+}
+
+function buildBackgroundRunSignalFromDesktopEvent(
+  event: DesktopBridgeEvent,
+): {
+  type: 'process_exit' | 'external_event';
+  content: string;
+  data?: Record<string, unknown>;
+} | undefined {
+  if (event.type === 'managed_process.exited') {
+    const processId =
+      typeof event.payload.processId === 'string'
+        ? event.payload.processId
+        : 'unknown-process';
+    const label =
+      typeof event.payload.label === 'string' && event.payload.label.trim().length > 0
+        ? event.payload.label.trim()
+        : undefined;
+    const exitCode =
+      typeof event.payload.exitCode === 'number'
+        ? `exitCode=${event.payload.exitCode}`
+        : undefined;
+    const signal =
+      typeof event.payload.signal === 'string' && event.payload.signal.trim().length > 0
+        ? `signal=${event.payload.signal}`
+        : undefined;
+    const status = [exitCode, signal].filter(Boolean).join(', ');
+    return {
+      type: 'process_exit',
+      content:
+        `Managed process ${label ? `"${label}" ` : ''}(${processId}) exited` +
+        (status ? ` (${status}).` : '.'),
+      data: {
+        processId,
+        ...(label ? { label } : {}),
+        ...(typeof event.payload.pid === 'number' ? { pid: event.payload.pid } : {}),
+        ...(typeof event.payload.pgid === 'number' ? { pgid: event.payload.pgid } : {}),
+        ...(typeof event.payload.startedAt === 'number' ? { startedAt: event.payload.startedAt } : {}),
+        ...(typeof event.payload.endedAt === 'number' ? { endedAt: event.payload.endedAt } : {}),
+        ...(typeof event.payload.exitCode === 'number' || event.payload.exitCode === null
+          ? { exitCode: event.payload.exitCode }
+          : {}),
+        ...(typeof event.payload.signal === 'string' || event.payload.signal === null
+          ? { signal: event.payload.signal }
+          : {}),
+        ...(typeof event.payload.logPath === 'string' ? { logPath: event.payload.logPath } : {}),
+      },
+    };
+  }
+
+  return {
+    type: 'external_event',
+    content: `Desktop event observed: ${event.type}`,
+  };
 }
 
 /** Minimum confidence score for injecting learned patterns into conversations. */
@@ -2536,6 +2607,13 @@ export class DaemonManager {
           memoryBackend,
           progressTracker,
         }),
+      hydrateSessionContext: (webSessionId: string) =>
+        this.hydrateWebSessionContext({
+          webSessionId,
+          sessionMgr,
+          resolveSessionId,
+          memoryBackend,
+        }),
       cancelBackgroundRun: (sessionId: string) =>
         this._backgroundRunSupervisor?.cancelRun(
           sessionId,
@@ -2566,10 +2644,15 @@ export class DaemonManager {
     gateway.setWebChatHandler(webChat);
     this._webChatChannel = webChat;
     if (this._chatExecutor && providers[0]) {
+      const runStore = new BackgroundRunStore({
+        memoryBackend,
+        logger: this.logger,
+      });
       this._backgroundRunSupervisor = new BackgroundRunSupervisor({
         chatExecutor: this._chatExecutor,
         supervisorLlm: providers[0],
         getSystemPrompt: () => this._systemPrompt,
+        runStore,
         createToolHandler: ({ sessionId, runId, cycleIndex }) =>
           this.createWebChatSessionToolHandler({
             sessionId,
@@ -2604,6 +2687,10 @@ export class DaemonManager {
         progressTracker,
         logger: this.logger,
       });
+      const recoveredRuns = await this._backgroundRunSupervisor.recoverRuns();
+      if (recoveredRuns > 0) {
+        this.logger.info(`Recovered ${recoveredRuns} background run(s) on boot`);
+      }
     } else {
       this._backgroundRunSupervisor = null;
     }
@@ -2687,6 +2774,43 @@ export class DaemonManager {
     const playwrightBridges = this._playwrightBridges;
     const desktopLogger = this.logger;
     const playwrightEnabled = config.desktop?.playwright?.enabled !== false;
+    const handleDesktopEvent = (sessionId: string, event: DesktopBridgeEvent): void => {
+      const eventType = mapDesktopBridgeEventTypeToWebChatEvent(event.type);
+      this._webChatChannel?.broadcastEvent(eventType, {
+        sessionId,
+        timestamp: event.timestamp,
+        ...event.payload,
+      });
+
+      const wakeSignal = buildBackgroundRunSignalFromDesktopEvent(event);
+      if (!wakeSignal) {
+        return;
+      }
+
+      void this._backgroundRunSupervisor?.signalRun({
+        sessionId,
+        type: wakeSignal.type,
+        content: wakeSignal.content,
+        data: wakeSignal.data,
+      }).then((signalled) => {
+        if (!signalled) {
+          return;
+        }
+        this._webChatChannel?.pushToSession(sessionId, {
+          type: 'agent.status',
+          payload: {
+            phase: 'background_run',
+            detail: wakeSignal.content,
+          },
+        });
+      }).catch((error) => {
+        this.logger.debug('Failed to signal background run from desktop event', {
+          sessionId,
+          eventType: event.type,
+          error: toErrorMessage(error),
+        });
+      });
+    };
 
     // Desktop tools are lazily initialized per session via the router.
     // Add static desktop tool definitions to LLM tools so the model knows
@@ -2719,6 +2843,7 @@ export class DaemonManager {
         containerMCPBridges:
           containerMCPConfigs.length > 0 ? containerMCPBridges : undefined,
         allowedToolNames,
+        onDesktopEvent: (event) => handleDesktopEvent(sessionId, event),
         logger: desktopLogger,
         // Force-disable automatic screenshot capture for action tools.
         autoScreenshot: false,
@@ -4680,6 +4805,43 @@ export class DaemonManager {
     await this.cleanupDesktopSessionResources(webSessionId);
   }
 
+  private async hydrateWebSessionContext(params: {
+    webSessionId: string;
+    sessionMgr: SessionManager;
+    resolveSessionId: (sessionKey: string) => string;
+    memoryBackend: MemoryBackend;
+  }): Promise<void> {
+    const { webSessionId, sessionMgr, resolveSessionId, memoryBackend } = params;
+
+    const historySessionId = resolveSessionId(webSessionId);
+    const session = sessionMgr.getOrCreate({
+      channel: 'webchat',
+      senderId: webSessionId,
+      scope: 'dm',
+      workspaceId: 'default',
+    });
+    if (session.history.length > 0) {
+      return;
+    }
+
+    const maxHistory = 100;
+    const thread = await memoryBackend.getThread(webSessionId, maxHistory).catch((error) => {
+      this.logger.debug("Failed to hydrate web session from memory", {
+        sessionId: webSessionId,
+        error: toErrorMessage(error),
+      });
+      return [];
+    });
+    if (thread.length === 0) {
+      return;
+    }
+
+    const history = thread
+      .filter((entry) => entry.role !== "tool")
+      .map((entry) => entryToMessage(entry));
+    sessionMgr.replaceHistory(historySessionId, history);
+  }
+
   private async cleanupDesktopSessionResources(sessionId: string): Promise<void> {
     if (!this._desktopManager) return;
 
@@ -6311,44 +6473,81 @@ export class DaemonManager {
         );
         if (!isDoomStopTurn) return;
       }
+      if (isBackgroundRunPauseRequest(msg.content)) {
+        const paused = await this._backgroundRunSupervisor?.pauseRun(msg.sessionId);
+        if (paused) return;
+      }
+      if (isBackgroundRunResumeRequest(msg.content)) {
+        const resumed = await this._backgroundRunSupervisor?.resumeRun(msg.sessionId);
+        if (resumed) return;
+      }
       if (isBackgroundRunStatusRequest(msg.content)) {
-        const nextCheck =
-          activeBackgroundRun.nextCheckAt !== undefined
-            ? Math.max(0, activeBackgroundRun.nextCheckAt - Date.now())
-            : undefined;
-        const nextHeartbeat =
-          activeBackgroundRun.nextHeartbeatAt !== undefined
-            ? Math.max(0, activeBackgroundRun.nextHeartbeatAt - Date.now())
-            : undefined;
-        const lastVerified =
-          activeBackgroundRun.lastVerifiedAt !== undefined
-            ? Math.max(0, Date.now() - activeBackgroundRun.lastVerifiedAt)
-            : undefined;
         await webChat.send({
           sessionId: msg.sessionId,
-          content:
-            `Background run: ${activeBackgroundRun.state}\n` +
-            `Objective: ${activeBackgroundRun.objective}\n` +
-            `Cycles: ${activeBackgroundRun.cycleCount}\n` +
-            (lastVerified !== undefined
-              ? `Last verified: ~${Math.max(1, Math.ceil(lastVerified / 1000))}s ago\n`
-              : "") +
-            (activeBackgroundRun.lastUserUpdate
-              ? `Latest update: ${activeBackgroundRun.lastUserUpdate}\n`
-              : "") +
-            (nextHeartbeat !== undefined
-              ? `Next heartbeat: ~${Math.ceil(nextHeartbeat / 1000)}s\n`
-              : "") +
-            (nextCheck !== undefined
-              ? `Next check: ~${Math.ceil(nextCheck / 1000)}s`
-              : "Next check: pending"),
+          content: formatBackgroundRunStatus(activeBackgroundRun),
         });
         return;
       }
-      await this._backgroundRunSupervisor?.cancelRun(
-        msg.sessionId,
-        "Background run stopped because a new user request took priority.",
-      );
+      const signalled = await this._backgroundRunSupervisor?.signalRun({
+        sessionId: msg.sessionId,
+        content: msg.content,
+        type: "user_input",
+      });
+      if (signalled) {
+        await memoryBackend.addEntry({
+          sessionId: msg.sessionId,
+          role: "user",
+          content: msg.content,
+        }).catch((error) => {
+          this.logger.debug("Background run signal memory write failed", {
+            sessionId: msg.sessionId,
+            error: toErrorMessage(error),
+          });
+        });
+        await webChat.send({
+          sessionId: msg.sessionId,
+          content:
+            activeBackgroundRun.state === "paused"
+              ? "Queued your latest instruction for the paused background run. Resume it when you want execution to continue."
+              : "Queued your latest instruction for the active background run and woke it for an immediate follow-up cycle.",
+        });
+        return;
+      }
+    }
+
+    if (!isDoomStopTurn && this._backgroundRunSupervisor) {
+      if (isBackgroundRunStatusRequest(msg.content)) {
+        const recentSnapshot =
+          await this._backgroundRunSupervisor.getRecentSnapshot(msg.sessionId);
+        await webChat.send({
+          sessionId: msg.sessionId,
+          content: formatInactiveBackgroundRunStatus(recentSnapshot),
+        });
+        return;
+      }
+      if (isBackgroundRunStopRequest(msg.content)) {
+        const recentSnapshot =
+          await this._backgroundRunSupervisor.getRecentSnapshot(msg.sessionId);
+        await webChat.send({
+          sessionId: msg.sessionId,
+          content: formatInactiveBackgroundRunStop(recentSnapshot),
+        });
+        return;
+      }
+      if (isBackgroundRunPauseRequest(msg.content)) {
+        await webChat.send({
+          sessionId: msg.sessionId,
+          content: "No active background run to pause.",
+        });
+        return;
+      }
+      if (isBackgroundRunResumeRequest(msg.content)) {
+        await webChat.send({
+          sessionId: msg.sessionId,
+          content: "No paused background run to resume.",
+        });
+        return;
+      }
     }
 
     if (inferBackgroundRunIntent(msg.content) && this._backgroundRunSupervisor) {
@@ -7337,6 +7536,10 @@ export class DaemonManager {
       }
       this._containerMCPBridges.clear();
       this._containerMCPConfigs = [];
+      if (this._backgroundRunSupervisor !== null) {
+        await this._backgroundRunSupervisor.shutdown();
+        this._backgroundRunSupervisor = null;
+      }
       if (this._desktopManager !== null) {
         await this._desktopManager.stop();
         this._desktopManager = null;
@@ -7362,10 +7565,6 @@ export class DaemonManager {
       if (this._cronScheduler !== null) {
         this._cronScheduler.stop();
         this._cronScheduler = null;
-      }
-      if (this._backgroundRunSupervisor !== null) {
-        await this._backgroundRunSupervisor.shutdown();
-        this._backgroundRunSupervisor = null;
       }
       // Stop legacy heartbeat timer (if still in use)
       if (this._heartbeatTimer !== null) {

--- a/runtime/src/gateway/session.ts
+++ b/runtime/src/gateway/session.ts
@@ -323,6 +323,15 @@ export class SessionManager {
     return true;
   }
 
+  /** Replace a session's history wholesale, preserving identity and metadata. */
+  replaceHistory(sessionId: string, history: readonly LLMMessage[]): boolean {
+    const session = this.sessions.get(sessionId);
+    if (!session) return false;
+    session.history = [...history];
+    session.lastActiveAt = Date.now();
+    return true;
+  }
+
   /**
    * Compact a session's history using the configured strategy.
    * Returns null if session not found.

--- a/runtime/src/utils/keyed-async-queue.test.ts
+++ b/runtime/src/utils/keyed-async-queue.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import { KeyedAsyncQueue } from "./keyed-async-queue.js";
+
+describe("KeyedAsyncQueue", () => {
+  it("serializes operations for the same key", async () => {
+    const queue = new KeyedAsyncQueue();
+    const order: string[] = [];
+    let releaseFirst: (() => void) | undefined;
+    const firstStarted = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+
+    const first = queue.run("alpha", async () => {
+      order.push("first:start");
+      await firstStarted;
+      order.push("first:end");
+      return 1;
+    });
+    const second = queue.run("alpha", async () => {
+      order.push("second:start");
+      order.push("second:end");
+      return 2;
+    });
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(["first:start"]);
+    });
+    releaseFirst?.();
+
+    await expect(first).resolves.toBe(1);
+    await expect(second).resolves.toBe(2);
+    expect(order).toEqual([
+      "first:start",
+      "first:end",
+      "second:start",
+      "second:end",
+    ]);
+  });
+
+  it("allows operations on different keys to proceed independently", async () => {
+    const queue = new KeyedAsyncQueue();
+    const order: string[] = [];
+
+    await Promise.all([
+      queue.run("alpha", async () => {
+        order.push("alpha");
+      }),
+      queue.run("beta", async () => {
+        order.push("beta");
+      }),
+    ]);
+
+    expect(order.sort()).toEqual(["alpha", "beta"]);
+  });
+});

--- a/runtime/src/utils/keyed-async-queue.ts
+++ b/runtime/src/utils/keyed-async-queue.ts
@@ -1,0 +1,50 @@
+import type { Logger } from "./logger.js";
+import { silentLogger } from "./logger.js";
+import { toErrorMessage } from "./async.js";
+
+export interface KeyedAsyncQueueConfig {
+  readonly logger?: Logger;
+  readonly label?: string;
+}
+
+export class KeyedAsyncQueue {
+  private readonly logger: Logger;
+  private readonly label: string;
+  private readonly chains = new Map<string, Promise<unknown>>();
+
+  constructor(config: KeyedAsyncQueueConfig = {}) {
+    this.logger = config.logger ?? silentLogger;
+    this.label = config.label ?? "keyed async queue";
+  }
+
+  async run<T>(key: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.chains.get(key) ?? Promise.resolve();
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const nextChain = previous
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          return await operation();
+        } finally {
+          release?.();
+        }
+      });
+    this.chains.set(key, gate);
+    try {
+      return await nextChain;
+    } catch (error) {
+      this.logger.debug(`${this.label} operation failed`, {
+        key,
+        error: toErrorMessage(error),
+      });
+      throw error;
+    } finally {
+      if (this.chains.get(key) === gate) {
+        this.chains.delete(key);
+      }
+    }
+  }
+}

--- a/web/src/hooks/useChat.test.ts
+++ b/web/src/hooks/useChat.test.ts
@@ -258,6 +258,7 @@ describe("useChat session lifecycle", () => {
       expect.objectContaining({
         type: "chat.new",
         id: expect.any(String),
+        payload: { clientKey: expect.any(String) },
       }),
     );
     expect(result.current.messages).toEqual([]);
@@ -276,7 +277,10 @@ describe("useChat session lifecycle", () => {
       expect.objectContaining({
         type: "chat.message",
         id: expect.any(String),
-        payload: { content: "hello" },
+        payload: {
+          content: "hello",
+          clientKey: expect.any(String),
+        },
       }),
     );
   });

--- a/web/src/hooks/useChat.ts
+++ b/web/src/hooks/useChat.ts
@@ -77,6 +77,28 @@ interface UseChatOptions {
   connected?: boolean;
 }
 
+const WEBCHAT_CLIENT_KEY_STORAGE_KEY = 'agenc-webchat-client-key';
+
+function createClientKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `client_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getOrCreateWebChatClientKey(): string {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return createClientKey();
+  }
+  const existing = window.localStorage.getItem(WEBCHAT_CLIENT_KEY_STORAGE_KEY);
+  if (existing && existing.trim().length > 0) {
+    return existing;
+  }
+  const next = createClientKey();
+  window.localStorage.setItem(WEBCHAT_CLIENT_KEY_STORAGE_KEY, next);
+  return next;
+}
+
 function asNumber(value: unknown): number | undefined {
   if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
   return value;
@@ -232,6 +254,7 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
   const pendingMsgIdRef = useRef<string | null>(null);
   const msgCounterRef = useRef(0);
   const requestCounterRef = useRef(0);
+  const clientKeyRef = useRef<string>(getOrCreateWebChatClientKey());
 
   const nextRequestId = useCallback((prefix: string): string => {
     requestCounterRef.current += 1;
@@ -239,7 +262,10 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
   }, []);
 
   const refreshSessions = useCallback(() => {
-    send({ type: WS_CHAT_SESSIONS });
+    send({
+      type: WS_CHAT_SESSIONS,
+      payload: { clientKey: clientKeyRef.current },
+    });
   }, [send]);
 
   // Fetch sessions when connected
@@ -248,7 +274,10 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
   }, [connected, refreshSessions]);
 
   const resumeSession = useCallback((targetSessionId: string) => {
-    send({ type: WS_CHAT_RESUME, payload: { sessionId: targetSessionId } });
+    send({
+      type: WS_CHAT_RESUME,
+      payload: { sessionId: targetSessionId, clientKey: clientKeyRef.current },
+    });
   }, [send]);
 
   const startNewChat = useCallback(() => {
@@ -257,11 +286,18 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
     setIsTyping(false);
     setTokenUsage(null);
     pendingMsgIdRef.current = null;
-    send({ type: WS_CHAT_NEW, id: nextRequestId('chat_new') });
+    send({
+      type: WS_CHAT_NEW,
+      id: nextRequestId('chat_new'),
+      payload: { clientKey: clientKeyRef.current },
+    });
   }, [nextRequestId, send]);
 
   const stopGeneration = useCallback(() => {
-    send({ type: WS_CHAT_CANCEL });
+    send({
+      type: WS_CHAT_CANCEL,
+      payload: { clientKey: clientKeyRef.current },
+    });
     setIsTyping(false);
   }, [send]);
 
@@ -291,7 +327,10 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
       send({
         type: WS_CHAT_MESSAGE,
         id: nextRequestId('chat_msg'),
-        payload: { content },
+        payload: {
+          content,
+          clientKey: clientKeyRef.current,
+        },
       });
       return;
     }
@@ -343,6 +382,7 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
         id: nextRequestId('chat_msg'),
         payload: {
           content,
+          clientKey: clientKeyRef.current,
           attachments: results.map((r) => r.wire),
         },
       });
@@ -631,7 +671,10 @@ export function useChat({ send, connected }: UseChatOptions): UseChatReturn {
         setSessionId(resumedId);
         // Fetch history for the resumed session
         if (resumedId) {
-          send({ type: WS_CHAT_HISTORY });
+          send({
+            type: WS_CHAT_HISTORY,
+            payload: { clientKey: clientKeyRef.current },
+          });
         }
         break;
       }


### PR DESCRIPTION
## Summary
- add a durable background-run supervisor with persisted run state, recent snapshots, and operator controls
- add structured desktop managed-process tooling plus native runtime verification/restart for long-running jobs
- recover desktop sandboxes across daemon restart so durable runs reattach to live workloads instead of probing fresh containers
- persist durable webchat session ownership/history so resumed sessions keep background-run context and updates
- harden webchat/background status handling and clean up reconnect log noise

## Testing
- [x] `npm --prefix containers/desktop/server test`
- [x] `npm --prefix runtime test -- src/gateway/background-run-supervisor.test.ts src/channels/webchat/plugin.test.ts src/desktop/manager.test.ts src/desktop/rest-bridge.test.ts src/desktop/session-router.test.ts`
- [x] `npm --prefix runtime run typecheck`
- [x] `npm --prefix web test -- src/hooks/useChat.test.ts`
- [x] `npm --prefix web run build`
- [x] `npm run -s security:desktop:hardening:check`
- [x] live websocket smoke: managed-process background run survives daemon restart and resumes to completion

## Risks
- desktop shutdown currently preserves live sandboxes for restart durability; follow-up work should split suspend vs full teardown semantics
- recovered sandboxes currently reset idle budget from current time because last-activity timestamps are not yet persisted
