### PR TITLE
docs(notes): add phase 5 desktop process debt report

### DIFF
--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -1,3 +1,10 @@
+## PR [pending]: add phase 5 desktop process debt note
+- **Date:** 2026-03-07
+- **Files changed:** `.claude/notes/pr-log.md`, `.claude/notes/techdebt-2026-03-08-phase5-desktop-process-handle-contract.md`
+- **What worked:** The Phase 5 desktop managed-process contract cleanup now has a committed debt note alongside the shipped runtime/code changes, instead of existing only as a local ignored artifact.
+- **What didn't:** This is documentation-only follow-up, so there is no additional product-surface behavior or validation beyond keeping the notes history complete.
+- **Rule added to CLAUDE.md:** no
+
 ## PR [pending]: durable task runtime foundation and phase 5 contract hardening
 - **Date:** 2026-03-07
 - **Files changed:** `runtime/src/gateway/{agent-run-contract.ts,background-run-store.ts,background-run-supervisor.ts,background-run-wake-bus.ts,background-run-wake-adapters.ts,run-domains.ts,webhooks.ts,daemon.ts,gateway.ts,channel.ts}`, `runtime/src/tools/system/{process.ts,browser-session.ts,handle-contract.ts,command-line.ts}`, `containers/desktop/server/src/tools.ts`, `runtime/src/desktop/tool-definitions.ts`, related tests under `runtime/src/**` and `containers/desktop/server/src/*.test.ts`, plus `docs/architecture/README.md`, `docs/ROADMAP.md`, `docs/RUNTIME_API.md`, and `.claude/notes/*`.

--- a/.claude/notes/techdebt-2026-03-08-phase5-desktop-process-handle-contract.md
+++ b/.claude/notes/techdebt-2026-03-08-phase5-desktop-process-handle-contract.md
@@ -1,0 +1,34 @@
+## Phase 5 Desktop Process Handle Contract
+
+- **Date:** 2026-03-08
+- **Scope:** `containers/desktop/server/src/tools.ts`, `containers/desktop/server/src/tools.test.ts`, generated desktop tool definitions, and desktop prompt guidance in `runtime/src/gateway/daemon.ts`.
+
+### What Was Fixed
+
+- Added first-class `idempotencyKey` support to `desktop.process_start/status/stop` so the desktop managed-process family now matches the durable handle identity model already used by host processes and browser sessions.
+- Separated `label` from `idempotencyKey` semantics in the desktop server. `label` is now a stable human-readable handle, while `idempotencyKey` deduplicates repeated start requests.
+- Added deterministic lookup ordering for desktop managed processes: `processId` first, then `idempotencyKey`, then `label`, then `pid`.
+- Tightened desktop process dedupe/conflict behavior:
+  - identical retries with the same `idempotencyKey` reuse the running handle
+  - conflicting retries with the same `idempotencyKey` fail explicitly
+  - conflicting concurrent starts with the same `label` fail explicitly instead of silently reusing the wrong running process
+- Added record/event/response propagation for `idempotencyKey`, plus backward-compatible load behavior for persisted desktop process registries.
+- Regenerated `runtime/src/desktop/tool-definitions.ts` and updated daemon desktop guidance so the runtime-visible tool catalog and prompt contract do not drift from the server implementation.
+
+### Validation
+
+- `npm --prefix containers/desktop/server test`
+- `npm --prefix runtime test -- src/gateway/background-run-supervisor.test.ts src/gateway/tool-routing.test.ts src/desktop/rest-bridge.test.ts`
+- `npm --prefix runtime run typecheck`
+- `git diff --check`
+
+### Remaining Debt
+
+- **Medium:** Phase 5 still has broader roadmap debt outside the managed-process/browser families. Downloads/uploads, web servers, remote MCP jobs, code sandboxes, and long-running research handles still need the same durable handle contract.
+- **Medium:** The repo still does not have one universal compliance suite that every long-lived tool family must pass across package boundaries. Host/browser and desktop families are now covered, but the full cross-family gate is still roadmap work.
+- **Medium:** Resource envelopes and the broader structured error taxonomy are still not standardized across every long-lived tool family.
+
+### Verdict
+
+- No critical or high debt remains in the desktop managed-process contract surface.
+- The remaining work is broader Phase 5 roadmap debt, not cleanup debt introduced by this slice.


### PR DESCRIPTION
# Summary
Add the tracked Phase 5 desktop process debt note that was still local-only after the runtime foundation PR.

# Changes
- add `.claude/notes/techdebt-2026-03-08-phase5-desktop-process-handle-contract.md`
- update `.claude/notes/pr-log.md`

# Testing
- [x] anchor test (N/A, docs-only)
- [x] cargo fmt --check (N/A, docs-only)
- [x] cargo clippy (N/A, docs-only)
- [x] cargo test (N/A, docs-only)

# Security / Risk
- [x] PDA seeds/constraints reviewed (N/A, docs-only)
- [x] No authority bypass introduced
- [x] Escrow/funds safety considered (N/A, docs-only)

# Checklist
- [x] Tests added/updated (or N/A)
- [x] Docs updated (if needed)

# Issue link(s)
- None
