### PR TITLE
fix(sdk): sync remote prover witness contract

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -36,6 +36,7 @@ const proof = await generateProof(
     agentPubkey: worker.publicKey,
     output: [1n, 2n, 3n, 4n],
     salt: generateSalt(),
+    agentSecret: 12345n,
   },
   { kind: 'remote', endpoint: 'https://prover.example.com' }
 );
@@ -69,7 +70,7 @@ The SDK derives and submits the required verification accounts:
 
 ### Proof functions
 
-- `generateProof(params, proverConfig)` — generates a real RISC Zero proof via a local binary or remote prover
+- `generateProof(params, proverConfig)` — generates a real RISC Zero proof via the remote prover service
 - `computeHashes(taskPda, agentPubkey, output, salt, agentSecret?)` — computes all hash fields without proof generation
 - `generateSalt()` — generates a cryptographically random salt
 

--- a/sdk/src/__tests__/proofs.test.ts
+++ b/sdk/src/__tests__/proofs.test.ts
@@ -20,6 +20,7 @@ import {
   generateSalt,
   generateProof,
   FIELD_MODULUS,
+  bigintToBytes32,
 } from "../proofs";
 import {
   OUTPUT_FIELD_COUNT,
@@ -579,6 +580,7 @@ describe("proofs", () => {
             agentPubkey,
             output: [1n, 2n, 3n, 4n],
             salt: 0n,
+            agentSecret: 12345n,
           },
           { kind: "remote", endpoint: "https://test.com" },
         ),
@@ -689,13 +691,14 @@ describe("proofs", () => {
       const expectedJournal = buildExpectedJournal(params);
       const fakeSealBytes = Buffer.alloc(RISC0_SEAL_BYTES_LEN, 0xab);
       const fakeImageId = Buffer.alloc(RISC0_IMAGE_ID_LEN, 0xcd);
+      const proveMock = vi.fn().mockResolvedValue({
+        sealBytes: fakeSealBytes,
+        journal: expectedJournal,
+        imageId: fakeImageId,
+      });
 
       vi.doMock("../prover", () => ({
-        prove: vi.fn().mockResolvedValue({
-          sealBytes: fakeSealBytes,
-          journal: expectedJournal,
-          imageId: fakeImageId,
-        }),
+        prove: proveMock,
       }));
 
       const { generateProof: fn } = await import("../proofs");
@@ -718,6 +721,23 @@ describe("proofs", () => {
       expect(result.nullifier.length).toBe(32);
       expect(result.proofSize).toBe(RISC0_SEAL_BYTES_LEN - RISC0_SELECTOR_LEN);
       expect(result.generationTime).toBeGreaterThanOrEqual(0);
+      expect(proveMock).toHaveBeenCalledTimes(1);
+
+      const proveInput = proveMock.mock.calls[0][0];
+      expect(proveInput.taskPda).toEqual(new Uint8Array(params.taskPda.toBytes()));
+      expect(proveInput.agentAuthority).toEqual(
+        new Uint8Array(params.agentPubkey.toBytes()),
+      );
+      expect(proveInput.output).toEqual([
+        Uint8Array.from(bigintToBytes32(1n)),
+        Uint8Array.from(bigintToBytes32(2n)),
+        Uint8Array.from(bigintToBytes32(3n)),
+        Uint8Array.from(bigintToBytes32(4n)),
+      ]);
+      expect(proveInput.salt).toEqual(Uint8Array.from(bigintToBytes32(12345n)));
+      expect(proveInput.agentSecret).toEqual(
+        Uint8Array.from(bigintToBytes32(67890n)),
+      );
 
       vi.doUnmock("../prover");
     });

--- a/sdk/src/__tests__/prover.test.ts
+++ b/sdk/src/__tests__/prover.test.ts
@@ -23,6 +23,14 @@ function validInput(): ProverInput {
     outputCommitment: new Uint8Array(32).fill(4),
     binding: new Uint8Array(32).fill(5),
     nullifier: new Uint8Array(32).fill(6),
+    output: [
+      new Uint8Array(32).fill(7),
+      new Uint8Array(32).fill(8),
+      new Uint8Array(32).fill(9),
+      new Uint8Array(32).fill(10),
+    ],
+    salt: new Uint8Array(32).fill(11),
+    agentSecret: new Uint8Array(32).fill(12),
   };
 }
 
@@ -94,6 +102,38 @@ describe("prove — input validation", () => {
     input.nullifier = new Uint8Array(1);
     await expect(prove(input, remoteConfig)).rejects.toThrow(
       "nullifier must be exactly 32 bytes",
+    );
+  });
+
+  it("rejects output arrays with the wrong element count", async () => {
+    const input = validInput();
+    input.output = [new Uint8Array(32).fill(7)];
+    await expect(prove(input, remoteConfig)).rejects.toThrow(
+      "output must contain exactly 4 field elements",
+    );
+  });
+
+  it("rejects output elements that are not 32 bytes", async () => {
+    const input = validInput();
+    input.output[2] = new Uint8Array(31);
+    await expect(prove(input, remoteConfig)).rejects.toThrow(
+      "output[2] must be exactly 32 bytes",
+    );
+  });
+
+  it("rejects salt that is not 32 bytes", async () => {
+    const input = validInput();
+    input.salt = new Uint8Array(16);
+    await expect(prove(input, remoteConfig)).rejects.toThrow(
+      "salt must be exactly 32 bytes",
+    );
+  });
+
+  it("rejects agentSecret that is not 32 bytes", async () => {
+    const input = validInput();
+    input.agentSecret = new Uint8Array(48);
+    await expect(prove(input, remoteConfig)).rejects.toThrow(
+      "agentSecret must be exactly 32 bytes",
     );
   });
 });
@@ -233,7 +273,7 @@ describe("prove — remote backend", () => {
     });
   });
 
-  it("sends correct JSON body with all 6 fields", async () => {
+  it("sends correct JSON body with public fields and witness", async () => {
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(validOutputPayload()),
@@ -252,6 +292,9 @@ describe("prove — remote backend", () => {
     );
     expect(body.binding).toEqual(Array.from(input.binding));
     expect(body.nullifier).toEqual(Array.from(input.nullifier));
+    expect(body.output).toEqual(input.output.map((field) => Array.from(field)));
+    expect(body.salt).toEqual(Array.from(input.salt));
+    expect(body.agent_secret).toEqual(Array.from(input.agentSecret));
   });
 });
 

--- a/sdk/src/proofs.ts
+++ b/sdk/src/proofs.ts
@@ -326,7 +326,7 @@ export function buildJournalBytes(fields: {
  * Generate a RISC Zero Groth16 proof via an external prover backend.
  *
  * This function computes all hashes locally (same as the simulated path), then
- * delegates proof generation to a local binary or remote prover. The returned
+ * delegates proof generation to the remote prover service. The returned
  * journal is validated against locally computed fields to ensure integrity.
  *
  * `params.imageId` and `params.sealSelector` are ignored — the real image ID
@@ -359,6 +359,15 @@ export async function generateProof(
   const outputCommitmentBuf = bigintToBytes32(hashes.outputCommitment);
   const bindingSeedBuf = bigintToBytes32(hashes.binding);
   const nullifierSeedBuf = bigintToBytes32(hashes.nullifier);
+  const outputWitness = params.output.map((value) =>
+    Uint8Array.from(bigintToBytes32(normalizeFieldElement(value))),
+  );
+  const saltWitness = Uint8Array.from(
+    bigintToBytes32(normalizeFieldElement(params.salt)),
+  );
+  const agentSecretWitness = Uint8Array.from(
+    bigintToBytes32(normalizeFieldElement(params.agentSecret)),
+  );
 
   const proverInput = {
     taskPda: new Uint8Array(params.taskPda.toBytes()),
@@ -367,6 +376,9 @@ export async function generateProof(
     outputCommitment: new Uint8Array(outputCommitmentBuf),
     binding: new Uint8Array(bindingSeedBuf),
     nullifier: new Uint8Array(nullifierSeedBuf),
+    output: outputWitness,
+    salt: saltWitness,
+    agentSecret: agentSecretWitness,
   };
 
   const { prove } = await import("./prover.js");

--- a/sdk/src/prover.ts
+++ b/sdk/src/prover.ts
@@ -10,6 +10,7 @@ import {
   RISC0_JOURNAL_LEN,
   RISC0_IMAGE_ID_LEN,
   HASH_SIZE,
+  OUTPUT_FIELD_COUNT,
 } from "./constants.js";
 import { validateProverEndpoint } from "./validation.js";
 
@@ -32,6 +33,9 @@ export interface ProverInput {
   outputCommitment: Uint8Array;
   binding: Uint8Array;
   nullifier: Uint8Array;
+  output: Uint8Array[];
+  salt: Uint8Array;
+  agentSecret: Uint8Array;
 }
 
 export class ProverError extends Error {
@@ -56,6 +60,18 @@ function validateInputField(name: string, field: Uint8Array): void {
   }
 }
 
+function validateOutputFields(output: Uint8Array[]): void {
+  if (output.length !== OUTPUT_FIELD_COUNT) {
+    throw new Error(
+      `output must contain exactly ${OUTPUT_FIELD_COUNT} field elements, got ${output.length}`,
+    );
+  }
+
+  output.forEach((field, index) => {
+    validateInputField(`output[${index}]`, field);
+  });
+}
+
 function validateProverInput(input: ProverInput): void {
   validateInputField("taskPda", input.taskPda);
   validateInputField("agentAuthority", input.agentAuthority);
@@ -63,6 +79,9 @@ function validateProverInput(input: ProverInput): void {
   validateInputField("outputCommitment", input.outputCommitment);
   validateInputField("binding", input.binding);
   validateInputField("nullifier", input.nullifier);
+  validateOutputFields(input.output);
+  validateInputField("salt", input.salt);
+  validateInputField("agentSecret", input.agentSecret);
 }
 
 interface RawProverOutput {
@@ -118,6 +137,9 @@ function buildInputJson(input: ProverInput): string {
     output_commitment: Array.from(input.outputCommitment),
     binding: Array.from(input.binding),
     nullifier: Array.from(input.nullifier),
+    output: input.output.map((field) => Array.from(field)),
+    salt: Array.from(input.salt),
+    agent_secret: Array.from(input.agentSecret),
   });
 }
 


### PR DESCRIPTION
## Problem
The SDK was still sending the old `/prove` payload shape: only the public journal fields. After the prover hardening, that is no longer enough. The remote prover now requires the private witness bytes (`output`, `salt`, and `agent_secret`) so it can derive and validate the public fields itself.

Without this SDK change, AgenC would keep calling the prover with an incompatible request shape and private proof generation would fail against the new contract.

## What this PR changes
- send the full witness required by the phase-2 prover contract: `output`, `salt`, and `agent_secret`
- validate the expanded request shape locally before calling `/prove`
- update tests and docs, including an assertion that `generateProof()` forwards the witness bytes to the prover

## Why this matters
This PR is the SDK-side half of the prover semantics fix. It keeps AgenC compatible with the hardened prover API and moves obvious request-shape failures into local validation instead of a confusing remote prover error.

## Validation
- `npm install --prefix sdk`
- `npm test --prefix sdk -- src/__tests__/prover.test.ts src/__tests__/proofs.test.ts`
- `npm run typecheck --prefix sdk`
- `npm run build --prefix sdk`

## Dependency
- depends on the prover-side contract change in tetsuo-ai/agenc-prover#6
- keep this PR as draft until the prover-side `image_id` regeneration is completed on a supported machine
