### PR TITLE
fix(runtime): block host typed artifact readers in desktop-only mode

### DIFF
--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -573,23 +573,36 @@ describe("resolveStructuredExecDenyExclusions", () => {
 
 describe("buildDesktopContext", () => {
   it("makes desktop-only host tool unavailability explicit", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", {
+      value: "linux",
+      configurable: true,
+    });
+
     const manager = new DaemonManager({
       configPath: "/tmp/agenc-test-config.json",
     });
 
-    const context = (manager as any).buildDesktopContext({
-      desktop: {
-        enabled: true,
-        environment: "desktop",
-      },
-    });
+    try {
+      const context = (manager as any).buildDesktopContext({
+        desktop: {
+          enabled: true,
+          environment: "desktop",
+        },
+      });
 
-    expect(context).toContain(
-      "system.bash and other raw host `system.*` shell/file mutation tools are NOT available in desktop-only mode.",
-    );
-    expect(context).toContain(
-      "DO NOT silently substitute desktop.bash, browser tools, or another environment",
-    );
+      expect(context).toContain(
+        "host-side typed artifact readers (`system.pdf*`, `system.sqlite*`, `system.spreadsheet*`, `system.officeDocument*`, `system.emailMessage*`, `system.calendar*`)",
+      );
+      expect(context).toContain(
+        "DO NOT silently substitute desktop.bash, browser tools, or another environment",
+      );
+    } finally {
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+        configurable: true,
+      });
+    }
   });
 });
 

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -9811,7 +9811,7 @@ export class DaemonManager {
         '- To run scripts: desktop.bash with "python app.py" or "node server.js"\n' +
         "- For durable code-execution environments, isolated workspace/container jobs, or sandbox lifecycle management, prefer system.sandboxStart plus system.sandboxJob* tools over desktop.process_* or raw shell commands.\n" +
         "- desktop.process_* manages processes inside the already-attached desktop sandbox. It does NOT replace system.sandbox* durable sandbox handles.\n" +
-        "- system.bash and other raw host `system.*` shell/file mutation tools are NOT available in desktop-only mode.\n" +
+        "- system.bash, host-side typed artifact readers (`system.pdf*`, `system.sqlite*`, `system.spreadsheet*`, `system.officeDocument*`, `system.emailMessage*`, `system.calendar*`), and other raw host `system.*` file tools are NOT available in desktop-only mode.\n" +
         "- If the user explicitly asks for an unavailable host tool like system.bash, DO NOT silently substitute desktop.bash, browser tools, or another environment and pretend it is equivalent. State that the requested tool is unavailable in this desktop-only session and only proceed with an allowed desktop/structured-host alternative if the user accepts that change.\n" +
         "- For long-running/background processes you need to inspect or stop later, use desktop.process_start/status/stop instead of desktop.bash.\n" +
         "- desktop.process_start is structured exec only: command = one executable token/path, args = flat string array. Do NOT use bash -lc there.\n" +

--- a/runtime/src/gateway/tool-environment-policy.test.ts
+++ b/runtime/src/gateway/tool-environment-policy.test.ts
@@ -29,32 +29,39 @@ function makeTool(name: string): Tool {
 }
 
 describe("tool-environment-policy", () => {
-  it("keeps only structured durable host handles available in desktop mode", () => {
-    expect(isToolAllowedForEnvironment("system.bash", "desktop")).toBe(false);
-    expect(isToolAllowedForEnvironment("system.open", "desktop")).toBe(false);
-    expect(isToolAllowedForEnvironment("system.processStart", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.serverStart", "desktop")).toBe(true);
-    expect(
-      isToolAllowedForEnvironment("system.browserSessionStart", "desktop"),
-    ).toBe(true);
-    expect(isToolAllowedForEnvironment("system.remoteJobStart", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.researchStart", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.sandboxStart", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.sqliteSchema", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.sqliteQuery", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.pdfInfo", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.pdfExtractText", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.spreadsheetInfo", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.spreadsheetRead", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.officeDocumentInfo", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.officeDocumentExtractText", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.emailMessageInfo", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.emailMessageExtractText", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.calendarInfo", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("system.calendarRead", "desktop")).toBe(true);
-    expect(isToolAllowedForEnvironment("execute_with_agent", "desktop")).toBe(
-      true,
-    );
+  it("keeps only structured durable host control tools available in desktop mode", () => {
+    const allowed = [
+      "system.processStart",
+      "system.serverStart",
+      "system.browserSessionStart",
+      "system.remoteJobStart",
+      "system.researchStart",
+      "system.sandboxStart",
+      "execute_with_agent",
+    ];
+    const blocked = [
+      "system.bash",
+      "system.open",
+      "system.sqliteSchema",
+      "system.sqliteQuery",
+      "system.pdfInfo",
+      "system.pdfExtractText",
+      "system.spreadsheetInfo",
+      "system.spreadsheetRead",
+      "system.officeDocumentInfo",
+      "system.officeDocumentExtractText",
+      "system.emailMessageInfo",
+      "system.emailMessageExtractText",
+      "system.calendarInfo",
+      "system.calendarRead",
+    ];
+
+    for (const toolName of allowed) {
+      expect(isToolAllowedForEnvironment(toolName, "desktop")).toBe(true);
+    }
+    for (const toolName of blocked) {
+      expect(isToolAllowedForEnvironment(toolName, "desktop")).toBe(false);
+    }
   });
 
   it("keeps host-scoped browser session tools available outside desktop-only mode", () => {
@@ -81,12 +88,6 @@ describe("tool-environment-policy", () => {
 
     expect(filtered.map((tool) => tool.function.name)).toEqual([
       "system.sandboxStart",
-      "system.sqliteSchema",
-      "system.pdfInfo",
-      "system.spreadsheetInfo",
-      "system.officeDocumentInfo",
-      "system.emailMessageInfo",
-      "system.calendarInfo",
       "desktop.bash",
       "playwright.browser_navigate",
       "execute_with_agent",
@@ -124,12 +125,6 @@ describe("tool-environment-policy", () => {
       ], "desktop"),
     ).toEqual([
       "system.sandboxStart",
-      "system.sqliteSchema",
-      "system.pdfInfo",
-      "system.spreadsheetInfo",
-      "system.officeDocumentInfo",
-      "system.emailMessageInfo",
-      "system.calendarInfo",
       "desktop.bash",
       "mcp.browser.browser_snapshot",
       "execute_with_agent",

--- a/runtime/src/gateway/tool-environment-policy.ts
+++ b/runtime/src/gateway/tool-environment-policy.ts
@@ -1,9 +1,9 @@
 /**
  * Shared tool-environment filtering helpers.
  *
- * Desktop-only mode excludes raw host-mutation tools like `system.bash`, but it
- * keeps the structured durable-handle families available so the runtime can
- * still supervise long-lived host resources deterministically.
+ * Desktop-only mode excludes raw host tools and host-side typed artifact
+ * readers, but it keeps the structured durable-handle families available so
+ * the runtime can still supervise long-lived host resources deterministically.
  * Host-only mode excludes desktop/container surfaces instead.
  *
  * @module
@@ -14,7 +14,7 @@ import type { LLMTool } from "../llm/types.js";
 export type ToolEnvironmentMode = "both" | "desktop" | "host";
 
 const HOST_TOOL_PREFIX = "system.";
-const DESKTOP_ALLOWED_HOST_TOOL_PREFIXES = [
+const DESKTOP_ALLOWED_HOST_CONTROL_TOOL_PREFIXES = [
   "system.process",
   "system.server",
   "system.browserSession",
@@ -22,12 +22,6 @@ const DESKTOP_ALLOWED_HOST_TOOL_PREFIXES = [
   "system.remoteJob",
   "system.research",
   "system.sandbox",
-  "system.sqlite",
-  "system.pdf",
-  "system.spreadsheet",
-  "system.officeDocument",
-  "system.emailMessage",
-  "system.calendar",
 ] as const;
 const DESKTOP_TOOL_PREFIXES = [
   "desktop.",
@@ -43,7 +37,7 @@ function isDesktopScopedToolName(name: string): boolean {
 }
 
 function isStructuredHostControlToolName(name: string): boolean {
-  return DESKTOP_ALLOWED_HOST_TOOL_PREFIXES.some((prefix) =>
+  return DESKTOP_ALLOWED_HOST_CONTROL_TOOL_PREFIXES.some((prefix) =>
     name.startsWith(prefix)
   );
 }

--- a/runtime/src/gateway/tool-routing.test.ts
+++ b/runtime/src/gateway/tool-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { LLMTool } from "../llm/types.js";
 import { ToolRouter } from "./tool-routing.js";
+import { filterLlmToolsByEnvironment } from "./tool-environment-policy.js";
 
 function makeTool(name: string, description: string): LLMTool {
   return {
@@ -429,6 +430,40 @@ describe("ToolRouter", () => {
     expect(decision.routedToolNames).toContain("system.calendarInfo");
     expect(decision.routedToolNames).toContain("system.calendarRead");
   });
+
+  it.each([
+    {
+      label: "PDF",
+      sessionId: "s-desktop-pdf",
+      messageText: "extract text from this pdf report and inspect its metadata",
+      blockedTools: ["system.pdfInfo", "system.pdfExtractText"],
+    },
+    {
+      label: "SQLite",
+      sessionId: "s-desktop-sqlite",
+      messageText: "inspect the sqlite schema and query the database tables",
+      blockedTools: ["system.sqliteSchema", "system.sqliteQuery"],
+    },
+  ])(
+    "does not route host-side typed artifact readers in desktop mode for $label prompts",
+    ({ sessionId, messageText, blockedTools }) => {
+      const router = new ToolRouter(filterLlmToolsByEnvironment(TOOLS, "desktop"), {
+        maxToolsPerTurn: 8,
+        minToolsPerTurn: 4,
+      });
+
+      const decision = router.route({
+        sessionId,
+        messageText,
+        history: [],
+      });
+
+      for (const toolName of blockedTools) {
+        expect(decision.routedToolNames).not.toContain(toolName);
+        expect(decision.expandedToolNames).not.toContain(toolName);
+      }
+    },
+  );
 
   it("prefers typed server handles for server monitoring tasks", () => {
     const router = new ToolRouter(TOOLS, {


### PR DESCRIPTION
## Summary
- remove host-side typed artifact reader families from the desktop-only host allowlist
- add routing coverage to ensure desktop sessions do not surface those readers for artifact prompts
- make the desktop-only daemon prompt explicitly state that the typed host readers are unavailable

Closes #1423

## Validation
- `npm run build` (in `sdk/`)
- `npx vitest run src/gateway/tool-environment-policy.test.ts src/gateway/tool-routing.test.ts src/gateway/daemon.test.ts`
- `npm run typecheck` (in `runtime/`)
- `npx --yes jscpd --min-lines 8 --min-tokens 60 runtime/src/gateway/tool-environment-policy.ts runtime/src/gateway/tool-environment-policy.test.ts runtime/src/gateway/tool-routing.test.ts runtime/src/gateway/daemon.ts runtime/src/gateway/daemon.test.ts`