### PR TITLE
fix(runtime): remove default policy blockers

### DIFF
--- a/runtime/src/gateway/approval-runtime.test.ts
+++ b/runtime/src/gateway/approval-runtime.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  approvalsEnabled,
+  resolveGatewayApprovalRules,
+} from './approval-runtime.js';
+
+describe("approval-runtime", () => {
+  describe("approvalsEnabled", () => {
+    it('defaults to disabled when the approvals section is omitted', () => {
+      expect(approvalsEnabled(undefined)).toBe(false);
+    });
+
+    it('honors explicit disablement', () => {
+      expect(approvalsEnabled({ enabled: false })).toBe(false);
+    });
+
+    it('requires explicit opt-in', () => {
+      expect(approvalsEnabled({ enabled: true })).toBe(true);
+    });
+  });
+
+  describe('resolveGatewayApprovalRules', () => {
+    it('returns no rules when approvals are explicitly disabled', () => {
+      expect(
+        resolveGatewayApprovalRules({
+          approvals: { enabled: false, gateDesktopAutomation: true },
+          mcpServers: [
+            {
+              name: "danger",
+              command: "npx",
+              args: ["-y", "@pkg/danger@1.2.3"],
+              trustTier: "untrusted",
+              container: "desktop",
+            },
+          ],
+        }),
+      ).toEqual([]);
+    });
+
+    it('keeps desktop automation gating opt-in', () => {
+      const defaultRules = resolveGatewayApprovalRules({
+        approvals: { enabled: true },
+      });
+      const strictRules = resolveGatewayApprovalRules({
+        approvals: { enabled: true, gateDesktopAutomation: true },
+      });
+
+      expect(defaultRules.map((rule) => rule.tool)).not.toContain(
+        "mcp.peekaboo.click",
+      );
+      expect(strictRules.map((rule) => rule.tool)).toContain(
+        "mcp.peekaboo.click",
+      );
+    });
+
+    it('still adds MCP trust-tier approval rules when approvals remain enabled', () => {
+      const rules = resolveGatewayApprovalRules({
+        approvals: { enabled: true },
+        mcpServers: [
+          {
+            name: "danger",
+            command: "npx",
+            args: ["-y", "@pkg/danger@1.2.3"],
+            trustTier: "untrusted",
+            container: "desktop",
+          },
+        ],
+      });
+
+      expect(rules.map((rule) => rule.tool)).toContain("mcp.danger.*");
+    });
+
+    it('does not create approval rules unless the approval engine is enabled', () => {
+      expect(resolveGatewayApprovalRules({})).toEqual([]);
+      expect(
+        resolveGatewayApprovalRules({
+          mcpServers: [
+            {
+              name: "danger",
+              command: "npx",
+              args: ["-y", "@pkg/danger@1.2.3"],
+              trustTier: "untrusted",
+              container: "desktop",
+            },
+          ],
+        }),
+      ).toEqual([]);
+    });
+  });
+});

--- a/runtime/src/gateway/approval-runtime.ts
+++ b/runtime/src/gateway/approval-runtime.ts
@@ -1,0 +1,31 @@
+import {
+  buildDefaultApprovalRules,
+  type ApprovalRule,
+} from './approvals.js';
+import { buildMCPApprovalRules } from '../policy/mcp-governance.js';
+import type {
+  GatewayApprovalConfig,
+  GatewayMCPServerConfig,
+} from './types.js';
+
+export function approvalsEnabled(
+  approvals: GatewayApprovalConfig | undefined,
+): boolean {
+  return approvals?.enabled === true;
+}
+
+export function resolveGatewayApprovalRules(params: {
+  approvals?: GatewayApprovalConfig;
+  mcpServers?: readonly GatewayMCPServerConfig[];
+}): ApprovalRule[] {
+  if (!approvalsEnabled(params.approvals)) {
+    return [];
+  }
+
+  return [
+    ...buildDefaultApprovalRules({
+      gateDesktopAutomation: params.approvals?.gateDesktopAutomation === true,
+    }),
+    ...buildMCPApprovalRules(params.mcpServers),
+  ];
+}

--- a/runtime/src/gateway/approvals.test.ts
+++ b/runtime/src/gateway/approvals.test.ts
@@ -3,7 +3,9 @@ import {
   globMatch,
   extractAmount,
   ApprovalEngine,
+  buildDefaultApprovalRules,
   createApprovalGateHook,
+  DEFAULT_DESKTOP_APPROVAL_RULES,
   DEFAULT_APPROVAL_RULES,
 } from './approvals.js';
 import { buildMCPApprovalRules } from '../policy/mcp-governance.js';
@@ -807,8 +809,8 @@ describe('ApprovalEngine', () => {
   // ============================================================================
 
   describe('DEFAULT_APPROVAL_RULES', () => {
-    it('has 10 rules', () => {
-      expect(DEFAULT_APPROVAL_RULES).toHaveLength(10);
+    it('has 6 baseline high-risk rules', () => {
+      expect(DEFAULT_APPROVAL_RULES).toHaveLength(6);
     });
 
     it('covers system.delete and system.evaluateJs', () => {
@@ -835,6 +837,32 @@ describe('ApprovalEngine', () => {
     it('agenc.createTask has minAmount 1 SOL in lamports', () => {
       const rule = DEFAULT_APPROVAL_RULES.find((r) => r.tool === 'agenc.createTask');
       expect(rule!.conditions!.minAmount).toBe(1_000_000_000);
+    });
+
+    it('does not include desktop automation tools by default', () => {
+      const tools = DEFAULT_APPROVAL_RULES.map((r) => r.tool);
+      expect(tools).not.toContain('mcp.peekaboo.click');
+      expect(tools).not.toContain('mcp.macos-automator.*');
+    });
+  });
+
+  describe('DEFAULT_DESKTOP_APPROVAL_RULES', () => {
+    it('keeps desktop automation gating separate from baseline defaults', () => {
+      expect(DEFAULT_DESKTOP_APPROVAL_RULES.map((rule) => rule.tool)).toEqual([
+        'mcp.peekaboo.click',
+        'mcp.peekaboo.type',
+        'mcp.peekaboo.scroll',
+        'mcp.macos-automator.*',
+      ]);
+    });
+  });
+
+  describe('buildDefaultApprovalRules', () => {
+    it('keeps desktop automation opt-in', () => {
+      expect(buildDefaultApprovalRules()).toHaveLength(6);
+      expect(
+        buildDefaultApprovalRules({ gateDesktopAutomation: true }),
+      ).toHaveLength(10);
     });
   });
 });

--- a/runtime/src/gateway/approvals.ts
+++ b/runtime/src/gateway/approvals.ts
@@ -248,11 +248,13 @@ function signResolverAssertion(params: {
 // ============================================================================
 
 /**
- * Built-in approval rules for common dangerous operations.
+ * Baseline approval rules for common dangerous operations.
  *
- * Note: `system.bash` and `desktop.bash` are intentionally NOT included by
- * default to avoid blocking normal terminal workflows. Teams that require
- * blanket shell approvals can add explicit rules via configuration.
+ * These rules are applied only when the gateway approval engine is explicitly
+ * enabled. `system.bash`, `desktop.bash`, and desktop automation tools are
+ * intentionally excluded from the baseline to avoid blocking normal
+ * interactive workflows. Teams that require stricter desktop approvals can
+ * opt in via gateway configuration.
  */
 export const DEFAULT_APPROVAL_RULES: readonly ApprovalRule[] = [
   {
@@ -281,7 +283,9 @@ export const DEFAULT_APPROVAL_RULES: readonly ApprovalRule[] = [
     tool: 'agenc.registerAgent',
     description: 'Agent registration with staked SOL',
   },
-  // Desktop automation — require approval by default
+];
+
+export const DEFAULT_DESKTOP_APPROVAL_RULES: readonly ApprovalRule[] = [
   {
     tool: "mcp.peekaboo.click",
     description: "Desktop mouse click",
@@ -299,6 +303,17 @@ export const DEFAULT_APPROVAL_RULES: readonly ApprovalRule[] = [
     description: "macOS automation script",
   },
 ];
+
+export function buildDefaultApprovalRules(options?: {
+  readonly gateDesktopAutomation?: boolean;
+}): ApprovalRule[] {
+  return [
+    ...DEFAULT_APPROVAL_RULES,
+    ...(options?.gateDesktopAutomation === true
+      ? DEFAULT_DESKTOP_APPROVAL_RULES
+      : []),
+  ];
+}
 
 // ============================================================================
 // ApprovalEngine

--- a/runtime/src/gateway/config-watcher.test.ts
+++ b/runtime/src/gateway/config-watcher.test.ts
@@ -590,6 +590,7 @@ describe("validateGatewayConfig approvals", () => {
       ...makeConfig(),
       approvals: {
         enabled: true,
+        gateDesktopAutomation: true,
         timeoutMs: 60_000,
         defaultSlaMs: 10_000,
         defaultEscalationDelayMs: 15_000,
@@ -605,6 +606,7 @@ describe("validateGatewayConfig approvals", () => {
       ...makeConfig(),
       approvals: {
         enabled: "yes" as unknown as boolean,
+        gateDesktopAutomation: "strict" as unknown as boolean,
         timeoutMs: "slow" as unknown as number,
         defaultSlaMs: "fast" as unknown as number,
         defaultEscalationDelayMs: {} as unknown as number,
@@ -614,6 +616,9 @@ describe("validateGatewayConfig approvals", () => {
 
     expect(result.valid).toBe(false);
     expect(result.errors).toContain("approvals.enabled must be a boolean");
+    expect(result.errors).toContain(
+      "approvals.gateDesktopAutomation must be a boolean",
+    );
     expect(result.errors).toContain("approvals.timeoutMs must be a number");
     expect(result.errors).toContain("approvals.defaultSlaMs must be a number");
     expect(result.errors).toContain(

--- a/runtime/src/gateway/config-watcher.ts
+++ b/runtime/src/gateway/config-watcher.ts
@@ -1033,6 +1033,12 @@ function validateApprovalsSection(approvals: unknown, errors: string[]): void {
     errors.push("approvals.enabled must be a boolean");
   }
   if (
+    approvals.gateDesktopAutomation !== undefined &&
+    typeof approvals.gateDesktopAutomation !== "boolean"
+  ) {
+    errors.push("approvals.gateDesktopAutomation must be a boolean");
+  }
+  if (
     approvals.timeoutMs !== undefined &&
     typeof approvals.timeoutMs !== "number"
   ) {

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -108,10 +108,10 @@ import { VoiceBridge } from './voice-bridge.js';
 import { createSessionToolHandler } from './tool-handler-factory.js';
 import type { DesktopBridgeEvent } from '../desktop/rest-bridge.js';
 import { InMemoryBackend } from '../memory/in-memory/backend.js';
-import { ApprovalEngine, DEFAULT_APPROVAL_RULES } from './approvals.js';
+import { ApprovalEngine } from './approvals.js';
+import { resolveGatewayApprovalRules } from "./approval-runtime.js";
 import { buildToolPolicyAction } from '../policy/tool-governance.js';
 import {
-  buildMCPApprovalRules,
   SessionCredentialBroker,
   type GovernanceAuditEventType,
   type RuntimeSessionCredentialConfig,
@@ -1914,7 +1914,7 @@ interface WebChatMessageHandlerDeps {
   sessionMgr: SessionManager;
   getSystemPrompt: () => string;
   baseToolHandler: ToolHandler;
-  approvalEngine: ApprovalEngine;
+  approvalEngine: ApprovalEngine | null;
   memoryBackend: MemoryBackend;
   signals: WebChatSignals;
   sessionTokenBudget: number;
@@ -2669,19 +2669,23 @@ export class DaemonManager {
       memoryBackend,
     });
 
-    const approvalEngine = new ApprovalEngine({
-      rules: [
-        ...DEFAULT_APPROVAL_RULES,
-        ...buildMCPApprovalRules(config.mcp?.servers),
-      ],
-      timeoutMs: config.approvals?.timeoutMs,
-      defaultSlaMs: config.approvals?.defaultSlaMs,
-      defaultEscalationDelayMs: config.approvals?.defaultEscalationDelayMs,
-      resolverSigningKey:
-        config.approvals?.resolverSigningKey ?? config.auth?.secret,
+    const approvalRules = resolveGatewayApprovalRules({
+      approvals: config.approvals,
+      mcpServers: config.mcp?.servers,
     });
+    const approvalEngine =
+      approvalRules.length > 0
+        ? new ApprovalEngine({
+            rules: approvalRules,
+            timeoutMs: config.approvals?.timeoutMs,
+            defaultSlaMs: config.approvals?.defaultSlaMs,
+            defaultEscalationDelayMs: config.approvals?.defaultEscalationDelayMs,
+            resolverSigningKey:
+              config.approvals?.resolverSigningKey ?? config.auth?.secret,
+          })
+        : null;
     this._approvalEngine = approvalEngine;
-    approvalEngine.onRequest(async (request) => {
+    approvalEngine?.onRequest(async (request) => {
       await this.appendGovernanceAuditEvent({
         type: 'approval.requested',
         actor: request.sessionId,
@@ -2705,7 +2709,7 @@ export class DaemonManager {
         },
       });
     });
-    approvalEngine.onEscalation(async (request, escalation) => {
+    approvalEngine?.onEscalation(async (request, escalation) => {
       await this.appendGovernanceAuditEvent({
         type: 'approval.escalated',
         actor: escalation.escalateToSessionId,
@@ -2750,7 +2754,7 @@ export class DaemonManager {
         });
       });
     });
-    approvalEngine.onResponse(async (request, response) => {
+    approvalEngine?.onResponse(async (request, response) => {
       await this.appendGovernanceAuditEvent({
         type: 'approval.resolved',
         actor: response.approvedBy,
@@ -2791,7 +2795,7 @@ export class DaemonManager {
     const pipelineExecutor = new PipelineExecutor({
       toolHandler: baseToolHandler,
       memoryBackend,
-      approvalEngine,
+      approvalEngine: approvalEngine ?? undefined,
       progressTracker,
       logger: this.logger,
     });
@@ -2873,7 +2877,7 @@ export class DaemonManager {
       getChatExecutor: () => this._chatExecutor,
       sessionManager: sessionMgr,
       hooks,
-      approvalEngine,
+      approvalEngine: approvalEngine ?? undefined,
       memoryBackend,
       delegation: this.resolveDelegationToolContext,
     };
@@ -2885,7 +2889,7 @@ export class DaemonManager {
       skills: skillList,
       voiceBridge,
       memoryBackend,
-      approvalEngine,
+      approvalEngine: approvalEngine ?? undefined,
       skillToggle,
       connection: this._connectionManager?.getConnection(),
       broadcastEvent: (type, data) => webChat.broadcastEvent(type, data),
@@ -3003,7 +3007,7 @@ export class DaemonManager {
             sessionId,
             webChat,
             hooks,
-            approvalEngine,
+            approvalEngine: approvalEngine ?? undefined,
             baseToolHandler,
             traceLabel: 'webchat.background',
             traceConfig: resolveTraceLoggingConfig(gateway.config.logging),
@@ -3809,7 +3813,7 @@ export class DaemonManager {
       getChatExecutor: () => ChatExecutor | null | undefined;
       sessionManager: SessionManager;
       hooks: HookDispatcher;
-      approvalEngine: ApprovalEngine;
+      approvalEngine?: ApprovalEngine;
       memoryBackend: MemoryBackend;
       delegation: DelegationToolCompositionResolver;
     };
@@ -7653,7 +7657,7 @@ export class DaemonManager {
     sessionId: string;
     webChat: WebChatChannel;
     hooks: HookDispatcher;
-    approvalEngine: ApprovalEngine;
+    approvalEngine?: ApprovalEngine;
     baseToolHandler: ToolHandler;
     traceLabel: string;
     traceConfig: ResolvedTraceLoggingConfig;
@@ -7970,9 +7974,6 @@ export class DaemonManager {
       });
     };
 
-    // Detect greeting messages — block tool execution for casual conversation
-    const GREETING_RE = /^(h(i|ello|ey|ola|owdy)|yo|sup|what'?s\s*up|greetings?|good\s*(morning|afternoon|evening)|gm|gn)\s*[!?.,:;\-)*]*$/i;
-    const isGreeting = GREETING_RE.test(msg.content.trim());
     const doomTurnContract = inferDoomTurnContract(msg.content);
     const requestedDesktopResolution =
       this._desktopManager?.getHandleBySession(msg.sessionId)?.resolution ??
@@ -7985,13 +7986,12 @@ export class DaemonManager {
         )
         : DEFAULT_DOOM_FIT_RESOLUTION;
     let doomStopIssued = false;
-    let doomLaunchIssued = false;
 
     const sessionToolHandler = this.createWebChatSessionToolHandler({
       sessionId: msg.sessionId,
       webChat,
       hooks,
-      approvalEngine,
+      approvalEngine: approvalEngine ?? undefined,
       baseToolHandler,
       traceLabel: 'webchat',
       traceConfig,
@@ -8005,28 +8005,9 @@ export class DaemonManager {
         if (nextArgs.screen_resolution === 'RES_1280X720' && requestedDoomResolution !== 'RES_1280X720') {
           nextArgs = { ...nextArgs, screen_resolution: requestedDoomResolution };
         }
-        doomLaunchIssued = true;
         return nextArgs;
       },
       beforeHandle: (toolName) => {
-        if (isGreeting) {
-          return JSON.stringify({
-            error: 'This is a greeting message. Respond conversationally without using any tools.',
-          });
-        }
-        if (
-          doomTurnContract?.requiresLaunch &&
-          toolName.startsWith('mcp.doom.') &&
-          toolName !== 'mcp.doom.start_game' &&
-          toolName !== 'mcp.doom.stop_game' &&
-          !doomLaunchIssued
-        ) {
-          return JSON.stringify({
-            error:
-              'Launch Doom first with `mcp.doom.start_game` before calling follow-up Doom tools in this turn. ' +
-              'For play-until-stop requests, the launch must include `async_player: true`.',
-          });
-        }
         if (isDoomStopTurn) {
           const blockedResult = blockUntilDoomStopTool(toolName, doomStopIssued);
           if (toolName === 'mcp.doom.stop_game' && !blockedResult) {

--- a/runtime/src/gateway/delegation-runtime.ts
+++ b/runtime/src/gateway/delegation-runtime.ts
@@ -42,12 +42,6 @@ export interface DelegationPolicyDecision {
   readonly threshold: number;
 }
 
-const DELEGATION_SCORE_KEYS = [
-  "spawnDecisionScore",
-  "delegationScore",
-  "utilityScore",
-] as const;
-
 export function isSubAgentSessionId(sessionId: string): boolean {
   return sessionId.startsWith(SUB_AGENT_SESSION_PREFIX);
 }
@@ -58,15 +52,6 @@ export function isDelegationToolName(toolName: string): boolean {
     toolName.startsWith("subagent.") ||
     toolName.startsWith("agenc.subagent.")
   );
-}
-
-function extractDelegationScore(args: Record<string, unknown>): number | undefined {
-  for (const key of DELEGATION_SCORE_KEYS) {
-    const value = args[key];
-    if (typeof value !== "number" || !Number.isFinite(value)) continue;
-    return value;
-  }
-  return undefined;
 }
 
 export class DelegationPolicyEngine {
@@ -159,21 +144,6 @@ export class DelegationPolicyEngine {
         allowed: false,
         reason: `Delegation tool "${input.toolName}" is not allowlisted`,
         matchedRule: "tool_not_allowlisted",
-        threshold: this.config.spawnDecisionThreshold,
-      };
-    }
-
-    const score = extractDelegationScore(input.args);
-    if (
-      typeof score === "number" &&
-      score < this.config.spawnDecisionThreshold
-    ) {
-      return {
-        allowed: false,
-        reason:
-          `Delegation score ${score.toFixed(3)} is below threshold ` +
-          `${this.config.spawnDecisionThreshold.toFixed(3)}`,
-        matchedRule: "score_below_threshold",
         threshold: this.config.spawnDecisionThreshold,
       };
     }

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -112,7 +112,7 @@ describe("createSessionToolHandler", () => {
     });
   });
 
-  it("blocks same-turn Doom follow-up calls after a failed launch", async () => {
+  it("does not block same-turn Doom follow-up calls after a failed launch", async () => {
     const sentMessages: ControlResponse[] = [];
     const send = vi.fn((msg: ControlResponse): void => {
       sentMessages.push(msg);
@@ -122,7 +122,7 @@ describe("createSessionToolHandler", () => {
       if (name === "mcp.doom.start_game") {
         return "Unknown resolution 'banana'. Valid: ['RES_1280X720']";
       }
-      return JSON.stringify({ status: "unexpected" });
+      return "Executor not running. Start game with async_player=True.";
     });
     const handler = createSessionToolHandler({
       sessionId: "session-1",
@@ -143,20 +143,18 @@ describe("createSessionToolHandler", () => {
       error: "Unknown resolution 'banana'. Valid: ['RES_1280X720']",
     });
     expect(JSON.parse(blockedResult)).toEqual({
-      error:
-        'Skipped "mcp.doom.set_objective" because the previous Doom launch in this turn failed: Unknown resolution \'banana\'. Valid: [\'RES_1280X720\']',
+      error: "Executor not running. Start game with async_player=True.",
     });
-    expect(baseHandler).toHaveBeenCalledTimes(1);
+    expect(baseHandler).toHaveBeenCalledTimes(2);
     expect(sentMessages.at(-1)).toMatchObject({
       type: "tools.result",
       payload: {
         toolName: "mcp.doom.set_objective",
-        isError: true,
       },
     });
   });
 
-  it("blocks duplicate same-turn Doom launches after a successful start", async () => {
+  it("does not block duplicate same-turn Doom launches after a successful start", async () => {
     const sentMessages: ControlResponse[] = [];
     const send = vi.fn((msg: ControlResponse): void => {
       sentMessages.push(msg);
@@ -180,16 +178,12 @@ describe("createSessionToolHandler", () => {
     });
 
     expect(JSON.parse(firstResult)).toEqual({ status: "running" });
-    expect(JSON.parse(secondResult)).toEqual({
-      error:
-        'Skipped "mcp.doom.start_game" because Doom is already running from an earlier launch in this turn. Reuse the active game or call "mcp.doom.stop_game" before starting again.',
-    });
-    expect(baseHandler).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(secondResult)).toEqual({ status: "running" });
+    expect(baseHandler).toHaveBeenCalledTimes(2);
     expect(sentMessages.at(-1)).toMatchObject({
       type: "tools.result",
       payload: {
         toolName: "mcp.doom.start_game",
-        isError: true,
       },
     });
   });
@@ -279,6 +273,36 @@ describe("createSessionToolHandler", () => {
         toolCallId: expect.any(String),
       }),
     );
+  });
+
+  it("surfaces the blocking reason returned by tool:before hooks", async () => {
+    const send = vi.fn();
+    const baseHandler = vi.fn(async () => '{"ok":true}');
+    const hooks = {
+      dispatch: vi.fn().mockResolvedValue({
+        completed: false,
+        payload: {
+          blocked: true,
+          reason: 'Policy blocked tool "system.delete": Tool is denied',
+        },
+      }),
+    } as any;
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler,
+      routerId: "router-a",
+      send,
+      hooks,
+    });
+
+    const result = await handler("system.delete", { target: "/tmp/file" });
+
+    expect(JSON.parse(result)).toEqual({
+      error: 'Policy blocked tool "system.delete": Tool is denied',
+    });
+    expect(baseHandler).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
   });
 
   it("injects session credentials into structured HTTP tools without exposing the secret in UI events", async () => {
@@ -1749,5 +1773,41 @@ describe("createSessionToolHandler", () => {
     expect(baseHandler).not.toHaveBeenCalled();
     expect(sentMessages.some((msg) => msg.type === "tools.executing")).toBe(false);
     expect(sentMessages.some((msg) => msg.type === "tools.result")).toBe(false);
+  });
+
+  it("does not veto execute_with_agent calls just because the score is below threshold", async () => {
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+
+    const policyEngine = new DelegationPolicyEngine({
+      enabled: true,
+      spawnDecisionThreshold: 0.95,
+      fallbackBehavior: "continue_without_delegation",
+    });
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      routerId: "router-a",
+      send,
+      delegation: () => ({
+        subAgentManager: null,
+        policyEngine,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "inspect logs",
+      spawnDecisionScore: 0.1,
+    });
+    const parsed = JSON.parse(result) as { error?: string };
+
+    expect(parsed.error).toContain("Delegation runtime unavailable");
+    expect(parsed.error).not.toContain("below threshold");
+    expect(sentMessages.some((msg) => msg.type === "tools.executing")).toBe(true);
+    expect(sentMessages.some((msg) => msg.type === "tools.result")).toBe(true);
   });
 });

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -47,8 +47,6 @@ const MAX_DELEGATION_TIMEOUT_MS = 3_600_000;
 const DELEGATION_FAILURE_SIGNAL_RE =
   /\b(command denied|tool denied|denied by user|timed out|timeout|tool not found|failed to spawn|permission denied)\b/i;
 const DOOM_TOOL_PREFIX = 'mcp.doom.';
-const DOOM_START_TOOL = 'mcp.doom.start_game';
-const DOOM_STOP_TOOL = 'mcp.doom.stop_game';
 const TOOL_NAME_ALIASES: Readonly<Record<string, string>> = {
   "system.makeDir": "system.mkdir",
   "system.listFiles": "system.listDir",
@@ -84,83 +82,6 @@ function canonicalizeToolFailureResult(
   return JSON.stringify({
     error: trimmed.length > 0 ? trimmed : `Tool "${toolName}" failed`,
   });
-}
-
-function extractToolFailureReason(result: string): string | null {
-  try {
-    const parsed = JSON.parse(result) as unknown;
-    if (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      !Array.isArray(parsed) &&
-      typeof (parsed as { error?: unknown }).error === 'string'
-    ) {
-      const error = (parsed as { error: string }).error.trim();
-      return error.length > 0 ? error : null;
-    }
-  } catch {
-    // Fall back to raw output below.
-  }
-
-  const trimmed = result.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-interface DoomTurnGuard {
-  beginTool(toolName: string): void;
-  blockedResult(toolName: string): string | null;
-  observeResult(toolName: string, result: string): string;
-}
-
-function createDoomTurnGuard(): DoomTurnGuard {
-  let failedLaunchReason: string | null = null;
-  let launchActive = false;
-
-  return {
-    beginTool(toolName: string): void {
-      if (toolName === DOOM_START_TOOL) {
-        failedLaunchReason = null;
-      }
-    },
-
-    blockedResult(toolName: string): string | null {
-      if (toolName === DOOM_START_TOOL && launchActive) {
-        return JSON.stringify({
-          error:
-            `Skipped "${toolName}" because Doom is already running from an earlier launch in this turn. ` +
-            `Reuse the active game or call "${DOOM_STOP_TOOL}" before starting again.`,
-        });
-      }
-
-      if (!failedLaunchReason || !isDoomTool(toolName) || toolName === DOOM_START_TOOL) {
-        return null;
-      }
-
-      return JSON.stringify({
-        error:
-          `Skipped "${toolName}" because the previous Doom launch in this turn failed: ` +
-          failedLaunchReason,
-      });
-    },
-
-    observeResult(toolName: string, result: string): string {
-      const canonicalResult = canonicalizeToolFailureResult(toolName, result);
-      if (toolName === DOOM_START_TOOL) {
-        const failed = didToolCallFail(false, canonicalResult);
-        failedLaunchReason = failed
-          ? extractToolFailureReason(canonicalResult)
-          : null;
-        launchActive = !failed;
-      } else if (
-        toolName === DOOM_STOP_TOOL &&
-        !didToolCallFail(false, canonicalResult)
-      ) {
-        launchActive = false;
-        failedLaunchReason = null;
-      }
-      return canonicalResult;
-    },
-  };
 }
 
 function normalizeDesktopBashCommand(
@@ -927,7 +848,6 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
   // Per-message duplicate guard to avoid opening the same GUI app twice when
   // the model emits repeated desktop.bash launch calls in one turn.
   const seenGuiLaunches = new Set<string>();
-  const doomTurnGuard = createDoomTurnGuard();
   const nextToolCallId = (): string =>
     `tool-${Date.now().toString(36)}-${++toolCallSeq}`;
 
@@ -1033,6 +953,11 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       if (!beforeResult.completed) {
         // Bug fix: do NOT send tools.executing when hook blocks — the tool
         // never started executing, so the client shouldn't show a tool card.
+        const hookReason =
+          typeof beforeResult.payload.reason === "string" &&
+          beforeResult.payload.reason.trim().length > 0
+            ? beforeResult.payload.reason.trim()
+            : `Tool "${toolName}" blocked by hook`;
         if (isSubAgentSession && lifecycleEmitter) {
           lifecycleEmitter.emit({
             type: 'subagents.failed',
@@ -1040,14 +965,12 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
             sessionId,
             subagentSessionId: sessionId,
             toolName,
-            payload: { stage: 'hook_before' },
+            payload: { stage: 'hook_before', reason: hookReason },
           });
         }
-        return JSON.stringify({ error: `Tool "${toolName}" blocked by hook` });
+        return JSON.stringify({ error: hookReason });
       }
     }
-
-    doomTurnGuard.beginTool(toolName);
 
     // 2. Notify caller: tool execution starting
     onToolStart?.(toolName, normalizedArgs, toolCallId);
@@ -1090,22 +1013,6 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     });
     if (approvalError) {
       return approvalError;
-    }
-
-    const blockedResult = doomTurnGuard.blockedResult(toolName);
-    if (blockedResult) {
-      return sendImmediateToolError({
-        send,
-        toolName,
-        result: blockedResult,
-        toolCallId,
-        sessionId,
-        isSubAgentSession,
-        onToolEnd,
-        hooks,
-        args: normalizedArgs,
-        hookMetadata: enrichedHookMetadata,
-      });
     }
 
     let executionArgs = normalizedArgs;
@@ -1173,7 +1080,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
       throw error;
     }
     const durationMs = Date.now() - start;
-    result = doomTurnGuard.observeResult(toolName, result);
+    result = canonicalizeToolFailureResult(toolName, result);
 
     if (launchKey && shouldMarkGuiLaunchSeen(result)) {
       seenGuiLaunches.add(launchKey);

--- a/runtime/src/gateway/types.ts
+++ b/runtime/src/gateway/types.ts
@@ -473,7 +473,10 @@ export interface GatewayPolicyConfig {
 }
 
 export interface GatewayApprovalConfig {
+  /** Opt-in approval engine for gated tool calls. */
   enabled?: boolean;
+  /** Require approval for desktop click/type/scroll automation tools. */
+  gateDesktopAutomation?: boolean;
   timeoutMs?: number;
   defaultSlaMs?: number;
   defaultEscalationDelayMs?: number;

--- a/runtime/src/gateway/voice-bridge.test.ts
+++ b/runtime/src/gateway/voice-bridge.test.ts
@@ -86,4 +86,39 @@ describe("VoiceBridge delegation", () => {
     );
     expect(result).toContain("Task completed");
   });
+
+  it("surfaces the concrete inbound hook block reason", async () => {
+    const send = vi.fn();
+    const bridge = new VoiceBridge({
+      apiKey: "voice-key",
+      toolHandler: vi.fn(async () => ""),
+      systemPrompt: "You are a helpful assistant.",
+      getChatExecutor: () => null,
+      hooks: {
+        dispatch: vi.fn(async () => ({
+          completed: false,
+          payload: {
+            reason: 'Policy blocked message: tenant is suspended',
+          },
+        })),
+      } as any,
+    });
+
+    const spoken = await (bridge as any).dispatchPolicyCheck(
+      "client-1",
+      "session-1",
+      "Investigate the failing run",
+      send,
+    );
+
+    expect(spoken).toBe("Policy blocked message: tenant is suspended");
+    expect(send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          status: "blocked",
+          error: "Policy blocked message: tenant is suspended",
+        }),
+      }),
+    );
+  });
 });

--- a/runtime/src/gateway/voice-bridge.ts
+++ b/runtime/src/gateway/voice-bridge.ts
@@ -659,11 +659,16 @@ export class VoiceBridge {
       channel: "voice",
     });
     if (!result.completed) {
+      const reason =
+        typeof result.payload.reason === "string" &&
+        result.payload.reason.trim().length > 0
+          ? result.payload.reason.trim()
+          : "Message blocked by policy";
       send({
         type: VM.DELEGATION,
-        payload: { status: "blocked", task, error: "Message blocked by policy" },
+        payload: { status: "blocked", task, error: reason },
       });
-      return "Sorry, that request was blocked by the security policy.";
+      return reason;
     }
     return null;
   }

--- a/runtime/src/llm/chat-executor-constants.ts
+++ b/runtime/src/llm/chat-executor-constants.ts
@@ -143,21 +143,6 @@ export const ENABLE_TOOL_IMAGE_REPLAY = false;
 // ============================================================================
 
 /**
- * macOS native tools that cause visible side-effects (opening apps, running scripts).
- * Once any tool in this set executes, further calls to ANY tool in the set are
- * skipped for the remainder of the request. This prevents the model from e.g.
- * opening 3 YouTube tabs.
- *
- * NOTE: Desktop sandbox tools (`desktop.*`) are intentionally excluded — multi-step
- * desktop automation (click → type → screenshot → verify) needs repeated calls.
- */
-export const MACOS_SIDE_EFFECT_TOOLS = new Set([
-  "system.open",
-  "system.applescript",
-  "system.notification",
-]);
-
-/**
  * High-risk side-effect tools MUST NOT be auto-retried unless an explicit
  * idempotency token is provided in tool args.
  */

--- a/runtime/src/llm/chat-executor-contract-guidance.test.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import type { ToolCallRecord } from "./chat-executor-types.js";
+import { resolveToolContractGuidance } from "./chat-executor-contract-guidance.js";
+
+function makeToolCall(
+  overrides: Partial<ToolCallRecord> & Pick<ToolCallRecord, "name">,
+): ToolCallRecord {
+  return {
+    name: overrides.name,
+    args: overrides.args ?? {},
+    result: overrides.result ?? JSON.stringify({ status: "ok" }),
+    isError: overrides.isError ?? false,
+    durationMs: overrides.durationMs ?? 1,
+  };
+}
+
+describe("chat-executor-contract-guidance", () => {
+  it("routes a Doom god-mode request to start_game first", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "tool_followup",
+      messageText: "Enable god mode in Doom.",
+      toolCalls: [],
+      allowedToolNames: ["mcp.doom.start_game", "mcp.doom.set_god_mode"],
+    });
+
+    expect(guidance).toEqual({
+      source: "doom",
+      runtimeInstruction:
+        "This Doom request is not complete yet. Launch Doom with `mcp.doom.start_game` before answering. " +
+        "For play-until-stop requests, set `async_player: true` and preserve the requested scenario/window settings.",
+      routedToolNames: ["mcp.doom.start_game"],
+      toolChoice: "required",
+    });
+  });
+
+  it("routes follow-up Doom turns to the next missing evidence step", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "tool_followup",
+      messageText: "Enable god mode in Doom.",
+      toolCalls: [
+        makeToolCall({
+          name: "mcp.doom.start_game",
+          result: JSON.stringify({ status: "running" }),
+        }),
+      ],
+      allowedToolNames: ["mcp.doom.start_game", "mcp.doom.set_god_mode"],
+    });
+
+    expect(guidance).toEqual({
+      source: "doom",
+      runtimeInstruction:
+        "God mode is still unverified. Call `mcp.doom.set_god_mode` with `enabled: true`, then verify with " +
+        "`mcp.doom.get_state` or `mcp.doom.get_situation_report` before claiming invulnerability. " +
+        "A `start_game` launch arg alone does not count as confirmation.",
+      routedToolNames: ["mcp.doom.set_god_mode"],
+      toolChoice: "required",
+    });
+  });
+
+  it("routes delegated implementation turns to an editor-first tool on initial guidance", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "initial",
+      messageText: "Implement the requested files.",
+      toolCalls: [],
+      allowedToolNames: ["desktop.bash", "desktop.text_editor"],
+      requiredToolEvidence: {
+        delegationSpec: {
+          task: "core_implementation",
+          objective: "Implement the game files in the desktop workspace",
+          inputContract: "JSON output with created files",
+        },
+      },
+    });
+
+    expect(guidance).toEqual({
+      source: "delegation-initial",
+      routedToolNames: ["desktop.text_editor"],
+      toolChoice: "required",
+    });
+  });
+
+  it("routes delegated correction turns to file-mutation tools after missing file evidence", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "correction",
+      messageText: "Implement the requested files.",
+      toolCalls: [],
+      allowedToolNames: ["desktop.bash", "desktop.text_editor"],
+      requiredToolEvidence: {
+        delegationSpec: {
+          task: "core_implementation",
+          objective: "Implement the game files in the desktop workspace",
+          inputContract: "JSON output with created files",
+        },
+      },
+      validationCode: "missing_file_mutation_evidence",
+    });
+
+    expect(guidance).toEqual({
+      source: "delegation-correction",
+      routedToolNames: ["desktop.text_editor"],
+      toolChoice: "required",
+    });
+  });
+});

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -1,0 +1,151 @@
+/**
+ * Contract-driven runtime guidance for tool-heavy chat turns.
+ *
+ * This module keeps domain-specific steering policies out of ChatExecutor's
+ * main tool loop. Add new contract resolvers here instead of branching inline
+ * in ChatExecutor when another tool family needs similar staged execution.
+ *
+ * @module
+ */
+
+import type { ToolCallRecord } from "./chat-executor-types.js";
+import type { LLMToolChoice } from "./types.js";
+import type {
+  DelegationContractSpec,
+  DelegationOutputValidationCode,
+} from "../utils/delegation-validation.js";
+import {
+  getMissingDoomEvidenceGap,
+  inferDoomTurnContract,
+  summarizeDoomToolEvidence,
+} from "./chat-executor-doom.js";
+import {
+  resolveDelegatedCorrectionToolChoiceToolNames,
+  resolveDelegatedInitialToolChoiceToolName,
+} from "../utils/delegation-validation.js";
+
+export type ToolContractGuidancePhase =
+  | "initial"
+  | "tool_followup"
+  | "correction";
+
+export interface ToolContractGuidanceContext {
+  readonly phase: ToolContractGuidancePhase;
+  readonly messageText: string;
+  readonly toolCalls: readonly ToolCallRecord[];
+  readonly allowedToolNames: readonly string[];
+  readonly requiredToolEvidence?: {
+    readonly delegationSpec?: DelegationContractSpec;
+  };
+  readonly validationCode?: DelegationOutputValidationCode;
+}
+
+export interface ToolContractGuidance {
+  readonly source: string;
+  readonly runtimeInstruction?: string;
+  readonly routedToolNames?: readonly string[];
+  readonly toolChoice: LLMToolChoice;
+}
+
+interface ToolContractGuidanceResolver {
+  readonly name: string;
+  readonly priority: number;
+  resolve(input: ToolContractGuidanceContext): ToolContractGuidance | undefined;
+}
+
+const TOOL_CONTRACT_GUIDANCE_RESOLVERS: readonly ToolContractGuidanceResolver[] = [
+  {
+    name: "delegation-correction",
+    priority: 300,
+    resolve: resolveDelegationCorrectionContractGuidance,
+  },
+  {
+    name: "doom",
+    priority: 200,
+    resolve: resolveDoomToolContractGuidance,
+  },
+  {
+    name: "delegation-initial",
+    priority: 100,
+    resolve: resolveDelegationInitialContractGuidance,
+  },
+];
+
+export function resolveToolContractGuidance(
+  input: ToolContractGuidanceContext,
+): ToolContractGuidance | undefined {
+  for (const resolver of TOOL_CONTRACT_GUIDANCE_RESOLVERS) {
+    const guidance = resolver.resolve(input);
+    if (guidance) return guidance;
+  }
+  return undefined;
+}
+
+function resolveDoomToolContractGuidance(
+  input: ToolContractGuidanceContext,
+): ToolContractGuidance | undefined {
+  const contract = inferDoomTurnContract(input.messageText);
+  if (!contract) return undefined;
+
+  const gap = getMissingDoomEvidenceGap(
+    contract,
+    summarizeDoomToolEvidence(input.toolCalls),
+  );
+  if (!gap) return undefined;
+
+  const routedToolNames = gap.preferredToolNames.filter(
+    (toolName) =>
+      input.allowedToolNames.length === 0 ||
+      input.allowedToolNames.includes(toolName),
+  );
+
+  return {
+    source: "doom",
+    runtimeInstruction: gap.message,
+    ...(routedToolNames.length > 0 ? { routedToolNames } : {}),
+    toolChoice: "required",
+  };
+}
+
+function resolveDelegationInitialContractGuidance(
+  input: ToolContractGuidanceContext,
+): ToolContractGuidance | undefined {
+  if (input.phase !== "initial") return undefined;
+
+  const spec = input.requiredToolEvidence?.delegationSpec;
+  if (!spec) return undefined;
+
+  const preferredToolName = resolveDelegatedInitialToolChoiceToolName(
+    spec,
+    input.allowedToolNames,
+  );
+  if (!preferredToolName) return undefined;
+
+  return {
+    source: "delegation-initial",
+    routedToolNames: [preferredToolName],
+    toolChoice: "required",
+  };
+}
+
+function resolveDelegationCorrectionContractGuidance(
+  input: ToolContractGuidanceContext,
+): ToolContractGuidance | undefined {
+  if (input.phase !== "correction") return undefined;
+
+  const spec = input.requiredToolEvidence?.delegationSpec;
+  if (!spec) return undefined;
+
+  const preferredToolNames = resolveDelegatedCorrectionToolChoiceToolNames(
+    spec,
+    input.allowedToolNames,
+    input.validationCode,
+  );
+  if (preferredToolNames.length === 0) return undefined;
+
+  return {
+    source: "delegation-correction",
+    routedToolNames: preferredToolNames,
+    toolChoice: "required",
+  };
+}

--- a/runtime/src/llm/chat-executor-tool-utils.test.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  checkToolCallPermission,
   didToolCallFail,
   normalizeDoomScreenResolution,
   normalizeToolCallArguments,
@@ -111,6 +112,42 @@ describe("chat-executor-tool-utils", () => {
         window_visible: true,
         render_hud: true,
       });
+    });
+  });
+
+  describe("checkToolCallPermission", () => {
+    it("does not block repeated side-effect tools within the same round", () => {
+      const permission = checkToolCallPermission(
+        {
+          id: "tool-1",
+          name: "system.open",
+          arguments: "{}",
+        },
+        null,
+        null,
+        false,
+        false,
+      );
+
+      expect(permission).toEqual({ action: "processed" });
+    });
+
+    it("still blocks tools outside the routed subset", () => {
+      const permission = checkToolCallPermission(
+        {
+          id: "tool-2",
+          name: "system.delete",
+          arguments: "{}",
+        },
+        null,
+        new Set(["system.readFile"]),
+        true,
+        false,
+      );
+
+      expect(permission.action).toBe("skip");
+      expect(permission.routingMiss).toBe(true);
+      expect(permission.expandAfterRound).toBe(true);
     });
   });
 });

--- a/runtime/src/llm/chat-executor-tool-utils.ts
+++ b/runtime/src/llm/chat-executor-tool-utils.ts
@@ -14,7 +14,6 @@ import {
   HIGH_RISK_TOOL_PREFIXES,
   SAFE_TOOL_RETRY_TOOLS,
   SAFE_TOOL_RETRY_PREFIXES,
-  MACOS_SIDE_EFFECT_TOOLS,
   MAX_CONSECUTIVE_IDENTICAL_FAILURES,
   MAX_CONSECUTIVE_ALL_FAILED_ROUNDS,
   MAX_CONSECUTIVE_SEMANTIC_DUPLICATE_ROUNDS,
@@ -172,25 +171,14 @@ export interface ToolCallPermissionResult {
   readonly routingMiss?: boolean;
 }
 
-/** Check side-effect dedup, global allowlist, and routed subset for a tool call. */
+/** Check global allowlist and routed subset constraints for a tool call. */
 export function checkToolCallPermission(
   toolCall: LLMToolCall,
   allowedTools: Set<string> | null,
   routedToolSet: Set<string> | null,
   canExpandOnRoutingMiss: boolean,
   routedToolsExpanded: boolean,
-  sideEffectExecuted: boolean,
 ): ToolCallPermissionResult {
-  // Side-effect dedup check.
-  if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name) && sideEffectExecuted) {
-    return {
-      action: "skip",
-      errorResult: safeStringify({
-        error: `Skipped "${toolCall.name}" — a desktop action was already performed. Combine actions into a single tool call.`,
-      }),
-    };
-  }
-
   // Global allowlist check.
   if (allowedTools && !allowedTools.has(toolCall.name)) {
     return {

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -576,7 +576,6 @@ export interface FullPlannerSummaryState extends MutablePlannerSummaryState {
 
 /** Loop-local mutable state shared across tool calls within a single round. */
 export interface ToolLoopState {
-  sideEffectExecuted: boolean;
   remainingToolImageChars: number;
   activeRoutedToolSet: Set<string> | null;
   expandAfterRound: boolean;

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -1485,6 +1485,128 @@ describe("ChatExecutor", () => {
       ).toBe(false);
     });
 
+    it("steers Doom turns toward start_game first and then the missing follow-up tool", async () => {
+      let started = false;
+      const toolHandler = vi.fn(async (name: string) => {
+        if (name === "mcp.doom.start_game") {
+          started = true;
+          return safeJson({ status: "running" });
+        }
+        if (name === "mcp.doom.set_god_mode") {
+          if (!started) {
+            return safeJson({
+              error:
+                "Launch Doom first with `mcp.doom.start_game` before calling follow-up Doom tools in this turn. " +
+                "For play-until-stop requests, the launch must include `async_player: true`.",
+            });
+          }
+          return safeJson({
+            status: "god_mode_updated",
+            god_mode_enabled: true,
+          });
+        }
+        return safeJson({ name });
+      });
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-god-early",
+                  name: "mcp.doom.set_god_mode",
+                  arguments: safeJson({ enabled: true }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-start",
+                  name: "mcp.doom.start_game",
+                  arguments: safeJson({}),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-god-correct",
+                  name: "mcp.doom.set_god_mode",
+                  arguments: safeJson({ enabled: true }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "God mode is enabled and Doom is running.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: ["mcp.doom.start_game", "mcp.doom.set_god_mode"],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage("Enable god mode in Doom."),
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toBe("God mode is enabled and Doom is running.");
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        1,
+        "mcp.doom.set_god_mode",
+        { enabled: true },
+      );
+      expect(toolHandler).toHaveBeenNthCalledWith(2, "mcp.doom.start_game", {
+        screen_resolution: "RES_1280X720",
+        window_visible: true,
+        render_hud: true,
+      });
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        3,
+        "mcp.doom.set_god_mode",
+        { enabled: true },
+      );
+
+      const firstOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[1] as LLMChatOptions | undefined;
+      expect(firstOptions?.toolChoice).toBe("required");
+      expect(firstOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.start_game",
+      ]);
+
+      const secondOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1]?.[1] as LLMChatOptions | undefined;
+      expect(secondOptions?.toolChoice).toBe("required");
+      expect(secondOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.start_game",
+      ]);
+
+      const thirdOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[2]?.[1] as LLMChatOptions | undefined;
+      expect(thirdOptions?.toolChoice).toBe("required");
+      expect(thirdOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.set_god_mode",
+      ]);
+    });
+
     it("passes routed tool subset to provider chat options", async () => {
       const provider = createMockProvider("primary");
       const executor = new ChatExecutor({ providers: [provider] });

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -22,6 +22,7 @@ import type {
   StreamProgressCallback,
   ToolHandler,
 } from "./types.js";
+import type { DelegationOutputValidationCode } from "../utils/delegation-validation.js";
 import {
   LLMProviderError,
   LLMRateLimitError,
@@ -110,7 +111,6 @@ import {
   DEFAULT_TOOL_FAILURE_BREAKER_THRESHOLD,
   DEFAULT_TOOL_FAILURE_BREAKER_WINDOW_MS,
   DEFAULT_TOOL_FAILURE_BREAKER_COOLDOWN_MS,
-  MACOS_SIDE_EFFECT_TOOLS,
   DEFAULT_EVAL_RUBRIC,
   MAX_COMPACT_INPUT,
 } from "./chat-executor-constants.js";
@@ -198,10 +198,12 @@ import {
 } from "./chat-executor-verifier.js";
 import {
   getMissingSuccessfulToolEvidenceMessage,
-  resolveDelegatedCorrectionToolChoiceToolNames,
-  resolveDelegatedInitialToolChoiceToolName,
   validateDelegatedOutputContract,
 } from "../utils/delegation-validation.js";
+import {
+  type ToolContractGuidancePhase,
+  resolveToolContractGuidance,
+} from "./chat-executor-contract-guidance.js";
 // ---------------------------------------------------------------------------
 // Re-exports — preserve backward-compatible import paths for consumers
 // ---------------------------------------------------------------------------
@@ -539,15 +541,48 @@ export class ChatExecutor {
     return this.allowedTools ? [...this.allowedTools] : [];
   }
 
-  private getRequiredToolEvidencePreferredToolName(
+  private maybePushRuntimeInstruction(
     ctx: ExecutionContext,
-  ): string | undefined {
-    const delegationSpec = ctx.requiredToolEvidence?.delegationSpec;
-    if (!delegationSpec) return undefined;
-    return resolveDelegatedInitialToolChoiceToolName(
-      delegationSpec,
-      this.getAllowedToolNamesForEvidence(ctx),
-    );
+    content: string,
+  ): void {
+    const runtimeHintCount = ctx.messageSections.filter(
+      (section) => section === "system_runtime",
+    ).length;
+    if (runtimeHintCount >= this.maxRuntimeSystemHints) return;
+
+    const alreadyPresent = ctx.messages.some((message, index) => {
+      if (ctx.messageSections[index] !== "system_runtime") return false;
+      return message.role === "system" &&
+        typeof message.content === "string" &&
+        message.content === content;
+    });
+    if (alreadyPresent) return;
+
+    this.pushMessage(ctx, { role: "system", content }, "system_runtime");
+  }
+
+  private resolveActiveToolContractGuidance(
+    ctx: ExecutionContext,
+    input?: {
+      readonly phase?: ToolContractGuidancePhase;
+      readonly allowedToolNames?: readonly string[];
+      readonly validationCode?: DelegationOutputValidationCode;
+    },
+  ): {
+    readonly source: string;
+    readonly runtimeInstruction?: string;
+    readonly routedToolNames?: readonly string[];
+    readonly toolChoice: LLMToolChoice;
+  } | undefined {
+    return resolveToolContractGuidance({
+      phase: input?.phase ?? "tool_followup",
+      messageText: ctx.messageText,
+      toolCalls: ctx.allToolCalls,
+      allowedToolNames:
+        input?.allowedToolNames ?? this.getAllowedToolNamesForEvidence(ctx),
+      requiredToolEvidence: ctx.requiredToolEvidence,
+      validationCode: input?.validationCode,
+    });
   }
 
   private async enforceRequiredToolEvidenceBeforeCompletion(
@@ -648,17 +683,14 @@ export class ChatExecutor {
       ctx.requiredToolEvidenceCorrectionAttempts += 1;
       retried = true;
 
-      const preferredToolNames =
-        contractValidation?.code && ctx.requiredToolEvidence?.delegationSpec
-          ? resolveDelegatedCorrectionToolChoiceToolNames(
-            ctx.requiredToolEvidence.delegationSpec,
-            correctionAllowedTools,
-            contractValidation.code,
-          )
-          : [];
-      const preferredToolName =
-        preferredToolNames[0] ??
-        this.getRequiredToolEvidencePreferredToolName(ctx);
+      const correctionContractGuidance = this.resolveActiveToolContractGuidance(
+        ctx,
+        {
+          phase: "correction",
+          allowedToolNames: correctionAllowedTools,
+          validationCode: contractValidation?.code,
+        },
+      );
       const nextResponse = await this.callModelForPhase(ctx, {
         phase,
         callMessages: ctx.messages,
@@ -666,12 +698,10 @@ export class ChatExecutor {
         onStreamChunk: ctx.activeStreamCallback,
         statefulSessionId: ctx.sessionId,
         statefulResumeAnchor: ctx.stateful?.resumeAnchor,
-        toolChoice: "required",
-        ...((preferredToolNames.length > 0 || preferredToolName)
+        toolChoice: correctionContractGuidance?.toolChoice ?? "required",
+        ...((correctionContractGuidance?.routedToolNames?.length ?? 0) > 0
           ? {
-            routedToolNames: preferredToolNames.length > 0
-              ? preferredToolNames
-              : [preferredToolName!] as const,
+            routedToolNames: correctionContractGuidance!.routedToolNames,
           }
           : {}),
         budgetReason:
@@ -1236,8 +1266,20 @@ export class ChatExecutor {
   }
 
   private async executeToolCallLoop(ctx: ExecutionContext): Promise<void> {
-    const preferredInitialToolName =
-      this.getRequiredToolEvidencePreferredToolName(ctx);
+    const initialContractGuidance = this.resolveActiveToolContractGuidance(ctx, {
+      phase: "initial",
+    });
+    if (initialContractGuidance?.runtimeInstruction) {
+      this.maybePushRuntimeInstruction(
+        ctx,
+        initialContractGuidance.runtimeInstruction,
+      );
+    }
+    const initialToolChoice =
+      initialContractGuidance?.toolChoice ??
+      (ctx.requiredToolEvidence ? "required" : undefined);
+    const initialRoutedToolNames =
+      initialContractGuidance?.routedToolNames;
     ctx.response = await this.callModelForPhase(ctx, {
       phase: "initial",
       callMessages: ctx.messages,
@@ -1245,11 +1287,13 @@ export class ChatExecutor {
       onStreamChunk: ctx.activeStreamCallback,
       statefulSessionId: ctx.sessionId,
       statefulResumeAnchor: ctx.stateful?.resumeAnchor,
-      ...(ctx.requiredToolEvidence
+      ...((initialToolChoice !== undefined || initialRoutedToolNames !== undefined)
         ? {
-          toolChoice: "required" as const,
-          ...(preferredInitialToolName
-            ? { routedToolNames: [preferredInitialToolName] as const }
+          ...(initialToolChoice !== undefined
+            ? { toolChoice: initialToolChoice }
+            : {}),
+          ...(initialRoutedToolNames !== undefined
+            ? { routedToolNames: initialRoutedToolNames }
             : {}),
         }
         : {}),
@@ -1270,7 +1314,6 @@ export class ChatExecutor {
       consecutiveSemanticDuplicateRounds: 0,
     };
     const loopState: ToolLoopState = {
-      sideEffectExecuted: false,
       remainingToolImageChars: MAX_TOOL_IMAGE_CHARS_BUDGET,
       activeRoutedToolSet: null,
       expandAfterRound: false,
@@ -1371,6 +1414,19 @@ export class ChatExecutor {
         }
       }
 
+      const followupContractGuidance = this.resolveActiveToolContractGuidance(
+        ctx,
+        {
+          phase: "tool_followup",
+        },
+      );
+      if (followupContractGuidance?.runtimeInstruction) {
+        this.maybePushRuntimeInstruction(
+          ctx,
+          followupContractGuidance.runtimeInstruction,
+        );
+      }
+
       // Re-call LLM.
       const nextResponse = await this.callModelForPhase(ctx, {
         phase: "tool_followup",
@@ -1379,6 +1435,14 @@ export class ChatExecutor {
         onStreamChunk: ctx.activeStreamCallback,
         statefulSessionId: ctx.sessionId,
         statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+        ...(followupContractGuidance
+          ? {
+            toolChoice: followupContractGuidance.toolChoice,
+            ...(followupContractGuidance.routedToolNames
+              ? { routedToolNames: followupContractGuidance.routedToolNames }
+              : {}),
+          }
+          : {}),
         budgetReason:
           "Max model recalls exceeded while following up after tool calls",
       });
@@ -1433,14 +1497,13 @@ export class ChatExecutor {
       return "abort_loop";
     }
 
-    // Permission check (side-effect dedup, allowlist, routed subset).
+    // Permission check (allowlist, routed subset).
     const permission = checkToolCallPermission(
       toolCall,
       this.allowedTools,
       loopState.activeRoutedToolSet,
       ctx.canExpandOnRoutingMiss,
       ctx.routedToolsExpanded,
-      loopState.sideEffectExecuted,
     );
     if (permission.errorResult) {
       if (permission.routingMiss) ctx.routedToolMisses++;
@@ -1464,8 +1527,6 @@ export class ChatExecutor {
       if (permission.expandAfterRound) loopState.expandAfterRound = true;
       return "skip";
     }
-    if (MACOS_SIDE_EFFECT_TOOLS.has(toolCall.name)) loopState.sideEffectExecuted = true;
-
     // Parse arguments.
     const parseResult = parseToolCallArguments(toolCall);
     if (!parseResult.ok) {

--- a/runtime/src/policy/policy-gate.test.ts
+++ b/runtime/src/policy/policy-gate.test.ts
@@ -27,6 +27,10 @@ describe("createPolicyGateHook", () => {
     });
 
     expect(result.continue).toBe(false);
+    expect(result.payload).toMatchObject({
+      blocked: true,
+      reason: expect.stringContaining('Policy blocked tool "system.delete"'),
+    });
   });
 
   it("allows denied tools in shadow mode and records the simulated violation", async () => {
@@ -112,5 +116,9 @@ describe("createPolicyGateHook", () => {
     });
 
     expect(result.continue).toBe(false);
+    expect(result.payload).toMatchObject({
+      blocked: true,
+      reason: expect.stringContaining('Policy blocked tool "system.httpGet"'),
+    });
   });
 });

--- a/runtime/src/policy/policy-gate.ts
+++ b/runtime/src/policy/policy-gate.ts
@@ -114,7 +114,15 @@ export function createPolicyGateHook(
       options.logger.warn?.(
         `Policy blocked tool "${toolName}": ${violationSummary}`,
       );
-      return { continue: false };
+      return {
+        continue: false,
+        payload: {
+          ...payload,
+          blocked: true,
+          reason: `Policy blocked tool "${toolName}": ${violationSummary}`,
+          violations: decision.violations,
+        },
+      };
     },
   };
 }


### PR DESCRIPTION
## Summary
- make approval gating explicit opt-in and split desktop automation approvals from baseline defaults
- route staged tool flows through shared contract guidance instead of gateway-only blockers
- remove execution-time heuristic denials for greetings, repeated side-effect tools, and low-score delegation vetoes while preserving hard runtime boundaries

## Test plan
- npm run typecheck
- npx vitest run src/gateway/approval-runtime.test.ts src/gateway/approvals.test.ts src/gateway/config-watcher.test.ts src/gateway/tool-handler-factory.test.ts src/gateway/voice-bridge.test.ts src/llm/chat-executor-tool-utils.test.ts src/policy/policy-gate.test.ts
- npx vitest run src/gateway/daemon.test.ts -t "approval"