### PR TITLE
feat(runtime): add typed productivity artifact tools

### DIFF
--- a/docs/AUTONOMY_USER_TEST_PROGRAM.md
+++ b/docs/AUTONOMY_USER_TEST_PROGRAM.md
@@ -19,6 +19,33 @@ behavior, user-path correctness, and operator trust.
 4. Copy prompts from [prompt.txt](/home/tetsuo/git/AgenC/prompt.txt).
 5. After every stage, verify the expected evidence before advancing.
 
+## Automated Watch Mode
+
+If you want AgenC to drive the same live tmux pane you are watching, use:
+
+```bash
+npm run autonomy:ladder -- --tmux-target agenc-watch:live.0 --client-key tmux-live-watch
+```
+
+What it does:
+
+- types prompts and operator commands into the live `agenc-watch` pane
+- inspects the same owner/session via a sidecar websocket client without
+  rebinding the visible session
+- scores each stage from durable run inspection plus TRACE detail
+- writes per-stage JSON artifacts under `.tmp/autonomy-ladder/<run-token>/`
+
+Use `--stages 0-4` to stop at the core prompt ladder or `--stages 5-8` to
+continue through operator controls, TRACE validation, restart recovery, and
+cleanup.
+
+Additional targeted scenarios:
+
+- `--scenario server` for typed durable HTTP service supervision
+- `--scenario spreadsheet` for typed workbook inspection through the live pane
+- `--scenario office-document` for typed DOCX/ODT inspection through the live pane
+- `--scenario productivity` for typed email-message and calendar inspection through the live pane
+
 If any stage fails:
 
 - stop the ladder
@@ -69,11 +96,13 @@ Pass:
 - CHAT shows a real tool execution
 - the tool result contains the token
 - the final answer includes the same token
+- the tool matches the active environment (`desktop.bash` in desktop mode,
+  `system.bash` in host mode)
 - TRACE shows the tool call and result for the same session
 
 Fail examples:
 - assistant claims a result without a tool
-- wrong command shape
+- wrong environment tool selection or wrong command shape
 - tool runs but final answer ignores the result
 
 ### Stage 2: Multi-Tool File Workflow
@@ -193,6 +222,62 @@ Fail examples:
 
 These are not required for the core ladder, but they should be run before
 claiming a domain is production-ready.
+
+### Local Data / Document Tools
+
+Goal:
+- validate typed host-side inspection of spreadsheets, local databases, and
+  documents without shell fallback
+
+Use:
+- ask AgenC to inspect a local spreadsheet/workbook with
+  `system.spreadsheetInfo` and `system.spreadsheetRead`, summarize the sheets,
+  and ground the answer in real rows
+- ask AgenC to inspect a local SQLite database with `system.sqliteSchema` and
+  `system.sqliteQuery`, summarize the schema, and ground the answer in real rows
+- ask AgenC to inspect a local PDF with `system.pdfInfo` and
+  `system.pdfExtractText`, then report both metadata and extracted text
+- ask AgenC to inspect a local DOCX/ODT document with
+  `system.officeDocumentInfo` and `system.officeDocumentExtractText`, then
+  report both metadata and extracted text exactly
+
+### Productivity Artifacts
+
+Goal:
+- validate typed host-side inspection of local productivity artifacts such as
+  email messages and calendar invites without browser or shell fallback
+
+Use:
+- ask AgenC to inspect a local EML file with `system.emailMessageInfo` and
+  `system.emailMessageExtractText`, then report exact headers and extracted text
+- ask AgenC to inspect a local ICS file with `system.calendarInfo` and
+  `system.calendarRead`, then report exact event count, summaries, and attendees
+
+Watch:
+- `[1] CHAT`
+- `[4] TRACE`
+
+Pass:
+- TRACE shows the typed email/calendar tool calls, not shell fallback
+- the final answer is grounded in real message/calendar metadata and text
+- desktop-mode sessions still reach these host-scoped typed tools correctly
+
+Automated watch mode:
+- `--scenario productivity` for typed email-message and calendar inspection
+
+Watch:
+- `[1] CHAT`
+- `[4] TRACE`
+
+Pass:
+- TRACE shows the typed tool calls, not `desktop.bash` / `system.bash`
+- the final answer cites real schema/metadata/text from the tool results
+- desktop-mode sessions still reach the host-scoped typed tools correctly
+
+Fail examples:
+- planner claims the typed tools are unavailable when they are registered
+- shell fallback is used even though the typed family exists
+- answer invents data not present in the typed tool result
 
 ### Desktop / Browser
 

--- a/docs/RUNTIME_API.md
+++ b/docs/RUNTIME_API.md
@@ -589,11 +589,27 @@ The tool surface is intentionally split by environment:
 
 - `system.browserSession*` is host-scoped and only available when
   `desktop.environment` is `"host"` or `"both"`.
+- `system.sqlite*` and `system.pdf*` are host-scoped typed inspection tools for
+  local databases and documents. They stay available in desktop mode because
+  they are structured read-only host tools, not raw host mutation surfaces.
+- `system.spreadsheet*` is a host-scoped typed table/workbook inspection family
+  for local CSV/TSV/XLS/XLSX files and also remains available in desktop mode
+  for the same reason.
+- `system.officeDocument*` is a host-scoped typed office-document inspection
+  family for local DOCX/ODT files and also remains available in desktop mode
+  for the same reason.
+- `system.emailMessage*` and `system.calendar*` are host-scoped typed
+  productivity inspection families for local EML and ICS files and also remain
+  available in desktop mode for the same reason.
 - `mcp.browser.*` / `playwright.*` is desktop-scoped and remains the correct
   choice for visible browser automation inside the sandboxed desktop.
 
 If you run the gateway in `desktop`-only mode, the runtime will correctly filter
-`system.browserSession*` out of the LLM-visible tool set.
+raw host-mutation tools like `system.bash`, while still exposing structured
+host families such as `system.process*`, `system.server*`, `system.browserSession*`,
+`system.sqlite*`, `system.pdf*`, `system.spreadsheet*`,
+`system.officeDocument*`, `system.emailMessage*`, and `system.calendar*` when
+their contracts are safe for that mode.
 
 ### Profile Selection Guide
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "security:cargo:lock:check": "node scripts/check-cargo-lock-security.mjs",
     "security:desktop:hardening:check": "node scripts/check-desktop-image-hardening.mjs",
     "desktop:image:doom:smoke": "node scripts/smoke-desktop-doom-image.mjs",
+    "autonomy:ladder": "node scripts/run-autonomy-ladder.mjs",
+    "test:autonomy:ladder": "node --test scripts/agenc-autonomy-ladder.test.mjs",
     "security:trivy:image": "trivy image --scanners vuln,misconfig,secret",
     "fender:list": "node scripts/solana-fender-mcp.mjs list",
     "fender:check:file": "node scripts/solana-fender-mcp.mjs check-file",

--- a/prompt.txt
+++ b/prompt.txt
@@ -15,8 +15,11 @@ any tools.
 
 Stage 1 — single tool grounding
 
-Use `system.bash` to run `/usr/bin/printf` with args
-`["AUTONOMY_STAGE1::RUN_TOKEN\n"]`.
+Use the shell tool appropriate for the current environment to print
+`AUTONOMY_STAGE1::RUN_TOKEN\n`.
+
+If you are in the `agenc-watch` desktop session, use `desktop.bash`.
+If you are in a host-only session, `system.bash` is also acceptable.
 
 Then answer with:
 - the exact output
@@ -77,6 +80,57 @@ is still active, then use the same web session and confirm:
 - the run continues or recovers instead of silently disappearing
 
 OPTIONAL EXTENSIONS
+
+Spreadsheet / workbook tools
+
+Use the typed spreadsheet tools to inspect `/tmp/agenc-tool-smoke/roster.xlsx`.
+Summarize the workbook, then read the `Roster` sheet and answer with:
+- the exact row count
+- the name/role pairs
+
+Do not use shell unless the typed spreadsheet tools fail.
+
+Office document tools
+
+Use the typed office document tools to inspect `/tmp/agenc-tool-smoke/launch-brief.docx`.
+Answer with:
+- the exact document metadata
+- the exact extracted text
+
+Do not use shell unless the typed office document tools fail.
+
+Productivity artifacts
+
+Use the typed email message tools to inspect `/tmp/agenc-tool-smoke/inbox.eml`.
+Answer with:
+- the exact message metadata
+- the exact extracted text
+
+Do not use shell unless the typed email message tools fail.
+
+Use the typed calendar tools to inspect `/tmp/agenc-tool-smoke/team-calendar.ics`.
+Answer with:
+- the calendar metadata
+- the exact event count
+- the event summaries and attendees
+
+Do not use shell unless the typed calendar tools fail.
+
+Local data / document tools
+
+Use the typed SQLite tools to inspect `/tmp/agenc-tool-smoke/sample.db`.
+Summarize the schema, then query the `users` table and answer with:
+- exactly how many users there are
+- each user's name and role
+
+Do not use shell unless the typed SQLite tools fail.
+
+Use the typed PDF tools to inspect `/tmp/agenc-tool-smoke/sample.pdf`.
+Answer with:
+- the document metadata
+- the exact extracted text
+
+Do not use shell unless the typed PDF tools fail.
 
 Desktop/browser
 

--- a/runtime/src/gateway/background-run-supervisor.test.ts
+++ b/runtime/src/gateway/background-run-supervisor.test.ts
@@ -4013,6 +4013,238 @@ describe("background-run-supervisor", () => {
     );
   });
 
+  it("uses system.serverStart for native bootstrap when the objective is a readiness-checked local HTTP service", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi.fn().mockResolvedValueOnce(
+      makeResult({
+        content:
+          'Use `python3 -m http.server 8765` under the label autonomy-http and verify readiness on `http://127.0.0.1:8765/`.',
+        toolCalls: [],
+      }),
+    );
+    const nativeTools = createManagedProcessToolHandler({
+      surface: "host_server",
+      initialProcessId: "proc_server",
+      initialServerId: "server_http",
+      label: "autonomy-http",
+      command: "python3",
+      args: ["-m", "http.server", "8765"],
+      cwd: "/home/tetsuo/git/AgenC",
+      healthUrl: "http://127.0.0.1:8765/",
+      ready: true,
+    });
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce({
+            content:
+              '{"kind":"until_stopped","successCriteria":["start the typed server handle"],"completionCriteria":["only stop after explicit user stop"],"blockedCriteria":["server handle fails to start"],"nextCheckMs":4000,"heartbeatMs":15000,"requiresUserStop":true,"managedProcessPolicy":{"mode":"keep_running"}}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"summary":"HTTP server handle is running.","verifiedFacts":["Ready on http://127.0.0.1:8765/."],"openLoops":["Await explicit stop request."],"nextFocus":"Continue server supervision."}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => nativeTools.handler,
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-native-host-server-bootstrap",
+      objective:
+        "Start a durable background run that uses typed server handle tools to run `python3 -m http.server 8765` from `/home/tetsuo/git/AgenC` under the label autonomy-http. Verify readiness on `http://127.0.0.1:8765/` and keep supervising it.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await eventually(() => {
+      const snapshot = supervisor.getStatusSnapshot(
+        "session-native-host-server-bootstrap",
+      );
+      expect(snapshot?.state).toBe("working");
+      expect(nativeTools.handler).toHaveBeenNthCalledWith(
+        1,
+        "system.serverStart",
+        expect.objectContaining({
+          command: "python3",
+          args: ["-m", "http.server", "8765"],
+          label: "autonomy-http",
+          healthUrl: "http://127.0.0.1:8765/",
+          readyStatusCodes: [200],
+          readinessTimeoutMs: 10_000,
+        }),
+      );
+      expect(nativeTools.handler).toHaveBeenNthCalledWith(
+        2,
+        "system.serverStatus",
+        expect.objectContaining({
+          label: "autonomy-http",
+        }),
+      );
+    });
+  });
+
+  it("promotes a server objective onto typed server supervision when readiness verification is required", async () => {
+    const publishUpdate = vi.fn(async () => undefined);
+    const execute = vi.fn().mockResolvedValueOnce(
+      makeResult({
+        content: "Started the HTTP server process.",
+        toolCalls: [
+          {
+            name: "system.processStart",
+            args: {
+              command: "python3",
+              args: ["-m", "http.server", "8765"],
+              cwd: "/home/tetsuo/git/AgenC",
+              label: "autonomy-http",
+            },
+            result:
+              '{"processId":"proc_server","label":"autonomy-http","command":"python3","args":["-m","http.server","8765"],"cwd":"/home/tetsuo/git/AgenC","state":"running"}',
+            isError: false,
+            durationMs: 5,
+          },
+          {
+            name: "system.processStatus",
+            args: { label: "autonomy-http" },
+            result:
+              '{"processId":"proc_server","label":"autonomy-http","command":"python3","args":["-m","http.server","8765"],"cwd":"/home/tetsuo/git/AgenC","state":"running"}',
+            isError: false,
+            durationMs: 1,
+          },
+        ],
+      }),
+    );
+    const handler = vi.fn<ToolHandler>(async (name, args) => {
+      if (name === "system.processStop") {
+        return JSON.stringify({
+          processId: "proc_server",
+          label: "autonomy-http",
+          command: "python3",
+          args: ["-m", "http.server", "8765"],
+          cwd: "/home/tetsuo/git/AgenC",
+          state: "exited",
+          exitCode: 0,
+        });
+      }
+      if (name === "system.serverStart") {
+        return JSON.stringify({
+          serverId: "server_http",
+          processId: "proc_server_upgraded",
+          label: "autonomy-http",
+          idempotencyKey: "background-run:bg-0-xd2v6v:autonomy-http",
+          command: "python3",
+          args: ["-m", "http.server", "8765"],
+          cwd: "/home/tetsuo/git/AgenC",
+          healthUrl: "http://127.0.0.1:8765/",
+          host: "127.0.0.1",
+          port: 8765,
+          protocol: "http",
+          readyStatusCodes: [200],
+          readinessTimeoutMs: 10000,
+          state: "running",
+          ready: true,
+        });
+      }
+      if (name === "system.serverStatus") {
+        return JSON.stringify({
+          serverId: "server_http",
+          processId: "proc_server_upgraded",
+          label: "autonomy-http",
+          command: "python3",
+          args: ["-m", "http.server", "8765"],
+          cwd: "/home/tetsuo/git/AgenC",
+          healthUrl: "http://127.0.0.1:8765/",
+          host: "127.0.0.1",
+          port: 8765,
+          protocol: "http",
+          readyStatusCodes: [200],
+          readinessTimeoutMs: 10000,
+          state: "running",
+          ready: true,
+        });
+      }
+      throw new Error(`unexpected tool ${name}`);
+    });
+    const supervisor = new BackgroundRunSupervisor({
+      chatExecutor: { execute } as any,
+      supervisorLlm: {
+        name: "supervisor",
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce({
+            content:
+              '{"kind":"until_stopped","successCriteria":["start the typed server handle"],"completionCriteria":["only stop after explicit user stop"],"blockedCriteria":["server handle fails to start"],"nextCheckMs":4000,"heartbeatMs":15000,"requiresUserStop":true,"managedProcessPolicy":{"mode":"keep_running"}}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          })
+          .mockResolvedValueOnce({
+            content:
+              '{"summary":"HTTP server handle is running.","verifiedFacts":["Ready on http://127.0.0.1:8765/."],"openLoops":["Await explicit stop request."],"nextFocus":"Continue server supervision."}',
+            toolCalls: [],
+            usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+            model: "supervisor-model",
+            finishReason: "stop",
+          }),
+        chatStream: vi.fn(),
+        healthCheck: vi.fn(async () => true),
+      },
+      getSystemPrompt: () => "base system prompt",
+      runStore: createRunStore(),
+      createToolHandler: (): ToolHandler => handler,
+      publishUpdate,
+    });
+
+    await supervisor.startRun({
+      sessionId: "session-server-upgrade",
+      objective:
+        "Start a durable background run that uses typed server handle tools to run `python3 -m http.server 8765` from `/home/tetsuo/git/AgenC` under the label autonomy-http. Verify readiness on `http://127.0.0.1:8765/` and keep supervising it.",
+    });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await eventually(() => {
+      expect(handler).toHaveBeenCalledWith(
+        "system.serverStart",
+        expect.objectContaining({
+          command: "python3",
+          args: ["-m", "http.server", "8765"],
+          label: "autonomy-http",
+          healthUrl: "http://127.0.0.1:8765/",
+        }),
+      );
+      expect(handler).toHaveBeenCalledWith(
+        "system.serverStatus",
+        expect.objectContaining({ label: "autonomy-http" }),
+      );
+    });
+
+    await expect(
+      supervisor.getRecentSnapshot("session-server-upgrade"),
+    ).resolves.toMatchObject({
+      lastToolEvidence: expect.stringContaining("system.serverStart"),
+    });
+    await expect(
+      supervisor.getRecentSnapshot("session-server-upgrade"),
+    ).resolves.toMatchObject({
+      lastToolEvidence: expect.stringContaining("system.serverStatus"),
+    });
+  });
+
   it("wakes immediately on process_exit signals and restarts a managed process natively", async () => {
     const publishUpdate = vi.fn(async () => undefined);
     const execute = vi.fn().mockResolvedValueOnce(

--- a/runtime/src/gateway/background-run-supervisor.ts
+++ b/runtime/src/gateway/background-run-supervisor.ts
@@ -2636,6 +2636,16 @@ function buildManagedProcessIdentity(
   return `${target.label ? `"${target.label}" ` : ""}(${target.processId})`;
 }
 
+const DEFAULT_NATIVE_SERVER_PROTOCOL = "http" as const;
+const DEFAULT_NATIVE_SERVER_HEALTH_PATH = "/";
+const DEFAULT_NATIVE_SERVER_READY_STATUS_CODES = [200] as const;
+const DEFAULT_NATIVE_SERVER_READINESS_TIMEOUT_MS = 10_000;
+
+interface ManagedProcessCommandSpec {
+  readonly command: string;
+  readonly args: readonly string[];
+}
+
 function listManagedProcessBootstrapCandidates(
   run: ActiveBackgroundRun,
 ): readonly string[] {
@@ -2696,12 +2706,294 @@ function extractManagedProcessBootstrapLabel(
   run: ActiveBackgroundRun,
 ): string | undefined {
   for (const candidate of listManagedProcessBootstrapCandidates(run)) {
-    const label = candidate.match(MANAGED_PROCESS_BOOTSTRAP_LABEL_RE)?.[1]?.trim();
+    const label = candidate
+      .match(MANAGED_PROCESS_BOOTSTRAP_LABEL_RE)?.[1]
+      ?.trim()
+      .replace(/[.,;:]+$/g, "");
     if (label) {
       return label;
     }
   }
   return undefined;
+}
+
+function extractBootstrapHealthUrl(run: ActiveBackgroundRun): URL | undefined {
+  const urlPattern = /https?:\/\/[^\s`"'<>]+/g;
+  for (const candidate of listManagedProcessBootstrapCandidates(run)) {
+    for (const match of candidate.matchAll(urlPattern)) {
+      const raw = match[0]?.trim();
+      if (!raw) {
+        continue;
+      }
+      try {
+        const parsed = new URL(raw);
+        if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+          return parsed;
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+  return undefined;
+}
+
+function extractBootstrapPortFromArgs(args: readonly string[]): number | undefined {
+  for (const value of args) {
+    if (!/^\d{2,5}$/.test(value)) {
+      continue;
+    }
+    const port = Number(value);
+    if (Number.isInteger(port) && port >= 1 && port <= 65535) {
+      return port;
+    }
+  }
+  return undefined;
+}
+
+function wantsManagedServerBootstrap(
+  run: ActiveBackgroundRun,
+  commandSpec: ManagedProcessCommandSpec,
+): boolean {
+  const objectiveCorpus = listManagedProcessBootstrapCandidates(run)
+    .join(" ")
+    .toLowerCase();
+  const explicitUrl = extractBootstrapHealthUrl(run);
+  const commandText = [commandSpec.command, ...commandSpec.args].join(" ").toLowerCase();
+  const commandLooksLikeServer =
+    commandText.includes("http.server") ||
+    commandText.includes("http-server") ||
+    commandText.includes("python -m http.server") ||
+    commandText.includes("python3 -m http.server");
+  const objectiveLooksLikeServer =
+    /\b(server|service)\b/.test(objectiveCorpus) &&
+    /\b(http|https|health|ready|readiness|localhost|127\.0\.0\.1|0\.0\.0\.0)\b/.test(
+      objectiveCorpus,
+    );
+  return Boolean(explicitUrl) || commandLooksLikeServer || objectiveLooksLikeServer;
+}
+
+function buildManagedProcessBootstrapStartSpec(
+  run: ActiveBackgroundRun,
+  commandSpec: ManagedProcessCommandSpec,
+  label: string | undefined,
+): {
+  readonly surface: "host" | "host_server";
+  readonly toolName: "system.processStart" | "system.serverStart";
+  readonly args: Record<string, unknown>;
+} {
+  const idempotencyKey = buildManagedProcessBootstrapIdempotencyKey(run, label);
+  const baseArgs: Record<string, unknown> = {
+    command: commandSpec.command,
+    args: [...commandSpec.args],
+    ...(label ? { label } : {}),
+    idempotencyKey,
+  };
+  if (wantsManagedServerBootstrap(run, commandSpec)) {
+    const explicitHealthUrl = extractBootstrapHealthUrl(run);
+    const port = explicitHealthUrl
+      ? Number(explicitHealthUrl.port || (explicitHealthUrl.protocol === "https:" ? 443 : 80))
+      : extractBootstrapPortFromArgs(commandSpec.args);
+    return {
+      surface: "host_server",
+      toolName: "system.serverStart",
+      args: {
+        ...baseArgs,
+        ...(explicitHealthUrl
+          ? { healthUrl: explicitHealthUrl.toString() }
+          : port
+            ? {
+                host: "127.0.0.1",
+                port,
+                protocol: DEFAULT_NATIVE_SERVER_PROTOCOL,
+                healthPath: DEFAULT_NATIVE_SERVER_HEALTH_PATH,
+              }
+            : {}),
+        readyStatusCodes: [...DEFAULT_NATIVE_SERVER_READY_STATUS_CODES],
+        readinessTimeoutMs: DEFAULT_NATIVE_SERVER_READINESS_TIMEOUT_MS,
+      },
+    };
+  }
+  return {
+    surface: "host",
+    toolName: "system.processStart",
+    args: baseArgs,
+  };
+}
+
+function buildManagedProcessStatusArgs(
+  target: Extract<BackgroundRunObservedTarget, { kind: "managed_process" }>,
+): Record<string, unknown> {
+  return getManagedProcessSurface(target) === "host_server"
+    ? target.label
+      ? { label: target.label }
+      : target.serverId
+        ? { serverId: target.serverId }
+        : { processId: target.processId }
+    : target.label
+      ? { label: target.label }
+      : { processId: target.processId };
+}
+
+function shouldUpgradeManagedProcessTargetToServerHandle(
+  run: ActiveBackgroundRun,
+  target: Extract<BackgroundRunObservedTarget, { kind: "managed_process" }>,
+): boolean {
+  if (target.surface !== "host") {
+    return false;
+  }
+  if (target.currentState !== "running") {
+    return false;
+  }
+  const launchSpec = target.launchSpec;
+  if (!launchSpec) {
+    return false;
+  }
+  return wantsManagedServerBootstrap(run, {
+    command: launchSpec.command,
+    args: launchSpec.args,
+  });
+}
+
+async function executeManagedServerUpgradeCycle(params: {
+  run: ActiveBackgroundRun;
+  toolHandler: ToolHandler;
+  now: number;
+  target: Extract<BackgroundRunObservedTarget, { kind: "managed_process" }>;
+}): Promise<NativeManagedProcessCycleResult> {
+  const { run, toolHandler, now, target } = params;
+  const launchSpec = target.launchSpec;
+  if (!launchSpec) {
+    return {
+      actorResult: buildNativeActorResult([], "Missing launch spec for server upgrade.", "managed-process-supervisor"),
+      decision: {
+        state: "blocked",
+        userUpdate: truncate(
+          `Managed process ${buildManagedProcessIdentity(target)} cannot be upgraded to a typed server handle because the launch spec is missing.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          "Native managed-process server upgrade failed because no launch spec was persisted.",
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  const label = target.label ?? launchSpec.label;
+  const bootstrapSpec = buildManagedProcessBootstrapStartSpec(
+    run,
+    {
+      command: launchSpec.command,
+      args: launchSpec.args,
+    },
+    label,
+  );
+  const toolCalls: ChatExecutorResult["toolCalls"][number][] = [];
+  const stopCall = await executeNativeToolCall(
+    toolHandler,
+    "system.processStop",
+    buildManagedProcessStopArgs(target),
+  );
+  toolCalls.push(stopCall);
+  if (stopCall.isError) {
+    return {
+      actorResult: buildNativeActorResult(
+        toolCalls,
+        `Failed to stop ${buildManagedProcessIdentity(target)} before server-handle upgrade.`,
+        "managed-process-supervisor",
+      ),
+      decision: {
+        state: "blocked",
+        userUpdate: truncate(
+          `Failed to stop ${buildManagedProcessIdentity(target)} before upgrading to a typed server handle: ${extractToolFailureText(stopCall)}`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          `Native managed-process server upgrade could not stop the existing process: ${extractToolFailureText(stopCall)}`,
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  const startCall = await executeNativeToolCall(
+    toolHandler,
+    bootstrapSpec.toolName,
+    bootstrapSpec.args,
+  );
+  toolCalls.push(startCall);
+  const startActorResult = buildNativeActorResult(
+    toolCalls,
+    `Upgrading ${buildManagedProcessIdentity(target)} to a typed server handle.`,
+    "managed-process-supervisor",
+  );
+  observeManagedProcessTargets(run, startActorResult, now);
+  run.lastVerifiedAt = now;
+  recordToolEvidence(run, toolCalls);
+
+  if (startCall.isError) {
+    return {
+      actorResult: startActorResult,
+      decision: {
+        state: "blocked",
+        userUpdate: truncate(
+          `Server-handle upgrade failed after stopping ${buildManagedProcessIdentity(target)}: ${extractToolFailureText(startCall)}`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          `Native managed-process server upgrade failed to start the typed server handle: ${extractToolFailureText(startCall)}`,
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  const upgradedTarget =
+    findLatestManagedProcessTarget(run.observedTargets) ?? target;
+  const statusCall = await executeNativeToolCall(
+    toolHandler,
+    managedProcessStatusToolName(getManagedProcessSurface(upgradedTarget)),
+    buildManagedProcessStatusArgs(upgradedTarget),
+  );
+  toolCalls.push(statusCall);
+  const actorResult = buildNativeActorResult(
+    toolCalls,
+    `Upgraded ${buildManagedProcessIdentity(target)} to typed server supervision.`,
+    "managed-process-supervisor",
+  );
+  observeManagedProcessTargets(run, actorResult, now);
+  run.lastVerifiedAt = now;
+  recordToolEvidence(run, toolCalls);
+
+  if (statusCall.isError) {
+    return {
+      actorResult,
+      decision: {
+        state: "working",
+        userUpdate: truncate(
+          `Started typed server supervision for ${buildManagedProcessIdentity(upgradedTarget)} but readiness verification failed and will retry: ${extractToolFailureText(statusCall)}`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        internalSummary:
+          `Native managed-process server upgrade started the typed server handle but status verification failed: ${extractToolFailureText(statusCall)}`,
+        nextCheckMs: MIN_POLL_INTERVAL_MS,
+        shouldNotifyUser: true,
+      },
+    };
+  }
+
+  return {
+    actorResult,
+    decision: {
+      state: "working",
+      userUpdate: truncate(
+        `Run ${run.id} in session ${run.sessionId}: upgraded to typed server supervision for ${buildManagedProcessIdentity(upgradedTarget)} and verified readiness state=${upgradedTarget.currentState}.`,
+        MAX_USER_UPDATE_CHARS,
+      ),
+      internalSummary:
+        "Native managed-process verifier upgraded a plain host process bootstrap to a typed server handle.",
+      nextCheckMs: FAST_FOLLOWUP_POLL_INTERVAL_MS,
+      shouldNotifyUser: true,
+    },
+  };
 }
 
 function buildManagedProcessBootstrapIdempotencyKey(
@@ -2793,20 +3085,16 @@ async function executeManagedProcessNativeCycle(params: {
       return undefined;
     }
     const label = extractManagedProcessBootstrapLabel(run);
+    const bootstrapSpec = buildManagedProcessBootstrapStartSpec(run, parsed, label);
     const startCall = await executeNativeToolCall(
       toolHandler,
-      "system.processStart",
-      {
-        command: parsed.command,
-        args: [...parsed.args],
-        ...(label ? { label } : {}),
-        idempotencyKey: buildManagedProcessBootstrapIdempotencyKey(run, label),
-      },
+      bootstrapSpec.toolName,
+      bootstrapSpec.args,
     );
     const toolCalls: ChatExecutorResult["toolCalls"][number][] = [startCall];
     const startActorResult = buildNativeActorResult(
       toolCalls,
-      `Started managed process ${label ? `"${label}" ` : ""}for background supervision.`,
+      `Started managed ${bootstrapSpec.surface === "host_server" ? "server" : "process"} ${label ? `"${label}" ` : ""}for background supervision.`,
       "managed-process-supervisor",
     );
     observeManagedProcessTargets(run, startActorResult, now);
@@ -2848,10 +3136,8 @@ async function executeManagedProcessNativeCycle(params: {
 
     const statusCall = await executeNativeToolCall(
       toolHandler,
-      "system.processStatus",
-      startedTarget.label
-        ? { label: startedTarget.label }
-        : { processId: startedTarget.processId },
+      managedProcessStatusToolName(getManagedProcessSurface(startedTarget)),
+      buildManagedProcessStatusArgs(startedTarget),
     );
     toolCalls.push(statusCall);
     const actorResult = buildNativeActorResult(
@@ -2903,17 +3189,16 @@ async function executeManagedProcessNativeCycle(params: {
   }
 
   const policy = getManagedProcessPolicy(run);
+  if (shouldUpgradeManagedProcessTargetToServerHandle(run, target)) {
+    return executeManagedServerUpgradeCycle({
+      run,
+      toolHandler,
+      now,
+      target,
+    });
+  }
   const surface = getManagedProcessSurface(target);
-  const statusArgs =
-    surface === "host_server"
-      ? target.label
-        ? { label: target.label }
-        : target.serverId
-          ? { serverId: target.serverId }
-          : { processId: target.processId }
-      : target.label
-        ? { label: target.label }
-        : { processId: target.processId };
+  const statusArgs = buildManagedProcessStatusArgs(target);
   const statusCall = await executeNativeToolCall(
     toolHandler,
     managedProcessStatusToolName(surface),
@@ -3282,6 +3567,19 @@ const MANAGED_PROCESS_RUN_DOMAIN: RunDomain<ActiveBackgroundRun> = {
       return toDomainVerificationFromDecision(terminalDecision);
     }
     const target = findLatestManagedProcessTarget(run.observedTargets);
+    if (target && shouldUpgradeManagedProcessTargetToServerHandle(run, target)) {
+      return {
+        state: "safe_to_continue",
+        summary:
+          "Managed-process domain detected a server-like host process without a typed server handle and will upgrade it deterministically.",
+        userUpdate: truncate(
+          `Upgrading ${buildManagedProcessIdentity(target)} to a typed server handle so readiness can be verified.`,
+          MAX_USER_UPDATE_CHARS,
+        ),
+        safeToContinue: true,
+        nextCheckMs: 0,
+      };
+    }
     if (target?.currentState === "running") {
       return {
         state: "safe_to_continue",

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -110,6 +110,10 @@ import { createHttpTools } from "../tools/system/http.js";
 import { createFilesystemTools } from "../tools/system/filesystem.js";
 import { createBrowserTools } from "../tools/system/browser.js";
 import { createProcessTools } from "../tools/system/process.js";
+import { createPdfTools } from "../tools/system/pdf.js";
+import { createOfficeDocumentTools } from "../tools/system/office-document.js";
+import { createEmailMessageTools } from "../tools/system/email-message.js";
+import { createCalendarTools } from "../tools/system/calendar.js";
 import {
   createRemoteJobTools,
   SystemRemoteJobManager,
@@ -117,6 +121,8 @@ import {
 import { createResearchTools } from "../tools/system/research.js";
 import { createSandboxTools } from "../tools/system/sandbox-handle.js";
 import { createServerTools } from "../tools/system/server.js";
+import { createSqliteTools } from "../tools/system/sqlite.js";
+import { createSpreadsheetTools } from "../tools/system/spreadsheet.js";
 import { resolveBrowserToolMode } from "./browser-tool-mode.js";
 import { createExecuteWithAgentTool } from "./delegation-tool.js";
 import { SkillDiscovery } from "../skills/markdown/discovery.js";
@@ -6150,6 +6156,42 @@ export class DaemonManager {
       createFilesystemTools({
         allowedPaths: allowedFilesystemPaths,
         allowDelete: false,
+      }),
+    );
+    registry.registerAll(
+      createPdfTools({
+        allowedPaths: allowedFilesystemPaths,
+        logger: this.logger,
+      }),
+    );
+    registry.registerAll(
+      createOfficeDocumentTools({
+        allowedPaths: allowedFilesystemPaths,
+        logger: this.logger,
+      }),
+    );
+    registry.registerAll(
+      createEmailMessageTools({
+        allowedPaths: allowedFilesystemPaths,
+        logger: this.logger,
+      }),
+    );
+    registry.registerAll(
+      createCalendarTools({
+        allowedPaths: allowedFilesystemPaths,
+        logger: this.logger,
+      }),
+    );
+    registry.registerAll(
+      createSqliteTools({
+        allowedPaths: allowedFilesystemPaths,
+        logger: this.logger,
+      }),
+    );
+    registry.registerAll(
+      createSpreadsheetTools({
+        allowedPaths: allowedFilesystemPaths,
+        logger: this.logger,
       }),
     );
     const browserToolMode = await resolveBrowserToolMode(this.logger);

--- a/runtime/src/gateway/tool-environment-policy.test.ts
+++ b/runtime/src/gateway/tool-environment-policy.test.ts
@@ -40,6 +40,18 @@ describe("tool-environment-policy", () => {
     expect(isToolAllowedForEnvironment("system.remoteJobStart", "desktop")).toBe(true);
     expect(isToolAllowedForEnvironment("system.researchStart", "desktop")).toBe(true);
     expect(isToolAllowedForEnvironment("system.sandboxStart", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.sqliteSchema", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.sqliteQuery", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.pdfInfo", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.pdfExtractText", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.spreadsheetInfo", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.spreadsheetRead", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.officeDocumentInfo", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.officeDocumentExtractText", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.emailMessageInfo", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.emailMessageExtractText", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.calendarInfo", "desktop")).toBe(true);
+    expect(isToolAllowedForEnvironment("system.calendarRead", "desktop")).toBe(true);
     expect(isToolAllowedForEnvironment("execute_with_agent", "desktop")).toBe(
       true,
     );
@@ -56,6 +68,12 @@ describe("tool-environment-policy", () => {
     const filtered = filterLlmToolsByEnvironment([
       makeLlmTool("system.bash"),
       makeLlmTool("system.sandboxStart"),
+      makeLlmTool("system.sqliteSchema"),
+      makeLlmTool("system.pdfInfo"),
+      makeLlmTool("system.spreadsheetInfo"),
+      makeLlmTool("system.officeDocumentInfo"),
+      makeLlmTool("system.emailMessageInfo"),
+      makeLlmTool("system.calendarInfo"),
       makeLlmTool("desktop.bash"),
       makeLlmTool("playwright.browser_navigate"),
       makeLlmTool("execute_with_agent"),
@@ -63,6 +81,12 @@ describe("tool-environment-policy", () => {
 
     expect(filtered.map((tool) => tool.function.name)).toEqual([
       "system.sandboxStart",
+      "system.sqliteSchema",
+      "system.pdfInfo",
+      "system.spreadsheetInfo",
+      "system.officeDocumentInfo",
+      "system.emailMessageInfo",
+      "system.calendarInfo",
       "desktop.bash",
       "playwright.browser_navigate",
       "execute_with_agent",
@@ -88,12 +112,24 @@ describe("tool-environment-policy", () => {
       filterToolNamesByEnvironment([
         "system.bash",
         "system.sandboxStart",
+        "system.sqliteSchema",
+        "system.pdfInfo",
+        "system.spreadsheetInfo",
+        "system.officeDocumentInfo",
+        "system.emailMessageInfo",
+        "system.calendarInfo",
         "desktop.bash",
         "mcp.browser.browser_snapshot",
         "execute_with_agent",
       ], "desktop"),
     ).toEqual([
       "system.sandboxStart",
+      "system.sqliteSchema",
+      "system.pdfInfo",
+      "system.spreadsheetInfo",
+      "system.officeDocumentInfo",
+      "system.emailMessageInfo",
+      "system.calendarInfo",
       "desktop.bash",
       "mcp.browser.browser_snapshot",
       "execute_with_agent",

--- a/runtime/src/gateway/tool-environment-policy.ts
+++ b/runtime/src/gateway/tool-environment-policy.ts
@@ -22,6 +22,12 @@ const DESKTOP_ALLOWED_HOST_TOOL_PREFIXES = [
   "system.remoteJob",
   "system.research",
   "system.sandbox",
+  "system.sqlite",
+  "system.pdf",
+  "system.spreadsheet",
+  "system.officeDocument",
+  "system.emailMessage",
+  "system.calendar",
 ] as const;
 const DESKTOP_TOOL_PREFIXES = [
   "desktop.",

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -165,6 +165,42 @@ const TOOLS: LLMTool[] = [
   makeTool("system.readFile", "Read a file"),
   makeTool("system.writeFile", "Write a file"),
   makeTool("system.listDir", "List files in directory"),
+  makeTool("system.pdfInfo", "Inspect PDF metadata such as pages, title, author, and encryption"),
+  makeTool("system.pdfExtractText", "Extract text from a local PDF document"),
+  makeTool("system.sqliteSchema", "Inspect SQLite tables, views, indexes, and columns"),
+  makeTool("system.sqliteQuery", "Run a read-only SQL query against a local SQLite database"),
+  makeTool(
+    "system.spreadsheetInfo",
+    "Inspect a local spreadsheet or CSV workbook and return sheet metadata and sample rows",
+  ),
+  makeTool(
+    "system.spreadsheetRead",
+    "Read structured rows from a local spreadsheet, workbook sheet, or CSV file",
+  ),
+  makeTool(
+    "system.officeDocumentInfo",
+    "Inspect a local DOCX or ODT office document and return metadata like title and creator",
+  ),
+  makeTool(
+    "system.officeDocumentExtractText",
+    "Extract text from a local DOCX or ODT office document",
+  ),
+  makeTool(
+    "system.emailMessageInfo",
+    "Inspect a local EML email message and return parsed headers, content types, and attachment summary",
+  ),
+  makeTool(
+    "system.emailMessageExtractText",
+    "Extract text from a local EML email message, preferring text/plain and falling back to stripped HTML",
+  ),
+  makeTool(
+    "system.calendarInfo",
+    "Inspect a local ICS calendar and return metadata such as calendar name, event count, and sample events",
+  ),
+  makeTool(
+    "system.calendarRead",
+    "Read structured VEVENT records from a local ICS calendar file with deterministic truncation",
+  ),
   makeTool("system.httpGet", "HTTP GET request"),
   makeTool("desktop.click", "Click on screen"),
   makeTool("desktop.type", "Type into focused element"),
@@ -292,6 +328,106 @@ describe("ToolRouter", () => {
     expect(decision.routedToolNames).toContain("system.browserSessionStart");
     expect(decision.routedToolNames).toContain("system.browserSessionResume");
     expect(decision.routedToolNames).toContain("system.browserSessionArtifacts");
+  });
+
+  it("prioritizes typed PDF tools for document extraction prompts", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+    });
+
+    const decision = router.route({
+      sessionId: "s-pdf",
+      messageText: "extract text from this pdf report and inspect its metadata",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("system.pdfInfo");
+    expect(decision.routedToolNames).toContain("system.pdfExtractText");
+  });
+
+  it("prioritizes typed SQLite tools for database prompts", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+    });
+
+    const decision = router.route({
+      sessionId: "s-sqlite",
+      messageText: "inspect the sqlite schema and query the database tables",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("system.sqliteSchema");
+    expect(decision.routedToolNames).toContain("system.sqliteQuery");
+  });
+
+  it("prioritizes typed spreadsheet tools for workbook prompts", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+    });
+
+    const decision = router.route({
+      sessionId: "s-spreadsheet",
+      messageText:
+        "inspect this spreadsheet workbook, summarize the sheet headers, and read the csv rows",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("system.spreadsheetInfo");
+    expect(decision.routedToolNames).toContain("system.spreadsheetRead");
+  });
+
+  it("prioritizes typed office document tools for docx prompts", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+    });
+
+    const decision = router.route({
+      sessionId: "s-office-doc",
+      messageText:
+        "inspect this docx office brief, extract the text, and summarize the document metadata",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("system.officeDocumentInfo");
+    expect(decision.routedToolNames).toContain("system.officeDocumentExtractText");
+  });
+
+  it("prioritizes typed email tools for eml prompts", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+    });
+
+    const decision = router.route({
+      sessionId: "s-email",
+      messageText:
+        "inspect this eml email message, summarize the subject and sender, and extract the attachment-aware body text",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("system.emailMessageInfo");
+    expect(decision.routedToolNames).toContain("system.emailMessageExtractText");
+  });
+
+  it("prioritizes typed calendar tools for ics prompts", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+    });
+
+    const decision = router.route({
+      sessionId: "s-calendar",
+      messageText:
+        "inspect this ics calendar invite, list the attendees, and read the scheduled meeting events",
+      history: [],
+    });
+
+    expect(decision.routedToolNames).toContain("system.calendarInfo");
+    expect(decision.routedToolNames).toContain("system.calendarRead");
   });
 
   it("prefers typed server handles for server monitoring tasks", () => {
@@ -441,6 +577,68 @@ describe("ToolRouter", () => {
 
     expect(next.diagnostics.cacheHit).toBe(false);
     expect(next.diagnostics.invalidatedReason).toBe("explicit_redirect");
+  });
+
+  it("invalidates cached typed email routing when the next turn requests calendar tools", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+      minCacheConfidence: 0,
+    });
+
+    router.route({
+      sessionId: "s-email-calendar-pivot",
+      messageText:
+        "inspect this eml email message, summarize the subject and sender, and extract the body text",
+      history: [],
+    });
+
+    const next = router.route({
+      sessionId: "s-email-calendar-pivot",
+      messageText:
+        "use the typed calendar tools to inspect this ics calendar invite, list the attendees, and read the scheduled meeting events",
+      history: [
+        {
+          role: "user",
+          content:
+            "inspect this eml email message, summarize the subject and sender, and extract the body text",
+          toolCalls: undefined,
+        },
+      ],
+    });
+
+    expect(next.diagnostics.cacheHit).toBe(false);
+    expect(next.diagnostics.invalidatedReason).toBe("missing_required_tools");
+    expect(next.diagnostics.clusterKey).not.toContain("email");
+    expect(next.routedToolNames).toContain("system.calendarInfo");
+    expect(next.routedToolNames).toContain("system.calendarRead");
+  });
+
+  it("does not blend previous user terms into strong typed-domain prompts", () => {
+    const router = new ToolRouter(TOOLS, {
+      maxToolsPerTurn: 8,
+      minToolsPerTurn: 4,
+      minCacheConfidence: 0,
+    });
+
+    const decision = router.route({
+      sessionId: "s-strong-prompt",
+      messageText:
+        "use the typed calendar tools to inspect this ics calendar invite, list the attendees, and read the scheduled meeting events",
+      history: [
+        {
+          role: "user",
+          content:
+            "use the typed email message tools to inspect this eml email message and extract the body text",
+          toolCalls: undefined,
+        },
+      ],
+    });
+
+    expect(decision.diagnostics.clusterKey).toContain("calendar");
+    expect(decision.diagnostics.clusterKey).not.toContain("email");
+    expect(decision.routedToolNames).toContain("system.calendarInfo");
+    expect(decision.routedToolNames).toContain("system.calendarRead");
   });
 
   it("invalidates cached route when explicit tmux intent needs mcp.tmux family", () => {

--- a/runtime/src/gateway/tool-routing.ts
+++ b/runtime/src/gateway/tool-routing.ts
@@ -2,6 +2,10 @@ import type { LLMMessage, LLMTool } from "../llm/types.js";
 import type { ChatToolRoutingSummary } from "../llm/chat-executor.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
+import {
+  createTypedArtifactTermSet,
+  createTypedArtifactToolNameSet,
+} from "../tools/system/typed-artifact-domains.js";
 
 const TOKEN_RE = /[a-z0-9_]+/g;
 
@@ -197,6 +201,13 @@ const SANDBOX_TOOL_NAMES = new Set([
   "system.sandboxJobLogs",
 ]);
 
+const SQLITE_TOOL_NAMES = createTypedArtifactToolNameSet("sqlite");
+const PDF_TOOL_NAMES = createTypedArtifactToolNameSet("pdf");
+const SPREADSHEET_TOOL_NAMES = createTypedArtifactToolNameSet("spreadsheet");
+const OFFICE_DOCUMENT_TOOL_NAMES = createTypedArtifactToolNameSet("office-document");
+const EMAIL_MESSAGE_TOOL_NAMES = createTypedArtifactToolNameSet("email-message");
+const CALENDAR_TOOL_NAMES = createTypedArtifactToolNameSet("calendar");
+
 const REMOTE_JOB_TERMS = new Set([
   "callback",
   "callbacks",
@@ -237,6 +248,20 @@ const SANDBOX_TERMS = new Set([
   "sandbox",
   "workspace",
 ]);
+
+const SQLITE_TERMS = createTypedArtifactTermSet("sqlite", "routingTerms");
+const DOCUMENT_TERMS = createTypedArtifactTermSet("pdf", "routingTerms");
+const SPREADSHEET_TERMS = createTypedArtifactTermSet("spreadsheet", "routingTerms");
+const OFFICE_DOCUMENT_TERMS = createTypedArtifactTermSet("office-document", "routingTerms");
+const EMAIL_MESSAGE_TERMS = createTypedArtifactTermSet("email-message", "routingTerms");
+const CALENDAR_TERMS = createTypedArtifactTermSet("calendar", "routingTerms");
+
+const HARD_SQLITE_TERMS = createTypedArtifactTermSet("sqlite", "hardRoutingTerms");
+const HARD_PDF_TERMS = createTypedArtifactTermSet("pdf", "hardRoutingTerms");
+const HARD_SPREADSHEET_TERMS = createTypedArtifactTermSet("spreadsheet", "hardRoutingTerms");
+const HARD_OFFICE_DOCUMENT_TERMS = createTypedArtifactTermSet("office-document", "hardRoutingTerms");
+const HARD_EMAIL_MESSAGE_TERMS = createTypedArtifactTermSet("email-message", "hardRoutingTerms");
+const HARD_CALENDAR_TERMS = createTypedArtifactTermSet("calendar", "hardRoutingTerms");
 
 const DOOM_TERMS = new Set([
   "doom",
@@ -516,6 +541,49 @@ function requiredFamiliesForTerms(terms: readonly string[]): Set<string> {
   return required;
 }
 
+function addToolSet(target: Set<string>, toolNames: ReadonlySet<string>): void {
+  for (const toolName of toolNames) {
+    target.add(toolName);
+  }
+}
+
+function requiredToolNamesForTerms(terms: readonly string[]): Set<string> {
+  const required = new Set<string>();
+  if (terms.some((term) => HARD_SQLITE_TERMS.has(term))) {
+    addToolSet(required, SQLITE_TOOL_NAMES);
+  }
+  if (terms.some((term) => HARD_PDF_TERMS.has(term))) {
+    addToolSet(required, PDF_TOOL_NAMES);
+  }
+  if (terms.some((term) => HARD_SPREADSHEET_TERMS.has(term))) {
+    addToolSet(required, SPREADSHEET_TOOL_NAMES);
+  }
+  if (terms.some((term) => HARD_OFFICE_DOCUMENT_TERMS.has(term))) {
+    addToolSet(required, OFFICE_DOCUMENT_TOOL_NAMES);
+  }
+  if (terms.some((term) => HARD_EMAIL_MESSAGE_TERMS.has(term))) {
+    addToolSet(required, EMAIL_MESSAGE_TOOL_NAMES);
+  }
+  if (terms.some((term) => HARD_CALENDAR_TERMS.has(term))) {
+    addToolSet(required, CALENDAR_TOOL_NAMES);
+  }
+  return required;
+}
+
+function hasAllRequiredToolNames(
+  toolNames: readonly string[],
+  requiredToolNames: ReadonlySet<string>,
+): boolean {
+  if (requiredToolNames.size === 0) return true;
+  const available = new Set(toolNames);
+  for (const toolName of requiredToolNames) {
+    if (!available.has(toolName)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function resolveTerminalIntent(terms: readonly string[]): TerminalIntent {
   const hasTerminalIntent = terms.some((term) => TERMINAL_TERMS.has(term));
   if (!hasTerminalIntent) return "none";
@@ -529,7 +597,28 @@ function hasAnyToolInFamily(toolNames: readonly string[], family: string): boole
   return toolNames.some((name) => familyFromToolName(name) === family);
 }
 
-function normalizeConfig(config: ToolRoutingConfig | undefined): NormalizedRoutingConfig {
+function hasStrongCurrentIntent(terms: readonly string[]): boolean {
+  return terms.some((term) =>
+    PROCESS_TERMS.has(term) ||
+    REMOTE_JOB_TERMS.has(term) ||
+    RESEARCH_TERMS.has(term) ||
+    SANDBOX_TERMS.has(term) ||
+    SQLITE_TERMS.has(term) ||
+    DOCUMENT_TERMS.has(term) ||
+    SPREADSHEET_TERMS.has(term) ||
+    OFFICE_DOCUMENT_TERMS.has(term) ||
+    EMAIL_MESSAGE_TERMS.has(term) ||
+    CALENDAR_TERMS.has(term) ||
+    DOOM_TERMS.has(term) ||
+    TERMINAL_TERMS.has(term) ||
+    BROWSER_TERMS.has(term) ||
+    MCP_TERMS.has(term)
+  );
+}
+
+function normalizeToolCountBounds(
+  config: ToolRoutingConfig | undefined,
+): Pick<NormalizedRoutingConfig, "minToolsPerTurn" | "maxToolsPerTurn" | "maxExpandedToolsPerTurn"> {
   const minToolsPerTurn = clamp(
     Math.floor(config?.minToolsPerTurn ?? 6),
     1,
@@ -545,38 +634,58 @@ function normalizeConfig(config: ToolRoutingConfig | undefined): NormalizedRouti
     maxToolsPerTurn,
     256,
   );
-  const cacheTtlMs = clamp(
-    Math.floor(config?.cacheTtlMs ?? 10 * 60_000),
-    10_000,
-    24 * 60 * 60_000,
-  );
-  const minCacheConfidence = clamp(
-    typeof config?.minCacheConfidence === "number"
-      ? config.minCacheConfidence
-      : 0.5,
-    0,
-    1,
-  );
-  const pivotSimilarityThreshold = clamp(
-    typeof config?.pivotSimilarityThreshold === "number"
-      ? config.pivotSimilarityThreshold
-      : 0.25,
-    0,
-    1,
-  );
-  const pivotMissThreshold = clamp(
-    Math.floor(config?.pivotMissThreshold ?? 2),
-    1,
-    20,
-  );
+  return {
+    minToolsPerTurn,
+    maxToolsPerTurn,
+    maxExpandedToolsPerTurn,
+  };
+}
 
-  const mandatoryTools = Array.from(
+function normalizeCacheConfig(
+  config: ToolRoutingConfig | undefined,
+): Pick<NormalizedRoutingConfig, "cacheTtlMs" | "minCacheConfidence" | "pivotSimilarityThreshold" | "pivotMissThreshold"> {
+  return {
+    cacheTtlMs: clamp(
+      Math.floor(config?.cacheTtlMs ?? 10 * 60_000),
+      10_000,
+      24 * 60 * 60_000,
+    ),
+    minCacheConfidence: clamp(
+      typeof config?.minCacheConfidence === "number"
+        ? config.minCacheConfidence
+        : 0.5,
+      0,
+      1,
+    ),
+    pivotSimilarityThreshold: clamp(
+      typeof config?.pivotSimilarityThreshold === "number"
+        ? config.pivotSimilarityThreshold
+        : 0.25,
+      0,
+      1,
+    ),
+    pivotMissThreshold: clamp(
+      Math.floor(config?.pivotMissThreshold ?? 2),
+      1,
+      20,
+    ),
+  };
+}
+
+function normalizeMandatoryTools(
+  config: ToolRoutingConfig | undefined,
+): string[] {
+  return Array.from(
     new Set([
       ...DEFAULT_MANDATORY_TOOLS,
       ...(config?.mandatoryTools ?? []),
     ]),
   );
+}
 
+function normalizeFamilyCaps(
+  config: ToolRoutingConfig | undefined,
+): Readonly<Record<string, number>> {
   const familyCaps: Record<string, number> = {
     ...DEFAULT_FAMILY_CAPS,
   };
@@ -584,18 +693,19 @@ function normalizeConfig(config: ToolRoutingConfig | undefined): NormalizedRouti
     if (!Number.isFinite(cap)) continue;
     familyCaps[family.toLowerCase()] = clamp(Math.floor(cap), 1, 128);
   }
+  return familyCaps;
+}
+
+function normalizeConfig(config: ToolRoutingConfig | undefined): NormalizedRoutingConfig {
+  const toolCountBounds = normalizeToolCountBounds(config);
+  const cacheConfig = normalizeCacheConfig(config);
 
   return {
     enabled: config?.enabled ?? true,
-    minToolsPerTurn,
-    maxToolsPerTurn,
-    maxExpandedToolsPerTurn,
-    cacheTtlMs,
-    minCacheConfidence,
-    pivotSimilarityThreshold,
-    pivotMissThreshold,
-    mandatoryTools,
-    familyCaps,
+    ...toolCountBounds,
+    ...cacheConfig,
+    mandatoryTools: normalizeMandatoryTools(config),
+    familyCaps: normalizeFamilyCaps(config),
   };
 }
 
@@ -685,13 +795,15 @@ export class ToolRouter {
       };
     }
 
-    const intentTerms = this.extractIntentTerms(params.messageText, params.history);
+    const currentIntentTerms = toTerms(params.messageText);
+    const intentTerms = this.extractIntentTerms(currentIntentTerms, params.history);
     const explicitToolMentions = this.extractExplicitToolMentions(params.messageText);
     const clusterKey = intentTerms.slice(0, 6).join("|") || "general";
     const now = Date.now();
     const cached = this.cache.get(params.sessionId);
-    const requiredFamilies = requiredFamiliesForTerms(intentTerms);
-    const terminalIntent = resolveTerminalIntent(intentTerms);
+    const requiredFamilies = requiredFamiliesForTerms(currentIntentTerms);
+    const requiredToolNames = requiredToolNamesForTerms(currentIntentTerms);
+    const terminalIntent = resolveTerminalIntent(currentIntentTerms);
 
     let invalidatedReason: string | undefined;
     if (cached) {
@@ -714,6 +826,10 @@ export class ToolRouter {
         )
       ) {
         invalidatedReason = "missing_required_family";
+      } else if (
+        !hasAllRequiredToolNames(cached.routedToolNames, requiredToolNames)
+      ) {
+        invalidatedReason = "missing_required_tools";
       } else {
         const similarity = jaccardSimilarity(intentTerms, cached.terms);
         if (intentTerms.length > 0 && similarity < this.config.pivotSimilarityThreshold) {
@@ -741,6 +857,7 @@ export class ToolRouter {
     const routedToolNames = this.selectRoutedTools(
       scored,
       requiredFamilies,
+      requiredToolNames,
       explicitToolMentions,
     );
     const expandedToolNames = this.selectExpandedTools(scored, routedToolNames);
@@ -809,10 +926,15 @@ export class ToolRouter {
   }
 
   private extractIntentTerms(
-    messageText: string,
+    currentTerms: readonly string[],
     history: readonly LLMMessage[],
   ): string[] {
-    const terms = new Set<string>(toTerms(messageText));
+    const terms = new Set<string>(currentTerms);
+    const shouldBlendHistory = currentTerms.length < 6 && !hasStrongCurrentIntent(currentTerms);
+
+    if (!shouldBlendHistory) {
+      return Array.from(terms).sort();
+    }
 
     for (let i = history.length - 1; i >= 0; i--) {
       const entry = history[i];
@@ -879,6 +1001,20 @@ export class ToolRouter {
     const hasRemoteJobIntent = intentTerms.some((term) => REMOTE_JOB_TERMS.has(term));
     const hasResearchIntent = intentTerms.some((term) => RESEARCH_TERMS.has(term));
     const hasSandboxIntent = intentTerms.some((term) => SANDBOX_TERMS.has(term));
+    const hasSqliteIntent = intentTerms.some((term) => SQLITE_TERMS.has(term));
+    const hasDocumentIntent = intentTerms.some((term) => DOCUMENT_TERMS.has(term));
+    const hasSpreadsheetIntent = intentTerms.some((term) =>
+      SPREADSHEET_TERMS.has(term)
+    );
+    const hasOfficeDocumentIntent = intentTerms.some((term) =>
+      OFFICE_DOCUMENT_TERMS.has(term)
+    );
+    const hasEmailMessageIntent = intentTerms.some((term) =>
+      EMAIL_MESSAGE_TERMS.has(term)
+    );
+    const hasCalendarIntent = intentTerms.some((term) =>
+      CALENDAR_TERMS.has(term)
+    );
     const wantsTypedServer =
       explicitToolMentions.has("system.serverStart") ||
       (
@@ -944,6 +1080,24 @@ export class ToolRouter {
       }
       if (wantsResearchHandles && RESEARCH_TOOL_NAMES.has(tool.name)) {
         score += 14;
+      }
+      if (hasSqliteIntent && SQLITE_TOOL_NAMES.has(tool.name)) {
+        score += 16;
+      }
+      if (hasDocumentIntent && PDF_TOOL_NAMES.has(tool.name)) {
+        score += 16;
+      }
+      if (hasSpreadsheetIntent && SPREADSHEET_TOOL_NAMES.has(tool.name)) {
+        score += 16;
+      }
+      if (hasOfficeDocumentIntent && OFFICE_DOCUMENT_TOOL_NAMES.has(tool.name)) {
+        score += 16;
+      }
+      if (hasEmailMessageIntent && EMAIL_MESSAGE_TOOL_NAMES.has(tool.name)) {
+        score += 16;
+      }
+      if (hasCalendarIntent && CALENDAR_TOOL_NAMES.has(tool.name)) {
+        score += 16;
       }
       if (hasSandboxIntent && SANDBOX_TOOL_NAMES.has(tool.name)) {
         score += 18;
@@ -1027,7 +1181,7 @@ export class ToolRouter {
           score += 5;
         }
         if (PRIMARY_BROWSER_START_TOOL_NAMES.has(tool.name)) {
-          score += 4;
+          score += 8;
         } else if (PRIMARY_BROWSER_READ_TOOL_NAMES.has(tool.name)) {
           score += 2;
         }
@@ -1052,6 +1206,17 @@ export class ToolRouter {
           score += 2;
         }
       }
+      if (
+        hasFileIntent &&
+        (
+          SQLITE_TOOL_NAMES.has(tool.name) ||
+          PDF_TOOL_NAMES.has(tool.name) ||
+          SPREADSHEET_TOOL_NAMES.has(tool.name) ||
+          OFFICE_DOCUMENT_TOOL_NAMES.has(tool.name)
+        )
+      ) {
+        score += 4;
+      }
       if (hasNetworkIntent && tool.name.startsWith("system.http")) {
         score += 2;
       }
@@ -1074,6 +1239,7 @@ export class ToolRouter {
   private selectRoutedTools(
     scored: ReadonlyArray<{ tool: IndexedTool; score: number }>,
     requiredFamilies: ReadonlySet<string>,
+    requiredToolNames: ReadonlySet<string>,
     explicitToolMentions: ReadonlySet<string>,
   ): string[] {
     const selected = new Set<string>();
@@ -1096,6 +1262,11 @@ export class ToolRouter {
       if (!bestRequired) continue;
       requiredFamilySelections.set(requiredFamily, bestRequired.tool);
       hardPinnedToolNames.add(bestRequired.tool.name);
+    }
+    for (const requiredToolName of requiredToolNames) {
+      if (this.allToolNames.includes(requiredToolName)) {
+        hardPinnedToolNames.add(requiredToolName);
+      }
     }
     for (const mentionedTool of explicitToolMentions) {
       if (this.allToolNames.includes(mentionedTool)) {
@@ -1127,6 +1298,15 @@ export class ToolRouter {
 
     for (const bestRequired of requiredFamilySelections.values()) {
       tryAdd(bestRequired, { limit: hardPinLimit });
+    }
+
+    for (const requiredToolName of requiredToolNames) {
+      const explicitMatch = scored.find((entry) => entry.tool.name === requiredToolName);
+      if (!explicitMatch) continue;
+      tryAdd(explicitMatch.tool, {
+        limit: hardPinLimit,
+        ignoreFamilyCap: true,
+      });
     }
 
     for (const mentionedTool of explicitToolMentions) {

--- a/runtime/src/llm/chat-executor-contract-guidance.test.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.test.ts
@@ -170,6 +170,79 @@ describe("chat-executor-contract-guidance", () => {
     });
   });
 
+  it("routes typed calendar inspection turns to calendarInfo first", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "initial",
+      messageText:
+        "Use the typed calendar tools to inspect this ics calendar invite, list the attendees, and read the scheduled meeting events.",
+      toolCalls: [],
+      allowedToolNames: ["desktop.bash", "system.calendarInfo", "system.calendarRead"],
+    });
+
+    expect(guidance).toEqual({
+      source: "typed-calendar",
+      runtimeInstruction:
+        "This typed calendar inspection is not complete yet. " +
+        "Start with `system.calendarInfo` so the answer is grounded in real metadata before you summarize or quote details.",
+      routedToolNames: ["system.calendarInfo"],
+      toolChoice: "required",
+      enforcement: {
+        mode: "block_other_tools",
+        message:
+          "This typed calendar inspection must begin with `system.calendarInfo`. " +
+          "Do not use `desktop.bash`, `desktop.text_editor`, `system.bash`, or ad hoc file parsing before the typed inspection path starts.",
+      },
+    });
+  });
+
+  it("routes typed calendar inspection turns to calendarRead after metadata", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "tool_followup",
+      messageText:
+        "Use the typed calendar tools to inspect this ics calendar invite, list the attendees, and read the scheduled meeting events.",
+      toolCalls: [
+        makeToolCall({
+          name: "system.calendarInfo",
+          result: JSON.stringify({ calendarName: "Team Calendar", eventCount: 2 }),
+        }),
+      ],
+      allowedToolNames: ["system.calendarInfo", "system.calendarRead"],
+    });
+
+    expect(guidance).toEqual({
+      source: "typed-calendar",
+      runtimeInstruction:
+        "Metadata alone is not enough for this typed calendar inspection. " +
+        "Call `system.calendarRead` before answering so the response includes grounded structured content, not just a metadata summary.",
+      routedToolNames: ["system.calendarRead"],
+      toolChoice: "required",
+      enforcement: {
+        mode: "block_other_tools",
+        message:
+          "This typed calendar inspection still requires `system.calendarRead`. " +
+          "Do not stop early or switch to shell/editor fallbacks while the typed read/extract step is still missing.",
+      },
+    });
+  });
+
+  it("blocks shell detours before typed calendar inspection metadata is loaded", () => {
+    const block = resolveToolContractExecutionBlock({
+      phase: "initial",
+      messageText:
+        "Use the typed calendar tools to inspect this ics calendar invite, list the attendees, and read the scheduled meeting events.",
+      toolCalls: [],
+      allowedToolNames: ["desktop.bash", "system.calendarInfo", "system.calendarRead"],
+      candidateToolName: "desktop.bash",
+    });
+
+    expect(block).toBe(
+      "This typed calendar inspection must begin with `system.calendarInfo`. " +
+      "Do not use `desktop.bash`, `desktop.text_editor`, `system.bash`, or ad hoc file parsing before the typed inspection path starts. " +
+      "Allowed now: `system.calendarInfo`. " +
+      "Do not use `desktop.bash` yet.",
+    );
+  });
+
   it("routes delegated implementation turns to an editor-first tool on initial guidance", () => {
     const guidance = resolveToolContractGuidance({
       phase: "initial",

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -23,6 +23,10 @@ import {
   resolveDelegatedCorrectionToolChoiceToolNames,
   resolveDelegatedInitialToolChoiceToolName,
 } from "../utils/delegation-validation.js";
+import {
+  TYPED_ARTIFACT_DOMAINS,
+  type TypedArtifactDomain,
+} from "../tools/system/typed-artifact-domains.js";
 
 export type ToolContractGuidancePhase =
   | "initial"
@@ -62,6 +66,11 @@ const TOOL_CONTRACT_GUIDANCE_RESOLVERS: readonly ToolContractGuidanceResolver[] 
     name: "server-handle",
     priority: 250,
     resolve: resolveServerHandleContractGuidance,
+  },
+  {
+    name: "typed-artifact",
+    priority: 225,
+    resolve: resolveTypedArtifactContractGuidance,
   },
   {
     name: "delegation-correction",
@@ -233,6 +242,106 @@ function resolveDoomToolContractGuidance(
     toolChoice: "required",
     ...(enforcement ? { enforcement } : {}),
   };
+}
+
+function resolveTypedArtifactContractGuidance(
+  input: ToolContractGuidanceContext,
+): ToolContractGuidance | undefined {
+  const contract = inferTypedArtifactContract(input);
+  if (!contract) return undefined;
+
+  const hasSuccessfulInfo = input.toolCalls.some(
+    (call) => call.name === contract.infoToolName && !call.isError,
+  );
+  const hasSuccessfulDetail = input.toolCalls.some(
+    (call) => call.name === contract.detailToolName && !call.isError,
+  );
+  const hasFailedRequiredCall = input.toolCalls.some(
+    (call) =>
+      (call.name === contract.infoToolName || call.name === contract.detailToolName) &&
+      call.isError,
+  );
+  if (hasFailedRequiredCall) {
+    return undefined;
+  }
+
+  if (!hasSuccessfulInfo) {
+    const routedToolNames = [contract.infoToolName].filter(
+      (toolName) =>
+        input.allowedToolNames.length === 0 ||
+        input.allowedToolNames.includes(toolName),
+    );
+    if (routedToolNames.length === 0) return undefined;
+    return {
+      source: contract.source,
+      runtimeInstruction:
+        `This ${contract.label} is not complete yet. ` +
+        `Start with \`${contract.infoToolName}\` so the answer is grounded in real metadata before you summarize or quote details.`,
+      routedToolNames,
+      toolChoice: "required",
+      enforcement: {
+        mode: "block_other_tools",
+        message:
+          `This ${contract.label} must begin with \`${contract.infoToolName}\`. ` +
+          "Do not use `desktop.bash`, `desktop.text_editor`, `system.bash`, or ad hoc file parsing before the typed inspection path starts.",
+      },
+    };
+  }
+
+  if (!hasSuccessfulDetail) {
+    const routedToolNames = [contract.detailToolName].filter(
+      (toolName) =>
+        input.allowedToolNames.length === 0 ||
+        input.allowedToolNames.includes(toolName),
+    );
+    if (routedToolNames.length === 0) return undefined;
+    return {
+      source: contract.source,
+      runtimeInstruction:
+        `Metadata alone is not enough for this ${contract.label}. ` +
+        `Call \`${contract.detailToolName}\` before answering so the response includes grounded structured content, not just a metadata summary.`,
+      routedToolNames,
+      toolChoice: "required",
+      enforcement: {
+        mode: "block_other_tools",
+        message:
+          `This ${contract.label} still requires \`${contract.detailToolName}\`. ` +
+          "Do not stop early or switch to shell/editor fallbacks while the typed read/extract step is still missing.",
+      },
+    };
+  }
+
+  return undefined;
+}
+
+function inferTypedArtifactContract(
+  input: ToolContractGuidanceContext,
+): TypedArtifactDomain | undefined {
+  const lower = input.messageText.toLowerCase();
+  for (const contract of TYPED_ARTIFACT_DOMAINS) {
+    const domainMatch = contract.guidanceDomainTerms.some((term) => lower.includes(term));
+    if (!domainMatch) continue;
+
+    const infoMatch = contract.guidanceInfoTerms.some((term) => lower.includes(term));
+    const detailMatch = contract.guidanceDetailTerms.some((term) => lower.includes(term));
+    const explicitToolMatch =
+      lower.includes(contract.infoToolName.toLowerCase()) ||
+      lower.includes(contract.detailToolName.toLowerCase()) ||
+      lower.includes(`typed ${contract.label}`);
+
+    if (!explicitToolMatch && !(infoMatch && detailMatch)) {
+      continue;
+    }
+
+    const hasAnyAllowedTool =
+      input.allowedToolNames.length === 0 ||
+      input.allowedToolNames.includes(contract.infoToolName) ||
+      input.allowedToolNames.includes(contract.detailToolName);
+    if (!hasAnyAllowedTool) continue;
+
+    return contract;
+  }
+  return undefined;
 }
 
 function resolveDelegationInitialContractGuidance(

--- a/runtime/src/observability/observability.test.ts
+++ b/runtime/src/observability/observability.test.ts
@@ -107,4 +107,100 @@ sqliteDescribe("ObservabilityService", () => {
 
     await service.close();
   });
+
+  it("treats handled slash-command traces as completed terminal traces", async () => {
+    const service = new ObservabilityService({
+      dbPath: join(tempDir, "observability.sqlite"),
+      daemonLogPath: join(tempDir, "daemon.log"),
+    });
+    writeFileSync(join(tempDir, "daemon.log"), "", "utf8");
+    const now = Date.now();
+
+    service.recordEvent({
+      eventName: "webchat.inbound",
+      level: "info",
+      traceId: "trace-command",
+      sessionId: "session-1",
+      timestampMs: now,
+      payloadPreview: { content: "/policy simulate system.delete {}" },
+    });
+    service.recordEvent({
+      eventName: "webchat.command.reply",
+      level: "info",
+      traceId: "trace-command",
+      sessionId: "session-1",
+      timestampMs: now + 1,
+      payloadPreview: { content: "Policy simulation..." },
+    });
+    service.recordEvent({
+      eventName: "webchat.command.handled",
+      level: "info",
+      traceId: "trace-command",
+      sessionId: "session-1",
+      timestampMs: now + 2,
+      payloadPreview: { command: "/policy simulate system.delete {}" },
+    });
+
+    const traces = await service.listTraces();
+    expect(traces).toHaveLength(1);
+    expect(traces[0]?.traceId).toBe("trace-command");
+    expect(traces[0]?.status).toBe("completed");
+
+    const detail = await service.getTrace("trace-command");
+    expect(detail?.summary.status).toBe("completed");
+    expect(detail?.summary.lastEventName).toBe("webchat.command.handled");
+    expect(detail?.completeness.complete).toBe(true);
+
+    const summary = await service.getSummary();
+    expect(summary.traces.total).toBe(1);
+    expect(summary.traces.completed).toBe(1);
+    expect(summary.traces.open).toBe(0);
+
+    await service.close();
+  });
+
+  it("treats working background cycle traces as completed cycle traces", async () => {
+    const service = new ObservabilityService({
+      dbPath: join(tempDir, "observability.sqlite"),
+      daemonLogPath: join(tempDir, "daemon.log"),
+    });
+    writeFileSync(join(tempDir, "daemon.log"), "", "utf8");
+    const now = Date.now();
+
+    service.recordEvent({
+      eventName: "background_run.cycle.decision_resolved",
+      level: "info",
+      traceId: "trace-background-cycle",
+      sessionId: "session-1",
+      channel: "background_run",
+      timestampMs: now,
+      payloadPreview: { decisionState: "working" },
+    });
+    service.recordEvent({
+      eventName: "background_run.cycle.working_applied",
+      level: "info",
+      traceId: "trace-background-cycle",
+      sessionId: "session-1",
+      channel: "background_run",
+      timestampMs: now + 1,
+      payloadPreview: { summary: "Managed process is still running." },
+    });
+
+    const traces = await service.listTraces();
+    expect(traces).toHaveLength(1);
+    expect(traces[0]?.traceId).toBe("trace-background-cycle");
+    expect(traces[0]?.status).toBe("completed");
+
+    const detail = await service.getTrace("trace-background-cycle");
+    expect(detail?.summary.status).toBe("completed");
+    expect(detail?.summary.lastEventName).toBe("background_run.cycle.working_applied");
+    expect(detail?.completeness.complete).toBe(true);
+
+    const summary = await service.getSummary();
+    expect(summary.traces.total).toBe(1);
+    expect(summary.traces.completed).toBe(1);
+    expect(summary.traces.open).toBe(0);
+
+    await service.close();
+  });
 });

--- a/runtime/src/observability/sqlite-store.ts
+++ b/runtime/src/observability/sqlite-store.ts
@@ -67,6 +67,22 @@ const TRACE_ARTIFACT_ROOT = resolvePath(homedir(), ".agenc", "trace-payloads");
 const DEFAULT_LOG_TAIL_BYTES = 256 * 1024;
 const DEFAULT_LOG_LINES = 200;
 
+function isCompletedTraceEventName(eventName: string): boolean {
+  return (
+    eventName.endsWith(".chat.response") ||
+    eventName.endsWith(".command.handled") ||
+    eventName === "background_run.cycle.working_applied" ||
+    eventName === "background_run.cycle.terminal_applied"
+  );
+}
+
+function isTerminalTraceEventName(eventName: string): boolean {
+  return (
+    isCompletedTraceEventName(eventName) ||
+    eventName.endsWith(".chat.error")
+  );
+}
+
 export interface SqliteObservabilityStoreConfig {
   readonly dbPath?: string;
   readonly daemonLogPath?: string;
@@ -201,7 +217,7 @@ export class SqliteObservabilityStore {
           ) AS stop_reason,
           CASE
             WHEN SUM(CASE WHEN level = 'error' THEN 1 ELSE 0 END) > 0 THEN 'error'
-            WHEN SUM(CASE WHEN event_name LIKE '%.chat.response' THEN 1 ELSE 0 END) > 0 THEN 'completed'
+            WHEN SUM(CASE WHEN event_name LIKE '%.chat.response' OR event_name LIKE '%.command.handled' OR event_name = 'background_run.cycle.working_applied' OR event_name = 'background_run.cycle.terminal_applied' THEN 1 ELSE 0 END) > 0 THEN 'completed'
             ELSE 'open'
           END AS status
         FROM observability_events oe
@@ -259,8 +275,8 @@ export class SqliteObservabilityStore {
           SELECT
             trace_id,
             SUM(CASE WHEN level = 'error' THEN 1 ELSE 0 END) AS error_count,
-            SUM(CASE WHEN event_name LIKE '%.chat.response' THEN 1 ELSE 0 END) AS completed_count,
-            SUM(CASE WHEN event_name LIKE '%.chat.response' OR level = 'error' THEN 1 ELSE 0 END) AS terminal_count
+            SUM(CASE WHEN event_name LIKE '%.chat.response' OR event_name LIKE '%.command.handled' OR event_name = 'background_run.cycle.working_applied' OR event_name = 'background_run.cycle.terminal_applied' THEN 1 ELSE 0 END) AS completed_count,
+            SUM(CASE WHEN event_name LIKE '%.chat.response' OR event_name LIKE '%.command.handled' OR event_name = 'background_run.cycle.working_applied' OR event_name = 'background_run.cycle.terminal_applied' OR level = 'error' THEN 1 ELSE 0 END) AS terminal_count
           FROM observability_events
           WHERE timestamp_ms >= @sinceMs
           GROUP BY trace_id
@@ -528,7 +544,7 @@ export class SqliteObservabilityStore {
     const last = events[events.length - 1]!;
     const errorCount = events.filter((event) => event.level === "error").length;
     const completed = events.some((event) =>
-      event.eventName.endsWith(".chat.response"),
+      isCompletedTraceEventName(event.eventName),
     );
     return {
       traceId: first.traceId,
@@ -547,12 +563,12 @@ export class SqliteObservabilityStore {
     const issues: string[] = [];
     const hasInbound = events.some((event) => event.eventName.endsWith(".inbound"));
     const hasTerminal = events.some(
-      (event) =>
-        event.eventName.endsWith(".chat.response") ||
-        event.eventName.endsWith(".chat.error"),
+      (event) => isTerminalTraceEventName(event.eventName),
     );
     if (hasInbound && !hasTerminal) {
-      issues.push("Trace has inbound activity but no terminal chat response/error event");
+      issues.push(
+        "Trace has inbound activity but no terminal chat/command response or error event",
+      );
     }
     return {
       complete: issues.length === 0,

--- a/runtime/src/tools/system/calendar.test.ts
+++ b/runtime/src/tools/system/calendar.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createCalendarTools } from "./calendar.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop()!;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function writeCalendarFixture(dir: string): string {
+  const path = join(dir, "team-calendar.ics");
+  writeFileSync(
+    path,
+    [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//AgenC//Autonomy Smoke//EN",
+      "X-WR-CALNAME:Team Calendar",
+      "BEGIN:VEVENT",
+      "UID:event-1",
+      "SUMMARY:Product Review",
+      "DTSTART:20260310T170000Z",
+      "DTEND:20260310T173000Z",
+      "LOCATION:War Room",
+      "ORGANIZER:mailto:alice@example.com",
+      "ATTENDEE:mailto:bob@example.com",
+      "ATTENDEE:mailto:carol@example.com",
+      "STATUS:CONFIRMED",
+      "END:VEVENT",
+      "BEGIN:VEVENT",
+      "UID:event-2",
+      "SUMMARY:Planning Day",
+      "DTSTART;VALUE=DATE:20260312",
+      "DTEND;VALUE=DATE:20260313",
+      "END:VEVENT",
+      "END:VCALENDAR",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return path;
+}
+
+function findTool(name: string) {
+  const tool = createCalendarTools({
+    allowedPaths: [tmpdir()],
+  }).find((entry) => entry.name === name);
+  expect(tool).toBeDefined();
+  return tool!;
+}
+
+describe("system.calendar tools", () => {
+  it("creates the typed calendar tools", () => {
+    const tools = createCalendarTools({
+      allowedPaths: [tmpdir()],
+    });
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "system.calendarInfo",
+      "system.calendarRead",
+    ]);
+  });
+
+  it("returns calendar metadata and sample events", async () => {
+    const dir = makeTempDir("agenc-calendar-info-");
+    const icsPath = writeCalendarFixture(dir);
+
+    const result = await findTool("system.calendarInfo").execute({ path: icsPath });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.format).toBe("ics");
+    expect(parsed.calendarName).toBe("Team Calendar");
+    expect(parsed.eventCount).toBe(2);
+    expect(parsed.sampleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ summary: "Product Review" }),
+      ]),
+    );
+  });
+
+  it("returns structured events with truncation", async () => {
+    const dir = makeTempDir("agenc-calendar-read-");
+    const icsPath = writeCalendarFixture(dir);
+
+    const result = await findTool("system.calendarRead").execute({
+      path: icsPath,
+      maxEvents: 1,
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.eventCount).toBe(2);
+    expect(parsed.truncated).toBe(true);
+    expect(parsed.events).toEqual([
+      expect.objectContaining({
+        summary: "Product Review",
+        organizer: "alice@example.com",
+        attendees: ["bob@example.com", "carol@example.com"],
+        location: "War Room",
+      }),
+    ]);
+  });
+
+  it("rejects unsupported formats", async () => {
+    const dir = makeTempDir("agenc-calendar-unsupported-");
+    const badPath = join(dir, "calendar.txt");
+    writeFileSync(badPath, "not a calendar", "utf8");
+
+    const result = await findTool("system.calendarInfo").execute({ path: badPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unsupported calendar format");
+  });
+
+  it("blocks calendar paths outside the allowlist", async () => {
+    const dir = makeTempDir("agenc-calendar-block-");
+    const icsPath = writeCalendarFixture(dir);
+    const tools = createCalendarTools({
+      allowedPaths: [join(tmpdir(), "different-root")],
+    });
+
+    const result = await tools[0].execute({ path: icsPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside allowed directories");
+  });
+});

--- a/runtime/src/tools/system/calendar.ts
+++ b/runtime/src/tools/system/calendar.ts
@@ -1,0 +1,401 @@
+/**
+ * Typed calendar inspection/extraction tools for @agenc/runtime.
+ *
+ * Provides:
+ * - system.calendarInfo — inspect local ICS calendar metadata
+ * - system.calendarRead — extract structured events from local ICS calendars
+ *
+ * @module
+ */
+
+import { readFile } from "node:fs/promises";
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import { silentLogger } from "../../utils/logger.js";
+import { safePath } from "./filesystem.js";
+import type { SystemCalendarToolConfig } from "./types.js";
+
+const DEFAULT_MAX_EVENTS = 50;
+const DEFAULT_MAX_EVENTS_CAP = 500;
+
+type CalendarEventRecord = {
+  readonly uid?: string;
+  readonly summary?: string;
+  readonly description?: string;
+  readonly location?: string;
+  readonly status?: string;
+  readonly organizer?: string;
+  readonly attendees: readonly string[];
+  readonly start?: string;
+  readonly end?: string;
+  readonly allDay?: boolean;
+};
+
+type MutableCalendarEvent = {
+  uid?: string;
+  summary?: string;
+  description?: string;
+  location?: string;
+  status?: string;
+  organizer?: string;
+  attendees: string[];
+  start?: string;
+  end?: string;
+  allDay?: boolean;
+};
+
+type ParsedCalendarLine = {
+  readonly key: string;
+  readonly value: string;
+};
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+function validateAllowedPaths(allowedPaths: readonly string[]): string[] {
+  if (!Array.isArray(allowedPaths) || allowedPaths.length === 0) {
+    throw new TypeError("allowedPaths must be a non-empty array of strings");
+  }
+  return allowedPaths.map((entry) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      throw new TypeError("Each allowedPaths entry must be a non-empty string");
+    }
+    return entry;
+  });
+}
+
+function normalizePositiveInteger(
+  value: unknown,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Expected a positive finite integer");
+  }
+  return Math.min(Math.floor(value), maximum);
+}
+
+async function resolveCalendarPath(
+  rawPath: unknown,
+  allowedPaths: readonly string[],
+): Promise<string | ToolResult> {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    return errorResult("Missing or invalid path");
+  }
+  const safe = await safePath(rawPath, allowedPaths);
+  if (!safe.safe) {
+    return errorResult(
+      safe.reason ?? "Calendar path is outside allowed directories",
+    );
+  }
+  return safe.resolved;
+}
+
+function assertCalendarPath(path: string): void {
+  if (!path.toLowerCase().endsWith(".ics")) {
+    throw new Error("Unsupported calendar format: expected .ics");
+  }
+}
+
+function unfoldIcsLines(raw: string): string[] {
+  return raw.replace(/\r?\n[ \t]/g, "").split(/\r?\n/u);
+}
+
+function parseCalendarDate(raw: string): { value: string; allDay: boolean } {
+  if (/^\d{8}$/u.test(raw)) {
+    return {
+      value: `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`,
+      allDay: true,
+    };
+  }
+  if (/^\d{8}T\d{6}Z$/u.test(raw)) {
+    const iso = `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}T${raw.slice(9, 11)}:${raw.slice(11, 13)}:${raw.slice(13, 15)}Z`;
+    return { value: iso, allDay: false };
+  }
+  if (/^\d{8}T\d{6}$/u.test(raw)) {
+    const iso = `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}T${raw.slice(9, 11)}:${raw.slice(11, 13)}:${raw.slice(13, 15)}`;
+    return { value: iso, allDay: false };
+  }
+  return { value: raw, allDay: false };
+}
+
+function unescapeIcsText(value: string): string {
+  return value
+    .replace(/\\n/giu, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\");
+}
+
+function extractCalendarPrincipal(raw: string): string {
+  const trimmed = raw.trim();
+  return trimmed.replace(/^mailto:/iu, "");
+}
+
+function parseCalendarContentLine(line: string): ParsedCalendarLine | undefined {
+  if (!line) return undefined;
+  const separator = line.indexOf(":");
+  if (separator <= 0) return undefined;
+  const rawKey = line.slice(0, separator);
+  const rawValue = line.slice(separator + 1);
+  const [keyPart] = rawKey.split(";", 1);
+  return {
+    key: keyPart.toUpperCase(),
+    value: unescapeIcsText(rawValue.trim()),
+  };
+}
+
+function createMutableCalendarEvent(): MutableCalendarEvent {
+  return { attendees: [] };
+}
+
+function finalizeCalendarEvent(
+  current: MutableCalendarEvent,
+): CalendarEventRecord {
+  return {
+    uid: current.uid,
+    summary: current.summary,
+    description: current.description,
+    location: current.location,
+    status: current.status,
+    organizer: current.organizer,
+    attendees: current.attendees,
+    start: current.start,
+    end: current.end,
+    allDay: current.allDay,
+  };
+}
+
+function applyCalendarDate(
+  current: MutableCalendarEvent,
+  field: "start" | "end",
+  rawValue: string,
+): void {
+  const parsed = parseCalendarDate(rawValue);
+  current[field] = parsed.value;
+  if (field === "start") {
+    current.allDay = parsed.allDay;
+    return;
+  }
+  if (current.allDay === undefined) {
+    current.allDay = parsed.allDay;
+  }
+}
+
+function applyCalendarEventField(
+  current: MutableCalendarEvent,
+  parsedLine: ParsedCalendarLine,
+): void {
+  switch (parsedLine.key) {
+    case "UID":
+      current.uid = parsedLine.value;
+      break;
+    case "SUMMARY":
+      current.summary = parsedLine.value;
+      break;
+    case "DESCRIPTION":
+      current.description = parsedLine.value;
+      break;
+    case "LOCATION":
+      current.location = parsedLine.value;
+      break;
+    case "STATUS":
+      current.status = parsedLine.value;
+      break;
+    case "ORGANIZER":
+      current.organizer = extractCalendarPrincipal(parsedLine.value);
+      break;
+    case "ATTENDEE":
+      current.attendees.push(extractCalendarPrincipal(parsedLine.value));
+      break;
+    case "DTSTART":
+      applyCalendarDate(current, "start", parsedLine.value);
+      break;
+    case "DTEND":
+      applyCalendarDate(current, "end", parsedLine.value);
+      break;
+    default:
+      break;
+  }
+}
+
+function parseCalendarFile(raw: string): {
+  readonly calendarName?: string;
+  readonly events: readonly CalendarEventRecord[];
+} {
+  const lines = unfoldIcsLines(raw);
+  const events: CalendarEventRecord[] = [];
+  let calendarName: string | undefined;
+  let current: MutableCalendarEvent | null = null;
+
+  for (const line of lines) {
+    const parsedLine = parseCalendarContentLine(line);
+    if (!parsedLine) continue;
+
+    if (parsedLine.key === "X-WR-CALNAME" || parsedLine.key === "NAME") {
+      calendarName ??= parsedLine.value;
+      continue;
+    }
+
+    if (parsedLine.key === "BEGIN" && parsedLine.value.toUpperCase() === "VEVENT") {
+      current = createMutableCalendarEvent();
+      continue;
+    }
+
+    if (parsedLine.key === "END" && parsedLine.value.toUpperCase() === "VEVENT") {
+      if (current) {
+        events.push(finalizeCalendarEvent(current));
+      }
+      current = null;
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+    applyCalendarEventField(current, parsedLine);
+  }
+
+  return { calendarName, events };
+}
+
+function createCalendarInfoTool(
+  allowedPaths: readonly string[],
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.calendarInfo",
+    description:
+      "Inspect a local ICS calendar and return metadata such as calendar name, event count, and sample events.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local ICS calendar file.",
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveCalendarPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        assertCalendarPath(resolved);
+        const raw = await readFile(resolved, "utf8");
+        const parsed = parseCalendarFile(raw);
+        return {
+          content: safeStringify({
+            path: resolved,
+            format: "ics",
+            calendarName: parsed.calendarName,
+            eventCount: parsed.events.length,
+            sampleEvents: parsed.events.slice(0, 3),
+          }),
+        };
+      } catch (error) {
+        logger.warn?.("system.calendarInfo failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error ? error.message : "Failed to inspect calendar",
+        );
+      }
+    },
+  };
+}
+
+function createCalendarReadTool(
+  allowedPaths: readonly string[],
+  defaultMaxEvents: number,
+  maxEventsCap: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.calendarRead",
+    description:
+      "Read structured VEVENT records from a local ICS calendar file with deterministic truncation.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local ICS calendar file.",
+        },
+        maxEvents: {
+          type: "number",
+          description: "Maximum number of events to return.",
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveCalendarPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        assertCalendarPath(resolved);
+        const maxEvents = normalizePositiveInteger(
+          args.maxEvents,
+          defaultMaxEvents,
+          maxEventsCap,
+        );
+        const raw = await readFile(resolved, "utf8");
+        const parsed = parseCalendarFile(raw);
+        const events = parsed.events.slice(0, maxEvents);
+        return {
+          content: safeStringify({
+            path: resolved,
+            format: "ics",
+            calendarName: parsed.calendarName,
+            eventCount: parsed.events.length,
+            events,
+            truncated: parsed.events.length > events.length,
+          }),
+        };
+      } catch (error) {
+        logger.warn?.("system.calendarRead failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error ? error.message : "Failed to read calendar",
+        );
+      }
+    },
+  };
+}
+
+export function createCalendarTools(config: SystemCalendarToolConfig): Tool[] {
+  const allowedPaths = validateAllowedPaths(config.allowedPaths);
+  const defaultMaxEvents = normalizePositiveInteger(
+    config.defaultMaxEvents,
+    DEFAULT_MAX_EVENTS,
+    DEFAULT_MAX_EVENTS_CAP,
+  );
+  const maxEventsCap = normalizePositiveInteger(
+    config.maxEventsCap,
+    DEFAULT_MAX_EVENTS_CAP,
+    5_000,
+  );
+  const logger = config.logger ?? silentLogger;
+
+  return [
+    createCalendarInfoTool(allowedPaths, logger),
+    createCalendarReadTool(
+      allowedPaths,
+      defaultMaxEvents,
+      maxEventsCap,
+      logger,
+    ),
+  ];
+}

--- a/runtime/src/tools/system/email-message.test.ts
+++ b/runtime/src/tools/system/email-message.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createEmailMessageTools } from "./email-message.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop()!;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function writeEmlFixture(dir: string): string {
+  const path = join(dir, "message.eml");
+  writeFileSync(
+    path,
+    [
+      "From: Alice <alice@example.com>",
+      "To: Bob <bob@example.com>",
+      "Subject: Sprint update",
+      "Date: Mon, 09 Mar 2026 08:00:00 +0000",
+      "Message-ID: <sprint-update@example.com>",
+      "MIME-Version: 1.0",
+      "Content-Type: multipart/mixed; boundary=\"BOUNDARY\"",
+      "",
+      "--BOUNDARY",
+      "Content-Type: text/plain; charset=utf-8",
+      "",
+      "Hello team,",
+      "",
+      "Sprint review is at 10:00 AM.",
+      "",
+      "--BOUNDARY",
+      "Content-Type: text/plain; name=\"agenda.txt\"",
+      "Content-Disposition: attachment; filename=\"agenda.txt\"",
+      "",
+      "agenda attachment",
+      "",
+      "--BOUNDARY--",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+  return path;
+}
+
+function findTool(name: string) {
+  const tool = createEmailMessageTools({
+    allowedPaths: [tmpdir()],
+  }).find((entry) => entry.name === name);
+  expect(tool).toBeDefined();
+  return tool!;
+}
+
+describe("system.emailMessage tools", () => {
+  it("creates the typed email message tools", () => {
+    const tools = createEmailMessageTools({
+      allowedPaths: [tmpdir()],
+    });
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "system.emailMessageInfo",
+      "system.emailMessageExtractText",
+    ]);
+  });
+
+  it("returns message metadata and attachment summary", async () => {
+    const dir = makeTempDir("agenc-email-info-");
+    const emlPath = writeEmlFixture(dir);
+
+    const result = await findTool("system.emailMessageInfo").execute({ path: emlPath });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.format).toBe("eml");
+    expect(parsed.subject).toBe("Sprint update");
+    expect(parsed.from).toContain("alice@example.com");
+    expect(parsed.to).toContain("bob@example.com");
+    expect(parsed.attachmentCount).toBe(1);
+    expect(parsed.attachmentNames).toEqual(["agenda.txt"]);
+  });
+
+  it("extracts plain text body from the message", async () => {
+    const dir = makeTempDir("agenc-email-text-");
+    const emlPath = writeEmlFixture(dir);
+
+    const result = await findTool("system.emailMessageExtractText").execute({
+      path: emlPath,
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.text).toContain("Hello team,");
+    expect(parsed.text).toContain("Sprint review is at 10:00 AM.");
+    expect(parsed.truncated).toBe(false);
+  });
+
+  it("rejects unsupported formats", async () => {
+    const dir = makeTempDir("agenc-email-unsupported-");
+    const badPath = join(dir, "message.txt");
+    writeFileSync(badPath, "plain text", "utf8");
+
+    const result = await findTool("system.emailMessageInfo").execute({ path: badPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unsupported email message format");
+  });
+
+  it("blocks email message paths outside the allowlist", async () => {
+    const dir = makeTempDir("agenc-email-block-");
+    const emlPath = writeEmlFixture(dir);
+    const tools = createEmailMessageTools({
+      allowedPaths: [join(tmpdir(), "different-root")],
+    });
+
+    const result = await tools[0].execute({ path: emlPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside allowed directories");
+  });
+});

--- a/runtime/src/tools/system/email-message.ts
+++ b/runtime/src/tools/system/email-message.ts
@@ -1,0 +1,363 @@
+/**
+ * Typed email-message inspection/extraction tools for @agenc/runtime.
+ *
+ * Provides:
+ * - system.emailMessageInfo — inspect local EML metadata
+ * - system.emailMessageExtractText — extract text from local EML messages
+ *
+ * @module
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import { silentLogger } from "../../utils/logger.js";
+import { safePath } from "./filesystem.js";
+import type { SystemEmailMessageToolConfig } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_CHARS = 100_000;
+const DEFAULT_MAX_CHARS_CAP = 500_000;
+const DEFAULT_MAX_BUFFER = 4 * 1024 * 1024;
+
+const PYTHON_EMAIL_HELPER = String.raw`
+import json
+import pathlib
+import sys
+from email import policy
+from email.parser import BytesParser
+from html.parser import HTMLParser
+
+
+class TextExtractor(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.parts = []
+
+    def handle_data(self, data):
+        if data and data.strip():
+            self.parts.append(data.strip())
+
+    def get_text(self):
+        return "\n".join(part for part in self.parts if part)
+
+
+def fail(message):
+    raise RuntimeError(message)
+
+
+def infer_format(path):
+    suffix = pathlib.Path(path).suffix.lower()
+    if suffix == ".eml":
+        return "eml"
+    fail(f"Unsupported email message format: {suffix or 'unknown'}")
+
+
+def truncate_text(text, max_chars):
+    if len(text) > max_chars:
+        return text[:max_chars] + "…", True
+    return text, False
+
+
+def parse_message(path):
+    with open(path, "rb") as handle:
+        message = BytesParser(policy=policy.default).parse(handle)
+
+    attachments = []
+    content_types = []
+    text_parts = []
+    html_parts = []
+
+    for part in message.walk():
+        content_type = part.get_content_type()
+        if content_type not in content_types:
+            content_types.append(content_type)
+
+        filename = part.get_filename()
+        disposition = part.get_content_disposition()
+        if filename or disposition == "attachment":
+            attachments.append(filename or content_type)
+            continue
+
+        if part.is_multipart():
+            continue
+
+        try:
+            payload = part.get_content()
+        except Exception:
+            payload = ""
+
+        if not isinstance(payload, str):
+            continue
+
+        payload = payload.strip()
+        if not payload:
+            continue
+
+        if content_type == "text/plain":
+            text_parts.append(payload)
+        elif content_type == "text/html":
+            parser = TextExtractor()
+            parser.feed(payload)
+            html_text = parser.get_text().strip()
+            if html_text:
+                html_parts.append(html_text)
+
+    body_text = "\n\n".join(text_parts if text_parts else html_parts)
+
+    metadata = {
+        "subject": message.get("subject"),
+        "from": message.get("from"),
+        "to": message.get("to"),
+        "cc": message.get("cc"),
+        "date": message.get("date"),
+        "messageId": message.get("message-id"),
+        "attachmentCount": len(attachments),
+        "attachmentNames": attachments,
+        "contentTypes": content_types,
+    }
+
+    return metadata, body_text
+
+
+def main():
+    if len(sys.argv) < 4:
+        fail("usage: email-helper <info|text> <path> <options_json>")
+
+    operation = sys.argv[1]
+    path = sys.argv[2]
+    options = json.loads(sys.argv[3])
+    fmt = infer_format(path)
+    metadata, body_text = parse_message(path)
+
+    if operation == "info":
+        payload = {
+            "path": path,
+            "format": fmt,
+            **metadata,
+        }
+    elif operation == "text":
+        excerpt, truncated = truncate_text(body_text, int(options.get("maxChars", 100000)))
+        payload = {
+            "path": path,
+            "format": fmt,
+            "text": excerpt,
+            "truncated": truncated,
+            "characters": len(body_text),
+            **metadata,
+        }
+    else:
+        fail(f"unknown operation: {operation}")
+
+    print(json.dumps(payload, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()
+`;
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+function validateAllowedPaths(allowedPaths: readonly string[]): string[] {
+  if (!Array.isArray(allowedPaths) || allowedPaths.length === 0) {
+    throw new TypeError("allowedPaths must be a non-empty array of strings");
+  }
+  return allowedPaths.map((entry) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      throw new TypeError("Each allowedPaths entry must be a non-empty string");
+    }
+    return entry;
+  });
+}
+
+function normalizePositiveInteger(
+  value: unknown,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Expected a positive finite integer");
+  }
+  return Math.min(Math.floor(value), maximum);
+}
+
+async function resolveEmailPath(
+  rawPath: unknown,
+  allowedPaths: readonly string[],
+): Promise<string | ToolResult> {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    return errorResult("Missing or invalid path");
+  }
+  const safe = await safePath(rawPath, allowedPaths);
+  if (!safe.safe) {
+    return errorResult(
+      safe.reason ?? "Email message path is outside allowed directories",
+    );
+  }
+  return safe.resolved;
+}
+
+async function runEmailHelper<T>(
+  operation: "info" | "text",
+  path: string,
+  options: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<T> {
+  const { stdout } = await execFileAsync(
+    "python3",
+    ["-c", PYTHON_EMAIL_HELPER, operation, path, JSON.stringify(options)],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      maxBuffer: DEFAULT_MAX_BUFFER,
+    },
+  );
+  return JSON.parse(stdout) as T;
+}
+
+function createEmailMessageInfoTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.emailMessageInfo",
+    description:
+      "Inspect a local EML email message and return parsed headers, content types, and attachment summary.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local EML email message file.",
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveEmailPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        const result = await runEmailHelper<Record<string, unknown>>(
+          "info",
+          resolved,
+          {},
+          timeoutMs,
+        );
+        return { content: safeStringify(result) };
+      } catch (error) {
+        logger.warn?.("system.emailMessageInfo failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error
+            ? error.message
+            : "Failed to inspect email message",
+        );
+      }
+    },
+  };
+}
+
+function createEmailMessageExtractTextTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  defaultMaxChars: number,
+  maxCharsCap: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.emailMessageExtractText",
+    description:
+      "Extract text from a local EML email message, preferring text/plain and falling back to stripped HTML.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local EML email message file.",
+        },
+        maxChars: {
+          type: "number",
+          description: "Maximum number of characters to return.",
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveEmailPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        const maxChars = normalizePositiveInteger(
+          args.maxChars,
+          defaultMaxChars,
+          maxCharsCap,
+        );
+        const result = await runEmailHelper<Record<string, unknown>>(
+          "text",
+          resolved,
+          { maxChars },
+          timeoutMs,
+        );
+        return { content: safeStringify(result) };
+      } catch (error) {
+        logger.warn?.("system.emailMessageExtractText failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error
+            ? error.message
+            : "Failed to extract email message text",
+        );
+      }
+    },
+  };
+}
+
+export function createEmailMessageTools(
+  config: SystemEmailMessageToolConfig,
+): Tool[] {
+  const allowedPaths = validateAllowedPaths(config.allowedPaths);
+  const timeoutMs = normalizePositiveInteger(
+    config.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    120_000,
+  );
+  const defaultMaxChars = normalizePositiveInteger(
+    config.defaultMaxChars,
+    DEFAULT_MAX_CHARS,
+    DEFAULT_MAX_CHARS_CAP,
+  );
+  const maxCharsCap = normalizePositiveInteger(
+    config.maxCharsCap,
+    DEFAULT_MAX_CHARS_CAP,
+    5_000_000,
+  );
+  const logger = config.logger ?? silentLogger;
+
+  return [
+    createEmailMessageInfoTool(allowedPaths, timeoutMs, logger),
+    createEmailMessageExtractTextTool(
+      allowedPaths,
+      timeoutMs,
+      defaultMaxChars,
+      maxCharsCap,
+      logger,
+    ),
+  ];
+}

--- a/runtime/src/tools/system/index.ts
+++ b/runtime/src/tools/system/index.ts
@@ -19,6 +19,30 @@ export {
 } from "./filesystem.js";
 
 export {
+  createPdfTools,
+} from "./pdf.js";
+
+export {
+  createOfficeDocumentTools,
+} from "./office-document.js";
+
+export {
+  createEmailMessageTools,
+} from "./email-message.js";
+
+export {
+  createCalendarTools,
+} from "./calendar.js";
+
+export {
+  createSqliteTools,
+} from "./sqlite.js";
+
+export {
+  createSpreadsheetTools,
+} from "./spreadsheet.js";
+
+export {
   createBrowserTools,
   closeBrowser,
   type BrowserToolConfig,
@@ -72,4 +96,10 @@ export {
   type SystemResearchToolConfig,
   type SystemSandboxToolConfig,
   type SystemSandboxWorkspaceAccessMode,
+  type SystemSqliteToolConfig,
+  type SystemPdfToolConfig,
+  type SystemSpreadsheetToolConfig,
+  type SystemOfficeDocumentToolConfig,
+  type SystemEmailMessageToolConfig,
+  type SystemCalendarToolConfig,
 } from "./types.js";

--- a/runtime/src/tools/system/office-document.test.ts
+++ b/runtime/src/tools/system/office-document.test.ts
@@ -1,0 +1,198 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createOfficeDocumentTools } from "./office-document.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop()!;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function writeDocxFixture(dir: string): string {
+  const path = join(dir, "brief.docx");
+  execFileSync(
+    "python3",
+    [
+      "-c",
+      [
+        "import sys, zipfile",
+        "from pathlib import Path",
+        "path = Path(sys.argv[1])",
+        "content_types = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">",
+        "  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>",
+        "  <Default Extension=\"xml\" ContentType=\"application/xml\"/>",
+        "  <Override PartName=\"/word/document.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml\"/>",
+        "  <Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/>",
+        "</Types>'''",
+        "rels = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">",
+        "  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"word/document.xml\"/>",
+        "  <Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/>",
+        "</Relationships>'''",
+        "document = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\">",
+        "  <w:body>",
+        "    <w:p><w:r><w:t>Hello DOCX Brief</w:t></w:r></w:p>",
+        "    <w:p><w:r><w:t>Status update line two.</w:t></w:r></w:p>",
+        "  </w:body>",
+        "</w:document>'''",
+        "core = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">",
+        "  <dc:title>Launch Brief</dc:title>",
+        "  <dc:creator>AgenC Test</dc:creator>",
+        "</cp:coreProperties>'''",
+        "with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:",
+        "    zf.writestr('[Content_Types].xml', content_types)",
+        "    zf.writestr('_rels/.rels', rels)",
+        "    zf.writestr('word/document.xml', document)",
+        "    zf.writestr('docProps/core.xml', core)",
+      ].join("\n"),
+      path,
+    ],
+    { stdio: "ignore" },
+  );
+  return path;
+}
+
+function writeOdtFixture(dir: string): string {
+  const path = join(dir, "brief.odt");
+  execFileSync(
+    "python3",
+    [
+      "-c",
+      [
+        "import sys, zipfile",
+        "from pathlib import Path",
+        "path = Path(sys.argv[1])",
+        "mimetype = 'application/vnd.oasis.opendocument.text'",
+        "content = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<office:document-content xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\">",
+        "  <office:body><office:text>",
+        "    <text:p>Hello ODT Brief</text:p>",
+        "    <text:p>Status update line two.</text:p>",
+        "  </office:text></office:body>",
+        "</office:document-content>'''",
+        "meta = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<office:document-meta xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">",
+        "  <office:meta>",
+        "    <dc:title>Launch Brief</dc:title>",
+        "    <dc:creator>AgenC Test</dc:creator>",
+        "  </office:meta>",
+        "</office:document-meta>'''",
+        "manifest = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<manifest:manifest xmlns:manifest=\"urn:oasis:names:tc:opendocument:xmlns:manifest:1.0\">",
+        "  <manifest:file-entry manifest:full-path=\"/\" manifest:media-type=\"application/vnd.oasis.opendocument.text\"/>",
+        "  <manifest:file-entry manifest:full-path=\"content.xml\" manifest:media-type=\"text/xml\"/>",
+        "  <manifest:file-entry manifest:full-path=\"meta.xml\" manifest:media-type=\"text/xml\"/>",
+        "</manifest:manifest>'''",
+        "with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:",
+        "    zf.writestr('mimetype', mimetype, compress_type=zipfile.ZIP_STORED)",
+        "    zf.writestr('content.xml', content)",
+        "    zf.writestr('meta.xml', meta)",
+        "    zf.writestr('META-INF/manifest.xml', manifest)",
+      ].join("\n"),
+      path,
+    ],
+    { stdio: "ignore" },
+  );
+  return path;
+}
+
+function findTool(name: string) {
+  const tool = createOfficeDocumentTools({
+    allowedPaths: [tmpdir()],
+  }).find((entry) => entry.name === name);
+  expect(tool).toBeDefined();
+  return tool!;
+}
+
+describe("system.officeDocument tools", () => {
+  it("creates the typed office document tools", () => {
+    const tools = createOfficeDocumentTools({
+      allowedPaths: [tmpdir()],
+    });
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "system.officeDocumentInfo",
+      "system.officeDocumentExtractText",
+    ]);
+  });
+
+  it("returns DOCX metadata", async () => {
+    const dir = makeTempDir("agenc-office-docx-");
+    const docxPath = writeDocxFixture(dir);
+
+    const result = await findTool("system.officeDocumentInfo").execute({ path: docxPath });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.format).toBe("docx");
+    expect(parsed.metadata).toMatchObject({
+      title: "Launch Brief",
+      creator: "AgenC Test",
+    });
+    expect(parsed.paragraphs).toBe(2);
+  });
+
+  it("extracts DOCX text", async () => {
+    const dir = makeTempDir("agenc-office-docx-text-");
+    const docxPath = writeDocxFixture(dir);
+
+    const result = await findTool("system.officeDocumentExtractText").execute({
+      path: docxPath,
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(String(parsed.text)).toContain("Hello DOCX Brief");
+    expect(parsed.truncated).toBe(false);
+  });
+
+  it("extracts ODT text", async () => {
+    const dir = makeTempDir("agenc-office-odt-text-");
+    const odtPath = writeOdtFixture(dir);
+
+    const result = await findTool("system.officeDocumentExtractText").execute({
+      path: odtPath,
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.format).toBe("odt");
+    expect(String(parsed.text)).toContain("Hello ODT Brief");
+  });
+
+  it("rejects unsupported formats", async () => {
+    const dir = makeTempDir("agenc-office-unsupported-");
+    const badPath = join(dir, "brief.txt");
+    writeFileSync(badPath, "plain text", "utf8");
+
+    const result = await findTool("system.officeDocumentInfo").execute({ path: badPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unsupported office document format");
+  });
+
+  it("blocks office document paths outside the allowlist", async () => {
+    const dir = makeTempDir("agenc-office-block-");
+    const docxPath = writeDocxFixture(dir);
+    const tools = createOfficeDocumentTools({
+      allowedPaths: [join(tmpdir(), "different-root")],
+    });
+
+    const result = await tools[0].execute({ path: docxPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside allowed directories");
+  });
+});

--- a/runtime/src/tools/system/office-document.ts
+++ b/runtime/src/tools/system/office-document.ts
@@ -1,0 +1,354 @@
+/**
+ * Typed office-document inspection/extraction tools for @agenc/runtime.
+ *
+ * Provides:
+ * - system.officeDocumentInfo — inspect local DOCX/ODT metadata
+ * - system.officeDocumentExtractText — extract text from local DOCX/ODT documents
+ *
+ * @module
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import { silentLogger } from "../../utils/logger.js";
+import { safePath } from "./filesystem.js";
+import type { SystemOfficeDocumentToolConfig } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_CHARS = 100_000;
+const DEFAULT_MAX_CHARS_CAP = 500_000;
+const DEFAULT_MAX_BUFFER = 4 * 1024 * 1024;
+
+const PYTHON_OFFICE_DOCUMENT_HELPER = String.raw`
+import json
+import pathlib
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+
+DOCX_CORE_NS = "http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+DC_NS = "http://purl.org/dc/elements/1.1/"
+DCTERMS_NS = "http://purl.org/dc/terms/"
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+ODF_TEXT_NS = "urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+ODF_META_NS = "urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
+ODF_DC_NS = "http://purl.org/dc/elements/1.1/"
+
+def fail(message):
+    raise RuntimeError(message)
+
+def infer_format(path):
+    suffix = pathlib.Path(path).suffix.lower()
+    if suffix == ".docx":
+        return "docx"
+    if suffix == ".odt":
+        return "odt"
+    fail(f"Unsupported office document format: {suffix or 'unknown'}")
+
+def truncate_text(text, max_chars):
+    if len(text) > max_chars:
+        return text[:max_chars] + "…", True
+    return text, False
+
+def parse_docx(path):
+    with zipfile.ZipFile(path) as zf:
+        metadata = {}
+        try:
+            core = ET.fromstring(zf.read("docProps/core.xml"))
+            for tag in ("title", "subject", "creator", "description", "language"):
+                node = core.find(f"{{{DC_NS}}}{tag}")
+                if node is not None and node.text:
+                    metadata[tag] = node.text
+            modified = core.find(f"{{{DCTERMS_NS}}}modified")
+            if modified is not None and modified.text:
+                metadata["modified"] = modified.text
+        except KeyError:
+            pass
+        document = ET.fromstring(zf.read("word/document.xml"))
+        parts = []
+        paragraphs = 0
+        for para in document.iterfind(f".//{{{W_NS}}}p"):
+            texts = [node.text or "" for node in para.iterfind(f".//{{{W_NS}}}t")]
+            if texts:
+                parts.append("".join(texts))
+            paragraphs += 1
+        text = "\n".join(part for part in parts if part)
+        return metadata, text, {"paragraphs": paragraphs}
+
+def parse_odt(path):
+    with zipfile.ZipFile(path) as zf:
+        metadata = {}
+        try:
+            meta = ET.fromstring(zf.read("meta.xml"))
+            title = meta.find(f".//{{{ODF_DC_NS}}}title")
+            creator = meta.find(f".//{{{ODF_DC_NS}}}creator")
+            description = meta.find(f".//{{{ODF_DC_NS}}}description")
+            language = meta.find(f".//{{{ODF_DC_NS}}}language")
+            keyword = meta.find(f".//{{{ODF_META_NS}}}keyword")
+            for key, node in (
+                ("title", title),
+                ("creator", creator),
+                ("description", description),
+                ("language", language),
+                ("keyword", keyword),
+            ):
+                if node is not None and node.text:
+                    metadata[key] = node.text
+        except KeyError:
+            pass
+        content = ET.fromstring(zf.read("content.xml"))
+        parts = []
+        paragraphs = 0
+        for para in content.iterfind(f".//{{{ODF_TEXT_NS}}}p"):
+            text = "".join(para.itertext()).strip()
+            if text:
+                parts.append(text)
+            paragraphs += 1
+        text = "\n".join(parts)
+        return metadata, text, {"paragraphs": paragraphs}
+
+def main():
+    if len(sys.argv) < 4:
+        fail("usage: office-document-helper <info|text> <path> <options_json>")
+    operation = sys.argv[1]
+    path = sys.argv[2]
+    options = json.loads(sys.argv[3])
+    fmt = infer_format(path)
+    if fmt == "docx":
+        metadata, text, stats = parse_docx(path)
+    elif fmt == "odt":
+        metadata, text, stats = parse_odt(path)
+    else:
+        fail(f"Unsupported office document format: {fmt}")
+    max_chars = int(options.get("maxChars", 100000))
+    if operation == "info":
+        payload = {
+            "path": path,
+            "format": fmt,
+            "metadata": metadata,
+            **stats,
+        }
+    elif operation == "text":
+        excerpt, truncated = truncate_text(text, max_chars)
+        payload = {
+            "path": path,
+            "format": fmt,
+            "text": excerpt,
+            "truncated": truncated,
+            "characters": len(text),
+            **stats,
+        }
+    else:
+        fail(f"unknown operation: {operation}")
+    print(json.dumps(payload, ensure_ascii=False))
+
+if __name__ == "__main__":
+    main()
+`;
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+function validateAllowedPaths(allowedPaths: readonly string[]): string[] {
+  if (!Array.isArray(allowedPaths) || allowedPaths.length === 0) {
+    throw new TypeError("allowedPaths must be a non-empty array of strings");
+  }
+  return allowedPaths.map((entry) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      throw new TypeError("Each allowedPaths entry must be a non-empty string");
+    }
+    return entry;
+  });
+}
+
+function normalizePositiveInteger(
+  value: unknown,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Expected a positive finite integer");
+  }
+  return Math.min(Math.floor(value), maximum);
+}
+
+async function resolveDocumentPath(
+  rawPath: unknown,
+  allowedPaths: readonly string[],
+): Promise<string | ToolResult> {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    return errorResult("Missing or invalid path");
+  }
+  const safe = await safePath(rawPath, allowedPaths);
+  if (!safe.safe) {
+    return errorResult(
+      safe.reason ?? "Office document path is outside allowed directories",
+    );
+  }
+  return safe.resolved;
+}
+
+async function runDocumentHelper<T>(
+  operation: "info" | "text",
+  path: string,
+  options: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<T> {
+  const { stdout } = await execFileAsync(
+    "python3",
+    ["-c", PYTHON_OFFICE_DOCUMENT_HELPER, operation, path, JSON.stringify(options)],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      maxBuffer: DEFAULT_MAX_BUFFER,
+    },
+  );
+  return JSON.parse(stdout) as T;
+}
+
+function createOfficeDocumentInfoTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.officeDocumentInfo",
+    description:
+      "Inspect a local DOCX or ODT office document and return parsed metadata such as title, creator, and paragraph count.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local DOCX or ODT file.",
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveDocumentPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        const result = await runDocumentHelper<Record<string, unknown>>(
+          "info",
+          resolved,
+          {},
+          timeoutMs,
+        );
+        return { content: safeStringify(result) };
+      } catch (error) {
+        logger.warn?.("system.officeDocumentInfo failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error
+            ? error.message
+            : "Failed to inspect office document",
+        );
+      }
+    },
+  };
+}
+
+function createOfficeDocumentExtractTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  defaultMaxChars: number,
+  maxCharsCap: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.officeDocumentExtractText",
+    description:
+      "Extract text from a local DOCX or ODT office document.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local DOCX or ODT file.",
+        },
+        maxChars: {
+          type: "number",
+          description: `Maximum extracted characters to return (default ${defaultMaxChars}, capped at ${maxCharsCap}).`,
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveDocumentPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        const maxChars = normalizePositiveInteger(
+          args.maxChars,
+          defaultMaxChars,
+          maxCharsCap,
+        );
+        const result = await runDocumentHelper<Record<string, unknown>>(
+          "text",
+          resolved,
+          { maxChars },
+          timeoutMs,
+        );
+        return { content: safeStringify(result) };
+      } catch (error) {
+        logger.warn?.("system.officeDocumentExtractText failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error
+            ? error.message
+            : "Failed to extract office document text",
+        );
+      }
+    },
+  };
+}
+
+export function createOfficeDocumentTools(
+  config: SystemOfficeDocumentToolConfig,
+): Tool[] {
+  const allowedPaths = validateAllowedPaths(config.allowedPaths);
+  const timeoutMs = normalizePositiveInteger(
+    config.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const defaultMaxChars = normalizePositiveInteger(
+    config.defaultMaxChars,
+    DEFAULT_MAX_CHARS,
+    DEFAULT_MAX_CHARS_CAP,
+  );
+  const maxCharsCap = normalizePositiveInteger(
+    config.maxCharsCap,
+    DEFAULT_MAX_CHARS_CAP,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const logger = config.logger ?? silentLogger;
+
+  return [
+    createOfficeDocumentInfoTool(allowedPaths, timeoutMs, logger),
+    createOfficeDocumentExtractTool(
+      allowedPaths,
+      timeoutMs,
+      defaultMaxChars,
+      maxCharsCap,
+      logger,
+    ),
+  ];
+}

--- a/runtime/src/tools/system/pdf.test.ts
+++ b/runtime/src/tools/system/pdf.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createPdfTools } from "./pdf.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop()!;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempPdf(name: string, contents: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "agenc-system-pdf-test-"));
+  cleanupPaths.push(dir);
+  const path = join(dir, name);
+  writeFileSync(path, contents, "utf8");
+  return path;
+}
+
+function minimalPdf(): string {
+  return [
+    "%PDF-1.4",
+    "1 0 obj",
+    "<< /Type /Catalog /Pages 2 0 R >>",
+    "endobj",
+    "2 0 obj",
+    "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+    "endobj",
+    "3 0 obj",
+    "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+    "endobj",
+    "4 0 obj",
+    "<< /Length 44 >>",
+    "stream",
+    "BT",
+    "/F1 24 Tf",
+    "72 72 Td",
+    "(Hello PDF) Tj",
+    "ET",
+    "endstream",
+    "endobj",
+    "5 0 obj",
+    "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    "endobj",
+    "xref",
+    "0 6",
+    "0000000000 65535 f ",
+    "0000000010 00000 n ",
+    "0000000060 00000 n ",
+    "0000000117 00000 n ",
+    "0000000243 00000 n ",
+    "0000000338 00000 n ",
+    "trailer",
+    "<< /Root 1 0 R /Size 6 >>",
+    "startxref",
+    "408",
+    "%%EOF",
+    "",
+  ].join("\n");
+}
+
+function findTool(name: string) {
+  const tool = createPdfTools({
+    allowedPaths: [tmpdir()],
+  }).find((entry) => entry.name === name);
+  expect(tool).toBeDefined();
+  return tool!;
+}
+
+describe("system.pdf tools", () => {
+  it("creates the typed PDF tools", () => {
+    const tools = createPdfTools({
+      allowedPaths: [tmpdir()],
+    });
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "system.pdfInfo",
+      "system.pdfExtractText",
+    ]);
+  });
+
+  it("returns PDF metadata", async () => {
+    const pdfPath = makeTempPdf("sample.pdf", minimalPdf());
+
+    const result = await findTool("system.pdfInfo").execute({ path: pdfPath });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.pages).toBe(1);
+    expect(parsed.metadata).toMatchObject({
+      Pages: 1,
+    });
+  });
+
+  it("extracts PDF text", async () => {
+    const pdfPath = makeTempPdf("sample.pdf", minimalPdf());
+
+    const result = await findTool("system.pdfExtractText").execute({
+      path: pdfPath,
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(String(parsed.text)).toContain("Hello PDF");
+    expect(parsed.truncated).toBe(false);
+  });
+
+  it("rejects invalid PDF files", async () => {
+    const pdfPath = makeTempPdf("not-a-pdf.pdf", "plain text");
+
+    const result = await findTool("system.pdfInfo").execute({ path: pdfPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("does not look like a PDF");
+  });
+
+  it("blocks PDF paths outside the allowlist", async () => {
+    const pdfPath = makeTempPdf("sample.pdf", minimalPdf());
+    const tools = createPdfTools({
+      allowedPaths: [join(tmpdir(), "different-root")],
+    });
+    const result = await tools[0].execute({ path: pdfPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside allowed directories");
+  });
+});

--- a/runtime/src/tools/system/pdf.ts
+++ b/runtime/src/tools/system/pdf.ts
@@ -1,0 +1,316 @@
+/**
+ * Typed PDF inspection/extraction tools for @agenc/runtime.
+ *
+ * Provides:
+ * - system.pdfInfo — inspect PDF metadata using pdfinfo
+ * - system.pdfExtractText — extract text content using pdftotext
+ *
+ * @module
+ */
+
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { promisify } from "node:util";
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import { silentLogger } from "../../utils/logger.js";
+import { safePath } from "./filesystem.js";
+import type { SystemPdfToolConfig } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_CHARS = 100_000;
+const DEFAULT_MAX_CHARS_CAP = 500_000;
+const PDF_SIGNATURE = "%PDF-";
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+function validateAllowedPaths(allowedPaths: readonly string[]): string[] {
+  if (!Array.isArray(allowedPaths) || allowedPaths.length === 0) {
+    throw new TypeError("allowedPaths must be a non-empty array of strings");
+  }
+  return allowedPaths.map((entry) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      throw new TypeError("Each allowedPaths entry must be a non-empty string");
+    }
+    return entry;
+  });
+}
+
+function normalizePositiveInteger(
+  value: unknown,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Expected a positive finite integer");
+  }
+  return Math.min(Math.floor(value), maximum);
+}
+
+async function resolvePdfPath(
+  rawPath: unknown,
+  allowedPaths: readonly string[],
+): Promise<string | ToolResult> {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    return errorResult("Missing or invalid path");
+  }
+  const safe = await safePath(rawPath, allowedPaths);
+  if (!safe.safe) {
+    return errorResult(safe.reason ?? "PDF path is outside allowed directories");
+  }
+  return safe.resolved;
+}
+
+async function assertPdfSignature(path: string): Promise<void> {
+  const handle = await readFile(path);
+  if (!handle.subarray(0, PDF_SIGNATURE.length).toString("utf8").startsWith(PDF_SIGNATURE)) {
+    throw new Error("File does not look like a PDF");
+  }
+}
+
+function truncateText(text: string, maxChars: number): {
+  readonly text: string;
+  readonly truncated: boolean;
+} {
+  return text.length > maxChars
+    ? { text: `${text.slice(0, maxChars)}…`, truncated: true }
+    : { text, truncated: false };
+}
+
+function parsePdfInfo(raw: string): Record<string, unknown> {
+  const metadata: Record<string, unknown> = {};
+  for (const line of raw.split(/\r?\n/u)) {
+    const separator = line.indexOf(":");
+    if (separator <= 0) {
+      continue;
+    }
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (!key) {
+      continue;
+    }
+    metadata[key] = /^\d+$/u.test(value) ? Number(value) : value;
+  }
+  return metadata;
+}
+
+function parsePageRange(args: Record<string, unknown>): {
+  readonly startPage?: number;
+  readonly endPage?: number;
+} {
+  const page = args.page;
+  if (page !== undefined) {
+    const normalized = normalizePositiveInteger(page, 1, Number.MAX_SAFE_INTEGER);
+    return { startPage: normalized, endPage: normalized };
+  }
+  const startPage =
+    args.startPage === undefined
+      ? undefined
+      : normalizePositiveInteger(args.startPage, 1, Number.MAX_SAFE_INTEGER);
+  const endPage =
+    args.endPage === undefined
+      ? undefined
+      : normalizePositiveInteger(args.endPage, 1, Number.MAX_SAFE_INTEGER);
+  if (
+    startPage !== undefined &&
+    endPage !== undefined &&
+    startPage > endPage
+  ) {
+    throw new TypeError("startPage cannot be greater than endPage");
+  }
+  return { startPage, endPage };
+}
+
+function createPdfInfoTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.pdfInfo",
+    description:
+      "Inspect a local PDF file and return parsed metadata such as page count, title, author, and encryption state.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the PDF file.",
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolvePdfPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        await assertPdfSignature(resolved);
+        const { stdout } = await execFileAsync("pdfinfo", [resolved], {
+          encoding: "utf8",
+          timeout: timeoutMs,
+          maxBuffer: 512 * 1024,
+        });
+        const metadata = parsePdfInfo(stdout);
+        return {
+          content: safeStringify({
+            path: resolved,
+            metadata,
+            pages: metadata.Pages,
+            title: metadata.Title,
+            author: metadata.Author,
+            encrypted: metadata.Encrypted,
+            pageSize: metadata["Page size"],
+          }),
+        };
+      } catch (error) {
+        logger.warn?.("system.pdfInfo failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error ? error.message : "Failed to inspect PDF",
+        );
+      }
+    },
+  };
+}
+
+function createPdfExtractTextTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  defaultMaxChars: number,
+  maxCharsCap: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.pdfExtractText",
+    description:
+      "Extract UTF-8 text from a local PDF file, optionally constrained to a page or page range.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the PDF file.",
+        },
+        page: {
+          type: "number",
+          description: "Extract a single 1-based page.",
+        },
+        startPage: {
+          type: "number",
+          description: "Start of a 1-based inclusive page range.",
+        },
+        endPage: {
+          type: "number",
+          description: "End of a 1-based inclusive page range.",
+        },
+        layout: {
+          type: "boolean",
+          description: "Preserve original layout spacing when true.",
+          default: false,
+        },
+        maxChars: {
+          type: "number",
+          description: `Maximum extracted characters to return (default ${defaultMaxChars}, capped at ${maxCharsCap}).`,
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolvePdfPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        await assertPdfSignature(resolved);
+        const { startPage, endPage } = parsePageRange(args);
+        const maxChars = normalizePositiveInteger(
+          args.maxChars,
+          defaultMaxChars,
+          maxCharsCap,
+        );
+        const commandArgs = [
+          "-enc",
+          "UTF-8",
+          ...(args.layout === true ? ["-layout"] : []),
+          ...(startPage !== undefined ? ["-f", String(startPage)] : []),
+          ...(endPage !== undefined ? ["-l", String(endPage)] : []),
+          resolved,
+          "-",
+        ];
+        const { stdout } = await execFileAsync("pdftotext", commandArgs, {
+          encoding: "utf8",
+          timeout: timeoutMs,
+          maxBuffer: Math.max(maxChars * 4, 512 * 1024),
+        });
+        const trimmed = stdout.trim();
+        const extracted = truncateText(trimmed, maxChars);
+        return {
+          content: safeStringify({
+            path: resolved,
+            pageRange:
+              startPage !== undefined || endPage !== undefined
+                ? {
+                    startPage: startPage ?? endPage,
+                    endPage: endPage ?? startPage,
+                  }
+                : undefined,
+            text: extracted.text,
+            truncated: extracted.truncated,
+            characters: trimmed.length,
+          }),
+        };
+      } catch (error) {
+        logger.warn?.("system.pdfExtractText failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error ? error.message : "Failed to extract PDF text",
+        );
+      }
+    },
+  };
+}
+
+export function createPdfTools(config: SystemPdfToolConfig): Tool[] {
+  const allowedPaths = validateAllowedPaths(config.allowedPaths);
+  const timeoutMs = normalizePositiveInteger(
+    config.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const defaultMaxChars = normalizePositiveInteger(
+    config.defaultMaxChars,
+    DEFAULT_MAX_CHARS,
+    DEFAULT_MAX_CHARS_CAP,
+  );
+  const maxCharsCap = normalizePositiveInteger(
+    config.maxCharsCap,
+    Math.max(DEFAULT_MAX_CHARS_CAP, defaultMaxChars),
+    Number.MAX_SAFE_INTEGER,
+  );
+  const logger = config.logger ?? silentLogger;
+
+  return [
+    createPdfInfoTool(allowedPaths, timeoutMs, logger),
+    createPdfExtractTextTool(
+      allowedPaths,
+      timeoutMs,
+      defaultMaxChars,
+      maxCharsCap,
+      logger,
+    ),
+  ];
+}

--- a/runtime/src/tools/system/spreadsheet.test.ts
+++ b/runtime/src/tools/system/spreadsheet.test.ts
@@ -1,0 +1,220 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createSpreadsheetTools } from "./spreadsheet.js";
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop()!;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  cleanupPaths.push(dir);
+  return dir;
+}
+
+function writeCsvFixture(dir: string): string {
+  const path = join(dir, "sample.csv");
+  writeFileSync(
+    path,
+    ["name,role", "Ada,admin", "Linus,user", "Grace,analyst", ""].join("\n"),
+    "utf8",
+  );
+  return path;
+}
+
+function writeXlsxFixture(dir: string): string {
+  const path = join(dir, "roster.xlsx");
+  execFileSync(
+    "python3",
+    [
+      "-c",
+      [
+        "import sys, zipfile",
+        "from pathlib import Path",
+        "path = Path(sys.argv[1])",
+        "shared_strings = [\"name\", \"role\", \"Ada\", \"admin\", \"Linus\", \"user\"]",
+        "content_types = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\">",
+        "  <Default Extension=\"rels\" ContentType=\"application/vnd.openxmlformats-package.relationships+xml\"/>",
+        "  <Default Extension=\"xml\" ContentType=\"application/xml\"/>",
+        "  <Override PartName=\"/xl/workbook.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml\"/>",
+        "  <Override PartName=\"/xl/worksheets/sheet1.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml\"/>",
+        "  <Override PartName=\"/xl/sharedStrings.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml\"/>",
+        "  <Override PartName=\"/docProps/core.xml\" ContentType=\"application/vnd.openxmlformats-package.core-properties+xml\"/>",
+        "  <Override PartName=\"/docProps/app.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.extended-properties+xml\"/>",
+        "</Types>'''",
+        "rels = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">",
+        "  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument\" Target=\"xl/workbook.xml\"/>",
+        "  <Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/package/2006/relationships/metadata/core-properties\" Target=\"docProps/core.xml\"/>",
+        "  <Relationship Id=\"rId3\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/extended-properties\" Target=\"docProps/app.xml\"/>",
+        "</Relationships>'''",
+        "workbook = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<workbook xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\">",
+        "  <sheets>",
+        "    <sheet name=\"Roster\" sheetId=\"1\" r:id=\"rId1\"/>",
+        "  </sheets>",
+        "</workbook>'''",
+        "workbook_rels = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\">",
+        "  <Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet\" Target=\"worksheets/sheet1.xml\"/>",
+        "  <Relationship Id=\"rId2\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/sharedStrings\" Target=\"sharedStrings.xml\"/>",
+        "</Relationships>'''",
+        "shared = ['<?xml version=\"1.0\" encoding=\"UTF-8\"?>', '<sst xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\" count=\"6\" uniqueCount=\"6\">']",
+        "for value in shared_strings:",
+        "    shared.append(f'<si><t>{value}</t></si>')",
+        "shared.append('</sst>')",
+        "shared_strings_xml = ''.join(shared)",
+        "sheet = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\">",
+        "  <sheetData>",
+        "    <row r=\"1\"><c r=\"A1\" t=\"s\"><v>0</v></c><c r=\"B1\" t=\"s\"><v>1</v></c></row>",
+        "    <row r=\"2\"><c r=\"A2\" t=\"s\"><v>2</v></c><c r=\"B2\" t=\"s\"><v>3</v></c></row>",
+        "    <row r=\"3\"><c r=\"A3\" t=\"s\"><v>4</v></c><c r=\"B3\" t=\"s\"><v>5</v></c></row>",
+        "  </sheetData>",
+        "</worksheet>'''",
+        "core = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<cp:coreProperties xmlns:cp=\"http://schemas.openxmlformats.org/package/2006/metadata/core-properties\" xmlns:dc=\"http://purl.org/dc/elements/1.1/\">",
+        "  <dc:title>Roster</dc:title>",
+        "</cp:coreProperties>'''",
+        "app = '''<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+        "<Properties xmlns=\"http://schemas.openxmlformats.org/officeDocument/2006/extended-properties\">",
+        "  <Application>AgenC Test</Application>",
+        "</Properties>'''",
+        "with zipfile.ZipFile(path, 'w', compression=zipfile.ZIP_DEFLATED) as zf:",
+        "    zf.writestr('[Content_Types].xml', content_types)",
+        "    zf.writestr('_rels/.rels', rels)",
+        "    zf.writestr('xl/workbook.xml', workbook)",
+        "    zf.writestr('xl/_rels/workbook.xml.rels', workbook_rels)",
+        "    zf.writestr('xl/sharedStrings.xml', shared_strings_xml)",
+        "    zf.writestr('xl/worksheets/sheet1.xml', sheet)",
+        "    zf.writestr('docProps/core.xml', core)",
+        "    zf.writestr('docProps/app.xml', app)",
+      ].join("\n"),
+      path,
+    ],
+    { stdio: "ignore" },
+  );
+  return path;
+}
+
+function findTool(name: string) {
+  const tool = createSpreadsheetTools({
+    allowedPaths: [tmpdir()],
+  }).find((entry) => entry.name === name);
+  expect(tool).toBeDefined();
+  return tool!;
+}
+
+describe("system.spreadsheet tools", () => {
+  it("creates the typed spreadsheet tools", () => {
+    const tools = createSpreadsheetTools({
+      allowedPaths: [tmpdir()],
+    });
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "system.spreadsheetInfo",
+      "system.spreadsheetRead",
+    ]);
+  });
+
+  it("returns spreadsheet info for CSV files", async () => {
+    const dir = makeTempDir("agenc-system-spreadsheet-csv-");
+    const csvPath = writeCsvFixture(dir);
+
+    const result = await findTool("system.spreadsheetInfo").execute({ path: csvPath });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.format).toBe("csv");
+    expect(parsed.sheetCount).toBe(1);
+    expect(parsed.sheets).toEqual([
+      expect.objectContaining({
+        name: "Sheet1",
+        rowCount: 3,
+        columnCount: 2,
+        columns: ["name", "role"],
+      }),
+    ]);
+  });
+
+  it("reads structured rows from CSV files", async () => {
+    const dir = makeTempDir("agenc-system-spreadsheet-read-");
+    const csvPath = writeCsvFixture(dir);
+
+    const result = await findTool("system.spreadsheetRead").execute({
+      path: csvPath,
+      maxRows: 2,
+    });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.columns).toEqual(["name", "role"]);
+    expect(parsed.rows).toEqual([
+      { name: "Ada", role: "admin" },
+      { name: "Linus", role: "user" },
+    ]);
+    expect(parsed.truncated).toBe(true);
+  });
+
+  it("supports XLSX workbook inspection and sheet reads", async () => {
+    const dir = makeTempDir("agenc-system-spreadsheet-xlsx-");
+    const xlsxPath = writeXlsxFixture(dir);
+
+    const infoResult = await findTool("system.spreadsheetInfo").execute({ path: xlsxPath });
+    expect(infoResult.isError).toBeFalsy();
+    const info = JSON.parse(infoResult.content) as Record<string, unknown>;
+    expect(info.format).toBe("xlsx");
+    expect(info.sheets).toEqual([
+      expect.objectContaining({
+        name: "Roster",
+        rowCount: 2,
+        columns: ["name", "role"],
+      }),
+    ]);
+
+    const readResult = await findTool("system.spreadsheetRead").execute({
+      path: xlsxPath,
+      sheet: "Roster",
+    });
+    expect(readResult.isError).toBeFalsy();
+    const parsed = JSON.parse(readResult.content) as Record<string, unknown>;
+    expect(parsed.sheet).toBe("Roster");
+    expect(parsed.rows).toEqual([
+      { name: "Ada", role: "admin" },
+      { name: "Linus", role: "user" },
+    ]);
+  });
+
+  it("rejects unknown sheet names", async () => {
+    const dir = makeTempDir("agenc-system-spreadsheet-missing-sheet-");
+    const xlsxPath = writeXlsxFixture(dir);
+
+    const result = await findTool("system.spreadsheetRead").execute({
+      path: xlsxPath,
+      sheet: "Missing",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Unknown sheet");
+  });
+
+  it("blocks spreadsheet paths outside the allowlist", async () => {
+    const dir = makeTempDir("agenc-system-spreadsheet-block-");
+    const csvPath = writeCsvFixture(dir);
+    const tools = createSpreadsheetTools({
+      allowedPaths: [join(tmpdir(), "different-root")],
+    });
+
+    const result = await tools[0].execute({ path: csvPath });
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside allowed directories");
+  });
+});

--- a/runtime/src/tools/system/spreadsheet.ts
+++ b/runtime/src/tools/system/spreadsheet.ts
@@ -1,0 +1,615 @@
+/**
+ * Typed spreadsheet inspection/extraction tools for @agenc/runtime.
+ *
+ * Provides:
+ * - system.spreadsheetInfo — inspect workbook/sheet metadata and sample rows
+ * - system.spreadsheetRead — extract structured rows from CSV/TSV/XLS/XLSX files
+ *
+ * @module
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import { silentLogger } from "../../utils/logger.js";
+import { safePath } from "./filesystem.js";
+import type { SystemSpreadsheetToolConfig } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_MAX_ROWS = 200;
+const DEFAULT_MAX_ROWS_CAP = 1_000;
+const DEFAULT_MAX_CELL_CHARS = 4_000;
+const DEFAULT_INFO_SAMPLE_ROWS = 5;
+const DEFAULT_INFO_SAMPLE_ROWS_CAP = 20;
+const DEFAULT_MAX_BUFFER = 4 * 1024 * 1024;
+
+const PYTHON_SPREADSHEET_HELPER = String.raw`
+import csv
+import json
+import pathlib
+import sys
+import zipfile
+import xml.etree.ElementTree as ET
+
+try:
+    import xlrd
+except Exception:
+    xlrd = None
+
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+
+def fail(message):
+    raise RuntimeError(message)
+
+def infer_format(path):
+    suffix = pathlib.Path(path).suffix.lower()
+    if suffix == ".csv":
+        return "csv"
+    if suffix in (".tsv", ".tab"):
+        return "tsv"
+    if suffix == ".xlsx":
+        return "xlsx"
+    if suffix == ".xls":
+        return "xls"
+    fail(f"Unsupported spreadsheet format: {suffix or 'unknown'}")
+
+def normalize_header(values):
+    headers = []
+    seen = {}
+    for index, value in enumerate(values):
+        raw = "" if value is None else str(value).strip()
+        name = raw if raw else f"column_{index + 1}"
+        base = name
+        suffix = 2
+        while name in seen:
+            name = f"{base}_{suffix}"
+            suffix += 1
+        seen[name] = True
+        headers.append(name)
+    return headers
+
+def sanitize_cell(value, max_chars):
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    text = str(value)
+    if len(text) > max_chars:
+        return text[:max_chars] + "…"
+    return text
+
+def build_sheet_summary(name, rows, sample_rows, max_chars):
+    if not rows:
+        return {
+            "name": name,
+            "rowCount": 0,
+            "columnCount": 0,
+            "columns": [],
+            "sampleRows": [],
+        }
+    headers = normalize_header(rows[0])
+    data_rows = rows[1:]
+    samples = []
+    for row in data_rows[:sample_rows]:
+        record = {}
+        for index, header in enumerate(headers):
+            record[header] = sanitize_cell(row[index] if index < len(row) else "", max_chars)
+        samples.append(record)
+    return {
+        "name": name,
+        "rowCount": len(data_rows),
+        "columnCount": len(headers),
+        "columns": headers,
+        "sampleRows": samples,
+    }
+
+def build_read_result(name, rows, start_row, max_rows, max_chars, selected_columns):
+    if not rows:
+        return {
+            "sheet": name,
+            "columns": [],
+            "rows": [],
+            "rowCount": 0,
+            "truncated": False,
+        }
+    headers = normalize_header(rows[0])
+    selected = headers if not selected_columns else selected_columns
+    missing = [column for column in selected if column not in headers]
+    if missing:
+        fail("Unknown columns requested: " + ", ".join(missing))
+    indices = [headers.index(column) for column in selected]
+    data_rows = rows[1:]
+    begin = max(start_row - 1, 0)
+    sliced = data_rows[begin:]
+    truncated = len(sliced) > max_rows
+    sliced = sliced[:max_rows]
+    records = []
+    for row in sliced:
+        record = {}
+        for column, index in zip(selected, indices):
+            record[column] = sanitize_cell(row[index] if index < len(row) else "", max_chars)
+        records.append(record)
+    return {
+        "sheet": name,
+        "columns": selected,
+        "rows": records,
+        "rowCount": len(data_rows),
+        "truncated": truncated,
+    }
+
+def read_delimited(path, delimiter):
+    with open(path, "r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.reader(handle, delimiter=delimiter)
+        return [list(row) for row in reader]
+
+def parse_xlsx_shared_strings(zf):
+    try:
+        root = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+    except KeyError:
+        return []
+    strings = []
+    for node in root.findall(f"{{{MAIN_NS}}}si"):
+        parts = []
+        for text_node in node.iterfind(f".//{{{MAIN_NS}}}t"):
+            parts.append(text_node.text or "")
+        strings.append("".join(parts))
+    return strings
+
+def parse_xlsx_workbook(zf):
+    workbook = ET.fromstring(zf.read("xl/workbook.xml"))
+    rels_root = ET.fromstring(zf.read("xl/_rels/workbook.xml.rels"))
+    rel_targets = {}
+    for rel in rels_root.findall(f"{{{PKG_REL_NS}}}Relationship"):
+        rel_targets[rel.attrib["Id"]] = rel.attrib["Target"]
+    sheets = []
+    for node in workbook.findall(f".//{{{MAIN_NS}}}sheet"):
+        rel_id = node.attrib.get(f"{{{REL_NS}}}id")
+        if not rel_id:
+            continue
+        target = rel_targets.get(rel_id)
+        if not target:
+            continue
+        if not target.startswith("xl/"):
+            target = "xl/" + target.lstrip("/")
+        sheets.append({
+            "name": node.attrib.get("name", "Sheet1"),
+            "target": target,
+        })
+    return sheets
+
+def cell_ref_to_index(ref):
+    letters = []
+    for char in ref:
+        if char.isalpha():
+            letters.append(char.upper())
+        else:
+            break
+    index = 0
+    for char in letters:
+        index = index * 26 + (ord(char) - 64)
+    return max(index - 1, 0)
+
+def parse_numeric(text):
+    if text is None or text == "":
+        return ""
+    try:
+        if "." in text:
+            return float(text)
+        return int(text)
+    except Exception:
+        return text
+
+def parse_xlsx_rows(zf, sheet_target, shared_strings):
+    root = ET.fromstring(zf.read(sheet_target))
+    rows = []
+    for row_node in root.findall(f".//{{{MAIN_NS}}}sheetData/{{{MAIN_NS}}}row"):
+        row_map = {}
+        max_index = -1
+        for cell in row_node.findall(f"{{{MAIN_NS}}}c"):
+            ref = cell.attrib.get("r", "A1")
+            index = cell_ref_to_index(ref)
+            cell_type = cell.attrib.get("t")
+            value_node = cell.find(f"{{{MAIN_NS}}}v")
+            inline_node = cell.find(f"{{{MAIN_NS}}}is")
+            value = ""
+            if cell_type == "s" and value_node is not None and value_node.text is not None:
+                string_index = int(value_node.text)
+                value = shared_strings[string_index] if string_index < len(shared_strings) else ""
+            elif cell_type == "inlineStr" and inline_node is not None:
+                value = "".join(node.text or "" for node in inline_node.iterfind(f".//{{{MAIN_NS}}}t"))
+            elif cell_type == "b" and value_node is not None:
+                value = value_node.text == "1"
+            elif value_node is not None:
+                value = parse_numeric(value_node.text)
+            row_map[index] = value
+            max_index = max(max_index, index)
+        if max_index < 0:
+            rows.append([])
+            continue
+        row = [row_map.get(index, "") for index in range(max_index + 1)]
+        rows.append(row)
+    return rows
+
+def read_xlsx(path):
+    with zipfile.ZipFile(path) as zf:
+        shared_strings = parse_xlsx_shared_strings(zf)
+        sheets = parse_xlsx_workbook(zf)
+        return [
+            {
+                "name": sheet["name"],
+                "rows": parse_xlsx_rows(zf, sheet["target"], shared_strings),
+            }
+            for sheet in sheets
+        ]
+
+def read_xls(path):
+    if xlrd is None:
+        fail("xlrd is not installed; .xls files are unavailable")
+    workbook = xlrd.open_workbook(path, on_demand=True)
+    sheets = []
+    for sheet in workbook.sheets():
+        rows = []
+        for row_index in range(sheet.nrows):
+            row = []
+            for column_index in range(sheet.ncols):
+                value = sheet.cell_value(row_index, column_index)
+                if isinstance(value, float) and value.is_integer():
+                    value = int(value)
+                row.append(value)
+            rows.append(row)
+        sheets.append({
+            "name": sheet.name,
+            "rows": rows,
+        })
+    return sheets
+
+def read_workbook(path, fmt):
+    if fmt == "csv":
+        return [{"name": "Sheet1", "rows": read_delimited(path, ",")}]
+    if fmt == "tsv":
+        return [{"name": "Sheet1", "rows": read_delimited(path, "\t")}]
+    if fmt == "xlsx":
+        return read_xlsx(path)
+    if fmt == "xls":
+        return read_xls(path)
+    fail(f"Unsupported spreadsheet format: {fmt}")
+
+def select_sheet(sheets, requested):
+    if requested is None:
+        return sheets[0] if sheets else {"name": "Sheet1", "rows": []}
+    for sheet in sheets:
+        if sheet["name"] == requested:
+            return sheet
+    fail(f"Unknown sheet: {requested}")
+
+def main():
+    if len(sys.argv) < 4:
+        fail("usage: spreadsheet-helper <info|read> <path> <options_json>")
+    operation = sys.argv[1]
+    path = sys.argv[2]
+    options = json.loads(sys.argv[3])
+    fmt = infer_format(path)
+    sheets = read_workbook(path, fmt)
+    max_chars = int(options.get("maxCellChars", 4000))
+    if operation == "info":
+        sample_rows = int(options.get("sampleRows", 5))
+        result = {
+            "path": path,
+            "format": fmt,
+            "sheetCount": len(sheets),
+            "sheets": [
+                build_sheet_summary(sheet["name"], sheet["rows"], sample_rows, max_chars)
+                for sheet in sheets
+            ],
+        }
+    elif operation == "read":
+        sheet = select_sheet(sheets, options.get("sheet"))
+        result = {
+            "path": path,
+            "format": fmt,
+            **build_read_result(
+                sheet["name"],
+                sheet["rows"],
+                int(options.get("startRow", 1)),
+                int(options.get("maxRows", 200)),
+                max_chars,
+                options.get("columns"),
+            ),
+        }
+    else:
+        fail(f"unknown operation: {operation}")
+    print(json.dumps(result, ensure_ascii=False))
+
+if __name__ == "__main__":
+    main()
+`;
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+function validateAllowedPaths(allowedPaths: readonly string[]): string[] {
+  if (!Array.isArray(allowedPaths) || allowedPaths.length === 0) {
+    throw new TypeError("allowedPaths must be a non-empty array of strings");
+  }
+  return allowedPaths.map((entry) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      throw new TypeError("Each allowedPaths entry must be a non-empty string");
+    }
+    return entry;
+  });
+}
+
+function normalizePositiveInteger(
+  value: unknown,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Expected a positive finite integer");
+  }
+  return Math.min(Math.floor(value), maximum);
+}
+
+async function resolveSpreadsheetPath(
+  rawPath: unknown,
+  allowedPaths: readonly string[],
+): Promise<string | ToolResult> {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    return errorResult("Missing or invalid path");
+  }
+  const safe = await safePath(rawPath, allowedPaths);
+  if (!safe.safe) {
+    return errorResult(
+      safe.reason ?? "Spreadsheet path is outside allowed directories",
+    );
+  }
+  return safe.resolved;
+}
+
+function normalizeSheetName(value: unknown): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new TypeError("sheet must be a non-empty string when provided");
+  }
+  return value.trim();
+}
+
+function normalizeColumnSelection(value: unknown): readonly string[] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new TypeError("columns must be a non-empty array of strings when provided");
+  }
+  return value.map((column) => {
+    if (typeof column !== "string" || column.trim().length === 0) {
+      throw new TypeError("columns must contain non-empty strings");
+    }
+    return column.trim();
+  });
+}
+
+async function runSpreadsheetHelper<T>(
+  operation: "info" | "read",
+  path: string,
+  options: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<T> {
+  const { stdout } = await execFileAsync(
+    "python3",
+    ["-c", PYTHON_SPREADSHEET_HELPER, operation, path, JSON.stringify(options)],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      maxBuffer: DEFAULT_MAX_BUFFER,
+    },
+  );
+  return JSON.parse(stdout) as T;
+}
+
+function createSpreadsheetInfoTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  infoSampleRows: number,
+  maxCellChars: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.spreadsheetInfo",
+    description:
+      "Inspect a local spreadsheet or delimited table file and return sheet metadata, columns, and sample rows.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local CSV, TSV, XLS, or XLSX file.",
+        },
+        sampleRows: {
+          type: "number",
+          description: `Number of sample data rows to preview per sheet (default ${infoSampleRows}).`,
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveSpreadsheetPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        const sampleRows = normalizePositiveInteger(
+          args.sampleRows,
+          infoSampleRows,
+          DEFAULT_INFO_SAMPLE_ROWS_CAP,
+        );
+        const result = await runSpreadsheetHelper<Record<string, unknown>>(
+          "info",
+          resolved,
+          {
+            sampleRows,
+            maxCellChars,
+          },
+          timeoutMs,
+        );
+        return { content: safeStringify(result) };
+      } catch (error) {
+        logger.warn?.("system.spreadsheetInfo failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error
+            ? error.message
+            : "Failed to inspect spreadsheet",
+        );
+      }
+    },
+  };
+}
+
+function createSpreadsheetReadTool(
+  allowedPaths: readonly string[],
+  timeoutMs: number,
+  defaultMaxRows: number,
+  maxRowsCap: number,
+  maxCellChars: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.spreadsheetRead",
+    description:
+      "Read structured rows from a local spreadsheet or delimited table file with optional sheet and column selection.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to a local CSV, TSV, XLS, or XLSX file.",
+        },
+        sheet: {
+          type: "string",
+          description: "Workbook sheet name. Omit to use the first sheet.",
+        },
+        startRow: {
+          type: "number",
+          description: "1-based data-row offset after the header row.",
+          default: 1,
+        },
+        maxRows: {
+          type: "number",
+          description: `Maximum data rows to return (default ${defaultMaxRows}, capped at ${maxRowsCap}).`,
+        },
+        columns: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional subset of normalized header names to return.",
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveSpreadsheetPath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      try {
+        const sheet = normalizeSheetName(args.sheet);
+        const startRow = normalizePositiveInteger(args.startRow, 1, Number.MAX_SAFE_INTEGER);
+        const maxRows = normalizePositiveInteger(
+          args.maxRows,
+          defaultMaxRows,
+          maxRowsCap,
+        );
+        const columns = normalizeColumnSelection(args.columns);
+        const result = await runSpreadsheetHelper<Record<string, unknown>>(
+          "read",
+          resolved,
+          {
+            sheet,
+            startRow,
+            maxRows,
+            columns,
+            maxCellChars,
+          },
+          timeoutMs,
+        );
+        return { content: safeStringify(result) };
+      } catch (error) {
+        logger.warn?.("system.spreadsheetRead failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error
+            ? error.message
+            : "Failed to read spreadsheet",
+        );
+      }
+    },
+  };
+}
+
+export function createSpreadsheetTools(
+  config: SystemSpreadsheetToolConfig,
+): Tool[] {
+  const allowedPaths = validateAllowedPaths(config.allowedPaths);
+  const timeoutMs = normalizePositiveInteger(
+    config.timeoutMs,
+    DEFAULT_TIMEOUT_MS,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const defaultMaxRows = normalizePositiveInteger(
+    config.defaultMaxRows,
+    DEFAULT_MAX_ROWS,
+    DEFAULT_MAX_ROWS_CAP,
+  );
+  const maxRowsCap = normalizePositiveInteger(
+    config.maxRowsCap,
+    DEFAULT_MAX_ROWS_CAP,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const maxCellChars = normalizePositiveInteger(
+    config.maxCellChars,
+    DEFAULT_MAX_CELL_CHARS,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const infoSampleRows = normalizePositiveInteger(
+    config.infoSampleRows,
+    DEFAULT_INFO_SAMPLE_ROWS,
+    DEFAULT_INFO_SAMPLE_ROWS_CAP,
+  );
+  const logger = config.logger ?? silentLogger;
+
+  return [
+    createSpreadsheetInfoTool(
+      allowedPaths,
+      timeoutMs,
+      infoSampleRows,
+      maxCellChars,
+      logger,
+    ),
+    createSpreadsheetReadTool(
+      allowedPaths,
+      timeoutMs,
+      defaultMaxRows,
+      maxRowsCap,
+      maxCellChars,
+      logger,
+    ),
+  ];
+}

--- a/runtime/src/tools/system/sqlite.test.ts
+++ b/runtime/src/tools/system/sqlite.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { createSqliteTools } from "./sqlite.js";
+
+let Database: (new (path: string) => {
+  exec(sql: string): unknown;
+  close(): void;
+}) | null = null;
+
+const cleanupPaths: string[] = [];
+
+beforeAll(async () => {
+  const mod = await import("better-sqlite3");
+  Database = mod.default as typeof Database;
+});
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop()!;
+    await rm(path, { recursive: true, force: true });
+  }
+});
+
+function makeDbPath(name: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "agenc-system-sqlite-test-"));
+  cleanupPaths.push(dir);
+  return join(dir, name);
+}
+
+function findTool(name: string) {
+  const tool = createSqliteTools({
+    allowedPaths: [tmpdir()],
+  }).find((entry) => entry.name === name);
+  expect(tool).toBeDefined();
+  return tool!;
+}
+
+function createSampleDatabase(path: string): void {
+  if (!Database) {
+    throw new Error("better-sqlite3 did not load for tests");
+  }
+  const db = new Database(path);
+  db.exec(`
+    CREATE TABLE users (
+      id INTEGER PRIMARY KEY,
+      name TEXT NOT NULL,
+      role TEXT NOT NULL
+    );
+    INSERT INTO users (name, role) VALUES
+      ('Ada', 'admin'),
+      ('Linus', 'user'),
+      ('Grace', 'analyst');
+  `);
+  db.close();
+}
+
+describe("system.sqlite tools", () => {
+  it("creates the typed SQLite tools", () => {
+    const tools = createSqliteTools({
+      allowedPaths: [tmpdir()],
+    });
+    expect(tools.map((tool) => tool.name)).toEqual([
+      "system.sqliteSchema",
+      "system.sqliteQuery",
+    ]);
+  });
+
+  it("returns typed schema information", async () => {
+    const dbPath = makeDbPath("schema.db");
+    createSampleDatabase(dbPath);
+
+    const result = await findTool("system.sqliteSchema").execute({ path: dbPath });
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    const objects = parsed.objects as Array<Record<string, unknown>>;
+    const users = objects.find((entry) => entry.name === "users");
+
+    expect(users).toMatchObject({
+      type: "table",
+      name: "users",
+    });
+    expect(users?.columns).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "id", primaryKey: true }),
+        expect.objectContaining({ name: "name", type: "TEXT", notNull: true }),
+      ]),
+    );
+  });
+
+  it("executes read-only queries and returns structured rows", async () => {
+    const dbPath = makeDbPath("query.db");
+    createSampleDatabase(dbPath);
+
+    const result = await findTool("system.sqliteQuery").execute({
+      path: dbPath,
+      sql: "SELECT name, role FROM users WHERE role = ? ORDER BY name ASC",
+      params: ["admin"],
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.columns).toEqual(["name", "role"]);
+    expect(parsed.rows).toEqual([{ name: "Ada", role: "admin" }]);
+    expect(parsed.truncated).toBe(false);
+  });
+
+  it("caps row output deterministically", async () => {
+    const dbPath = makeDbPath("truncate.db");
+    createSampleDatabase(dbPath);
+
+    const result = await findTool("system.sqliteQuery").execute({
+      path: dbPath,
+      sql: "SELECT id, name FROM users ORDER BY id ASC",
+      maxRows: 2,
+    });
+
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(result.content) as Record<string, unknown>;
+    expect(parsed.rows).toEqual([
+      { id: 1, name: "Ada" },
+      { id: 2, name: "Linus" },
+    ]);
+    expect(parsed.truncated).toBe(true);
+  });
+
+  it("rejects mutating statements", async () => {
+    const dbPath = makeDbPath("mutate.db");
+    createSampleDatabase(dbPath);
+
+    const result = await findTool("system.sqliteQuery").execute({
+      path: dbPath,
+      sql: "DELETE FROM users",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("Only read-only SQLite statements are allowed");
+  });
+
+  it("blocks paths outside the allowlist", async () => {
+    const dbPath = makeDbPath("blocked.db");
+    createSampleDatabase(dbPath);
+
+    const tools = createSqliteTools({
+      allowedPaths: [join(tmpdir(), "different-root")],
+    });
+    const result = await tools[1].execute({
+      path: dbPath,
+      sql: "SELECT 1",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content).toContain("outside allowed directories");
+  });
+});

--- a/runtime/src/tools/system/sqlite.ts
+++ b/runtime/src/tools/system/sqlite.ts
@@ -1,0 +1,482 @@
+/**
+ * Typed SQLite inspection/query tools for @agenc/runtime.
+ *
+ * Provides:
+ * - system.sqliteSchema — inspect tables, views, indexes, and columns
+ * - system.sqliteQuery — execute read-only SQL and return structured rows
+ *
+ * @module
+ */
+
+import { resolve } from "node:path";
+
+import type { Tool, ToolResult } from "../types.js";
+import { safeStringify } from "../types.js";
+import { silentLogger } from "../../utils/logger.js";
+import { ensureLazyModule } from "../../utils/lazy-import.js";
+import { safePath } from "./filesystem.js";
+import type { SystemSqliteToolConfig } from "./types.js";
+
+const DEFAULT_MAX_SQL_CHARS = 20_000;
+const DEFAULT_MAX_ROWS = 200;
+const DEFAULT_MAX_ROWS_CAP = 1_000;
+const DEFAULT_MAX_CELL_CHARS = 4_000;
+
+type SqliteValue = string | number | boolean | null | Uint8Array;
+
+interface SqliteColumnInfo {
+  readonly cid: number;
+  readonly name: string;
+  readonly type: string;
+  readonly notnull: 0 | 1;
+  readonly dflt_value: string | null;
+  readonly pk: 0 | 1;
+}
+
+interface SqliteIndexInfo {
+  readonly seq: number;
+  readonly name: string;
+  readonly unique: 0 | 1;
+  readonly origin: string;
+  readonly partial: 0 | 1;
+}
+
+interface SqliteMasterRow {
+  readonly type: "table" | "view" | "index";
+  readonly name: string;
+  readonly tbl_name: string;
+  readonly sql: string | null;
+}
+
+interface SqliteStatement {
+  readonly reader: boolean;
+  columns(): Array<{ readonly name: string }>;
+  iterate(params?: unknown): Iterable<Record<string, SqliteValue>>;
+  all(params?: unknown): unknown[];
+}
+
+interface SqliteDatabase {
+  pragma(source: string, options?: { readonly simple?: boolean }): unknown;
+  prepare(sql: string): SqliteStatement;
+  close(): void;
+}
+
+type SqliteDatabaseConstructor = new (
+  path: string,
+  options?: {
+    readonly readonly?: boolean;
+    readonly fileMustExist?: boolean;
+  },
+) => SqliteDatabase;
+
+function errorResult(message: string): ToolResult {
+  return { content: safeStringify({ error: message }), isError: true };
+}
+
+function createSqliteError(message: string): Error {
+  return new Error(message);
+}
+
+async function loadSqliteDatabaseCtor(): Promise<SqliteDatabaseConstructor> {
+  return ensureLazyModule<SqliteDatabaseConstructor>(
+    "better-sqlite3",
+    createSqliteError,
+    (mod) => mod.default as SqliteDatabaseConstructor,
+  );
+}
+
+function validateAllowedPaths(allowedPaths: readonly string[]): string[] {
+  if (!Array.isArray(allowedPaths) || allowedPaths.length === 0) {
+    throw new TypeError("allowedPaths must be a non-empty array of strings");
+  }
+  return allowedPaths.map((entry) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      throw new TypeError("Each allowedPaths entry must be a non-empty string");
+    }
+    return resolve(entry).normalize("NFC");
+  });
+}
+
+function normalizePositiveInteger(
+  value: unknown,
+  fallback: number,
+  maximum: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new TypeError("Expected a positive finite integer");
+  }
+  return Math.min(Math.floor(value), maximum);
+}
+
+async function resolveSqlitePath(
+  rawPath: unknown,
+  allowedPaths: readonly string[],
+): Promise<string | ToolResult> {
+  if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+    return errorResult("Missing or invalid path");
+  }
+  const safe = await safePath(rawPath, allowedPaths);
+  if (!safe.safe) {
+    return errorResult(safe.reason ?? "Database path is outside allowed directories");
+  }
+  return safe.resolved;
+}
+
+function normalizeScalar(value: unknown): string | number | boolean | null {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  throw new TypeError(
+    "SQLite params only support string, number, boolean, or null values",
+  );
+}
+
+function normalizeSqliteParams(
+  rawParams: unknown,
+): readonly unknown[] | Record<string, unknown> | undefined {
+  if (rawParams === undefined) {
+    return undefined;
+  }
+  if (Array.isArray(rawParams)) {
+    return rawParams.map((value) => normalizeScalar(value));
+  }
+  if (rawParams && typeof rawParams === "object") {
+    return Object.fromEntries(
+      Object.entries(rawParams).map(([key, value]) => [key, normalizeScalar(value)]),
+    );
+  }
+  throw new TypeError("params must be an array, object, or omitted");
+}
+
+function normalizeSql(sql: unknown, maxSqlChars: number): string {
+  if (typeof sql !== "string" || sql.trim().length === 0) {
+    throw new TypeError("Missing or invalid sql");
+  }
+  const trimmed = sql.trim();
+  if (trimmed.length > maxSqlChars) {
+    throw new TypeError(`sql exceeds ${maxSqlChars} characters`);
+  }
+  const normalized = trimmed.replace(/;+\s*$/u, "");
+  if (normalized.includes(";")) {
+    throw new TypeError("Only a single SQL statement is allowed");
+  }
+  return normalized;
+}
+
+function previewSqliteValue(value: unknown, maxCellChars: number): unknown {
+  if (Buffer.isBuffer(value) || value instanceof Uint8Array) {
+    const buffer = Buffer.from(value);
+    const base64 = buffer.toString("base64");
+    return {
+      type: "base64",
+      bytes: buffer.byteLength,
+      truncated: base64.length > maxCellChars,
+      value: base64.slice(0, maxCellChars),
+    };
+  }
+  if (typeof value === "string") {
+    return value.length > maxCellChars ? `${value.slice(0, maxCellChars)}…` : value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  return value;
+}
+
+function extractRows(
+  statement: SqliteStatement,
+  params: readonly unknown[] | Record<string, unknown> | undefined,
+  maxRows: number,
+  maxCellChars: number,
+): {
+  readonly columns: readonly string[];
+  readonly rows: readonly Record<string, unknown>[];
+  readonly truncated: boolean;
+} {
+  const rows: Record<string, unknown>[] = [];
+  const iterator = params === undefined ? statement.iterate() : statement.iterate(params);
+  let truncated = false;
+  for (const row of iterator) {
+    if (rows.length >= maxRows) {
+      truncated = true;
+      break;
+    }
+    rows.push(
+      Object.fromEntries(
+        Object.entries(row).map(([key, value]) => [
+          key,
+          previewSqliteValue(value, maxCellChars),
+        ]),
+      ),
+    );
+  }
+  return {
+    columns: statement.columns().map((column) => column.name),
+    rows,
+    truncated,
+  };
+}
+
+function parseTableName(rawName: string): string {
+  return `"${rawName.replaceAll('"', '""')}"`;
+}
+
+async function withReadonlyDatabase<T>(
+  dbPath: string,
+  fn: (db: SqliteDatabase) => T,
+): Promise<T> {
+  const Database = await loadSqliteDatabaseCtor();
+  const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+function createSqliteSchemaTool(
+  allowedPaths: readonly string[],
+  maxCellChars: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.sqliteSchema",
+    description:
+      "Inspect a local SQLite database with a typed schema view of tables, views, indexes, and columns.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the SQLite database file.",
+        },
+        includeIndexes: {
+          type: "boolean",
+          description: "Include index definitions alongside tables and views.",
+          default: true,
+        },
+      },
+      required: ["path"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveSqlitePath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+      const includeIndexes = args.includeIndexes !== false;
+      try {
+        return await withReadonlyDatabase(resolved, (db) => {
+          const master = db
+            .prepare(
+              [
+                "SELECT type, name, tbl_name, sql",
+                "FROM sqlite_master",
+                "WHERE type IN ('table','view','index')",
+                "AND name NOT LIKE 'sqlite_%'",
+                "ORDER BY CASE type",
+                "  WHEN 'table' THEN 0",
+                "  WHEN 'view' THEN 1",
+                "  ELSE 2 END, name ASC",
+              ].join(" "),
+            )
+            .all() as SqliteMasterRow[];
+
+          const objects = master
+            .filter((row) => includeIndexes || row.type !== "index")
+            .map((row) => {
+              if (row.type === "index") {
+                return {
+                  type: row.type,
+                  name: row.name,
+                  tableName: row.tbl_name,
+                  sql: row.sql,
+                };
+              }
+              const columns = db
+                .prepare(`PRAGMA table_info(${parseTableName(row.name)})`)
+                .all() as SqliteColumnInfo[];
+              const indexes = includeIndexes
+                ? ((db
+                    .prepare(`PRAGMA index_list(${parseTableName(row.name)})`)
+                    .all() as SqliteIndexInfo[]).map((index) => ({
+                    name: index.name,
+                    unique: index.unique === 1,
+                    origin: index.origin,
+                    partial: index.partial === 1,
+                  })))
+                : [];
+              return {
+                type: row.type,
+                name: row.name,
+                sql:
+                  typeof row.sql === "string"
+                    ? previewSqliteValue(row.sql, maxCellChars)
+                    : row.sql,
+                columns: columns.map((column) => ({
+                  cid: column.cid,
+                  name: column.name,
+                  type: column.type,
+                  notNull: column.notnull === 1,
+                  defaultValue: column.dflt_value,
+                  primaryKey: column.pk === 1,
+                })),
+                indexes,
+              };
+            });
+
+          return {
+            content: safeStringify({
+              path: resolved,
+              objects,
+            }),
+          };
+        });
+      } catch (error) {
+        logger.warn?.("system.sqliteSchema failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error ? error.message : "Failed to inspect SQLite schema",
+        );
+      }
+    },
+  };
+}
+
+function createSqliteQueryTool(
+  allowedPaths: readonly string[],
+  maxSqlChars: number,
+  defaultMaxRows: number,
+  maxRowsCap: number,
+  maxCellChars: number,
+  logger = silentLogger,
+): Tool {
+  return {
+    name: "system.sqliteQuery",
+    description:
+      "Execute a single read-only SQL statement against a local SQLite database and return structured rows.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        path: {
+          type: "string",
+          description: "Path to the SQLite database file.",
+        },
+        sql: {
+          type: "string",
+          description:
+            "Single read-only SQL statement. Mutating statements are rejected.",
+        },
+        params: {
+          description:
+            "Optional positional array or named-object query parameters using only scalar JSON values.",
+          oneOf: [
+            { type: "array", items: {} },
+            { type: "object", additionalProperties: true },
+          ],
+        },
+        maxRows: {
+          type: "number",
+          description: `Maximum rows to return (default ${defaultMaxRows}, capped at ${maxRowsCap}).`,
+        },
+      },
+      required: ["path", "sql"],
+    },
+    async execute(args: Record<string, unknown>): Promise<ToolResult> {
+      const resolved = await resolveSqlitePath(args.path, allowedPaths);
+      if (typeof resolved !== "string") {
+        return resolved;
+      }
+
+      let sql: string;
+      let params: readonly unknown[] | Record<string, unknown> | undefined;
+      let maxRows: number;
+      try {
+        sql = normalizeSql(args.sql, maxSqlChars);
+        params = normalizeSqliteParams(args.params);
+        maxRows = normalizePositiveInteger(args.maxRows, defaultMaxRows, maxRowsCap);
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : "Invalid SQLite query input");
+      }
+
+      try {
+        return await withReadonlyDatabase(resolved, (db) => {
+          const statement = db.prepare(sql);
+          if (!statement.reader) {
+            return errorResult("Only read-only SQLite statements are allowed");
+          }
+          const { columns, rows, truncated } = extractRows(
+            statement,
+            params,
+            maxRows,
+            maxCellChars,
+          );
+          return {
+            content: safeStringify({
+              path: resolved,
+              sql,
+              columns,
+              rows,
+              rowCount: rows.length,
+              truncated,
+            }),
+          };
+        });
+      } catch (error) {
+        logger.warn?.("system.sqliteQuery failed", {
+          path: resolved,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return errorResult(
+          error instanceof Error ? error.message : "SQLite query failed",
+        );
+      }
+    },
+  };
+}
+
+export function createSqliteTools(config: SystemSqliteToolConfig): Tool[] {
+  const allowedPaths = validateAllowedPaths(config.allowedPaths);
+  const maxSqlChars = normalizePositiveInteger(
+    config.maxSqlChars,
+    DEFAULT_MAX_SQL_CHARS,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const defaultMaxRows = normalizePositiveInteger(
+    config.defaultMaxRows,
+    DEFAULT_MAX_ROWS,
+    DEFAULT_MAX_ROWS_CAP,
+  );
+  const maxRowsCap = normalizePositiveInteger(
+    config.maxRowsCap,
+    Math.max(DEFAULT_MAX_ROWS_CAP, defaultMaxRows),
+    Number.MAX_SAFE_INTEGER,
+  );
+  const maxCellChars = normalizePositiveInteger(
+    config.maxCellChars,
+    DEFAULT_MAX_CELL_CHARS,
+    Number.MAX_SAFE_INTEGER,
+  );
+  const logger = config.logger ?? silentLogger;
+
+  return [
+    createSqliteSchemaTool(allowedPaths, maxCellChars, logger),
+    createSqliteQueryTool(
+      allowedPaths,
+      maxSqlChars,
+      defaultMaxRows,
+      maxRowsCap,
+      maxCellChars,
+      logger,
+    ),
+  ];
+}

--- a/runtime/src/tools/system/typed-artifact-domains.ts
+++ b/runtime/src/tools/system/typed-artifact-domains.ts
@@ -1,0 +1,117 @@
+export interface TypedArtifactDomain {
+  readonly id: string;
+  readonly source: string;
+  readonly label: string;
+  readonly infoToolName: string;
+  readonly detailToolName: string;
+  readonly routingTerms: readonly string[];
+  readonly hardRoutingTerms: readonly string[];
+  readonly guidanceDomainTerms: readonly string[];
+  readonly guidanceInfoTerms: readonly string[];
+  readonly guidanceDetailTerms: readonly string[];
+}
+
+export const TYPED_ARTIFACT_DOMAINS: readonly TypedArtifactDomain[] = [
+  {
+    id: "sqlite",
+    source: "typed-sqlite",
+    label: "typed SQLite inspection",
+    infoToolName: "system.sqliteSchema",
+    detailToolName: "system.sqliteQuery",
+    routingTerms: ["sqlite", "sql", "query", "queries", "database", "db", "table", "tables", "schema", "schemas", "rows", "columns"],
+    hardRoutingTerms: ["sqlite", "sql", "database", "db", "schema", "table", "tables", "query", "queries"],
+    guidanceDomainTerms: ["sqlite", "database", "db"],
+    guidanceInfoTerms: ["schema", "table", "tables", "column", "columns", "inspect"],
+    guidanceDetailTerms: ["query", "rows", "select", "read"],
+  },
+  {
+    id: "pdf",
+    source: "typed-pdf",
+    label: "typed PDF inspection",
+    infoToolName: "system.pdfInfo",
+    detailToolName: "system.pdfExtractText",
+    routingTerms: ["document", "documents", "pdf", "pdfs", "extract", "metadata", "page", "pages", "report", "reports"],
+    hardRoutingTerms: ["pdf", "pdfs"],
+    guidanceDomainTerms: ["pdf"],
+    guidanceInfoTerms: ["metadata", "page", "pages", "title", "author", "inspect"],
+    guidanceDetailTerms: ["extract", "text", "content", "read"],
+  },
+  {
+    id: "spreadsheet",
+    source: "typed-spreadsheet",
+    label: "typed spreadsheet inspection",
+    infoToolName: "system.spreadsheetInfo",
+    detailToolName: "system.spreadsheetRead",
+    routingTerms: ["spreadsheet", "spreadsheets", "workbook", "workbooks", "sheet", "sheets", "excel", "csv", "tsv", "xlsx", "xls", "header", "headers", "cells"],
+    hardRoutingTerms: ["spreadsheet", "spreadsheets", "workbook", "workbooks", "sheet", "sheets", "excel", "csv", "tsv", "xlsx", "xls"],
+    guidanceDomainTerms: ["spreadsheet", "workbook", "sheet", "xlsx", "xls", "csv", "tsv"],
+    guidanceInfoTerms: ["inspect", "header", "headers", "metadata", "sheet", "sheets"],
+    guidanceDetailTerms: ["read", "rows", "cells", "values"],
+  },
+  {
+    id: "office-document",
+    source: "typed-office-document",
+    label: "typed office document inspection",
+    infoToolName: "system.officeDocumentInfo",
+    detailToolName: "system.officeDocumentExtractText",
+    routingTerms: ["docx", "odt", "word", "writer", "office", "proposal", "memo", "letter", "brief", "transcript"],
+    hardRoutingTerms: ["docx", "odt", "word", "writer", "office"],
+    guidanceDomainTerms: ["docx", "odt", "office", "word", "writer"],
+    guidanceInfoTerms: ["metadata", "title", "creator", "inspect"],
+    guidanceDetailTerms: ["extract", "text", "content", "read"],
+  },
+  {
+    id: "email-message",
+    source: "typed-email-message",
+    label: "typed email message inspection",
+    infoToolName: "system.emailMessageInfo",
+    detailToolName: "system.emailMessageExtractText",
+    routingTerms: ["attachment", "attachments", "email", "emails", "eml", "inbox", "mail", "message", "messages", "recipient", "recipients", "sender", "subject", "thread"],
+    hardRoutingTerms: ["attachment", "attachments", "email", "emails", "eml", "inbox", "mail", "recipient", "recipients", "sender", "subject", "thread"],
+    guidanceDomainTerms: ["email", "eml", "mail", "inbox", "message"],
+    guidanceInfoTerms: ["metadata", "subject", "sender", "recipient", "inspect"],
+    guidanceDetailTerms: ["extract", "text", "body", "attachment", "attachments", "read"],
+  },
+  {
+    id: "calendar",
+    source: "typed-calendar",
+    label: "typed calendar inspection",
+    infoToolName: "system.calendarInfo",
+    detailToolName: "system.calendarRead",
+    routingTerms: ["attendee", "attendees", "availability", "calendar", "calendars", "ics", "invite", "invites", "meeting", "meetings", "organizer", "organizers", "schedule", "scheduled", "timezone"],
+    hardRoutingTerms: ["attendee", "attendees", "calendar", "calendars", "ics", "invite", "invites", "meeting", "meetings", "organizer", "organizers", "schedule", "scheduled", "timezone"],
+    guidanceDomainTerms: ["calendar", "ics", "invite", "meeting", "meetings"],
+    guidanceInfoTerms: ["metadata", "inspect", "calendar"],
+    guidanceDetailTerms: ["attendee", "attendees", "event", "events", "read", "schedule", "scheduled"],
+  },
+] as const;
+
+export function createTypedArtifactToolNameSet(
+  domainId: string,
+): ReadonlySet<string> {
+  const domain = getTypedArtifactDomain(domainId);
+  return new Set([domain.infoToolName, domain.detailToolName]);
+}
+
+export function createTypedArtifactTermSet(
+  domainId: string,
+  field: "routingTerms" | "hardRoutingTerms",
+): ReadonlySet<string> {
+  return new Set(getTypedArtifactDomain(domainId)[field]);
+}
+
+export function getTypedArtifactDomain(domainId: string): TypedArtifactDomain {
+  const domain = TYPED_ARTIFACT_DOMAINS.find((entry) => entry.id === domainId);
+  if (!domain) {
+    throw new Error(`Unknown typed artifact domain: ${domainId}`);
+  }
+  return domain;
+}
+
+export function matchesTypedArtifactTerms(
+  terms: readonly string[],
+  domain: TypedArtifactDomain,
+  field: "routingTerms" | "hardRoutingTerms" | "guidanceDomainTerms" | "guidanceInfoTerms" | "guidanceDetailTerms",
+): boolean {
+  return terms.some((term) => domain[field].includes(term));
+}

--- a/runtime/src/tools/system/types.ts
+++ b/runtime/src/tools/system/types.ts
@@ -181,6 +181,106 @@ export interface SystemSandboxToolConfig {
   readonly now?: () => number;
 }
 
+/**
+ * Configuration for typed SQLite inspection/query tools.
+ */
+export interface SystemSqliteToolConfig {
+  /** Allowed SQLite database path prefixes (required). */
+  readonly allowedPaths: readonly string[];
+  /** Maximum SQL text length accepted per query. */
+  readonly maxSqlChars?: number;
+  /** Default maximum rows returned from a query. */
+  readonly defaultMaxRows?: number;
+  /** Hard ceiling for maxRows overrides. */
+  readonly maxRowsCap?: number;
+  /** Maximum string/binary cell preview length. */
+  readonly maxCellChars?: number;
+  /** Logger for query execution and denials. */
+  readonly logger?: Logger;
+}
+
+/**
+ * Configuration for typed PDF inspection/extraction tools.
+ */
+export interface SystemPdfToolConfig {
+  /** Allowed PDF path prefixes (required). */
+  readonly allowedPaths: readonly string[];
+  /** Default subprocess timeout for pdfinfo/pdftotext. */
+  readonly timeoutMs?: number;
+  /** Maximum extracted text characters returned by default. */
+  readonly defaultMaxChars?: number;
+  /** Hard ceiling for maxChars overrides. */
+  readonly maxCharsCap?: number;
+  /** Logger for extraction and validation failures. */
+  readonly logger?: Logger;
+}
+
+/**
+ * Configuration for typed spreadsheet inspection/extraction tools.
+ */
+export interface SystemSpreadsheetToolConfig {
+  /** Allowed spreadsheet path prefixes (required). */
+  readonly allowedPaths: readonly string[];
+  /** Default subprocess timeout for spreadsheet parsing helpers. */
+  readonly timeoutMs?: number;
+  /** Default maximum rows returned from a spreadsheet read. */
+  readonly defaultMaxRows?: number;
+  /** Hard ceiling for maxRows overrides. */
+  readonly maxRowsCap?: number;
+  /** Maximum string cell preview length. */
+  readonly maxCellChars?: number;
+  /** Number of sample rows returned by spreadsheetInfo. */
+  readonly infoSampleRows?: number;
+  /** Logger for extraction and validation failures. */
+  readonly logger?: Logger;
+}
+
+/**
+ * Configuration for typed office-document inspection/extraction tools.
+ */
+export interface SystemOfficeDocumentToolConfig {
+  /** Allowed document path prefixes (required). */
+  readonly allowedPaths: readonly string[];
+  /** Default subprocess timeout for parsing/conversion helpers. */
+  readonly timeoutMs?: number;
+  /** Maximum extracted text characters returned by default. */
+  readonly defaultMaxChars?: number;
+  /** Hard ceiling for maxChars overrides. */
+  readonly maxCharsCap?: number;
+  /** Logger for extraction and validation failures. */
+  readonly logger?: Logger;
+}
+
+/**
+ * Configuration for typed email-message inspection/extraction tools.
+ */
+export interface SystemEmailMessageToolConfig {
+  /** Allowed email message path prefixes (required). */
+  readonly allowedPaths: readonly string[];
+  /** Default subprocess timeout for parsing helpers. */
+  readonly timeoutMs?: number;
+  /** Maximum extracted text characters returned by default. */
+  readonly defaultMaxChars?: number;
+  /** Hard ceiling for maxChars overrides. */
+  readonly maxCharsCap?: number;
+  /** Logger for extraction and validation failures. */
+  readonly logger?: Logger;
+}
+
+/**
+ * Configuration for typed calendar inspection/extraction tools.
+ */
+export interface SystemCalendarToolConfig {
+  /** Allowed calendar path prefixes (required). */
+  readonly allowedPaths: readonly string[];
+  /** Default maximum events returned by calendarRead. */
+  readonly defaultMaxEvents?: number;
+  /** Hard ceiling for maxEvents overrides. */
+  readonly maxEventsCap?: number;
+  /** Logger for extraction and validation failures. */
+  readonly logger?: Logger;
+}
+
 // ============================================================================
 // Shell mode safety types
 // ============================================================================

--- a/scripts/agenc-autonomy-ladder.test.mjs
+++ b/scripts/agenc-autonomy-ladder.test.mjs
@@ -1,0 +1,388 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildAutonomyStages,
+  deriveRunPort,
+  evaluateAutonomyStage,
+  isTypedHandleTool,
+  normalizeInteractiveInput,
+  parseStageSelection,
+  pickLatestSession,
+  pickTrackedSession,
+  pickLatestTrace,
+  replaceRunVariables,
+  replaceRunToken,
+} from "./lib/agenc-autonomy-ladder.mjs";
+
+test("replaceRunToken substitutes every placeholder", () => {
+  assert.equal(
+    replaceRunToken("RUN_TOKEN::RUN_TOKEN", "abc123"),
+    "abc123::abc123",
+  );
+});
+
+test("replaceRunVariables substitutes token and derived port placeholders", () => {
+  const port = deriveRunPort("abc123");
+  assert.equal(
+    replaceRunVariables("RUN_TOKEN::RUN_PORT", "abc123", port),
+    `abc123::${port}`,
+  );
+});
+
+test("normalizeInteractiveInput flattens multiline prompts for the tmux TUI", () => {
+  assert.equal(
+    normalizeInteractiveInput("line one\n\n  line two\n- bullet"),
+    "line one line two - bullet",
+  );
+});
+
+test("parseStageSelection expands ranges and dedupes ids", () => {
+  const stages = buildAutonomyStages("token");
+  const selected = parseStageSelection("0-2,2,4", stages);
+  assert.deepEqual(
+    selected.map((stage) => stage.id),
+    ["0", "1", "2", "4"],
+  );
+});
+
+test("buildAutonomyStages supports the server scenario", () => {
+  const stages = buildAutonomyStages("token", "server");
+  assert.deepEqual(
+    stages.map((stage) => stage.id),
+    ["srv1", "srv2", "srv3", "srv4", "srv5"],
+  );
+  assert.match(stages[0].actions[0].input, /http:\/\/127\.0\.0\.1:\d+\//);
+  assert.match(stages[0].actions[0].input, /system.*server|typed server handle tools/i);
+});
+
+test("buildAutonomyStages supports the spreadsheet scenario", () => {
+  const stages = buildAutonomyStages("token", "spreadsheet");
+  assert.deepEqual(stages.map((stage) => stage.id), ["sheet1"]);
+  assert.match(stages[0].actions[0].input, /typed spreadsheet tools/i);
+  assert.match(stages[0].actions[0].input, /roster\.xlsx/i);
+});
+
+test("buildAutonomyStages supports the office-document scenario", () => {
+  const stages = buildAutonomyStages("token", "office-document");
+  assert.deepEqual(stages.map((stage) => stage.id), ["doc1"]);
+  assert.match(stages[0].actions[0].input, /typed office document tools/i);
+  assert.match(stages[0].actions[0].input, /launch-brief\.docx/i);
+});
+
+test("buildAutonomyStages supports the productivity scenario", () => {
+  const stages = buildAutonomyStages("token", "productivity");
+  assert.deepEqual(stages.map((stage) => stage.id), ["mail1", "cal1"]);
+  assert.match(stages[0].actions[0].input, /typed email message tools/i);
+  assert.match(stages[1].actions[0].input, /typed calendar tools/i);
+  assert.equal(stages[0].timeoutMs, 35_000);
+  assert.equal(stages[1].timeoutMs, 35_000);
+});
+
+test("pickLatestSession returns the most recent session", () => {
+  const latest = pickLatestSession([
+    { sessionId: "older", lastActiveAt: 10 },
+    { sessionId: "newer", lastActiveAt: 20 },
+  ]);
+  assert.equal(latest.sessionId, "newer");
+});
+
+test("pickTrackedSession prefers the current tracked session when present", () => {
+  const tracked = pickTrackedSession(
+    [
+      { sessionId: "older", lastActiveAt: 10 },
+      { sessionId: "tracked", lastActiveAt: 5 },
+      { sessionId: "newer", lastActiveAt: 20 },
+    ],
+    "tracked",
+  );
+  assert.equal(tracked.sessionId, "tracked");
+});
+
+test("pickLatestTrace prefers traces at or after the stage start", () => {
+  const picked = pickLatestTrace(
+    [
+      { traceId: "old", updatedAt: 10 },
+      { traceId: "new", updatedAt: 30 },
+    ],
+    20,
+  );
+  assert.equal(picked.traceId, "new");
+});
+
+test("isTypedHandleTool recognizes structured long-lived tools", () => {
+  assert.equal(isTypedHandleTool("system.processStart"), true);
+  assert.equal(isTypedHandleTool("desktop.process_start"), true);
+  assert.equal(isTypedHandleTool("system.bash"), false);
+});
+
+test("evaluateAutonomyStage stage0 rejects tool usage", () => {
+  const result = evaluateAutonomyStage("stage0", {
+    runToken: "abc",
+    paneText: "AUTONOMY_STAGE0::abc",
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [{ toolName: "system.bash" }],
+    },
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.reasons.join("\n"), /no-tool stage/i);
+});
+
+test("evaluateAutonomyStage stage0 waits for a completed trace", () => {
+  const result = evaluateAutonomyStage("stage0", {
+    runToken: "abc",
+    paneText: "AUTONOMY_STAGE0::abc",
+    traceDetail: {
+      summary: { status: "open" },
+      events: [],
+    },
+  });
+  assert.equal(result.passed, false);
+  assert.match(result.reasons.join("\n"), /completed status/i);
+});
+
+test("evaluateAutonomyStage stage4 requires typed handle evidence", () => {
+  const result = evaluateAutonomyStage("stage4", {
+    runToken: "abc",
+    sessionId: "session-1",
+    paneText: "watching run",
+    runDetail: {
+      runId: "run-1",
+      state: "working",
+      lastToolEvidence: "system.processStatus [ok] running",
+      observedTargets: [{ processId: "proc-1" }],
+    },
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [{ toolName: "system.processStart" }],
+    },
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.runId, "run-1");
+});
+
+test("evaluateAutonomyStage stage4 accepts typed handle evidence from run state", () => {
+  const result = evaluateAutonomyStage("stage4", {
+    runToken: "abc",
+    sessionId: "session-1",
+    paneText: "watching run",
+    runDetail: {
+      runId: "run-1",
+      state: "working",
+      lastToolEvidence:
+        "system.processStatus [ok] {\"processId\":\"proc-1\",\"state\":\"running\"}",
+      observedTargets: [{ processId: "proc-1" }],
+    },
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [{ toolName: "background.placeholder" }],
+    },
+    traceText: "",
+    runText:
+      "{\"lastToolEvidence\":\"system.processStatus [ok] {\\\"processId\\\":\\\"proc-1\\\"}\"}",
+  });
+  assert.equal(result.passed, true);
+});
+
+test("evaluateAutonomyStage server_stage_start requires server-handle readiness evidence", () => {
+  const result = evaluateAutonomyStage("server_stage_start", {
+    runToken: "abc",
+    sessionId: "session-1",
+    paneText: "watching run",
+    runDetail: {
+      runId: "run-1",
+      state: "working",
+      observedTargets: [{ processId: "proc-1" }],
+    },
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [],
+    },
+    runText:
+      "{\"lastToolEvidence\":\"- system.serverStart [ok] {\\\"serverId\\\":\\\"server-1\\\",\\\"ready\\\":true,\\\"healthUrl\\\":\\\"http://127.0.0.1:9300/\\\"}\\n- system.serverStatus [ok] {\\\"ready\\\":true}\"}",
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.runId, "run-1");
+});
+
+test("evaluateAutonomyStage server_stage_start accepts structured server readiness evidence", () => {
+  const result = evaluateAutonomyStage("server_stage_start", {
+    runToken: "abc",
+    sessionId: "session-1",
+    paneText: "watching run",
+    runDetail: {
+      runId: "run-1",
+      state: "working",
+      observedTargets: [
+        {
+          kind: "managed_process",
+          surface: "host_server",
+          processId: "proc-1",
+          serverId: "server-1",
+          ready: true,
+          launchSpec: {
+            kind: "server",
+            healthUrl: "http://127.0.0.1:9300/",
+          },
+        },
+      ],
+      artifacts: [{ source: "system.serverStart" }],
+    },
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [],
+    },
+    runText: "",
+  });
+  assert.equal(result.passed, true);
+  assert.equal(result.runId, "run-1");
+});
+
+test("evaluateAutonomyStage stage1 accepts desktop.bash in desktop mode", () => {
+  const result = evaluateAutonomyStage("stage1", {
+    runToken: "abc",
+    paneText: "AUTONOMY_STAGE1::abc",
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [{ toolName: "desktop.bash" }],
+    },
+    traceText: "desktop.bash",
+    runText: "",
+  });
+  assert.equal(result.passed, true);
+});
+
+test("evaluateAutonomyStage spreadsheet_stage_read requires typed spreadsheet evidence", () => {
+  const result = evaluateAutonomyStage("spreadsheet_stage_read", {
+    runToken: "abc",
+    paneText:
+      "Exact row count: **2**\n- Ada -> admin\n- Linus -> user",
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [
+        { toolName: "system.spreadsheetInfo" },
+        { toolName: "system.spreadsheetRead" },
+      ],
+    },
+  });
+  assert.equal(result.passed, true);
+});
+
+test("evaluateAutonomyStage office_document_stage_read requires typed office document evidence", () => {
+  const result = evaluateAutonomyStage("office_document_stage_read", {
+    runToken: "abc",
+    paneText:
+      "Format: DOCX\nLaunch Brief\nAgenC Smoke\nHello DOCX Brief\nStatus update line two.",
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [
+        { toolName: "system.officeDocumentInfo" },
+        { toolName: "system.officeDocumentExtractText" },
+      ],
+    },
+  });
+  assert.equal(result.passed, true);
+});
+
+test("evaluateAutonomyStage email_message_stage_read requires typed email evidence", () => {
+  const result = evaluateAutonomyStage("email_message_stage_read", {
+    runToken: "abc",
+    paneText:
+      "Sprint update\nalice@example.com\nbob@example.com\nHello team,\nSprint review is at 10:00 AM.",
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [
+        { toolName: "system.emailMessageInfo" },
+        { toolName: "system.emailMessageExtractText" },
+      ],
+    },
+  });
+  assert.equal(result.passed, true);
+});
+
+test("evaluateAutonomyStage calendar_stage_read requires typed calendar evidence", () => {
+  const result = evaluateAutonomyStage("calendar_stage_read", {
+    runToken: "abc",
+    paneText:
+      "Team Calendar\nExact event count: **2**\nProduct Review\nPlanning Day\nbob@example.com\ncarol@example.com",
+    traceDetail: {
+      summary: { status: "completed" },
+      events: [
+        { toolName: "system.calendarInfo" },
+        { toolName: "system.calendarRead" },
+      ],
+    },
+  });
+  assert.equal(result.passed, true);
+});
+
+test("evaluateAutonomyStage stage7 preserves the durable run id across restart", () => {
+  const result = evaluateAutonomyStage(
+    "stage7",
+    {
+      runToken: "abc",
+      sessionId: "session-1",
+      paneText: "session healthy session-1",
+      runDetail: {
+        runId: "run-1",
+        state: "working",
+      },
+    },
+    { runId: "run-1" },
+  );
+  assert.equal(result.passed, true);
+});
+
+test("evaluateAutonomyStage stage7 rejects a still-reconnecting operator console", () => {
+  const result = evaluateAutonomyStage(
+    "stage7",
+    {
+      runToken: "abc",
+      sessionId: "session-1",
+      paneText: "[LINK] reconnecting\nUnknown message type: chat.new",
+      runDetail: {
+        runId: "run-1",
+        state: "working",
+      },
+    },
+    { runId: "run-1" },
+  );
+  assert.equal(result.passed, false);
+  assert.match(result.reasons.join("\n"), /operator console/i);
+});
+
+test("evaluateAutonomyStage stage7 rejects a bootstrap-retrying operator console", () => {
+  const result = evaluateAutonomyStage(
+    "stage7",
+    {
+      runToken: "abc",
+      sessionId: "session-1",
+      paneText: "[INFO] webchat handler still starting; retrying in 1500ms",
+      runDetail: {
+        runId: "run-1",
+        state: "running",
+      },
+    },
+    { runId: "run-1" },
+  );
+  assert.equal(result.passed, false);
+  assert.match(result.reasons.join("\n"), /operator console/i);
+});
+
+test("evaluateAutonomyStage stage7 rejects the wrong resumed session", () => {
+  const result = evaluateAutonomyStage(
+    "stage7",
+    {
+      runToken: "abc",
+      sessionId: "session-1",
+      paneText: "session healthy but attached to session-9",
+      runDetail: {
+        runId: "run-1",
+        state: "working",
+      },
+    },
+    { runId: "run-1" },
+  );
+  assert.equal(result.passed, false);
+  assert.match(result.reasons.join("\n"), /different session/i);
+});

--- a/scripts/agenc-watch.mjs
+++ b/scripts/agenc-watch.mjs
@@ -42,11 +42,16 @@ let runInspectPending = false;
 let isOpen = false;
 let reconnectAttempts = 0;
 let reconnectTimer = null;
+let bootstrapTimer = null;
+let bootstrapAttempts = 0;
+let bootstrapReady = false;
 let shuttingDown = false;
 let ws = null;
 let enteredAltScreen = false;
 let renderPending = false;
 let transientStatus = "Booting watch client…";
+let lastStatus = null;
+const queuedOperatorInputs = [];
 
 const pendingFrames = [];
 const events = [];
@@ -259,6 +264,108 @@ function requestRunInspect(reason) {
   setTransientStatus(`refreshing run card (${reason})`);
 }
 
+function isExpectedMissingRunInspect(errorText) {
+  return (
+    typeof errorText === "string" &&
+    errorText.includes("Background run") &&
+    errorText.includes("not found")
+  );
+}
+
+function isRetryableBootstrapError(errorText) {
+  return (
+    typeof errorText === "string" &&
+    (
+      errorText === "Unknown message type: chat.new" ||
+      errorText === "Unknown message type: chat.sessions" ||
+      errorText === "Unknown message type: chat.resume"
+    )
+  );
+}
+
+function latestSessionSummary(payload, preferredSessionId = null) {
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return null;
+  }
+  if (preferredSessionId) {
+    const preferred = payload.find((session) => session?.sessionId === preferredSessionId);
+    if (preferred) {
+      return preferred;
+    }
+  }
+  return [...payload].sort((left, right) => {
+    const leftTime = Number(left?.lastActiveAt ?? 0);
+    const rightTime = Number(right?.lastActiveAt ?? 0);
+    return rightTime - leftTime;
+  })[0] ?? null;
+}
+
+function clearBootstrapTimer() {
+  if (!bootstrapTimer) {
+    return;
+  }
+  clearTimeout(bootstrapTimer);
+  bootstrapTimer = null;
+}
+
+function bootstrapPending() {
+  return !bootstrapReady;
+}
+
+function queueOperatorInput(value, reason = "bootstrap pending") {
+  queuedOperatorInputs.push(value);
+  pushEvent(
+    "queued",
+    "Queued Input",
+    `${value}\n\n${reason}`,
+    "amber",
+  );
+  setTransientStatus(`queued ${value} until session restore completes`);
+}
+
+function flushQueuedOperatorInputs() {
+  if (!isOpen || bootstrapPending() || queuedOperatorInputs.length === 0) {
+    return;
+  }
+  while (queuedOperatorInputs.length > 0) {
+    const value = queuedOperatorInputs.shift();
+    if (!value) {
+      continue;
+    }
+    dispatchOperatorInput(value, { replayed: true });
+  }
+}
+
+function markBootstrapReady(statusText) {
+  bootstrapReady = true;
+  bootstrapAttempts = 0;
+  clearBootstrapTimer();
+  setTransientStatus(statusText);
+  flushQueuedOperatorInputs();
+}
+
+function sendBootstrapProbe() {
+  if (!isOpen || shuttingDown) {
+    return;
+  }
+  send("chat.sessions", { clientKey });
+}
+
+function scheduleBootstrap(reason = "restoring session") {
+  if (shuttingDown || !isOpen) {
+    return;
+  }
+  bootstrapReady = false;
+  clearBootstrapTimer();
+  const delayMs = Math.min(2_000, Math.max(250, bootstrapAttempts * 250));
+  bootstrapTimer = setTimeout(() => {
+    bootstrapTimer = null;
+    bootstrapAttempts += 1;
+    sendBootstrapProbe();
+  }, delayMs);
+  setTransientStatus(`${reason}; retrying in ${delayMs}ms`);
+}
+
 function headerLines(width) {
   const inner = width - 2;
   const shortSession = sessionId ? sessionId.slice(-8) : "--------";
@@ -412,6 +519,9 @@ function scheduleReconnect() {
 function handleToolResult(toolName, isError, result) {
   latestTool = toolName;
   latestToolState = isError ? "error" : "ok";
+  setTransientStatus(
+    isError ? `${toolName} failed` : `${toolName} completed`,
+  );
   const parsed = tryParseJson(result);
   const summary = buildToolSummary(parsed);
   const formatted = tryPrettyJson(result);
@@ -427,12 +537,14 @@ function attachSocket(socket) {
     ws = socket;
     isOpen = true;
     reconnectAttempts = 0;
+    bootstrapAttempts = 0;
+    bootstrapReady = false;
     connectionState = "live";
     setTransientStatus(`connected to ${wsUrl}`);
     while (pendingFrames.length > 0) {
       socket.send(pendingFrames.shift());
     }
-    send("chat.new", { clientKey });
+    sendBootstrapProbe();
   });
 
   socket.addEventListener("message", (event) => {
@@ -451,20 +563,37 @@ function attachSocket(socket) {
         runDetail = null;
         runState = "idle";
         runPhase = null;
-        setTransientStatus(`session ready: ${sessionId}`);
+        markBootstrapReady(`session ready: ${sessionId}`);
         break;
       case "chat.resumed":
         sessionId = msg.payload?.sessionId ?? sessionId;
-        setTransientStatus(`session resumed: ${sessionId}`);
+        markBootstrapReady(`session resumed: ${sessionId}`);
         requestRunInspect("resume");
         break;
+      case "chat.sessions": {
+        const target = latestSessionSummary(msg.payload, sessionId);
+        if (target?.sessionId) {
+          sessionId = target.sessionId;
+          setTransientStatus(`resuming session ${sessionId}`);
+          send("chat.resume", { sessionId: target.sessionId, clientKey });
+        } else {
+          setTransientStatus("no existing session; creating a new one");
+          send("chat.new", { clientKey });
+        }
+        break;
+      }
       case "chat.history": {
         const history = Array.isArray(msg.payload) ? msg.payload : [];
-        setTransientStatus(`history restored: ${history.length} item(s)`);
+        if (!bootstrapReady && sessionId) {
+          markBootstrapReady(`history restored: ${history.length} item(s)`);
+        } else {
+          setTransientStatus(`history restored: ${history.length} item(s)`);
+        }
         break;
       }
       case "chat.message":
         latestAgentSummary = msg.payload?.content ?? null;
+        setTransientStatus("agent reply received");
         pushEvent("agent", "Agent Reply", msg.payload?.content ?? "", "cyan");
         if (currentObjective) {
           requestRunInspect("agent reply");
@@ -479,6 +608,7 @@ function attachSocket(socket) {
         setTransientStatus("agent is typing…");
         break;
       case "chat.cancelled":
+        setTransientStatus("chat cancelled");
         pushEvent("cancelled", "Chat Cancelled", tryPrettyJson(msg.payload ?? {}), "amber");
         break;
       case "tools.executing":
@@ -509,11 +639,13 @@ function attachSocket(socket) {
         currentObjective = msg.payload?.objective ?? currentObjective;
         runState = msg.payload?.state ?? runState;
         runPhase = msg.payload?.currentPhase ?? runPhase;
+        setTransientStatus(`run inspect loaded: ${runState ?? "unknown"}`);
         pushEvent("inspect", "Run Inspect", tryPrettyJson(msg.payload ?? {}), "blue");
         break;
       case "run.updated":
         runState = msg.payload?.state ?? runState;
         runPhase = msg.payload?.currentPhase ?? runPhase;
+        setTransientStatus(`run updated: ${runState ?? "unknown"}`);
         pushEvent(
           "run",
           "Run Update",
@@ -530,9 +662,11 @@ function attachSocket(socket) {
         requestRunInspect("run update");
         break;
       case "observability.traces":
+        setTransientStatus("trace list loaded");
         pushEvent("trace", "Trace List", tryPrettyJson(msg.payload ?? []), "slate");
         break;
       case "observability.trace":
+        setTransientStatus("trace detail loaded");
         pushEvent(
           "trace",
           "Trace Detail",
@@ -542,6 +676,7 @@ function attachSocket(socket) {
         break;
       case "status.update":
         lastStatus = msg.payload ?? lastStatus;
+        setTransientStatus("gateway status loaded");
         pushEvent("status", "Gateway Status", tryPrettyJson(msg.payload ?? {}), "blue");
         break;
       case "agent.status":
@@ -554,6 +689,16 @@ function attachSocket(socket) {
         break;
       case "error":
         runInspectPending = false;
+        if (isExpectedMissingRunInspect(msg.error)) {
+          runDetail = null;
+          setTransientStatus("no active background run for this session");
+          break;
+        }
+        if (isRetryableBootstrapError(msg.error)) {
+          scheduleBootstrap("webchat handler still starting");
+          break;
+        }
+        setTransientStatus("runtime error");
         pushEvent("error", "Runtime Error", msg.error ?? tryPrettyJson(msg.payload ?? msg), "red");
         break;
       default:
@@ -566,7 +711,9 @@ function attachSocket(socket) {
   socket.addEventListener("close", () => {
     isOpen = false;
     ws = null;
+    bootstrapReady = false;
     connectionState = "reconnecting";
+    clearBootstrapTimer();
     if (shuttingDown) {
       leaveAltScreen();
       process.exit(0);
@@ -608,6 +755,156 @@ function printHelp() {
   );
 }
 
+function shouldQueueOperatorInput(value) {
+  if (!isOpen || bootstrapPending()) {
+    return true;
+  }
+  if (!value.startsWith("/")) {
+    return false;
+  }
+  return false;
+}
+
+function dispatchOperatorInput(value, { replayed = false } = {}) {
+  const maybeQueue = (reason) => {
+    if (replayed) {
+      pushEvent("error", "Queued Input Failed", `${value}\n\n${reason}`, "red");
+      return true;
+    }
+    queueOperatorInput(value, reason);
+    return true;
+  };
+
+  if (value === "/quit" || value === "/exit") {
+    shuttingDown = true;
+    if (reconnectTimer) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    clearBootstrapTimer();
+    rl.close();
+    ws?.close();
+    leaveAltScreen();
+    return true;
+  }
+
+  if (value === "/help") {
+    printHelp();
+    return true;
+  }
+
+  if (value === "/clear") {
+    events.length = 0;
+    setTransientStatus("console cleared");
+    return true;
+  }
+
+  if (value === "/new") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    currentObjective = null;
+    runDetail = null;
+    runState = "idle";
+    runPhase = null;
+    bootstrapAttempts = 0;
+    clearBootstrapTimer();
+    pushEvent("operator", "New Session", "Requested a fresh chat session.", "teal");
+    send("chat.new", { clientKey });
+    return true;
+  }
+
+  if (value === "/runs") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    pushEvent("operator", "Run List", "Requested active runs for this session.", "teal");
+    send("runs.list", sessionId ? { sessionId } : {});
+    return true;
+  }
+
+  if (value === "/inspect") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    if (!requireSession("/inspect")) return;
+    runInspectPending = true;
+    pushEvent("operator", "Run Inspect", `Inspecting run for ${sessionId}.`, "teal");
+    send("run.inspect", { sessionId });
+    return true;
+  }
+
+  if (value === "/trace") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    pushEvent("operator", "Trace Query", "Requested recent traces.", "teal");
+    send("observability.traces", sessionId ? { sessionId, limit: 5 } : { limit: 5 });
+    return true;
+  }
+
+  if (value === "/status") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    pushEvent("operator", "Gateway Status", "Requested daemon status.", "teal");
+    send("status.get", {});
+    return true;
+  }
+
+  if (value === "/cancel") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    pushEvent("operator", "Cancel Chat", `Cancelling chat for ${clientKey}.`, "teal");
+    send("chat.cancel", { clientKey });
+    return true;
+  }
+
+  if (value === "/pause") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    if (!requireSession("/pause")) return;
+    runInspectPending = true;
+    pushEvent("operator", "Pause Run", `Pausing run for ${sessionId}.`, "teal");
+    send("run.control", { action: "pause", sessionId, reason: "operator pause" });
+    return true;
+  }
+
+  if (value === "/resume") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    if (!requireSession("/resume")) return;
+    runInspectPending = true;
+    pushEvent("operator", "Resume Run", `Resuming run for ${sessionId}.`, "teal");
+    send("run.control", { action: "resume", sessionId, reason: "operator resume" });
+    return true;
+  }
+
+  if (value === "/stop") {
+    if (shouldQueueOperatorInput(value)) {
+      return maybeQueue("session bootstrap not complete");
+    }
+    if (!requireSession("/stop")) return;
+    runInspectPending = true;
+    pushEvent("operator", "Stop Run", `Stopping run for ${sessionId}.`, "teal");
+    send("run.control", { action: "stop", sessionId, reason: "operator stop" });
+    return true;
+  }
+
+  if (shouldQueueOperatorInput(value)) {
+    return maybeQueue("session bootstrap not complete");
+  }
+  currentObjective = value;
+  runState = "starting";
+  runPhase = "queued";
+  pushEvent("you", "Prompt", value, "teal");
+  send("chat.message", { content: value, clientKey });
+  return true;
+}
+
 connect();
 scheduleRender();
 
@@ -617,101 +914,7 @@ rl.on("line", (input) => {
     scheduleRender();
     return;
   }
-
-  if (value === "/quit" || value === "/exit") {
-    shuttingDown = true;
-    if (reconnectTimer) {
-      clearTimeout(reconnectTimer);
-      reconnectTimer = null;
-    }
-    rl.close();
-    ws?.close();
-    leaveAltScreen();
-    return;
-  }
-
-  if (value === "/help") {
-    printHelp();
-    return;
-  }
-
-  if (value === "/clear") {
-    events.length = 0;
-    setTransientStatus("console cleared");
-    return;
-  }
-
-  if (value === "/new") {
-    currentObjective = null;
-    runDetail = null;
-    runState = "idle";
-    runPhase = null;
-    pushEvent("operator", "New Session", "Requested a fresh chat session.", "teal");
-    send("chat.new", { clientKey });
-    return;
-  }
-
-  if (value === "/runs") {
-    pushEvent("operator", "Run List", "Requested active runs for this session.", "teal");
-    send("runs.list", sessionId ? { sessionId } : {});
-    return;
-  }
-
-  if (value === "/inspect") {
-    if (!requireSession("/inspect")) return;
-    runInspectPending = true;
-    pushEvent("operator", "Run Inspect", `Inspecting run for ${sessionId}.`, "teal");
-    send("run.inspect", { sessionId });
-    return;
-  }
-
-  if (value === "/trace") {
-    pushEvent("operator", "Trace Query", "Requested recent traces.", "teal");
-    send("observability.traces", sessionId ? { sessionId, limit: 5 } : { limit: 5 });
-    return;
-  }
-
-  if (value === "/status") {
-    pushEvent("operator", "Gateway Status", "Requested daemon status.", "teal");
-    send("status.get", {});
-    return;
-  }
-
-  if (value === "/cancel") {
-    pushEvent("operator", "Cancel Chat", `Cancelling chat for ${clientKey}.`, "teal");
-    send("chat.cancel", { clientKey });
-    return;
-  }
-
-  if (value === "/pause") {
-    if (!requireSession("/pause")) return;
-    runInspectPending = true;
-    pushEvent("operator", "Pause Run", `Pausing run for ${sessionId}.`, "teal");
-    send("run.control", { action: "pause", sessionId, reason: "operator pause" });
-    return;
-  }
-
-  if (value === "/resume") {
-    if (!requireSession("/resume")) return;
-    runInspectPending = true;
-    pushEvent("operator", "Resume Run", `Resuming run for ${sessionId}.`, "teal");
-    send("run.control", { action: "resume", sessionId, reason: "operator resume" });
-    return;
-  }
-
-  if (value === "/stop") {
-    if (!requireSession("/stop")) return;
-    runInspectPending = true;
-    pushEvent("operator", "Stop Run", `Stopping run for ${sessionId}.`, "teal");
-    send("run.control", { action: "stop", sessionId, reason: "operator stop" });
-    return;
-  }
-
-  currentObjective = value;
-  runState = "starting";
-  runPhase = "queued";
-  pushEvent("you", "Prompt", value, "teal");
-  send("chat.message", { content: value, clientKey });
+  dispatchOperatorInput(value);
 });
 
 rl.on("SIGINT", () => {
@@ -726,6 +929,7 @@ rl.on("close", () => {
     clearTimeout(reconnectTimer);
     reconnectTimer = null;
   }
+  clearBootstrapTimer();
   try {
     ws?.close();
   } catch {}

--- a/scripts/lib/agenc-autonomy-ladder.mjs
+++ b/scripts/lib/agenc-autonomy-ladder.mjs
@@ -1,0 +1,421 @@
+export {
+  evaluateAutonomyStage,
+  isTypedHandleTool,
+} from "./agenc-autonomy-stage-evaluators.mjs";
+
+const DEFAULT_SESSION_STAGE_TIMEOUT_MS = 20_000;
+const DEFAULT_BACKGROUND_STAGE_TIMEOUT_MS = 45_000;
+const DEFAULT_RESTART_STAGE_TIMEOUT_MS = 75_000;
+const DEFAULT_TYPED_ARTIFACT_STAGE_TIMEOUT_MS = 35_000;
+
+const BASELINE_STAGE_TEMPLATES = [
+  {
+    id: "0",
+    title: "Transport Sanity",
+    timeoutMs: DEFAULT_SESSION_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Reply with exactly `AUTONOMY_STAGE0::RUN_TOKEN` and nothing else. Do not call any tools.",
+        evaluationId: "stage0",
+      },
+    ],
+  },
+  {
+    id: "1",
+    title: "Single Tool Grounding",
+    timeoutMs: DEFAULT_SESSION_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Use the shell tool appropriate for the current environment to run `/usr/bin/printf` so it prints `AUTONOMY_STAGE1::RUN_TOKEN\\n`. In the `agenc-watch` desktop session, that means `desktop.bash`; in a host-only session, `system.bash` is also acceptable.\n\nThen answer with:\n- the exact output\n- the tool name you used\n\nDo not invent results. If the tool fails, explain the real failure.",
+        evaluationId: "stage1",
+      },
+    ],
+  },
+  {
+    id: "2",
+    title: "Multi-Tool File Workflow",
+    timeoutMs: DEFAULT_SESSION_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Use tools to create `/tmp/agenc-autonomy-RUN_TOKEN.txt` with the exact content `AUTONOMY_STAGE2::RUN_TOKEN`, then read the file back and answer with:\n- the absolute path\n- the exact contents you verified\n\nDo not skip the verification read.",
+        evaluationId: "stage2",
+      },
+    ],
+  },
+  {
+    id: "3",
+    title: "Policy Simulation",
+    timeoutMs: DEFAULT_SESSION_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "/policy simulate system.delete {\"target\":\"/tmp/agenc-autonomy-RUN_TOKEN.txt\"}",
+        evaluationId: "stage3",
+      },
+    ],
+  },
+  {
+    id: "4",
+    title: "Durable Background Supervision",
+    timeoutMs: DEFAULT_BACKGROUND_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Start a durable background run that uses typed long-lived handle tools, not raw shell backgrounding, to run `/bin/sleep 45` under the label `autonomy-watch-RUN_TOKEN`.\n\nRequirements:\n- use the structured process/runtime path\n- keep supervising it in the background\n- emit operator-visible progress updates\n- record verified evidence\n- when setup is complete, report the run/session id, the handle id, and the latest verified evidence",
+        evaluationId: "stage4",
+      },
+    ],
+  },
+  {
+    id: "5",
+    title: "Operator Controls",
+    timeoutMs: DEFAULT_BACKGROUND_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "pause",
+        kind: "command",
+        input: "/pause",
+        evaluationId: "stage5_pause",
+      },
+      {
+        id: "resume",
+        kind: "command",
+        input: "/resume",
+        evaluationId: "stage5_resume",
+      },
+      {
+        id: "inspect",
+        kind: "command",
+        input: "/inspect",
+        evaluationId: "stage5_inspect",
+      },
+    ],
+  },
+  {
+    id: "6",
+    title: "TRACE Validation",
+    timeoutMs: DEFAULT_SESSION_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "trace",
+        kind: "command",
+        input: "/trace",
+        evaluationId: "stage6",
+      },
+    ],
+  },
+  {
+    id: "7",
+    title: "Restart Recovery",
+    timeoutMs: DEFAULT_RESTART_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "restart",
+        kind: "restart",
+        evaluationId: "stage7",
+      },
+    ],
+  },
+  {
+    id: "8",
+    title: "Cleanup Stop",
+    timeoutMs: DEFAULT_BACKGROUND_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "stop",
+        kind: "command",
+        input: "/stop",
+        evaluationId: "stage8",
+      },
+    ],
+  },
+];
+
+const SERVER_STAGE_TEMPLATES = [
+  {
+    id: "srv1",
+    title: "Durable HTTP Service Supervision",
+    timeoutMs: DEFAULT_BACKGROUND_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Start a durable background run that uses typed server handle tools, not raw shell backgrounding, to run `python3 -m http.server RUN_PORT` from `/home/tetsuo/git/AgenC` under the label `autonomy-server-RUN_TOKEN`.\n\nRequirements:\n- use the structured server/runtime path\n- verify readiness on `http://127.0.0.1:RUN_PORT/`\n- keep supervising it in the background\n- emit operator-visible progress updates\n- record verified evidence\n- when setup is complete, report the run/session id, the server handle id, the process handle id, and the latest verified evidence",
+        evaluationId: "server_stage_start",
+      },
+    ],
+  },
+  {
+    id: "srv2",
+    title: "Operator Controls",
+    timeoutMs: DEFAULT_BACKGROUND_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "pause",
+        kind: "command",
+        input: "/pause",
+        evaluationId: "stage5_pause",
+      },
+      {
+        id: "resume",
+        kind: "command",
+        input: "/resume",
+        evaluationId: "stage5_resume",
+      },
+      {
+        id: "inspect",
+        kind: "command",
+        input: "/inspect",
+        evaluationId: "stage5_inspect",
+      },
+    ],
+  },
+  {
+    id: "srv3",
+    title: "TRACE Validation",
+    timeoutMs: DEFAULT_SESSION_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "trace",
+        kind: "command",
+        input: "/trace",
+        evaluationId: "stage6",
+      },
+    ],
+  },
+  {
+    id: "srv4",
+    title: "Restart Recovery",
+    timeoutMs: DEFAULT_RESTART_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "restart",
+        kind: "restart",
+        evaluationId: "stage7",
+      },
+    ],
+  },
+  {
+    id: "srv5",
+    title: "Cleanup Stop",
+    timeoutMs: DEFAULT_BACKGROUND_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "stop",
+        kind: "command",
+        input: "/stop",
+        evaluationId: "stage8",
+      },
+    ],
+  },
+];
+
+const SPREADSHEET_STAGE_TEMPLATES = [
+  {
+    id: "sheet1",
+    title: "Typed Spreadsheet Inspection",
+    timeoutMs: DEFAULT_TYPED_ARTIFACT_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Use the typed spreadsheet tools to inspect `/tmp/agenc-tool-smoke/roster.xlsx`. Summarize the workbook, then read the `Roster` sheet and answer with:\n- the exact row count\n- the name/role pairs\n\nDo not use shell unless the typed spreadsheet tools fail.",
+        evaluationId: "spreadsheet_stage_read",
+      },
+    ],
+  },
+];
+
+const OFFICE_DOCUMENT_STAGE_TEMPLATES = [
+  {
+    id: "doc1",
+    title: "Typed Office Document Inspection",
+    timeoutMs: DEFAULT_TYPED_ARTIFACT_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Use the typed office document tools to inspect `/tmp/agenc-tool-smoke/launch-brief.docx`. Answer with:\n- the exact document metadata\n- the exact extracted text\n\nDo not use shell unless the typed office document tools fail.",
+        evaluationId: "office_document_stage_read",
+      },
+    ],
+  },
+];
+
+const PRODUCTIVITY_STAGE_TEMPLATES = [
+  {
+    id: "mail1",
+    title: "Typed Email Message Inspection",
+    timeoutMs: DEFAULT_TYPED_ARTIFACT_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Use the typed email message tools to inspect `/tmp/agenc-tool-smoke/inbox.eml`. Answer with:\n- the exact message metadata\n- the exact extracted text\n\nDo not use shell unless the typed email message tools fail.",
+        evaluationId: "email_message_stage_read",
+      },
+    ],
+  },
+  {
+    id: "cal1",
+    title: "Typed Calendar Inspection",
+    timeoutMs: DEFAULT_TYPED_ARTIFACT_STAGE_TIMEOUT_MS,
+    actions: [
+      {
+        id: "prompt",
+        kind: "input",
+        input:
+          "Use the typed calendar tools to inspect `/tmp/agenc-tool-smoke/team-calendar.ics`. Answer with:\n- the calendar metadata\n- the exact event count\n- the event summaries and attendees\n\nDo not use shell unless the typed calendar tools fail.",
+        evaluationId: "calendar_stage_read",
+      },
+    ],
+  },
+];
+
+const SCENARIO_STAGE_TEMPLATES = {
+  baseline: BASELINE_STAGE_TEMPLATES,
+  server: SERVER_STAGE_TEMPLATES,
+  spreadsheet: SPREADSHEET_STAGE_TEMPLATES,
+  "office-document": OFFICE_DOCUMENT_STAGE_TEMPLATES,
+  productivity: PRODUCTIVITY_STAGE_TEMPLATES,
+};
+
+export function replaceRunToken(value, runToken) {
+  return value.replaceAll("RUN_TOKEN", runToken);
+}
+
+export function deriveRunPort(runToken, base = 9200, span = 600) {
+  const normalized = String(runToken ?? "");
+  let hash = 0;
+  for (const char of normalized) {
+    hash = (hash * 33 + char.charCodeAt(0)) % span;
+  }
+  return base + hash;
+}
+
+export function replaceRunVariables(value, runToken, runPort) {
+  return replaceRunToken(value, runToken).replaceAll("RUN_PORT", String(runPort));
+}
+
+export function normalizeInteractiveInput(value) {
+  return value.replace(/\s*\n+\s*/g, " ").replace(/\s{2,}/g, " ").trim();
+}
+
+export function buildAutonomyStages(runToken, scenario = "baseline") {
+  const templates = SCENARIO_STAGE_TEMPLATES[scenario];
+  if (!templates) {
+    throw new Error(`Unknown autonomy scenario: ${scenario}`);
+  }
+  const runPort = deriveRunPort(runToken);
+  return templates.map((stage) => ({
+    ...stage,
+    actions: stage.actions.map((action) => ({
+      ...action,
+      ...(action.input
+        ? {
+            input: normalizeInteractiveInput(
+              replaceRunVariables(action.input, runToken, runPort),
+            ),
+          }
+        : {}),
+    })),
+  }));
+}
+
+export function parseStageSelection(selection, stages) {
+  if (!selection || selection.trim().length === 0 || selection.trim() === "all") {
+    return stages;
+  }
+
+  const byId = new Map(stages.map((stage) => [stage.id, stage]));
+  const orderedIds = stages.map((stage) => stage.id);
+  const selected = [];
+
+  for (const rawPart of selection.split(",")) {
+    const part = rawPart.trim();
+    if (part.length === 0) continue;
+    if (part.includes("-")) {
+      const [start, end] = part.split("-", 2).map((value) => value.trim());
+      const startIndex = orderedIds.indexOf(start);
+      const endIndex = orderedIds.indexOf(end);
+      if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+        throw new Error(`Invalid stage range: ${part}`);
+      }
+      for (let index = startIndex; index <= endIndex; index += 1) {
+        const stage = byId.get(orderedIds[index]);
+        if (stage && !selected.some((item) => item.id === stage.id)) {
+          selected.push(stage);
+        }
+      }
+      continue;
+    }
+
+    const stage = byId.get(part);
+    if (!stage) {
+      throw new Error(`Unknown stage id: ${part}`);
+    }
+    if (!selected.some((item) => item.id === stage.id)) {
+      selected.push(stage);
+    }
+  }
+
+  return selected;
+}
+
+export function pickLatestSession(sessions) {
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    return undefined;
+  }
+  return [...sessions].sort((left, right) => {
+    const leftTime = Number(left?.lastActiveAt ?? 0);
+    const rightTime = Number(right?.lastActiveAt ?? 0);
+    return rightTime - leftTime;
+  })[0];
+}
+
+export function pickTrackedSession(sessions, preferredSessionId) {
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    return undefined;
+  }
+  if (typeof preferredSessionId === "string" && preferredSessionId.length > 0) {
+    const preferred = sessions.find(
+      (session) => session?.sessionId === preferredSessionId,
+    );
+    if (preferred) {
+      return preferred;
+    }
+  }
+  return pickLatestSession(sessions);
+}
+
+export function pickLatestTrace(traces, startedAt = 0) {
+  if (!Array.isArray(traces) || traces.length === 0) {
+    return undefined;
+  }
+  const sorted = [...traces].sort((left, right) => {
+    const leftTime = Number(left?.updatedAt ?? left?.startedAt ?? 0);
+    const rightTime = Number(right?.updatedAt ?? right?.startedAt ?? 0);
+    return rightTime - leftTime;
+  });
+  return (
+    sorted.find((trace) => Number(trace?.updatedAt ?? trace?.startedAt ?? 0) >= startedAt) ??
+    sorted[0]
+  );
+}

--- a/scripts/lib/agenc-autonomy-stage-evaluators.mjs
+++ b/scripts/lib/agenc-autonomy-stage-evaluators.mjs
@@ -1,0 +1,490 @@
+const TYPED_PROCESS_TOOL_NAMES = new Set([
+  "system.processStart",
+  "system.processStatus",
+  "system.processResume",
+  "system.processStop",
+  "system.processLogs",
+  "desktop.process_start",
+  "desktop.process_status",
+  "desktop.process_stop",
+  "system.serverStart",
+  "system.serverStatus",
+  "system.serverStop",
+  "system.sandboxStart",
+  "system.sandboxExec",
+  "system.sandboxStop",
+]);
+
+const TYPED_PROCESS_TOOL_NAME_LIST = [...TYPED_PROCESS_TOOL_NAMES];
+
+function extractToolNames(traceDetail) {
+  if (!traceDetail || !Array.isArray(traceDetail.events)) {
+    return [];
+  }
+  return traceDetail.events
+    .map((event) => event?.toolName)
+    .filter((toolName) => typeof toolName === "string");
+}
+
+function containsAll(text, parts) {
+  return parts.every((part) => text.includes(part));
+}
+
+function containsOne(text, parts) {
+  return parts.some((part) => text.includes(part));
+}
+
+function textOfEvidence(evidence) {
+  return [evidence.paneText ?? "", evidence.traceText ?? "", evidence.runText ?? ""]
+    .filter(Boolean)
+    .join("\n");
+}
+
+function stagePass(passed, reasons, extra = {}) {
+  return { passed, reasons, ...extra };
+}
+
+function buildStageEvaluationContext(evidence, context = {}) {
+  const paneText = evidence.paneText ?? "";
+  const traceDetail = evidence.traceDetail;
+  const runDetail = evidence.runDetail;
+  return {
+    paneText,
+    traceDetail,
+    runDetail,
+    toolNames: extractToolNames(traceDetail),
+    combinedText: textOfEvidence(evidence),
+    runToken: evidence.runToken,
+    sessionId: evidence.sessionId,
+    currentRunId: runDetail?.runId,
+    traceCompleted: traceDetail?.summary?.status === "completed",
+    paneBusy:
+      paneText.includes("agent is typing") ||
+      paneText.includes("[INFO] agent is typing"),
+    priorRunId: context.runId,
+  };
+}
+
+function evaluateStage0(ctx) {
+  const expectedToken = `AUTONOMY_STAGE0::${ctx.runToken}`;
+  return stagePass(
+    ctx.paneText.includes(expectedToken) &&
+      ctx.toolNames.length === 0 &&
+      ctx.traceCompleted &&
+      !ctx.paneBusy,
+    [
+      ctx.paneText.includes(expectedToken)
+        ? undefined
+        : `pane did not contain ${expectedToken}`,
+      ctx.toolNames.length === 0 ? undefined : "trace recorded tool usage for a no-tool stage",
+      ctx.traceCompleted ? undefined : "trace did not reach completed status",
+      ctx.paneBusy ? "pane still showed an active typing state" : undefined,
+    ].filter(Boolean),
+  );
+}
+
+function evaluateStage1(ctx) {
+  const expectedToken = `AUTONOMY_STAGE1::${ctx.runToken}`;
+  const shellToolSeen =
+    ctx.toolNames.includes("desktop.bash") || ctx.toolNames.includes("system.bash");
+  return stagePass(
+    ctx.paneText.includes(expectedToken) &&
+      shellToolSeen &&
+      containsOne(ctx.combinedText, ["desktop.bash", "system.bash"]) &&
+      ctx.traceCompleted &&
+      !ctx.paneBusy,
+    [
+      ctx.paneText.includes(expectedToken)
+        ? undefined
+        : `pane did not contain ${expectedToken}`,
+      shellToolSeen
+        ? undefined
+        : "trace did not record a supported shell tool",
+      containsOne(ctx.combinedText, ["desktop.bash", "system.bash"])
+        ? undefined
+        : "user-visible output did not mention the shell tool that was used",
+      ctx.traceCompleted ? undefined : "trace did not reach completed status",
+      ctx.paneBusy ? "pane still showed an active typing state" : undefined,
+    ].filter(Boolean),
+  );
+}
+
+function evaluateStage2(ctx) {
+  const expectedToken = `AUTONOMY_STAGE2::${ctx.runToken}`;
+  const expectedPath = `/tmp/agenc-autonomy-${ctx.runToken}.txt`;
+  return stagePass(
+    containsAll(ctx.paneText, [expectedToken, expectedPath]) &&
+      ctx.toolNames.length >= 2 &&
+      ctx.traceCompleted &&
+      !ctx.paneBusy,
+    [
+      containsAll(ctx.paneText, [expectedToken, expectedPath])
+        ? undefined
+        : "pane did not show the verified path and contents",
+      ctx.toolNames.length >= 2
+        ? undefined
+        : "trace did not show at least two tool calls for write/read verification",
+      ctx.traceCompleted ? undefined : "trace did not reach completed status",
+      ctx.paneBusy ? "pane still showed an active typing state" : undefined,
+    ].filter(Boolean),
+  );
+}
+
+function evaluateStage3(ctx) {
+  return stagePass(
+    containsAll(ctx.combinedText, ["system.delete"]) &&
+      containsOne(ctx.combinedText.toLowerCase(), [
+        "allowed",
+        "denied",
+        "approval",
+        "requires approval",
+      ]) &&
+      ctx.traceCompleted &&
+      !ctx.paneBusy,
+    [
+      ctx.combinedText.includes("system.delete")
+        ? undefined
+        : "policy preview did not mention system.delete",
+      containsOne(ctx.combinedText.toLowerCase(), [
+        "allowed",
+        "denied",
+        "approval",
+        "requires approval",
+      ])
+        ? undefined
+        : "policy preview did not state allow/deny/approval outcome",
+      ctx.traceCompleted ? undefined : "trace did not reach completed status",
+      ctx.paneBusy ? "pane still showed an active typing state" : undefined,
+    ].filter(Boolean),
+  );
+}
+
+function evaluateStage4(ctx) {
+  const typedToolSeen =
+    ctx.toolNames.some((toolName) => isTypedHandleTool(toolName)) ||
+    containsOne(ctx.combinedText, TYPED_PROCESS_TOOL_NAME_LIST);
+  const observedTargetSeen =
+    Array.isArray(ctx.runDetail?.observedTargets) &&
+    ctx.runDetail.observedTargets.length > 0;
+  const activeState =
+    ctx.runDetail?.state === "working" ||
+    ctx.runDetail?.state === "running" ||
+    ctx.runDetail?.state === "paused" ||
+    ctx.runDetail?.state === "completed";
+  const evidenceSeen =
+    typeof ctx.runDetail?.lastToolEvidence === "string" &&
+    ctx.runDetail.lastToolEvidence.trim().length > 0;
+  return stagePass(
+    Boolean(ctx.sessionId) &&
+      Boolean(ctx.currentRunId) &&
+      typedToolSeen &&
+      observedTargetSeen &&
+      activeState &&
+      evidenceSeen &&
+      ctx.traceCompleted &&
+      !ctx.paneBusy,
+    [
+      ctx.sessionId ? undefined : "no durable session id was observed",
+      ctx.currentRunId ? undefined : "run.inspect did not return a run id",
+      typedToolSeen ? undefined : "trace did not show a typed long-lived handle tool",
+      observedTargetSeen ? undefined : "run.inspect did not show any observed targets",
+      activeState ? undefined : `run state was not active: ${ctx.runDetail?.state ?? "missing"}`,
+      evidenceSeen ? undefined : "run.inspect did not include verified tool evidence",
+      ctx.traceCompleted ? undefined : "trace did not reach completed status",
+      ctx.paneBusy ? "pane still showed an active typing state" : undefined,
+    ].filter(Boolean),
+    { runId: ctx.currentRunId },
+  );
+}
+
+function evaluateServerStageStart(ctx) {
+  const structuredServerTargetSeen = Array.isArray(ctx.runDetail?.observedTargets)
+    ? ctx.runDetail.observedTargets.some((target) => {
+        const launchSpec = target?.launchSpec;
+        return (
+          target?.kind === "managed_process" &&
+          (target?.surface === "host_server" ||
+            typeof target?.serverId === "string" ||
+            launchSpec?.kind === "server")
+        );
+      })
+    : false;
+  const serverToolSeen =
+    structuredServerTargetSeen ||
+    containsOne(ctx.combinedText, ["system.serverStart", "system.serverStatus"]) ||
+    (Array.isArray(ctx.runDetail?.artifacts) &&
+      ctx.runDetail.artifacts.some(
+        (artifact) =>
+          artifact?.source === "system.serverStart" ||
+          artifact?.source === "system.serverStatus",
+      ));
+  const structuredReadinessSeen = Array.isArray(ctx.runDetail?.observedTargets)
+    ? ctx.runDetail.observedTargets.some((target) => {
+        const launchSpec = target?.launchSpec;
+        const healthUrl = launchSpec?.healthUrl;
+        return (
+          target?.kind === "managed_process" &&
+          target?.ready === true &&
+          typeof target?.serverId === "string" &&
+          typeof healthUrl === "string" &&
+          healthUrl.startsWith("http://127.0.0.1:")
+        );
+      })
+    : false;
+  const readinessSeen =
+    structuredReadinessSeen ||
+    containsOne(ctx.combinedText, [
+      '"ready":true',
+      '\\"ready\\":true',
+      "ready=true",
+      '"healthUrl":"http://127.0.0.1:',
+      '\\"healthUrl\\":\\"http://127.0.0.1:',
+      "healthUrl=http://127.0.0.1:",
+    ]);
+  const observedTargetSeen =
+    Array.isArray(ctx.runDetail?.observedTargets) &&
+    ctx.runDetail.observedTargets.length > 0;
+  const activeState =
+    ctx.runDetail?.state === "working" ||
+    ctx.runDetail?.state === "running" ||
+    ctx.runDetail?.state === "paused" ||
+    ctx.runDetail?.state === "completed";
+  return stagePass(
+    Boolean(ctx.sessionId) &&
+      Boolean(ctx.currentRunId) &&
+      serverToolSeen &&
+      readinessSeen &&
+      observedTargetSeen &&
+      activeState &&
+      ctx.traceCompleted &&
+      !ctx.paneBusy,
+    [
+      ctx.sessionId ? undefined : "no durable session id was observed",
+      ctx.currentRunId ? undefined : "run.inspect did not return a run id",
+      serverToolSeen
+        ? undefined
+        : "evidence did not show system.serverStart/system.serverStatus",
+      readinessSeen ? undefined : "server readiness evidence was missing",
+      observedTargetSeen ? undefined : "run.inspect did not show any observed targets",
+      activeState ? undefined : `run state was not active: ${ctx.runDetail?.state ?? "missing"}`,
+      ctx.traceCompleted ? undefined : "trace did not reach completed status",
+      ctx.paneBusy ? "pane still showed an active typing state" : undefined,
+    ].filter(Boolean),
+    { runId: ctx.currentRunId },
+  );
+}
+
+function evaluatePauseStage(ctx) {
+  const sameRun = !ctx.priorRunId || ctx.priorRunId === ctx.currentRunId;
+  return stagePass(
+    ctx.runDetail?.state === "paused" && sameRun,
+    [
+      ctx.runDetail?.state === "paused"
+        ? undefined
+        : `run did not enter paused state: ${ctx.runDetail?.state ?? "missing"}`,
+      sameRun ? undefined : "pause changed the durable run id",
+    ].filter(Boolean),
+  );
+}
+
+function evaluateResumeStage(ctx) {
+  const sameRun = !ctx.priorRunId || ctx.priorRunId === ctx.currentRunId;
+  const resumed =
+    ctx.runDetail?.state === "working" ||
+    ctx.runDetail?.state === "running" ||
+    ctx.runDetail?.currentPhase === "active";
+  return stagePass(
+    resumed && sameRun,
+    [
+      resumed
+        ? undefined
+        : `run did not return to an active state: ${ctx.runDetail?.state ?? "missing"}`,
+      sameRun ? undefined : "resume changed the durable run id",
+    ].filter(Boolean),
+  );
+}
+
+function evaluateInspectStage(ctx) {
+  return stagePass(
+    Boolean(ctx.runDetail?.lastToolEvidence) &&
+      Array.isArray(ctx.runDetail?.recentEvents),
+    [
+      ctx.runDetail?.lastToolEvidence
+        ? undefined
+        : "inspect did not return verified tool evidence",
+      Array.isArray(ctx.runDetail?.recentEvents)
+        ? undefined
+        : "inspect did not return recent events",
+    ].filter(Boolean),
+  );
+}
+
+function evaluateTraceStage(ctx) {
+  return stagePass(
+    Boolean(ctx.traceDetail?.summary?.traceId) &&
+      Number(ctx.traceDetail?.summary?.eventCount ?? 0) > 0 &&
+      ctx.traceDetail?.summary?.sessionId === ctx.sessionId &&
+      ctx.traceDetail?.completeness?.complete === true,
+    [
+      ctx.traceDetail?.summary?.traceId ? undefined : "no trace detail was returned",
+      Number(ctx.traceDetail?.summary?.eventCount ?? 0) > 0
+        ? undefined
+        : "trace detail had no events",
+      ctx.traceDetail?.summary?.sessionId === ctx.sessionId
+        ? undefined
+        : "trace detail session id did not match the active session",
+      ctx.traceDetail?.completeness?.complete === true
+        ? undefined
+        : `trace completeness issues: ${(ctx.traceDetail?.completeness?.issues ?? []).join(", ")}`,
+    ].filter(Boolean),
+  );
+}
+
+function evaluateRestartStage(ctx) {
+  const sameRun = !ctx.priorRunId || ctx.priorRunId === ctx.currentRunId;
+  const recovered =
+    ctx.runDetail?.state === "working" ||
+    ctx.runDetail?.state === "running" ||
+    ctx.runDetail?.state === "paused" ||
+    ctx.runDetail?.state === "completed" ||
+    ctx.runDetail?.state === "suspended";
+  const sessionShort = typeof ctx.sessionId === "string" ? ctx.sessionId.slice(-8) : "";
+  const paneRecovered =
+    !ctx.paneText.includes("[LINK] reconnecting") &&
+    !ctx.paneText.includes("Unknown message type: chat.new") &&
+    !ctx.paneText.includes("[ERROR] Runtime Error") &&
+    !ctx.paneText.includes("webchat handler still starting") &&
+    !ctx.paneText.includes("retrying in ");
+  const paneSessionMatches =
+    sessionShort.length === 0 || ctx.paneText.includes(sessionShort);
+  return stagePass(
+    Boolean(ctx.sessionId) &&
+      sameRun &&
+      recovered &&
+      paneRecovered &&
+      paneSessionMatches,
+    [
+      ctx.sessionId ? undefined : "session was not recoverable after restart",
+      sameRun ? undefined : "restart lost or replaced the durable run id",
+      recovered
+        ? undefined
+        : `run state after restart was not recoverable: ${ctx.runDetail?.state ?? "missing"}`,
+      paneRecovered
+        ? undefined
+        : "operator console did not finish reconnecting cleanly after restart",
+      paneSessionMatches
+        ? undefined
+        : "operator console resumed a different session after restart",
+    ].filter(Boolean),
+  );
+}
+
+function evaluateStopStage(ctx) {
+  return stagePass(
+    ctx.runDetail?.state === "cancelled" || ctx.runDetail?.state === "completed",
+    [
+      ctx.runDetail?.state === "cancelled" || ctx.runDetail?.state === "completed"
+        ? undefined
+        : `stop did not reach a terminal state: ${ctx.runDetail?.state ?? "missing"}`,
+    ].filter(Boolean),
+  );
+}
+
+function createTypedArtifactEvaluator(config) {
+  return (ctx) => {
+    const toolsSeen =
+      ctx.toolNames.includes(config.infoToolName) &&
+      ctx.toolNames.includes(config.detailToolName);
+    const groundedAnswerSeen =
+      containsAll(ctx.paneText, config.requiredPaneTerms) &&
+      (config.extraPaneCheck ? config.extraPaneCheck(ctx.paneText) : true);
+    return stagePass(
+      toolsSeen && groundedAnswerSeen && ctx.traceCompleted && !ctx.paneBusy,
+      [
+        toolsSeen
+          ? undefined
+          : `trace did not show both ${config.infoToolName} and ${config.detailToolName}`,
+        groundedAnswerSeen
+          ? undefined
+          : config.paneFailureMessage,
+        ctx.traceCompleted ? undefined : "trace did not reach completed status",
+        ctx.paneBusy ? "pane still showed an active typing state" : undefined,
+      ].filter(Boolean),
+    );
+  };
+}
+
+const STAGE_EVALUATORS = {
+  stage0: evaluateStage0,
+  stage1: evaluateStage1,
+  stage2: evaluateStage2,
+  stage3: evaluateStage3,
+  stage4: evaluateStage4,
+  server_stage_start: evaluateServerStageStart,
+  stage5_pause: evaluatePauseStage,
+  stage5_resume: evaluateResumeStage,
+  stage5_inspect: evaluateInspectStage,
+  stage6: evaluateTraceStage,
+  stage7: evaluateRestartStage,
+  stage8: evaluateStopStage,
+  spreadsheet_stage_read: createTypedArtifactEvaluator({
+    infoToolName: "system.spreadsheetInfo",
+    detailToolName: "system.spreadsheetRead",
+    requiredPaneTerms: ["Ada", "Linus", "admin", "user"],
+    extraPaneCheck: (paneText) =>
+      containsOne(paneText, ["2 rows", "row count: **2**", "Exact row count: **2**"]),
+    paneFailureMessage: "pane did not show the grounded workbook rows/count",
+  }),
+  office_document_stage_read: createTypedArtifactEvaluator({
+    infoToolName: "system.officeDocumentInfo",
+    detailToolName: "system.officeDocumentExtractText",
+    requiredPaneTerms: [
+      "Launch Brief",
+      "AgenC Smoke",
+      "Hello DOCX Brief",
+      "Status update line two.",
+    ],
+    extraPaneCheck: (paneText) => containsOne(paneText, ["DOCX", "Format: DOCX"]),
+    paneFailureMessage: "pane did not show the grounded office document metadata/text",
+  }),
+  email_message_stage_read: createTypedArtifactEvaluator({
+    infoToolName: "system.emailMessageInfo",
+    detailToolName: "system.emailMessageExtractText",
+    requiredPaneTerms: [
+      "Sprint update",
+      "alice@example.com",
+      "bob@example.com",
+      "Hello team,",
+      "Sprint review is at 10:00 AM.",
+    ],
+    paneFailureMessage: "pane did not show the grounded email metadata/text",
+  }),
+  calendar_stage_read: createTypedArtifactEvaluator({
+    infoToolName: "system.calendarInfo",
+    detailToolName: "system.calendarRead",
+    requiredPaneTerms: [
+      "Team Calendar",
+      "Product Review",
+      "Planning Day",
+      "bob@example.com",
+      "carol@example.com",
+    ],
+    extraPaneCheck: (paneText) =>
+      /\bexact event count\b[^0-9]*2\b/i.test(paneText) ||
+      /\bevent count\b[^0-9]*2\b/i.test(paneText) ||
+      /\b2 events\b/i.test(paneText),
+    paneFailureMessage: "pane did not show the grounded calendar metadata/events",
+  }),
+};
+
+export function isTypedHandleTool(toolName) {
+  return TYPED_PROCESS_TOOL_NAMES.has(toolName);
+}
+
+export function evaluateAutonomyStage(evaluationId, evidence, context = {}) {
+  const evaluator = STAGE_EVALUATORS[evaluationId];
+  if (!evaluator) {
+    throw new Error(`Unknown evaluation id: ${evaluationId}`);
+  }
+  return evaluator(buildStageEvaluationContext(evidence, context));
+}

--- a/scripts/run-autonomy-ladder.mjs
+++ b/scripts/run-autonomy-ladder.mjs
@@ -1,0 +1,559 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { spawn } from "node:child_process";
+import WebSocket from "../node_modules/ws/wrapper.mjs";
+import {
+  buildAutonomyStages,
+  evaluateAutonomyStage,
+  parseStageSelection,
+  pickTrackedSession,
+  pickLatestTrace,
+} from "./lib/agenc-autonomy-ladder.mjs";
+
+const DEFAULT_WS_URL = "ws://127.0.0.1:3100";
+const DEFAULT_TMUX_TARGET = "agenc-watch:live.0";
+const DEFAULT_CLIENT_KEY = "tmux-live-watch";
+const DEFAULT_POLL_MS = 1_500;
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const DEFAULT_PANE_CAPTURE_LINES = 220;
+const DEFAULT_DAEMON_CONFIG = "/home/tetsuo/.agenc/config.json";
+const DEFAULT_DAEMON_PID_PATH = "/home/tetsuo/.agenc/daemon.pid";
+
+function nextRunToken() {
+  const date = new Date();
+  const stamp = [
+    date.getUTCFullYear(),
+    String(date.getUTCMonth() + 1).padStart(2, "0"),
+    String(date.getUTCDate()).padStart(2, "0"),
+    "-",
+    String(date.getUTCHours()).padStart(2, "0"),
+    String(date.getUTCMinutes()).padStart(2, "0"),
+    String(date.getUTCSeconds()).padStart(2, "0"),
+  ].join("");
+  return `ladder-${stamp}`;
+}
+
+function sleep(ms) {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function execFileOutput(command, args, options = {}) {
+  return new Promise((resolveExec, rejectExec) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? process.cwd(),
+      env: options.env ?? process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", rejectExec);
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolveExec({ stdout, stderr, code });
+        return;
+      }
+      rejectExec(
+        new Error(
+          `${command} ${args.join(" ")} failed with code ${code}: ${stderr || stdout}`,
+        ),
+      );
+    });
+  });
+}
+
+class WebchatInspector {
+  constructor({ wsUrl, clientKey, requestTimeoutMs }) {
+    this.wsUrl = wsUrl;
+    this.clientKey = clientKey;
+    this.requestTimeoutMs = requestTimeoutMs;
+    this.socket = null;
+    this.openPromise = null;
+    this.pending = new Map();
+    this.requestCounter = 0;
+  }
+
+  async connect() {
+    if (this.socket && this.socket.readyState === WebSocket.OPEN) {
+      return;
+    }
+    if (this.openPromise) {
+      await this.openPromise;
+      return;
+    }
+
+    this.openPromise = new Promise((resolveOpen, rejectOpen) => {
+      const socket = new WebSocket(this.wsUrl);
+      this.socket = socket;
+      socket.addEventListener("open", () => {
+        this.openPromise = null;
+        resolveOpen();
+      });
+      socket.addEventListener("message", (event) => {
+        const raw = typeof event.data === "string" ? event.data : event.data.toString();
+        let message;
+        try {
+          message = JSON.parse(raw);
+        } catch {
+          return;
+        }
+        if (!message?.id) return;
+        const pending = this.pending.get(message.id);
+        if (!pending) return;
+        clearTimeout(pending.timeout);
+        this.pending.delete(message.id);
+        pending.resolve(message);
+      });
+      socket.addEventListener("close", () => {
+        for (const [id, pending] of this.pending) {
+          clearTimeout(pending.timeout);
+          pending.reject(new Error(`WebSocket closed before response for ${id}`));
+        }
+        this.pending.clear();
+        this.socket = null;
+        this.openPromise = null;
+      });
+      socket.addEventListener("error", (error) => {
+        if (this.openPromise) {
+          this.openPromise = null;
+          rejectOpen(error);
+          return;
+        }
+      });
+    });
+
+    await this.openPromise;
+    await this.request("chat.sessions", { clientKey: this.clientKey }).catch(() => undefined);
+  }
+
+  async request(type, payload) {
+    await this.connect();
+    const id = `${type}-${++this.requestCounter}`;
+    const frame = JSON.stringify({ type, payload, id });
+    return new Promise((resolveRequest, rejectRequest) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id);
+        rejectRequest(new Error(`Timed out waiting for ${type}`));
+      }, this.requestTimeoutMs);
+      this.pending.set(id, {
+        resolve: resolveRequest,
+        reject: rejectRequest,
+        timeout,
+      });
+      this.socket.send(frame);
+    });
+  }
+
+  async listSessions() {
+    const response = await this.request("chat.sessions", {
+      clientKey: this.clientKey,
+    });
+    return Array.isArray(response.payload) ? response.payload : [];
+  }
+
+  async inspectRun(sessionId) {
+    try {
+      const response = await this.request("run.inspect", { sessionId });
+      return response.payload ?? undefined;
+    } catch (error) {
+      if (String(error?.message ?? error).includes("not found")) {
+        return undefined;
+      }
+      throw error;
+    }
+  }
+
+  async listTraces(sessionId) {
+    const response = await this.request("observability.traces", {
+      sessionId,
+      limit: 10,
+    });
+    return Array.isArray(response.payload) ? response.payload : [];
+  }
+
+  async getTrace(traceId) {
+    const response = await this.request("observability.trace", { traceId });
+    return response.payload ?? undefined;
+  }
+
+  async close() {
+    if (!this.socket) return;
+    try {
+      this.socket.close();
+    } catch {}
+    this.socket = null;
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    scenario: "baseline",
+    wsUrl: DEFAULT_WS_URL,
+    tmuxTarget: DEFAULT_TMUX_TARGET,
+    clientKey: DEFAULT_CLIENT_KEY,
+    pollMs: DEFAULT_POLL_MS,
+    requestTimeoutMs: DEFAULT_REQUEST_TIMEOUT_MS,
+    paneCaptureLines: DEFAULT_PANE_CAPTURE_LINES,
+    daemonConfig: DEFAULT_DAEMON_CONFIG,
+    daemonPidPath: DEFAULT_DAEMON_PID_PATH,
+    resetSession: true,
+    runToken: nextRunToken(),
+    stages: "0-8",
+    artifactsDir: resolve(
+      process.cwd(),
+      ".tmp",
+      "autonomy-ladder",
+      nextRunToken(),
+    ),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--ws-url" && argv[index + 1]) {
+      options.wsUrl = argv[++index];
+      continue;
+    }
+    if (arg === "--scenario" && argv[index + 1]) {
+      options.scenario = argv[++index];
+      continue;
+    }
+    if (arg === "--tmux-target" && argv[index + 1]) {
+      options.tmuxTarget = argv[++index];
+      continue;
+    }
+    if (arg === "--client-key" && argv[index + 1]) {
+      options.clientKey = argv[++index];
+      continue;
+    }
+    if (arg === "--poll-ms" && argv[index + 1]) {
+      options.pollMs = Number(argv[++index]);
+      continue;
+    }
+    if (arg === "--request-timeout-ms" && argv[index + 1]) {
+      options.requestTimeoutMs = Number(argv[++index]);
+      continue;
+    }
+    if (arg === "--pane-capture-lines" && argv[index + 1]) {
+      options.paneCaptureLines = Number(argv[++index]);
+      continue;
+    }
+    if (arg === "--run-token" && argv[index + 1]) {
+      options.runToken = argv[++index];
+      continue;
+    }
+    if (arg === "--stages" && argv[index + 1]) {
+      options.stages = argv[++index];
+      continue;
+    }
+    if (arg === "--artifacts-dir" && argv[index + 1]) {
+      options.artifactsDir = resolve(process.cwd(), argv[++index]);
+      continue;
+    }
+    if (arg === "--daemon-config" && argv[index + 1]) {
+      options.daemonConfig = argv[++index];
+      continue;
+    }
+    if (arg === "--daemon-pid-path" && argv[index + 1]) {
+      options.daemonPidPath = argv[++index];
+      continue;
+    }
+    if (arg === "--no-reset") {
+      options.resetSession = false;
+      continue;
+    }
+    if (arg === "--help") {
+      console.log(
+        [
+          "Usage: node scripts/run-autonomy-ladder.mjs [options]",
+          "",
+          "Options:",
+          `  --tmux-target <pane>        Default: ${DEFAULT_TMUX_TARGET}`,
+          `  --client-key <key>         Default: ${DEFAULT_CLIENT_KEY}`,
+          `  --ws-url <url>             Default: ${DEFAULT_WS_URL}`,
+          "  --scenario <name>          baseline | server | spreadsheet | office-document | productivity",
+          "  --stages <ids>             Example: 0-4,6,8",
+          "  --run-token <token>        Reuse a stable stage token",
+          "  --artifacts-dir <path>     Output directory for JSON/txt artifacts",
+          "  --poll-ms <ms>             Poll interval for evidence capture",
+          "  --request-timeout-ms <ms>  Inspector request timeout",
+          "  --pane-capture-lines <n>   tmux capture depth",
+          "  --daemon-config <path>     Config used for restart stage",
+          "  --daemon-pid-path <path>   PID file used for restart stage",
+          "  --no-reset                 Keep the current chat session instead of /new",
+        ].join("\n"),
+      );
+      process.exit(0);
+    }
+  }
+
+  if (!options.artifactsDir.endsWith(options.runToken)) {
+    options.artifactsDir = resolve(options.artifactsDir, options.runToken);
+  }
+  return options;
+}
+
+async function verifyTmuxTarget(tmuxTarget) {
+  const result = await execFileOutput("tmux", [
+    "list-panes",
+    "-a",
+    "-F",
+    "#{session_name}:#{window_name}.#{pane_index}",
+  ]);
+  const panes = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (!panes.includes(tmuxTarget)) {
+    throw new Error(`tmux target ${tmuxTarget} not found. Available: ${panes.join(", ")}`);
+  }
+}
+
+async function sendTmuxInput(tmuxTarget, input) {
+  await execFileOutput("tmux", ["send-keys", "-t", tmuxTarget, "C-u"]);
+  await execFileOutput("tmux", ["send-keys", "-t", tmuxTarget, "-l", "--", input]);
+  await execFileOutput("tmux", ["send-keys", "-t", tmuxTarget, "Enter"]);
+}
+
+async function capturePane(tmuxTarget, paneCaptureLines) {
+  const result = await execFileOutput("tmux", [
+    "capture-pane",
+    "-p",
+    "-J",
+    "-t",
+    tmuxTarget,
+    "-S",
+    `-${paneCaptureLines}`,
+  ]);
+  return result.stdout;
+}
+
+async function restartDaemon(options) {
+  await execFileOutput(
+    "node",
+    [
+      "runtime/dist/bin/agenc-runtime.js",
+      "restart",
+      "--config",
+      options.daemonConfig,
+      "--pid-path",
+      options.daemonPidPath,
+    ],
+    { cwd: process.cwd() },
+  );
+}
+
+async function collectEvidence(inspector, options, stageStartedAt, context) {
+  const paneText = await capturePane(options.tmuxTarget, options.paneCaptureLines);
+  const sessions = await inspector.listSessions();
+  const session = pickTrackedSession(sessions, context.sessionId);
+  const sessionId = session?.sessionId;
+  let runDetail;
+  let traceSummary;
+  let traceDetail;
+  if (sessionId) {
+    runDetail = await inspector.inspectRun(sessionId);
+    const traces = await inspector.listTraces(sessionId);
+    traceSummary = pickLatestTrace(traces, stageStartedAt);
+    if (traceSummary?.traceId) {
+      traceDetail = await inspector.getTrace(traceSummary.traceId);
+    }
+  }
+
+  return {
+    runToken: options.runToken,
+    sessionId,
+    session,
+    runDetail,
+    traceSummary,
+    traceDetail,
+    paneText,
+    runText: runDetail ? JSON.stringify(runDetail, null, 2) : "",
+    traceText: traceDetail ? JSON.stringify(traceDetail, null, 2) : "",
+    context,
+  };
+}
+
+async function waitForStageEvaluation({
+  inspector,
+  options,
+  action,
+  timeoutMs,
+  context,
+}) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt <= timeoutMs) {
+    const evidence = await collectEvidence(inspector, options, startedAt, context);
+    const evaluation = evaluateAutonomyStage(action.evaluationId, evidence, context);
+    if (evaluation.passed) {
+      return {
+        startedAt,
+        completedAt: Date.now(),
+        evidence,
+        evaluation,
+      };
+    }
+    await sleep(options.pollMs);
+  }
+
+  const evidence = await collectEvidence(inspector, options, startedAt, context);
+  const evaluation = evaluateAutonomyStage(action.evaluationId, evidence, context);
+  return {
+    startedAt,
+    completedAt: Date.now(),
+    evidence,
+    evaluation,
+  };
+}
+
+async function runStage(stage, inspector, options, context) {
+  const stageArtifact = {
+    stageId: stage.id,
+    title: stage.title,
+    startedAt: Date.now(),
+    actions: [],
+  };
+
+  for (const action of stage.actions) {
+    if (action.kind === "input" || action.kind === "command") {
+      await sendTmuxInput(options.tmuxTarget, action.input);
+    } else if (action.kind === "restart") {
+      await restartDaemon(options);
+    } else {
+      throw new Error(`Unsupported action kind: ${action.kind}`);
+    }
+
+    const result = await waitForStageEvaluation({
+      inspector,
+      options,
+      action,
+      timeoutMs: stage.timeoutMs,
+      context,
+    });
+    stageArtifact.actions.push({
+      id: action.id,
+      kind: action.kind,
+      input: action.input,
+      startedAt: result.startedAt,
+      completedAt: result.completedAt,
+      passed: result.evaluation.passed,
+      reasons: result.evaluation.reasons,
+      sessionId: result.evidence.sessionId,
+      runId: result.evidence.runDetail?.runId,
+      traceId: result.evidence.traceSummary?.traceId,
+      runState: result.evidence.runDetail?.state,
+      paneText: result.evidence.paneText,
+      runDetail: result.evidence.runDetail,
+      traceSummary: result.evidence.traceSummary,
+      traceDetail: result.evidence.traceDetail,
+    });
+
+    if (!result.evaluation.passed) {
+      stageArtifact.passed = false;
+      stageArtifact.completedAt = Date.now();
+      stageArtifact.runId = result.evidence.runDetail?.runId ?? context.runId;
+      stageArtifact.sessionId = result.evidence.sessionId ?? context.sessionId;
+      stageArtifact.traceId = result.evidence.traceSummary?.traceId;
+      stageArtifact.failureReasons = result.evaluation.reasons;
+      return stageArtifact;
+    }
+
+    context.sessionId = result.evidence.sessionId ?? context.sessionId;
+    context.runId = result.evaluation.runId ?? result.evidence.runDetail?.runId ?? context.runId;
+    context.traceId = result.evidence.traceSummary?.traceId ?? context.traceId;
+    context.lastStageCompletedAt = result.completedAt;
+  }
+
+  stageArtifact.passed = true;
+  stageArtifact.completedAt = Date.now();
+  stageArtifact.runId = context.runId;
+  stageArtifact.sessionId = context.sessionId;
+  stageArtifact.traceId = context.traceId;
+  return stageArtifact;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const stages = parseStageSelection(
+    options.stages,
+    buildAutonomyStages(options.runToken, options.scenario),
+  );
+  await verifyTmuxTarget(options.tmuxTarget);
+  await mkdir(options.artifactsDir, { recursive: true });
+
+  const inspector = new WebchatInspector({
+    wsUrl: options.wsUrl,
+    clientKey: options.clientKey,
+    requestTimeoutMs: options.requestTimeoutMs,
+  });
+
+  const runArtifact = {
+    runToken: options.runToken,
+    tmuxTarget: options.tmuxTarget,
+    wsUrl: options.wsUrl,
+    scenario: options.scenario,
+    clientKey: options.clientKey,
+    startedAt: Date.now(),
+    stages: [],
+  };
+  const context = {};
+
+  try {
+    if (options.resetSession) {
+      await sendTmuxInput(options.tmuxTarget, "/new");
+      await sleep(1_000);
+    }
+
+    for (const stage of stages) {
+      console.log(`[autonomy] running stage ${stage.id}: ${stage.title}`);
+      const stageArtifact = await runStage(stage, inspector, options, context);
+      runArtifact.stages.push(stageArtifact);
+      const stagePath = resolve(options.artifactsDir, `stage-${stage.id}.json`);
+      await writeFile(`${stagePath}`, `${JSON.stringify(stageArtifact, null, 2)}\n`, "utf8");
+      if (!stageArtifact.passed) {
+        runArtifact.completedAt = Date.now();
+        runArtifact.passed = false;
+        runArtifact.failedStage = stage.id;
+        runArtifact.failureReasons = stageArtifact.failureReasons;
+        await writeFile(
+          resolve(options.artifactsDir, "run.json"),
+          `${JSON.stringify(runArtifact, null, 2)}\n`,
+          "utf8",
+        );
+        console.error(
+          `[autonomy] stage ${stage.id} failed: ${(stageArtifact.failureReasons ?? []).join("; ")}`,
+        );
+        process.exit(1);
+      }
+    }
+
+    runArtifact.completedAt = Date.now();
+    runArtifact.passed = true;
+    await writeFile(
+      resolve(options.artifactsDir, "run.json"),
+      `${JSON.stringify(runArtifact, null, 2)}\n`,
+      "utf8",
+    );
+    console.log(
+      [
+        `[autonomy] completed ${runArtifact.stages.length} stages`,
+        `[autonomy] artifacts: ${resolve(options.artifactsDir, "run.json")}`,
+        `[autonomy] run token: ${options.runToken}`,
+      ].join("\n"),
+    );
+  } finally {
+    await inspector.close();
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  console.error(`[autonomy] runner failed: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add typed sqlite, pdf, spreadsheet, office document, email, and calendar artifact tools
- harden tool routing and staged contract guidance for typed artifact workflows
- add live autonomy ladder coverage, watch-console prompts, and operator docs for typed productivity checks

## Testing
- npm --prefix runtime test -- src/gateway/tool-routing.test.ts src/llm/chat-executor-contract-guidance.test.ts src/tools/system/calendar.test.ts src/tools/system/email-message.test.ts src/gateway/tool-environment-policy.test.ts
- npm --prefix runtime run typecheck
- npm --prefix runtime run build
- node --test scripts/agenc-autonomy-ladder.test.mjs
- node scripts/run-autonomy-ladder.mjs --scenario productivity --stages mail1,cal1 --run-token live-productivity-20260309-06 --artifacts-dir .tmp/autonomy-ladder-live/live-productivity-20260309-06