### PR TITLE
fix(runtime): persist stateful continuity and toolless subagents

### DIFF
--- a/runtime/src/gateway/daemon-trace.ts
+++ b/runtime/src/gateway/daemon-trace.ts
@@ -475,6 +475,12 @@ function summarizeStatefulDiagnosticsForTrace(
     previousResponseId: diagnostics.previousResponseId,
     responseId: diagnostics.responseId,
     reconciliationHash: diagnostics.reconciliationHash,
+    previousReconciliationHash: diagnostics.previousReconciliationHash,
+    reconciliationMessageCount: diagnostics.reconciliationMessageCount,
+    reconciliationSource: diagnostics.reconciliationSource,
+    anchorMatched: diagnostics.anchorMatched,
+    historyCompacted: diagnostics.historyCompacted,
+    compactedHistoryTrusted: diagnostics.compactedHistoryTrusted,
     fallbackReason: diagnostics.fallbackReason,
     events: diagnostics.events,
   };

--- a/runtime/src/gateway/daemon.test.ts
+++ b/runtime/src/gateway/daemon.test.ts
@@ -89,6 +89,8 @@ import {
   resolveStructuredExecDenyExclusions,
   ensureChromiumCompatShims,
   ensureAgencRuntimeShim,
+  resolveSessionStatefulContinuation,
+  persistSessionStatefulContinuation,
   DaemonManager,
   generateSystemdUnit,
   generateLaunchdPlist,
@@ -99,8 +101,14 @@ import { loadGatewayConfig } from "./config-watcher.js";
 import { WorkspaceValidationError } from "./workspace.js";
 import { ToolRouter } from "./tool-routing.js";
 import type { ToolCallRecord } from "../llm/chat-executor.js";
+import type { ChatExecutorResult } from "../llm/chat-executor.js";
 import { didToolCallFail } from "../llm/chat-executor-tool-utils.js";
 import { resolveToolContractExecutionBlock } from "../llm/chat-executor-contract-guidance.js";
+import {
+  SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY,
+  SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
+  type Session,
+} from "./session.js";
 
 // ============================================================================
 // Command availability classifier
@@ -164,6 +172,191 @@ describe("sanitizeToolResultTextForTrace", () => {
     expect(sanitized).toContain("[terminal capture omitted");
     expect(sanitized).not.toContain("\u001b[");
     expect(sanitized).not.toContain("AGEN C LIVE");
+  });
+});
+
+describe("resolveSessionStatefulContinuation", () => {
+  function createResult(
+    overrides: Partial<ChatExecutorResult> = {},
+  ): ChatExecutorResult {
+    return {
+      content: "ok",
+      provider: "grok",
+      usedFallback: false,
+      toolCalls: [],
+      tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+      callUsage: [],
+      durationMs: 10,
+      compacted: false,
+      stopReason: "completed",
+      ...overrides,
+    };
+  }
+
+  it("persists the latest lineage-preserving stateful anchor", () => {
+    const result = createResult({
+      callUsage: [
+        {
+          callIndex: 1,
+          phase: "initial",
+          provider: "grok",
+          finishReason: "stop",
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+          beforeBudget: {
+            messageCount: 2,
+            systemMessages: 1,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 100,
+            systemPromptChars: 50,
+          },
+          afterBudget: {
+            messageCount: 2,
+            systemMessages: 1,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 100,
+            systemPromptChars: 50,
+          },
+          statefulDiagnostics: {
+            enabled: true,
+            attempted: true,
+            continued: true,
+            store: true,
+            fallbackToStateless: true,
+            responseId: "resp-next",
+            reconciliationHash: "hash-next",
+            events: [],
+          },
+        },
+      ],
+    });
+
+    expect(resolveSessionStatefulContinuation(result)).toEqual({
+      mode: "persist",
+      anchor: {
+        previousResponseId: "resp-next",
+        reconciliationHash: "hash-next",
+      },
+    });
+  });
+
+  it("clears stale anchors after planner-driven turns", () => {
+    const result = createResult({
+      callUsage: [
+        {
+          callIndex: 1,
+          phase: "planner",
+          provider: "grok",
+          finishReason: "stop",
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+          beforeBudget: {
+            messageCount: 2,
+            systemMessages: 1,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 100,
+            systemPromptChars: 50,
+          },
+          afterBudget: {
+            messageCount: 2,
+            systemMessages: 1,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 100,
+            systemPromptChars: 50,
+          },
+        },
+        {
+          callIndex: 2,
+          phase: "planner_synthesis",
+          provider: "grok",
+          finishReason: "stop",
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+          beforeBudget: {
+            messageCount: 4,
+            systemMessages: 3,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 200,
+            systemPromptChars: 120,
+          },
+          afterBudget: {
+            messageCount: 4,
+            systemMessages: 3,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 200,
+            systemPromptChars: 120,
+          },
+        },
+      ],
+    });
+
+    expect(resolveSessionStatefulContinuation(result)).toEqual({
+      mode: "clear",
+    });
+  });
+
+  it("clears persisted session metadata when planner turns break lineage", () => {
+    const session: Session = {
+      id: "session-1",
+      workspaceId: "workspace-1",
+      history: [],
+      createdAt: Date.now(),
+      lastActiveAt: Date.now(),
+      metadata: {
+        [SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY]: {
+          previousResponseId: "resp-prev",
+          reconciliationHash: "hash-prev",
+        },
+        [SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY]: true,
+      },
+    };
+    const result = createResult({
+      callUsage: [
+        {
+          callIndex: 1,
+          phase: "planner",
+          provider: "grok",
+          finishReason: "stop",
+          usage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 },
+          beforeBudget: {
+            messageCount: 2,
+            systemMessages: 1,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 100,
+            systemPromptChars: 50,
+          },
+          afterBudget: {
+            messageCount: 2,
+            systemMessages: 1,
+            userMessages: 1,
+            assistantMessages: 0,
+            toolMessages: 0,
+            estimatedChars: 100,
+            systemPromptChars: 50,
+          },
+        },
+      ],
+    });
+
+    persistSessionStatefulContinuation(session, result);
+
+    expect(
+      session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY],
+    ).toBeUndefined();
+    expect(
+      session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY],
+    ).toBeUndefined();
   });
 });
 

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -88,6 +88,7 @@ import type {
   ToolHandler,
   StreamProgressCallback,
   LLMMessage,
+  LLMStatefulResumeAnchor,
 } from "../llm/types.js";
 import { type Tool } from "../tools/types.js";
 import { classifyLLMFailure } from "../llm/errors.js";
@@ -115,6 +116,8 @@ import type {
   MemoryRetriever,
   ToolCallRecord,
   ChatToolRoutingSummary,
+  ChatExecuteParams,
+  ChatExecutorResult,
 } from "../llm/chat-executor.js";
 import {
   DelegationBanditPolicyTuner,
@@ -171,7 +174,12 @@ import { DailyLogManager, CuratedMemoryManager } from "../memory/structured.js";
 import { UnifiedTelemetryCollector } from "../telemetry/collector.js";
 import type { TelemetrySnapshot } from "../telemetry/types.js";
 import { TELEMETRY_METRIC_NAMES } from "../telemetry/metric-names.js";
-import { SessionManager } from "./session.js";
+import {
+  SessionManager,
+  SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY,
+  SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
+  type Session,
+} from "./session.js";
 import {
   WorkspaceLoader,
   getDefaultWorkspacePath,
@@ -276,6 +284,114 @@ function chooseDoomResolutionForDisplay(width: number, height: number): string {
   if (width >= 1024 && height >= 768) return "RES_1024X768";
   if (width >= 800 && height >= 600) return "RES_800X600";
   return "RES_640X480";
+}
+
+function isStatefulResumeAnchor(
+  value: unknown,
+): value is LLMStatefulResumeAnchor {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.previousResponseId !== "string") return false;
+  if (candidate.previousResponseId.trim().length === 0) return false;
+  if (
+    candidate.reconciliationHash !== undefined &&
+    typeof candidate.reconciliationHash !== "string"
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function buildSessionStatefulOptions(
+  session: Session,
+): ChatExecuteParams["stateful"] | undefined {
+  const resumeAnchorCandidate =
+    session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY];
+  const resumeAnchor = isStatefulResumeAnchor(resumeAnchorCandidate)
+    ? resumeAnchorCandidate
+    : undefined;
+  const historyCompacted =
+    session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY] === true;
+  if (!resumeAnchor && !historyCompacted) return undefined;
+  return {
+    ...(resumeAnchor ? { resumeAnchor } : {}),
+    ...(historyCompacted ? { historyCompacted: true } : {}),
+  };
+}
+
+const SESSION_STATEFUL_LINEAGE_PHASES = new Set([
+  "initial",
+  "tool_followup",
+  "evaluator_retry",
+]);
+
+const SESSION_STATEFUL_NON_LINEAGE_PHASES = new Set([
+  "planner",
+  "planner_verifier",
+  "planner_synthesis",
+]);
+
+export function resolveSessionStatefulContinuation(
+  result: ChatExecutorResult,
+):
+  | {
+    readonly mode: "persist";
+    readonly anchor: LLMStatefulResumeAnchor;
+  }
+  | {
+    readonly mode: "clear";
+  }
+  | {
+    readonly mode: "noop";
+  } {
+  if (result.callUsage.length === 0) {
+    return { mode: "noop" };
+  }
+
+  const containsNonLineagePhase = result.callUsage.some((entry) =>
+    SESSION_STATEFUL_NON_LINEAGE_PHASES.has(entry.phase)
+  );
+  if (containsNonLineagePhase) {
+    return { mode: "clear" };
+  }
+
+  const latestLineageDiagnostics = [...result.callUsage]
+    .reverse()
+    .find((entry) => SESSION_STATEFUL_LINEAGE_PHASES.has(entry.phase))
+    ?.statefulDiagnostics;
+  const responseId = latestLineageDiagnostics?.responseId?.trim();
+  const reconciliationHash =
+    latestLineageDiagnostics?.reconciliationHash?.trim();
+  if (responseId && responseId.length > 0) {
+    return {
+      mode: "persist",
+      anchor: {
+        previousResponseId: responseId,
+        ...(reconciliationHash ? { reconciliationHash } : {}),
+      },
+    };
+  }
+
+  return { mode: "clear" };
+}
+
+export function persistSessionStatefulContinuation(
+  session: Session,
+  result: ChatExecutorResult,
+): void {
+  const continuation = resolveSessionStatefulContinuation(result);
+  if (continuation.mode === "noop") {
+    return;
+  }
+  if (continuation.mode === "persist") {
+    session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY] =
+      continuation.anchor;
+    delete session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY];
+    return;
+  }
+
+  delete session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY];
+  delete session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY];
 }
 
 /** Minimum confidence score for injecting learned patterns into conversations. */
@@ -3867,6 +3983,7 @@ export class DaemonManager {
           sessionId: msg.sessionId,
           baseSessionHandler,
         });
+        const sessionStateful = buildSessionStatefulOptions(session);
 
         const result = await chatExecutor.execute({
           message: msg,
@@ -3874,6 +3991,7 @@ export class DaemonManager {
           systemPrompt,
           sessionId: msg.sessionId,
           toolHandler,
+          ...(sessionStateful ? { stateful: sessionStateful } : {}),
           toolRouting: toolRoutingDecision
             ? {
                 routedToolNames: toolRoutingDecision.routedToolNames,
@@ -4005,6 +4123,7 @@ export class DaemonManager {
           });
         }
 
+        persistSessionStatefulContinuation(session, result);
         sessionMgr.appendMessage(session.id, {
           role: "user",
           content: msg.content,
@@ -4243,6 +4362,7 @@ export class DaemonManager {
           sessionId: msg.sessionId,
           baseSessionHandler,
         });
+        const sessionStateful = buildSessionStatefulOptions(session);
 
         const result = await chatExecutor.execute({
           message: msg,
@@ -4250,6 +4370,7 @@ export class DaemonManager {
           systemPrompt,
           sessionId: msg.sessionId,
           toolHandler,
+          ...(sessionStateful ? { stateful: sessionStateful } : {}),
           toolRouting: toolRoutingDecision
             ? {
                 routedToolNames: toolRoutingDecision.routedToolNames,
@@ -4353,6 +4474,7 @@ export class DaemonManager {
           });
         }
 
+        persistSessionStatefulContinuation(session, result);
         sessionMgr.appendMessage(session.id, {
           role: "user",
           content: msg.content,
@@ -8678,6 +8800,7 @@ export class DaemonManager {
 
       // Create an AbortController so the user can cancel mid-execution
       const abortController = webChat.createAbortController(msg.sessionId);
+      const sessionStateful = buildSessionStatefulOptions(session);
 
       const result = await chatExecutor.execute({
         message: msg,
@@ -8687,6 +8810,7 @@ export class DaemonManager {
         toolHandler: sessionToolHandler,
         onStreamChunk: sessionStreamCallback,
         signal: abortController.signal,
+        ...(sessionStateful ? { stateful: sessionStateful } : {}),
         toolRouting: toolRoutingDecision
           ? {
               routedToolNames: toolRoutingDecision.routedToolNames,
@@ -8827,6 +8951,7 @@ export class DaemonManager {
         });
       }
 
+      persistSessionStatefulContinuation(session, result);
       // If ChatExecutor compacted context, also trim session history
       if (result.compacted) {
         void sessionMgr.compact(session.id);

--- a/runtime/src/gateway/llm-stateful-defaults.test.ts
+++ b/runtime/src/gateway/llm-stateful-defaults.test.ts
@@ -9,7 +9,7 @@ describe("resolveGatewayStatefulResponses", () => {
     expect(resolved.usedDefaults).toBe(true);
     expect(resolved.config).toEqual({
       enabled: true,
-      store: false,
+      store: true,
       fallbackToStateless: true,
       compaction: {
         enabled: true,
@@ -30,10 +30,29 @@ describe("resolveGatewayStatefulResponses", () => {
     expect(resolved.usedDefaults).toBe(true);
     expect(resolved.config).toEqual({
       enabled: true,
-      store: false,
+      store: true,
       fallbackToStateless: true,
       compaction: {
         enabled: false,
+        compactThreshold: 16_000,
+        fallbackOnUnsupported: true,
+      },
+    });
+  });
+
+  it("preserves explicit Grok store=false overrides", () => {
+    const resolved = resolveGatewayStatefulResponses("grok", {
+      enabled: true,
+      store: false,
+    });
+
+    expect(resolved.usedDefaults).toBe(true);
+    expect(resolved.config).toEqual({
+      enabled: true,
+      store: false,
+      fallbackToStateless: true,
+      compaction: {
+        enabled: true,
         compactThreshold: 16_000,
         fallbackOnUnsupported: true,
       },

--- a/runtime/src/gateway/llm-stateful-defaults.ts
+++ b/runtime/src/gateway/llm-stateful-defaults.ts
@@ -29,7 +29,7 @@ export function resolveGatewayStatefulResponses(
   const enabled = statefulResponses?.enabled ?? true;
   if (statefulResponses?.enabled === undefined) usedDefaults = true;
 
-  const store = statefulResponses?.store ?? false;
+  const store = statefulResponses?.store ?? enabled;
   if (statefulResponses?.store === undefined) usedDefaults = true;
 
   const fallbackToStateless = statefulResponses?.fallbackToStateless ?? true;

--- a/runtime/src/gateway/session.test.ts
+++ b/runtime/src/gateway/session.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createHash } from "node:crypto";
 import {
   SessionManager,
+  SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY,
+  SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY,
   deriveSessionId,
   type SessionConfig,
   type SessionCompactionHookPayload,
@@ -181,6 +183,27 @@ describe("SessionManager", () => {
       expect(session.metadata.key).toBe("value");
     });
 
+    it("clears only stateful continuation metadata on reset", () => {
+      const session = manager.getOrCreate(makeParams());
+      session.history.push(msg("user", "hello"));
+      session.metadata.key = "value";
+      session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY] = {
+        previousResponseId: "resp_1",
+        reconciliationHash: "hash_1",
+      };
+      session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY] = true;
+
+      manager.reset(session.id);
+
+      expect(session.metadata.key).toBe("value");
+      expect(
+        session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY],
+      ).toBeUndefined();
+      expect(
+        session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY],
+      ).toBeUndefined();
+    });
+
     it("returns false for unknown session", () => {
       expect(manager.reset("nonexistent")).toBe(false);
     });
@@ -238,6 +261,32 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("replaceHistory", () => {
+    it("clears only stateful continuation metadata when replacing history", () => {
+      const session = manager.getOrCreate(makeParams());
+      session.metadata.key = "value";
+      session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY] = {
+        previousResponseId: "resp_2",
+        reconciliationHash: "hash_2",
+      };
+      session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY] = true;
+
+      const replaced = manager.replaceHistory(session.id, [
+        msg("user", "fresh"),
+      ]);
+
+      expect(replaced).toBe(true);
+      expect(session.history).toEqual([msg("user", "fresh")]);
+      expect(session.metadata.key).toBe("value");
+      expect(
+        session.metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY],
+      ).toBeUndefined();
+      expect(
+        session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY],
+      ).toBeUndefined();
+    });
+  });
+
   // --- compact -------------------------------------------------------------
 
   describe("compact", () => {
@@ -275,6 +324,9 @@ describe("SessionManager", () => {
       expect(session.history[0].content).toContain(
         "5 earlier messages removed",
       );
+      expect(
+        session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY],
+      ).toBe(true);
     });
 
     it("'summarize' with summarizer calls callback", async () => {

--- a/runtime/src/gateway/session.ts
+++ b/runtime/src/gateway/session.ts
@@ -10,6 +10,18 @@
 import { createHash } from "node:crypto";
 import type { LLMMessage } from "../llm/types.js";
 
+export const SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY =
+  "statefulResumeAnchor";
+export const SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY =
+  "statefulHistoryCompacted";
+
+export function clearStatefulContinuationMetadata(
+  metadata: Record<string, unknown>,
+): void {
+  delete metadata[SESSION_STATEFUL_RESUME_ANCHOR_METADATA_KEY];
+  delete metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY];
+}
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -293,6 +305,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId);
     if (!session) return false;
     session.history = [];
+    clearStatefulContinuationMetadata(session.metadata);
     session.lastActiveAt = Date.now();
     return true;
   }
@@ -328,6 +341,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId);
     if (!session) return false;
     session.history = [...history];
+    clearStatefulContinuationMetadata(session.metadata);
     session.lastActiveAt = Date.now();
     return true;
   }
@@ -452,6 +466,10 @@ export class SessionManager {
             break;
           }
         }
+      }
+
+      if (result.messagesRemoved > 0) {
+        session.metadata[SESSION_STATEFUL_HISTORY_COMPACTED_METADATA_KEY] = true;
       }
 
       await this.emitCompactionHook({

--- a/runtime/src/gateway/subagent-orchestrator.test.ts
+++ b/runtime/src/gateway/subagent-orchestrator.test.ts
@@ -1469,6 +1469,58 @@ describe("SubAgentOrchestrator", () => {
     expect(taskPrompt).toContain("Assigned phase only: design_research");
   });
 
+  it("sanitizes compact required-orchestration prompts without parentheses or backticks", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new FakeSubAgentManager(5, true);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+      resolveAvailableToolNames: () => ["desktop.bash"],
+    });
+
+    const pipeline: Pipeline = {
+      id: "planner:session-parent-sanitize-compact:123",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "recover_marker",
+          stepType: "subagent_task",
+          objective:
+            "Recover the earlier continuity marker from parent conversation context only.",
+          inputContract: "Return the marker only",
+          acceptanceCriteria: ["Recover the exact prior marker from context only"],
+          requiredToolCapabilities: ["context_retrieval"],
+          contextRequirements: ["parent conversation history"],
+          maxBudgetHint: "minimal",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Sub-agent orchestration plan required: 1. recover_marker: recover marker from context only. 2. echo_marker: print it once. Final deliverables: recovered marker, printed output, known limitations.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+      },
+    };
+
+    const result = await orchestrator.execute(pipeline);
+
+    expect(result.status).toBe("completed");
+    const taskPrompt = manager.spawnCalls[0]?.task ?? "";
+    expect(taskPrompt).not.toContain("Sub-agent orchestration plan required:");
+    expect(taskPrompt).not.toContain("echo_marker");
+    expect(taskPrompt).toContain("Assigned phase only: recover_marker");
+  });
+
   it("adds semantic fallback tools for implementation steps when planner capabilities are unusable", async () => {
     const fallback = createFallbackExecutor(async (pipeline) => ({
       status: "completed",
@@ -1635,6 +1687,64 @@ describe("SubAgentOrchestrator", () => {
     expect(result.status).toBe("failed");
     expect(result.error).toContain("No permitted child tools remain");
     expect(manager.spawnCalls).toHaveLength(0);
+  });
+
+  it("allows context-only subagent steps to run without tools when policy scope resolves no explicit tools", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new FakeSubAgentManager(20, true);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 10,
+      childToolAllowlistStrategy: "inherit_intersection",
+      allowedParentTools: ["desktop.bash", "desktop.text_editor"],
+      resolveAvailableToolNames: () => ["desktop.bash", "desktop.text_editor"],
+    });
+
+    const pipeline: Pipeline = {
+      id: "planner:session-context-only:123",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerContext: {
+        history: [{
+          role: "user",
+          content:
+            "Memory continuity M1. Memorize token OBSIDIAN-LATTICE-44 and checksum 7A91-KAPPA for a later exact recall.",
+        }],
+      },
+      plannerSteps: [
+        {
+          name: "recover_marker",
+          stepType: "subagent_task",
+          objective:
+            "Recover the earlier continuity marker from parent conversation context only; do not invent missing facts",
+          inputContract: "Provided recent conversation context and partial response",
+          acceptanceCriteria: [
+            "Recover the exact prior marker from context only",
+          ],
+          requiredToolCapabilities: ["context_retrieval"],
+          contextRequirements: ["parent_conversation_context"],
+          maxBudgetHint: "minimal",
+          canRunParallel: false,
+        },
+      ],
+    };
+
+    const result = await orchestrator.execute(pipeline);
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls[0]?.tools).toEqual([]);
+    expect(manager.spawnCalls[0]?.task).toContain(
+      "Allowed tools (policy-scoped): none. Complete this phase from curated parent context, memory, and dependency outputs only.",
+    );
+    expect(manager.spawnCalls[0]?.task).toContain("OBSIDIAN-LATTICE-44");
   });
 
   it("fails fast when browser-grounded work is left with only low-signal tab inspection tools", async () => {

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -189,6 +189,7 @@ interface SubagentContextDiagnostics {
     readonly parentPolicyAllowed: readonly string[];
     readonly parentPolicyForbidden: readonly string[];
     readonly resolved: readonly string[];
+    readonly allowsToollessExecution: boolean;
     readonly semanticFallback: readonly string[];
     readonly removedLowSignalBrowserTools: readonly string[];
     readonly removedByPolicy: readonly string[];
@@ -236,7 +237,7 @@ const FILE_URL_RE = /\bfile:\/\/[^\s"'`)]+/gi;
 const ABSOLUTE_PATH_RE =
   /(^|[\s"'`])((?:\/home|\/Users|\/root|\/etc|\/var|\/opt|\/srv|\/tmp)\/[^\s"'`]+)/g;
 const SUBAGENT_ORCHESTRATION_SECTION_RE =
-  /\bsub-agent orchestration plan\s*\((?:required|mandatory)\)\s*:[\s\S]*$/i;
+  /\bsub-agent orchestration plan(?:\s*\((?:required|mandatory)\)|\s+(?:required|mandatory))\s*:[\s\S]*$/i;
 
 const SUBAGENT_RETRY_POLICY: Readonly<
   Record<SubagentFailureClass, SubagentRetryRule>
@@ -906,7 +907,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         stopReasonHint: "validation_error",
       };
     }
-    if (toolScope.allowedTools.length === 0) {
+    if (toolScope.allowedTools.length === 0 && !toolScope.allowsToollessExecution) {
       return {
         status: "failed",
         error:
@@ -1750,6 +1751,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     results: Readonly<Record<string, string>>,
     toolScope: {
       allowedTools: readonly string[];
+      allowsToollessExecution: boolean;
       semanticFallback: readonly string[];
       removedLowSignalBrowserTools: readonly string[];
       removedByPolicy: readonly string[];
@@ -1818,11 +1820,15 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           `Context requirements:\n${step.contextRequirements.map((item) => `- ${this.redactSensitiveData(item)}`).join("\n")}`,
         );
       }
-      if (step.requiredToolCapabilities.length > 0) {
+      if (toolScope.allowedTools.length > 0) {
         sections.push(
-          `Required tool capabilities (policy-scoped):\n${
+          `Allowed tools (policy-scoped):\n${
             toolScope.allowedTools.map((item) => `- ${item}`).join("\n")
           }`,
+        );
+      } else if (toolScope.allowsToollessExecution) {
+        sections.push(
+          "Allowed tools (policy-scoped): none. Complete this phase from curated parent context, memory, and dependency outputs only.",
         );
       }
       if (historySection.lines.length > 0) {
@@ -1879,6 +1885,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         parentPolicyAllowed: [...toolScope.parentPolicyAllowed],
         parentPolicyForbidden: [...this.forbiddenParentTools],
         resolved: [...toolScope.allowedTools],
+        allowsToollessExecution: toolScope.allowsToollessExecution,
         semanticFallback: [...toolScope.semanticFallback],
         removedLowSignalBrowserTools: [
           ...toolScope.removedLowSignalBrowserTools,
@@ -1909,6 +1916,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     pipeline: Pipeline,
   ): {
     allowedTools: readonly string[];
+    allowsToollessExecution: boolean;
     semanticFallback: readonly string[];
     removedLowSignalBrowserTools: readonly string[];
     blockedReason?: string;
@@ -1927,7 +1935,6 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         inputContract: step.inputContract,
         acceptanceCriteria: step.acceptanceCriteria,
         requiredToolCapabilities: step.requiredToolCapabilities,
-        tools: step.requiredToolCapabilities,
       },
       requestedTools: step.requiredToolCapabilities,
       parentAllowedTools: parentPolicyAllowed,
@@ -1939,6 +1946,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
 
     return {
       allowedTools: resolvedScope.allowedTools,
+      allowsToollessExecution: resolvedScope.allowsToollessExecution,
       semanticFallback: resolvedScope.semanticFallback,
       removedLowSignalBrowserTools: resolvedScope.removedLowSignalBrowserTools,
       blockedReason: resolvedScope.blockedReason,

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { extractExplicitSubagentOrchestrationRequirements } from "./chat-executor-planner.js";
+
+describe("chat-executor-planner explicit orchestration requirements", () => {
+  it("extracts required subagent steps from the compact 'plan required' prompt shape", () => {
+    const requirements = extractExplicitSubagentOrchestrationRequirements(
+      "Subagent context audit SG3. Sub-agent orchestration plan required: " +
+        "1. recover_marker: recover the earlier continuity marker from parent conversation context only; do not invent missing facts. " +
+        "2. echo_marker: using desktop.bash, run /usr/bin/printf so it prints the recovered marker exactly once. " +
+        "Final deliverables: recovered marker, printed output, known limitations.",
+    );
+
+    expect(requirements).toBeDefined();
+    expect(requirements?.stepNames).toEqual([
+      "recover_marker",
+      "echo_marker",
+    ]);
+    expect(requirements?.requiresSynthesis).toBe(true);
+    expect(requirements?.steps[0]?.description).toContain(
+      "recover the earlier continuity marker",
+    );
+  });
+});

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -140,6 +140,33 @@ export function assessPlannerDecision(
     reasons.push("prior_no_progress_signal");
   }
 
+  const isExactResponseTurn = isDialogueOnlyExactResponseTurn(messageText);
+  if (isExactResponseTurn) {
+    return {
+      score,
+      shouldPlan: false,
+      reason: "exact_response_turn",
+    };
+  }
+
+  const isDialogueMemoryTurn = isDialogueOnlyMemoryTurn(messageText);
+  if (isDialogueMemoryTurn) {
+    return {
+      score,
+      shouldPlan: false,
+      reason: "dialogue_memory_turn",
+    };
+  }
+
+  const isDialogueRecallTurn = isDialogueOnlyRecallTurn(messageText);
+  if (isDialogueRecallTurn) {
+    return {
+      score,
+      shouldPlan: false,
+      reason: "dialogue_recall_turn",
+    };
+  }
+
   const directFastPath =
     score < 3 ||
     normalized.trim().length < 20 ||
@@ -150,6 +177,39 @@ export function assessPlannerDecision(
     shouldPlan: !directFastPath,
     reason: reasons.length > 0 ? reasons.join("+") : "direct_fast_path",
   };
+}
+
+const EXACT_RESPONSE_CUE_RE =
+  /\b(?:return|reply|respond|output)(?:\s+with)?\s+exactly\b/i;
+const DIALOGUE_MEMORY_CUE_RE =
+  /\b(?:memorize|remember|keep in mind|later recall|for later recall|recall later)\b/i;
+const DIALOGUE_RECALL_CUE_RE =
+  /\b(?:recall|remember|repeat|return|what(?:'s| is| were| did))\b/i;
+const DIALOGUE_RECALL_REFERENCE_CUE_RE =
+  /\b(?:from (?:test|earlier|before|above|prior|previous)|(?:you|i) (?:stored|memorized|remembered|told)|those facts|these facts|the facts|last turn|prior turn|previous turn|continuity test)\b/i;
+const EXPLICIT_ENV_ACTION_CUE_RE =
+  /\b(?:use|call|invoke|run|start|stop|create|write|edit|save|open|navigate|click|search|browse|inspect|read|check|verify|delegate|spawn|launch|post|publish|deploy|install|build|implement|refactor|migrate)\b[\s\S]{0,48}\b(?:tool|tools|desktop|system|mcp|browser|bash|command|terminal|file|files|server|process|service|sub[\s-]?agent|task|api|endpoint|project|tests?)\b/i;
+
+function isDialogueOnlyExactResponseTurn(messageText: string): boolean {
+  return (
+    EXACT_RESPONSE_CUE_RE.test(messageText) &&
+    !EXPLICIT_ENV_ACTION_CUE_RE.test(messageText)
+  );
+}
+
+function isDialogueOnlyMemoryTurn(messageText: string): boolean {
+  return (
+    DIALOGUE_MEMORY_CUE_RE.test(messageText) &&
+    !EXPLICIT_ENV_ACTION_CUE_RE.test(messageText)
+  );
+}
+
+function isDialogueOnlyRecallTurn(messageText: string): boolean {
+  return (
+    DIALOGUE_RECALL_CUE_RE.test(messageText) &&
+    DIALOGUE_RECALL_REFERENCE_CUE_RE.test(messageText) &&
+    !EXPLICIT_ENV_ACTION_CUE_RE.test(messageText)
+  );
 }
 
 // ============================================================================
@@ -268,9 +328,9 @@ export interface ExplicitSubagentOrchestrationRequirements {
 }
 
 const REQUIRED_SUBAGENT_PLAN_MARKER_RE =
-  /sub-agent orchestration plan\s*\((?:required|mandatory)\)\s*:/i;
+  /sub-agent orchestration plan(?:\s*\((?:required|mandatory)\)|\s+(?:required|mandatory))\s*:/i;
 const REQUIRED_SUBAGENT_STEP_NAME_RE =
-  /(?:^|\s)(\d+)[\).:]\s*`([^`]+)`/g;
+  /(?:^|\s)(\d+)[\).:]\s*(?:`([^`]+)`|([A-Za-z0-9_-]+))/g;
 const REQUIRED_DELIVERABLE_CUE_RE =
   /\b(final deliverables|how to play|known limitations|architecture summary)\b/i;
 
@@ -284,15 +344,17 @@ export function extractExplicitSubagentOrchestrationRequirements(
   const steps: ExplicitSubagentOrchestrationRequirementStep[] = [];
   const seen = new Set<string>();
   const itemMatches = section.matchAll(
-    /(\d+)[\).:]\s*`([^`]+)`\s*:\s*([\s\S]*?)(?=(?:\s+\d+[\).:]\s*`)|$)/g,
+    /(\d+)[\).:]\s*(?:`([^`]+)`|([A-Za-z0-9_-]+))\s*:\s*([\s\S]*?)(?=(?:\s+\d+[\).:]\s*(?:`[^`]+`|[A-Za-z0-9_-]+)\s*:)|$)/g,
   );
   for (const match of itemMatches) {
-    const normalizedName = sanitizePlannerStepName(match[2] ?? "");
+    const normalizedName = sanitizePlannerStepName(
+      match[2] ?? match[3] ?? "",
+    );
     if (normalizedName.length === 0 || seen.has(normalizedName)) continue;
     seen.add(normalizedName);
     steps.push({
       name: normalizedName,
-      description: normalizeExplicitRequirementDescription(match[3] ?? ""),
+      description: normalizeExplicitRequirementDescription(match[4] ?? ""),
     });
   }
 
@@ -301,7 +363,9 @@ export function extractExplicitSubagentOrchestrationRequirements(
     REQUIRED_SUBAGENT_STEP_NAME_RE.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = REQUIRED_SUBAGENT_STEP_NAME_RE.exec(section)) !== null) {
-      const normalizedName = sanitizePlannerStepName(match[2] ?? "");
+      const normalizedName = sanitizePlannerStepName(
+        match[2] ?? match[3] ?? "",
+      );
       if (normalizedName.length === 0 || seen.has(normalizedName)) continue;
       seen.add(normalizedName);
       stepNames.push(normalizedName);

--- a/runtime/src/llm/chat-executor-text.test.ts
+++ b/runtime/src/llm/chat-executor-text.test.ts
@@ -247,6 +247,26 @@ describe("chat-executor-text", () => {
     expect(content).toBe("AUTONOMY_STAGE0::SMOKE");
   });
 
+  it("preserves unquoted exact-output contracts with delimiters like equals and pipe", () => {
+    const content = reconcileExactResponseContract(
+      "TOKEN=BLACK-CIRCUIT-91|CODE=ORBITAL-SHARD",
+      [],
+      "Return exactly TOKEN=BLACK-CIRCUIT-91|CODE=ORBITAL-SHARD with no extra text.",
+    );
+
+    expect(content).toBe("TOKEN=BLACK-CIRCUIT-91|CODE=ORBITAL-SHARD");
+  });
+
+  it("preserves unquoted exact-output contracts with spaces", () => {
+    const content = reconcileExactResponseContract(
+      "terminal check complete",
+      [],
+      "Reply with exactly terminal check complete and nothing else.",
+    );
+
+    expect(content).toBe("terminal check complete");
+  });
+
   it("replaces low-information partial timeout completions with a failure fallback", () => {
     const content = reconcileTerminalFailureContent({
       content: "Completed execute_with_agent\nCompleted execute_with_agent",

--- a/runtime/src/llm/chat-executor-text.ts
+++ b/runtime/src/llm/chat-executor-text.ts
@@ -20,7 +20,6 @@ import {
   REPETITIVE_LINE_MIN_COUNT,
   REPETITIVE_LINE_MIN_REPEATS,
   REPETITIVE_LINE_MAX_UNIQUE_RATIO,
-  MAX_HISTORY_MESSAGES,
   MAX_HISTORY_MESSAGE_CHARS,
   MAX_TOOL_RESULT_CHARS,
   MAX_TOOL_RESULT_FIELD_CHARS,
@@ -314,9 +313,15 @@ function extractExactResponseLiteral(messageText: string): string | undefined {
     return undefined;
   }
 
-  const bareMatch = /^([A-Za-z0-9:_./-]+)/.exec(remainder);
-  if (bareMatch?.[1]) {
-    return bareMatch[1].trim();
+  const unquoted = remainder
+    .replace(/\s+/g, " ")
+    .replace(
+      /\s+(?:and|with)\s+(?:nothing\s+else|no\s+extra\s+(?:text|words)|no\s+other\s+text)\b[\s\S]*$/i,
+      "",
+    )
+    .trim();
+  if (unquoted.length > 0) {
+    return unquoted;
   }
 
   return undefined;
@@ -793,8 +798,7 @@ export function estimatePromptShape(
 // ============================================================================
 
 export function normalizeHistory(history: readonly LLMMessage[]): LLMMessage[] {
-  const recent = history.slice(-MAX_HISTORY_MESSAGES);
-  return recent.map((entry) => {
+  return history.map((entry) => {
     const sanitizedToolCalls = sanitizeToolCallsForReplay(
       entry.toolCalls,
     );

--- a/runtime/src/llm/chat-executor-types.ts
+++ b/runtime/src/llm/chat-executor-types.ts
@@ -160,6 +160,7 @@ export interface ChatExecuteParams {
   /** Optional provider-managed continuation hints restored by the runtime. */
   readonly stateful?: {
     readonly resumeAnchor?: LLMStatefulResumeAnchor;
+    readonly historyCompacted?: boolean;
   };
   /** Optional provider-payload tracing hooks for incident diagnostics. */
   readonly trace?: {

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -3862,7 +3862,12 @@ describe("ChatExecutor", () => {
       expect(provider.chatStream).toHaveBeenCalledWith(
         expect.any(Array),
         perCallCallback,
-        { stateful: { sessionId: "session-1" } },
+        expect.objectContaining({
+          stateful: expect.objectContaining({
+            sessionId: "session-1",
+            reconciliationMessages: expect.any(Array),
+          }),
+        }),
       );
       expect(provider.chat).not.toHaveBeenCalled();
     });
@@ -3877,7 +3882,12 @@ describe("ChatExecutor", () => {
       expect(provider.chatStream).toHaveBeenCalledWith(
         expect.any(Array),
         perCallCallback,
-        { stateful: { sessionId: "session-1" } },
+        expect.objectContaining({
+          stateful: expect.objectContaining({
+            sessionId: "session-1",
+            reconciliationMessages: expect.any(Array),
+          }),
+        }),
       );
       expect(provider.chat).not.toHaveBeenCalled();
     });
@@ -3895,7 +3905,12 @@ describe("ChatExecutor", () => {
       expect(provider.chatStream).toHaveBeenCalledWith(
         expect.any(Array),
         constructorCallback,
-        { stateful: { sessionId: "session-1" } },
+        expect.objectContaining({
+          stateful: expect.objectContaining({
+            sessionId: "session-1",
+            reconciliationMessages: expect.any(Array),
+          }),
+        }),
       );
       expect(provider.chat).not.toHaveBeenCalled();
     });
@@ -3940,13 +3955,23 @@ describe("ChatExecutor", () => {
         1,
         expect.any(Array),
         perCallCallback,
-        { stateful: { sessionId: "session-1" } },
+        expect.objectContaining({
+          stateful: expect.objectContaining({
+            sessionId: "session-1",
+            reconciliationMessages: expect.any(Array),
+          }),
+        }),
       );
       expect(provider.chatStream).toHaveBeenNthCalledWith(
         2,
         expect.any(Array),
         perCallCallback,
-        { stateful: { sessionId: "session-1" } },
+        expect.objectContaining({
+          stateful: expect.objectContaining({
+            sessionId: "session-1",
+            reconciliationMessages: expect.any(Array),
+          }),
+        }),
       );
     });
   });
@@ -4193,6 +4218,134 @@ describe("ChatExecutor", () => {
       expect(result.callUsage.map((entry) => entry.phase)).toEqual(["planner"]);
       expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
       expect(result.plannerSummary?.used).toBe(true);
+    });
+
+    it("keeps exact-response turns on the direct no-tool path even with noisy autonomy keywords", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "ACK-13",
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        allowedTools: ["desktop.text_editor", "execute_with_agent"],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          history: [
+            { role: "tool", content: "{\"output\":\"ok\"}", toolName: "desktop.text_editor" },
+            { role: "tool", content: "{\"output\":\"ok\"}", toolName: "desktop.text_editor" },
+            { role: "tool", content: "{\"output\":\"ok\"}", toolName: "desktop.text_editor" },
+            { role: "tool", content: "{\"output\":\"ok\"}", toolName: "desktop.text_editor" },
+          ],
+          toolRouting: {
+            routedToolNames: ["desktop.text_editor", "execute_with_agent"],
+            expandedToolNames: ["desktop.text_editor", "execute_with_agent"],
+          },
+          message: createMessage(
+            "Compaction single-line turn 13. Reply with exactly ACK-13 and nothing else. autonomy-stateful-compaction-delegation-routing-evidence-daemon-log-verification-signal-bus-terminal-uplink-protocol-runtime",
+          ),
+        }),
+      );
+
+      expect(result.content).toBe("ACK-13");
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual(["initial"]);
+      expect(result.plannerSummary?.used).toBe(false);
+      expect(result.plannerSummary?.routeReason).toBe("exact_response_turn");
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]).toMatchObject({
+        toolChoice: "none",
+        toolRouting: { allowedToolNames: [] },
+      });
+    });
+
+    it("suppresses tools for dialogue-memory turns instead of persisting them via desktop mutation", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "STORED-A",
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        allowedTools: ["desktop.text_editor", "execute_with_agent"],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          toolRouting: {
+            routedToolNames: ["desktop.text_editor", "execute_with_agent"],
+            expandedToolNames: ["desktop.text_editor", "execute_with_agent"],
+          },
+          message: createMessage(
+            "Stateful continuity test A. Memorize exactly these facts for later recall: codename=BLACK-ORBIT, port=8771, checksum=SIGMA-42. Reply with exactly STORED-A.",
+          ),
+        }),
+      );
+
+      expect(result.content).toBe("STORED-A");
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual(["initial"]);
+      expect(result.plannerSummary?.used).toBe(false);
+      expect(result.plannerSummary?.routeReason).toBe("exact_response_turn");
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]).toMatchObject({
+        toolChoice: "none",
+        toolRouting: { allowedToolNames: [] },
+      });
+    });
+
+    it("keeps dialogue recall turns on the direct no-tool path", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "BLACK-ORBIT|8771|SIGMA-42",
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        allowedTools: ["desktop.text_editor", "execute_with_agent"],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          history: [
+            {
+              role: "user",
+              content:
+                "Stateful continuity test A3. Memorize exactly these facts for later recall: codename=BLACK-ORBIT, port=8771, checksum=SIGMA-42. Reply with exactly STORED-A3.",
+            },
+            { role: "assistant", content: "STORED-A3" },
+          ],
+          toolRouting: {
+            routedToolNames: ["desktop.text_editor", "execute_with_agent"],
+            expandedToolNames: ["desktop.text_editor", "execute_with_agent"],
+          },
+          message: createMessage(
+            "Stateful continuity test B3. Without extra words, return codename|port|checksum from test A3.",
+          ),
+        }),
+      );
+
+      expect(result.content).toBe("BLACK-ORBIT|8771|SIGMA-42");
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual(["initial"]);
+      expect(result.plannerSummary?.used).toBe(false);
+      expect(result.plannerSummary?.routeReason).toBe("dialogue_recall_turn");
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1]).toMatchObject({
+        toolChoice: "none",
+        toolRouting: { allowedToolNames: [] },
+      });
     });
 
     it("routes high-complexity turns through deterministic planner/executor path", async () => {
@@ -5330,9 +5483,19 @@ describe("ChatExecutor", () => {
 
       const result = await executor.execute(
         createParams({
-          message: createMessage(
-            "First analyze timeout clusters across CI logs, then cross-check source hotspots, then synthesize a remediation summary with evidence.",
-          ),
+          sessionId: "planner-verifier-boundary",
+          message: {
+            ...createMessage(
+              "First analyze timeout clusters across CI logs, then cross-check source hotspots, then synthesize a remediation summary with evidence.",
+            ),
+            sessionId: "planner-verifier-boundary",
+          },
+          stateful: {
+            resumeAnchor: {
+              previousResponseId: "resp-prev",
+              reconciliationHash: "hash-prev",
+            },
+          },
         }),
       );
 
@@ -5351,6 +5514,15 @@ describe("ChatExecutor", () => {
       });
       expect(result.content).toContain("[source:delegate_a]");
       expect(result.stopReason).toBe("completed");
+      const verifierOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1]?.[1] as LLMChatOptions | undefined;
+      const retryVerifierOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[2]?.[1] as LLMChatOptions | undefined;
+      const synthesisOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[3]?.[1] as LLMChatOptions | undefined;
+      expect(verifierOptions?.stateful).toBeUndefined();
+      expect(retryVerifierOptions?.stateful).toBeUndefined();
+      expect(synthesisOptions?.stateful).toBeUndefined();
     });
 
     it("adds provenance citations when synthesis output omits explicit child source tags", async () => {
@@ -8104,8 +8276,62 @@ describe("ChatExecutor", () => {
 
       expect(provider.chat).toHaveBeenCalledWith(
         expect.any(Array),
-        { stateful: { sessionId: "stateful-session" } },
+        expect.objectContaining({
+          stateful: expect.objectContaining({
+            sessionId: "stateful-session",
+            reconciliationMessages: expect.any(Array),
+          }),
+        }),
       );
+    });
+
+    it("passes the full normalized history into reconciliationMessages", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "ok",
+            stateful: {
+              enabled: true,
+              attempted: false,
+              continued: false,
+              store: true,
+              fallbackToStateless: true,
+              events: [],
+            },
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({ providers: [provider] });
+      const history = Array.from({ length: 24 }, (_, index) => ({
+        role: index % 2 === 0 ? "user" : "assistant",
+        content: `history-${index}`,
+      })) as LLMMessage[];
+
+      await executor.execute(
+        createParams({
+          history,
+          sessionId: "stateful-history-window",
+          message: {
+            ...createMessage("continue"),
+            sessionId: "stateful-history-window",
+          },
+        }),
+      );
+
+      const options = (provider.chat as ReturnType<typeof vi.fn>).mock.calls[0]?.[1];
+      const reconciliationMessages = options?.stateful?.reconciliationMessages as
+        | LLMMessage[]
+        | undefined;
+      expect(reconciliationMessages).toBeDefined();
+      expect(reconciliationMessages).toHaveLength(26);
+      expect(reconciliationMessages?.[1]).toMatchObject({
+        role: "user",
+        content: "history-0",
+      });
+      expect(reconciliationMessages?.at(-1)).toMatchObject({
+        role: "user",
+        content: "continue",
+      });
     });
 
     it("passes persisted stateful resume anchors through provider calls", async () => {
@@ -8145,16 +8371,94 @@ describe("ChatExecutor", () => {
 
       expect(provider.chat).toHaveBeenCalledWith(
         expect.any(Array),
-        {
-          stateful: {
+        expect.objectContaining({
+          stateful: expect.objectContaining({
             sessionId: "stateful-resume",
+            reconciliationMessages: expect.any(Array),
             resumeAnchor: {
               previousResponseId: "resp_prev",
               reconciliationHash: "hash-prev",
             },
-          },
-        },
+          }),
+        }),
       );
+    });
+
+    it("does not pass session stateful options into planner synthesis calls", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason: "deterministic_summary",
+                requiresSynthesis: true,
+                steps: [
+                  {
+                    name: "prep",
+                    step_type: "deterministic_tool",
+                    tool: "system.bash",
+                    args: { command: "echo", args: ["ok"] },
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "final synthesized answer",
+              stateful: {
+                enabled: false,
+                attempted: false,
+                continued: false,
+                store: true,
+                fallbackToStateless: true,
+                events: [],
+              },
+            }),
+          ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          context: { results: {} },
+          completedSteps: 1,
+          totalSteps: 1,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("ok"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+      });
+
+      const result = await executor.execute(
+        createParams({
+          sessionId: "planner-stateful-boundary",
+          message: {
+            ...createMessage(
+              "First run setup checks, then delegate deeper research, then synthesize results.",
+            ),
+            sessionId: "planner-stateful-boundary",
+          },
+          stateful: {
+            resumeAnchor: {
+              previousResponseId: "resp-prev",
+              reconciliationHash: "hash-prev",
+            },
+          },
+        }),
+      );
+
+      expect(result.callUsage.map((entry) => entry.phase)).toEqual([
+        "planner",
+        "planner_synthesis",
+      ]);
+
+      const synthesisOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[1]?.[1] as LLMChatOptions | undefined;
+      expect(synthesisOptions?.stateful).toBeUndefined();
     });
 
     it("aggregates stateful fallback reason counters in result summary", async () => {

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -160,6 +160,12 @@ function shouldBypassStreamingForForcedSingleToolTurn(
     options.toolChoice.type === "function";
 }
 
+function shouldUseSessionStatefulContinuationForPhase(
+  phase: ChatCallUsageRecord["phase"],
+): boolean {
+  return phase === "initial" || phase === "tool_followup";
+}
+
 function mergeProviderEvidence(
   current: LLMProviderEvidence | undefined,
   incoming: LLMProviderEvidence | undefined,
@@ -825,6 +831,7 @@ export class ChatExecutor {
         onStreamChunk: ctx.activeStreamCallback,
         statefulSessionId: ctx.sessionId,
         statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+        statefulHistoryCompacted: ctx.stateful?.historyCompacted,
         toolChoice: correctionContractGuidance?.toolChoice ?? "required",
         ...((correctionContractGuidance?.routedToolNames?.length ?? 0) > 0
           ? {
@@ -850,6 +857,7 @@ export class ChatExecutor {
       onStreamChunk?: StreamProgressCallback;
       statefulSessionId?: string;
       statefulResumeAnchor?: LLMStatefulResumeAnchor;
+      statefulHistoryCompacted?: boolean;
       routedToolNames?: readonly string[];
       toolChoice?: LLMToolChoice;
       budgetReason: string;
@@ -868,6 +876,8 @@ export class ChatExecutor {
       activeRoutedToolNames: ctx.activeRoutedToolNames,
       allowedTools: this.allowedTools ?? undefined,
     });
+    const allowStatefulContinuation =
+      shouldUseSessionStatefulContinuationForPhase(input.phase);
     applyActiveRoutedToolNames(ctx, effectiveRoutedToolNames);
     const groundingMessage =
       input.phase === "tool_followup" || input.phase === "planner_synthesis"
@@ -908,9 +918,12 @@ export class ChatExecutor {
         effectiveCallSections,
         {
           requestDeadlineAt: ctx.requestDeadlineAt,
-          ...(input.statefulSessionId
+          ...(allowStatefulContinuation && input.statefulSessionId
             ? {
               statefulSessionId: input.statefulSessionId,
+              ...(input.statefulHistoryCompacted
+                ? { statefulHistoryCompacted: true }
+                : {}),
               ...(input.statefulResumeAnchor
                 ? { statefulResumeAnchor: input.statefulResumeAnchor }
                 : {}),
@@ -1052,6 +1065,7 @@ export class ChatExecutor {
       callSections: verifierSections,
       statefulSessionId: ctx.sessionId,
       statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+      statefulHistoryCompacted: ctx.stateful?.historyCompacted,
       budgetReason:
         "Planner verifier blocked by max model recalls per request budget",
     });
@@ -1406,6 +1420,7 @@ export class ChatExecutor {
           {
             statefulSessionId: ctx.sessionId,
             statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+            statefulHistoryCompacted: ctx.stateful?.historyCompacted,
             ...(ctx.toolRouting
               ? { routedToolNames: ctx.activeRoutedToolNames }
               : {}),
@@ -1448,6 +1463,11 @@ export class ChatExecutor {
   }
 
   private async executeToolCallLoop(ctx: ExecutionContext): Promise<void> {
+    const suppressToolsForDialogueTurn =
+      !ctx.plannerDecision.shouldPlan &&
+      (ctx.plannerDecision.reason === "exact_response_turn" ||
+        ctx.plannerDecision.reason === "dialogue_memory_turn" ||
+        ctx.plannerDecision.reason === "dialogue_recall_turn");
     const initialContractGuidance = this.resolveActiveToolContractGuidance(ctx, {
       phase: "initial",
     });
@@ -1475,9 +1495,14 @@ export class ChatExecutor {
     }
     const initialToolChoice =
       initialContractGuidance?.toolChoice ??
-      (ctx.requiredToolEvidence ? "required" : undefined);
+      (ctx.requiredToolEvidence
+        ? "required"
+        : suppressToolsForDialogueTurn
+          ? "none"
+          : undefined);
     const initialRoutedToolNames =
-      initialContractGuidance?.routedToolNames;
+      initialContractGuidance?.routedToolNames ??
+      (suppressToolsForDialogueTurn ? [] : undefined);
     ctx.response = await this.callModelForPhase(ctx, {
       phase: "initial",
       callMessages: ctx.messages,
@@ -1485,6 +1510,7 @@ export class ChatExecutor {
       onStreamChunk: ctx.activeStreamCallback,
       statefulSessionId: ctx.sessionId,
       statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+      statefulHistoryCompacted: ctx.stateful?.historyCompacted,
       ...((initialToolChoice !== undefined || initialRoutedToolNames !== undefined)
         ? {
           ...(initialToolChoice !== undefined
@@ -1662,6 +1688,7 @@ export class ChatExecutor {
         onStreamChunk: ctx.activeStreamCallback,
         statefulSessionId: ctx.sessionId,
         statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+        statefulHistoryCompacted: ctx.stateful?.historyCompacted,
         ...(followupContractGuidance
           ? {
             toolChoice: followupContractGuidance.toolChoice,
@@ -2470,6 +2497,7 @@ export class ChatExecutor {
             onStreamChunk: ctx.activeStreamCallback,
             statefulSessionId: ctx.sessionId,
             statefulResumeAnchor: ctx.stateful?.resumeAnchor,
+            statefulHistoryCompacted: ctx.stateful?.historyCompacted,
             budgetReason:
               "Planner synthesis blocked by max model recalls per request budget",
           });
@@ -2675,6 +2703,7 @@ export class ChatExecutor {
     options?: {
       statefulSessionId?: string;
       statefulResumeAnchor?: LLMStatefulResumeAnchor;
+      statefulHistoryCompacted?: boolean;
       routedToolNames?: readonly string[];
       toolChoice?: LLMToolChoice;
       requestDeadlineAt?: number;
@@ -2697,9 +2726,9 @@ export class ChatExecutor {
     const hasStatefulSessionId = Boolean(options?.statefulSessionId);
     const hasStatefulResumeAnchor =
       hasStatefulSessionId && options?.statefulResumeAnchor !== undefined;
-    const hasRoutedToolNames = Boolean(
-      options?.routedToolNames && options.routedToolNames.length > 0,
-    );
+    const hasStatefulHistoryCompacted =
+      hasStatefulSessionId && options?.statefulHistoryCompacted === true;
+    const hasRoutedToolNames = options?.routedToolNames !== undefined;
     const hasToolChoice = options?.toolChoice !== undefined;
     const hasProviderTrace =
       options?.trace?.includeProviderPayloads === true ||
@@ -2711,6 +2740,10 @@ export class ChatExecutor {
             ? {
               stateful: {
                 sessionId: String(options?.statefulSessionId),
+                reconciliationMessages: messages,
+                ...(hasStatefulHistoryCompacted
+                  ? { historyCompacted: true }
+                  : {}),
                 ...(hasStatefulResumeAnchor
                   ? { resumeAnchor: options?.statefulResumeAnchor }
                   : {}),

--- a/runtime/src/llm/grok/adapter-utils.test.ts
+++ b/runtime/src/llm/grok/adapter-utils.test.ts
@@ -54,6 +54,44 @@ describe("grok adapter utils", () => {
     );
   });
 
+  it("ignores dynamic system injections when hashing reconciliation state", () => {
+    const first: LLMMessage[] = [
+      { role: "system", content: "base prompt" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+    const second: LLMMessage[] = [
+      { role: "system", content: "base prompt updated" },
+      { role: "system", content: "<memory>fresh working summary</memory>" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi" },
+    ];
+
+    expect(computeReconciliationChain(first, 8)).toEqual(
+      computeReconciliationChain(second, 8),
+    );
+  });
+
+  it("keeps recent anchors matchable after the reconciliation window shifts", () => {
+    const first: LLMMessage[] = Array.from({ length: 50 }, (_, index) => ({
+      role: index % 2 === 0 ? "user" : "assistant",
+      content: `turn-${index}`,
+    }));
+    const second: LLMMessage[] = [
+      ...first,
+      { role: "assistant", content: "turn-50" },
+      { role: "user", content: "turn-51" },
+    ];
+
+    const firstChain = computeReconciliationChain(first, 48);
+    const secondChain = computeReconciliationChain(second, 48);
+
+    expect(secondChain.chain).toContain(firstChain.anchorHash);
+    expect(firstChain.messageCountUsed).toBe(50);
+    expect(secondChain.messageCountUsed).toBe(52);
+    expect(firstChain.source).toBe("non_system_messages");
+  });
+
   it("collapses oversized tool schemas to an open object", () => {
     const hugeProperties = Object.fromEntries(
       Array.from({ length: 400 }, (_, index) => [

--- a/runtime/src/llm/grok/adapter-utils.ts
+++ b/runtime/src/llm/grok/adapter-utils.ts
@@ -226,27 +226,46 @@ function normalizeMessageForReconciliation(message: LLMMessage): unknown {
   return normalized;
 }
 
+function isReconciliationRelevantMessage(message: LLMMessage): boolean {
+  // Stateful continuation should follow the stable user/assistant/tool lineage.
+  // Dynamic system injections (memory, progress, runtime hints) can vary between
+  // turns without invalidating the provider's previous_response_id anchor.
+  return message.role !== "system";
+}
+
 export function computeReconciliationChain(
   messages: readonly LLMMessage[],
   windowSize: number,
-): { anchorHash: string; chain: string[] } {
+): {
+  anchorHash: string;
+  chain: string[];
+  messageCountUsed: number;
+  source: "non_system_messages" | "all_messages";
+} {
   const boundedWindowSize = Math.min(
     MAX_STATEFUL_RECONCILIATION_WINDOW,
     Math.max(1, Math.floor(windowSize)),
   );
-  const start = Math.max(0, messages.length - boundedWindowSize);
-  const window = messages.slice(start);
+  const relevantMessages = messages.filter(isReconciliationRelevantMessage);
+  const sourceWindow =
+    relevantMessages.length > 0 ? relevantMessages : messages;
   let rolling = hashText(`agenc:grok:stateful:${STATEFUL_HASH_VERSION}:root`);
-  const chain: string[] = [];
+  const fullChain: string[] = [];
 
-  for (const message of window) {
+  for (const message of sourceWindow) {
     const normalized = normalizeMessageForReconciliation(message);
     const turnHash = hashText(stableStringify(normalized));
     rolling = hashText(`${rolling}|${turnHash}`);
-    chain.push(rolling);
+    fullChain.push(rolling);
   }
 
-  return { anchorHash: rolling, chain };
+  return {
+    anchorHash: rolling,
+    chain: fullChain.slice(-boundedWindowSize),
+    messageCountUsed: sourceWindow.length,
+    source:
+      relevantMessages.length > 0 ? "non_system_messages" : "all_messages",
+  };
 }
 
 export function isContinuationRetrievalFailure(error: unknown): boolean {

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -247,6 +247,46 @@ describe("GrokProvider", () => {
     });
   });
 
+  it("treats an empty routed allowlist as no attached tools", async () => {
+    mockCreate.mockResolvedValueOnce(makeCompletion());
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "system.bash",
+            description: "run command",
+            parameters: {
+              type: "object",
+              properties: { command: { type: "string" } },
+            },
+          },
+        },
+      ],
+    });
+
+    const response = await provider.chat(
+      [{ role: "user", content: "reply with exactly ACK" }],
+      {
+        toolRouting: { allowedToolNames: [] },
+        toolChoice: "none",
+      },
+    );
+
+    const params = mockCreate.mock.calls.at(-1)?.[0];
+    expect(params.tools).toBeUndefined();
+    expect(response.requestMetrics).toMatchObject({
+      toolCount: 0,
+      toolNames: [],
+      requestedToolNames: [],
+      toolResolution: "all_tools_empty_filter",
+      toolsAttached: false,
+      store: false,
+    });
+  });
+
   it("normalizes forced function tool_choice for the Responses API", async () => {
     mockCreate.mockResolvedValueOnce(makeCompletion());
 
@@ -1564,9 +1604,66 @@ describe("GrokProvider", () => {
     const secondParams = mockCreate.mock.calls[1][0];
     expect(secondParams.previous_response_id).toBeUndefined();
     expect(second.stateful?.fallbackReason).toBe("state_reconciliation_mismatch");
+    expect(second.stateful?.previousReconciliationHash).toBeDefined();
+    expect(second.stateful?.reconciliationMessageCount).toBe(1);
+    expect(second.stateful?.reconciliationSource).toBe("non_system_messages");
+    expect(second.stateful?.anchorMatched).toBe(false);
     expect(second.stateful?.events?.some((event) =>
       event.type === "state_reconciliation_mismatch"
     )).toBe(true);
+  });
+
+  it("trusts a known local compaction boundary and keeps previous_response_id", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_compacted_1",
+          output_text: "Stored",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_compacted_2",
+          output_text: "Resumed after compaction",
+        }),
+      );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      statefulResponses: {
+        enabled: true,
+        store: true,
+        fallbackToStateless: true,
+      },
+    });
+
+    await provider.chat(
+      [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "first turn" },
+      ],
+      { stateful: { sessionId: "sess-compacted-trust" } },
+    );
+    const second = await provider.chat(
+      [
+        { role: "system", content: "[Compacted: 51 earlier messages removed]" },
+        { role: "user", content: "follow up after local compaction" },
+      ],
+      {
+        stateful: {
+          sessionId: "sess-compacted-trust",
+          historyCompacted: true,
+        },
+      },
+    );
+
+    const secondParams = mockCreate.mock.calls[1][0];
+    expect(secondParams.previous_response_id).toBe("resp_compacted_1");
+    expect(second.stateful?.continued).toBe(true);
+    expect(second.stateful?.anchorMatched).toBe(false);
+    expect(second.stateful?.historyCompacted).toBe(true);
+    expect(second.stateful?.compactedHistoryTrusted).toBe(true);
+    expect(second.stateful?.fallbackReason).toBeUndefined();
   });
 
   it("retries stateless when previous_response_id retrieval fails", async () => {
@@ -1713,5 +1810,112 @@ describe("GrokProvider", () => {
     expect(params.previous_response_id).toBe("resp_anchor");
     expect(response.stateful?.continued).toBe(true);
     expect(response.stateful?.responseId).toBe("resp_resumed");
+  });
+
+  it("continues statefully across changing system context injections", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_dynamic_1",
+          output_text: "Stored",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_dynamic_2",
+          output_text: "BLACK-ORBIT|8771|SIGMA-42",
+        }),
+      );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      statefulResponses: {
+        enabled: true,
+        store: true,
+        fallbackToStateless: true,
+      },
+    });
+
+    await provider.chat(
+      [
+        { role: "system", content: "# Agent Configuration\nstatic prompt" },
+        { role: "user", content: "Stateful continuity test A3" },
+      ],
+      { stateful: { sessionId: "sess-dynamic-context" } },
+    );
+    const second = await provider.chat(
+      [
+        { role: "system", content: "# Agent Configuration\nstatic prompt" },
+        { role: "system", content: "## Recent Progress\nupdated working summary" },
+        { role: "user", content: "Stateful continuity test A3" },
+        { role: "assistant", content: "Stored", phase: "final_answer" },
+        { role: "user", content: "Stateful continuity test B3" },
+      ],
+      { stateful: { sessionId: "sess-dynamic-context" } },
+    );
+
+    const secondParams = mockCreate.mock.calls[1][0];
+    expect(secondParams.previous_response_id).toBe("resp_dynamic_1");
+    expect(second.stateful?.continued).toBe(true);
+    expect(second.stateful?.anchorMatched).toBe(true);
+    expect(second.stateful?.reconciliationMessageCount).toBe(3);
+    expect(second.stateful?.fallbackReason).toBeUndefined();
+  });
+
+  it("uses reconciliationMessages when prompt budgeting trims the provider payload", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_trim_1",
+          output_text: "Stored",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_trim_2",
+          output_text: "Resumed",
+        }),
+      );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      statefulResponses: {
+        enabled: true,
+        store: true,
+        fallbackToStateless: true,
+      },
+    });
+
+    await provider.chat(
+      [
+        { role: "system", content: "# Agent Configuration\nstatic prompt" },
+        { role: "user", content: "Stateful continuity test A5" },
+      ],
+      { stateful: { sessionId: "sess-trimmed-reconciliation" } },
+    );
+    const second = await provider.chat(
+      [
+        { role: "system", content: "# Agent Configuration\nstatic prompt" },
+        { role: "user", content: "Stateful continuity test B5" },
+      ],
+      {
+        stateful: {
+          sessionId: "sess-trimmed-reconciliation",
+          reconciliationMessages: [
+            { role: "system", content: "# Agent Configuration\nstatic prompt" },
+            { role: "user", content: "Stateful continuity test A5" },
+            { role: "assistant", content: "Stored", phase: "final_answer" },
+            { role: "user", content: "Stateful continuity test B5" },
+          ],
+        },
+      },
+    );
+
+    const secondParams = mockCreate.mock.calls[1][0];
+    expect(secondParams.previous_response_id).toBe("resp_trim_1");
+    expect(second.stateful?.continued).toBe(true);
+    expect(second.stateful?.anchorMatched).toBe(true);
+    expect(second.stateful?.reconciliationMessageCount).toBe(3);
+    expect(second.stateful?.fallbackReason).toBeUndefined();
   });
 });

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -966,11 +966,13 @@ export class GrokProvider implements LLMProvider {
     const events: LLMStatefulEvent[] = [
       ...(overrides?.inheritedEvents ?? []),
     ];
-    const continuationTurn = messages.some(
+    const reconciliationMessages =
+      options?.stateful?.reconciliationMessages ?? messages;
+    const continuationTurn = reconciliationMessages.some(
       (message) => message.role === "assistant" || message.role === "tool",
     );
     const reconciliation = computeReconciliationChain(
-      messages,
+      reconciliationMessages,
       this.statefulConfig.reconciliationWindow,
     );
     const persistedResumeAnchor = options?.stateful?.resumeAnchor;
@@ -990,6 +992,9 @@ export class GrokProvider implements LLMProvider {
     let continued = false;
     let previousResponseId: string | undefined;
     let fallbackReason = overrides?.fallbackReason;
+    let anchorMatched: boolean | undefined;
+    const historyCompacted = options?.stateful?.historyCompacted === true;
+    let compactedHistoryTrusted = false;
 
     if (!forceStateless && anchor?.responseId) {
       attempted = true;
@@ -998,9 +1003,16 @@ export class GrokProvider implements LLMProvider {
         detail: `session=${sessionId}`,
       });
 
-      if (reconciliation.chain.includes(anchor.reconciliationHash)) {
+      anchorMatched = reconciliation.chain.includes(anchor.reconciliationHash);
+      if (anchorMatched) {
         continued = true;
         appendStatefulEvent(events, "stateful_continuation_success");
+      } else if (historyCompacted) {
+        continued = true;
+        compactedHistoryTrusted = true;
+        appendStatefulEvent(events, "stateful_continuation_success", {
+          detail: `session=${sessionId}; trusted_compacted_history=true`,
+        });
       } else {
         fallbackReason = "state_reconciliation_mismatch";
         appendStatefulEvent(events, "state_reconciliation_mismatch", {
@@ -1073,6 +1085,12 @@ export class GrokProvider implements LLMProvider {
         previousResponseId: continued ? previousResponseId : undefined,
         fallbackReason,
         reconciliationHash: reconciliation.anchorHash,
+        previousReconciliationHash: anchor?.reconciliationHash,
+        reconciliationMessageCount: reconciliation.messageCountUsed,
+        reconciliationSource: reconciliation.source,
+        anchorMatched,
+        historyCompacted,
+        compactedHistoryTrusted,
         events,
       },
     };
@@ -1258,7 +1276,7 @@ export class GrokProvider implements LLMProvider {
   ): ToolSelectionDiagnostics {
     const providerCatalogToolCount = this.responseTools.length;
     const providerCatalogToolNames = extractTraceToolNames(this.responseTools);
-    if (!allowedToolNames || allowedToolNames.length === 0) {
+    if (allowedToolNames === undefined) {
       return {
         tools: this.responseTools,
         chars: this.toolChars,
@@ -1271,6 +1289,20 @@ export class GrokProvider implements LLMProvider {
       };
     }
 
+    if (allowedToolNames.length === 0) {
+      return {
+        tools: [],
+        chars: 0,
+        requestedToolNames: [],
+        resolvedToolNames: [],
+        missingRequestedToolNames: [],
+        providerCatalogToolCount,
+        toolResolution: "all_tools_empty_filter",
+        toolsAttached: false,
+        toolSuppressionReason: "empty_allowlist",
+      };
+    }
+
     const allowed = new Set(
       allowedToolNames
         .map((name) => name.trim())
@@ -1278,14 +1310,15 @@ export class GrokProvider implements LLMProvider {
     );
     if (allowed.size === 0) {
       return {
-        tools: this.responseTools,
-        chars: this.toolChars,
+        tools: [],
+        chars: 0,
         requestedToolNames: [],
-        resolvedToolNames: providerCatalogToolNames,
+        resolvedToolNames: [],
         missingRequestedToolNames: [],
         providerCatalogToolCount,
         toolResolution: "all_tools_empty_filter",
         toolsAttached: false,
+        toolSuppressionReason: "empty_allowlist",
       };
     }
 

--- a/runtime/src/llm/ollama/adapter.test.ts
+++ b/runtime/src/llm/ollama/adapter.test.ts
@@ -234,6 +234,40 @@ describe("OllamaProvider", () => {
     });
   });
 
+  it("treats an empty routed allowlist as no attached tools", async () => {
+    mockChat.mockResolvedValueOnce(makeResponse());
+
+    const provider = new OllamaProvider({
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "lookup",
+            description: "Look up info",
+            parameters: { type: "object" },
+          },
+        },
+      ],
+    });
+
+    const result = await provider.chat(
+      [{ role: "user", content: "test" }],
+      {
+        toolRouting: { allowedToolNames: [] },
+      },
+    );
+
+    expect(result.requestMetrics).toMatchObject({
+      toolCount: 0,
+      toolNames: [],
+      requestedToolNames: [],
+      missingRequestedToolNames: [],
+      toolResolution: "all_tools_empty_filter",
+      toolsAttached: false,
+      stream: undefined,
+    });
+  });
+
   it("emits provider request and response trace events when enabled", async () => {
     mockChat.mockResolvedValueOnce(makeResponse());
 

--- a/runtime/src/llm/ollama/adapter.ts
+++ b/runtime/src/llm/ollama/adapter.ts
@@ -475,7 +475,7 @@ export class OllamaProvider implements LLMProvider {
   ): ToolSelectionDiagnostics {
     const providerCatalogToolCount = this.tools.length;
     const providerCatalogToolNames = this.tools.map((tool) => tool.function.name);
-    if (!allowedToolNames || allowedToolNames.length === 0) {
+    if (allowedToolNames === undefined) {
       return {
         tools: this.tools,
         requestedToolNames: [],
@@ -487,6 +487,18 @@ export class OllamaProvider implements LLMProvider {
       };
     }
 
+    if (allowedToolNames.length === 0) {
+      return {
+        tools: [],
+        requestedToolNames: [],
+        resolvedToolNames: [],
+        missingRequestedToolNames: [],
+        providerCatalogToolCount,
+        toolResolution: "all_tools_empty_filter",
+        toolsAttached: false,
+      };
+    }
+
     const allowed = new Set(
       allowedToolNames
         .map((name) => name.trim())
@@ -494,13 +506,13 @@ export class OllamaProvider implements LLMProvider {
     );
     if (allowed.size === 0) {
       return {
-        tools: this.tools,
+        tools: [],
         requestedToolNames: [],
-        resolvedToolNames: providerCatalogToolNames,
+        resolvedToolNames: [],
         missingRequestedToolNames: [],
         providerCatalogToolCount,
         toolResolution: "all_tools_empty_filter",
-        toolsAttached: true,
+        toolsAttached: false,
       };
     }
 

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -156,6 +156,24 @@ export interface LLMStatefulDiagnostics {
   readonly responseId?: string;
   /** Reconciliation anchor hash for this call (provider-defined). */
   readonly reconciliationHash?: string;
+  /** Previous reconciliation anchor restored from local/provider session state. */
+  readonly previousReconciliationHash?: string;
+  /** Number of messages used to compute the reconciliation chain for this call. */
+  readonly reconciliationMessageCount?: number;
+  /** Which message set was used to build the reconciliation chain. */
+  readonly reconciliationSource?: "non_system_messages" | "all_messages";
+  /** Whether the restored anchor hash matched the current reconciliation chain. */
+  readonly anchorMatched?: boolean;
+  /**
+   * True when the runtime compacted local history after the previous anchor was
+   * recorded, so a mismatch can be expected.
+   */
+  readonly historyCompacted?: boolean;
+  /**
+   * True when continuation proceeded despite a mismatch because the runtime
+   * trusted its own compaction boundary.
+   */
+  readonly compactedHistoryTrusted?: boolean;
   /** Fallback reason when continuation was bypassed or retried statelessly. */
   readonly fallbackReason?: LLMStatefulFallbackReason;
   /** Structured trace events emitted during stateful decisioning. */
@@ -273,6 +291,19 @@ export interface LLMChatStatefulOptions {
   readonly sessionId: string;
   /** Persisted continuation anchor restored by the runtime after restart. */
   readonly resumeAnchor?: LLMStatefulResumeAnchor;
+  /**
+   * True when the local session manager compacted history after the previous
+   * anchor was recorded.
+   */
+  readonly historyCompacted?: boolean;
+  /**
+   * Full local dialogue lineage used only for reconciliation hashing.
+   *
+   * This lets the runtime keep provider prompt payloads budgeted/truncated
+   * while still validating `previous_response_id` against the complete local
+   * conversation state.
+   */
+  readonly reconciliationMessages?: readonly LLMMessage[];
 }
 
 /**

--- a/runtime/src/utils/delegation-validation.test.ts
+++ b/runtime/src/utils/delegation-validation.test.ts
@@ -471,6 +471,28 @@ describe("delegation-validation", () => {
     expect(resolved.blockedReason).toBeUndefined();
   });
 
+  it("allows toolless execution for context-only recall steps with abstract capabilities", () => {
+    const resolved = resolveDelegatedChildToolScope({
+      spec: {
+        task: "recover_marker",
+        objective:
+          "Recover the earlier continuity marker from parent conversation context only; do not invent missing facts",
+        inputContract: "Provided recent conversation context and partial response",
+        acceptanceCriteria: ["Recover the exact prior marker from context only"],
+        requiredToolCapabilities: ["context_retrieval"],
+      },
+      requestedTools: ["context_retrieval"],
+      parentAllowedTools: ["desktop.bash", "desktop.text_editor"],
+      availableTools: ["desktop.bash", "desktop.text_editor"],
+      enforceParentIntersection: true,
+    });
+
+    expect(resolved.allowedTools).toEqual([]);
+    expect(resolved.allowsToollessExecution).toBe(true);
+    expect(resolved.blockedReason).toBeUndefined();
+    expect(resolved.semanticFallback).toEqual([]);
+  });
+
   it("prefers provider-native web search over browser tools for research child scope", () => {
     const resolved = resolveDelegatedChildToolScope({
       spec: {

--- a/runtime/src/utils/delegation-validation.ts
+++ b/runtime/src/utils/delegation-validation.ts
@@ -64,6 +64,7 @@ export interface ResolvedDelegatedChildToolScope
   readonly removedByPolicy: readonly string[];
   readonly removedAsDelegationTools: readonly string[];
   readonly removedAsUnknownTools: readonly string[];
+  readonly allowsToollessExecution: boolean;
 }
 
 const EMPTY_DELEGATION_OUTPUT_VALUES = new Set(["null", "undefined", "{}", "[]"]);
@@ -218,6 +219,8 @@ const INITIAL_FILE_INSPECTION_TOOL_NAMES = [
   "mcp.neovim.vim_buffer_save",
   "mcp.neovim.vim_search_replace",
 ] as const;
+const CONTEXT_ONLY_CAPABILITY_RE =
+  /\b(?:context|history|memory|conversation|recall|retrieve|retrieval|prior|previous)\b/i;
 
 function normalizeToolNames(toolNames: readonly string[] | undefined): string[] {
   return [
@@ -237,6 +240,12 @@ function looksLikeExplicitDelegatedToolName(toolName: string): boolean {
     normalized.startsWith("desktop") ||
     normalized.startsWith("system") ||
     normalized.startsWith("mcp");
+}
+
+function isContextOnlyCapabilityName(capability: string): boolean {
+  if (looksLikeExplicitDelegatedToolName(capability)) return false;
+  const normalized = capability.trim().replace(/[_-]+/g, " ");
+  return CONTEXT_ONLY_CAPABILITY_RE.test(normalized);
 }
 
 function extractExplicitDelegatedToolNames(
@@ -915,6 +924,8 @@ export function resolveDelegatedChildToolScope(params: {
   const requireBrowser = specRequiresMeaningfulBrowserEvidence(params.spec);
   const requireFileMutation = specRequiresFileMutationEvidence(params.spec);
   const localFileInspectionTask = specTargetsLocalFiles(params.spec);
+  const contextOnlyCapabilityRequest =
+    requested.length > 0 && requested.every(isContextOnlyCapabilityName);
 
   const addCandidate = (
     toolName: string,
@@ -995,7 +1006,7 @@ export function resolveDelegatedChildToolScope(params: {
     addSemanticFallback("mcp.browser.browser_run_code");
   }
 
-  if (allowedTools.length === 0) {
+  if (allowedTools.length === 0 && !contextOnlyCapabilityRequest) {
     addShellSemanticFallback();
   }
 
@@ -1010,19 +1021,24 @@ export function resolveDelegatedChildToolScope(params: {
   const profiledSemanticFallback = semanticFallback.filter((toolName) =>
     profiledAllowedTools.includes(toolName)
   );
+  const allowsToollessExecution =
+    profiledAllowedTools.length === 0 &&
+    !specRequiresSuccessfulToolEvidence(params.spec) &&
+    !refined.blockedReason;
 
   return {
     allowedTools: profiledAllowedTools,
     removedLowSignalBrowserTools: refined.removedLowSignalBrowserTools,
     blockedReason:
       refined.blockedReason ??
-      (profiledAllowedTools.length === 0
+      (!allowsToollessExecution && profiledAllowedTools.length === 0
         ? "No permitted child tools remain after policy scoping"
         : undefined),
     semanticFallback: profiledSemanticFallback,
     removedByPolicy,
     removedAsDelegationTools,
     removedAsUnknownTools,
+    allowsToollessExecution,
   };
 }
 


### PR DESCRIPTION
# Summary
Persist provider resume anchors across daemon turns and restarts, keep stateful defaults aligned with continuation mode, and stop rejecting context-only subagent phases that intentionally require no tools.

# Changes
- persist `previous_response_id` + reconciliation hash in session metadata and feed it back into chat execution
- mark compacted session history in metadata so continuation decisions survive history trimming and reset correctly on session clear/replace
- default stateful provider storage to enabled when stateful continuity is enabled
- allow context/history-only delegated steps to execute without forced shell fallback and broaden explicit required-subagent parsing
- add regression coverage for daemon/session stateful lineage, planner parsing, subagent scoping, and adapter behavior

# Testing
- [x] `npm --prefix runtime exec vitest run src/gateway/daemon.test.ts src/gateway/session.test.ts src/gateway/llm-stateful-defaults.test.ts src/gateway/subagent-orchestrator.test.ts src/llm/chat-executor-planner.test.ts src/llm/chat-executor-text.test.ts src/llm/chat-executor.test.ts src/llm/grok/adapter-utils.test.ts src/llm/grok/adapter.test.ts src/llm/ollama/adapter.test.ts src/utils/delegation-validation.test.ts`
- [ ] anchor test
- [ ] cargo fmt --check
- [ ] cargo clippy
- [ ] cargo test
- [x] `npm --prefix runtime run typecheck`
- [x] `npm --prefix runtime run build`

# Security / Risk
- [x] PDA seeds/constraints reviewed (if applicable)
- [x] No authority bypass introduced
- [x] Escrow/funds safety considered (if applicable)

# Checklist
- [x] Tests added/updated (or N/A)
- [x] Docs updated (if needed)

# Issue link(s)
- #1430