### PR TITLE
feat(runtime): harden routed execution and live console

### DIFF
--- a/runtime/src/gateway/daemon-trace.ts
+++ b/runtime/src/gateway/daemon-trace.ts
@@ -1,0 +1,858 @@
+/**
+ * Trace/logging summarization helpers for the runtime daemon.
+ *
+ * @module
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { persistTracePayloadArtifact, type TracePayloadArtifactRef } from "../utils/trace-payload-store.js";
+import {
+  formatTracePayloadForLog as formatSharedTracePayloadForLog,
+  sanitizeTraceTextForLogSnippet,
+  summarizeTracePayloadForPreview,
+  summarizeTraceTextForPreview,
+} from "../utils/trace-payload-serialization.js";
+import type { Logger } from "../utils/logger.js";
+import type {
+  LLMMessage,
+  LLMProviderTraceEvent,
+} from "../llm/types.js";
+import type {
+  ChatCallUsageRecord,
+  ChatExecutionTraceEvent,
+  ChatToolRoutingSummary,
+  ToolCallRecord,
+} from "../llm/chat-executor-types.js";
+import type { GatewayMessage } from "./message.js";
+import type { ToolRoutingDecision } from "./tool-routing.js";
+import type { GatewayLoggingConfig } from "./types.js";
+import type { SubAgentLifecycleEvent } from "./delegation-runtime.js";
+import { recordObservabilityTraceEvent } from "../observability/index.js";
+
+const TOOL_LOG_SNIPPET_MAX_CHARS = 240;
+export const EVAL_REPLY_MAX_CHARS = 4_000;
+const TRACE_LOG_DEFAULT_MAX_CHARS = 20_000;
+const TRACE_LOG_MIN_MAX_CHARS = 256;
+const TRACE_LOG_MAX_MAX_CHARS = 200_000;
+const TRACE_HISTORY_MAX_MESSAGES = 500;
+
+const TRACE_DATA_IMAGE_URL_PATTERN =
+  /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g;
+const TRACE_JSON_BINARY_FIELD_PATTERN =
+  /"([A-Za-z0-9_.-]*(?:image|dataurl|data|base64)[A-Za-z0-9_.-]*)"\s*:\s*"([A-Za-z0-9+/=\r\n]{128,})"/gi;
+const TRACE_QUOTED_BASE64_BLOB_PATTERN = /"([A-Za-z0-9+/=\r\n]{512,})"/g;
+const TRACE_RAW_BASE64_BLOB_PATTERN = /[A-Za-z0-9+/=\r\n]{2048,}/g;
+
+export interface ToolFailureSummary {
+  readonly name: string;
+  readonly durationMs: number;
+  readonly error: string;
+  args?: Record<string, unknown>;
+}
+
+export interface ResolvedTraceLoggingConfig {
+  readonly enabled: boolean;
+  readonly includeHistory: boolean;
+  readonly includeSystemPrompt: boolean;
+  readonly includeToolArgs: boolean;
+  readonly includeToolResults: boolean;
+  readonly includeProviderPayloads: boolean;
+  readonly maxChars: number;
+}
+
+interface TraceEventLogOptions {
+  readonly artifactPayload?: Record<string, unknown>;
+}
+
+const DEFAULT_TRACE_LOGGING_CONFIG: ResolvedTraceLoggingConfig = {
+  enabled: false,
+  includeHistory: true,
+  includeSystemPrompt: true,
+  includeToolArgs: true,
+  includeToolResults: true,
+  includeProviderPayloads: false,
+  maxChars: TRACE_LOG_DEFAULT_MAX_CHARS,
+};
+
+export function truncateToolLogText(
+  value: string,
+  maxChars = TOOL_LOG_SNIPPET_MAX_CHARS,
+): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
+  return value.slice(0, maxChars - 3) + "...";
+}
+
+export function sanitizeToolResultTextForTrace(rawResult: string): string {
+  const sanitized = rawResult
+    .replace(TRACE_DATA_IMAGE_URL_PATTERN, "(see image)")
+    .replace(
+      TRACE_JSON_BINARY_FIELD_PATTERN,
+      (_match: string, key: string) => `"${key}":"(base64 omitted)"`,
+    )
+    .replace(TRACE_QUOTED_BASE64_BLOB_PATTERN, '"(base64 omitted)"')
+    .replace(TRACE_RAW_BASE64_BLOB_PATTERN, "(base64 omitted)");
+  return sanitizeTraceTextForLogSnippet(sanitized, TRACE_LOG_DEFAULT_MAX_CHARS);
+}
+
+function summarizeArtifactText(value: string, maxChars: number): unknown {
+  return summarizeTraceTextForPreview(value, maxChars);
+}
+
+function clampTraceMaxChars(maxChars: number | undefined): number {
+  if (maxChars === undefined) return TRACE_LOG_DEFAULT_MAX_CHARS;
+  if (!Number.isFinite(maxChars)) return TRACE_LOG_DEFAULT_MAX_CHARS;
+  return Math.min(
+    TRACE_LOG_MAX_MAX_CHARS,
+    Math.max(TRACE_LOG_MIN_MAX_CHARS, Math.floor(maxChars)),
+  );
+}
+
+export function resolveTraceLoggingConfig(
+  logging?: GatewayLoggingConfig,
+): ResolvedTraceLoggingConfig {
+  const trace = logging?.trace;
+  if (!trace?.enabled) {
+    return DEFAULT_TRACE_LOGGING_CONFIG;
+  }
+
+  return {
+    enabled: true,
+    includeHistory: trace.includeHistory ?? true,
+    includeSystemPrompt: trace.includeSystemPrompt ?? true,
+    includeToolArgs: trace.includeToolArgs ?? true,
+    includeToolResults: trace.includeToolResults ?? true,
+    includeProviderPayloads: trace.includeProviderPayloads ?? false,
+    maxChars: clampTraceMaxChars(trace.maxChars),
+  };
+}
+
+export function summarizeTraceValue(
+  value: unknown,
+  maxChars: number,
+): unknown {
+  return summarizeTracePayloadForPreview(value, maxChars);
+}
+
+export function formatTracePayloadForLog(
+  payload: Record<string, unknown>,
+  maxChars = TRACE_LOG_DEFAULT_MAX_CHARS,
+): string {
+  return formatSharedTracePayloadForLog(payload, maxChars);
+}
+
+function buildTraceLogPayload(
+  eventName: string,
+  payload: Record<string, unknown>,
+  options?: TraceEventLogOptions,
+): Record<string, unknown> {
+  const artifactPayload = options?.artifactPayload;
+  const traceId =
+    typeof payload.traceId === "string" ? payload.traceId : undefined;
+  const payloadArtifact = artifactPayload
+    ? persistTracePayloadArtifact({
+        traceId,
+        eventName,
+        payload: artifactPayload,
+      })
+    : undefined;
+  return {
+    ...payload,
+    ...(payloadArtifact ? { traceArtifact: payloadArtifact } : {}),
+  };
+}
+
+export function logTraceEvent(
+  logger: Logger,
+  eventName: string,
+  payload: Record<string, unknown>,
+  maxChars: number,
+  options?: TraceEventLogOptions,
+): void {
+  const artifactPayload = options?.artifactPayload;
+  const builtPayload = buildTraceLogPayload(eventName, payload, options);
+  const artifact = builtPayload.traceArtifact as TracePayloadArtifactRef | undefined;
+  recordObservabilityTraceEvent({
+    eventName,
+    level: "info",
+    traceId: typeof payload.traceId === "string" ? payload.traceId : undefined,
+    sessionId:
+      typeof payload.sessionId === "string" ? payload.sessionId : undefined,
+    channel: eventName.split(".", 1)[0],
+    payloadPreview: builtPayload,
+    rawPayload: artifactPayload ?? payload,
+    artifact,
+  });
+  logger.info(
+    `[trace] ${eventName} ` +
+      formatTracePayloadForLog(builtPayload, maxChars),
+  );
+}
+
+export function logTraceErrorEvent(
+  logger: Logger,
+  eventName: string,
+  payload: Record<string, unknown>,
+  maxChars: number,
+  options?: TraceEventLogOptions,
+): void {
+  const artifactPayload = options?.artifactPayload;
+  const builtPayload = buildTraceLogPayload(eventName, payload, options);
+  const artifact = builtPayload.traceArtifact as TracePayloadArtifactRef | undefined;
+  recordObservabilityTraceEvent({
+    eventName,
+    level: "error",
+    traceId: typeof payload.traceId === "string" ? payload.traceId : undefined,
+    sessionId:
+      typeof payload.sessionId === "string" ? payload.sessionId : undefined,
+    channel: eventName.split(".", 1)[0],
+    payloadPreview: builtPayload,
+    rawPayload: artifactPayload ?? payload,
+    artifact,
+  });
+  logger.error(
+    `[trace] ${eventName} ` +
+      formatTracePayloadForLog(builtPayload, maxChars),
+  );
+}
+
+export function logProviderPayloadTraceEvent(params: {
+  logger: Logger;
+  channelName: string;
+  traceId: string;
+  sessionId: string;
+  traceConfig: ResolvedTraceLoggingConfig;
+  event: LLMProviderTraceEvent;
+}): void {
+  const { logger, channelName, traceId, sessionId, traceConfig, event } =
+    params;
+  logTraceEvent(
+    logger,
+    `${channelName}.provider.${event.kind}`,
+    {
+      traceId,
+      sessionId,
+      provider: event.provider,
+      model: event.model,
+      transport: event.transport,
+      ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
+      ...(event.callPhase !== undefined ? { callPhase: event.callPhase } : {}),
+      ...(event.context
+        ? { contextPreview: summarizeTraceValue(event.context, traceConfig.maxChars) }
+        : {}),
+      payloadPreview: summarizeTraceValue(event.payload, traceConfig.maxChars),
+    },
+    traceConfig.maxChars,
+    {
+      artifactPayload: {
+        traceId,
+        sessionId,
+        provider: event.provider,
+        model: event.model,
+        transport: event.transport,
+        ...(event.callIndex !== undefined
+          ? { callIndex: event.callIndex }
+          : {}),
+        ...(event.callPhase !== undefined
+          ? { callPhase: event.callPhase }
+          : {}),
+        payload: event.payload,
+        ...(event.context ? { context: event.context } : {}),
+      },
+    },
+  );
+}
+
+export function logExecutionTraceEvent(params: {
+  logger: Logger;
+  channelName: string;
+  traceId: string;
+  sessionId: string;
+  traceConfig: ResolvedTraceLoggingConfig;
+  event: ChatExecutionTraceEvent;
+}): void {
+  const { logger, channelName, traceId, sessionId, traceConfig, event } =
+    params;
+  logTraceEvent(
+    logger,
+    `${channelName}.executor.${event.type}`,
+    {
+      traceId,
+      sessionId,
+      ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
+      ...(event.phase !== undefined ? { callPhase: event.phase } : {}),
+      payloadPreview: summarizeTraceValue(event.payload, traceConfig.maxChars),
+    },
+    traceConfig.maxChars,
+    {
+      artifactPayload: {
+        traceId,
+        sessionId,
+        ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
+        ...(event.phase !== undefined ? { callPhase: event.phase } : {}),
+        payload: event.payload,
+      },
+    },
+  );
+}
+
+function summarizeLlmContentForTrace(
+  content: LLMMessage["content"],
+  maxChars: number,
+): unknown {
+  if (typeof content === "string") {
+    return truncateToolLogText(content, maxChars);
+  }
+  if (!Array.isArray(content)) {
+    return summarizeTraceValue(content, maxChars);
+  }
+
+  return content.map((part) => {
+    if (!part || typeof part !== "object") {
+      return summarizeTraceValue(part, maxChars);
+    }
+
+    if (part.type === "text") {
+      return {
+        type: "text",
+        text: truncateToolLogText(part.text, maxChars),
+      };
+    }
+
+    if (part.type === "image_url") {
+      return {
+        type: "image_url",
+        image_url: {
+          url: summarizeArtifactText(part.image_url.url, maxChars),
+        },
+      };
+    }
+
+    return summarizeTraceValue(part, maxChars);
+  });
+}
+
+export function summarizeHistoryForTrace(
+  history: readonly LLMMessage[],
+  traceConfig: ResolvedTraceLoggingConfig,
+): unknown[] {
+  const sliceStart = Math.max(0, history.length - TRACE_HISTORY_MAX_MESSAGES);
+  const entries = history.slice(sliceStart).map((entry) => {
+    const output: Record<string, unknown> = {
+      role: entry.role,
+      content: summarizeLlmContentForTrace(entry.content, traceConfig.maxChars),
+    };
+
+    if (entry.toolCalls && entry.toolCalls.length > 0) {
+      output.toolCalls = entry.toolCalls.map((toolCall) => ({
+        id: toolCall.id,
+        name: toolCall.name,
+        ...(traceConfig.includeToolArgs
+          ? {
+              arguments: truncateToolLogText(
+                toolCall.arguments,
+                traceConfig.maxChars,
+              ),
+            }
+          : {}),
+      }));
+    }
+
+    if (entry.toolCallId) output.toolCallId = entry.toolCallId;
+    if (entry.toolName) output.toolName = entry.toolName;
+    return output;
+  });
+
+  if (sliceStart > 0) {
+    entries.unshift({
+      notice: `${sliceStart} oldest history message(s) omitted`,
+    });
+  }
+
+  return entries;
+}
+
+export function summarizeRoleCounts(
+  messages: readonly LLMMessage[],
+): Record<string, number> {
+  const counts = {
+    system: 0,
+    user: 0,
+    assistant: 0,
+    tool: 0,
+  };
+  for (const entry of messages) {
+    if (entry.role === "system") counts.system += 1;
+    else if (entry.role === "user") counts.user += 1;
+    else if (entry.role === "assistant") counts.assistant += 1;
+    else if (entry.role === "tool") counts.tool += 1;
+  }
+  return counts;
+}
+
+export function createTurnTraceId(msg: GatewayMessage): string {
+  const messageId = typeof msg.id === "string" ? msg.id.trim() : "";
+  if (messageId.length > 0) {
+    return `${msg.sessionId}:${messageId}`;
+  }
+  const stamp = Date.now().toString(36);
+  return `${msg.sessionId}:${stamp}:${randomUUID().slice(0, 8)}`;
+}
+
+export function sanitizeLifecyclePayloadData(
+  payload: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!payload) return {};
+  const summarized = summarizeTraceValue(payload, TRACE_LOG_DEFAULT_MAX_CHARS);
+  if (
+    typeof summarized === "object" &&
+    summarized !== null &&
+    !Array.isArray(summarized)
+  ) {
+    return summarized as Record<string, unknown>;
+  }
+  return { value: summarized };
+}
+
+export function buildSubagentTraceId(
+  parentTraceId: string | undefined,
+  event: SubAgentLifecycleEvent,
+): string | undefined {
+  if (!parentTraceId) return undefined;
+  const sessionRef = event.subagentSessionId ?? event.sessionId;
+  const fingerprint = createHash("sha256")
+    .update(`${parentTraceId}|${event.type}|${sessionRef}|${event.timestamp}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `${parentTraceId}:sub:${fingerprint}`;
+}
+
+function summarizeBudgetDiagnosticsForTrace(
+  diagnostics: ChatCallUsageRecord["budgetDiagnostics"],
+): Record<string, unknown> | undefined {
+  if (!diagnostics) return undefined;
+
+  const constrainedSections: Record<string, unknown> = {};
+  for (const [section, stats] of Object.entries(diagnostics.sections)) {
+    if (
+      stats.beforeChars > stats.afterChars ||
+      stats.droppedMessages > 0 ||
+      stats.truncatedMessages > 0
+    ) {
+      constrainedSections[section] = {
+        capChars: stats.capChars,
+        beforeMessages: stats.beforeMessages,
+        afterMessages: stats.afterMessages,
+        beforeChars: stats.beforeChars,
+        afterChars: stats.afterChars,
+        droppedMessages: stats.droppedMessages,
+        truncatedMessages: stats.truncatedMessages,
+      };
+    }
+  }
+
+  return {
+    constrained: diagnostics.constrained,
+    totalBeforeChars: diagnostics.totalBeforeChars,
+    totalAfterChars: diagnostics.totalAfterChars,
+    capChars: diagnostics.caps.totalChars,
+    model: diagnostics.model,
+    droppedSections: diagnostics.droppedSections,
+    constrainedSections,
+  };
+}
+
+function summarizeStatefulDiagnosticsForTrace(
+  diagnostics: ChatCallUsageRecord["statefulDiagnostics"],
+): Record<string, unknown> | undefined {
+  if (!diagnostics) return undefined;
+  return {
+    enabled: diagnostics.enabled,
+    attempted: diagnostics.attempted,
+    continued: diagnostics.continued,
+    store: diagnostics.store,
+    fallbackToStateless: diagnostics.fallbackToStateless,
+    previousResponseId: diagnostics.previousResponseId,
+    responseId: diagnostics.responseId,
+    reconciliationHash: diagnostics.reconciliationHash,
+    fallbackReason: diagnostics.fallbackReason,
+    events: diagnostics.events,
+  };
+}
+
+export function summarizeCallUsageForTrace(
+  callUsage: readonly ChatCallUsageRecord[],
+): unknown[] {
+  return callUsage.map((entry) => ({
+    callIndex: entry.callIndex,
+    phase: entry.phase,
+    provider: entry.provider,
+    model: entry.model,
+    finishReason: entry.finishReason,
+    usage: entry.usage,
+    promptShapeBeforeBudget: entry.beforeBudget,
+    promptShapeAfterBudget: entry.afterBudget,
+    providerRequestMetrics: entry.providerRequestMetrics,
+    budgetDiagnostics: summarizeBudgetDiagnosticsForTrace(
+      entry.budgetDiagnostics,
+    ),
+    statefulDiagnostics: summarizeStatefulDiagnosticsForTrace(
+      entry.statefulDiagnostics,
+    ),
+  }));
+}
+
+export function summarizeInitialRequestShape(
+  callUsage: readonly ChatCallUsageRecord[],
+): Record<string, unknown> | undefined {
+  const first = callUsage[0];
+  if (!first) return undefined;
+  return {
+    messageCountsBeforeBudget: {
+      system: first.beforeBudget.systemMessages,
+      user: first.beforeBudget.userMessages,
+      assistant: first.beforeBudget.assistantMessages,
+      tool: first.beforeBudget.toolMessages,
+      total: first.beforeBudget.messageCount,
+    },
+    messageCountsAfterBudget: {
+      system: first.afterBudget.systemMessages,
+      user: first.afterBudget.userMessages,
+      assistant: first.afterBudget.assistantMessages,
+      tool: first.afterBudget.toolMessages,
+      total: first.afterBudget.messageCount,
+    },
+    estimatedPromptCharsBeforeBudget: first.beforeBudget.estimatedChars,
+    estimatedPromptCharsAfterBudget: first.afterBudget.estimatedChars,
+    systemPromptCharsAfterBudget: first.afterBudget.systemPromptChars,
+    toolSchemaChars: first.providerRequestMetrics?.toolSchemaChars,
+    budgetDiagnostics: summarizeBudgetDiagnosticsForTrace(
+      first.budgetDiagnostics,
+    ),
+    statefulDiagnostics: summarizeStatefulDiagnosticsForTrace(
+      first.statefulDiagnostics,
+    ),
+  };
+}
+
+export function summarizeToolRoutingDecisionForTrace(
+  decision: ToolRoutingDecision | undefined,
+): Record<string, unknown> | undefined {
+  if (!decision) return undefined;
+  return {
+    routedToolNames: decision.routedToolNames,
+    expandedToolNames: decision.expandedToolNames,
+    diagnostics: decision.diagnostics,
+  };
+}
+
+export function summarizeToolRoutingSummaryForTrace(
+  summary: ChatToolRoutingSummary | undefined,
+): Record<string, unknown> | undefined {
+  if (!summary) return undefined;
+  return {
+    enabled: summary.enabled,
+    initialToolCount: summary.initialToolCount,
+    finalToolCount: summary.finalToolCount,
+    routeMisses: summary.routeMisses,
+    expanded: summary.expanded,
+  };
+}
+
+export function summarizeGatewayMessageForTrace(
+  msg: GatewayMessage,
+  maxChars: number,
+): Record<string, unknown> {
+  return {
+    id: msg.id,
+    channel: msg.channel,
+    senderId: msg.senderId,
+    senderName: msg.senderName,
+    sessionId: msg.sessionId,
+    scope: msg.scope,
+    timestamp: msg.timestamp,
+    content: truncateToolLogText(msg.content, maxChars),
+    attachments: msg.attachments?.map((attachment) => ({
+      type: attachment.type,
+      mimeType: attachment.mimeType,
+      filename: attachment.filename,
+      url: attachment.url
+        ? truncateToolLogText(attachment.url, maxChars)
+        : undefined,
+      sizeBytes: attachment.sizeBytes,
+      durationSeconds: attachment.durationSeconds,
+      dataBytes: attachment.data?.byteLength,
+    })),
+    metadata: summarizeTraceValue(msg.metadata, maxChars),
+  };
+}
+
+function summarizeExecuteWithAgentArgs(
+  args: Record<string, unknown>,
+  maxChars: number,
+): Record<string, unknown> | undefined {
+  const summary: Record<string, unknown> = {};
+  if (typeof args.objective === "string" && args.objective.trim().length > 0) {
+    summary.objective = truncateToolLogText(args.objective, maxChars);
+  } else if (typeof args.task === "string" && args.task.trim().length > 0) {
+    summary.task = truncateToolLogText(args.task, maxChars);
+  }
+  if (
+    typeof args.inputContract === "string" &&
+    args.inputContract.trim().length > 0
+  ) {
+    summary.inputContract = truncateToolLogText(args.inputContract, maxChars);
+  }
+  if (Array.isArray(args.tools) && args.tools.length > 0) {
+    summary.tools = args.tools
+      .filter(
+        (tool): tool is string =>
+          typeof tool === "string" && tool.trim().length > 0,
+      )
+      .slice(0, 8);
+  }
+  if (
+    Array.isArray(args.requiredToolCapabilities) &&
+    args.requiredToolCapabilities.length > 0
+  ) {
+    summary.requiredToolCapabilities = args.requiredToolCapabilities
+      .filter(
+        (tool): tool is string =>
+          typeof tool === "string" && tool.trim().length > 0,
+      )
+      .slice(0, 8);
+  }
+  if (
+    Array.isArray(args.acceptanceCriteria) &&
+    args.acceptanceCriteria.length > 0
+  ) {
+    summary.acceptanceCriteria = args.acceptanceCriteria
+      .filter(
+        (criterion): criterion is string =>
+          typeof criterion === "string" && criterion.trim().length > 0,
+      )
+      .slice(0, 4)
+      .map((criterion) => truncateToolLogText(criterion, maxChars));
+  }
+  if (typeof args.timeoutMs === "number" && Number.isFinite(args.timeoutMs)) {
+    summary.timeoutMs = args.timeoutMs;
+  }
+  return Object.keys(summary).length > 0 ? summary : undefined;
+}
+
+function summarizeExecuteWithAgentToolCallsForTrace(
+  value: unknown,
+  maxChars: number,
+): unknown {
+  if (!Array.isArray(value)) return undefined;
+  const limit = Math.min(value.length, 6);
+  const summarized = value.slice(0, limit).map((entry) => {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      return summarizeTraceValue(entry, maxChars);
+    }
+    const toolCall = entry as Record<string, unknown>;
+    const record: Record<string, unknown> = {};
+    if (typeof toolCall.name === "string") record.name = toolCall.name;
+    if (typeof toolCall.isError === "boolean") {
+      record.isError = toolCall.isError;
+    }
+    if (
+      typeof toolCall.durationMs === "number" &&
+      Number.isFinite(toolCall.durationMs)
+    ) {
+      record.durationMs = toolCall.durationMs;
+    }
+    if (
+      toolCall.args &&
+      typeof toolCall.args === "object" &&
+      !Array.isArray(toolCall.args)
+    ) {
+      record.args =
+        summarizeToolArgsForLog(
+          typeof toolCall.name === "string" ? toolCall.name : "",
+          toolCall.args as Record<string, unknown>,
+        ) ?? summarizeTraceValue(toolCall.args, maxChars);
+    }
+    if (
+      typeof toolCall.result === "string" &&
+      toolCall.result.trim().length > 0
+    ) {
+      record.result = summarizeToolResultForTrace(toolCall.result, maxChars);
+    }
+    return record;
+  });
+  if (value.length > limit) {
+    summarized.push(`[${value.length - limit} more tool call(s)]`);
+  }
+  return summarized;
+}
+
+export function summarizeToolResultForTrace(
+  rawResult: string,
+  maxChars: number,
+): unknown {
+  try {
+    const parsed = JSON.parse(rawResult) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+    ) {
+      const record = parsed as Record<string, unknown>;
+      const status =
+        typeof record.status === "string" ? record.status : undefined;
+      const objective =
+        typeof record.objective === "string" &&
+        record.objective.trim().length > 0
+          ? truncateToolLogText(record.objective, maxChars)
+          : undefined;
+      const output =
+        typeof record.output === "string" && record.output.trim().length > 0
+          ? summarizeTraceTextForPreview(
+              sanitizeToolResultTextForTrace(record.output),
+              maxChars,
+            )
+          : undefined;
+      const error =
+        typeof record.error === "string" && record.error.trim().length > 0
+          ? summarizeTraceTextForPreview(
+              sanitizeTraceTextForLogSnippet(record.error, maxChars),
+              maxChars,
+            )
+          : undefined;
+      const validationCode =
+        typeof record.validationCode === "string"
+          ? record.validationCode
+          : undefined;
+      const stopReason =
+        typeof record.stopReason === "string" ? record.stopReason : undefined;
+      const stopReasonDetail =
+        typeof record.stopReasonDetail === "string" &&
+        record.stopReasonDetail.trim().length > 0
+          ? truncateToolLogText(record.stopReasonDetail, maxChars)
+          : undefined;
+      const failedToolCalls =
+        typeof record.failedToolCalls === "number" &&
+        Number.isFinite(record.failedToolCalls)
+          ? record.failedToolCalls
+          : undefined;
+      const toolCalls = summarizeExecuteWithAgentToolCallsForTrace(
+        record.toolCalls,
+        maxChars,
+      );
+      const decomposition = summarizeTraceValue(record.decomposition, maxChars);
+
+      if (
+        status !== undefined ||
+        objective !== undefined ||
+        output !== undefined ||
+        error !== undefined ||
+        validationCode !== undefined ||
+        stopReason !== undefined ||
+        stopReasonDetail !== undefined ||
+        failedToolCalls !== undefined ||
+        toolCalls !== undefined
+      ) {
+        return {
+          ...(typeof record.success === "boolean"
+            ? { success: record.success }
+            : {}),
+          ...(status !== undefined ? { status } : {}),
+          ...(objective !== undefined ? { objective } : {}),
+          ...(validationCode !== undefined ? { validationCode } : {}),
+          ...(stopReason !== undefined ? { stopReason } : {}),
+          ...(stopReasonDetail !== undefined ? { stopReasonDetail } : {}),
+          ...(failedToolCalls !== undefined ? { failedToolCalls } : {}),
+          ...(decomposition !== undefined ? { decomposition } : {}),
+          ...(error !== undefined ? { error } : {}),
+          ...(output !== undefined ? { output } : {}),
+          ...(toolCalls !== undefined ? { toolCalls } : {}),
+        };
+      }
+    }
+    return summarizeTraceValue(parsed, maxChars);
+  } catch {
+    return truncateToolLogText(
+      sanitizeToolResultTextForTrace(rawResult),
+      maxChars,
+    );
+  }
+}
+
+export function summarizeToolArgsForLog(
+  name: string,
+  args: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (name === "execute_with_agent") {
+    return summarizeExecuteWithAgentArgs(args, 300);
+  }
+
+  if (
+    (name === "desktop.bash" || name === "system.bash") &&
+    typeof args.command === "string"
+  ) {
+    return {
+      command: truncateToolLogText(args.command, 400),
+    };
+  }
+
+  if (name === "desktop.text_editor") {
+    const summary: Record<string, unknown> = {};
+    if (typeof args.action === "string") summary.action = args.action;
+    if (typeof args.filePath === "string") summary.filePath = args.filePath;
+    if (typeof args.text === "string") {
+      summary.textPreview = truncateToolLogText(args.text, 200);
+    }
+    return Object.keys(summary).length > 0 ? summary : undefined;
+  }
+
+  return undefined;
+}
+
+export function summarizeToolFailureForLog(
+  toolCall: ToolCallRecord,
+): ToolFailureSummary | null {
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    const decoded = JSON.parse(toolCall.result) as unknown;
+    if (
+      typeof decoded === "object" &&
+      decoded !== null &&
+      !Array.isArray(decoded)
+    ) {
+      parsed = decoded as Record<string, unknown>;
+    }
+  } catch {
+    // Non-JSON tool result
+  }
+
+  const parsedError =
+    parsed && typeof parsed.error === "string" ? parsed.error : undefined;
+  const exitCode =
+    parsed && typeof parsed.exitCode === "number" ? parsed.exitCode : undefined;
+  const stderr =
+    parsed && typeof parsed.stderr === "string" ? parsed.stderr : undefined;
+
+  let error: string | undefined;
+  if (toolCall.isError) {
+    error = parsedError ?? toolCall.result;
+  } else if (parsedError) {
+    error = parsedError;
+  } else if (exitCode !== undefined && exitCode !== 0) {
+    error =
+      stderr && stderr.trim().length > 0
+        ? `exitCode ${exitCode}: ${stderr}`
+        : `exitCode ${exitCode}`;
+  }
+
+  if (!error) return null;
+
+  const summary: ToolFailureSummary = {
+    name: toolCall.name,
+    durationMs: toolCall.durationMs,
+    error: sanitizeTraceTextForLogSnippet(error, TOOL_LOG_SNIPPET_MAX_CHARS),
+  };
+  const args = summarizeToolArgsForLog(toolCall.name, toolCall.args);
+  if (args) summary.args = args;
+  return summary;
+}

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -148,6 +148,23 @@ describe("sanitizeToolResultTextForTrace", () => {
     expect(sanitized).toContain("(see image)");
     expect(sanitized).not.toContain("data:image/png;base64,");
   });
+
+  it("collapses ANSI-heavy terminal frames into a trace-safe placeholder", () => {
+    const raw = [
+      "\u001b[H\u001b[2J\u001b[38;5;239m╭──────────╮\u001b[0m",
+      "\u001b[38;5;239m│\u001b[0mAGEN C LIVE\u001b[38;5;239m│\u001b[0m",
+      "\u001b[38;5;239m│\u001b[0mSTATUS connecting…\u001b[38;5;239m│\u001b[0m",
+      "\u001b[38;5;239m╰──────────╯\u001b[0m",
+      " ".repeat(96),
+      " ".repeat(96),
+    ].join("\n");
+
+    const sanitized = sanitizeToolResultTextForTrace(raw);
+
+    expect(sanitized).toContain("[terminal capture omitted");
+    expect(sanitized).not.toContain("\u001b[");
+    expect(sanitized).not.toContain("AGEN C LIVE");
+  });
 });
 
 describe("summarizeToolFailureForLog", () => {
@@ -223,6 +240,24 @@ describe("summarizeToolFailureForLog", () => {
         "Return JSON only",
       ],
     });
+  });
+
+  it("sanitizes ANSI-rich tool failure payloads before logging them", () => {
+    const summary = summarizeToolFailureForLog({
+      name: "desktop.bash",
+      args: { command: "node scripts/agenc-watch.mjs" },
+      result: JSON.stringify({
+        error:
+          "\u001b[H\u001b[2J\u001b[38;5;239m╭──────────╮\u001b[0m\n\u001b[38;5;239m│\u001b[0mAGEN C LIVE\u001b[38;5;239m│\u001b[0m",
+      }),
+      isError: true,
+      durationMs: 8011,
+    });
+
+    expect(summary).not.toBeNull();
+    expect(summary?.error).toContain("[terminal capture omitted");
+    expect(summary?.error).not.toContain("\u001b[");
+    expect(summary?.error).not.toContain("AGEN C LIVE");
   });
 });
 
@@ -677,6 +712,87 @@ describe("webchat background-run routing", () => {
     });
     expect(execute).not.toHaveBeenCalled();
     expect(webChat.send).not.toHaveBeenCalled();
+  });
+
+  it("keeps Doom until-stop prompts on the foreground Doom MCP path", async () => {
+    const dm = new DaemonManager({ configPath: "/tmp/config.json" });
+    const startRun = vi.fn(async () => undefined);
+    const getStatusSnapshot = vi.fn(() => undefined);
+    const executeWebChatConversationTurn = vi
+      .spyOn(dm as any, "executeWebChatConversationTurn")
+      .mockResolvedValue(undefined);
+    const webChat = {
+      send: vi.fn(async () => undefined),
+      pushToSession: vi.fn(),
+      broadcastEvent: vi.fn(),
+      createAbortController: vi.fn(() => new AbortController()),
+      clearAbortController: vi.fn(),
+    } as any;
+    const commandRegistry = {
+      dispatch: vi.fn(async () => false),
+    } as any;
+    const hooks = {
+      dispatch: vi.fn(async () => ({ completed: true, payload: {} })),
+    } as any;
+    const sessionMgr = {
+      getOrCreate: vi.fn(() => ({ history: [] })),
+      appendMessage: vi.fn(),
+      compact: vi.fn(),
+    } as any;
+    const memoryBackend = {
+      addEntry: vi.fn(async () => undefined),
+    } as any;
+    const baseToolHandler = vi.fn(async () => JSON.stringify({ status: "running" }));
+
+    (dm as any).gateway = {
+      config: {
+        autonomy: {
+          enabled: true,
+          featureFlags: { backgroundRuns: true, canaryRollout: false },
+        },
+        desktop: {
+          resolution: {
+            width: 1024,
+            height: 768,
+          },
+        },
+      },
+    };
+    (dm as any)._backgroundRunSupervisor = {
+      getStatusSnapshot,
+      startRun,
+    };
+
+    await (dm as any).handleWebChatInboundMessage(
+      {
+        sessionId: "session-doom-until-stop",
+        senderId: "operator-1",
+        channel: "webchat",
+        content:
+          "Start Doom in a desktop container with god mode enabled, defend the center, and keep playing until I tell you to stop. Use the Doom MCP tools and verify that the game is running.",
+      },
+      {
+        webChat,
+        commandRegistry,
+        getChatExecutor: () => ({ execute: vi.fn() }),
+        getLoggingConfig: () => ({ enabled: false }),
+        hooks,
+        sessionMgr,
+        getSystemPrompt: () => "",
+        baseToolHandler,
+        approvalEngine: undefined,
+        memoryBackend,
+        signals: { signalThinking: vi.fn(), signalIdle: vi.fn() } as any,
+        sessionTokenBudget: 16_000,
+        contextWindowTokens: 64_000,
+      },
+    );
+
+    expect(commandRegistry.dispatch).toHaveBeenCalledOnce();
+    expect(getStatusSnapshot).toHaveBeenCalledWith("session-doom-until-stop");
+    expect(startRun).not.toHaveBeenCalled();
+    expect(memoryBackend.addEntry).not.toHaveBeenCalled();
+    expect(executeWebChatConversationTurn).toHaveBeenCalledOnce();
   });
 });
 

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -19,18 +19,11 @@ import {
 import { constants } from "node:fs";
 import { delimiter, dirname, join, resolve as resolvePath } from "node:path";
 import { homedir } from "node:os";
-import { createHash, randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
 import { Gateway } from "./gateway.js";
 import { loadGatewayConfig } from "./config-watcher.js";
 import { GatewayLifecycleError, GatewayStateError } from "./errors.js";
 import { toErrorMessage } from "../utils/async.js";
-import { persistTracePayloadArtifact } from "../utils/trace-payload-store.js";
-import {
-  formatTracePayloadForLog as formatSharedTracePayloadForLog,
-  summarizeTracePayloadForPreview,
-  summarizeTraceTextForPreview,
-} from "../utils/trace-payload-serialization.js";
 import type {
   GatewayConfig,
   GatewayLLMConfig,
@@ -44,6 +37,30 @@ import type {
 } from "./types.js";
 import type { Logger } from "../utils/logger.js";
 import { silentLogger } from "../utils/logger.js";
+import {
+  EVAL_REPLY_MAX_CHARS,
+  logExecutionTraceEvent,
+  logProviderPayloadTraceEvent,
+  logTraceErrorEvent,
+  logTraceEvent,
+  resolveTraceLoggingConfig,
+  sanitizeLifecyclePayloadData,
+  summarizeCallUsageForTrace,
+  summarizeGatewayMessageForTrace,
+  summarizeHistoryForTrace,
+  summarizeInitialRequestShape,
+  summarizeRoleCounts,
+  summarizeTraceValue,
+  summarizeToolArgsForLog,
+  summarizeToolFailureForLog,
+  summarizeToolResultForTrace,
+  summarizeToolRoutingDecisionForTrace,
+  summarizeToolRoutingSummaryForTrace,
+  truncateToolLogText,
+  buildSubagentTraceId,
+  createTurnTraceId,
+} from "./daemon-trace.js";
+import type { ResolvedTraceLoggingConfig, ToolFailureSummary } from "./daemon-trace.js";
 import { WebChatChannel } from "../channels/webchat/plugin.js";
 import { TelegramChannel } from "../channels/telegram/plugin.js";
 import { WorkspaceManager, WorkspaceValidationError } from "./workspace.js";
@@ -91,12 +108,12 @@ import {
   getProviderNativeWebSearchRoutingDecision,
   supportsProviderNativeWebSearch,
 } from "../llm/provider-native-search.js";
+import { resolveGatewayStatefulResponses } from "./llm-stateful-defaults.js";
 import type {
   DeterministicPipelineExecutor,
   SkillInjector,
   MemoryRetriever,
   ToolCallRecord,
-  ChatCallUsageRecord,
   ChatToolRoutingSummary,
 } from "../llm/chat-executor.js";
 import {
@@ -233,9 +250,18 @@ import {
 } from "./doom-stop-guard.js";
 import {
   ObservabilityService,
-  recordObservabilityTraceEvent,
   setDefaultObservabilityService,
 } from "../observability/index.js";
+
+export {
+  formatTracePayloadForLog,
+  resolveTraceLoggingConfig,
+  sanitizeToolResultTextForTrace,
+  summarizeToolArgsForLog,
+  summarizeToolFailureForLog,
+  summarizeToolResultForTrace,
+} from "./daemon-trace.js";
+export type { ResolvedTraceLoggingConfig } from "./daemon-trace.js";
 
 // ============================================================================
 // Constants
@@ -303,14 +329,8 @@ const DEFAULT_SESSION_TOKEN_BUDGET = 120_000;
 const MAX_SYSTEM_PROMPT_CHARS = 60_000;
 const MODEL_QUERY_RE =
   /\b(what|which|actual|current)\b[\s\S]{0,80}(model|llm|provider)\b/i;
-const TOOL_LOG_SNIPPET_MAX_CHARS = 240;
 const EVAL_SCRIPT_NAME = "agenc-eval-test.cjs";
 const EVAL_SCRIPT_TIMEOUT_MS = 10 * 60_000;
-const EVAL_REPLY_MAX_CHARS = 4_000;
-const TRACE_LOG_DEFAULT_MAX_CHARS = 20_000;
-const TRACE_LOG_MIN_MAX_CHARS = 256;
-const TRACE_LOG_MAX_MAX_CHARS = 200_000;
-const TRACE_HISTORY_MAX_MESSAGES = 500;
 type DelegationAggressivenessProfile =
   | "conservative"
   | "balanced"
@@ -1089,44 +1109,6 @@ export function isCommandUnavailableError(error: unknown): boolean {
   return message.includes("enoent") || message.includes("command not found");
 }
 
-function truncateToolLogText(
-  value: string,
-  maxChars = TOOL_LOG_SNIPPET_MAX_CHARS,
-): string {
-  if (value.length <= maxChars) return value;
-  if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
-  return value.slice(0, maxChars - 3) + "...";
-}
-
-const TRACE_DATA_IMAGE_URL_PATTERN =
-  /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=]+/g;
-const TRACE_JSON_BINARY_FIELD_PATTERN =
-  /"([A-Za-z0-9_.-]*(?:image|dataurl|data|base64)[A-Za-z0-9_.-]*)"\s*:\s*"([A-Za-z0-9+/=\r\n]{128,})"/gi;
-const TRACE_QUOTED_BASE64_BLOB_PATTERN = /"([A-Za-z0-9+/=\r\n]{512,})"/g;
-const TRACE_RAW_BASE64_BLOB_PATTERN = /[A-Za-z0-9+/=\r\n]{2048,}/g;
-
-export function sanitizeToolResultTextForTrace(rawResult: string): string {
-  return rawResult
-    .replace(TRACE_DATA_IMAGE_URL_PATTERN, "(see image)")
-    .replace(
-      TRACE_JSON_BINARY_FIELD_PATTERN,
-      (_match: string, key: string) => `"${key}":"(base64 omitted)"`,
-    )
-    .replace(TRACE_QUOTED_BASE64_BLOB_PATTERN, '"(base64 omitted)"')
-    .replace(TRACE_RAW_BASE64_BLOB_PATTERN, "(base64 omitted)");
-}
-
-function summarizeArtifactText(value: string, maxChars: number): unknown {
-  return summarizeTraceTextForPreview(value, maxChars);
-}
-
-interface ToolFailureSummary {
-  readonly name: string;
-  readonly durationMs: number;
-  readonly error: string;
-  args?: Record<string, unknown>;
-}
-
 interface EvalScriptResult {
   readonly exitCode: number | null;
   readonly stdout: string;
@@ -1304,788 +1286,6 @@ async function runEvalScript(
       finalize(code ?? 1);
     });
   });
-}
-
-export interface ResolvedTraceLoggingConfig {
-  readonly enabled: boolean;
-  readonly includeHistory: boolean;
-  readonly includeSystemPrompt: boolean;
-  readonly includeToolArgs: boolean;
-  readonly includeToolResults: boolean;
-  readonly includeProviderPayloads: boolean;
-  readonly maxChars: number;
-}
-
-function clampTraceMaxChars(maxChars: number | undefined): number {
-  if (maxChars === undefined) return TRACE_LOG_DEFAULT_MAX_CHARS;
-  if (!Number.isFinite(maxChars)) return TRACE_LOG_DEFAULT_MAX_CHARS;
-  return Math.min(
-    TRACE_LOG_MAX_MAX_CHARS,
-    Math.max(TRACE_LOG_MIN_MAX_CHARS, Math.floor(maxChars)),
-  );
-}
-
-const DEFAULT_TRACE_LOGGING_CONFIG: ResolvedTraceLoggingConfig = {
-  enabled: false,
-  includeHistory: true,
-  includeSystemPrompt: true,
-  includeToolArgs: true,
-  includeToolResults: true,
-  includeProviderPayloads: false,
-  maxChars: TRACE_LOG_DEFAULT_MAX_CHARS,
-};
-
-export function resolveTraceLoggingConfig(
-  logging?: GatewayLoggingConfig,
-): ResolvedTraceLoggingConfig {
-  const trace = logging?.trace;
-  if (!trace?.enabled) {
-    return DEFAULT_TRACE_LOGGING_CONFIG;
-  }
-
-  return {
-    enabled: true,
-    includeHistory: trace.includeHistory ?? true,
-    includeSystemPrompt: trace.includeSystemPrompt ?? true,
-    includeToolArgs: trace.includeToolArgs ?? true,
-    includeToolResults: trace.includeToolResults ?? true,
-    includeProviderPayloads: trace.includeProviderPayloads ?? false,
-    maxChars: clampTraceMaxChars(trace.maxChars),
-  };
-}
-
-function summarizeTraceValue(
-  value: unknown,
-  maxChars: number,
-): unknown {
-  return summarizeTracePayloadForPreview(value, maxChars);
-}
-
-export function formatTracePayloadForLog(
-  payload: Record<string, unknown>,
-  maxChars = TRACE_LOG_DEFAULT_MAX_CHARS,
-): string {
-  return formatSharedTracePayloadForLog(payload, maxChars);
-}
-
-interface TraceEventLogOptions {
-  readonly artifactPayload?: Record<string, unknown>;
-}
-
-function buildTraceLogPayload(
-  eventName: string,
-  payload: Record<string, unknown>,
-  options?: TraceEventLogOptions,
-): Record<string, unknown> {
-  const artifactPayload = options?.artifactPayload;
-  const traceId =
-    typeof payload.traceId === "string" ? payload.traceId : undefined;
-  const payloadArtifact = artifactPayload
-    ? persistTracePayloadArtifact({
-        traceId,
-        eventName,
-        payload: artifactPayload,
-      })
-    : undefined;
-  return {
-    ...payload,
-    ...(payloadArtifact ? { traceArtifact: payloadArtifact } : {}),
-  };
-}
-
-function logTraceEvent(
-  logger: Logger,
-  eventName: string,
-  payload: Record<string, unknown>,
-  maxChars: number,
-  options?: TraceEventLogOptions,
-): void {
-  const artifactPayload = options?.artifactPayload;
-  const builtPayload = buildTraceLogPayload(eventName, payload, options);
-  const artifact = builtPayload.traceArtifact as
-    | import("../utils/trace-payload-store.js").TracePayloadArtifactRef
-    | undefined;
-  recordObservabilityTraceEvent({
-    eventName,
-    level: "info",
-    traceId: typeof payload.traceId === "string" ? payload.traceId : undefined,
-    sessionId:
-      typeof payload.sessionId === "string" ? payload.sessionId : undefined,
-    channel: eventName.split(".", 1)[0],
-    payloadPreview: builtPayload,
-    rawPayload: artifactPayload ?? payload,
-    artifact,
-  });
-  logger.info(
-    `[trace] ${eventName} ` +
-      formatTracePayloadForLog(builtPayload, maxChars),
-  );
-}
-
-function logTraceErrorEvent(
-  logger: Logger,
-  eventName: string,
-  payload: Record<string, unknown>,
-  maxChars: number,
-  options?: TraceEventLogOptions,
-): void {
-  const artifactPayload = options?.artifactPayload;
-  const builtPayload = buildTraceLogPayload(eventName, payload, options);
-  const artifact = builtPayload.traceArtifact as
-    | import("../utils/trace-payload-store.js").TracePayloadArtifactRef
-    | undefined;
-  recordObservabilityTraceEvent({
-    eventName,
-    level: "error",
-    traceId: typeof payload.traceId === "string" ? payload.traceId : undefined,
-    sessionId:
-      typeof payload.sessionId === "string" ? payload.sessionId : undefined,
-    channel: eventName.split(".", 1)[0],
-    payloadPreview: builtPayload,
-    rawPayload: artifactPayload ?? payload,
-    artifact,
-  });
-  logger.error(
-    `[trace] ${eventName} ` +
-      formatTracePayloadForLog(builtPayload, maxChars),
-  );
-}
-
-function logProviderPayloadTraceEvent(params: {
-  logger: Logger;
-  channelName: string;
-  traceId: string;
-  sessionId: string;
-  traceConfig: ResolvedTraceLoggingConfig;
-  event: LLMProviderTraceEvent;
-}): void {
-  const { logger, channelName, traceId, sessionId, traceConfig, event } =
-    params;
-  logTraceEvent(
-    logger,
-    `${channelName}.provider.${event.kind}`,
-    {
-      traceId,
-      sessionId,
-      provider: event.provider,
-      model: event.model,
-      transport: event.transport,
-      ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
-      ...(event.callPhase !== undefined ? { callPhase: event.callPhase } : {}),
-      ...(event.context
-        ? { contextPreview: summarizeTraceValue(event.context, traceConfig.maxChars) }
-        : {}),
-      payloadPreview: summarizeTraceValue(event.payload, traceConfig.maxChars),
-    },
-    traceConfig.maxChars,
-    {
-      artifactPayload: {
-        traceId,
-        sessionId,
-        provider: event.provider,
-        model: event.model,
-        transport: event.transport,
-        ...(event.callIndex !== undefined
-          ? { callIndex: event.callIndex }
-          : {}),
-        ...(event.callPhase !== undefined
-          ? { callPhase: event.callPhase }
-          : {}),
-        payload: event.payload,
-        ...(event.context ? { context: event.context } : {}),
-      },
-    },
-  );
-}
-
-function logExecutionTraceEvent(params: {
-  logger: Logger;
-  channelName: string;
-  traceId: string;
-  sessionId: string;
-  traceConfig: ResolvedTraceLoggingConfig;
-  event: ChatExecutionTraceEvent;
-}): void {
-  const { logger, channelName, traceId, sessionId, traceConfig, event } =
-    params;
-  logTraceEvent(
-    logger,
-    `${channelName}.executor.${event.type}`,
-    {
-      traceId,
-      sessionId,
-      ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
-      ...(event.phase !== undefined ? { callPhase: event.phase } : {}),
-      payloadPreview: summarizeTraceValue(event.payload, traceConfig.maxChars),
-    },
-    traceConfig.maxChars,
-    {
-      artifactPayload: {
-        traceId,
-        sessionId,
-        ...(event.callIndex !== undefined ? { callIndex: event.callIndex } : {}),
-        ...(event.phase !== undefined ? { callPhase: event.phase } : {}),
-        payload: event.payload,
-      },
-    },
-  );
-}
-
-function summarizeLlmContentForTrace(
-  content: LLMMessage["content"],
-  maxChars: number,
-): unknown {
-  if (typeof content === "string") {
-    return truncateToolLogText(content, maxChars);
-  }
-  if (!Array.isArray(content)) {
-    return summarizeTraceValue(content, maxChars);
-  }
-
-  return content.map((part) => {
-    if (!part || typeof part !== "object") {
-      return summarizeTraceValue(part, maxChars);
-    }
-
-    if (part.type === "text") {
-      return {
-        type: "text",
-        text: truncateToolLogText(part.text, maxChars),
-      };
-    }
-
-    if (part.type === "image_url") {
-      return {
-        type: "image_url",
-        image_url: {
-          url: summarizeArtifactText(part.image_url.url, maxChars),
-        },
-      };
-    }
-
-    return summarizeTraceValue(part, maxChars);
-  });
-}
-
-function summarizeHistoryForTrace(
-  history: readonly LLMMessage[],
-  traceConfig: ResolvedTraceLoggingConfig,
-): unknown[] {
-  const sliceStart = Math.max(0, history.length - TRACE_HISTORY_MAX_MESSAGES);
-  const entries = history.slice(sliceStart).map((entry) => {
-    const output: Record<string, unknown> = {
-      role: entry.role,
-      content: summarizeLlmContentForTrace(entry.content, traceConfig.maxChars),
-    };
-
-    if (entry.toolCalls && entry.toolCalls.length > 0) {
-      output.toolCalls = entry.toolCalls.map((toolCall) => ({
-        id: toolCall.id,
-        name: toolCall.name,
-        ...(traceConfig.includeToolArgs
-          ? {
-              arguments: truncateToolLogText(
-                toolCall.arguments,
-                traceConfig.maxChars,
-              ),
-            }
-          : {}),
-      }));
-    }
-
-    if (entry.toolCallId) output.toolCallId = entry.toolCallId;
-    if (entry.toolName) output.toolName = entry.toolName;
-    return output;
-  });
-
-  if (sliceStart > 0) {
-    entries.unshift({
-      notice: `${sliceStart} oldest history message(s) omitted`,
-    });
-  }
-
-  return entries;
-}
-
-function summarizeRoleCounts(
-  messages: readonly LLMMessage[],
-): Record<string, number> {
-  const counts = {
-    system: 0,
-    user: 0,
-    assistant: 0,
-    tool: 0,
-  };
-  for (const entry of messages) {
-    if (entry.role === "system") counts.system += 1;
-    else if (entry.role === "user") counts.user += 1;
-    else if (entry.role === "assistant") counts.assistant += 1;
-    else if (entry.role === "tool") counts.tool += 1;
-  }
-  return counts;
-}
-
-function createTurnTraceId(msg: GatewayMessage): string {
-  const messageId = typeof msg.id === "string" ? msg.id.trim() : "";
-  if (messageId.length > 0) {
-    return `${msg.sessionId}:${messageId}`;
-  }
-  const stamp = Date.now().toString(36);
-  return `${msg.sessionId}:${stamp}:${randomUUID().slice(0, 8)}`;
-}
-
-function sanitizeLifecyclePayloadData(
-  payload: Record<string, unknown> | undefined,
-): Record<string, unknown> {
-  if (!payload) return {};
-  const summarized = summarizeTraceValue(payload, TRACE_LOG_DEFAULT_MAX_CHARS);
-  if (
-    typeof summarized === "object" &&
-    summarized !== null &&
-    !Array.isArray(summarized)
-  ) {
-    return summarized as Record<string, unknown>;
-  }
-  return { value: summarized };
-}
-
-function buildSubagentTraceId(
-  parentTraceId: string | undefined,
-  event: SubAgentLifecycleEvent,
-): string | undefined {
-  if (!parentTraceId) return undefined;
-  const sessionRef = event.subagentSessionId ?? event.sessionId;
-  const fingerprint = createHash("sha256")
-    .update(`${parentTraceId}|${event.type}|${sessionRef}|${event.timestamp}`)
-    .digest("hex")
-    .slice(0, 16);
-  return `${parentTraceId}:sub:${fingerprint}`;
-}
-
-function summarizeBudgetDiagnosticsForTrace(
-  diagnostics: ChatCallUsageRecord["budgetDiagnostics"],
-): Record<string, unknown> | undefined {
-  if (!diagnostics) return undefined;
-
-  const constrainedSections: Record<string, unknown> = {};
-  for (const [section, stats] of Object.entries(diagnostics.sections)) {
-    if (
-      stats.beforeChars > stats.afterChars ||
-      stats.droppedMessages > 0 ||
-      stats.truncatedMessages > 0
-    ) {
-      constrainedSections[section] = {
-        capChars: stats.capChars,
-        beforeMessages: stats.beforeMessages,
-        afterMessages: stats.afterMessages,
-        beforeChars: stats.beforeChars,
-        afterChars: stats.afterChars,
-        droppedMessages: stats.droppedMessages,
-        truncatedMessages: stats.truncatedMessages,
-      };
-    }
-  }
-
-  return {
-    constrained: diagnostics.constrained,
-    totalBeforeChars: diagnostics.totalBeforeChars,
-    totalAfterChars: diagnostics.totalAfterChars,
-    capChars: diagnostics.caps.totalChars,
-    model: diagnostics.model,
-    droppedSections: diagnostics.droppedSections,
-    constrainedSections,
-  };
-}
-
-function summarizeStatefulDiagnosticsForTrace(
-  diagnostics: ChatCallUsageRecord["statefulDiagnostics"],
-): Record<string, unknown> | undefined {
-  if (!diagnostics) return undefined;
-  return {
-    enabled: diagnostics.enabled,
-    attempted: diagnostics.attempted,
-    continued: diagnostics.continued,
-    store: diagnostics.store,
-    fallbackToStateless: diagnostics.fallbackToStateless,
-    previousResponseId: diagnostics.previousResponseId,
-    responseId: diagnostics.responseId,
-    reconciliationHash: diagnostics.reconciliationHash,
-    fallbackReason: diagnostics.fallbackReason,
-    events: diagnostics.events,
-  };
-}
-
-function summarizeCallUsageForTrace(
-  callUsage: readonly ChatCallUsageRecord[],
-): unknown[] {
-  return callUsage.map((entry) => ({
-    callIndex: entry.callIndex,
-    phase: entry.phase,
-    provider: entry.provider,
-    model: entry.model,
-    finishReason: entry.finishReason,
-    usage: entry.usage,
-    promptShapeBeforeBudget: entry.beforeBudget,
-    promptShapeAfterBudget: entry.afterBudget,
-    providerRequestMetrics: entry.providerRequestMetrics,
-    budgetDiagnostics: summarizeBudgetDiagnosticsForTrace(
-      entry.budgetDiagnostics,
-    ),
-    statefulDiagnostics: summarizeStatefulDiagnosticsForTrace(
-      entry.statefulDiagnostics,
-    ),
-  }));
-}
-
-function summarizeInitialRequestShape(
-  callUsage: readonly ChatCallUsageRecord[],
-): Record<string, unknown> | undefined {
-  const first = callUsage[0];
-  if (!first) return undefined;
-  return {
-    messageCountsBeforeBudget: {
-      system: first.beforeBudget.systemMessages,
-      user: first.beforeBudget.userMessages,
-      assistant: first.beforeBudget.assistantMessages,
-      tool: first.beforeBudget.toolMessages,
-      total: first.beforeBudget.messageCount,
-    },
-    messageCountsAfterBudget: {
-      system: first.afterBudget.systemMessages,
-      user: first.afterBudget.userMessages,
-      assistant: first.afterBudget.assistantMessages,
-      tool: first.afterBudget.toolMessages,
-      total: first.afterBudget.messageCount,
-    },
-    estimatedPromptCharsBeforeBudget: first.beforeBudget.estimatedChars,
-    estimatedPromptCharsAfterBudget: first.afterBudget.estimatedChars,
-    systemPromptCharsAfterBudget: first.afterBudget.systemPromptChars,
-    toolSchemaChars: first.providerRequestMetrics?.toolSchemaChars,
-    budgetDiagnostics: summarizeBudgetDiagnosticsForTrace(
-      first.budgetDiagnostics,
-    ),
-    statefulDiagnostics: summarizeStatefulDiagnosticsForTrace(
-      first.statefulDiagnostics,
-    ),
-  };
-}
-
-function summarizeToolRoutingDecisionForTrace(
-  decision: ToolRoutingDecision | undefined,
-): Record<string, unknown> | undefined {
-  if (!decision) return undefined;
-  return {
-    routedToolNames: decision.routedToolNames,
-    expandedToolNames: decision.expandedToolNames,
-    diagnostics: decision.diagnostics,
-  };
-}
-
-function summarizeToolRoutingSummaryForTrace(
-  summary: ChatToolRoutingSummary | undefined,
-): Record<string, unknown> | undefined {
-  if (!summary) return undefined;
-  return {
-    enabled: summary.enabled,
-    initialToolCount: summary.initialToolCount,
-    finalToolCount: summary.finalToolCount,
-    routeMisses: summary.routeMisses,
-    expanded: summary.expanded,
-  };
-}
-
-function summarizeGatewayMessageForTrace(
-  msg: GatewayMessage,
-  maxChars: number,
-): Record<string, unknown> {
-  return {
-    id: msg.id,
-    channel: msg.channel,
-    senderId: msg.senderId,
-    senderName: msg.senderName,
-    sessionId: msg.sessionId,
-    scope: msg.scope,
-    timestamp: msg.timestamp,
-    content: truncateToolLogText(msg.content, maxChars),
-    attachments: msg.attachments?.map((attachment) => ({
-      type: attachment.type,
-      mimeType: attachment.mimeType,
-      filename: attachment.filename,
-      url: attachment.url
-        ? truncateToolLogText(attachment.url, maxChars)
-        : undefined,
-      sizeBytes: attachment.sizeBytes,
-      durationSeconds: attachment.durationSeconds,
-      dataBytes: attachment.data?.byteLength,
-    })),
-    metadata: summarizeTraceValue(msg.metadata, maxChars),
-  };
-}
-
-function summarizeExecuteWithAgentArgs(
-  args: Record<string, unknown>,
-  maxChars: number,
-): Record<string, unknown> | undefined {
-  const summary: Record<string, unknown> = {};
-  if (typeof args.objective === "string" && args.objective.trim().length > 0) {
-    summary.objective = truncateToolLogText(args.objective, maxChars);
-  } else if (typeof args.task === "string" && args.task.trim().length > 0) {
-    summary.task = truncateToolLogText(args.task, maxChars);
-  }
-  if (
-    typeof args.inputContract === "string" &&
-    args.inputContract.trim().length > 0
-  ) {
-    summary.inputContract = truncateToolLogText(args.inputContract, maxChars);
-  }
-  if (Array.isArray(args.tools) && args.tools.length > 0) {
-    summary.tools = args.tools
-      .filter(
-        (tool): tool is string =>
-          typeof tool === "string" && tool.trim().length > 0,
-      )
-      .slice(0, 8);
-  }
-  if (
-    Array.isArray(args.requiredToolCapabilities) &&
-    args.requiredToolCapabilities.length > 0
-  ) {
-    summary.requiredToolCapabilities = args.requiredToolCapabilities
-      .filter(
-        (tool): tool is string =>
-          typeof tool === "string" && tool.trim().length > 0,
-      )
-      .slice(0, 8);
-  }
-  if (
-    Array.isArray(args.acceptanceCriteria) &&
-    args.acceptanceCriteria.length > 0
-  ) {
-    summary.acceptanceCriteria = args.acceptanceCriteria
-      .filter(
-        (criterion): criterion is string =>
-          typeof criterion === "string" && criterion.trim().length > 0,
-      )
-      .slice(0, 4)
-      .map((criterion) => truncateToolLogText(criterion, maxChars));
-  }
-  if (typeof args.timeoutMs === "number" && Number.isFinite(args.timeoutMs)) {
-    summary.timeoutMs = args.timeoutMs;
-  }
-  return Object.keys(summary).length > 0 ? summary : undefined;
-}
-
-function summarizeExecuteWithAgentToolCallsForTrace(
-  value: unknown,
-  maxChars: number,
-): unknown {
-  if (!Array.isArray(value)) return undefined;
-  const limit = Math.min(value.length, 6);
-  const summarized = value.slice(0, limit).map((entry) => {
-    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-      return summarizeTraceValue(entry, maxChars);
-    }
-    const toolCall = entry as Record<string, unknown>;
-    const record: Record<string, unknown> = {};
-    if (typeof toolCall.name === "string") record.name = toolCall.name;
-    if (typeof toolCall.isError === "boolean")
-      record.isError = toolCall.isError;
-    if (
-      typeof toolCall.durationMs === "number" &&
-      Number.isFinite(toolCall.durationMs)
-    ) {
-      record.durationMs = toolCall.durationMs;
-    }
-    if (
-      toolCall.args &&
-      typeof toolCall.args === "object" &&
-      !Array.isArray(toolCall.args)
-    ) {
-      record.args =
-        summarizeToolArgsForLog(
-          typeof toolCall.name === "string" ? toolCall.name : "",
-          toolCall.args as Record<string, unknown>,
-        ) ?? summarizeTraceValue(toolCall.args, maxChars);
-    }
-    if (
-      typeof toolCall.result === "string" &&
-      toolCall.result.trim().length > 0
-    ) {
-      record.result = summarizeToolResultForTrace(toolCall.result, maxChars);
-    }
-    return record;
-  });
-  if (value.length > limit) {
-    summarized.push(`[${value.length - limit} more tool call(s)]`);
-  }
-  return summarized;
-}
-
-export function summarizeToolResultForTrace(
-  rawResult: string,
-  maxChars: number,
-): unknown {
-  try {
-    const parsed = JSON.parse(rawResult) as unknown;
-    if (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      !Array.isArray(parsed)
-    ) {
-      const record = parsed as Record<string, unknown>;
-      const status =
-        typeof record.status === "string" ? record.status : undefined;
-      const objective =
-        typeof record.objective === "string" &&
-        record.objective.trim().length > 0
-          ? truncateToolLogText(record.objective, maxChars)
-          : undefined;
-      const output =
-        typeof record.output === "string" && record.output.trim().length > 0
-          ? truncateToolLogText(
-              sanitizeToolResultTextForTrace(record.output),
-              maxChars,
-            )
-          : undefined;
-      const error =
-        typeof record.error === "string" && record.error.trim().length > 0
-          ? truncateToolLogText(record.error, maxChars)
-          : undefined;
-      const validationCode =
-        typeof record.validationCode === "string"
-          ? record.validationCode
-          : undefined;
-      const stopReason =
-        typeof record.stopReason === "string" ? record.stopReason : undefined;
-      const stopReasonDetail =
-        typeof record.stopReasonDetail === "string" &&
-        record.stopReasonDetail.trim().length > 0
-          ? truncateToolLogText(record.stopReasonDetail, maxChars)
-          : undefined;
-      const failedToolCalls =
-        typeof record.failedToolCalls === "number" &&
-        Number.isFinite(record.failedToolCalls)
-          ? record.failedToolCalls
-          : undefined;
-      const toolCalls = summarizeExecuteWithAgentToolCallsForTrace(
-        record.toolCalls,
-        maxChars,
-      );
-      const decomposition = summarizeTraceValue(record.decomposition, maxChars);
-
-      if (
-        status !== undefined ||
-        objective !== undefined ||
-        output !== undefined ||
-        error !== undefined ||
-        validationCode !== undefined ||
-        stopReason !== undefined ||
-        stopReasonDetail !== undefined ||
-        failedToolCalls !== undefined ||
-        toolCalls !== undefined
-      ) {
-        return {
-          ...(typeof record.success === "boolean"
-            ? { success: record.success }
-            : {}),
-          ...(status !== undefined ? { status } : {}),
-          ...(objective !== undefined ? { objective } : {}),
-          ...(validationCode !== undefined ? { validationCode } : {}),
-          ...(stopReason !== undefined ? { stopReason } : {}),
-          ...(stopReasonDetail !== undefined ? { stopReasonDetail } : {}),
-          ...(failedToolCalls !== undefined ? { failedToolCalls } : {}),
-          ...(decomposition !== undefined ? { decomposition } : {}),
-          ...(error !== undefined ? { error } : {}),
-          ...(output !== undefined ? { output } : {}),
-          ...(toolCalls !== undefined ? { toolCalls } : {}),
-        };
-      }
-    }
-    return summarizeTraceValue(parsed, maxChars);
-  } catch {
-    return truncateToolLogText(
-      sanitizeToolResultTextForTrace(rawResult),
-      maxChars,
-    );
-  }
-}
-
-export function summarizeToolArgsForLog(
-  name: string,
-  args: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  if (name === "execute_with_agent") {
-    return summarizeExecuteWithAgentArgs(args, 300);
-  }
-
-  if (
-    (name === "desktop.bash" || name === "system.bash") &&
-    typeof args.command === "string"
-  ) {
-    return {
-      command: truncateToolLogText(args.command, 400),
-    };
-  }
-
-  if (name === "desktop.text_editor") {
-    const summary: Record<string, unknown> = {};
-    if (typeof args.action === "string") summary.action = args.action;
-    if (typeof args.filePath === "string") summary.filePath = args.filePath;
-    if (typeof args.text === "string") {
-      summary.textPreview = truncateToolLogText(args.text, 200);
-    }
-    return Object.keys(summary).length > 0 ? summary : undefined;
-  }
-
-  return undefined;
-}
-
-export function summarizeToolFailureForLog(
-  toolCall: ToolCallRecord,
-): ToolFailureSummary | null {
-  let parsed: Record<string, unknown> | null = null;
-  try {
-    const decoded = JSON.parse(toolCall.result) as unknown;
-    if (
-      typeof decoded === "object" &&
-      decoded !== null &&
-      !Array.isArray(decoded)
-    ) {
-      parsed = decoded as Record<string, unknown>;
-    }
-  } catch {
-    // Non-JSON tool result
-  }
-
-  const parsedError =
-    parsed && typeof parsed.error === "string" ? parsed.error : undefined;
-  const exitCode =
-    parsed && typeof parsed.exitCode === "number" ? parsed.exitCode : undefined;
-  const stderr =
-    parsed && typeof parsed.stderr === "string" ? parsed.stderr : undefined;
-
-  let error: string | undefined;
-  if (toolCall.isError) {
-    error = parsedError ?? toolCall.result;
-  } else if (parsedError) {
-    error = parsedError;
-  } else if (exitCode !== undefined && exitCode !== 0) {
-    error =
-      stderr && stderr.trim().length > 0
-        ? `exitCode ${exitCode}: ${stderr}`
-        : `exitCode ${exitCode}`;
-  }
-
-  if (!error) return null;
-
-  const summary: ToolFailureSummary = {
-    name: toolCall.name,
-    durationMs: toolCall.durationMs,
-    error: truncateToolLogText(error),
-  };
-  const args = summarizeToolArgsForLog(toolCall.name, toolCall.args);
-  if (args) summary.args = args;
-  return summary;
 }
 
 export interface LLMFailureSurfaceSummary {
@@ -9023,6 +8223,7 @@ export class DaemonManager {
 
     webChat.broadcastEvent("chat.inbound", { sessionId: msg.sessionId });
     const isDoomStopTurn = isDoomStopRequest(msg.content);
+    const doomTurnContract = inferDoomTurnContract(msg.content);
 
     const activeBackgroundRun =
       this._backgroundRunSupervisor?.getStatusSnapshot(msg.sessionId);
@@ -9118,6 +8319,7 @@ export class DaemonManager {
     }
 
     if (
+      !doomTurnContract &&
       inferBackgroundRunIntent(msg.content) &&
       this._backgroundRunSupervisor
     ) {
@@ -9167,7 +8369,6 @@ export class DaemonManager {
       });
     };
 
-    const doomTurnContract = inferDoomTurnContract(msg.content);
     const requestedDesktopResolution =
       this._desktopManager?.getHandleBySession(msg.sessionId)?.resolution ??
       this.gateway?.config.desktop?.resolution;
@@ -10113,12 +9314,25 @@ export class DaemonManager {
       case "grok": {
         const { GrokProvider } = await import("../llm/grok/adapter.js");
         const normalizedModel = normalizeGrokModel(model) ?? DEFAULT_GROK_MODEL;
+        const resolvedStatefulResponses = resolveGatewayStatefulResponses(
+          provider,
+          statefulResponses,
+        );
         const nativeWebSearchEnabled = supportsProviderNativeWebSearch({
           provider,
           model: normalizedModel,
           webSearch,
           searchMode,
         });
+        if (resolvedStatefulResponses.usedDefaults) {
+          this.logger.info(
+            "Enabled Grok stateful response defaults for provider continuity",
+            {
+              model: normalizedModel,
+              statefulResponses: resolvedStatefulResponses.config,
+            },
+          );
+        }
         return new GrokProvider({
           apiKey: apiKey ?? "",
           model: normalizedModel,
@@ -10128,7 +9342,7 @@ export class DaemonManager {
           timeoutMs,
           maxTokens,
           parallelToolCalls,
-          statefulResponses,
+          statefulResponses: resolvedStatefulResponses.config,
           tools,
         });
       }

--- a/runtime/src/gateway/delegation-tool.test.ts
+++ b/runtime/src/gateway/delegation-tool.test.ts
@@ -43,16 +43,18 @@ describe("delegation-tool", () => {
     expect(parsed.value.objective).toBe("compare three modules");
   });
 
-  it("prefers objective over task when both are provided", () => {
+  it("preserves explicit task scope when task and objective are both provided", () => {
     const parsed = parseExecuteWithAgentInput({
-      task: "agent-1",
-      objective: "Echo exactly: hello+1",
+      task: "Inspect docs/RUNTIME_API.md sections 4b and 8",
+      objective: "Extract one autonomy-validation risk with a direct reference",
     });
 
     expect(parsed.ok).toBe(true);
     if (!parsed.ok) return;
-    expect(parsed.value.task).toBe("Echo exactly: hello+1");
-    expect(parsed.value.objective).toBe("Echo exactly: hello+1");
+    expect(parsed.value.task).toBe("Inspect docs/RUNTIME_API.md sections 4b and 8");
+    expect(parsed.value.objective).toBe(
+      "Extract one autonomy-validation risk with a direct reference",
+    );
   });
 
   it("rejects missing task/objective", () => {

--- a/runtime/src/gateway/delegation-tool.ts
+++ b/runtime/src/gateway/delegation-tool.ts
@@ -66,7 +66,7 @@ export function parseExecuteWithAgentInput(
   args: Record<string, unknown>,
 ): ParseExecuteWithAgentResult {
   const objective = toNonEmptyString(args.objective);
-  const task = objective ?? toNonEmptyString(args.task);
+  const task = toNonEmptyString(args.task) ?? objective;
   if (!task) {
     return {
       ok: false,

--- a/runtime/src/gateway/llm-stateful-defaults.test.ts
+++ b/runtime/src/gateway/llm-stateful-defaults.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveGatewayStatefulResponses } from "./llm-stateful-defaults.js";
+
+describe("resolveGatewayStatefulResponses", () => {
+  it("enables Grok stateful responses with compaction defaults when omitted", () => {
+    const resolved = resolveGatewayStatefulResponses("grok", undefined);
+
+    expect(resolved.usedDefaults).toBe(true);
+    expect(resolved.config).toEqual({
+      enabled: true,
+      store: false,
+      fallbackToStateless: true,
+      compaction: {
+        enabled: true,
+        compactThreshold: 16_000,
+        fallbackOnUnsupported: true,
+      },
+    });
+  });
+
+  it("fills missing Grok fields while preserving explicit partial overrides", () => {
+    const resolved = resolveGatewayStatefulResponses("grok", {
+      enabled: true,
+      compaction: {
+        enabled: false,
+      },
+    });
+
+    expect(resolved.usedDefaults).toBe(true);
+    expect(resolved.config).toEqual({
+      enabled: true,
+      store: false,
+      fallbackToStateless: true,
+      compaction: {
+        enabled: false,
+        compactThreshold: 16_000,
+        fallbackOnUnsupported: true,
+      },
+    });
+  });
+
+  it("preserves explicit Grok disable without forcing defaults", () => {
+    const config = {
+      enabled: false,
+      store: false,
+      fallbackToStateless: true,
+      compaction: {
+        enabled: false,
+      },
+    };
+    const resolved = resolveGatewayStatefulResponses("grok", config);
+
+    expect(resolved.usedDefaults).toBe(false);
+    expect(resolved.config).toBe(config);
+  });
+
+  it("leaves non-Grok providers unchanged", () => {
+    const config = {
+      enabled: true,
+      store: true,
+      fallbackToStateless: false,
+      compaction: {
+        enabled: true,
+        compactThreshold: 9_000,
+        fallbackOnUnsupported: false,
+      },
+    };
+    const resolved = resolveGatewayStatefulResponses("ollama", config);
+
+    expect(resolved.usedDefaults).toBe(false);
+    expect(resolved.config).toBe(config);
+  });
+});

--- a/runtime/src/gateway/llm-stateful-defaults.ts
+++ b/runtime/src/gateway/llm-stateful-defaults.ts
@@ -1,0 +1,67 @@
+import type { GatewayLLMConfig } from "./types.js";
+
+const DEFAULT_GROK_COMPACTION_THRESHOLD = 16_000;
+
+export interface GatewayStatefulResponsesResolution {
+  readonly config: GatewayLLMConfig["statefulResponses"];
+  readonly usedDefaults: boolean;
+}
+
+export function resolveGatewayStatefulResponses(
+  provider: GatewayLLMConfig["provider"],
+  statefulResponses: GatewayLLMConfig["statefulResponses"],
+): GatewayStatefulResponsesResolution {
+  if (provider !== "grok") {
+    return {
+      config: statefulResponses,
+      usedDefaults: false,
+    };
+  }
+
+  if (statefulResponses?.enabled === false) {
+    return {
+      config: statefulResponses,
+      usedDefaults: false,
+    };
+  }
+
+  let usedDefaults = false;
+  const enabled = statefulResponses?.enabled ?? true;
+  if (statefulResponses?.enabled === undefined) usedDefaults = true;
+
+  const store = statefulResponses?.store ?? false;
+  if (statefulResponses?.store === undefined) usedDefaults = true;
+
+  const fallbackToStateless = statefulResponses?.fallbackToStateless ?? true;
+  if (statefulResponses?.fallbackToStateless === undefined) usedDefaults = true;
+
+  const compactionEnabled = statefulResponses?.compaction?.enabled ?? true;
+  if (statefulResponses?.compaction?.enabled === undefined) usedDefaults = true;
+
+  const compactThreshold =
+    statefulResponses?.compaction?.compactThreshold ??
+    DEFAULT_GROK_COMPACTION_THRESHOLD;
+  if (statefulResponses?.compaction?.compactThreshold === undefined) {
+    usedDefaults = true;
+  }
+
+  const fallbackOnUnsupported =
+    statefulResponses?.compaction?.fallbackOnUnsupported ?? true;
+  if (statefulResponses?.compaction?.fallbackOnUnsupported === undefined) {
+    usedDefaults = true;
+  }
+
+  return {
+    config: {
+      enabled,
+      store,
+      fallbackToStateless,
+      compaction: {
+        enabled: compactionEnabled,
+        compactThreshold,
+        fallbackOnUnsupported,
+      },
+    },
+    usedDefaults,
+  };
+}

--- a/runtime/src/gateway/sub-agent.test.ts
+++ b/runtime/src/gateway/sub-agent.test.ts
@@ -1264,6 +1264,29 @@ describe("SubAgentManager", () => {
       expect(userMsg!.content).toBe("analyze data");
     });
 
+    it("prefers prompt over task for user message content when provided", async () => {
+      const mockContext = makeMockContext();
+      const chatSpy = mockContext.llmProvider.chat as ReturnType<typeof vi.fn>;
+      const manager = new SubAgentManager(
+        makeManagerConfig({ createContext: vi.fn(async () => mockContext) }),
+      );
+
+      await manager.spawn({
+        parentSessionId: "p",
+        task: "inspect docs",
+        prompt:
+          "Task: inspect docs\nObjective: Read /workspace/docs/RUNTIME_API.md and extract one risk.",
+      });
+      await settle();
+
+      const messages = chatSpy.mock.calls[0][0] as LLMMessage[];
+      const userMsg = messages.find((m) => m.role === "user");
+      expect(userMsg).toBeDefined();
+      expect(userMsg!.content).toBe(
+        "Task: inspect docs\nObjective: Read /workspace/docs/RUNTIME_API.md and extract one risk.",
+      );
+    });
+
     it("does not call destroyContext when createContext fails", async () => {
       const destroyContext = vi.fn(async () => {});
       const createContext = vi.fn(async () => {

--- a/runtime/src/gateway/sub-agent.ts
+++ b/runtime/src/gateway/sub-agent.ts
@@ -128,6 +128,7 @@ export type SubAgentStatus =
 export interface SubAgentConfig {
   readonly parentSessionId: string;
   readonly task: string;
+  readonly prompt?: string;
   readonly timeoutMs?: number;
   readonly workspace?: string;
   readonly tools?: readonly string[];
@@ -544,7 +545,7 @@ export class SubAgentManager {
         senderId: handle.parentSessionId,
         senderName: "sub-agent",
         sessionId: handle.sessionId,
-        content: handle.task,
+        content: handle.config.prompt ?? handle.task,
         scope: "dm",
       });
 

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -1655,6 +1655,72 @@ describe("createSessionToolHandler", () => {
     );
   });
 
+  it("keeps the explicit execute_with_agent delegation spec while promoting an objective-rich child prompt", async () => {
+    const subAgentManager = {
+      spawn: vi.fn(async () => "subagent:spawned"),
+      getResult: vi
+        .fn()
+        .mockReturnValueOnce(null)
+        .mockReturnValue({
+          sessionId: "subagent:spawned",
+          output:
+            'Risk: Stateful compaction can silently fall back without an operator-visible mismatch note. Reference: docs/RUNTIME_API.md "Stateful Response Compaction".',
+          success: true,
+          durationMs: 25,
+          toolCalls: [{
+            name: "desktop.text_editor",
+            args: {
+              command: "view",
+              path: "docs/RUNTIME_API.md",
+              view_range: [1, 120],
+            },
+            result: '{"ok":true}',
+            isError: false,
+            durationMs: 5,
+          }],
+          tokenUsage: undefined,
+          providerName: "mock",
+          stopReason: "completed",
+        }),
+      getInfo: vi.fn(() => ({ status: "completed" })),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "session-parent",
+      baseHandler: vi.fn(async () => "should-not-run"),
+      availableToolNames: ["desktop.text_editor", "web_search"],
+      routerId: "router-a",
+      send: vi.fn(),
+      delegation: () => ({
+        subAgentManager: subAgentManager as any,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: null,
+      }),
+    });
+
+    const result = await handler("execute_with_agent", {
+      task: "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections",
+      objective:
+        'Read docs/RUNTIME_API.md (full path /workspace/docs/RUNTIME_API.md). Focus ONLY on "Delegation Runtime Surface" and "Stateful Response Compaction" sections. Identify exactly one autonomy-validation risk/mismatch with a direct reference.',
+      acceptanceCriteria: ["one specific risk or mismatch identified"],
+    });
+    expect(typeof result).toBe("string");
+    expect(subAgentManager.spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: expect.stringContaining("/workspace/docs/RUNTIME_API.md"),
+        prompt: expect.stringContaining("/workspace/docs/RUNTIME_API.md"),
+        tools: ["desktop.text_editor"],
+        delegationSpec: expect.objectContaining({
+          task:
+            "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections",
+          objective:
+            'Read docs/RUNTIME_API.md (full path /workspace/docs/RUNTIME_API.md). Focus ONLY on "Delegation Runtime Surface" and "Stateful Response Compaction" sections. Identify exactly one autonomy-validation risk/mismatch with a direct reference.',
+        }),
+      }),
+    );
+  });
+
   it("returns structured error when execute_with_agent spawn fails", async () => {
     const sentMessages: ControlResponse[] = [];
     const send = vi.fn((msg: ControlResponse): void => {

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -17,6 +17,7 @@ import type { HookDispatcher } from './hooks.js';
 import type { ApprovalEngine } from './approvals.js';
 import {
   EXECUTE_WITH_AGENT_TOOL_NAME,
+  type ExecuteWithAgentInput,
   parseExecuteWithAgentInput,
 } from './delegation-tool.js';
 import {
@@ -187,6 +188,15 @@ function normalizeDelegationTimeoutMs(
     MAX_DELEGATION_TIMEOUT_MS,
     Math.max(MIN_DELEGATION_TIMEOUT_MS, rounded),
   );
+}
+
+function buildDelegatedChildPrompt(input: ExecuteWithAgentInput): string {
+  const objective = input.objective?.trim();
+  if (!objective || objective === input.task) {
+    return input.task;
+  }
+
+  return `Task: ${input.task}\nObjective: ${objective}`;
 }
 
 type DelegationContext = NonNullable<
@@ -515,6 +525,7 @@ async function executeDelegationTool(params: {
     });
   }
   const objective = input.objective ?? input.task;
+  const childPrompt = buildDelegatedChildPrompt(input);
   const effectiveTimeoutMs = normalizeDelegationTimeoutMs(input.timeoutMs);
   const resolvedChildScope = resolveDelegatedChildToolScope({
     spec: input,
@@ -560,7 +571,8 @@ async function executeDelegationTool(params: {
   try {
     childSessionId = await subAgentManager.spawn({
       parentSessionId: sessionId,
-      task: input.task,
+      task: childPrompt,
+      prompt: childPrompt,
       ...(effectiveTimeoutMs ? { timeoutMs: effectiveTimeoutMs } : {}),
       tools: resolvedChildScope.allowedTools,
       ...(input.requiredToolCapabilities

--- a/runtime/src/llm/chat-executor-contract-flow.test.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildRequiredToolEvidenceRetryInstruction,
+  resolveCorrectionAllowedToolNames,
+  resolveExecutionToolContractGuidance,
+} from "./chat-executor-contract-flow.js";
+
+describe("chat-executor-contract-flow", () => {
+  it("resolves contract guidance against the broader allowed tool universe", () => {
+    const guidance = resolveExecutionToolContractGuidance({
+      ctx: {
+        messageText:
+          "Start a durable HTTP server on port 3000 and keep it running until I tell you to stop.",
+        allToolCalls: [],
+        activeRoutedToolNames: ["system.serverStatus"],
+        initialRoutedToolNames: ["desktop.bash"],
+        expandedRoutedToolNames: [
+          "system.serverStatus",
+        ],
+        requiredToolEvidence: undefined,
+        providerEvidence: undefined,
+        response: undefined,
+      },
+      allowedTools: [
+        "desktop.bash",
+        "system.serverStart",
+        "system.serverStatus",
+      ],
+    });
+
+    expect(guidance?.routedToolNames).toEqual(["system.serverStart"]);
+    expect(guidance?.toolChoice).toBe("required");
+  });
+
+  it("prefers the full allowed tool collection for correction retries", () => {
+    expect(
+      resolveCorrectionAllowedToolNames(
+        ["mcp.doom.get_situation_report"],
+        ["mcp.doom.start_game", "mcp.doom.set_objective"],
+      ),
+    ).toEqual([
+      "mcp.doom.start_game",
+      "mcp.doom.set_objective",
+    ]);
+  });
+
+  it("adds validation-specific retry guidance", () => {
+    expect(
+      buildRequiredToolEvidenceRetryInstruction({
+        missingEvidenceMessage: "Expected browser-grounded evidence",
+        validationCode: "low_signal_browser_evidence",
+        allowedToolNames: ["browser.navigate", "browser.snapshot"],
+      }),
+    ).toContain("about:blank state checks do not count");
+  });
+});

--- a/runtime/src/llm/chat-executor-contract-flow.ts
+++ b/runtime/src/llm/chat-executor-contract-flow.ts
@@ -1,0 +1,156 @@
+/**
+ * Contract-guidance and required-evidence helpers for ChatExecutor.
+ *
+ * @module
+ */
+
+import type {
+  DelegationOutputValidationCode,
+  DelegationOutputValidationResult,
+} from "../utils/delegation-validation.js";
+import {
+  getMissingSuccessfulToolEvidenceMessage,
+  validateDelegatedOutputContract,
+} from "../utils/delegation-validation.js";
+import type { ExecutionContext } from "./chat-executor-types.js";
+import {
+  type ToolContractGuidance,
+  type ToolContractGuidancePhase,
+  resolveToolContractGuidance,
+} from "./chat-executor-contract-guidance.js";
+import {
+  getAllowedToolNamesForContractGuidance,
+  getAllowedToolNamesForEvidence,
+} from "./chat-executor-routing-state.js";
+
+type ToolNameCollection = Iterable<string> | readonly string[];
+
+type ContractFlowContext = Pick<
+  ExecutionContext,
+  | "messageText"
+  | "allToolCalls"
+  | "activeRoutedToolNames"
+  | "initialRoutedToolNames"
+  | "expandedRoutedToolNames"
+  | "requiredToolEvidence"
+  | "providerEvidence"
+  | "response"
+>;
+
+export function resolveExecutionToolContractGuidance(input: {
+  readonly ctx: ContractFlowContext;
+  readonly allowedTools?: ToolNameCollection;
+  readonly phase?: ToolContractGuidancePhase;
+  readonly allowedToolNames?: readonly string[];
+  readonly validationCode?: DelegationOutputValidationCode;
+}): ToolContractGuidance | undefined {
+  return resolveToolContractGuidance({
+    phase: input.phase ?? "tool_followup",
+    messageText: input.ctx.messageText,
+    toolCalls: input.ctx.allToolCalls,
+    allowedToolNames: getAllowedToolNamesForContractGuidance({
+      override: input.allowedToolNames,
+      activeRoutedToolNames: input.ctx.activeRoutedToolNames,
+      initialRoutedToolNames: input.ctx.initialRoutedToolNames,
+      expandedRoutedToolNames: input.ctx.expandedRoutedToolNames,
+      allowedTools: input.allowedTools,
+    }),
+    requiredToolEvidence: input.ctx.requiredToolEvidence,
+    validationCode: input.validationCode,
+  });
+}
+
+export function validateRequiredToolEvidence(input: {
+  readonly ctx: ContractFlowContext;
+}): {
+  readonly contractValidation?: DelegationOutputValidationResult;
+  readonly missingEvidenceMessage?: string;
+} {
+  const requiredToolEvidence = input.ctx.requiredToolEvidence;
+  if (!requiredToolEvidence) {
+    return {};
+  }
+
+  const responseContent =
+    typeof input.ctx.response?.content === "string"
+      ? input.ctx.response.content
+      : "";
+  const contractValidation = requiredToolEvidence.delegationSpec
+    ? validateDelegatedOutputContract({
+        spec: requiredToolEvidence.delegationSpec,
+        output: responseContent,
+        toolCalls: input.ctx.allToolCalls,
+        providerEvidence: input.ctx.providerEvidence,
+      })
+    : undefined;
+  const missingEvidenceMessage = contractValidation?.error ??
+    getMissingSuccessfulToolEvidenceMessage(
+      input.ctx.allToolCalls,
+      requiredToolEvidence.delegationSpec,
+      input.ctx.providerEvidence,
+    );
+  return {
+    contractValidation,
+    missingEvidenceMessage: missingEvidenceMessage ?? undefined,
+  };
+}
+
+export function resolveCorrectionAllowedToolNames(
+  activeRoutedToolNames: readonly string[],
+  allowedTools?: ToolNameCollection,
+): readonly string[] {
+  if (allowedTools) {
+    return [...allowedTools];
+  }
+  return getAllowedToolNamesForEvidence(
+    activeRoutedToolNames,
+    allowedTools,
+  );
+}
+
+export function buildRequiredToolEvidenceRetryInstruction(input: {
+  readonly missingEvidenceMessage: string;
+  readonly validationCode?: DelegationOutputValidationCode;
+  readonly allowedToolNames: readonly string[];
+}): string {
+  const allowedToolSummary = input.allowedToolNames.length > 0
+    ? ` Allowed tools: ${input.allowedToolNames.join(", ")}.`
+    : "";
+  const correctionLines = [
+    "Tool-grounded evidence is required for this delegated task.",
+    "Before answering, call one or more allowed tools and base the answer on those results.",
+    "Do not answer from memory or restate the plan.",
+  ];
+  if (
+    input.validationCode === "low_signal_browser_evidence" ||
+    /browser-grounded evidence/i.test(input.missingEvidenceMessage)
+  ) {
+    correctionLines.push(
+      "Use concrete non-blank URLs or localhost targets with browser navigation plus snapshot/run_code. `browser_tabs` and about:blank state checks do not count.",
+    );
+  }
+  if (
+    input.validationCode === "expected_json_object" ||
+    input.validationCode === "empty_structured_payload"
+  ) {
+    correctionLines.push(
+      "Your final answer must be a single JSON object only, with no markdown fences or prose around it.",
+    );
+  }
+  if (
+    input.validationCode === "missing_file_mutation_evidence" ||
+    /file creation\/edit evidence|file mutation tools/i.test(
+      input.missingEvidenceMessage,
+    )
+  ) {
+    correctionLines.push(
+      "Create or edit the required files with the allowed file-mutation tools before answering, and name those files in the final output.",
+    );
+  }
+  return (
+    "Delegated output validation failed. " +
+    `${input.missingEvidenceMessage}. ` +
+    correctionLines.join(" ") +
+    allowedToolSummary
+  );
+}

--- a/runtime/src/llm/chat-executor-contract-guidance.test.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.test.ts
@@ -66,6 +66,43 @@ describe("chat-executor-contract-guidance", () => {
     });
   });
 
+  it("prefers get_situation_report for Doom async verification when multiple probes are allowed", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "tool_followup",
+      messageText:
+        "Start Doom in god mode, defend the center, and keep playing until I tell you to stop.",
+      toolCalls: [
+        makeToolCall({
+          name: "mcp.doom.start_game",
+          args: {
+            scenario: "defend_the_center",
+            async_player: true,
+            god_mode: true,
+          },
+          result: JSON.stringify({ status: "running", god_mode_enabled: true }),
+        }),
+        makeToolCall({
+          name: "mcp.doom.set_objective",
+          args: { objective_type: "hold_position" },
+          result: JSON.stringify({ status: "objective_set" }),
+        }),
+      ],
+      allowedToolNames: [
+        "mcp.doom.get_state",
+        "mcp.doom.get_situation_report",
+      ],
+    });
+
+    expect(guidance).toEqual({
+      source: "doom",
+      runtimeInstruction:
+        "Continuous autonomous play is still unverified. Call `mcp.doom.get_situation_report` or `mcp.doom.get_state` " +
+        "and confirm the live executor state before answering.",
+      routedToolNames: ["mcp.doom.get_situation_report"],
+      toolChoice: "required",
+    });
+  });
+
   it("blocks desktop/bash detours before the Doom launch contract is satisfied", () => {
     const block = resolveToolContractExecutionBlock({
       phase: "initial",
@@ -254,6 +291,41 @@ describe("chat-executor-contract-guidance", () => {
           task: "core_implementation",
           objective: "Implement the game files in the desktop workspace",
           inputContract: "JSON output with created files",
+        },
+      },
+    });
+
+    expect(guidance).toEqual({
+      source: "delegation-initial",
+      routedToolNames: ["desktop.text_editor"],
+      toolChoice: "required",
+    });
+  });
+
+  it("routes read-only delegated local docs review to desktop.text_editor instead of browser navigation", () => {
+    const guidance = resolveToolContractGuidance({
+      phase: "initial",
+      messageText:
+        "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections using only non-browser tools.",
+      toolCalls: [],
+      allowedToolNames: [
+        "desktop.text_editor",
+        "desktop.bash",
+        "mcp.browser.browser_navigate",
+      ],
+      requiredToolEvidence: {
+        delegationSpec: {
+          task:
+            "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections using only non-browser tools. Return one short bullet with one autonomy risk.",
+          objective:
+            "Identify and output exactly one short bullet describing one autonomy risk from the sections",
+          inputContract: "Read-only access to docs/RUNTIME_API.md via text_editor",
+          acceptanceCriteria: [
+            "Exactly one short bullet output",
+            "No browser tools used",
+            "Risk tied to delegation or compaction",
+          ],
+          tools: ["desktop.text_editor", "desktop.bash"],
         },
       },
     });

--- a/runtime/src/llm/chat-executor-contract-guidance.ts
+++ b/runtime/src/llm/chat-executor-contract-guidance.ts
@@ -213,10 +213,9 @@ function resolveDoomToolContractGuidance(
   );
   if (!gap) return undefined;
 
-  const routedToolNames = gap.preferredToolNames.filter(
-    (toolName) =>
-      input.allowedToolNames.length === 0 ||
-      input.allowedToolNames.includes(toolName),
+  const routedToolNames = resolvePreferredContractTools(
+    gap.preferredToolNames,
+    input.allowedToolNames,
   );
   const enforcement =
     gap.code === "missing_launch"
@@ -242,6 +241,24 @@ function resolveDoomToolContractGuidance(
     toolChoice: "required",
     ...(enforcement ? { enforcement } : {}),
   };
+}
+
+function resolvePreferredContractTools(
+  preferredToolNames: readonly string[],
+  allowedToolNames: readonly string[],
+): readonly string[] {
+  for (const toolName of preferredToolNames) {
+    if (
+      allowedToolNames.length === 0 ||
+      allowedToolNames.includes(toolName)
+    ) {
+      return [toolName];
+    }
+  }
+
+  return preferredToolNames.filter(
+    (toolName) => allowedToolNames.includes(toolName),
+  );
 }
 
 function resolveTypedArtifactContractGuidance(

--- a/runtime/src/llm/chat-executor-routing-state.test.ts
+++ b/runtime/src/llm/chat-executor-routing-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyActiveRoutedToolNames,
+  getAllowedToolNamesForContractGuidance,
+  getAllowedToolNamesForEvidence,
+  resolveEffectiveRoutedToolNames,
+} from "./chat-executor-routing-state.js";
+
+describe("chat-executor-routing-state", () => {
+  it("prefers the active routed subset for evidence checks", () => {
+    expect(
+      getAllowedToolNamesForEvidence(
+        ["mcp.doom.get_situation_report"],
+        ["desktop.bash", "mcp.doom.start_game"],
+      ),
+    ).toEqual(["mcp.doom.get_situation_report"]);
+  });
+
+  it("keeps the broader turn universe available for contract guidance", () => {
+    expect(
+      getAllowedToolNamesForContractGuidance({
+        activeRoutedToolNames: ["mcp.doom.set_objective"],
+        initialRoutedToolNames: ["desktop.bash", "mcp.doom.start_game"],
+        expandedRoutedToolNames: ["mcp.doom.set_objective", "mcp.doom.get_state"],
+      }),
+    ).toEqual([
+      "desktop.bash",
+      "mcp.doom.start_game",
+      "mcp.doom.set_objective",
+      "mcp.doom.get_state",
+    ]);
+  });
+
+  it("carries forward the current routed subset when no explicit override is provided", () => {
+    expect(
+      resolveEffectiveRoutedToolNames({
+        hasToolRouting: true,
+        activeRoutedToolNames: ["mcp.doom.get_situation_report"],
+        allowedTools: ["desktop.bash", "mcp.doom.start_game"],
+      }),
+    ).toEqual(["mcp.doom.get_situation_report"]);
+  });
+
+  it("normalizes and applies the active routed subset in one place", () => {
+    const ctx = {
+      activeRoutedToolNames: ["desktop.bash"],
+    };
+
+    expect(
+      applyActiveRoutedToolNames(ctx, [
+        " mcp.doom.get_situation_report ",
+        "mcp.doom.get_situation_report",
+        "",
+      ]),
+    ).toEqual(["mcp.doom.get_situation_report"]);
+    expect(ctx.activeRoutedToolNames).toEqual(["mcp.doom.get_situation_report"]);
+  });
+});

--- a/runtime/src/llm/chat-executor-routing-state.ts
+++ b/runtime/src/llm/chat-executor-routing-state.ts
@@ -1,0 +1,92 @@
+/**
+ * Routed-tool state helpers for ChatExecutor.
+ *
+ * This keeps the active/permitted tool subset logic in one place so contract
+ * guidance and tool-dispatch permission checks cannot drift apart.
+ *
+ * @module
+ */
+
+import type { ExecutionContext } from "./chat-executor-types.js";
+
+type ToolNameCollection = Iterable<string> | readonly string[];
+
+function toToolNameArray(toolNames: ToolNameCollection | undefined): readonly string[] {
+  if (!toolNames) return [];
+  return Array.isArray(toolNames) ? toolNames : [...toolNames];
+}
+
+function normalizeToolNames(toolNames: ToolNameCollection | undefined): readonly string[] {
+  const toolNameArray = toToolNameArray(toolNames);
+  if (toolNameArray.length === 0) return [];
+  return Array.from(
+    new Set(
+      toolNameArray
+        .map((toolName) => toolName.trim())
+        .filter((toolName) => toolName.length > 0),
+    ),
+  );
+}
+
+export function getAllowedToolNamesForEvidence(
+  activeRoutedToolNames: readonly string[],
+  allowedTools?: ToolNameCollection,
+): readonly string[] {
+  if (activeRoutedToolNames.length > 0) {
+    return activeRoutedToolNames;
+  }
+  return allowedTools ? [...allowedTools] : [];
+}
+
+export function getAllowedToolNamesForContractGuidance(input: {
+  readonly override?: readonly string[];
+  readonly activeRoutedToolNames: readonly string[];
+  readonly initialRoutedToolNames: readonly string[];
+  readonly expandedRoutedToolNames: readonly string[];
+  readonly allowedTools?: ToolNameCollection;
+}): readonly string[] {
+  if (input.override !== undefined) return normalizeToolNames(input.override);
+  if (input.allowedTools) return normalizeToolNames(input.allowedTools);
+
+  return normalizeToolNames([
+    ...input.initialRoutedToolNames,
+    ...input.activeRoutedToolNames,
+    ...input.expandedRoutedToolNames,
+  ]);
+}
+
+export function resolveEffectiveRoutedToolNames(input: {
+  readonly requestedRoutedToolNames?: readonly string[];
+  readonly hasToolRouting: boolean;
+  readonly activeRoutedToolNames: readonly string[];
+  readonly allowedTools?: ToolNameCollection;
+}): readonly string[] | undefined {
+  if (input.requestedRoutedToolNames !== undefined) {
+    return normalizeToolNames(input.requestedRoutedToolNames);
+  }
+  const activeRoutedToolNames = normalizeToolNames(input.activeRoutedToolNames);
+  if (activeRoutedToolNames.length > 0) {
+    return activeRoutedToolNames;
+  }
+  if (input.hasToolRouting) {
+    return [];
+  }
+  return input.allowedTools ? normalizeToolNames(input.allowedTools) : undefined;
+}
+
+export function applyActiveRoutedToolNames(
+  ctx: Pick<ExecutionContext, "activeRoutedToolNames">,
+  routedToolNames?: readonly string[],
+): readonly string[] {
+  const next = normalizeToolNames(routedToolNames);
+  ctx.activeRoutedToolNames = next;
+  return next;
+}
+
+export function buildActiveRoutedToolSet(
+  activeRoutedToolNames: readonly string[],
+): Set<string> | null {
+  return activeRoutedToolNames.length > 0
+    ? new Set(activeRoutedToolNames)
+    : null;
+}

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -1394,6 +1394,402 @@ describe("ChatExecutor", () => {
       });
     });
 
+    it("records normalized async Doom launches as evidence for autonomous follow-up routing", async () => {
+      const toolHandler = vi.fn(async (name: string, args: Record<string, unknown>) => {
+        if (name === "mcp.doom.start_game") {
+          return safeJson({
+            status: "running",
+            god_mode_enabled: true,
+            scenario: args.scenario,
+          });
+        }
+        if (name === "mcp.doom.set_objective") {
+          return safeJson({ status: "objective_set" });
+        }
+        if (name === "mcp.doom.get_situation_report") {
+          return safeJson({
+            executor_state: "running",
+            god_mode_enabled: true,
+          });
+        }
+        return safeJson({ name, args });
+      });
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-start",
+                  name: "mcp.doom.start_game",
+                  arguments: safeJson({
+                    scenario: "defend_the_center",
+                    god_mode: true,
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-objective",
+                  name: "mcp.doom.set_objective",
+                  arguments: safeJson({ objective_type: "hold_position" }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-report",
+                  name: "mcp.doom.get_situation_report",
+                  arguments: safeJson({}),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "Doom is running in async defend-the-center mode with god mode enabled.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: [
+          "mcp.doom.start_game",
+          "mcp.doom.set_objective",
+          "mcp.doom.get_situation_report",
+        ],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Start Doom in god mode, defend the center, and keep playing until I tell you to stop.",
+          ),
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toContain("Doom is running");
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        1,
+        "mcp.doom.start_game",
+        expect.objectContaining({
+          scenario: "defend_the_center",
+          god_mode: true,
+          async_player: true,
+          window_visible: true,
+          render_hud: true,
+        }),
+      );
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        2,
+        "mcp.doom.set_objective",
+        { objective_type: "hold_position" },
+      );
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        3,
+        "mcp.doom.get_situation_report",
+        {},
+      );
+      expect(result.toolCalls[0]?.args).toEqual(
+        expect.objectContaining({
+          async_player: true,
+          god_mode: true,
+          scenario: "defend_the_center",
+        }),
+      );
+
+      const secondOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1]?.[1] as LLMChatOptions | undefined;
+      expect(secondOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.set_objective",
+      ]);
+
+      const thirdOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[2]?.[1] as LLMChatOptions | undefined;
+      expect(thirdOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.get_situation_report",
+      ]);
+
+      const fourthOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[3]?.[1] as LLMChatOptions | undefined;
+      expect(fourthOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.get_situation_report",
+      ]);
+    });
+
+    it("keeps Doom contract-required tools available even when the generic routed subset omits them", async () => {
+      const toolHandler = vi.fn(async (name: string, args: Record<string, unknown>) => {
+        if (name === "mcp.doom.start_game") {
+          return safeJson({
+            status: "running",
+            god_mode_enabled: true,
+            scenario: args.scenario,
+          });
+        }
+        if (name === "mcp.doom.set_objective") {
+          return safeJson({ status: "objective_set", objective_type: "hold_position" });
+        }
+        if (name === "mcp.doom.get_situation_report") {
+          return safeJson({
+            executor_state: "fighting",
+            god_mode_enabled: true,
+            objectives: [{ type: "hold_position" }],
+          });
+        }
+        return safeJson({ name, args });
+      });
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-start",
+                  name: "mcp.doom.start_game",
+                  arguments: safeJson({
+                    scenario: "defend_the_center",
+                    god_mode: true,
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-objective",
+                  name: "mcp.doom.set_objective",
+                  arguments: safeJson({ objective_type: "hold_position" }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-report",
+                  name: "mcp.doom.get_situation_report",
+                  arguments: safeJson({}),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "Doom is running in async hold-position defense mode with god mode enabled.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: [
+          "desktop.bash",
+          "mcp.doom.start_game",
+          "mcp.doom.set_objective",
+          "mcp.doom.get_situation_report",
+        ],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Start Doom in god mode, defend the center, and keep playing until I tell you to stop.",
+          ),
+          toolRouting: {
+            routedToolNames: [
+              "desktop.bash",
+              "mcp.doom.start_game",
+              "mcp.doom.get_situation_report",
+            ],
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toContain("hold-position defense");
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        1,
+        "mcp.doom.start_game",
+        expect.objectContaining({
+          scenario: "defend_the_center",
+          god_mode: true,
+          async_player: true,
+        }),
+      );
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        2,
+        "mcp.doom.set_objective",
+        { objective_type: "hold_position" },
+      );
+      expect(toolHandler).toHaveBeenNthCalledWith(
+        3,
+        "mcp.doom.get_situation_report",
+        {},
+      );
+
+      const firstOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[1] as LLMChatOptions | undefined;
+      expect(firstOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.start_game",
+      ]);
+
+      const secondOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1]?.[1] as LLMChatOptions | undefined;
+      expect(secondOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.set_objective",
+      ]);
+
+      const thirdOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[2]?.[1] as LLMChatOptions | undefined;
+      expect(thirdOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.get_situation_report",
+      ]);
+
+      const fourthOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[3]?.[1] as LLMChatOptions | undefined;
+      expect(fourthOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.get_situation_report",
+      ]);
+    });
+
+    it("uses non-stream chat for deterministic single-tool Doom follow-ups and streams only the final answer", async () => {
+      const onStreamChunk = vi.fn();
+      const toolHandler = vi.fn(async (name: string, args: Record<string, unknown>) => {
+        if (name === "mcp.doom.start_game") {
+          return safeJson({
+            status: "running",
+            god_mode_enabled: true,
+            scenario: args.scenario,
+          });
+        }
+        if (name === "mcp.doom.set_objective") {
+          return safeJson({ status: "objective_set", objective_type: "hold_position" });
+        }
+        if (name === "mcp.doom.get_situation_report") {
+          return safeJson({
+            executor_state: "running",
+            god_mode_enabled: true,
+          });
+        }
+        return safeJson({ name, args });
+      });
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-start",
+                  name: "mcp.doom.start_game",
+                  arguments: safeJson({
+                    scenario: "defend_the_center",
+                    god_mode: true,
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-objective",
+                  name: "mcp.doom.set_objective",
+                  arguments: safeJson({ objective_type: "hold_position" }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-report",
+                  name: "mcp.doom.get_situation_report",
+                  arguments: safeJson({}),
+                },
+              ],
+            }),
+          ),
+        chatStream: vi.fn().mockResolvedValue(
+          mockResponse({
+            content:
+              "Doom is running in async defend-the-center mode with god mode enabled.",
+          }),
+        ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        onStreamChunk,
+        allowedTools: [
+          "mcp.doom.start_game",
+          "mcp.doom.set_objective",
+          "mcp.doom.get_situation_report",
+          "mcp.doom.get_state",
+        ],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Start Doom in god mode, defend the center, and keep playing until I tell you to stop.",
+          ),
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(provider.chat).toHaveBeenCalledTimes(3);
+      expect(provider.chatStream).toHaveBeenCalledTimes(1);
+
+      const thirdOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[2]?.[1] as LLMChatOptions | undefined;
+      expect(thirdOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.get_situation_report",
+      ]);
+
+      const finalOptions = (provider.chatStream as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[2] as LLMChatOptions | undefined;
+      expect(finalOptions?.toolRouting?.allowedToolNames).toEqual([
+        "mcp.doom.get_situation_report",
+      ]);
+    });
+
     it("ends a Doom tool round after failed start_game so dependent calls do not run", async () => {
       const toolHandler = vi.fn(async (name: string, args: Record<string, unknown>) => {
         if (name === "mcp.doom.start_game") {
@@ -1591,21 +1987,17 @@ describe("ChatExecutor", () => {
 
       expect(result.stopReason).toBe("completed");
       expect(result.content).toBe("God mode is enabled and Doom is running.");
-      expect(toolHandler).toHaveBeenNthCalledWith(
-        1,
-        "mcp.doom.set_god_mode",
-        { enabled: true },
-      );
-      expect(toolHandler).toHaveBeenNthCalledWith(2, "mcp.doom.start_game", {
-        screen_resolution: "RES_1280X720",
-        window_visible: true,
-        render_hud: true,
-      });
-      expect(toolHandler).toHaveBeenNthCalledWith(
-        3,
-        "mcp.doom.set_god_mode",
-        { enabled: true },
-      );
+      expect(toolHandler.mock.calls).toEqual([
+        [
+          "mcp.doom.start_game",
+          {
+            screen_resolution: "RES_1280X720",
+            window_visible: true,
+            render_hud: true,
+          },
+        ],
+        ["mcp.doom.set_god_mode", { enabled: true }],
+      ]);
 
       const firstOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
         .calls[0]?.[1] as LLMChatOptions | undefined;

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -118,6 +118,12 @@ import {
   MAX_COMPACT_INPUT,
 } from "./chat-executor-constants.js";
 import {
+  buildRequiredToolEvidenceRetryInstruction,
+  resolveCorrectionAllowedToolNames,
+  resolveExecutionToolContractGuidance,
+  validateRequiredToolEvidence,
+} from "./chat-executor-contract-flow.js";
+import {
   didToolCallFail,
   resolveRetryPolicyMatrix,
   enrichToolResultMetadata,
@@ -130,6 +136,29 @@ import {
   buildToolLoopRecoveryMessages,
   buildRoutingExpansionMessage,
 } from "./chat-executor-tool-utils.js";
+import { inferDoomTurnContract } from "./chat-executor-doom.js";
+import {
+  applyActiveRoutedToolNames,
+  buildActiveRoutedToolSet,
+  resolveEffectiveRoutedToolNames,
+} from "./chat-executor-routing-state.js";
+
+function shouldBypassStreamingForForcedSingleToolTurn(
+  options: LLMChatOptions | undefined,
+): boolean {
+  if (!options?.toolRouting?.allowedToolNames) {
+    return false;
+  }
+  if (options.toolRouting.allowedToolNames.length !== 1) {
+    return false;
+  }
+  if (options.toolChoice === "required") {
+    return true;
+  }
+  return typeof options.toolChoice === "object" &&
+    options.toolChoice !== null &&
+    options.toolChoice.type === "function";
+}
 
 function mergeProviderEvidence(
   current: LLMProviderEvidence | undefined,
@@ -201,14 +230,6 @@ import {
   parseSubagentVerifierDecision,
   mergeSubagentVerifierDecisions,
 } from "./chat-executor-verifier.js";
-import {
-  getMissingSuccessfulToolEvidenceMessage,
-  validateDelegatedOutputContract,
-} from "../utils/delegation-validation.js";
-import {
-  type ToolContractGuidancePhase,
-  resolveToolContractGuidance,
-} from "./chat-executor-contract-guidance.js";
 // ---------------------------------------------------------------------------
 // Re-exports — preserve backward-compatible import paths for consumers
 // ---------------------------------------------------------------------------
@@ -555,13 +576,6 @@ export class ChatExecutor {
     return ctx.requestDeadlineAt - Date.now();
   }
 
-  private getAllowedToolNamesForEvidence(ctx: ExecutionContext): readonly string[] {
-    if (ctx.activeRoutedToolNames.length > 0) {
-      return ctx.activeRoutedToolNames;
-    }
-    return this.allowedTools ? [...this.allowedTools] : [];
-  }
-
   private emitExecutionTrace(
     ctx: ExecutionContext,
     event: ChatExecutionTraceEvent,
@@ -660,7 +674,7 @@ export class ChatExecutor {
   private resolveActiveToolContractGuidance(
     ctx: ExecutionContext,
     input?: {
-      readonly phase?: ToolContractGuidancePhase;
+      readonly phase?: "initial" | "tool_followup" | "correction";
       readonly allowedToolNames?: readonly string[];
       readonly validationCode?: DelegationOutputValidationCode;
     },
@@ -670,13 +684,11 @@ export class ChatExecutor {
     readonly routedToolNames?: readonly string[];
     readonly toolChoice: LLMToolChoice;
   } | undefined {
-    return resolveToolContractGuidance({
-      phase: input?.phase ?? "tool_followup",
-      messageText: ctx.messageText,
-      toolCalls: ctx.allToolCalls,
-      allowedToolNames:
-        input?.allowedToolNames ?? this.getAllowedToolNamesForEvidence(ctx),
-      requiredToolEvidence: ctx.requiredToolEvidence,
+    return resolveExecutionToolContractGuidance({
+      ctx,
+      allowedTools: this.allowedTools ?? undefined,
+      phase: input?.phase,
+      allowedToolNames: input?.allowedToolNames,
       validationCode: input?.validationCode,
     });
   }
@@ -700,22 +712,10 @@ export class ChatExecutor {
 
     let retried = false;
     while (ctx.response?.finishReason !== "tool_calls") {
-      const responseContent =
-        typeof ctx.response?.content === "string" ? ctx.response.content : "";
-      const contractValidation = ctx.requiredToolEvidence.delegationSpec
-        ? validateDelegatedOutputContract({
-          spec: ctx.requiredToolEvidence.delegationSpec,
-          output: responseContent,
-          toolCalls: ctx.allToolCalls,
-          providerEvidence: ctx.providerEvidence,
-        })
-        : undefined;
-      const missingEvidenceMessage = contractValidation?.error ??
-        getMissingSuccessfulToolEvidenceMessage(
-          ctx.allToolCalls,
-          ctx.requiredToolEvidence.delegationSpec,
-          ctx.providerEvidence,
-        );
+      const {
+        contractValidation,
+        missingEvidenceMessage,
+      } = validateRequiredToolEvidence({ ctx });
       if (!missingEvidenceMessage) {
         this.emitExecutionTrace(ctx, {
           type: "completion_gate_checked",
@@ -751,48 +751,15 @@ export class ChatExecutor {
         return "failed";
       }
 
-      const correctionAllowedTools = this.allowedTools
-        ? [...this.allowedTools]
-        : this.getAllowedToolNamesForEvidence(ctx);
-      const allowedToolSummary = correctionAllowedTools.length > 0
-        ? ` Allowed tools: ${correctionAllowedTools.join(", ")}.`
-        : "";
-      const correctionLines = [
-        "Tool-grounded evidence is required for this delegated task.",
-        "Before answering, call one or more allowed tools and base the answer on those results.",
-        "Do not answer from memory or restate the plan.",
-      ];
-      if (
-        contractValidation?.code === "low_signal_browser_evidence" ||
-        /browser-grounded evidence/i.test(missingEvidenceMessage)
-      ) {
-        correctionLines.push(
-          "Use concrete non-blank URLs or localhost targets with browser navigation plus snapshot/run_code. `browser_tabs` and about:blank state checks do not count.",
-        );
-      }
-      if (
-        contractValidation?.code === "expected_json_object" ||
-        contractValidation?.code === "empty_structured_payload"
-      ) {
-        correctionLines.push(
-          "Your final answer must be a single JSON object only, with no markdown fences or prose around it.",
-        );
-      }
-      if (
-        contractValidation?.code === "missing_file_mutation_evidence" ||
-        /file creation\/edit evidence|file mutation tools/i.test(
-          missingEvidenceMessage,
-        )
-      ) {
-        correctionLines.push(
-          "Create or edit the required files with the allowed file-mutation tools before answering, and name those files in the final output.",
-        );
-      }
-      const retryInstruction =
-        "Delegated output validation failed. " +
-        `${missingEvidenceMessage}. ` +
-        correctionLines.join(" ") +
-        allowedToolSummary;
+      const correctionAllowedTools = resolveCorrectionAllowedToolNames(
+        ctx.activeRoutedToolNames,
+        this.allowedTools ?? undefined,
+      );
+      const retryInstruction = buildRequiredToolEvidenceRetryInstruction({
+        missingEvidenceMessage,
+        validationCode: contractValidation?.code,
+        allowedToolNames: correctionAllowedTools,
+      });
 
       if (
         typeof ctx.response?.content === "string" &&
@@ -895,11 +862,13 @@ export class ChatExecutor {
     if (this.checkRequestTimeout(ctx, `${input.phase} model call`)) {
       return undefined;
     }
-    const effectiveRoutedToolNames = input.routedToolNames !== undefined
-      ? input.routedToolNames
-      : ctx.toolRouting
-      ? ctx.activeRoutedToolNames
-      : (this.allowedTools ? [...this.allowedTools] : undefined);
+    const effectiveRoutedToolNames = resolveEffectiveRoutedToolNames({
+      requestedRoutedToolNames: input.routedToolNames,
+      hasToolRouting: Boolean(ctx.toolRouting),
+      activeRoutedToolNames: ctx.activeRoutedToolNames,
+      allowedTools: this.allowedTools ?? undefined,
+    });
+    applyActiveRoutedToolNames(ctx, effectiveRoutedToolNames);
     const groundingMessage =
       input.phase === "tool_followup" || input.phase === "planner_synthesis"
         ? buildToolExecutionGroundingMessage({
@@ -1570,9 +1539,9 @@ export class ChatExecutor {
 
       rounds++;
       const roundToolCallStart = ctx.allToolCalls.length;
-      loopState.activeRoutedToolSet = ctx.activeRoutedToolNames.length > 0
-        ? new Set(ctx.activeRoutedToolNames)
-        : null;
+      loopState.activeRoutedToolSet = buildActiveRoutedToolSet(
+        ctx.activeRoutedToolNames,
+      );
       loopState.expandAfterRound = false;
 
       this.pushMessage(
@@ -1631,7 +1600,7 @@ export class ChatExecutor {
       if (loopState.expandAfterRound && ctx.expandedRoutedToolNames.length > 0) {
         const previousRoutedToolNames = [...ctx.activeRoutedToolNames];
         ctx.routedToolsExpanded = true;
-        ctx.activeRoutedToolNames = ctx.expandedRoutedToolNames;
+        applyActiveRoutedToolNames(ctx, ctx.expandedRoutedToolNames);
         this.emitExecutionTrace(ctx, {
           type: "route_expanded",
           phase: "tool_followup",
@@ -1831,7 +1800,16 @@ export class ChatExecutor {
       });
       return "skip";
     }
-    const args = normalizeToolCallArguments(toolCall.name, parseResult.args);
+    let args = normalizeToolCallArguments(toolCall.name, parseResult.args);
+    if (toolCall.name === "mcp.doom.start_game") {
+      const doomTurnContract = inferDoomTurnContract(ctx.messageText);
+      if (
+        doomTurnContract?.requiresAutonomousPlay &&
+        args.async_player !== true
+      ) {
+        args = { ...args, async_player: true };
+      }
+    }
     this.emitExecutionTrace(ctx, {
       type: "tool_dispatch_started",
       phase: "tool_followup",
@@ -2782,7 +2760,10 @@ export class ChatExecutor {
       let attempts = 0;
       while (true) {
         try {
-          const providerCall = onStreamChunk
+          const shouldStream =
+            onStreamChunk !== undefined &&
+            !shouldBypassStreamingForForcedSingleToolTurn(chatOptions);
+          const providerCall = shouldStream
             ? provider.chatStream(
               boundedMessages,
               onStreamChunk,

--- a/runtime/src/llm/grok/adapter-utils.test.ts
+++ b/runtime/src/llm/grok/adapter-utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { LLMMessage, LLMTool } from "../types.js";
+import {
+  computeReconciliationChain,
+  extractCompactionItemRefs,
+  extractTraceToolNames,
+  toSlimTool,
+} from "./adapter-utils.js";
+
+describe("grok adapter utils", () => {
+  it("extracts trace tool names from mixed provider tool shapes", () => {
+    expect(
+      extractTraceToolNames([
+        { type: "web_search" },
+        { name: "system.bash" },
+        {
+          type: "function",
+          function: {
+            name: "desktop.screenshot",
+          },
+        },
+      ]),
+    ).toEqual([
+      "web_search",
+      "system.bash",
+      "desktop.screenshot",
+    ]);
+  });
+
+  it("keeps reconciliation hashes stable across tool-call order changes", () => {
+    const first: LLMMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "b", name: "system.bash", arguments: "{\"command\":\"pwd\"}" },
+          { id: "a", name: "system.bash", arguments: "{\"command\":\"ls\"}" },
+        ],
+      },
+    ];
+    const second: LLMMessage[] = [
+      {
+        role: "assistant",
+        content: "",
+        toolCalls: [
+          { id: "a", name: "system.bash", arguments: "{\"command\":\"ls\"}" },
+          { id: "b", name: "system.bash", arguments: "{\"command\":\"pwd\"}" },
+        ],
+      },
+    ];
+
+    expect(computeReconciliationChain(first, 8)).toEqual(
+      computeReconciliationChain(second, 8),
+    );
+  });
+
+  it("collapses oversized tool schemas to an open object", () => {
+    const hugeProperties = Object.fromEntries(
+      Array.from({ length: 400 }, (_, index) => [
+        `field_${index}`,
+        { type: "string", description: "x".repeat(32) },
+      ]),
+    );
+    const tool: LLMTool = {
+      type: "function",
+      function: {
+        name: "system.bash",
+        description: "y".repeat(400),
+        parameters: {
+          type: "object",
+          properties: hugeProperties,
+        },
+      },
+    };
+
+    const slim = toSlimTool(tool).tool;
+
+    expect(slim.function.description?.length).toBeLessThanOrEqual(200);
+    expect(slim.function.parameters).toEqual({
+      type: "object",
+      additionalProperties: true,
+    });
+  });
+
+  it("extracts opaque provider compaction items with digests", () => {
+    const refs = extractCompactionItemRefs({
+      output: [
+        { type: "message", id: "msg_1" },
+        { type: "compaction", id: "cmp_1", encrypted_content: "opaque" },
+      ],
+    });
+
+    expect(refs).toEqual([
+      expect.objectContaining({
+        type: "compaction",
+        id: "cmp_1",
+      }),
+    ]);
+    expect(refs[0]?.digest).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/runtime/src/llm/grok/adapter-utils.ts
+++ b/runtime/src/llm/grok/adapter-utils.ts
@@ -1,0 +1,454 @@
+/**
+ * Trace, stateful continuation, and tool-selection helpers for the Grok adapter.
+ *
+ * @module
+ */
+
+import { createHash } from "node:crypto";
+import type {
+  LLMCompactionItemRef,
+  LLMMessage,
+  LLMTool,
+  LLMToolChoice,
+} from "../types.js";
+import { safeStringify } from "../../tools/types.js";
+
+const MAX_TOOL_DESCRIPTION_CHARS = 200;
+const MAX_TOOL_SCHEMA_CHARS_PER_TOOL = 3_000;
+const MAX_TOOL_SCHEMA_CHARS_TOTAL = 40_000;
+const MAX_STATEFUL_RECONCILIATION_WINDOW = 256;
+const STATEFUL_HASH_VERSION = "v1";
+const TOOL_METADATA_KEYS = new Set([
+  "description",
+  "title",
+  "examples",
+  "default",
+  "$comment",
+  "deprecated",
+  "readOnly",
+  "writeOnly",
+]);
+const PRIORITY_TOOL_NAMES = new Set([
+  "system.bash",
+  "desktop.bash",
+  "desktop.screenshot",
+  "desktop.window_list",
+  "desktop.click",
+  "desktop.type",
+  "desktop.keypress",
+  "desktop.mouse_move",
+  "desktop.scroll",
+]);
+
+export type ToolResolutionStrategy =
+  | "all_tools_no_filter"
+  | "all_tools_empty_filter"
+  | "subset_exact"
+  | "subset_partial"
+  | "fallback_full_catalog_no_matches";
+
+export interface ToolSelectionDiagnostics {
+  readonly tools: Record<string, unknown>[];
+  readonly chars: number;
+  readonly requestedToolNames: readonly string[];
+  readonly resolvedToolNames: readonly string[];
+  readonly missingRequestedToolNames: readonly string[];
+  readonly providerCatalogToolCount: number;
+  readonly toolResolution: ToolResolutionStrategy;
+  readonly toolsAttached: boolean;
+  readonly toolSuppressionReason?: string;
+}
+
+export function truncate(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
+  return value.slice(0, maxChars - 3) + "...";
+}
+
+export function extractTraceToolNames(tools: readonly unknown[]): string[] {
+  const names: string[] = [];
+  for (const tool of tools) {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) continue;
+    const record = tool as Record<string, unknown>;
+    if (typeof record.name === "string" && record.name.trim().length > 0) {
+      names.push(record.name.trim());
+      continue;
+    }
+    if (
+      record.function &&
+      typeof record.function === "object" &&
+      !Array.isArray(record.function) &&
+      typeof (record.function as Record<string, unknown>).name === "string"
+    ) {
+      names.push(String((record.function as Record<string, unknown>).name).trim());
+      continue;
+    }
+    if (typeof record.type === "string" && record.type.trim().length > 0) {
+      names.push(record.type.trim());
+    }
+  }
+  return names;
+}
+
+export function summarizeTraceToolChoice(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.type === "function" &&
+    typeof record.name === "string" &&
+    record.name.trim().length > 0
+  ) {
+    return `function:${record.name.trim()}`;
+  }
+  try {
+    return safeStringify(record);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+export function buildToolSelectionTraceContext(
+  selection: ToolSelectionDiagnostics,
+  toolChoice: LLMToolChoice | undefined,
+): Record<string, unknown> {
+  return {
+    requestedToolNames: selection.requestedToolNames,
+    resolvedToolNames: selection.resolvedToolNames,
+    missingRequestedToolNames: selection.missingRequestedToolNames,
+    toolResolution: selection.toolResolution,
+    providerCatalogToolCount: selection.providerCatalogToolCount,
+    toolsAttached: selection.toolsAttached,
+    ...(selection.toolSuppressionReason
+      ? { toolSuppressionReason: selection.toolSuppressionReason }
+      : {}),
+    requestedToolChoice:
+      typeof toolChoice === "string"
+        ? toolChoice
+        : toolChoice?.name,
+  };
+}
+
+export function cloneProviderTracePayload(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(safeStringify(value)) as Record<string, unknown>;
+  } catch {
+    return undefined;
+  }
+}
+
+export function buildProviderTraceErrorPayload(
+  error: unknown,
+): Record<string, unknown> {
+  if (error instanceof Error) {
+    const payload: Record<string, unknown> = {
+      name: error.name,
+      message: error.message,
+    };
+    if (error.stack) payload.stack = error.stack;
+    const code = (error as { code?: unknown }).code;
+    if (
+      typeof code === "string" ||
+      typeof code === "number" ||
+      typeof code === "boolean"
+    ) {
+      payload.code = code;
+    }
+    const status = (error as { status?: unknown }).status;
+    if (
+      typeof status === "string" ||
+      typeof status === "number" ||
+      typeof status === "boolean"
+    ) {
+      payload.status = status;
+    }
+    return payload;
+  }
+  return { error: String(error) };
+}
+
+function hashText(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  const entries = keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
+  return `{${entries.join(",")}}`;
+}
+
+function normalizeHashContent(content: LLMMessage["content"]): unknown {
+  if (typeof content === "string") return content;
+  return content.map((part) => {
+    if (part.type === "text") {
+      return { type: "text", text: part.text };
+    }
+    return {
+      type: "image_url",
+      url: part.image_url.url,
+    };
+  });
+}
+
+function normalizeMessageForReconciliation(message: LLMMessage): unknown {
+  const normalized: Record<string, unknown> = {
+    role: message.role,
+    content: normalizeHashContent(message.content),
+  };
+  if (message.phase) normalized.phase = message.phase;
+  if (message.toolCallId) normalized.toolCallId = message.toolCallId;
+  if (message.toolName) normalized.toolName = message.toolName;
+  if (message.toolCalls && message.toolCalls.length > 0) {
+    normalized.toolCalls = message.toolCalls
+      .map((toolCall) => ({
+        id: toolCall.id,
+        name: toolCall.name,
+        arguments: toolCall.arguments,
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id));
+  }
+  return normalized;
+}
+
+export function computeReconciliationChain(
+  messages: readonly LLMMessage[],
+  windowSize: number,
+): { anchorHash: string; chain: string[] } {
+  const boundedWindowSize = Math.min(
+    MAX_STATEFUL_RECONCILIATION_WINDOW,
+    Math.max(1, Math.floor(windowSize)),
+  );
+  const start = Math.max(0, messages.length - boundedWindowSize);
+  const window = messages.slice(start);
+  let rolling = hashText(`agenc:grok:stateful:${STATEFUL_HASH_VERSION}:root`);
+  const chain: string[] = [];
+
+  for (const message of window) {
+    const normalized = normalizeMessageForReconciliation(message);
+    const turnHash = hashText(stableStringify(normalized));
+    rolling = hashText(`${rolling}|${turnHash}`);
+    chain.push(rolling);
+  }
+
+  return { anchorHash: rolling, chain };
+}
+
+export function isContinuationRetrievalFailure(error: unknown): boolean {
+  const e = error as Record<string, unknown> | null;
+  const statusRaw = e?.status ?? e?.statusCode;
+  const parsedStatus =
+    typeof statusRaw === "number"
+      ? statusRaw
+      : Number.parseInt(String(statusRaw ?? ""), 10);
+  const status = Number.isFinite(parsedStatus) ? parsedStatus : undefined;
+  const message = String(e?.message ?? "").toLowerCase();
+
+  if (status === 404 && message.includes("response")) return true;
+  if (!message.includes("previous") && !message.includes("response")) {
+    return false;
+  }
+  return (
+    message.includes("previous_response_id") ||
+    message.includes("previous response") ||
+    message.includes("not found") ||
+    message.includes("expired") ||
+    message.includes("retriev")
+  );
+}
+
+function toProviderErrorMessage(error: unknown): string {
+  if (typeof error === "string") return error.toLowerCase();
+  if (!error || typeof error !== "object") return "";
+  return String((error as { message?: unknown }).message ?? "").toLowerCase();
+}
+
+function isUnsupportedFieldError(message: string): boolean {
+  return (
+    message.includes("unknown") ||
+    message.includes("unsupported") ||
+    message.includes("invalid") ||
+    message.includes("unexpected") ||
+    message.includes("additional properties") ||
+    message.includes("not allowed")
+  );
+}
+
+export function isAssistantPhaseRejection(error: unknown): boolean {
+  const message = toProviderErrorMessage(error);
+  return message.includes("phase") && isUnsupportedFieldError(message);
+}
+
+export function isServerCompactionRejection(error: unknown): boolean {
+  const message = toProviderErrorMessage(error);
+  if (
+    !message.includes("context_management") &&
+    !message.includes("compact_threshold") &&
+    !message.includes("compaction")
+  ) {
+    return false;
+  }
+  return isUnsupportedFieldError(message);
+}
+
+function hashOpaqueCompactionItem(value: unknown): string {
+  return createHash("sha256").update(stableStringify(value)).digest("hex").slice(0, 16);
+}
+
+export function extractCompactionItemRefs(
+  response: Record<string, unknown>,
+): LLMCompactionItemRef[] {
+  const output = Array.isArray(response.output)
+    ? (response.output as Array<Record<string, unknown>>)
+    : [];
+  const items: LLMCompactionItemRef[] = [];
+  for (const item of output) {
+    const type = typeof item.type === "string" ? item.type.trim() : "";
+    if (type.length === 0 || !/compact/i.test(type)) {
+      continue;
+    }
+    const id =
+      typeof item.id === "string" && item.id.trim().length > 0
+        ? item.id.trim()
+        : undefined;
+    items.push({
+      type,
+      id,
+      digest: hashOpaqueCompactionItem(item),
+    });
+  }
+  return items;
+}
+
+function sanitizeSchema(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.slice(0, 64).map((item) => sanitizeSchema(item));
+  }
+  if (value && typeof value === "object") {
+    const input = value as Record<string, unknown>;
+    const output: Record<string, unknown> = {};
+    for (const [key, field] of Object.entries(input)) {
+      if (TOOL_METADATA_KEYS.has(key)) continue;
+      if (key === "enum" && Array.isArray(field)) {
+        output[key] = field.slice(0, 64);
+        continue;
+      }
+      output[key] = sanitizeSchema(field);
+    }
+    return output;
+  }
+  return value;
+}
+
+function toolPriority(name: string): number {
+  if (PRIORITY_TOOL_NAMES.has(name)) return 0;
+  if (name.startsWith("desktop.")) return 1;
+  if (name.startsWith("system.")) return 2;
+  return 3;
+}
+
+export function slimTools(
+  tools: readonly LLMTool[],
+): { tools: LLMTool[]; chars: number } {
+  if (tools.length === 0) return { tools: [], chars: 0 };
+
+  const ordered = [...tools].sort((a, b) => {
+    const pa = toolPriority(a.function.name);
+    const pb = toolPriority(b.function.name);
+    if (pa !== pb) return pa - pb;
+    return a.function.name.localeCompare(b.function.name);
+  });
+
+  const selected: LLMTool[] = [];
+  let usedChars = 0;
+
+  for (const tool of ordered) {
+    const sanitizedParams = sanitizeSchema(tool.function.parameters);
+    let normalizedParams = sanitizedParams;
+    if (
+      JSON.stringify(sanitizedParams).length > MAX_TOOL_SCHEMA_CHARS_PER_TOOL
+    ) {
+      normalizedParams = { type: "object", additionalProperties: true };
+    }
+
+    const slim: LLMTool = {
+      type: "function",
+      function: {
+        name: tool.function.name,
+        description: truncate(
+          tool.function.description ?? "",
+          MAX_TOOL_DESCRIPTION_CHARS,
+        ),
+        parameters: normalizedParams as Record<string, unknown>,
+      },
+    };
+
+    const slimChars = JSON.stringify(slim).length;
+    if (usedChars + slimChars > MAX_TOOL_SCHEMA_CHARS_TOTAL) {
+      continue;
+    }
+    selected.push(slim);
+    usedChars += slimChars;
+  }
+
+  if (selected.length === 0) {
+    const first = ordered[0];
+    const fallbackTool: LLMTool = {
+      type: "function",
+      function: {
+        name: first.function.name,
+        description: truncate(
+          first.function.description ?? "",
+          MAX_TOOL_DESCRIPTION_CHARS,
+        ),
+        parameters: { type: "object", additionalProperties: true },
+      },
+    };
+    const chars = JSON.stringify(fallbackTool).length;
+    return { tools: [fallbackTool], chars };
+  }
+
+  return { tools: selected, chars: usedChars };
+}
+
+export function toSlimTool(tool: LLMTool): { tool: LLMTool; chars: number } {
+  const sanitizedParams = sanitizeSchema(tool.function.parameters);
+  let normalizedParams = sanitizedParams;
+  if (
+    JSON.stringify(sanitizedParams).length > MAX_TOOL_SCHEMA_CHARS_PER_TOOL
+  ) {
+    normalizedParams = { type: "object", additionalProperties: true };
+  }
+
+  const slim: LLMTool = {
+    type: "function",
+    function: {
+      name: tool.function.name,
+      description: truncate(
+        tool.function.description ?? "",
+        MAX_TOOL_DESCRIPTION_CHARS,
+      ),
+      parameters: normalizedParams as Record<string, unknown>,
+    },
+  };
+
+  return {
+    tool: slim,
+    chars: JSON.stringify(slim).length,
+  };
+}

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -165,7 +165,7 @@ describe("GrokProvider", () => {
     expect(params.tools[0].name).toBe("system.bash");
   });
 
-  it("passes tool_choice through to the Responses API when provided", async () => {
+  it("normalizes required single-tool choice to a named function for the Responses API", async () => {
     mockCreate.mockResolvedValueOnce(makeCompletion());
 
     const provider = new GrokProvider({
@@ -191,7 +191,10 @@ describe("GrokProvider", () => {
     );
 
     const params = mockCreate.mock.calls[0][0];
-    expect(params.tool_choice).toBe("required");
+    expect(params.tool_choice).toEqual({
+      type: "function",
+      name: "system.bash",
+    });
   });
 
   it("captures selected tools and tool_choice in request metrics", async () => {
@@ -239,7 +242,7 @@ describe("GrokProvider", () => {
       requestedToolNames: ["system.bash"],
       missingRequestedToolNames: [],
       toolResolution: "subset_exact",
-      toolChoice: "required",
+      toolChoice: "function:system.bash",
       store: false,
     });
   });
@@ -323,7 +326,10 @@ describe("GrokProvider", () => {
         toolResolution: "subset_exact",
       },
       payload: {
-        tool_choice: "required",
+        tool_choice: {
+          type: "function",
+          name: "system.bash",
+        },
       },
     });
     expect((events[0].payload as { tools?: Array<{ name?: string }> }).tools?.[0]?.name).toBe(
@@ -388,6 +394,65 @@ describe("GrokProvider", () => {
         toolResolution: "fallback_full_catalog_no_matches",
         providerCatalogToolCount: 1,
       },
+    });
+  });
+
+  it("preserves explicitly routed tools even when they were dropped from the slimmed full catalog", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const bulkySystemTools: LLMTool[] = Array.from({ length: 180 }, (_, index) => ({
+      type: "function",
+      function: {
+        name: `system.tool_${String(index).padStart(3, "0")}`,
+        description: `tool ${index} ` + "x".repeat(240),
+        parameters: {
+          type: "object",
+          properties: {
+            payload: {
+              type: "string",
+              description: "y".repeat(500),
+            },
+          },
+        },
+      },
+    }));
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      tools: [
+        ...bulkySystemTools,
+        {
+          type: "function",
+          function: {
+            name: "mcp.doom.start_game",
+            description: "start doom",
+            parameters: {
+              type: "object",
+              properties: {
+                scenario: { type: "string" },
+                async_player: { type: "boolean" },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await provider.chat(
+      [{ role: "user", content: "start doom" }],
+      { toolRouting: { allowedToolNames: ["mcp.doom.start_game"] } },
+    );
+
+    const params = mockCreate.mock.calls[0][0];
+    expect(params.tools).toBeDefined();
+    expect(params.tools).toHaveLength(1);
+    expect(params.tools[0].name).toBe("mcp.doom.start_game");
+    expect(response.requestMetrics).toMatchObject({
+      toolCount: 1,
+      toolNames: ["mcp.doom.start_game"],
+      requestedToolNames: ["mcp.doom.start_game"],
+      missingRequestedToolNames: [],
+      toolResolution: "subset_exact",
     });
   });
 

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -7,12 +7,10 @@
  * @module
  */
 
-import { createHash } from "node:crypto";
 import type {
   LLMChatOptions,
   LLMCompactionDiagnostics,
   LLMCompactionFallbackReason,
-  LLMCompactionItemRef,
   LLMProviderTraceEvent,
   LLMToolChoice,
   LLMProvider,
@@ -37,8 +35,23 @@ import {
 import { supportsGrokServerSideTools } from "../provider-native-search.js";
 import { withTimeout } from "../timeout.js";
 import { validateToolTurnSequence } from "../tool-turn-validator.js";
-import { safeStringify } from "../../tools/types.js";
 import type { GrokProviderConfig } from "./types.js";
+import {
+  buildProviderTraceErrorPayload,
+  buildToolSelectionTraceContext,
+  cloneProviderTracePayload,
+  computeReconciliationChain,
+  extractCompactionItemRefs,
+  extractTraceToolNames,
+  isAssistantPhaseRejection,
+  isContinuationRetrievalFailure,
+  isServerCompactionRejection,
+  slimTools,
+  summarizeTraceToolChoice,
+  toSlimTool,
+  truncate,
+  type ToolSelectionDiagnostics,
+} from "./adapter-utils.js";
 
 const DEFAULT_BASE_URL = "https://api.x.ai/v1";
 const DEFAULT_MODEL = "grok-4-1-fast-reasoning";
@@ -47,68 +60,17 @@ const DEFAULT_TIMEOUT_MS = 60_000;
 const MAX_MESSAGES_PAYLOAD_CHARS = 80_000;
 const MAX_SYSTEM_MESSAGE_CHARS = 16_000;
 const MAX_MESSAGE_CHARS_PER_ENTRY = 4_000;
-const MAX_TOOL_DESCRIPTION_CHARS = 200;
-const MAX_TOOL_SCHEMA_CHARS_PER_TOOL = 3_000;
-const MAX_TOOL_SCHEMA_CHARS_TOTAL = 40_000;
 const MAX_TOOL_SCHEMA_CHARS_FOLLOWUP = 20_000;
-const TOOL_METADATA_KEYS = new Set([
-  "description",
-  "title",
-  "examples",
-  "default",
-  "$comment",
-  "deprecated",
-  "readOnly",
-  "writeOnly",
-]);
-const PRIORITY_TOOL_NAMES = new Set([
-  "system.bash",
-  "desktop.bash",
-  "desktop.screenshot",
-  "desktop.window_list",
-  "desktop.click",
-  "desktop.type",
-  "desktop.keypress",
-  "desktop.mouse_move",
-  "desktop.scroll",
-]);
-
-type ToolResolutionStrategy =
-  | "all_tools_no_filter"
-  | "all_tools_empty_filter"
-  | "subset_exact"
-  | "subset_partial"
-  | "fallback_full_catalog_no_matches";
-
-interface ToolSelectionDiagnostics {
-  readonly tools: Record<string, unknown>[];
-  readonly chars: number;
-  readonly requestedToolNames: readonly string[];
-  readonly resolvedToolNames: readonly string[];
-  readonly missingRequestedToolNames: readonly string[];
-  readonly providerCatalogToolCount: number;
-  readonly toolResolution: ToolResolutionStrategy;
-  readonly toolsAttached: boolean;
-  readonly toolSuppressionReason?: string;
-}
 
 /** Vision models known to support function-calling alongside image understanding. */
 const VISION_MODELS_WITH_TOOLS = new Set([
   "grok-4-0709",
 ]);
-const MAX_STATEFUL_RECONCILIATION_WINDOW = 256;
-const STATEFUL_HASH_VERSION = "v1";
 
 interface StatefulSessionAnchor {
   responseId: string;
   reconciliationHash: string;
   updatedAt: number;
-}
-
-function truncate(value: string, maxChars: number): string {
-  if (value.length <= maxChars) return value;
-  if (maxChars <= 3) return value.slice(0, Math.max(0, maxChars));
-  return value.slice(0, maxChars - 3) + "...";
 }
 
 function createStreamTimeoutError(providerName: string, timeoutMs: number): Error {
@@ -203,6 +165,25 @@ function normalizeResponsesToolChoice(
   }
 
   return toolChoice;
+}
+
+function resolveResponsesToolChoice(
+  toolChoice: LLMToolChoice | undefined,
+  selection: ToolSelectionDiagnostics,
+): LLMToolChoice | undefined {
+  const normalized = normalizeResponsesToolChoice(toolChoice);
+  if (normalized !== "required") {
+    return normalized;
+  }
+
+  if (!selection.toolsAttached || selection.resolvedToolNames.length !== 1) {
+    return normalized;
+  }
+
+  return {
+    type: "function",
+    name: selection.resolvedToolNames[0],
+  };
 }
 
 function estimateOpenAIContentChars(content: unknown): number {
@@ -333,216 +314,11 @@ function collectParamDiagnostics(
   };
 }
 
-function extractTraceToolNames(tools: readonly unknown[]): string[] {
-  const names: string[] = [];
-  for (const tool of tools) {
-    if (!tool || typeof tool !== "object" || Array.isArray(tool)) continue;
-    const record = tool as Record<string, unknown>;
-    if (typeof record.name === "string" && record.name.trim().length > 0) {
-      names.push(record.name.trim());
-      continue;
-    }
-    if (
-      record.function &&
-      typeof record.function === "object" &&
-      !Array.isArray(record.function) &&
-      typeof (record.function as Record<string, unknown>).name === "string"
-    ) {
-      names.push(String((record.function as Record<string, unknown>).name).trim());
-      continue;
-    }
-    if (typeof record.type === "string" && record.type.trim().length > 0) {
-      names.push(record.type.trim());
-    }
-  }
-  return names;
-}
-
-function summarizeTraceToolChoice(value: unknown): string | undefined {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value.trim();
-  }
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  const record = value as Record<string, unknown>;
-  if (
-    record.type === "function" &&
-    typeof record.name === "string" &&
-    record.name.trim().length > 0
-  ) {
-    return `function:${record.name.trim()}`;
-  }
-  try {
-    return safeStringify(record);
-  } catch {
-    return "[unserializable]";
-  }
-}
-
-function buildToolSelectionTraceContext(
-  selection: ToolSelectionDiagnostics,
-  toolChoice: LLMToolChoice | undefined,
-): Record<string, unknown> {
-  return {
-    requestedToolNames: selection.requestedToolNames,
-    resolvedToolNames: selection.resolvedToolNames,
-    missingRequestedToolNames: selection.missingRequestedToolNames,
-    toolResolution: selection.toolResolution,
-    providerCatalogToolCount: selection.providerCatalogToolCount,
-    toolsAttached: selection.toolsAttached,
-    ...(selection.toolSuppressionReason
-      ? { toolSuppressionReason: selection.toolSuppressionReason }
-      : {}),
-    requestedToolChoice:
-      typeof toolChoice === "string"
-        ? toolChoice
-        : toolChoice?.name,
-  };
-}
-
-function cloneProviderTracePayload(
-  value: unknown,
-): Record<string, unknown> | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(safeStringify(value)) as Record<string, unknown>;
-  } catch {
-    return undefined;
-  }
-}
-
-function buildProviderTraceErrorPayload(error: unknown): Record<string, unknown> {
-  if (error instanceof Error) {
-    const payload: Record<string, unknown> = {
-      name: error.name,
-      message: error.message,
-    };
-    if (error.stack) payload.stack = error.stack;
-    const code = (error as { code?: unknown }).code;
-    if (
-      typeof code === "string" ||
-      typeof code === "number" ||
-      typeof code === "boolean"
-    ) {
-      payload.code = code;
-    }
-    const status = (error as { status?: unknown }).status;
-    if (
-      typeof status === "string" ||
-      typeof status === "number" ||
-      typeof status === "boolean"
-    ) {
-      payload.status = status;
-    }
-    return payload;
-  }
-  return { error: String(error) };
-}
-
 function emitProviderTraceEvent(
   options: LLMChatOptions | undefined,
   event: LLMProviderTraceEvent,
 ): void {
   options?.trace?.onProviderTraceEvent?.(event);
-}
-
-function hashText(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") {
-    return JSON.stringify(value);
-  }
-  if (Array.isArray(value)) {
-    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
-  }
-  const record = value as Record<string, unknown>;
-  const keys = Object.keys(record).sort();
-  const entries = keys.map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`);
-  return `{${entries.join(",")}}`;
-}
-
-function normalizeHashContent(content: LLMMessage["content"]): unknown {
-  if (typeof content === "string") return content;
-  return content.map((part) => {
-    if (part.type === "text") {
-      return { type: "text", text: part.text };
-    }
-    return {
-      type: "image_url",
-      url: part.image_url.url,
-    };
-  });
-}
-
-function normalizeMessageForReconciliation(message: LLMMessage): unknown {
-  const normalized: Record<string, unknown> = {
-    role: message.role,
-    content: normalizeHashContent(message.content),
-  };
-  if (message.phase) normalized.phase = message.phase;
-  if (message.toolCallId) normalized.toolCallId = message.toolCallId;
-  if (message.toolName) normalized.toolName = message.toolName;
-  if (message.toolCalls && message.toolCalls.length > 0) {
-    normalized.toolCalls = message.toolCalls
-      .map((toolCall) => ({
-        id: toolCall.id,
-        name: toolCall.name,
-        arguments: toolCall.arguments,
-      }))
-      .sort((a, b) => a.id.localeCompare(b.id));
-  }
-  return normalized;
-}
-
-function computeReconciliationChain(
-  messages: readonly LLMMessage[],
-  windowSize: number,
-): { anchorHash: string; chain: string[] } {
-  const boundedWindowSize = Math.min(
-    MAX_STATEFUL_RECONCILIATION_WINDOW,
-    Math.max(1, Math.floor(windowSize)),
-  );
-  const start = Math.max(0, messages.length - boundedWindowSize);
-  const window = messages.slice(start);
-  let rolling = hashText(`agenc:grok:stateful:${STATEFUL_HASH_VERSION}:root`);
-  const chain: string[] = [];
-
-  for (const message of window) {
-    const normalized = normalizeMessageForReconciliation(message);
-    const turnHash = hashText(stableStringify(normalized));
-    rolling = hashText(`${rolling}|${turnHash}`);
-    chain.push(rolling);
-  }
-
-  return { anchorHash: rolling, chain };
-}
-
-function isContinuationRetrievalFailure(error: unknown): boolean {
-  const e = error as Record<string, unknown> | null;
-  const statusRaw = e?.status ?? e?.statusCode;
-  const parsedStatus =
-    typeof statusRaw === "number"
-      ? statusRaw
-      : Number.parseInt(String(statusRaw ?? ""), 10);
-  const status = Number.isFinite(parsedStatus) ? parsedStatus : undefined;
-  const message = String(e?.message ?? "").toLowerCase();
-
-  if (status === 404 && message.includes("response")) return true;
-  if (!message.includes("previous") && !message.includes("response")) {
-    return false;
-  }
-  return (
-    message.includes("previous_response_id") ||
-    message.includes("previous response") ||
-    message.includes("not found") ||
-    message.includes("expired") ||
-    message.includes("retriev")
-  );
 }
 
 function appendStatefulEvent(
@@ -558,69 +334,6 @@ function appendStatefulEvent(
     reason: options?.reason,
     detail: options?.detail,
   });
-}
-
-function toProviderErrorMessage(error: unknown): string {
-  if (typeof error === "string") return error.toLowerCase();
-  if (!error || typeof error !== "object") return "";
-  return String((error as { message?: unknown }).message ?? "").toLowerCase();
-}
-
-function isUnsupportedFieldError(message: string): boolean {
-  return (
-    message.includes("unknown") ||
-    message.includes("unsupported") ||
-    message.includes("invalid") ||
-    message.includes("unexpected") ||
-    message.includes("additional properties") ||
-    message.includes("not allowed")
-  );
-}
-
-function isAssistantPhaseRejection(error: unknown): boolean {
-  const message = toProviderErrorMessage(error);
-  return message.includes("phase") && isUnsupportedFieldError(message);
-}
-
-function isServerCompactionRejection(error: unknown): boolean {
-  const message = toProviderErrorMessage(error);
-  if (
-    !message.includes("context_management") &&
-    !message.includes("compact_threshold") &&
-    !message.includes("compaction")
-  ) {
-    return false;
-  }
-  return isUnsupportedFieldError(message);
-}
-
-function hashOpaqueCompactionItem(value: unknown): string {
-  return createHash("sha256").update(stableStringify(value)).digest("hex").slice(0, 16);
-}
-
-function extractCompactionItemRefs(
-  response: Record<string, unknown>,
-): LLMCompactionItemRef[] {
-  const output = Array.isArray(response.output)
-    ? (response.output as Array<Record<string, unknown>>)
-    : [];
-  const items: LLMCompactionItemRef[] = [];
-  for (const item of output) {
-    const type = typeof item.type === "string" ? item.type.trim() : "";
-    if (type.length === 0 || !/compact/i.test(type)) {
-      continue;
-    }
-    const id =
-      typeof item.id === "string" && item.id.trim().length > 0
-        ? item.id.trim()
-        : undefined;
-    items.push({
-      type,
-      id,
-      digest: hashOpaqueCompactionItem(item),
-    });
-  }
-  return items;
 }
 
 function hasImageContent(content: unknown): boolean {
@@ -711,101 +424,12 @@ function enforceMessageBudget(
   return firstSystem ? [firstSystem, ...selected] : selected;
 }
 
-function sanitizeSchema(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.slice(0, 64).map((item) => sanitizeSchema(item));
-  }
-  if (value && typeof value === "object") {
-    const input = value as Record<string, unknown>;
-    const output: Record<string, unknown> = {};
-    for (const [key, field] of Object.entries(input)) {
-      if (TOOL_METADATA_KEYS.has(key)) continue;
-      if (key === "enum" && Array.isArray(field)) {
-        output[key] = field.slice(0, 64);
-        continue;
-      }
-      output[key] = sanitizeSchema(field);
-    }
-    return output;
-  }
-  return value;
-}
-
-function toolPriority(name: string): number {
-  if (PRIORITY_TOOL_NAMES.has(name)) return 0;
-  if (name.startsWith("desktop.")) return 1;
-  if (name.startsWith("system.")) return 2;
-  return 3;
-}
-
-function slimTools(tools: LLMTool[]): { tools: LLMTool[]; chars: number } {
-  if (tools.length === 0) return { tools: [], chars: 0 };
-
-  const ordered = [...tools].sort((a, b) => {
-    const pa = toolPriority(a.function.name);
-    const pb = toolPriority(b.function.name);
-    if (pa !== pb) return pa - pb;
-    return a.function.name.localeCompare(b.function.name);
-  });
-
-  const selected: LLMTool[] = [];
-  let usedChars = 0;
-
-  for (const tool of ordered) {
-    const sanitizedParams = sanitizeSchema(tool.function.parameters);
-    let normalizedParams = sanitizedParams;
-    if (
-      JSON.stringify(sanitizedParams).length > MAX_TOOL_SCHEMA_CHARS_PER_TOOL
-    ) {
-      normalizedParams = { type: "object", additionalProperties: true };
-    }
-
-    const slim: LLMTool = {
-      type: "function",
-      function: {
-        name: tool.function.name,
-        description: truncate(
-          tool.function.description ?? "",
-          MAX_TOOL_DESCRIPTION_CHARS,
-        ),
-        parameters: normalizedParams as Record<string, unknown>,
-      },
-    };
-
-    const slimChars = JSON.stringify(slim).length;
-    if (usedChars + slimChars > MAX_TOOL_SCHEMA_CHARS_TOTAL) {
-      continue;
-    }
-    selected.push(slim);
-    usedChars += slimChars;
-  }
-
-  // Always keep at least one tool if any were provided.
-  if (selected.length === 0) {
-    const first = ordered[0];
-    const fallbackTool: LLMTool = {
-      type: "function",
-      function: {
-        name: first.function.name,
-        description: truncate(
-          first.function.description ?? "",
-          MAX_TOOL_DESCRIPTION_CHARS,
-        ),
-        parameters: { type: "object", additionalProperties: true },
-      },
-    };
-    const chars = JSON.stringify(fallbackTool).length;
-    return { tools: [fallbackTool], chars };
-  }
-
-  return { tools: selected, chars: usedChars };
-}
-
 export class GrokProvider implements LLMProvider {
   readonly name = "grok";
 
   private client: unknown | null = null;
   private readonly config: GrokProviderConfig;
+  private readonly rawToolsByName = new Map<string, LLMTool>();
   private readonly tools: LLMTool[];
   private readonly responseTools: Record<string, unknown>[];
   private readonly responseToolsByName = new Map<string, Record<string, unknown>>();
@@ -831,6 +455,9 @@ export class GrokProvider implements LLMProvider {
 
     // Build tools list — optionally inject web_search
     const rawTools = [...(config.tools ?? [])];
+    for (const tool of rawTools) {
+      this.rawToolsByName.set(tool.function.name, tool);
+    }
     const slimmed = slimTools(rawTools);
     const webSearchEnabled =
       config.webSearch === true && supportsGrokServerSideTools(this.config.model);
@@ -1610,8 +1237,12 @@ export class GrokProvider implements LLMProvider {
         params.tools = selectedTools.tools;
         selectedTools.toolsAttached = true;
         params.parallel_tool_calls = this.config.parallelToolCalls;
-        if (options?.toolChoice !== undefined) {
-          params.tool_choice = normalizeResponsesToolChoice(options.toolChoice);
+        const toolChoice = resolveResponsesToolChoice(
+          options?.toolChoice,
+          selectedTools,
+        );
+        if (toolChoice !== undefined) {
+          params.tool_choice = toolChoice;
         }
       } else if (hasImages && !VISION_MODELS_WITH_TOOLS.has(visionModel)) {
         selectedTools.toolSuppressionReason = "vision_model_without_tool_support";
@@ -1661,13 +1292,20 @@ export class GrokProvider implements LLMProvider {
     const requestedToolNames = [...allowed];
     const selected: Record<string, unknown>[] = [];
     let chars = 0;
-    for (const tool of this.tools) {
-      const name = tool.function.name;
-      if (!allowed.has(name)) continue;
-      const responseTool = this.responseToolsByName.get(name);
+    for (const name of requestedToolNames) {
+      let responseTool = this.responseToolsByName.get(name);
+      let responseToolChars = this.responseToolCharsByName.get(name);
+      if (!responseTool) {
+        const rawTool = this.rawToolsByName.get(name);
+        if (rawTool) {
+          const slimTool = toSlimTool(rawTool);
+          responseTool = this.toResponseTools([slimTool.tool])[0];
+          responseToolChars = JSON.stringify(responseTool).length;
+        }
+      }
       if (!responseTool) continue;
       selected.push(responseTool);
-      chars += this.responseToolCharsByName.get(name) ?? JSON.stringify(responseTool).length;
+      chars += responseToolChars ?? JSON.stringify(responseTool).length;
     }
 
     if (this.webSearchTool && allowed.has("web_search")) {

--- a/runtime/src/llm/provider-trace-logger.test.ts
+++ b/runtime/src/llm/provider-trace-logger.test.ts
@@ -167,6 +167,60 @@ describe("createProviderTraceEventLogger", () => {
     rmSync(payloadArtifactMatch![1], { force: true });
   });
 
+  it("summarizes ANSI-heavy terminal payloads in the log preview while keeping the artifact payload", () => {
+    const logger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      setLevel: vi.fn(),
+    };
+
+    const logEvent = createProviderTraceEventLogger({
+      logger,
+      traceLabel: "webchat.provider",
+      traceId: "trace-terminal",
+      sessionId: "session-terminal",
+    });
+
+    const terminalCapture = [
+      "\u001b[H\u001b[2J\u001b[38;5;239m╭──────────╮\u001b[0m",
+      "\u001b[38;5;239m│\u001b[0mAGEN C LIVE\u001b[38;5;239m│\u001b[0m",
+      "\u001b[38;5;239m│\u001b[0mSTATUS connecting…\u001b[38;5;239m│\u001b[0m",
+      "\u001b[38;5;239m╰──────────╯\u001b[0m",
+      " ".repeat(80),
+      " ".repeat(80),
+    ].join("\n");
+
+    logEvent({
+      kind: "response",
+      transport: "chat",
+      provider: "grok",
+      model: "grok-test",
+      payload: {
+        stdout: terminalCapture,
+      },
+    });
+
+    const line = logger.info.mock.calls[0]?.[0] as string;
+    expect(line).toContain('"artifactType":"terminal_capture"');
+    expect(line).not.toContain("\\u001b[H");
+    expect(line).not.toContain("AGEN C LIVE");
+
+    const payloadArtifactMatch = line.match(
+      /"payloadArtifact":\{"path":"([^"]+)"/,
+    );
+    expect(payloadArtifactMatch?.[1]).toBeTruthy();
+    const artifactPath = payloadArtifactMatch?.[1]!;
+    const artifact = JSON.parse(readFileSync(artifactPath, "utf8")) as {
+      payload: {
+        payload?: { stdout?: string };
+      };
+    };
+    expect(artifact.payload.payload?.stdout).toContain("\u001b[H");
+    rmSync(artifactPath, { force: true });
+  });
+
   it("serializes structured runtime trace events as single-line JSON", () => {
     const logger = {
       info: vi.fn(),

--- a/runtime/src/utils/delegation-validation.test.ts
+++ b/runtime/src/utils/delegation-validation.test.ts
@@ -195,6 +195,22 @@ describe("delegation-validation", () => {
     })).toBe(false);
   });
 
+  it("does not treat negative browser exclusions on local docs review as browser-grounded", () => {
+    expect(specRequiresMeaningfulBrowserEvidence({
+      task:
+        "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections using only non-browser tools. Return one short bullet with one autonomy risk.",
+      objective:
+        "Identify and output exactly one short bullet describing one autonomy risk from the sections",
+      inputContract: "Read-only access to docs/RUNTIME_API.md via text_editor",
+      acceptanceCriteria: [
+        "Exactly one short bullet output",
+        "No browser tools used",
+        "Risk tied to delegation or compaction",
+      ],
+      tools: ["desktop.text_editor", "desktop.bash"],
+    })).toBe(false);
+  });
+
   it("does not let parent implementation instructions force file artifacts onto research steps", () => {
     const result = validateDelegatedOutputContract({
       spec: {
@@ -260,6 +276,22 @@ describe("delegation-validation", () => {
       inputContract: "Name the documentation files created",
       acceptanceCriteria: ["Create README.md", "Create docs/architecture.md"],
     })).toBe(true);
+  });
+
+  it("does not require file mutation evidence for read-only local docs review that allows desktop.text_editor", () => {
+    expect(specRequiresFileMutationEvidence({
+      task:
+        "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections using only non-browser tools. Return one short bullet with one autonomy risk.",
+      objective:
+        "Identify and output exactly one short bullet describing one autonomy risk from the sections",
+      inputContract: "Read-only access to docs/RUNTIME_API.md via text_editor",
+      acceptanceCriteria: [
+        "Exactly one short bullet output",
+        "No browser tools used",
+        "Risk tied to delegation or compaction",
+      ],
+      tools: ["desktop.text_editor", "desktop.bash"],
+    })).toBe(false);
   });
 
   it("flags unsupported narrative file claims without write evidence", () => {
@@ -468,6 +500,61 @@ describe("delegation-validation", () => {
     expect(resolved.semanticFallback).toEqual([PROVIDER_NATIVE_WEB_SEARCH_TOOL]);
   });
 
+  it("keeps local file inspection tools for repository docs review instead of switching to provider-native search", () => {
+    const resolved = resolveDelegatedChildToolScope({
+      spec: {
+        task:
+          "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections",
+        objective:
+          "Extract key details from specified sections then pinpoint one autonomy-validation risk/mismatch with direct quote or reference.",
+      },
+      parentAllowedTools: [
+        "desktop.text_editor",
+        PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+      ],
+      availableTools: [
+        "desktop.text_editor",
+        PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+      ],
+      enforceParentIntersection: true,
+    });
+
+    expect(resolved.allowedTools).toEqual(["desktop.text_editor"]);
+    expect(resolved.semanticFallback).toEqual(["desktop.text_editor"]);
+  });
+
+  it("keeps read-only local docs review scoped to desktop.text_editor even when browser tools are excluded in criteria", () => {
+    const resolved = resolveDelegatedChildToolScope({
+      spec: {
+        task:
+          "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections using only non-browser tools. Return one short bullet with one autonomy risk.",
+        objective:
+          "Identify and output exactly one short bullet describing one autonomy risk from the sections",
+        inputContract: "Read-only access to docs/RUNTIME_API.md via text_editor",
+        acceptanceCriteria: [
+          "Exactly one short bullet output",
+          "No browser tools used",
+          "Risk tied to delegation or compaction",
+        ],
+        tools: ["desktop.text_editor", "desktop.bash"],
+      },
+      parentAllowedTools: [
+        "desktop.text_editor",
+        "desktop.bash",
+        "mcp.browser.browser_navigate",
+      ],
+      availableTools: [
+        "desktop.text_editor",
+        "desktop.bash",
+        "mcp.browser.browser_navigate",
+      ],
+      enforceParentIntersection: true,
+    });
+
+    expect(resolved.allowedTools).toEqual(["desktop.text_editor"]);
+    expect(resolved.semanticFallback).toEqual(["desktop.text_editor"]);
+  });
+
   it("resolves a navigation-first initial tool choice for browser-grounded work", () => {
     const toolChoice = resolveDelegatedInitialToolChoiceToolName(
       {
@@ -498,6 +585,48 @@ describe("delegation-validation", () => {
     );
 
     expect(toolChoice).toBe(PROVIDER_NATIVE_WEB_SEARCH_TOOL);
+  });
+
+  it("resolves a local file inspection tool before provider-native search for repository docs review", () => {
+    const toolChoice = resolveDelegatedInitialToolChoiceToolName(
+      {
+        task:
+          "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections",
+        objective:
+          "Extract key details from specified sections then pinpoint one autonomy-validation risk/mismatch with direct quote or reference.",
+      },
+      [
+        "desktop.text_editor",
+        PROVIDER_NATIVE_WEB_SEARCH_TOOL,
+      ],
+    );
+
+    expect(toolChoice).toBe("desktop.text_editor");
+  });
+
+  it("resolves desktop.text_editor first for read-only local docs review even when browser use is explicitly forbidden", () => {
+    const toolChoice = resolveDelegatedInitialToolChoiceToolName(
+      {
+        task:
+          "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections using only non-browser tools. Return one short bullet with one autonomy risk.",
+        objective:
+          "Identify and output exactly one short bullet describing one autonomy risk from the sections",
+        inputContract: "Read-only access to docs/RUNTIME_API.md via text_editor",
+        acceptanceCriteria: [
+          "Exactly one short bullet output",
+          "No browser tools used",
+          "Risk tied to delegation or compaction",
+        ],
+        tools: ["desktop.text_editor", "desktop.bash"],
+      },
+      [
+        "desktop.text_editor",
+        "desktop.bash",
+        "mcp.browser.browser_navigate",
+      ],
+    );
+
+    expect(toolChoice).toBe("desktop.text_editor");
   });
 
   it("resolves an editor-first initial tool choice for implementation work", () => {
@@ -582,6 +711,36 @@ describe("delegation-validation", () => {
         name: "mcp.neovim.vim_buffer_save",
         args: { filename: "/workspace/neon-heist/index.html" },
         result: '{"ok":true}',
+      }],
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts read-only local docs review backed by shell read evidence without requiring file edits", () => {
+    const result = validateDelegatedOutputContract({
+      spec: {
+        task:
+          "Inspect docs/RUNTIME_API.md Delegation Runtime Surface and Stateful Response Compaction sections using only non-browser tools. Return one short bullet with one autonomy risk.",
+        objective:
+          "Identify and output exactly one short bullet describing one autonomy risk from the sections",
+        inputContract: "Read-only access to docs/RUNTIME_API.md via text_editor",
+        acceptanceCriteria: [
+          "Exactly one short bullet output",
+          "No browser tools used",
+          "Risk tied to delegation or compaction",
+        ],
+        tools: ["desktop.text_editor", "desktop.bash"],
+      },
+      output:
+        "- Adaptive delegation can still escalate autonomy if child caps drift from verifier-visible diagnostics.",
+      toolCalls: [{
+        name: "desktop.bash",
+        args: {
+          command:
+            "sed -n '/## Delegation Runtime Surface/,/## Stateful Response Compaction/p' docs/RUNTIME_API.md",
+        },
+        result: '{"stdout":"## Delegation Runtime Surface\\n...","stderr":"","exitCode":0}',
       }],
     });
 

--- a/runtime/src/utils/delegation-validation.ts
+++ b/runtime/src/utils/delegation-validation.ts
@@ -79,6 +79,15 @@ const FILE_ARTIFACT_RE =
   /(?:^|[\s`'"])(?:\/[^\s`'"]+|\.{1,2}\/[^\s`'"]+|[a-z0-9_.-]+\.[a-z0-9]{1,10})(?=$|[\s`'"])/i;
 const EXPLICIT_FILE_ARTIFACT_RE =
   /(?:^|[\s`'"])(?:\/[^\s`'"]*?\.[a-z0-9]{1,10}|\.{1,2}\/[^\s`'"]*?\.[a-z0-9]{1,10}|[a-z0-9_.-]+\.[a-z0-9]{1,10})(?=$|[\s`'"])/i;
+const LOCAL_FILE_REFERENCE_RE =
+  /(?:^|[\s`'"])(?:\/[^\s`'"]+|\.{1,2}\/[^\s`'"]+|(?:[a-z0-9_.-]+\/)+[a-z0-9_.-]+|(?:ag(?:ent)?s|readme)\.md|[a-z0-9_.-]+\.(?:md|txt|json|js|jsx|ts|tsx|py|rs|go|toml|ya?ml|html?|css))(?=$|[\s`'"])/i;
+const LOCAL_FILE_BROWSER_OVERRIDE_RE =
+  /\b(?:localhost|127\.0\.0\.1|about:blank|browser|playwright|mcp\.browser|chromium|navigate|snapshot|click|type|hover|scroll|fill|select|console|network|playtest|qa|end-to-end|e2e|url|web(?:site|page)?)\b/i;
+const NEGATED_BROWSER_REQUIREMENT_RE =
+  /\b(?:no|non|without|avoid(?:ing)?|exclude(?:d|ing)?)\s+(?:any\s+|the\s+)?(?:browser(?:-grounded)?(?:\s+tools?)?|mcp\.browser|playwright)\b/gi;
+const DO_NOT_USE_BROWSER_RE =
+  /\bdo\s+not\s+use\s+(?:any\s+|the\s+)?(?:browser(?:-grounded)?(?:\s+tools?)?|mcp\.browser|playwright)\b/gi;
+const ONLY_NON_BROWSER_TOOLS_RE = /\bonly\s+non-browser\s+tools?\b/gi;
 const SHELL_FILE_WRITE_RE =
   /\b(?:cat|tee|touch|cp|mv|install)\b|(?:^|[^>])>{1,2}\s*\S/i;
 const SHELL_SCAFFOLD_RE =
@@ -128,10 +137,16 @@ const BROWSER_INTERACTION_TOOL_NAMES = new Set([
   "playwright.browser_network_requests",
   "playwright.browser_console_messages",
 ]);
-const FILE_MUTATION_TOOL_NAMES = new Set([
+const EXPLICIT_FILE_MUTATION_TOOL_NAMES = new Set([
   "system.writeFile",
   "system.appendFile",
+  "mcp.neovim.vim_buffer_save",
+  "mcp.neovim.vim_search_replace",
+]);
+const LOCAL_FILE_INSPECTION_TOOL_NAMES = new Set([
   "desktop.text_editor",
+  "system.readFile",
+  "system.listDir",
   "mcp.neovim.vim_edit",
   "mcp.neovim.vim_buffer_save",
   "mcp.neovim.vim_search_replace",
@@ -196,6 +211,13 @@ const INITIAL_FILE_MUTATION_TOOL_NAMES = [
   "mcp.neovim.vim_search_replace",
   "mcp.neovim.vim_buffer_save",
 ] as const;
+const INITIAL_FILE_INSPECTION_TOOL_NAMES = [
+  "desktop.text_editor",
+  "system.readFile",
+  "mcp.neovim.vim_edit",
+  "mcp.neovim.vim_buffer_save",
+  "mcp.neovim.vim_search_replace",
+] as const;
 
 function normalizeToolNames(toolNames: readonly string[] | undefined): string[] {
   return [
@@ -254,6 +276,23 @@ function collectDelegationPrimaryText(spec: DelegationContractSpec): string {
     .join(" ");
 }
 
+function stripNegativeBrowserLanguage(value: string): string {
+  return value
+    .replace(NEGATED_BROWSER_REQUIREMENT_RE, " ")
+    .replace(DO_NOT_USE_BROWSER_RE, " ")
+    .replace(ONLY_NON_BROWSER_TOOLS_RE, " ");
+}
+
+function hasPositiveBrowserGroundingCue(value: string): boolean {
+  if (value.trim().length === 0) return false;
+  return BROWSER_GROUNDED_TASK_RE.test(stripNegativeBrowserLanguage(value));
+}
+
+function hasExplicitBrowserInteractionCue(value: string): boolean {
+  if (value.trim().length === 0) return false;
+  return LOCAL_FILE_BROWSER_OVERRIDE_RE.test(stripNegativeBrowserLanguage(value));
+}
+
 function classifyDelegatedTaskIntent(
   spec: DelegationContractSpec,
 ): "research" | "implementation" | "validation" | "documentation" | "other" {
@@ -275,6 +314,12 @@ function isBrowserToolName(toolName: string): boolean {
     toolName.startsWith("playwright.");
 }
 
+function specTargetsLocalFiles(spec: DelegationContractSpec): boolean {
+  const combined = collectDelegationStepText(spec);
+  if (!LOCAL_FILE_REFERENCE_RE.test(combined)) return false;
+  return !NON_BLANK_BROWSER_TARGET_RE.test(combined);
+}
+
 function pruneDelegatedToolsByIntent(
   spec: DelegationContractSpec,
   tools: readonly string[],
@@ -283,11 +328,23 @@ function pruneDelegatedToolsByIntent(
   const taskIntent = classifyDelegatedTaskIntent(spec);
   const requireBrowser = specRequiresMeaningfulBrowserEvidence(spec);
   const requireFileMutation = specRequiresFileMutationEvidence(spec);
+  const localFileInspectionTask = specTargetsLocalFiles(spec);
   const hasPreferredImplementationEditor = normalized.some((toolName) =>
     PREFERRED_IMPLEMENTATION_EDITOR_TOOL_NAMES.has(toolName)
   );
+  const localFileInspectionTools = normalized.filter((toolName) =>
+    LOCAL_FILE_INSPECTION_TOOL_NAMES.has(toolName)
+  );
 
   const filtered = normalized.filter((toolName) => {
+    if (
+      localFileInspectionTask &&
+      !requireBrowser &&
+      localFileInspectionTools.length > 0
+    ) {
+      return LOCAL_FILE_INSPECTION_TOOL_NAMES.has(toolName);
+    }
+
     if (taskIntent === "research") {
       if (PREFERRED_PROVIDER_NATIVE_RESEARCH_TOOL_NAMES.has(toolName)) {
         return true;
@@ -380,7 +437,7 @@ export function specRequiresFileMutationEvidence(
   const taskIntent = classifyDelegatedTaskIntent(spec);
   if (
     [...(spec.requiredToolCapabilities ?? []), ...(spec.tools ?? [])].some((toolName) =>
-      FILE_MUTATION_TOOL_NAMES.has(toolName.trim())
+      EXPLICIT_FILE_MUTATION_TOOL_NAMES.has(toolName.trim())
     )
   ) {
     return true;
@@ -525,11 +582,25 @@ export function hasToolCallFileMutationEvidence(
     return false;
   }
 
-  if (FILE_MUTATION_TOOL_NAMES.has(toolCall.name.trim())) {
+  const normalizedToolName = toolCall.name.trim();
+  if (EXPLICIT_FILE_MUTATION_TOOL_NAMES.has(normalizedToolName)) {
     return true;
   }
 
-  if (toolCall.name === "execute_with_agent") {
+  if (normalizedToolName === "desktop.text_editor") {
+    const command =
+      typeof toolCall.args === "object" &&
+        toolCall.args !== null &&
+        !Array.isArray(toolCall.args) &&
+        typeof (toolCall.args as { command?: unknown }).command === "string"
+        ? (toolCall.args as { command: string }).command.trim().toLowerCase()
+        : "";
+    return command === "create" ||
+      command === "str_replace" ||
+      command === "insert";
+  }
+
+  if (normalizedToolName === "execute_with_agent") {
     if (typeof toolCall.result !== "string" || toolCall.result.trim().length === 0) {
       return false;
     }
@@ -541,7 +612,7 @@ export function hasToolCallFileMutationEvidence(
   }
 
   return (
-    (toolCall.name === "system.bash" || toolCall.name === "desktop.bash") &&
+    (normalizedToolName === "system.bash" || normalizedToolName === "desktop.bash") &&
     hasShellFileMutationArgs(toolCall.args)
   );
 }
@@ -740,19 +811,34 @@ export function specRequiresSuccessfulToolEvidence(
 export function specRequiresMeaningfulBrowserEvidence(
   spec: DelegationContractSpec,
 ): boolean {
-  if ((spec.requiredToolCapabilities ?? []).some((capability) => {
+  const stepText = collectDelegationStepText(spec);
+  const explicitTools = normalizeToolNames([
+    ...(spec.tools ?? []),
+    ...(spec.requiredToolCapabilities ?? []),
+  ]);
+  const hasExplicitBrowserTool = explicitTools.some((capability) => {
     const normalized = capability.trim().toLowerCase();
     return normalized.startsWith("mcp.browser.") ||
       normalized.startsWith("playwright.");
-  })) {
+  });
+  if (hasExplicitBrowserTool) {
     return true;
   }
-  const stepText = collectDelegationStepText(spec);
+  const hasExplicitLocalFileInspectionTool = explicitTools.some((toolName) =>
+    LOCAL_FILE_INSPECTION_TOOL_NAMES.has(toolName)
+  );
+  if (
+    specTargetsLocalFiles(spec) &&
+    !hasExplicitBrowserInteractionCue(stepText) &&
+    (hasExplicitLocalFileInspectionTool || !hasExplicitBrowserTool)
+  ) {
+    return false;
+  }
   const taskIntent = classifyDelegatedTaskIntent(spec);
-  if (BROWSER_GROUNDED_TASK_RE.test(stepText)) return true;
+  if (hasPositiveBrowserGroundingCue(stepText)) return true;
   return (
     (taskIntent === "research" || taskIntent === "validation") &&
-    BROWSER_GROUNDED_TASK_RE.test(collectDelegationContextText(spec))
+    hasPositiveBrowserGroundingCue(collectDelegationContextText(spec))
   );
 }
 
@@ -828,6 +914,7 @@ export function resolveDelegatedChildToolScope(params: {
   const taskIntent = classifyDelegatedTaskIntent(params.spec);
   const requireBrowser = specRequiresMeaningfulBrowserEvidence(params.spec);
   const requireFileMutation = specRequiresFileMutationEvidence(params.spec);
+  const localFileInspectionTask = specTargetsLocalFiles(params.spec);
 
   const addCandidate = (
     toolName: string,
@@ -880,7 +967,14 @@ export function resolveDelegatedChildToolScope(params: {
     addSemanticFallback("system.bash");
   };
 
-  if (requireBrowser || taskIntent === "research") {
+  if (localFileInspectionTask && !requireBrowser && !requireFileMutation) {
+    addSemanticFallback("desktop.text_editor");
+    addSemanticFallback("system.readFile");
+    addSemanticFallback("mcp.neovim.vim_edit");
+    addSemanticFallback("mcp.neovim.vim_buffer_save");
+  }
+
+  if ((requireBrowser || taskIntent === "research") && !localFileInspectionTask) {
     addSemanticFallback(PROVIDER_NATIVE_WEB_SEARCH_TOOL);
     addSemanticFallback("mcp.browser.browser_navigate");
     addSemanticFallback("mcp.browser.browser_snapshot");
@@ -941,6 +1035,7 @@ export function resolveDelegatedInitialToolChoiceToolName(
   const requireBrowser = specRequiresMeaningfulBrowserEvidence(spec);
   const requireFileMutation = specRequiresFileMutationEvidence(spec);
   const setupHeavy = isSetupHeavyDelegatedTask(spec);
+  const localFileInspectionTask = specTargetsLocalFiles(spec);
 
   if (setupHeavy) {
     return INITIAL_SETUP_TOOL_NAMES.find((toolName) =>
@@ -953,6 +1048,12 @@ export function resolveDelegatedInitialToolChoiceToolName(
     taskIntent !== "validation"
   ) {
     return INITIAL_FILE_MUTATION_TOOL_NAMES.find((toolName) =>
+      normalizedTools.includes(toolName)
+    );
+  }
+
+  if (localFileInspectionTask && !requireBrowser) {
+    return INITIAL_FILE_INSPECTION_TOOL_NAMES.find((toolName) =>
       normalizedTools.includes(toolName)
     );
   }
@@ -994,7 +1095,7 @@ export function resolveDelegatedCorrectionToolChoiceToolNames(
       return [preferredEditor];
     }
     const systemFileWriteTool = normalizedTools.find((toolName) =>
-      FILE_MUTATION_TOOL_NAMES.has(toolName)
+      EXPLICIT_FILE_MUTATION_TOOL_NAMES.has(toolName)
     );
     if (systemFileWriteTool) {
       return [systemFileWriteTool];

--- a/runtime/src/utils/trace-payload-serialization.test.ts
+++ b/runtime/src/utils/trace-payload-serialization.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatTracePayloadForLog,
+  sanitizeTraceTextForLogSnippet,
   sanitizeTracePayloadForArtifact,
   summarizeTracePayloadForPreview,
 } from "./trace-payload-serialization.js";
@@ -53,5 +54,42 @@ describe("trace-payload-serialization", () => {
 
     expect(formatted).toContain('"artifactType":"image_data_url"');
     expect(formatted).toContain('"nested":{"ok":true}');
+  });
+
+  it("summarizes large ANSI terminal captures instead of logging raw escape sequences", () => {
+    const capture = [
+      "\u001b[H\u001b[2J\u001b[38;5;239m╭──────────╮\u001b[0m",
+      "\u001b[38;5;239m│\u001b[0mAGEN C LIVE\u001b[38;5;239m│\u001b[0m",
+      "\u001b[38;5;239m│\u001b[0mSTATUS connecting…\u001b[38;5;239m│\u001b[0m",
+      "\u001b[38;5;239m╰──────────╯\u001b[0m",
+      " ".repeat(80),
+      " ".repeat(80),
+    ].join("\n");
+
+    const formatted = formatTracePayloadForLog({
+      stdout: capture,
+    });
+
+    expect(formatted).toContain('"artifactType":"terminal_capture"');
+    expect(formatted).not.toContain("\\u001b[H");
+    expect(formatted).not.toContain("AGEN C LIVE");
+  });
+
+  it("summarizes binary-like text dumps instead of logging replacement noise", () => {
+    const formatted = formatTracePayloadForLog({
+      stdout: `\u007fELF\u0002\u0001\u0001\u0000${"\u0000".repeat(16)}${"\uFFFD".repeat(12)}`,
+    });
+
+    expect(formatted).toContain('"artifactType":"binary_like_text"');
+    expect(formatted).not.toContain("\\u0000");
+  });
+
+  it("strips ANSI from short inline snippets while preserving the readable text", () => {
+    const snippet = sanitizeTraceTextForLogSnippet(
+      "\u001b[31mterminal check complete\u001b[0m",
+      200,
+    );
+
+    expect(snippet).toBe("terminal check complete");
   });
 });

--- a/runtime/src/utils/trace-payload-serialization.ts
+++ b/runtime/src/utils/trace-payload-serialization.ts
@@ -4,6 +4,10 @@ import { safeStringify } from "../tools/types.js";
 const BASE64_DATA_URL_PREFIX = /^data:([^;,]+)?;base64,/i;
 const BASE64_BLOCK_PATTERN =
   /^(?:[A-Za-z0-9+/]{4}){256,}(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+const ANSI_ESCAPE_PATTERN = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
+const DISALLOWED_CONTROL_CHAR_PATTERN = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g;
+const REPLACEMENT_CHAR_PATTERN = /\uFFFD/g;
+const BOX_DRAWING_CHAR_PATTERN = /[╭╮╰╯│─┌┐└┘├┤┬┴┼═║╔╗╚╝]/g;
 
 const DEFAULT_PREVIEW_MAX_CHARS = 20_000;
 const DEFAULT_PREVIEW_MAX_DEPTH = 4;
@@ -34,6 +38,43 @@ export interface TracePreviewSerializationOptions {
 function truncateTraceText(value: string, maxChars: number): string {
   if (value.length <= maxChars) return value;
   return `${value.slice(0, maxChars)}... [truncated ${value.length - maxChars} chars]`;
+}
+
+function countMatches(value: string, pattern: RegExp): number {
+  return value.match(pattern)?.length ?? 0;
+}
+
+function buildShaDigest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function inspectTraceText(value: string): {
+  cleaned: string;
+  ansiEscapes: number;
+  controlChars: number;
+  replacementChars: number;
+  frameChars: number;
+  lineCount: number;
+  hasWhitespaceRun: boolean;
+} {
+  const ansiEscapes = countMatches(value, ANSI_ESCAPE_PATTERN);
+  const withoutAnsi = value.replace(ANSI_ESCAPE_PATTERN, "");
+  const controlChars = countMatches(
+    withoutAnsi,
+    DISALLOWED_CONTROL_CHAR_PATTERN,
+  );
+  const replacementChars = countMatches(withoutAnsi, REPLACEMENT_CHAR_PATTERN);
+  const frameChars = countMatches(withoutAnsi, BOX_DRAWING_CHAR_PATTERN);
+  const cleaned = withoutAnsi.replace(DISALLOWED_CONTROL_CHAR_PATTERN, " ");
+  return {
+    cleaned,
+    ansiEscapes,
+    controlChars,
+    replacementChars,
+    frameChars,
+    lineCount: cleaned.length === 0 ? 0 : cleaned.split(/\r?\n/).length,
+    hasWhitespaceRun: / {24,}/.test(cleaned),
+  };
 }
 
 function summarizeBinaryStringForArtifact(
@@ -88,6 +129,68 @@ function summarizeBinaryStringForPreview(
   }
 
   return undefined;
+}
+
+function summarizeSpecialTextForPreview(
+  value: string,
+): Record<string, unknown> | undefined {
+  const inspection = inspectTraceText(value);
+  if (
+    value.includes("\0") ||
+    inspection.controlChars >= 8 ||
+    (inspection.controlChars >= 2 && value.length >= 128) ||
+    (inspection.replacementChars >= 8 && value.length >= 128)
+  ) {
+    return {
+      artifactType: "binary_like_text",
+      digest: buildShaDigest(value),
+      chars: value.length,
+      lines: inspection.lineCount,
+      controlChars: inspection.controlChars,
+      replacementChars: inspection.replacementChars,
+      externalized: true,
+    };
+  }
+
+  if (
+    inspection.ansiEscapes > 0 &&
+    (value.length >= 256 ||
+      inspection.lineCount > 4 ||
+      inspection.frameChars >= 4 ||
+      inspection.hasWhitespaceRun)
+  ) {
+    return {
+      artifactType: "terminal_capture",
+      digest: buildShaDigest(value),
+      chars: value.length,
+      lines: inspection.lineCount,
+      ansiEscapes: inspection.ansiEscapes,
+      frameChars: inspection.frameChars,
+      externalized: true,
+    };
+  }
+
+  return undefined;
+}
+
+function formatTraceTextSummaryForSnippet(
+  summary: Record<string, unknown>,
+): string {
+  const digest =
+    typeof summary.digest === "string" ? ` ${summary.digest}` : "";
+  if (summary.artifactType === "terminal_capture") {
+    return `[terminal capture omitted${digest} lines:${summary.lines ?? "?"} ansiEscapes:${summary.ansiEscapes ?? 0} chars:${summary.chars ?? "?"}]`;
+  }
+  if (summary.artifactType === "binary_like_text") {
+    return `[binary-like text omitted${digest} controlChars:${summary.controlChars ?? 0} chars:${summary.chars ?? "?"}]`;
+  }
+  if (summary.artifactType === "image_data_url") {
+    return `[image data url omitted${digest} bytes:${summary.bytes ?? "?"}]`;
+  }
+  if (summary.artifactType === "base64_blob") {
+    return `[base64 blob omitted${digest} chars:${summary.chars ?? "?"}]`;
+  }
+  return safeStringify(summary);
 }
 
 function toSerializableError(error: Error): Record<string, unknown> {
@@ -185,7 +288,24 @@ export function summarizeTraceTextForPreview(
   value: string,
   maxChars: number,
 ): unknown {
-  return summarizeBinaryStringForPreview(value) ?? truncateTraceText(value, maxChars);
+  return (
+    summarizeBinaryStringForPreview(value) ??
+    summarizeSpecialTextForPreview(value) ??
+    truncateTraceText(inspectTraceText(value).cleaned, maxChars)
+  );
+}
+
+export function sanitizeTraceTextForLogSnippet(
+  value: string,
+  maxChars = DEFAULT_PREVIEW_MAX_CHARS,
+): string {
+  const preview =
+    summarizeBinaryStringForPreview(value) ??
+    summarizeSpecialTextForPreview(value);
+  if (preview) {
+    return formatTraceTextSummaryForSnippet(preview);
+  }
+  return truncateTraceText(inspectTraceText(value).cleaned, maxChars);
 }
 
 export function summarizeTracePayloadForPreview(

--- a/scripts/agenc-trace-watch.mjs
+++ b/scripts/agenc-trace-watch.mjs
@@ -4,16 +4,18 @@ const color = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
   dim: "\x1b[2m",
-  slate: "\x1b[38;5;246m",
-  blue: "\x1b[38;5;75m",
-  cyan: "\x1b[38;5;81m",
-  teal: "\x1b[38;5;44m",
-  green: "\x1b[38;5;42m",
+  slate: "\x1b[38;5;141m",
+  fog: "\x1b[38;5;97m",
+  blue: "\x1b[38;5;39m",
+  cyan: "\x1b[38;5;51m",
+  teal: "\x1b[38;5;45m",
+  green: "\x1b[38;5;50m",
   yellow: "\x1b[38;5;221m",
-  amber: "\x1b[38;5;214m",
-  magenta: "\x1b[38;5;213m",
+  amber: "\x1b[38;5;213m",
+  magenta: "\x1b[38;5;177m",
   red: "\x1b[38;5;203m",
-  border: "\x1b[38;5;238m",
+  border: "\x1b[38;5;54m",
+  borderStrong: "\x1b[38;5;45m",
 };
 
 function toneForLabel(label) {
@@ -32,7 +34,23 @@ function short(value, max = 48) {
 }
 
 function badge(label, tone) {
-  return `${tone}${color.bold}[${label}]${color.reset}`;
+  return `${tone}${color.bold}${label}${color.reset}${color.borderStrong}::${color.reset}`;
+}
+
+function frameWidth() {
+  return Math.max(52, Math.min(process.stdout.columns || 72, 120));
+}
+
+function divider(width = frameWidth()) {
+  return `${color.border}${"─".repeat(width)}${color.reset}`;
+}
+
+function frameLine(left, right = "", leftTone = color.cyan, rightTone = color.magenta) {
+  const width = frameWidth();
+  const inner = width - 2;
+  const safeLeft = short(left, Math.max(12, inner - right.length - 1));
+  const spaces = " ".repeat(Math.max(1, inner - safeLeft.length - right.length));
+  return `${color.border}│${color.reset}${leftTone}${color.bold}${safeLeft}${color.reset}${spaces}${right ? `${rightTone}${color.bold}${right}${color.reset}` : ""}${color.border}│${color.reset}`;
 }
 
 function extractKeyFacts(payload) {
@@ -77,11 +95,11 @@ function renderTrace(line) {
   const parsed = parseTraceLine(line);
   if (!parsed) {
     if (line.includes("ERROR")) {
-      process.stdout.write(`${badge("ERROR", color.red)} ${line}\n`);
+      process.stdout.write(`${badge("FAULT", color.red)} ${line}\n${divider()}\n`);
       return;
     }
     if (line.includes("WARN")) {
-      process.stdout.write(`${badge("WARN", color.amber)} ${line}\n`);
+      process.stdout.write(`${badge("WARN", color.amber)} ${line}\n${divider()}\n`);
       return;
     }
     return;
@@ -90,19 +108,24 @@ function renderTrace(line) {
   const tone = toneForLabel(parsed.label);
   const facts = extractKeyFacts(parsed.payload);
   const time = parsed.ts.split("T")[1]?.replace("Z", "") ?? parsed.ts;
+  const width = frameWidth();
   const head = `${color.slate}${time}${color.reset} ${badge("TRACE", tone)} ${tone}${parsed.label}${color.reset}`;
   process.stdout.write(`${head}\n`);
   if (facts.length > 0) {
-    process.stdout.write(`  ${color.slate}${facts.join("  ")}${color.reset}\n`);
+    process.stdout.write(`  ${color.fog}${short(facts.join(" // "), Math.max(20, width - 2))}${color.reset}\n`);
   }
-  process.stdout.write(`${color.border}${"─".repeat(68)}${color.reset}\n`);
+  process.stdout.write(`${divider(width)}\n`);
 }
 
-process.stdout.write(
-  `${color.border}${"═".repeat(72)}${color.reset}\n` +
-  `${color.cyan}${color.bold}AgenC High-Signal Trace${color.reset}\n` +
-  `${color.border}${"═".repeat(72)}${color.reset}\n`,
-);
+{
+  const width = frameWidth();
+  const inner = width - 2;
+  const top = `${color.border}┌${color.borderStrong}${"─".repeat(inner)}${color.reset}${color.border}┐${color.reset}`;
+  const bottom = `${color.border}└${color.borderStrong}${"─".repeat(inner)}${color.reset}${color.border}┘${color.reset}`;
+  const title = frameLine(" A G E N / C TRACE BUS", "HIGH SIGNAL ");
+  const subtitle = frameLine(" provider / tool / background diagnostics", "", color.fog, color.fog);
+  process.stdout.write(`${top}\n${title}\n${subtitle}\n${bottom}\n`);
+}
 
 const rl = readline.createInterface({
   input: process.stdin,

--- a/scripts/agenc-watch.mjs
+++ b/scripts/agenc-watch.mjs
@@ -1,5 +1,5 @@
 import readline from "node:readline";
-import WebSocket from "file:///home/tetsuo/git/AgenC/node_modules/ws/wrapper.mjs";
+import WebSocket from "../node_modules/ws/wrapper.mjs";
 
 const wsUrl = process.env.AGENC_WATCH_WS_URL ?? "ws://127.0.0.1:3100";
 const clientKey = process.env.AGENC_WATCH_CLIENT_KEY ?? "tmux-live-watch";
@@ -14,19 +14,42 @@ const color = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
   dim: "\x1b[2m",
-  border: "\x1b[38;5;238m",
-  ink: "\x1b[38;5;255m",
-  slate: "\x1b[38;5;246m",
-  cyan: "\x1b[38;5;81m",
-  teal: "\x1b[38;5;44m",
-  blue: "\x1b[38;5;75m",
-  green: "\x1b[38;5;42m",
-  lime: "\x1b[38;5;119m",
+  border: "\x1b[38;5;54m",
+  borderStrong: "\x1b[38;5;45m",
+  ink: "\x1b[38;5;225m",
+  softInk: "\x1b[38;5;189m",
+  slate: "\x1b[38;5;141m",
+  fog: "\x1b[38;5;97m",
+  cyan: "\x1b[38;5;51m",
+  teal: "\x1b[38;5;45m",
+  blue: "\x1b[38;5;39m",
+  green: "\x1b[38;5;50m",
+  lime: "\x1b[38;5;87m",
   yellow: "\x1b[38;5;221m",
-  amber: "\x1b[38;5;214m",
-  magenta: "\x1b[38;5;213m",
+  amber: "\x1b[38;5;213m",
+  magenta: "\x1b[38;5;177m",
   red: "\x1b[38;5;203m",
+  heroBg: "\x1b[49m",
+  panelBg: "\x1b[49m",
+  panelAltBg: "\x1b[48;5;233m",
+  panelHiBg: "\x1b[48;5;234m",
 };
+
+const toneTheme = {
+  ink: { fg: color.ink, bg: "\x1b[49m" },
+  slate: { fg: color.slate, bg: "\x1b[49m" },
+  cyan: { fg: color.cyan, bg: "\x1b[49m" },
+  teal: { fg: color.teal, bg: "\x1b[49m" },
+  blue: { fg: color.blue, bg: "\x1b[49m" },
+  green: { fg: color.green, bg: "\x1b[49m" },
+  lime: { fg: color.lime, bg: "\x1b[49m" },
+  yellow: { fg: color.yellow, bg: "\x1b[49m" },
+  amber: { fg: color.amber, bg: "\x1b[49m" },
+  magenta: { fg: color.magenta, bg: "\x1b[49m" },
+  red: { fg: color.red, bg: "\x1b[49m" },
+};
+
+const maxEventBodyLines = 5;
 
 let requestCounter = 0;
 let sessionId = null;
@@ -51,6 +74,8 @@ let enteredAltScreen = false;
 let renderPending = false;
 let transientStatus = "Booting watch client…";
 let lastStatus = null;
+let lastUsageSummary = null;
+let lastActivityAt = null;
 const queuedOperatorInputs = [];
 
 const pendingFrames = [];
@@ -84,14 +109,57 @@ function stable(value) {
   }
 }
 
+function sanitizeLargeText(value) {
+  return String(value)
+    .replace(
+      /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\r\n]+/g,
+      "(image omitted)",
+    )
+    .replace(/"data":"[A-Za-z0-9+/=\r\n]{120,}"/g, '"data":"(image omitted)"')
+    .replace(/[A-Za-z0-9+/=\r\n]{400,}/g, "(blob omitted)");
+}
+
+function sanitizeInlineText(value) {
+  return sanitizeLargeText(value).replace(/\s+/g, " ").trim();
+}
+
+function stripMarkdownDecorators(value) {
+  return String(value ?? "")
+    .replace(/```/g, "")
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/__(.*?)__/g, "$1")
+    .replace(/`([^`]*)`/g, "$1")
+    .replace(/^\s*[-*]\s+/gm, "")
+    .replace(/^\s*\d+\.\s+/gm, "");
+}
+
+function sanitizeDisplayText(value) {
+  return stripMarkdownDecorators(sanitizeLargeText(value));
+}
+
 function tryPrettyJson(value) {
-  if (typeof value !== "string") {
-    return stable(value);
+  const raw = typeof value === "string" ? sanitizeLargeText(value) : stable(value);
+  if (typeof raw !== "string") {
+    return stable(raw);
   }
   try {
-    return JSON.stringify(JSON.parse(value), null, 2);
+    return JSON.stringify(JSON.parse(raw), null, 2);
   } catch {
-    return value;
+    const parts = raw.split("\n");
+    if (parts.length > 1) {
+      return parts
+        .map((line) => {
+          const trimmed = line.trim();
+          if (!trimmed) return "";
+          try {
+            return JSON.stringify(JSON.parse(trimmed), null, 2);
+          } catch {
+            return trimmed;
+          }
+        })
+        .join("\n");
+    }
+    return raw;
   }
 }
 
@@ -113,12 +181,75 @@ function truncate(value, maxChars = maxInlineChars) {
   return `${value.slice(0, maxChars - 1)}…`;
 }
 
+function formatCompactNumber(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return null;
+  }
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: numeric >= 10_000 ? 0 : 1,
+  }).format(numeric);
+}
+
 function toneColor(tone) {
   return color[tone] ?? color.ink;
 }
 
+function toneSpec(tone) {
+  return toneTheme[tone] ?? toneTheme.slate;
+}
+
 function badge(label, tone = "ink") {
-  return `${toneColor(tone)}${color.bold}[${label}]${color.reset}`;
+  const spec = toneSpec(tone);
+  return `${spec.fg}${color.bold}${label}${color.reset}${color.borderStrong}::${color.reset}`;
+}
+
+function chip(label, value, tone = "ink") {
+  return `${badge(label, tone)} ${toneColor(tone)}${color.bold}${truncate(String(value), 32)}${color.reset}`;
+}
+
+function meterBar(level, width = 10, tone = "green") {
+  const clamped = Math.max(0, Math.min(1, Number(level) || 0));
+  const fill = Math.max(0, Math.min(width, Math.round(clamped * width)));
+  return `${toneColor(tone)}${"█".repeat(fill)}${color.border}${"·".repeat(Math.max(0, width - fill))}${color.reset}`;
+}
+
+function meter(label, level, tone = "green", width = 10) {
+  return `${badge(label, tone)} ${meterBar(level, width, tone)}`;
+}
+
+function connectionLevel() {
+  if (connectionState === "live") return 1;
+  if (connectionState === "reconnecting") return 0.55;
+  if (connectionState === "connecting") return 0.35;
+  return 0.15;
+}
+
+function cognitionLevel() {
+  const phase = String(runPhase ?? runState ?? "").toLowerCase();
+  if (phase.includes("tool")) return 0.9;
+  if (phase.includes("thinking")) return 0.76;
+  if (phase.includes("typing") || phase.includes("stream")) return 0.68;
+  if (phase.includes("idle")) return 0.32;
+  return 0.5;
+}
+
+function queueLevel() {
+  return Math.min(1, queuedOperatorInputs.length / 4);
+}
+
+function activityLevel() {
+  return Math.min(1, events.length / 12);
+}
+
+function bannerMood() {
+  if (!bootstrapReady) return "carrier acquisition in progress";
+  if (latestToolState === "error") return "fault recovery path engaged";
+  if (latestToolState === "running") return "execution bus hot";
+  if ((runPhase ?? "").toLowerCase().includes("thinking")) return "cognitive loop engaged";
+  if (connectionState === "live") return "neural uplink nominal";
+  return "standby for operator signal";
 }
 
 function termWidth() {
@@ -126,16 +257,48 @@ function termWidth() {
 }
 
 function termHeight() {
-  return Math.max(24, process.stdout.rows || 40);
+  return Math.max(12, process.stdout.rows || 40);
 }
 
 function visibleLength(text) {
   return text.replace(/\x1b\[[0-9;]*m/g, "").length;
 }
 
+function truncateAnsi(text, maxChars = maxInlineChars) {
+  if (visibleLength(text) <= maxChars) {
+    return text;
+  }
+  let index = 0;
+  let visible = 0;
+  let output = "";
+  while (index < text.length) {
+    if (text[index] === "\x1b") {
+      const match = text.slice(index).match(/^\x1b\[[0-9;]*m/);
+      if (match) {
+        output += match[0];
+        index += match[0].length;
+        continue;
+      }
+    }
+    if (visible >= Math.max(0, maxChars - 1)) {
+      output += "…";
+      break;
+    }
+    output += text[index];
+    visible += 1;
+    index += 1;
+  }
+  return `${output}${color.reset}`;
+}
+
+function fitAnsi(text, width) {
+  return visibleLength(text) > width ? truncateAnsi(text, width) : text;
+}
+
 function padAnsi(text, width) {
-  const needed = Math.max(0, width - visibleLength(text));
-  return `${text}${" ".repeat(needed)}`;
+  const fitted = fitAnsi(text, width);
+  const needed = Math.max(0, width - visibleLength(fitted));
+  return `${fitted}${" ".repeat(needed)}`;
 }
 
 function wrapLine(line, width) {
@@ -167,14 +330,156 @@ function wrapBlock(text, width) {
     .flatMap((line) => wrapLine(line, width));
 }
 
+function onSurface(text, bg) {
+  return `${bg}${String(text).replace(/\x1b\[0m/g, `${color.reset}${bg}`)}${color.reset}`;
+}
+
+function paintSurface(text, width, bg) {
+  return onSurface(padAnsi(text, width), bg);
+}
+
+function flexBetween(left, right, width) {
+  const leftLen = visibleLength(left);
+  const rightLen = visibleLength(right);
+  if (leftLen + rightLen + 1 > width) {
+    return fitAnsi(`${left} ${right}`, width);
+  }
+  return `${left}${" ".repeat(Math.max(1, width - leftLen - rightLen))}${right}`;
+}
+
+function blankRow(width) {
+  return " ".repeat(width);
+}
+
+function stateTone(value) {
+  const normalized = String(value ?? "").toLowerCase();
+  if (/(error|failed|stopped|cancelled|blocked)/.test(normalized)) return "red";
+  if (/(live|running|ready|completed|ok)/.test(normalized)) return "cyan";
+  if (/idle/.test(normalized)) return "magenta";
+  if (/(typing|thinking|queued|starting|connecting|reconnecting|pause|pending|refresh)/.test(normalized)) return "amber";
+  if (/(generating|active|stream)/.test(normalized)) return "magenta";
+  return "slate";
+}
+
+function panelTop(width, tone = "slate") {
+  const inner = width - 2;
+  const accent = Math.min(10, Math.max(3, Math.floor(inner * 0.14)));
+  return `${color.border}┌${toneColor(tone)}${"─".repeat(accent)}${color.borderStrong}${"─".repeat(Math.max(0, inner - accent))}${color.reset}${color.border}┐${color.reset}`;
+}
+
+function panelBottom(width) {
+  return `${color.border}└${color.borderStrong}${"─".repeat(Math.max(0, width - 2))}${color.reset}${color.border}┘${color.reset}`;
+}
+
+function panelRow(text, width, bg = color.panelBg) {
+  const inner = width - 2;
+  return `${color.border}│${color.reset}${paintSurface(text, inner, bg)}${color.border}│${color.reset}`;
+}
+
+function renderPanel({ title, subtitle = null, tone = "slate", width, bg = color.panelBg, lines = [] }) {
+  const inner = width - 2;
+  const titleLine = subtitle
+    ? flexBetween(
+      `${toneColor(tone)}${color.bold}${title}${color.reset}`,
+      `${color.fog}${subtitle}${color.reset}`,
+      inner,
+    )
+    : `${toneColor(tone)}${color.bold}${title}${color.reset}`;
+  const normalizedLines = lines.map((entry) => (
+    typeof entry === "string" ? { text: entry, bg } : { text: entry?.text ?? "", bg: entry?.bg ?? bg }
+  ));
+  return [
+    panelTop(width, tone),
+    panelRow(titleLine, width, bg),
+    ...normalizedLines.map((line) => panelRow(line.text, width, line.bg)),
+    panelBottom(width),
+  ];
+}
+
+function row(text = "", bg = color.panelBg) {
+  return { text, bg };
+}
+
+function wrapAndLimit(text, width, maxLines = 2) {
+  const lines = wrapBlock(sanitizeLargeText(String(text ?? "")), width);
+  if (maxLines <= 0 || lines.length <= maxLines) {
+    return lines;
+  }
+  return [...lines.slice(0, maxLines), `+${lines.length - maxLines} more`];
+}
+
+function formatMetric(label, value, width, tone = "slate") {
+  return flexBetween(
+    `${color.fog}${label.toUpperCase()}${color.reset}`,
+    `${toneColor(tone)}${color.bold}${truncate(sanitizeInlineText(String(value ?? "n/a")), 34)}${color.reset}`,
+    width,
+  );
+}
+
+function joinColumns(leftLines, rightLines, leftWidth, rightWidth, gap = 2) {
+  const totalRows = Math.max(leftLines.length, rightLines.length);
+  const gapSpacer = " ".repeat(gap);
+  const lines = [];
+  for (let index = 0; index < totalRows; index += 1) {
+    const left = leftLines[index] ? padAnsi(leftLines[index], leftWidth) : blankRow(leftWidth);
+    const right = rightLines[index] ? padAnsi(rightLines[index], rightWidth) : blankRow(rightWidth);
+    lines.push(`${left}${gapSpacer}${right}`);
+  }
+  return lines;
+}
+
+function parseStructuredJson(value) {
+  if (typeof value !== "string") {
+    return value && typeof value === "object" ? [value] : [];
+  }
+  const single = tryParseJson(value);
+  if (single && typeof single === "object" && !Array.isArray(single)) {
+    return [single];
+  }
+  return value
+    .split("\n")
+    .map((line) => tryParseJson(line.trim()))
+    .filter((entry) => entry && typeof entry === "object" && !Array.isArray(entry));
+}
+
+function compactBodyLines(value, maxLines = 4) {
+  const lines = sanitizeDisplayText(value)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^[\[\]{}(),]+$/.test(line));
+  if (lines.length === 0) {
+    const fallback = sanitizeInlineText(stripMarkdownDecorators(value ?? ""));
+    return fallback ? [fallback] : [];
+  }
+  return lines.slice(0, maxLines).map((line) => truncate(line, maxInlineChars));
+}
+
+function summarizeUsage(payload) {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const parts = [];
+  const prompt = formatCompactNumber(payload.promptTokens);
+  const total = formatCompactNumber(payload.totalTokens);
+  const maxOutput = formatCompactNumber(payload.maxOutputTokens);
+  if (prompt) parts.push(`${prompt} prompt`);
+  if (total) parts.push(`${total} total`);
+  if (maxOutput) parts.push(`${maxOutput} max out`);
+  if (payload.compacted) parts.push("compacted");
+  return parts.length > 0 ? parts.join(" / ") : null;
+}
+
 function pushEvent(kind, title, body, tone) {
+  const timestamp = nowStamp();
   events.push({
     kind,
     title,
     tone,
-    timestamp: nowStamp(),
-    body: truncate(body || "(empty)", maxBodyChars),
+    timestamp,
+    body: truncate(tryPrettyJson(body || "(empty)"), maxBodyChars),
   });
+  lastActivityAt = timestamp;
   while (events.length > maxEvents) {
     events.shift();
   }
@@ -182,7 +487,7 @@ function pushEvent(kind, title, body, tone) {
 }
 
 function setTransientStatus(value) {
-  transientStatus = truncate(value, 160);
+  transientStatus = truncate(sanitizeInlineText(value || "idle"), 160);
   scheduleRender();
 }
 
@@ -204,31 +509,75 @@ function requireSession(command) {
 }
 
 function buildToolSummary(parsed) {
-  if (!parsed || typeof parsed !== "object") {
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object"
+      ? [parsed]
+      : [];
+  if (entries.length === 0) {
     return [];
   }
   const lines = [];
+  const seen = new Set();
   const add = (key, value) => {
-    if (value === undefined || value === null || value === "") {
+    if (value === undefined || value === null || value === "" || seen.has(key)) {
       return;
     }
     lines.push(`${key}: ${String(value)}`);
+    seen.add(key);
   };
-  add("state", parsed.state);
-  add("ready", parsed.ready);
-  add("label", parsed.label);
-  add("serverId", parsed.serverId);
-  add("processId", parsed.processId);
-  add("sessionId", parsed.sessionId);
-  add("port", parsed.port);
-  add("url", parsed.healthUrl ?? parsed.currentUrl ?? parsed.url);
-  add("title", parsed.title);
-  add("pid", parsed.pid);
-  add("exitCode", parsed.exitCode);
-  if (typeof parsed.recentOutput === "string" && parsed.recentOutput.trim()) {
-    lines.push(`recentOutput: ${truncate(parsed.recentOutput.trim(), 280)}`);
+  for (const parsedEntry of entries) {
+    add("state", parsedEntry.executor_state ?? parsedEntry.state);
+    add("status", parsedEntry.status);
+    add("ready", parsedEntry.ready);
+    add("label", parsedEntry.label);
+    add("serverId", parsedEntry.serverId);
+    add("processId", parsedEntry.processId);
+    add("sessionId", parsedEntry.sessionId);
+    add("port", parsedEntry.port);
+    add("url", parsedEntry.healthUrl ?? parsedEntry.currentUrl ?? parsedEntry.url);
+    add("title", parsedEntry.title);
+    add("pid", parsedEntry.pid);
+    add("exitCode", parsedEntry.exitCode);
+    add("scenario", parsedEntry.scenario);
+    add("god mode", parsedEntry.god_mode_enabled);
+    add("artifact", parsedEntry.mimeType);
+    if (typeof parsedEntry.error === "string") {
+      add("error", sanitizeInlineText(parsedEntry.error));
+    }
+    if (typeof parsedEntry.message === "string") {
+      add("message", sanitizeInlineText(parsedEntry.message));
+    }
+    if (typeof parsedEntry.stderr === "string" && parsedEntry.stderr.trim()) {
+      add("stderr", sanitizeInlineText(parsedEntry.stderr.split("\n")[0]));
+    }
+    if (Array.isArray(parsedEntry.objectives) && parsedEntry.objectives.length > 0) {
+      add("objective", parsedEntry.objectives[0]?.type);
+    }
+    if (
+      parsedEntry.objective &&
+      typeof parsedEntry.objective === "object" &&
+      !Array.isArray(parsedEntry.objective)
+    ) {
+      add("objective", parsedEntry.objective.type);
+    }
+    if (
+      parsedEntry.game_variables &&
+      typeof parsedEntry.game_variables === "object" &&
+      !Array.isArray(parsedEntry.game_variables)
+    ) {
+      add("health", parsedEntry.game_variables.HEALTH);
+      add("armor", parsedEntry.game_variables.ARMOR);
+      add("kills", parsedEntry.game_variables.KILLCOUNT);
+    }
+    if (
+      typeof parsedEntry.recentOutput === "string" &&
+      parsedEntry.recentOutput.trim()
+    ) {
+      lines.push(`recent output: ${truncate(sanitizeInlineText(parsedEntry.recentOutput.trim()), 180)}`);
+    }
   }
-  return lines;
+  return lines.slice(0, 8);
 }
 
 function summarizeRunDetail(detail) {
@@ -366,82 +715,343 @@ function scheduleBootstrap(reason = "restoring session") {
   setTransientStatus(`${reason}; retrying in ${delayMs}ms`);
 }
 
-function headerLines(width) {
+function heroLines(width) {
   const inner = width - 2;
   const shortSession = sessionId ? sessionId.slice(-8) : "--------";
   const runLabel = `${runState ?? "idle"}${runPhase ? ` / ${runPhase}` : ""}`;
-  const linkTone = connectionState === "live" ? "green" : "amber";
+  const objective = currentObjective ?? runDetail?.objective ?? "No active run";
+  const heroTone = connectionState === "live" ? "cyan" : "amber";
+  const toolSummary = latestTool ?? "waiting";
   const toolTone =
     latestToolState === "error"
       ? "red"
       : latestToolState === "ok"
         ? "green"
         : latestToolState === "running"
-          ? "yellow"
+          ? "magenta"
           : "slate";
 
-  const lines = [];
-  const top = `${color.border}╔${"═".repeat(inner)}╗${color.reset}`;
-  const bottom = `${color.border}╚${"═".repeat(inner)}╝${color.reset}`;
-  lines.push(top);
-  lines.push(
-    `${color.border}║${color.reset}${padAnsi(`${color.cyan}${color.bold}AGEN C // AUTONOMY CONSOLE${color.reset}`, inner)}${color.border}║${color.reset}`,
-  );
-  lines.push(
-    `${color.border}║${color.reset}${padAnsi(`${badge("SESSION", "teal")} ${shortSession}  ${badge("RUN", "magenta")} ${runLabel}  ${badge("LINK", linkTone)} ${connectionState}`, inner)}${color.border}║${color.reset}`,
-  );
-  lines.push(
-    `${color.border}║${color.reset}${padAnsi(`${badge("TOOL", toolTone)} ${latestTool ?? "none"}  ${badge("LAST", "slate")} ${truncate(latestAgentSummary ?? "waiting for agent output", maxSummaryChars)}`, inner)}${color.border}║${color.reset}`,
-  );
-  lines.push(
-    `${color.border}║${color.reset}${padAnsi(`${badge("INFO", "blue")} ${transientStatus}`, inner)}${color.border}║${color.reset}`,
-  );
-  lines.push(
-    `${color.border}║${color.reset}${padAnsi(`${badge("CMDS", "yellow")} /new /runs /inspect /trace /status /pause /resume /stop /cancel /clear /help /quit`, inner)}${color.border}║${color.reset}`,
-  );
-  lines.push(bottom);
-  return lines;
+  return renderPanel({
+    title: "A G E N / C",
+    subtitle: connectionState === "live" ? `carrier ${lastActivityAt ?? "--:--:--"}` : "carrier scan",
+    tone: heroTone,
+    width,
+    bg: color.heroBg,
+    lines: [
+      row(
+        flexBetween(
+          `${color.cyan}${color.bold}COGNITIVE UPLINK // AUTONOMOUS TERMINAL${color.reset}`,
+          `${color.magenta}${color.bold}SYSOP LINK :: ${connectionState.toUpperCase()}${color.reset}`,
+          inner,
+        ),
+        color.heroBg,
+      ),
+      row(
+        `${color.fog}${truncate("0101 1100 0011 1010 1110 0111 0001 1010 0100 1110", Math.max(22, inner - 28))}${color.reset} ${color.borderStrong}//${color.reset} ${color.softInk}${bannerMood()}${color.reset}`,
+        color.heroBg,
+      ),
+      row(
+        flexBetween(
+          `${chip("NODE", shortSession, "slate")} ${chip("UPLINK", connectionState, stateTone(connectionState))} ${chip("CORE", runLabel, stateTone(runLabel))}`,
+          `${chip("LOG", events.length, "blue")} ${chip("QUEUE", queuedOperatorInputs.length, queuedOperatorInputs.length > 0 ? "amber" : "green")}`,
+          inner,
+        ),
+        color.heroBg,
+      ),
+      row(
+        `${badge("FOCUS", currentObjective || runDetail?.objective ? "magenta" : "slate")} ${color.softInk}${truncate(sanitizeInlineText(objective), Math.max(24, inner - 12))}${color.reset}`,
+        color.heroBg,
+      ),
+      row(
+        flexBetween(
+          `${badge("STATUS", stateTone(transientStatus))} ${color.softInk}${truncate(transientStatus, Math.max(18, inner - 38))}${color.reset}`,
+          lastUsageSummary
+            ? `${badge("TOKENS", "teal")} ${color.teal}${truncate(lastUsageSummary, 32)}${color.reset}`
+            : `${chip("MODE", bootstrapReady ? "synced" : "restoring", bootstrapReady ? "green" : "amber")}`,
+          inner,
+        ),
+        color.heroBg,
+      ),
+      row(
+        flexBetween(
+          `${meter("LINK", connectionLevel(), stateTone(connectionState), 10)} ${meter("CORE", cognitionLevel(), stateTone(runPhase ?? runState), 10)}`,
+          `${meter("QUEUE", queueLevel(), queuedOperatorInputs.length > 0 ? "amber" : "green", 8)} ${meter("LOG", activityLevel(), "blue", 8)}`,
+          inner,
+        ),
+        color.heroBg,
+      ),
+      row(
+        `${color.fog}SYSOP${color.reset} ${color.softInk}/help  /clear  enter${color.reset}  ${color.fog}SURFACE${color.reset} ${color.softInk}signal feed + trace bus${color.reset}`,
+        color.heroBg,
+      ),
+    ],
+  });
 }
 
-function runCardLines(width) {
+function compactHeroLines(width) {
   const inner = width - 2;
-  const top = `${color.border}╔${"═".repeat(inner)}╗${color.reset}`;
-  const bottom = `${color.border}╚${"═".repeat(inner)}╝${color.reset}`;
-  const lines = [
-    top,
-    `${color.border}║${color.reset}${padAnsi(`${color.magenta}${color.bold}CURRENT RUN${color.reset}`, inner)}${color.border}║${color.reset}`,
-  ];
-  const detailLines = summarizeRunDetail(runDetail) ?? [
-    `objective: ${currentObjective ?? "waiting for a durable run"}`,
-    `state: ${runState}`,
-    `phase: ${runPhase ?? "idle"}`,
-    `explanation: no run inspection loaded yet`,
-  ];
-  for (const rawLine of detailLines) {
-    for (const wrapped of wrapLine(rawLine, inner)) {
-      lines.push(
-        `${color.border}║${color.reset}${padAnsi(wrapped, inner)}${color.border}║${color.reset}`,
-      );
-    }
-  }
-  lines.push(bottom);
-  return lines;
+  const shortSession = sessionId ? sessionId.slice(-8) : "--------";
+  const runLabel = `${runState ?? "idle"}${runPhase ? ` / ${runPhase}` : ""}`;
+  return renderPanel({
+    title: "A G E N / C",
+    subtitle: connectionState === "live" ? `carrier ${lastActivityAt ?? "--:--:--"}` : "carrier scan",
+    tone: connectionState === "live" ? "cyan" : "amber",
+    width,
+    bg: color.heroBg,
+    lines: [
+      row(
+        flexBetween(
+          `${color.cyan}${color.bold}COGNITIVE UPLINK${color.reset} ${chip("NODE", shortSession, "slate")} ${chip("CORE", runLabel, stateTone(runLabel))}`,
+          `${chip("LOG", events.length, "blue")}`,
+          inner,
+        ),
+        color.heroBg,
+      ),
+      row(
+        flexBetween(
+          `${badge("STATUS", stateTone(transientStatus))} ${color.softInk}${truncate(transientStatus, Math.max(18, inner - 18))}${color.reset}`,
+          `${meter("LINK", connectionLevel(), stateTone(connectionState), 8)}`,
+          inner,
+        ),
+        color.heroBg,
+      ),
+    ],
+  });
 }
 
-function formatEventLines(width) {
-  const inner = Math.max(24, width - 6);
-  const blocks = [];
-  for (const event of events) {
-    const tone = toneColor(event.tone);
-    const title = `${badge(event.kind.toUpperCase(), event.tone)} ${tone}${color.bold}${event.title}${color.reset} ${color.slate}${event.timestamp}${color.reset}`;
-    blocks.push(...wrapLine(title, width));
-    const bodyLines = wrapBlock(event.body, inner);
-    for (const line of bodyLines) {
-      blocks.push(`  ${line}`);
-    }
-    blocks.push(`${color.border}${"─".repeat(Math.max(16, width - 2))}${color.reset}`);
+function runPanelLines(width) {
+  const inner = width - 2;
+  const objective = currentObjective ?? runDetail?.objective ?? "No active run";
+  const explanation = runDetail?.explanation ?? "No durable run inspection loaded yet.";
+  const evidence =
+    runDetail?.lastToolEvidence ??
+    runDetail?.carryForwardSummary ??
+    runDetail?.lastUserUpdate ??
+    "No verified evidence yet.";
+  const nextCheck = runDetail?.nextCheckAt
+    ? new Date(runDetail.nextCheckAt).toLocaleTimeString("en-US", { hour12: false })
+    : "pending";
+  const subtitle = runDetail ? truncate(sanitizeInlineText(runDetail.state ?? runState), 20) : "idle";
+  const lines = [
+    row(
+      flexBetween(
+        `${chip("STATE", runState, stateTone(runState))}`,
+        `${chip("PHASE", runPhase ?? "idle", stateTone(runPhase ?? runState))}`,
+        inner,
+      ),
+      color.panelHiBg,
+    ),
+    row(formatMetric("next check", nextCheck, inner, nextCheck === "pending" ? "amber" : "green"), color.panelAltBg),
+    ...wrapAndLimit(`objective: ${objective}`, inner, 2).map((line, index) => (
+      row(`${color.softInk}${line}${color.reset}`, index === 0 ? color.panelBg : color.panelAltBg)
+    )),
+    ...wrapAndLimit(`evidence: ${evidence}`, inner, 1).map((line, index) => (
+      row(`${color.fog}${line}${color.reset}`, index === 0 ? color.panelBg : color.panelAltBg)
+    )),
+    ...wrapAndLimit(`note: ${explanation}`, inner, 1).map((line, index) => (
+      row(`${color.fog}${line}${color.reset}`, index === 0 ? color.panelAltBg : color.panelBg)
+    )),
+  ];
+  return renderPanel({
+    title: "NET // STATE",
+    subtitle,
+    tone: stateTone(runState),
+    width,
+    bg: color.panelBg,
+    lines,
+  });
+}
+
+function signalPanelLines(width) {
+  const inner = width - 2;
+  const shortSession = sessionId ? sessionId.slice(-8) : "--------";
+  const queued = queuedOperatorInputs.length;
+  const summary = latestAgentSummary
+    ? truncate(sanitizeInlineText(latestAgentSummary), maxSummaryChars)
+    : "waiting for agent output";
+  const lines = [
+    row(
+      flexBetween(
+        `${chip("SESSION", shortSession, "slate")}`,
+        `${chip("QUEUE", queued, queued > 0 ? "amber" : "green")}`,
+        inner,
+      ),
+      color.panelHiBg,
+    ),
+    row(formatMetric("connection", connectionState, inner, stateTone(connectionState)), color.panelAltBg),
+    row(formatMetric("latest tool", latestTool ?? "none", inner, stateTone(latestToolState ?? "idle")), color.panelBg),
+    row(formatMetric("usage", lastUsageSummary ?? "n/a", inner, lastUsageSummary ? "teal" : "slate"), color.panelAltBg),
+    row(`${color.softInk}${truncate(summary, inner)}${color.reset}`, color.panelBg),
+  ];
+  return renderPanel({
+    title: "SYS // LINK",
+    subtitle: lastActivityAt ? `carrier ${lastActivityAt}` : "carrier locked",
+    tone: connectionState === "live" ? "teal" : "amber",
+    width,
+    bg: color.panelAltBg,
+    lines,
+  });
+}
+
+function compactSummaryLines(width) {
+  const inner = width - 2;
+  const objective = currentObjective ?? runDetail?.objective ?? "No active run";
+  const toolSummary = latestTool ?? "none";
+  const toolTone =
+    latestToolState === "error"
+      ? "red"
+      : latestToolState === "ok"
+        ? "green"
+        : latestToolState === "running"
+          ? "magenta"
+          : "slate";
+  const rightSummary = lastUsageSummary
+    ? `usage ${lastUsageSummary}`
+    : `queue ${queuedOperatorInputs.length}`;
+  return renderPanel({
+    title: "NODE // SNAPSHOT",
+    subtitle: runDetail ? truncate(sanitizeInlineText(runDetail.state ?? runState), 18) : "idle",
+    tone: stateTone(runState),
+    width,
+    bg: color.panelBg,
+    lines: [
+      row(
+        flexBetween(
+          `${color.softInk}${truncate(`objective ${sanitizeInlineText(objective)}`, 56)}${color.reset}`,
+          `${chip("TOOL", toolSummary, toolTone)}`,
+          inner,
+        ),
+        color.panelBg,
+      ),
+      row(
+        flexBetween(
+          `${color.fog}phase${color.reset} ${color.softInk}${runPhase ?? "idle"}${color.reset}  ${color.fog}next${color.reset} ${color.softInk}${runDetail?.nextCheckAt ? new Date(runDetail.nextCheckAt).toLocaleTimeString("en-US", { hour12: false }) : "pending"}${color.reset}`,
+          `${color.fog}${truncate(rightSummary, 28)}${color.reset}`,
+          inner,
+        ),
+        color.panelAltBg,
+      ),
+    ],
+  });
+}
+
+function styleEventBodyLine(line) {
+  const match = line.match(/^([A-Za-z0-9 _./-]{2,26}):(.*)$/);
+  if (!match) {
+    return `${color.softInk}${line}${color.reset}`;
   }
-  return blocks;
+  return `${color.fog}${match[1]}:${color.reset}${color.softInk}${match[2]}${color.reset}`;
+}
+
+function eventBadgeLabel(kind) {
+  switch (kind) {
+    case "tool result":
+      return "RETURN";
+    case "tool error":
+      return "FAULT";
+    case "tool":
+      return "EXEC";
+    case "agent":
+      return "CORE";
+    case "you":
+      return "SYSOP";
+    case "operator":
+      return "CTRL";
+    case "run":
+    case "inspect":
+      return "STATE";
+    case "trace":
+      return "TRACE";
+    case "approval":
+      return "AUTH";
+    default:
+      return kind.toUpperCase().slice(0, 10);
+  }
+}
+
+function eventPreviewLines(event, width) {
+  const maxLines =
+    event.kind === "agent"
+      ? 3
+      : event.kind === "tool result" || event.kind === "tool error"
+        ? 3
+        : 2;
+  const preview = compactBodyLines(event.body, 8)
+    .flatMap((line) => wrapLine(line, width))
+    .slice(0, maxLines);
+  return preview;
+}
+
+function renderEventBlock(event, width) {
+  const rows = [];
+  const title = flexBetween(
+    `${badge(eventBadgeLabel(event.kind), event.tone)} ${toneColor(event.tone)}${color.bold}${truncate(sanitizeDisplayText(event.title), 34)}${color.reset}`,
+    `${color.fog}@${event.timestamp}${color.reset}`,
+    width,
+  );
+  rows.push(row(title, color.panelHiBg));
+
+  const bodyLines = eventPreviewLines(event, Math.max(12, width - 2));
+  bodyLines.forEach((line, index) => {
+    rows.push(row(`${color.softInk}${index === 0 ? ":: " : "   "}${styleEventBodyLine(line)}${color.reset}`, color.panelBg));
+  });
+  const hiddenCount = Math.max(0, compactBodyLines(event.body, 8).length - bodyLines.length);
+  if (hiddenCount > 0) {
+    rows.push(
+      row(
+        `${color.fog}+${hiddenCount} more line(s)${color.reset}`,
+        color.panelBg,
+      ),
+    );
+  }
+  return rows;
+}
+
+function collectEventRows(width, maxRows) {
+  if (events.length === 0) {
+    return [
+      row(`${color.softInk}No signal packets on the uplink yet.${color.reset}`, color.panelBg),
+      row(`${color.fog}Operator prompts, execution returns, and core replies will surface here.${color.reset}`, color.panelAltBg),
+    ];
+  }
+
+  const blocks = [];
+  let usedRows = 0;
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const block = renderEventBlock(events[index], width);
+    const needed = block.length + (blocks.length > 0 ? 1 : 0);
+    if (blocks.length > 0 && usedRows + needed > maxRows) {
+      break;
+    }
+    blocks.unshift(block);
+    usedRows += needed;
+  }
+
+  const rows = [];
+  blocks.forEach((block, index) => {
+    if (index > 0) {
+      rows.push(row("", color.panelBg));
+    }
+    rows.push(...block);
+  });
+  return rows;
+}
+
+function activityPanelLines(width, targetHeight) {
+  const chromeRows = 3;
+  const contentRows = Math.max(8, targetHeight - chromeRows);
+  const lines = collectEventRows(width - 2, contentRows).slice(-contentRows);
+  while (lines.length < contentRows) {
+    lines.push(row("", color.panelBg));
+  }
+  return renderPanel({
+    title: "SIGNAL FEED",
+    subtitle: events.length > 0 ? `${events.length} records` : "quiet",
+    tone: "blue",
+    width,
+    bg: color.panelBg,
+    lines,
+  });
 }
 
 function enterAltScreen() {
@@ -463,7 +1073,7 @@ function leaveAltScreen() {
 function promptLabel() {
   const shortSession = sessionId ? sessionId.slice(-8) : "--------";
   const runLabel = runPhase ? `${runState}/${runPhase}` : runState;
-  return `${color.lime}${color.bold}agenc${color.reset}${color.slate}:${shortSession}${runLabel ? ` ${runLabel}` : ""}${color.reset}> `;
+  return `${color.amber}${color.bold}SYSOP${color.reset}${color.borderStrong}::${color.reset} ${color.slate}${shortSession}${color.reset} ${toneColor(stateTone(runLabel))}${runLabel}${color.reset} >> `;
 }
 
 function render() {
@@ -471,19 +1081,45 @@ function render() {
   enterAltScreen();
   const width = termWidth();
   const height = termHeight();
-  const header = headerLines(width);
-  const runCard = runCardLines(width);
   const footerRows = 2;
-  const availableEventRows = Math.max(6, height - header.length - runCard.length - footerRows);
-  const allEventLines = formatEventLines(width);
-  const eventLines = allEventLines.slice(-availableEventRows);
-  const blankRows = Math.max(0, availableEventRows - eventLines.length);
-  const frame = [
-    ...header,
-    ...runCard,
-    ...eventLines,
-    ...Array.from({ length: blankRows }, () => ""),
-  ];
+  const compactHeightMode = height <= 22;
+  const hero = compactHeightMode ? compactHeroLines(width) : heroLines(width);
+  const bodyHeight = Math.max(8, height - hero.length - footerRows);
+  let frame;
+
+  if (compactHeightMode) {
+    const summary = compactSummaryLines(width);
+    const activityPanel = activityPanelLines(width, Math.max(6, bodyHeight - summary.length));
+    frame = [
+      ...hero,
+      ...summary,
+      ...activityPanel,
+    ];
+  } else if (width >= 92) {
+    const gap = 2;
+    const leftWidth = Math.floor((width - gap) / 2);
+    const rightWidth = width - leftWidth - gap;
+    const runPanel = runPanelLines(leftWidth);
+    const sessionPanel = signalPanelLines(rightWidth);
+    const summaryRows = joinColumns(runPanel, sessionPanel, leftWidth, rightWidth, gap);
+    const activityPanel = activityPanelLines(width, Math.max(8, bodyHeight - summaryRows.length - 1));
+    frame = [
+      ...hero,
+      ...summaryRows,
+      "",
+      ...activityPanel,
+    ];
+  } else {
+    const runPanel = runPanelLines(width);
+    const sessionPanel = signalPanelLines(width);
+    const activityPanel = activityPanelLines(width, Math.max(8, bodyHeight - runPanel.length - sessionPanel.length));
+    frame = [
+      ...hero,
+      ...runPanel,
+      ...sessionPanel,
+      ...activityPanel,
+    ];
+  }
 
   process.stdout.write("\x1b[H\x1b[2J");
   process.stdout.write(frame.join("\n"));
@@ -522,13 +1158,12 @@ function handleToolResult(toolName, isError, result) {
   setTransientStatus(
     isError ? `${toolName} failed` : `${toolName} completed`,
   );
-  const parsed = tryParseJson(result);
-  const summary = buildToolSummary(parsed);
-  const formatted = tryPrettyJson(result);
+  const parsedEntries = parseStructuredJson(result);
+  const summary = buildToolSummary(parsedEntries);
   const body =
     summary.length > 0
-      ? `${summary.join("\n")}\n\n${truncate(formatted, maxBodyChars)}`
-      : truncate(formatted, maxBodyChars);
+      ? summary.join("\n")
+      : compactBodyLines(tryPrettyJson(result), maxEventBodyLines).join("\n");
   pushEvent(isError ? "tool error" : "tool result", toolName, body, isError ? "red" : "green");
 }
 
@@ -592,7 +1227,7 @@ function attachSocket(socket) {
         break;
       }
       case "chat.message":
-        latestAgentSummary = msg.payload?.content ?? null;
+        latestAgentSummary = sanitizeInlineText(msg.payload?.content ?? "") || null;
         setTransientStatus("agent reply received");
         pushEvent("agent", "Agent Reply", msg.payload?.content ?? "", "cyan");
         if (currentObjective) {
@@ -630,6 +1265,9 @@ function attachSocket(socket) {
         );
         requestRunInspect("tool result");
         break;
+      case "chat.usage":
+        lastUsageSummary = summarizeUsage(msg.payload);
+        break;
       case "runs.list":
         pushEvent("runs", "Run List", tryPrettyJson(msg.payload ?? []), "blue");
         break;
@@ -640,7 +1278,6 @@ function attachSocket(socket) {
         runState = msg.payload?.state ?? runState;
         runPhase = msg.payload?.currentPhase ?? runPhase;
         setTransientStatus(`run inspect loaded: ${runState ?? "unknown"}`);
-        pushEvent("inspect", "Run Inspect", tryPrettyJson(msg.payload ?? {}), "blue");
         break;
       case "run.updated":
         runState = msg.payload?.state ?? runState;
@@ -677,7 +1314,6 @@ function attachSocket(socket) {
       case "status.update":
         lastStatus = msg.payload ?? lastStatus;
         setTransientStatus("gateway status loaded");
-        pushEvent("status", "Gateway Status", tryPrettyJson(msg.payload ?? {}), "blue");
         break;
       case "agent.status":
         runPhase = msg.payload?.phase ?? runPhase;


### PR DESCRIPTION
## Summary
- harden routed tool execution, delegation validation, provider trace serialization, and Grok stateful continuation defaults
- split large daemon/provider/executor helpers into dedicated modules and add regression coverage
- rework the AgenC live operator console and high-signal trace view for stream-safe tmux use

Fixes #1428

## Test plan
- [x] 
 RUN  v2.1.9 /home/tetsuo/git/AgenC

 ✓ runtime/src/gateway/delegation-tool.test.ts (5 tests) 2ms
 ✓ runtime/src/utils/trace-payload-serialization.test.ts (6 tests) 3ms
 ✓ runtime/src/utils/delegation-validation.test.ts (36 tests) 11ms
 ✓ runtime/src/llm/chat-executor-contract-guidance.test.ts (14 tests) 7ms
 ✓ runtime/src/llm/provider-trace-logger.test.ts (5 tests) 5ms
 ✓ runtime/src/llm/grok/adapter.test.ts (53 tests) 126ms
 ✓ runtime/src/gateway/sub-agent.test.ts (63 tests) 36ms
 ✓ runtime/src/llm/chat-executor.test.ts (161 tests) 173ms
 ✓ runtime/src/gateway/tool-handler-factory.test.ts (38 tests) 174ms
 ✓ runtime/src/gateway/daemon.test.ts (98 tests) 281ms

 Test Files  10 passed (10)
      Tests  479 passed (479)
   Start at  05:39:10
   Duration  1.85s (transform 2.28s, setup 0ms, collect 4.71s, tests 817ms, environment 1ms, prepare 343ms)
- [x] 
> @agenc/runtime@0.1.0 pretypecheck
> npm run check:desktop-tool-definitions


> @agenc/runtime@0.1.0 check:desktop-tool-definitions
> npx tsx scripts/generate-desktop-tool-definitions.ts --check


> @agenc/runtime@0.1.0 typecheck
> tsc --noEmit
- [x] 
> @agenc/runtime@0.1.0 prebuild
> npm run check:desktop-tool-definitions && npm run build --prefix ../sdk && node scripts/copy-idl.js


> @agenc/runtime@0.1.0 check:desktop-tool-definitions
> npx tsx scripts/generate-desktop-tool-definitions.ts --check


> @agenc/sdk@1.3.0 build
> tsup src/index.ts src/bin/agenc.ts --format cjs,esm --dts --clean --external privacycash --external @solana/spl-token

CLI Building entry: src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
CJS dist/index.js 157.15 KB
CJS ⚡️ Build success in 27ms
ESM dist/index.mjs           134.02 KB
ESM dist/prover-D5ZI3S77.mjs 98.00 B
ESM dist/chunk-CERBNWGO.mjs  12.39 KB
ESM ⚡️ Build success in 28ms
DTS Build start
DTS ⚡️ Build success in 868ms
DTS dist/index.d.ts  64.44 KB
DTS dist/index.d.mts 64.44 KB
Copying IDL and types from Anchor build output...
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Copied: /home/tetsuo/git/AgenC/target/idl/agenc_coordination.json -> /home/tetsuo/git/AgenC/runtime/idl/agenc_coordination.json
  Warning: Overwriting existing /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts
  Copied: /home/tetsuo/git/AgenC/target/types/agenc_coordination.ts -> /home/tetsuo/git/AgenC/runtime/src/types/agenc_coordination.ts (with DO NOT EDIT header)
Done.

> @agenc/runtime@0.1.0 build
> tsup src/index.ts src/bin/agenc-runtime.ts src/bin/daemon.ts --format cjs,esm --dts --clean --external openai --external ollama --external better-sqlite3 --external ioredis --external @solana/spl-token --external ws --external grammy --external discord.js --external @slack/bolt --external @whiskeysockets/baileys --external matrix-js-sdk --external cheerio --external playwright --external edge-tts --external @modelcontextprotocol/sdk

CLI Building entry: src/index.ts, src/bin/agenc-runtime.ts, src/bin/daemon.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Target: es2022
CLI Cleaning output folder
CJS Build start
ESM Build start
ESM dist/scheduler-FVPM2YBX.mjs             236.00 B
ESM dist/social-YHMGMSYP.mjs                12.13 KB
ESM dist/marketplace-KJ3PUK6D.mjs           8.62 KB
ESM dist/macos-2F2WV6QG.mjs                 5.67 KB
ESM dist/mcp-client-GLL7764X.mjs            418.00 B
ESM dist/chunk-CGPMEWUY.mjs                 455.00 B
ESM dist/collaboration-FPXDT373.mjs         348.00 B
ESM dist/proactive-CYJR4COA.mjs             2.86 KB
ESM dist/x-QMQSCBNX.mjs                     25.94 KB
ESM dist/self-learning-Z3ON3TS6.mjs         4.42 KB
ESM dist/meta-planner-TDEIDUPX.mjs          6.48 KB
ESM dist/heartbeat-actions-PQO46ZWO.mjs     583.00 B
ESM dist/curiosity-AMMNBDCI.mjs             6.68 KB
ESM dist/desktop-awareness-HI5MT3CM.mjs     300.00 B
ESM dist/heartbeat-5XEDNQNF.mjs             383.00 B
ESM dist/tool-bridge-C6R6CI5V.mjs           183.00 B
ESM dist/tool-definitions-CUDILVJL.mjs      121.00 B
ESM dist/plugin-UFM2P6W3.mjs                243.00 B
ESM dist/feed-BW3PHI3A.mjs                  377.00 B
ESM dist/discovery-TEK3VI6U.mjs             303.00 B
ESM dist/messaging-5LKS3SMS.mjs             334.00 B
ESM dist/agenc-3MCEN4SN.mjs                 785.00 B
ESM dist/session-router-K4L7QCVC.mjs        638.00 B
ESM dist/reputation-CCDKFUFV.mjs            214.00 B
ESM dist/engine-UD2ZY2GV.mjs                187.00 B
ESM dist/backend-VGSU6VUD.mjs               299.00 B
ESM dist/engine-UP5DN27J.mjs                156.00 B
ESM dist/service-marketplace-ILELSHLY.mjs   187.00 B
ESM dist/manager-NRB3B5SR.mjs               286.00 B
ESM dist/connection-SEIZSQSZ.mjs            158.00 B
ESM dist/health-42IT5K5C.mjs                226.00 B
ESM dist/goal-manager-KXOIANFV.mjs          111.00 B
ESM dist/goal-executor-action-RDU7CKIB.mjs  199.00 B
ESM dist/engine-PHR5KSSO.mjs                175.00 B
ESM dist/governance-audit-log-2IGX3RDV.mjs  271.00 B
ESM dist/awareness-goal-bridge-MPRSHJLS.mjs 199.00 B
ESM dist/backend-SZQ7N5GG.mjs               332.00 B
ESM dist/policy-gate-BAVXKEM2.mjs           129.00 B
ESM dist/esm-SSGDQW65.mjs                   3.64 KB
ESM dist/chunk-ENZIMFXZ.mjs                 3.19 KB
ESM dist/chunk-QRYAK5M6.mjs                 7.30 KB
ESM dist/chunk-XBIBFXSU.mjs                 6.03 KB
ESM dist/chunk-5JGBR75C.mjs                 14.55 KB
ESM dist/chunk-WEKDVXQG.mjs                 3.63 KB
ESM dist/chunk-U7ILZWI3.mjs                 2.68 KB
ESM dist/chunk-UTS2WKPT.mjs                 4.04 KB
ESM dist/chunk-TLQ3XHQZ.mjs                 5.03 KB
ESM dist/chunk-MPRDXD7D.mjs                 42.48 KB
ESM dist/chunk-KCQV7RZT.mjs                 8.26 KB
ESM dist/chunk-ZK2VX7RT.mjs                 22.81 KB
ESM dist/chunk-QWMH3X2A.mjs                 11.26 KB
ESM dist/chunk-AQ67QRSZ.mjs                 9.50 KB
ESM dist/chunk-44LNGX42.mjs                 10.81 KB
ESM dist/chunk-LVCD4KAY.mjs                 466.00 B
ESM dist/chunk-OWYG2E5X.mjs                 9.00 KB
ESM dist/chunk-43LBLC7L.mjs                 41.84 KB
ESM dist/chunk-GYGCP4XQ.mjs                 61.03 KB
ESM dist/chunk-C2CKY35O.mjs                 14.79 KB
ESM dist/chunk-ANNTXC2O.mjs                 1.73 KB
ESM dist/chunk-HFDETXEE.mjs                 27.14 KB
ESM dist/chunk-NYKQBEMS.mjs                 26.77 KB
ESM dist/chunk-VES3BK7Z.mjs                 4.21 KB
ESM dist/chunk-XLLA4H5K.mjs                 416.00 B
ESM dist/chunk-FLAOA457.mjs                 1.43 KB
ESM dist/chunk-EY5AFGZ3.mjs                 1.93 KB
ESM dist/chunk-CH5DPZ7M.mjs                 2.81 KB
ESM dist/chunk-CXUL4RKY.mjs                 5.52 KB
ESM dist/chunk-AL7OSK2Q.mjs                 13.24 KB
ESM dist/bin/daemon.mjs                     2.26 KB
ESM dist/chunk-XW6MSVGT.mjs                 9.46 KB
ESM dist/chunk-CWUB4Z3C.mjs                 381.00 B
ESM dist/chunk-4WT77HO6.mjs                 13.83 KB
ESM dist/chunk-YUDOMYD3.mjs                 1.02 KB
ESM dist/chunk-CHFV6ICP.mjs                 5.85 KB
ESM dist/bin/agenc-runtime.mjs              155.65 KB
ESM dist/chunk-LB55JSDJ.mjs                 10.55 KB
ESM dist/chunk-P6LT5F4K.mjs                 4.00 KB
ESM dist/chunk-4WXN4BAX.mjs                 9.76 KB
ESM dist/chunk-KIO24XXI.mjs                 5.35 KB
ESM dist/chunk-UC4I2WWR.mjs                 186.71 KB
ESM dist/chunk-ZRTIOCMA.mjs                 1.62 KB
ESM dist/chunk-DOCRJ22L.mjs                 1.46 KB
ESM dist/chunk-NVWTP56S.mjs                 13.20 KB
ESM dist/chunk-OFECOW5N.mjs                 1.18 KB
ESM dist/chunk-XC3EEDOE.mjs                 1.42 KB
ESM dist/chunk-E5QOHXBX.mjs                 3.30 KB
ESM dist/adapter-N3MOMUPV.mjs               299.00 B
ESM dist/chunk-RMUCQG7L.mjs                 29.90 KB
ESM dist/chunk-IOHOZEWY.mjs                 6.63 KB
ESM dist/chunk-BSX6LNOC.mjs                 32.61 KB
ESM dist/idl-DPTIGNHR.mjs                   209.00 B
ESM dist/wallet-XGB7XVHT.mjs                385.00 B
ESM dist/chunk-PKXIREFX.mjs                 3.55 KB
ESM dist/chunk-AV7YMWQ5.mjs                 12.62 KB
ESM dist/chunk-JDERXCXW.mjs                 57.96 KB
ESM dist/chunk-TCKODS2V.mjs                 7.13 KB
ESM dist/chunk-6JS5WR5V.mjs                 15.03 KB
ESM dist/adapter-2NXDGK4G.mjs               272.00 B
ESM dist/chunk-A63JJ2M4.mjs                 7.69 KB
ESM dist/chunk-VZIWSB36.mjs                 13.11 KB
ESM dist/chunk-PV42QZAA.mjs                 305.00 B
ESM dist/chunk-4WEF4TK4.mjs                 291.00 B
ESM dist/chunk-Y6FXYEAI.mjs                 390.00 B
ESM dist/chunk-U6V2S5W7.mjs                 255.00 B
ESM dist/chunk-U4RXJR3U.mjs                 345.00 B
ESM dist/desktop-executor-2RK6VBYD.mjs      305.00 B
ESM dist/chunk-LCENTSMQ.mjs                 242.16 KB
ESM dist/chunk-EIUVJOSE.mjs                 34.32 KB
ESM dist/chunk-36GGSHEM.mjs                 36.92 KB
ESM dist/index.mjs                          683.31 KB
ESM dist/chunk-WZ353BYB.mjs                 1.93 MB
ESM ⚡️ Build success in 184ms
CJS dist/bin/daemon.js        2.97 MB
CJS dist/index.js             3.89 MB
CJS dist/bin/agenc-runtime.js 3.27 MB
CJS ⚡️ Build success in 185ms
DTS Build start
DTS ⚡️ Build success in 8155ms
DTS dist/bin/agenc-runtime.d.ts  20.00 B
DTS dist/index.d.ts              1.22 MB
DTS dist/bin/daemon.d.ts         20.00 B
DTS dist/bin/agenc-runtime.d.mts 20.00 B
DTS dist/index.d.mts             1.22 MB
DTS dist/bin/daemon.d.mts        20.00 B
- [x] live tmux validation of  and Doom/tool-routing flow
