### PR TITLE
fix(runtime): scope WebChat observability log access

### DIFF
--- a/runtime/src/channels/webchat/handlers.ts
+++ b/runtime/src/channels/webchat/handlers.ts
@@ -1224,20 +1224,26 @@ export async function handleObservabilityLogs(
   send: SendFn,
   request: HandlerRequestContext,
 ): Promise<void> {
-  if (!deps.getObservabilityLogTail) {
+  if (!deps.getObservabilityLogTail || !deps.getObservabilityTrace) {
     send({ type: 'error', error: 'Observability API not available', id });
     return;
   }
-  const traceId = typeof payload?.traceId === 'string' ? payload.traceId.trim() : undefined;
-  if (traceId && deps.getObservabilityTrace) {
-    const detail = await deps.getObservabilityTrace(traceId);
-    if (
-      detail?.summary.sessionId &&
-      !request.isSessionOwned(detail.summary.sessionId)
-    ) {
-      send({ type: 'error', error: 'Not authorized for target session trace data', id });
-      return;
-    }
+  const traceId = typeof payload?.traceId === 'string' ? payload.traceId.trim() : '';
+  if (!traceId) {
+    send({ type: 'error', error: 'Missing traceId in payload', id });
+    return;
+  }
+  const detail = await deps.getObservabilityTrace(traceId);
+  if (!detail) {
+    send({ type: 'error', error: `Observability trace "${traceId}" not found`, id });
+    return;
+  }
+  if (
+    detail.summary.sessionId &&
+    !request.isSessionOwned(detail.summary.sessionId)
+  ) {
+    send({ type: 'error', error: 'Not authorized for target session trace data', id });
+    return;
   }
   await safeAsync(send, id, 'error', 'Failed to read daemon logs', async () => {
     const logs = await deps.getObservabilityLogTail!({

--- a/runtime/src/channels/webchat/plugin.test.ts
+++ b/runtime/src/channels/webchat/plugin.test.ts
@@ -1592,7 +1592,7 @@ describe("WebChatChannel", () => {
         body: { payload: { ok: true } },
       }));
       const getObservabilityLogTail = vi.fn(async () => ({
-        path: '/home/tetsuo/.agenc/daemon.log',
+        path: 'daemon.log',
         lines: [`${traceDetail.summary.traceId} line`],
       }));
       (channel as unknown as { deps: WebChatDeps }).deps = {
@@ -1708,6 +1708,7 @@ describe("WebChatChannel", () => {
             type: 'observability.logs',
             id: 'req-observability-logs',
             payload: expect.objectContaining({
+              path: 'daemon.log',
               lines: [`${traceDetail.summary.traceId} line`],
             }),
           }),
@@ -1847,6 +1848,79 @@ describe("WebChatChannel", () => {
         ),
       );
       expect(listObservabilityTraces).not.toHaveBeenCalled();
+    });
+
+    it('requires traceId for observability logs', async () => {
+      const getObservabilityTrace = vi.fn();
+      const getObservabilityLogTail = vi.fn();
+
+      deps = createDeps({ getObservabilityTrace, getObservabilityLogTail });
+      context = createContext();
+      channel = new WebChatChannel(deps);
+      await channel.initialize(context);
+      await channel.start();
+
+      const send = vi.fn<(response: ControlResponse) => void>();
+      openChatSession(channel, context, 'client_1', send, 'owned session');
+
+      channel.handleMessage(
+        'client_1',
+        'observability.logs',
+        msg('observability.logs', { lines: 50 }, 'req-observability-logs-missing-trace'),
+        send,
+      );
+
+      await vi.waitFor(() =>
+        expect(send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'error',
+            id: 'req-observability-logs-missing-trace',
+            error: 'Missing traceId in payload',
+          }),
+        ),
+      );
+
+      expect(getObservabilityTrace).not.toHaveBeenCalled();
+      expect(getObservabilityLogTail).not.toHaveBeenCalled();
+    });
+
+    it('rejects observability logs for foreign traces', async () => {
+      const traceDetail = makeTraceDetail('foreign-session');
+      const getObservabilityTrace = vi.fn(async () => traceDetail);
+      const getObservabilityLogTail = vi.fn();
+
+      deps = createDeps({ getObservabilityTrace, getObservabilityLogTail });
+      context = createContext();
+      channel = new WebChatChannel(deps);
+      await channel.initialize(context);
+      await channel.start();
+
+      const send = vi.fn<(response: ControlResponse) => void>();
+      openChatSession(channel, context, 'client_1', send, 'owned session');
+
+      channel.handleMessage(
+        'client_1',
+        'observability.logs',
+        msg(
+          'observability.logs',
+          { traceId: traceDetail.summary.traceId, lines: 50 },
+          'req-observability-logs-foreign',
+        ),
+        send,
+      );
+
+      await vi.waitFor(() =>
+        expect(send).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'error',
+            id: 'req-observability-logs-foreign',
+            error: 'Not authorized for target session trace data',
+          }),
+        ),
+      );
+
+      expect(getObservabilityTrace).toHaveBeenCalledWith(traceDetail.summary.traceId);
+      expect(getObservabilityLogTail).not.toHaveBeenCalled();
     });
   });
 

--- a/runtime/src/observability/observability.test.ts
+++ b/runtime/src/observability/observability.test.ts
@@ -105,6 +105,7 @@ sqliteDescribe("ObservabilityService", () => {
     });
 
     const logs = await service.getLogTail({ lines: 10, traceId: "trace-1" });
+    expect(logs.path).toBe("daemon.log");
     expect(logs.lines).toEqual(["line-2 trace-1"]);
 
     await service.close();
@@ -194,7 +195,6 @@ sqliteDescribe("ObservabilityService", () => {
       "trace-background-cycle",
       "background_run.cycle.working_applied",
     );
-
     await service.close();
   });
 

--- a/runtime/src/observability/sqlite-store.ts
+++ b/runtime/src/observability/sqlite-store.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, stat } from "node:fs/promises";
-import { dirname, join, resolve as resolvePath } from "node:path";
+import { basename, dirname, join, resolve as resolvePath } from "node:path";
 import { homedir } from "node:os";
 import { safeStringify } from "../tools/types.js";
 import { ensureLazyModule } from "../utils/lazy-import.js";
@@ -421,7 +421,7 @@ export class SqliteObservabilityStore {
           : line.trim().length > 0,
       );
     return {
-      path: this.daemonLogPath,
+      path: basename(this.daemonLogPath),
       lines: filtered.slice(-lineLimit),
     };
   }


### PR DESCRIPTION
## Summary
- require `observability.logs` requests to include a `traceId`
- authorize the trace against the caller's owned session before returning log lines
- stop leaking the absolute daemon log path in log-tail responses
- add regression coverage for missing trace IDs, foreign traces, and sanitized log paths

## Problem
`observability.logs` allowed WebChat clients to omit `traceId` and receive the daemon-wide log tail. That exposed unrelated session activity and returned the server's absolute daemon log path.

## Fix
- reject unscoped `observability.logs` requests with a clear error
- resolve the requested trace first and require ownership of the associated session
- reject unknown trace IDs instead of falling through to raw log filtering
- return only the daemon log basename from the observability store

## Validation
- `npx vitest run src/observability/observability.test.ts src/channels/webchat/plugin.test.ts`
- `npm run typecheck`
- `npx --yes jscpd --min-lines 8 --min-tokens 60 runtime/src/channels/webchat/plugin.test.ts runtime/src/observability/observability.test.ts runtime/src/channels/webchat/handlers.ts runtime/src/observability/sqlite-store.ts`

Closes #1422
