### PR TITLE
fix(runtime): harden delegated stateful codegen traces

### DIFF
--- a/.claude/notes/gotchas.md
+++ b/.claude/notes/gotchas.md
@@ -99,6 +99,52 @@
 - A flat default like “150k tokens per planned subagent step” underbudgets long coding phases and overbudgets short research phases.
 - When no explicit operator ceiling is set, derive request-tree child-token headroom from the planner’s `max_budget_hint` durations, then apply retry/verifier pass multipliers on top of that derived per-step envelope.
 
+## 2026-03-12 - Execution turns must fail closed on plan-only completions
+
+- If a coding or file-mutating turn can be grounded with tools, do not accept a bare `Plan` reply as `completed`.
+- Keep two layers aligned:
+  - the daemon system prompt must be execute-first for tool-using turns
+  - the executor must locally reject or retry plan-only completions even if the model ignores that prompt
+- Live watch UIs should also avoid mixed-state headers like `idle / thinking`; contradictory chrome makes backend retries look like hangs.
+
+## 2026-03-12 - Live watch layout must fit whole panels and follow current source writes
+
+- In `agenc-watch`, never truncate the sidebar by slicing a raw stack of panel rows to viewport height. Fit whole panels or compact them first, or borders and metric rows will get cut off mid-box.
+- In follow mode, recent source-preview events should anchor the viewport. Blind bottom-following hides the code being written behind later summary rows and makes the operator surface look stale even while writes are happening.
+
+## 2026-03-12 - Watch surfaces must not mix direct `subagents.*` messages with observability replay as independent UI events
+
+- `agenc-watch` receives both typed websocket lifecycle messages and the generic `events.event` observability feed for subagent activity.
+- If both feeds are rendered independently, the transcript duplicates `spawned/started` rows and anonymous top-level lifecycle events create ghost `child` plan entries that never retire.
+- The safe pattern is:
+  - treat typed `subagents.*` messages as the operator surface source of truth
+  - use `events.event` only for raw diagnostics or explicit observability views
+  - never create a persistent plan step when a lifecycle payload has no `subagentSessionId`, `stepName`, or `objective`
+
+## 2026-03-12 - Top-level delegation lifecycle events must include the delegated objective
+
+- Parent-side `subagents.planned` and `subagents.policy_bypassed` events are operator-facing, not just internal telemetry.
+- If those payloads omit the delegated task text, the live watch can only show anonymous filler like `child` or `Delegation planned`, which makes the surface feel broken even when the runtime is behaving correctly.
+- When emitting top-level delegation lifecycle events from `execute_with_agent`, include the normalized delegated task/objective in the payload.
+
+## 2026-03-12 - Recall budget defaults must not silently cap healthy autonomous runs
+
+- `ChatExecutor` previously treated an omitted `llm.maxModelRecallsPerRequest` as a hidden hardcoded cap of 24, and treated `0` as zero recalls instead of unlimited.
+- That drift is especially dangerous because other runtime surfaces were already using `0` as the intended "unlimited" value for autonomous/background work.
+- Keep the semantics aligned: `0` or omitted means unlimited recall budget, while request timeout, tool budgets, failure budgets, and no-progress breakers remain the real stop conditions.
+
+## 2026-03-12 - Live codegen benchmarks should reveal routing bugs, not hide them with prompt policy
+
+- If a streamed benchmark prompt includes hard tool rules like "use only host code/file/system tools," the run stops being a realistic autonomy test and starts becoming a routing workaround.
+- The right fix is to make natural coding prompts route to the correct host file/code tools in `tool-routing.ts`, then verify that behavior from daemon traces.
+- The live benchmark prompt should stay normal-language, while any routing failure is treated as a runtime/logging bug to patch and regression-test.
+
+## 2026-03-12 - xAI Responses `store:false` must not use `previous_response_id`
+
+- The xAI Responses docs and live daemon traces agree: `store:false` requests should continue locally via replayed `response.output`, not by sending `previous_response_id`.
+- If the Grok adapter still sends `previous_response_id` while `store:false`, xAI responds with `404 Response ... not found` and every delegated follow-up pays an avoidable stateless retry.
+- Treat `store:false` as a local-replay-only mode in the adapter and emit an explicit `store_disabled` fallback reason so the trace explains why provider continuation was skipped.
+
 ## 2026-03-10 - Newer SBF toolchains expose stack overflows in large Anchor `Accounts` validators
 
 - `cargo-build-sbf --tools-version v1.52` surfaced 4 KB frame overflows that the older local toolchain was not blocking on.

--- a/.claude/notes/pr-log.md
+++ b/.claude/notes/pr-log.md
@@ -60,3 +60,24 @@
 - **What worked:** Moved trusted RISC Zero image selection on-chain via `zk_config`, regenerated and synced IDL/types, added a thin authority CLI for show/init/rotate, and closed the stale runtime event-contract drift so the IDL gate passes again.
 - **What didn't:** The admin flow still depends on an operator providing the new guest image ID explicitly; that is deliberate, but it means release discipline around the separate prover repo remains mandatory.
 - **Rule added to CLAUDE.md:** yes, `Authority Model: Do not invent multisig requirements for ZK image rotation`; `Scope Control: Do not spin up historical worktrees without explicit user buy-in`; `Architecture Advice: Clarify deployment model before recommending prover topology`
+
+## PR #[local]: unlimited recall budget default for autonomous runs
+- **Date:** 2026-03-12
+- **Files changed:** runtime/src/llm/{chat-executor-constants,chat-executor,chat-executor-types,chat-executor.test}.ts, runtime/src/gateway/types.ts, docs/{RUNTIME_API.md,architecture/flows/runtime-chat-pipeline.md}, .claude/notes/{gotchas,pr-log,techdebt-2026-03-12-recall-budget.md}, CLAUDE.md
+- **What worked:** Aligned `maxModelRecallsPerRequest` semantics so `0` and an omitted value both mean unlimited, removed the hidden 24-recall stop for long codegen runs, updated docs/comments, and verified with targeted executor/background-run tests plus a live daemon restart into `agenc-watch`.
+- **What didn't:** "Indefinite" is still bounded by the real guards: request timeout, tool budgets, failure budgets, and no-progress breakers. Child subagents also still inherit their own tool budgets, so long delegated phases can stop there even though recall budget no longer does.
+- **Rule added to CLAUDE.md:** yes, `Autonomous budgets: keep recall budget unlimited unless an operator sets a cap`
+
+## PR #[local]: live benchmark routing and prompt neutrality
+- **Date:** 2026-03-12
+- **Files changed:** runtime/src/gateway/tool-routing.ts, runtime/src/gateway/tool-routing.test.ts, CLAUDE.md, .claude/notes/{gotchas,pr-log}.md
+- **What worked:** Fixed the host code/file/system phrasing route miss that collapsed a live codegen benchmark into the wrong tool subset, relaunched the benchmark with a normal user-style prompt, and codified that streamed autonomy prompts must not carry tool-policy steering.
+- **What didn't:** The routed host coding subset is still noisier than it should be for pure codegen turns, so follow-up routing cleanup is still warranted after the stream-critical regressions are closed.
+- **Rule added to CLAUDE.md:** yes, `Benchmark prompts: keep streamed codegen prompts natural`
+
+## PR #[local]: grok store-disabled continuation gating and delegation trace cleanup
+- **Date:** 2026-03-12
+- **Files changed:** runtime/src/gateway/{llm-stateful-defaults,subagent-orchestrator,tool-handler-factory}.{ts,test.ts}, runtime/src/llm/{chat-executor-recovery,chat-executor,grok/adapter,grok/adapter.test,provider-capabilities,provider-capabilities.test,types}.ts, .claude/notes/{gotchas,pr-log,techdebt-2026-03-12-grok-store-disabled}.md
+- **What worked:** Reproduced delegated full-codebase generation in isolated `/workspace` sandboxes, fixed noisy retry lifecycle emissions, surfaced tool-result `isError` on both client and subagent events, gated Grok `previous_response_id` continuation behind `store:true`, and then centralized fallback-reason defaults so stateful summary accounting no longer relies on a hand-maintained mirror map.
+- **What didn't:** The live verification used focused daemon probes and targeted Vitest coverage rather than a full repo-wide test pass, so broader runtime confidence still depends on the existing larger suite.
+- **Rule added to CLAUDE.md:** no

--- a/.claude/notes/techdebt-2026-03-12-grok-store-disabled.md
+++ b/.claude/notes/techdebt-2026-03-12-grok-store-disabled.md
@@ -1,0 +1,26 @@
+## Tech Debt Report - 2026-03-12
+
+### Critical (Fix Now)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| None | - | No critical tech debt introduced in the touched runtime stateful/delegation paths. | - |
+
+### High (Fix This Sprint)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| None | - | No high-priority debt found in the changed files. | - |
+
+### Medium (Backlog)
+| Issue | Location | Impact | Suggested Fix |
+|-------|----------|--------|---------------|
+| None | - | No remaining medium-priority debt in the touched stateful fallback path after centralizing fallback-reason defaults. | - |
+
+### Duplications Found
+| Pattern | Locations | Lines | Refactor To |
+|---------|-----------|-------|-------------|
+| None in touched files | - | - | - |
+
+### Summary
+- Total issues: 0
+- Estimated cleanup: 0 files
+- Recommended priority: none

--- a/runtime/src/gateway/llm-stateful-defaults.test.ts
+++ b/runtime/src/gateway/llm-stateful-defaults.test.ts
@@ -9,7 +9,7 @@ describe("resolveGatewayStatefulResponses", () => {
     expect(resolved.usedDefaults).toBe(true);
     expect(resolved.config).toEqual({
       enabled: true,
-      store: true,
+      store: false,
       fallbackToStateless: true,
       compaction: {
         enabled: true,
@@ -30,7 +30,7 @@ describe("resolveGatewayStatefulResponses", () => {
     expect(resolved.usedDefaults).toBe(true);
     expect(resolved.config).toEqual({
       enabled: true,
-      store: true,
+      store: false,
       fallbackToStateless: true,
       compaction: {
         enabled: false,

--- a/runtime/src/gateway/llm-stateful-defaults.ts
+++ b/runtime/src/gateway/llm-stateful-defaults.ts
@@ -29,7 +29,7 @@ export function resolveGatewayStatefulResponses(
   const enabled = statefulResponses?.enabled ?? true;
   if (statefulResponses?.enabled === undefined) usedDefaults = true;
 
-  const store = statefulResponses?.store ?? enabled;
+  const store = statefulResponses?.store ?? false;
   if (statefulResponses?.store === undefined) usedDefaults = true;
 
   const fallbackToStateless = statefulResponses?.fallbackToStateless ?? true;

--- a/runtime/src/gateway/subagent-orchestrator.test.ts
+++ b/runtime/src/gateway/subagent-orchestrator.test.ts
@@ -285,6 +285,58 @@ describe("SubAgentOrchestrator", () => {
     ]);
   });
 
+  it("preserves full webchat session ids when planner pipeline ids include session prefixes", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new FakeSubAgentManager(5, true);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
+      pollIntervalMs: 5,
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:session:abc123:456",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "delegate_session_scoped_step",
+          stepType: "subagent_task",
+          objective: "Inspect the current workspace state",
+          inputContract: "Return findings",
+          acceptanceCriteria: ["Include grounded evidence"],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["cwd=/tmp/session-scope"],
+          maxBudgetHint: "1m",
+          canRunParallel: false,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls[0]?.parentSessionId).toBe("session:abc123");
+    const plannedEvent = lifecycleEvents.find(
+      (event) => event.type === "subagents.planned",
+    );
+    expect(plannedEvent).toEqual(
+      expect.objectContaining({
+        sessionId: "session:abc123",
+        parentSessionId: "session:abc123",
+      }),
+    );
+  });
+
   it("emits parent pipeline events for delegated DAG steps", async () => {
     const fallback = createFallbackExecutor(async (pipeline) => ({
       status: "completed",
@@ -404,7 +456,7 @@ describe("SubAgentOrchestrator", () => {
     );
     expect(manager.spawnCalls[0]?.delegationSpec?.contextRequirements).toEqual([
       "repo_context",
-      "working_directory:/home/tetsuo/agent-test/grid-router-ts",
+      "cwd=/home/tetsuo/agent-test/grid-router-ts",
     ]);
   });
 
@@ -585,6 +637,46 @@ describe("SubAgentOrchestrator", () => {
 
     expect(manager.spawnCalls).toHaveLength(1);
     expect(manager.spawnCalls[0]?.timeoutMs).toBe(60_000);
+  });
+
+  it("derives a larger child tool budget for long delegated steps", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new FakeSubAgentManager(10, true);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:session-tool-budget:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "analyze_renderer_logs",
+          stepType: "subagent_task",
+          objective: "Analyze renderer logs and summarize the failure",
+          inputContract: "Recent CI logs exist",
+          acceptanceCriteria: ["Include the renderer failure summary"],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["ci_logs"],
+          maxBudgetHint: "8m",
+          canRunParallel: false,
+        },
+      ],
+      edges: [],
+    });
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls[0]?.toolBudgetPerRequest).toBe(64);
   });
 
   it("emits normalized child trajectory records when trajectory sink is configured", async () => {
@@ -1070,6 +1162,99 @@ describe("SubAgentOrchestrator", () => {
         cumulativeToolCalls: 0,
       }),
     );
+  });
+
+  it("treats maxCumulativeTokensPerRequestTree=0 as unlimited for autonomous request trees", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 5,
+        result: {
+          output: "Included findings from phase one",
+          success: true,
+          durationMs: 10,
+          toolCalls: [{
+            name: "system.writeFile",
+            args: { path: "/tmp/phase-one.ts", content: "export const phaseOne = true;\n" },
+            result: '{"path":"/tmp/phase-one.ts","bytesWritten":31}',
+            isError: false,
+            durationMs: 1,
+          }],
+          tokenUsage: {
+            promptTokens: 180_000,
+            completionTokens: 20_000,
+            totalTokens: 200_000,
+          },
+        },
+      },
+      {
+        delayMs: 5,
+        result: {
+          output: "Included findings from phase two",
+          success: true,
+          durationMs: 10,
+          toolCalls: [{
+            name: "system.writeFile",
+            args: { path: "/tmp/phase-two.ts", content: "export const phaseTwo = true;\n" },
+            result: '{"path":"/tmp/phase-two.ts","bytesWritten":31}',
+            isError: false,
+            durationMs: 1,
+          }],
+          tokenUsage: {
+            promptTokens: 180_000,
+            completionTokens: 20_000,
+            totalTokens: 200_000,
+          },
+        },
+      },
+    ]);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      maxCumulativeTokensPerRequestTree: 0,
+      maxCumulativeTokensPerRequestTreeExplicitlyConfigured: true,
+      pollIntervalMs: 5,
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:session-token-unlimited:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "delegate_phase_one",
+          stepType: "subagent_task",
+          objective: "Implement phase one",
+          inputContract: "Return findings",
+          acceptanceCriteria: ["Include findings"],
+          requiredToolCapabilities: ["system.writeFile"],
+          contextRequirements: ["workspace_files"],
+          maxBudgetHint: "5m",
+          canRunParallel: true,
+        },
+        {
+          name: "delegate_phase_two",
+          stepType: "subagent_task",
+          objective: "Implement phase two",
+          inputContract: "Return findings",
+          acceptanceCriteria: ["Include findings"],
+          requiredToolCapabilities: ["system.writeFile"],
+          contextRequirements: ["workspace_files"],
+          maxBudgetHint: "5m",
+          canRunParallel: true,
+          dependsOn: ["delegate_phase_one"],
+        },
+      ],
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.completedSteps).toBe(2);
   });
 
   it("scales the effective child-token budget with planned subagent count when using the default ceiling", async () => {
@@ -2940,6 +3125,289 @@ describe("SubAgentOrchestrator", () => {
     expect(taskPrompt).toContain("workspace:*");
     expect(taskPrompt).toContain("\"hostTooling\":{");
     expect(taskPrompt).toContain("\"npmWorkspaceProtocolSupport\":\"unsupported\"");
+  });
+
+  it("does not inject node workspace guidance into Rust cargo workspace child prompts", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => null,
+      pollIntervalMs: 5,
+      resolveAvailableToolNames: () => [
+        "system.bash",
+        "system.readFile",
+        "system.writeFile",
+      ],
+      resolveHostToolingProfile: () => ({
+        nodeVersion: "v25.2.1",
+        npm: {
+          version: "11.7.0",
+          workspaceProtocolSupport: "unsupported",
+          workspaceProtocolEvidence:
+            'Unsupported URL Type "workspace:": workspace:*',
+        },
+      }),
+    });
+
+    const pipeline: Pipeline = {
+      id: "planner:session-rust-workspace:123",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "implement_core",
+          stepType: "subagent_task",
+          objective:
+            "Implement the Rust parser and routing algorithms in the cargo workspace.",
+          inputContract: "Fresh cargo workspace scaffolded.",
+          acceptanceCriteria: ["gridforge-core compiles cleanly."],
+          requiredToolCapabilities: [
+            "system.writeFile",
+            "system.readFile",
+            "system.bash",
+          ],
+          contextRequirements: ["cwd=/workspace/gridforge", "Cargo.toml workspace"],
+          maxBudgetHint: "6m",
+          canRunParallel: false,
+        },
+        {
+          name: "add_tests_examples_readme",
+          stepType: "subagent_task",
+          dependsOn: ["implement_core"],
+          objective:
+            "Add README, example maps, and Rust tests for the cargo workspace.",
+          inputContract:
+            "gridforge-core and gridforge-cli crates already exist in the Cargo.toml workspace.",
+          acceptanceCriteria: [
+            "README and example maps added.",
+            "cargo test --workspace succeeds.",
+          ],
+          requiredToolCapabilities: [
+            "system.writeFile",
+            "system.readFile",
+            "system.bash",
+          ],
+          contextRequirements: ["cwd=/workspace/gridforge", "Cargo.toml workspace"],
+          maxBudgetHint: "4m",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Build a Rust cargo workspace and verify it with cargo test --workspace.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+      },
+    };
+
+    const dependencyResult = JSON.stringify({
+      status: "completed",
+      success: true,
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: {
+            path: "Cargo.toml",
+            content:
+              '[workspace]\nmembers = ["gridforge-core", "gridforge-cli"]\nresolver = "2"\n',
+          },
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "gridforge-core/src/lib.rs",
+            content: "pub fn dijkstra() -> usize { 0 }\n",
+          },
+        },
+      ],
+    });
+
+    const step = pipeline.plannerSteps[1]!;
+    const toolScope = (orchestrator as unknown as {
+      deriveChildToolAllowlist: (
+        step: Pipeline["plannerSteps"][number],
+        pipeline: Pipeline,
+      ) => {
+        allowedTools: readonly string[];
+        allowsToollessExecution: boolean;
+        semanticFallback: readonly string[];
+        removedLowSignalBrowserTools: readonly string[];
+        removedByPolicy: readonly string[];
+        removedAsDelegationTools: readonly string[];
+        removedAsUnknownTools: readonly string[];
+        parentPolicyAllowed: readonly string[];
+      };
+    }).deriveChildToolAllowlist(step, pipeline);
+    const { taskPrompt } = await (orchestrator as unknown as {
+      buildSubagentTaskPrompt: (
+        step: Pipeline["plannerSteps"][number],
+        pipeline: Pipeline,
+        results: Readonly<Record<string, string>>,
+        toolScope: typeof toolScope,
+      ) => Promise<{ taskPrompt: string }>;
+    }).buildSubagentTaskPrompt(
+      step,
+      pipeline,
+      { implement_core: dependencyResult },
+      toolScope,
+    );
+
+    expect(taskPrompt).toContain("cargo test --workspace succeeds.");
+    expect(taskPrompt).not.toContain("Host tooling constraints:");
+    expect(taskPrompt).not.toContain("workspace:*");
+    expect(taskPrompt).not.toContain(
+      "Buildable TypeScript workspace packages use package-local tsconfig/project references",
+    );
+    expect(taskPrompt).not.toContain("npm run build --workspace=<workspace-name>");
+  });
+
+  it("filters generated rust target artifacts from dependency-derived workspace context", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => null,
+      pollIntervalMs: 5,
+      resolveAvailableToolNames: () => [
+        "system.bash",
+        "system.readFile",
+        "system.writeFile",
+      ],
+    });
+
+    const pipeline: Pipeline = {
+      id: "planner:session-rust-target-filter:123",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "implement_core",
+          stepType: "subagent_task",
+          objective:
+            "Implement the Rust parser and routing algorithms in the cargo workspace.",
+          inputContract: "Fresh cargo workspace scaffolded.",
+          acceptanceCriteria: ["gridforge-core compiles cleanly."],
+          requiredToolCapabilities: [
+            "system.writeFile",
+            "system.readFile",
+            "system.bash",
+          ],
+          contextRequirements: ["cwd=/workspace/gridforge", "Cargo.toml workspace"],
+          maxBudgetHint: "6m",
+          canRunParallel: false,
+        },
+        {
+          name: "add_tests_examples_readme",
+          stepType: "subagent_task",
+          dependsOn: ["implement_core"],
+          objective:
+            "Add tests, example maps, and README while preserving the Cargo.toml workspace build.",
+          inputContract:
+            "Use the existing Cargo.toml workspace and current gridforge-core sources as context.",
+          acceptanceCriteria: [
+            "README and example maps added.",
+            "cargo test --workspace succeeds.",
+          ],
+          requiredToolCapabilities: [
+            "system.writeFile",
+            "system.readFile",
+            "system.bash",
+          ],
+          contextRequirements: ["cwd=/workspace/gridforge", "Cargo.toml workspace"],
+          maxBudgetHint: "4m",
+          canRunParallel: false,
+        },
+      ],
+      plannerContext: {
+        parentRequest:
+          "Build a Rust cargo workspace and verify it with cargo test --workspace.",
+        history: [],
+        memory: [],
+        toolOutputs: [],
+      },
+    };
+
+    const dependencyResult = JSON.stringify({
+      status: "completed",
+      success: true,
+      toolCalls: [
+        {
+          name: "system.writeFile",
+          args: {
+            path: "Cargo.toml",
+            content:
+              '[workspace]\nmembers = ["gridforge-core", "gridforge-cli"]\nresolver = "2"\n',
+          },
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "gridforge-core/src/lib.rs",
+            content: "pub fn dijkstra() -> usize { 0 }\n",
+          },
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "target/.rustc_info.json",
+            content: '{"rustc_fingerprint":"abc123"}',
+          },
+        },
+        {
+          name: "system.writeFile",
+          args: {
+            path: "target/debug/.fingerprint/gridforge-core/hash.json",
+            content: '{"fingerprint":"deadbeef"}',
+          },
+        },
+      ],
+    });
+
+    const step = pipeline.plannerSteps[1]!;
+    const toolScope = (orchestrator as unknown as {
+      deriveChildToolAllowlist: (
+        step: Pipeline["plannerSteps"][number],
+        pipeline: Pipeline,
+      ) => {
+        allowedTools: readonly string[];
+        allowsToollessExecution: boolean;
+        semanticFallback: readonly string[];
+        removedLowSignalBrowserTools: readonly string[];
+        removedByPolicy: readonly string[];
+        removedAsDelegationTools: readonly string[];
+        removedAsUnknownTools: readonly string[];
+        parentPolicyAllowed: readonly string[];
+      };
+    }).deriveChildToolAllowlist(step, pipeline);
+    const { taskPrompt } = await (orchestrator as unknown as {
+      buildSubagentTaskPrompt: (
+        step: Pipeline["plannerSteps"][number],
+        pipeline: Pipeline,
+        results: Readonly<Record<string, string>>,
+        toolScope: typeof toolScope,
+      ) => Promise<{ taskPrompt: string }>;
+    }).buildSubagentTaskPrompt(
+      step,
+      pipeline,
+      { implement_core: dependencyResult },
+      toolScope,
+    );
+
+    expect(taskPrompt).toContain("[artifact:implement_core:Cargo.toml]");
+    expect(taskPrompt).not.toContain("target/.rustc_info.json");
+    expect(taskPrompt).not.toContain(".fingerprint/gridforge-core");
   });
 
   it("surfaces empty package source gaps before verification in implementation prompts", async () => {
@@ -4861,12 +5329,23 @@ describe("SubAgentOrchestrator", () => {
     const failedEvents = lifecycleEvents.filter(
       (event) => event.type === "subagents.failed",
     );
-    expect(failedEvents).toHaveLength(1);
-    const failedPayload = failedEvents[0]?.payload as
-      | { retrying?: boolean; nextRetryDelayMs?: number }
+    expect(failedEvents).toHaveLength(0);
+    const retryEvents = lifecycleEvents.filter(
+      (event) => event.type === "subagents.progress",
+    );
+    expect(retryEvents).toHaveLength(1);
+    const retryPayload = retryEvents[0]?.payload as
+      | {
+          phase?: string;
+          retrying?: boolean;
+          nextRetryDelayMs?: number;
+          failureClass?: string;
+        }
       | undefined;
-    expect(failedPayload?.retrying).toBe(true);
-    expect(failedPayload?.nextRetryDelayMs).toBe(75);
+    expect(retryPayload?.phase).toBe("retry_backoff");
+    expect(retryPayload?.retrying).toBe(true);
+    expect(retryPayload?.failureClass).toBe("timeout");
+    expect(retryPayload?.nextRetryDelayMs).toBe(75);
   });
 
   it("applies malformed result-contract retry semantics and maps validation stop reason", async () => {
@@ -4896,9 +5375,13 @@ describe("SubAgentOrchestrator", () => {
         },
       },
     ]);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
     const orchestrator = new SubAgentOrchestrator({
       fallbackExecutor: fallback,
       resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
       pollIntervalMs: 5,
       fallbackBehavior: "fail_request",
     });
@@ -4994,9 +5477,13 @@ describe("SubAgentOrchestrator", () => {
         },
       },
     ]);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
     const orchestrator = new SubAgentOrchestrator({
       fallbackExecutor: fallback,
       resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
       pollIntervalMs: 5,
       fallbackBehavior: "fail_request",
     });
@@ -5179,15 +5666,90 @@ describe("SubAgentOrchestrator", () => {
         },
       },
     ]);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
     const orchestrator = new SubAgentOrchestrator({
       fallbackExecutor: fallback,
       resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
       pollIntervalMs: 5,
       fallbackBehavior: "fail_request",
     });
 
     const result = await orchestrator.execute({
       id: "planner:session-blocked-phase-output:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "implement_cli",
+          stepType: "subagent_task",
+          objective: "Build the CLI package and keep the workspace buildable",
+          inputContract: "Core package implemented and buildable",
+          acceptanceCriteria: ["CLI reads input and outputs summary"],
+          requiredToolCapabilities: ["system.bash", "system.writeFile"],
+          contextRequirements: ["cwd=/workspace/terrain-router-ts"],
+          maxBudgetHint: "3m",
+          canRunParallel: true,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.error).toContain("blocked or incomplete");
+    expect(result.stopReasonHint).toBe("validation_error");
+    expect(manager.spawnCalls).toHaveLength(1);
+  });
+
+  it("does not retry child validation_error results that already carry blocked phase validation codes", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 5,
+        result: {
+          output:
+            "Delegated task output reported the phase as blocked or incomplete instead of completing it: " +
+            '{"phase":"implement_cli","status":"complete","blocked":"core build is still failing"}',
+          success: false,
+          durationMs: 14,
+          toolCalls: [{
+            name: "system.writeFile",
+            args: {
+              path: "packages/cli/src/index.ts",
+              content: "export {};\n",
+            },
+            result:
+              '{"path":"packages/cli/src/index.ts","bytesWritten":10}',
+            durationMs: 3,
+          }],
+          stopReason: "validation_error",
+          stopReasonDetail:
+            "Delegated task output reported the phase as blocked or incomplete instead of completing it: " +
+            '{"phase":"implement_cli","status":"complete","blocked":"core build is still failing"}',
+          validationCode: "blocked_phase_output",
+        },
+      },
+    ]);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
+      pollIntervalMs: 5,
+      fallbackBehavior: "fail_request",
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:session-blocked-validation-code:1",
       createdAt: Date.now(),
       context: { results: {} },
       steps: [],
@@ -5250,9 +5812,13 @@ describe("SubAgentOrchestrator", () => {
         },
       },
     ]);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
     const orchestrator = new SubAgentOrchestrator({
       fallbackExecutor: fallback,
       resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
       pollIntervalMs: 5,
       fallbackBehavior: "fail_request",
     });
@@ -5355,6 +5921,82 @@ describe("SubAgentOrchestrator", () => {
     });
   });
 
+  it("inherits an absolute delegated workspace from planner context when a downstream child uses cwd=.", async () => {
+    const workspaceRoot = "/tmp/codegen-bench-3dgame-cpp-20260312-r2";
+    const fallback = createFallbackExecutor(async () => ({
+      status: "completed",
+      context: { results: {} },
+      completedSteps: 0,
+      totalSteps: 0,
+    }));
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 5,
+        result: {
+          output: "main.cpp updated",
+          success: true,
+          durationMs: 9,
+          toolCalls: [
+            {
+              name: "system.writeFile",
+              args: {
+                path: `${workspaceRoot}/main.cpp`,
+                content: "int main() { return 0; }\n",
+              },
+              result: `{\"path\":\"${workspaceRoot}/main.cpp\",\"bytesWritten\":25}`,
+              isError: false,
+              durationMs: 2,
+            } as any,
+          ],
+        },
+      },
+    ]);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
+      pollIntervalMs: 5,
+      fallbackBehavior: "fail_request",
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:session-relative-cwd-inherited:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerContext: {
+        parentRequest:
+          `Continue only on the existing project at ${workspaceRoot}.`,
+        history: [],
+        memory: [],
+        toolOutputs: [],
+      },
+      plannerSteps: [
+        {
+          name: "repair_autopilot",
+          stepType: "subagent_task",
+          objective: "Repair the main gameplay loop without leaving the current project.",
+          inputContract: "Current project workspace already exists.",
+          acceptanceCriteria: ["Edit the existing main.cpp file in place."],
+          requiredToolCapabilities: ["system.readFile", "system.writeFile"],
+          contextRequirements: ["cwd=.", "existing source files from the workspace"],
+          maxBudgetHint: "2m",
+          canRunParallel: false,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls[0]?.workingDirectory).toBe(workspaceRoot);
+    expect(manager.spawnCalls[0]?.delegationSpec?.contextRequirements).toContain(
+      `cwd=${workspaceRoot}`,
+    );
+  });
+
   it("blocks dependent DAG nodes when an upstream delegated step falls back unresolved", async () => {
     const fallback = createFallbackExecutor(async (pipeline) => {
       const step = pipeline.steps[0]!;
@@ -5377,6 +6019,16 @@ describe("SubAgentOrchestrator", () => {
           output: "Tool budget exceeded (24 per request)",
           success: false,
           durationMs: 12,
+          toolCalls: [],
+          stopReason: "budget_exceeded",
+        },
+      },
+      {
+        delayMs: 5,
+        result: {
+          output: "Tool budget exceeded (36 per request)",
+          success: false,
+          durationMs: 13,
           toolCalls: [],
           stopReason: "budget_exceeded",
         },
@@ -5432,7 +6084,7 @@ describe("SubAgentOrchestrator", () => {
     expect(result.error).toContain("implement_cli");
     expect(result.error).toContain("implement_core");
     expect(result.stopReasonHint).toBe("budget_exceeded");
-    expect(manager.spawnCalls).toHaveLength(1);
+    expect(manager.spawnCalls).toHaveLength(2);
     expect(fallback.execute).toHaveBeenCalledTimes(1);
 
     const corePayload = JSON.parse(
@@ -5454,6 +6106,74 @@ describe("SubAgentOrchestrator", () => {
     expect(cliPayload.status).toBe("dependency_blocked");
     expect(cliPayload.stopReasonHint).toBe("budget_exceeded");
     expect(cliPayload.unmetDependencies?.[0]?.stepName).toBe("implement_core");
+  });
+
+  it("retries delegated budget exhaustion once with an expanded child tool budget", async () => {
+    const fallback = createFallbackExecutor(async (pipeline) => ({
+      status: "completed",
+      context: pipeline.context,
+      completedSteps: pipeline.steps.length,
+      totalSteps: pipeline.steps.length,
+    }));
+    const manager = new SequencedSubAgentManager([
+      {
+        delayMs: 5,
+        result: {
+          output: "Tool budget exceeded (64 per request)",
+          success: false,
+          durationMs: 20,
+          toolCalls: [],
+          stopReason: "budget_exceeded",
+        },
+      },
+      {
+        delayMs: 5,
+        result: {
+          output: "Included the renderer failure summary.",
+          success: true,
+          durationMs: 18,
+          toolCalls: [{
+            name: "system.readFile",
+            args: { path: "/tmp/renderer.log" },
+            result: '{"content":"renderer stack trace"}',
+            isError: false,
+            durationMs: 2,
+          }],
+          stopReason: "completed",
+        },
+      },
+    ]);
+    const orchestrator = new SubAgentOrchestrator({
+      fallbackExecutor: fallback,
+      resolveSubAgentManager: () => manager,
+      pollIntervalMs: 5,
+      fallbackBehavior: "fail_request",
+    });
+
+    const result = await orchestrator.execute({
+      id: "planner:session-budget-retry:1",
+      createdAt: Date.now(),
+      context: { results: {} },
+      steps: [],
+      plannerSteps: [
+        {
+          name: "analyze_renderer_logs",
+          stepType: "subagent_task",
+          objective: "Analyze renderer logs and summarize the failure",
+          inputContract: "Recent CI logs exist",
+          acceptanceCriteria: ["Include the renderer failure summary"],
+          requiredToolCapabilities: ["system.readFile"],
+          contextRequirements: ["ci_logs"],
+          maxBudgetHint: "8m",
+          canRunParallel: false,
+        },
+      ],
+    });
+
+    expect(result.status).toBe("completed");
+    expect(manager.spawnCalls).toHaveLength(2);
+    expect(manager.spawnCalls[0]?.toolBudgetPerRequest).toBe(64);
+    expect(manager.spawnCalls[1]?.toolBudgetPerRequest).toBe(96);
   });
 
   it("retries child validation failures that return non-completed stop reasons without tool evidence", async () => {
@@ -5662,9 +6382,13 @@ describe("SubAgentOrchestrator", () => {
         },
       },
     ]);
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
     const orchestrator = new SubAgentOrchestrator({
       fallbackExecutor: fallback,
       resolveSubAgentManager: () => manager,
+      resolveLifecycleEmitter: () => ({
+        emit: (event: Record<string, unknown>) => lifecycleEvents.push(event),
+      } as any),
       pollIntervalMs: 5,
       fallbackBehavior: "fail_request",
     });
@@ -5720,6 +6444,25 @@ describe("SubAgentOrchestrator", () => {
     );
     expect(manager.spawnCalls[1]?.task).toContain("Cannot find module 'fs'");
     expect(acceptanceProbeCalls).toBe(2);
+    expect(
+      lifecycleEvents.filter((event) => event.type === "subagents.acceptance_probe.failed"),
+    ).toHaveLength(1);
+    expect(
+      lifecycleEvents.filter((event) => event.type === "subagents.failed"),
+    ).toHaveLength(0);
+    expect(
+      lifecycleEvents.filter((event) => event.type === "subagents.completed"),
+    ).toHaveLength(1);
+    const retryPayload = lifecycleEvents.find(
+      (event) => event.type === "subagents.progress",
+    )?.payload as
+      | { validationCode?: string; phase?: string; retrying?: boolean }
+      | undefined;
+    expect(retryPayload).toMatchObject({
+      phase: "retry_backoff",
+      validationCode: "acceptance_probe_failed",
+      retrying: true,
+    });
 
     const fallbackCalls = vi.mocked(fallback.execute).mock.calls;
     const acceptanceProbePipeline = fallbackCalls

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -36,6 +36,7 @@ import {
   type PromptBudgetConfig,
 } from "../llm/prompt-budget.js";
 import {
+  type DelegatedWorkingDirectoryResolution,
   resolveDelegatedWorkingDirectory,
   resolveDelegatedWorkingDirectoryPath,
 } from "./delegation-tool.js";
@@ -46,7 +47,10 @@ import type {
   LLMProviderExecutionProfile,
   LLMUsage,
 } from "../llm/types.js";
-import { DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS } from "../llm/chat-executor-constants.js";
+import {
+  DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS,
+  DEFAULT_TOOL_BUDGET_PER_REQUEST,
+} from "../llm/chat-executor-constants.js";
 import type {
   SubAgentLifecycleEmitter,
 } from "./delegation-runtime.js";
@@ -122,6 +126,7 @@ export interface SubAgentOrchestratorConfig {
 
 type SubagentFailureClass =
   | "timeout"
+  | "budget_exceeded"
   | "tool_misuse"
   | "malformed_result_contract"
   | "needs_decomposition"
@@ -157,6 +162,7 @@ interface ExecuteSubagentAttemptParams {
   readonly parentRequest?: string;
   readonly lastValidationCode?: DelegationOutputValidationCode;
   readonly timeoutMs: number;
+  readonly toolBudgetPerRequest: number;
   readonly taskPrompt: string;
   readonly diagnostics: SubagentContextDiagnostics;
   readonly tools: readonly string[];
@@ -327,7 +333,7 @@ const DEFAULT_MAX_SUBAGENT_DEPTH = 4;
 const DEFAULT_MAX_SUBAGENT_FANOUT_PER_TURN = 8;
 const DEFAULT_MAX_TOTAL_SUBAGENTS_PER_REQUEST = 32;
 const DEFAULT_MAX_CUMULATIVE_TOOL_CALLS_PER_REQUEST_TREE = 256;
-const DEFAULT_MAX_CUMULATIVE_TOKENS_PER_REQUEST_TREE = 250_000;
+const DEFAULT_MAX_CUMULATIVE_TOKENS_PER_REQUEST_TREE = 0;
 const DEFAULT_MIN_TOKENS_PER_PLANNED_SUBAGENT_STEP = 150_000;
 const DEFAULT_PLANNED_SUBAGENT_TOKENS_PER_MS =
   DEFAULT_MIN_TOKENS_PER_PLANNED_SUBAGENT_STEP /
@@ -336,6 +342,10 @@ const DEFAULT_REQUEST_TREE_SUBAGENT_PASSES = Math.max(
   1,
   DEFAULT_SUBAGENT_VERIFIER_MAX_ROUNDS,
 );
+const DEFAULT_PLANNED_SUBAGENT_TOOL_BUDGET = DEFAULT_TOOL_BUDGET_PER_REQUEST;
+const MAX_PLANNED_SUBAGENT_TOOL_BUDGET = 96;
+const PLANNED_SUBAGENT_TOOL_BUDGET_MS_PER_CALL = 7_500;
+const BUDGET_EXCEEDED_RETRY_TOOL_BUDGET_MULTIPLIER = 1.5;
 const CONTEXT_TERM_MIN_LENGTH = 3;
 const CONTEXT_HISTORY_TAIL_PIN = 2;
 const FALLBACK_CONTEXT_HISTORY_CHARS = 2_000;
@@ -351,9 +361,13 @@ const REDACTED_BEARER_TOKEN = "Bearer [REDACTED_TOKEN]";
 const REDACTED_API_KEY = "[REDACTED_API_KEY]";
 const REDACTED_ABSOLUTE_PATH = "[REDACTED_ABSOLUTE_PATH]";
 const NODE_PACKAGE_TOOLING_RE =
-  /\b(?:node(?:\.js)?|npm|npx|package\.json|package-lock\.json|pnpm|pnpm-workspace\.yaml|yarn|bun|workspaces?|typescript|tsconfig(?:\.[a-z]+)?\.json|tsx|vitest|commander)\b/i;
+  /\b(?:node(?:\.js)?|npm|npx|package\.json|package-lock\.json|pnpm|pnpm-workspace\.yaml|yarn|bun|typescript|tsconfig(?:\.[a-z]+)?\.json|tsx|vitest|commander)\b/i;
 const NODE_PACKAGE_MANIFEST_PATH_RE =
   /(?:^|\/)(?:package\.json|package-lock\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml|yarn\.lock|bun\.lockb|tsconfig(?:\.[a-z]+)?\.json)$/i;
+const NODE_WORKSPACE_AUTHORING_RE =
+  /\b(?:package\.json|pnpm-workspace\.yaml|tsconfig(?:\.[a-z]+)?\.json|vite\.config(?:\.[a-z]+)?|vitest\.config(?:\.[a-z]+)?|workspaces|dependencies|devdependencies|scripts?|bin)\b/i;
+const RUST_WORKSPACE_TOOLING_RE =
+  /\b(?:cargo(?:\.toml|\.lock)?|rustc|rustfmt|clippy|crates?)\b|(?:^|\/)(?:src\/)?(?:lib|main)\.rs\b/i;
 const TEST_ARTIFACT_PATH_RE =
   /(?:^|\/)(?:tests?|__tests__|specs?)\/|(?:^|\/)[^/]+\.(?:test|spec)\.[cm]?[jt]sx?$/i;
 const SOURCE_ARTIFACT_PATH_RE = /\.(?:[cm]?[jt]sx?)$/i;
@@ -375,7 +389,7 @@ const ABSOLUTE_PATH_RE =
 const SUBAGENT_ORCHESTRATION_SECTION_RE =
   /\bsub-agent orchestration plan(?:\s*\((?:required|mandatory)\)|\s+(?:required|mandatory))\s*:[\s\S]*$/i;
 const WORKSPACE_CONTEXT_CANDIDATE_PATH_RE =
-  /\.(?:[cm]?[jt]sx?|json|md|txt|html|css)$/i;
+  /\.(?:[cm]?[jt]sx?|json|md|txt|html|css|toml|lock|ya?ml)$/i;
 const WORKSPACE_CONTEXT_SKIP_DIRS = new Set([
   ".git",
   ".next",
@@ -386,6 +400,7 @@ const WORKSPACE_CONTEXT_SKIP_DIRS = new Set([
   "dist",
   "node_modules",
   "out",
+  "target",
 ]);
 const WORKSPACE_CONTEXT_MAX_SCAN_FILES = 160;
 const WORKSPACE_CONTEXT_MAX_SCAN_DEPTH = 5;
@@ -400,6 +415,8 @@ const PACKAGE_AUTHORING_SCAN_SKIP_DIRS = new Set([
   "node_modules",
 ]);
 const PACKAGE_AUTHORING_MAX_SCAN_FILES = 128;
+const RUST_GENERATED_ARTIFACT_PATH_RE =
+  /(?:^|\/)target(?:\/|$)|(?:^|\/)\.fingerprint(?:\/|$)|(?:^|\/)incremental(?:\/|$)|(?:^|\/)\.rustc_info\.json$/i;
 
 function isPipelineStopReasonHint(
   value: unknown,
@@ -421,6 +438,7 @@ const SUBAGENT_RETRY_POLICY: Readonly<
   Record<SubagentFailureClass, SubagentRetryRule>
 > = {
   timeout: { maxRetries: 1, baseDelayMs: 75, maxDelayMs: 250 },
+  budget_exceeded: { maxRetries: 1, baseDelayMs: 50, maxDelayMs: 150 },
   tool_misuse: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0 },
   malformed_result_contract: { maxRetries: 1, baseDelayMs: 50, maxDelayMs: 150 },
   needs_decomposition: { maxRetries: 0, baseDelayMs: 0, maxDelayMs: 0 },
@@ -435,6 +453,7 @@ const SUBAGENT_FAILURE_STOP_REASON: Readonly<
   Record<SubagentFailureClass, PipelineStopReasonHint>
 > = {
   timeout: "timeout",
+  budget_exceeded: "budget_exceeded",
   tool_misuse: "tool_error",
   malformed_result_contract: "validation_error",
   needs_decomposition: "validation_error",
@@ -567,6 +586,7 @@ class RequestTreeBudgetTracker {
     this.cumulativeToolCalls += normalizedToolCalls;
     this.cumulativeTokens += normalizedTokens;
     if (
+      this.maxCumulativeToolCallsPerRequestTree > 0 &&
       this.cumulativeToolCalls > this.maxCumulativeToolCallsPerRequestTree
     ) {
       this.circuitBreakerReason =
@@ -580,6 +600,7 @@ class RequestTreeBudgetTracker {
       };
     }
     if (
+      this.maxCumulativeTokensPerRequestTree > 0 &&
       this.cumulativeTokens > this.maxCumulativeTokensPerRequestTree
     ) {
       this.circuitBreakerReason =
@@ -701,7 +722,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       ),
     );
     this.maxCumulativeTokensPerRequestTree = Math.max(
-      1,
+      0,
       Math.floor(
         config.maxCumulativeTokensPerRequestTree ??
           DEFAULT_MAX_CUMULATIVE_TOKENS_PER_REQUEST_TREE,
@@ -1612,6 +1633,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         parentRequest: pipeline.plannerContext?.parentRequest,
         lastValidationCode: lastFailure?.validationCode,
         timeoutMs,
+        toolBudgetPerRequest: this.resolveSubagentToolBudgetPerRequest({
+          timeoutMs,
+          priorFailureClass: lastFailure?.failureClass,
+        }),
         taskPrompt,
         diagnostics: subagentTask.diagnostics,
         tools: toolScope.allowedTools,
@@ -1735,6 +1760,20 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
             stopReasonHint: "budget_exceeded",
           };
         }
+        lifecycleEmitter?.emit({
+          type: "subagents.completed",
+          timestamp: Date.now(),
+          sessionId: parentSessionId,
+          parentSessionId,
+          subagentSessionId: attemptOutcome.subagentSessionId,
+          toolName: "execute_with_agent",
+          payload: {
+            stepName: step.name,
+            durationMs: attemptOutcome.durationMs,
+            toolCalls: attemptOutcome.toolCalls.length,
+            providerName: attemptOutcome.providerName,
+          },
+        });
         return {
           status: "completed",
           result: safeStringify({
@@ -1825,31 +1864,6 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         ? this.computeRetryDelayMs(retryRule, retryAttempt)
         : 0;
 
-      lifecycleEmitter?.emit({
-        type:
-          lastFailure.failureClass === "cancelled"
-            ? "subagents.cancelled"
-            : "subagents.failed",
-        timestamp: Date.now(),
-        sessionId: parentSessionId,
-        parentSessionId,
-        subagentSessionId: lastFailure.childSessionId,
-        toolName: "execute_with_agent",
-        payload: {
-          stepName: step.name,
-          output: lastFailure.message,
-          durationMs: lastFailure.durationMs,
-          failureClass: lastFailure.failureClass,
-          validationCode: lastFailure.validationCode,
-          decomposition: lastFailure.decomposition,
-          attempt,
-          retrying: shouldRetry,
-          retryAttempt,
-          maxRetries: retryRule.maxRetries,
-          nextRetryDelayMs: retryDelayMs,
-        },
-      });
-
       this.recordSubagentTrajectory({
         traceId: trajectoryTraceId,
         turnId: `child:${step.name}:${attempt}:${lastFailure.childSessionId ?? "unknown"}`,
@@ -1902,10 +1916,17 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           payload: {
             stepName: step.name,
             phase: "retry_backoff",
+            output: lastFailure.message,
+            durationMs: lastFailure.durationMs,
             failureClass: lastFailure.failureClass,
+            validationCode: lastFailure.validationCode,
+            decomposition: lastFailure.decomposition,
             attempt,
+            retrying: true,
             retryAttempt,
+            maxRetries: retryRule.maxRetries,
             delayMs: retryDelayMs,
+            nextRetryDelayMs: retryDelayMs,
           },
         });
         if (retryDelayMs > 0) {
@@ -1913,6 +1934,31 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         }
         continue;
       }
+
+      lifecycleEmitter?.emit({
+        type:
+          lastFailure.failureClass === "cancelled"
+            ? "subagents.cancelled"
+            : "subagents.failed",
+        timestamp: Date.now(),
+        sessionId: parentSessionId,
+        parentSessionId,
+        subagentSessionId: lastFailure.childSessionId,
+        toolName: "execute_with_agent",
+        payload: {
+          stepName: step.name,
+          output: lastFailure.message,
+          durationMs: lastFailure.durationMs,
+          failureClass: lastFailure.failureClass,
+          validationCode: lastFailure.validationCode,
+          decomposition: lastFailure.decomposition,
+          attempt,
+          retrying: false,
+          retryAttempt,
+          maxRetries: retryRule.maxRetries,
+          nextRetryDelayMs: retryDelayMs,
+        },
+      });
 
       if (
         lastFailure.failureClass === "needs_decomposition" &&
@@ -2085,9 +2131,27 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     );
   }
 
+  private resolveSubagentToolBudgetPerRequest(params: {
+    readonly timeoutMs: number;
+    readonly priorFailureClass?: SubagentFailureClass;
+  }): number {
+    const baseBudget = Math.max(
+      DEFAULT_PLANNED_SUBAGENT_TOOL_BUDGET,
+      Math.ceil(params.timeoutMs / PLANNED_SUBAGENT_TOOL_BUDGET_MS_PER_CALL),
+    );
+    const boostedBudget =
+      params.priorFailureClass === "budget_exceeded"
+        ? Math.ceil(
+            baseBudget * BUDGET_EXCEEDED_RETRY_TOOL_BUDGET_MULTIPLIER,
+          )
+        : baseBudget;
+    return Math.min(MAX_PLANNED_SUBAGENT_TOOL_BUDGET, boostedBudget);
+  }
+
   private createRetryAttemptTracker(): Record<SubagentFailureClass, number> {
     return {
       timeout: 0,
+      budget_exceeded: 0,
       tool_misuse: 0,
       malformed_result_contract: 0,
       needs_decomposition: 0,
@@ -2177,6 +2241,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     result: Pick<SubAgentResult, "output" | "stopReason" | "stopReasonDetail">,
   ): SubagentFailureClass {
     if (result.stopReason === "timeout") return "timeout";
+    if (result.stopReason === "budget_exceeded") return "budget_exceeded";
     if (result.stopReason === "cancelled") return "cancelled";
     if (
       result.stopReason === "provider_error" ||
@@ -2214,6 +2279,198 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     };
   }
 
+  private isAnchoredDelegatedWorkingDirectory(path: string): boolean {
+    const trimmed = path.trim();
+    return (
+      trimmed.startsWith("/") ||
+      trimmed.startsWith("~/") ||
+      trimmed.startsWith("~\\")
+    );
+  }
+
+  private normalizeAnchoredDelegatedWorkingDirectory(
+    resolution?: DelegatedWorkingDirectoryResolution,
+  ): DelegatedWorkingDirectoryResolution | undefined {
+    if (!resolution) return undefined;
+    if (!this.isAnchoredDelegatedWorkingDirectory(resolution.path)) {
+      return undefined;
+    }
+    return {
+      ...resolution,
+      path: resolveDelegatedWorkingDirectoryPath(
+        resolution.path,
+        this.resolveHostWorkspaceRoot() ?? undefined,
+      ),
+    };
+  }
+
+  private resolvePlannerContextDelegatedWorkingDirectory(
+    pipeline: Pipeline,
+  ): DelegatedWorkingDirectoryResolution | undefined {
+    const plannerContext = pipeline.plannerContext;
+    if (!plannerContext) return undefined;
+    const history = plannerContext.history ?? [];
+    const toolOutputs = plannerContext.toolOutputs ?? [];
+    return this.normalizeAnchoredDelegatedWorkingDirectory(
+      resolveDelegatedWorkingDirectory({
+        task: plannerContext.parentRequest,
+        acceptanceCriteria: [
+          ...history.map((entry) => entry.content),
+          ...toolOutputs.map((entry) => entry.content),
+        ],
+      }),
+    );
+  }
+
+  private resolveInheritedDelegatedWorkingDirectory(
+    step: PipelinePlannerSubagentStep,
+    pipeline: Pipeline,
+  ): DelegatedWorkingDirectoryResolution | undefined {
+    const plannerSteps = pipeline.plannerSteps ?? [];
+    const plannerStepByName = new Map(
+      plannerSteps.map((plannerStep) => [plannerStep.name, plannerStep]),
+    );
+    const dependencyQueue = [...(step.dependsOn ?? [])];
+    const visited = new Set<string>();
+    const candidates = new Map<string, DelegatedWorkingDirectoryResolution>();
+
+    while (dependencyQueue.length > 0) {
+      const dependencyName = dependencyQueue.shift();
+      if (!dependencyName || visited.has(dependencyName)) continue;
+      visited.add(dependencyName);
+      const dependencyStep = plannerStepByName.get(dependencyName);
+      if (!dependencyStep) continue;
+      if (dependencyStep.stepType === "subagent_task") {
+        const candidate = this.normalizeAnchoredDelegatedWorkingDirectory(
+          this.resolveEffectiveDelegatedWorkingDirectory({
+            task: dependencyStep.name,
+            objective: dependencyStep.objective,
+            inputContract: dependencyStep.inputContract,
+            acceptanceCriteria: dependencyStep.acceptanceCriteria,
+            contextRequirements: dependencyStep.contextRequirements,
+          }),
+        );
+        if (candidate) {
+          candidates.set(candidate.path, candidate);
+        }
+      }
+      for (const nestedDependency of dependencyStep.dependsOn ?? []) {
+        dependencyQueue.push(nestedDependency);
+      }
+    }
+
+    if (candidates.size === 1) {
+      return [...candidates.values()][0];
+    }
+
+    if (candidates.size === 0) {
+      for (const plannerStep of plannerSteps) {
+        if (plannerStep.stepType !== "subagent_task") continue;
+        const candidate = this.normalizeAnchoredDelegatedWorkingDirectory(
+          this.resolveEffectiveDelegatedWorkingDirectory({
+            task: plannerStep.name,
+            objective: plannerStep.objective,
+            inputContract: plannerStep.inputContract,
+            acceptanceCriteria: plannerStep.acceptanceCriteria,
+            contextRequirements: plannerStep.contextRequirements,
+          }),
+        );
+        if (candidate) {
+          candidates.set(candidate.path, candidate);
+        }
+      }
+      if (candidates.size === 1) {
+        return [...candidates.values()][0];
+      }
+    }
+
+    return this.resolvePlannerContextDelegatedWorkingDirectory(pipeline);
+  }
+
+  private resolvePlannerStepWorkingDirectory(
+    step: PipelinePlannerSubagentStep,
+    pipeline: Pipeline,
+  ): DelegatedWorkingDirectoryResolution | undefined {
+    const direct = this.resolveEffectiveDelegatedWorkingDirectory({
+      task: step.name,
+      objective: step.objective,
+      inputContract: step.inputContract,
+      acceptanceCriteria: step.acceptanceCriteria,
+      contextRequirements: step.contextRequirements,
+    });
+    const anchoredDirect =
+      this.normalizeAnchoredDelegatedWorkingDirectory(direct);
+    if (anchoredDirect) {
+      return anchoredDirect;
+    }
+
+    const inherited = this.resolveInheritedDelegatedWorkingDirectory(
+      step,
+      pipeline,
+    );
+    if (!direct) {
+      return inherited;
+    }
+
+    const rawPath = direct.path.trim();
+    if (rawPath.length === 0) {
+      return inherited;
+    }
+
+    if (inherited) {
+      return {
+        path: resolvePath(inherited.path, rawPath),
+        source: direct.source,
+      };
+    }
+
+    const hostWorkspaceRoot = this.resolveHostWorkspaceRoot() ?? undefined;
+    if (hostWorkspaceRoot) {
+      return {
+        path: resolvePath(hostWorkspaceRoot, rawPath),
+        source: direct.source,
+      };
+    }
+
+    return undefined;
+  }
+
+  private buildEffectiveContextRequirements(
+    step: PipelinePlannerSubagentStep,
+    delegatedWorkingDirectory?: string,
+  ): readonly string[] {
+    if (
+      typeof delegatedWorkingDirectory !== "string" ||
+      delegatedWorkingDirectory.trim().length === 0
+    ) {
+      return step.contextRequirements;
+    }
+
+    const normalizedRequirement = `cwd=${delegatedWorkingDirectory}`;
+    let replaced = false;
+    const rewritten = step.contextRequirements
+      .map((requirement) => {
+        if (
+          /^(?:cwd|working(?:[_ -]?directory))\s*(?:=|:)\s*(.+)$/i.test(
+            requirement,
+          )
+        ) {
+          replaced = true;
+          return normalizedRequirement;
+        }
+        return requirement;
+      })
+      .filter((requirement, index, entries) =>
+        requirement.length > 0 && entries.indexOf(requirement) === index
+      );
+
+    if (replaced) {
+      return rewritten;
+    }
+
+    return [normalizedRequirement, ...rewritten];
+  }
+
   private async executeSubagentAttempt(
     input: ExecuteSubagentAttemptParams,
   ): Promise<ExecuteSubagentAttemptOutcome> {
@@ -2236,15 +2493,19 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       };
     }
 
-    const delegatedWorkingDirectory = this.resolveEffectiveDelegatedWorkingDirectory({
-      task: input.step.name,
-      objective: input.step.objective,
-      inputContract: input.step.inputContract,
-      acceptanceCriteria: input.step.acceptanceCriteria,
-      contextRequirements: input.step.contextRequirements,
-    });
-    const effectiveDelegationSpec = this.buildEffectiveDelegationSpec(
+    const delegatedWorkingDirectory = this.resolvePlannerStepWorkingDirectory(
       input.step,
+      input.pipeline,
+    );
+    const effectiveStep = {
+      ...input.step,
+      contextRequirements: this.buildEffectiveContextRequirements(
+        input.step,
+        delegatedWorkingDirectory?.path,
+      ),
+    } satisfies PipelinePlannerSubagentStep;
+    const effectiveDelegationSpec = this.buildEffectiveDelegationSpec(
+      effectiveStep,
       input.pipeline,
       {
         parentRequest: input.parentRequest,
@@ -2259,18 +2520,19 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
         parentSessionId: input.parentSessionId,
         task: input.taskPrompt,
         timeoutMs: input.timeoutMs,
+        toolBudgetPerRequest: input.toolBudgetPerRequest,
         ...(workingDirectory ? { workingDirectory } : {}),
         ...(delegatedWorkingDirectory
           ? { workingDirectorySource: delegatedWorkingDirectory.source }
           : {}),
         tools: input.tools,
-        requiredCapabilities: input.step.requiredToolCapabilities,
+        requiredCapabilities: effectiveStep.requiredToolCapabilities,
         requireToolCall: specRequiresSuccessfulToolEvidence({
-            objective: input.step.objective,
-            inputContract: input.step.inputContract,
+            objective: effectiveStep.objective,
+            inputContract: effectiveStep.inputContract,
             acceptanceCriteria:
               effectiveDelegationSpec.acceptanceCriteria,
-            requiredToolCapabilities: input.step.requiredToolCapabilities,
+            requiredToolCapabilities: effectiveStep.requiredToolCapabilities,
             tools: input.tools,
           }),
         delegationSpec: effectiveDelegationSpec,
@@ -2300,6 +2562,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       payload: {
         stepName: input.step.name,
         timeoutMs: input.timeoutMs,
+        toolBudgetPerRequest: input.toolBudgetPerRequest,
         contextCuration: input.diagnostics,
         ...(this.unsafeBenchmarkMode ? { unsafeBenchmarkMode: true } : {}),
         ...(delegatedWorkingDirectory
@@ -2353,21 +2616,6 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
             },
           };
         }
-
-        input.lifecycleEmitter?.emit({
-          type: "subagents.completed",
-          timestamp: Date.now(),
-          sessionId: input.parentSessionId,
-          parentSessionId: input.parentSessionId,
-          subagentSessionId: childSessionId,
-          toolName: "execute_with_agent",
-          payload: {
-            stepName: input.step.name,
-            durationMs: result.durationMs,
-            toolCalls: result.toolCalls.length,
-            providerName: result.providerName,
-          },
-        });
 
         return {
           status: "completed",
@@ -2554,13 +2802,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       return [];
     }
 
-    const delegatedWorkingDirectory = this.resolveEffectiveDelegatedWorkingDirectory({
-      task: step.name,
-      objective: step.objective,
-      inputContract: step.inputContract,
-      acceptanceCriteria: step.acceptanceCriteria,
-      contextRequirements: step.contextRequirements,
-    });
+    const delegatedWorkingDirectory = this.resolvePlannerStepWorkingDirectory(
+      step,
+      pipeline,
+    );
     const packageDirectories = this.collectAcceptanceProbePackageDirectories(
       toolCalls,
       delegatedWorkingDirectory?.path,
@@ -3026,15 +3271,22 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       : undefined;
     const relevanceTerms = this.buildRelevanceTerms(step);
     const artifactRelevanceTerms = this.buildArtifactRelevanceTerms(step);
-    const requirementTerms = this.extractTerms(step.contextRequirements.join(" "));
+    const delegatedWorkingDirectory = this.resolvePlannerStepWorkingDirectory(
+      step,
+      pipeline,
+    );
+    const effectiveContextRequirements = this.buildEffectiveContextRequirements(
+      step,
+      delegatedWorkingDirectory?.path,
+    );
+    const effectiveStep = {
+      ...step,
+      contextRequirements: effectiveContextRequirements,
+    } satisfies PipelinePlannerSubagentStep;
+    const requirementTerms = this.extractTerms(
+      effectiveContextRequirements.join(" "),
+    );
     const dependencies = this.collectDependencyContexts(step, pipeline, results);
-    const delegatedWorkingDirectory = this.resolveEffectiveDelegatedWorkingDirectory({
-      task: step.name,
-      objective: step.objective,
-      inputContract: step.inputContract,
-      acceptanceCriteria: step.acceptanceCriteria,
-      contextRequirements: step.contextRequirements,
-    });
     const dependencyArtifactCandidates = this.collectDependencyArtifactCandidates(
       dependencies,
       artifactRelevanceTerms,
@@ -3073,12 +3325,12 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     );
     const memorySection = this.curateMemorySection(
       plannerContext?.memory ?? [],
-      step.contextRequirements,
+      effectiveContextRequirements,
       relevanceTerms,
       promptBudgetCaps.memoryChars,
     );
     const toolOutputSection = this.curateToolOutputSection(
-      step,
+      effectiveStep,
       plannerContext?.toolOutputs ?? [],
       dependencies,
       relevanceTerms,
@@ -3090,23 +3342,24 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       toolContextBudgets.dependencyArtifacts ?? 0,
     );
     const workspaceStateGuidanceLines = this.buildWorkspaceStateGuidanceLines(
-      step,
+      effectiveStep,
       pipeline,
       promptArtifactCandidates,
       delegatedWorkingDirectory?.path,
     );
     const hostToolingSection = this.buildHostToolingPromptSection(
-      step,
+      effectiveStep,
+      pipeline,
       dependencyArtifactCandidates,
     );
     const downstreamRequirementLines = this.buildDownstreamRequirementLines(
-      step,
+      effectiveStep,
       pipeline,
     );
     const workspaceVerificationContractLines =
-      this.buildWorkspaceVerificationContractLines(step, pipeline);
+      this.buildWorkspaceVerificationContractLines(effectiveStep, pipeline);
     const effectiveAcceptanceCriteria = this.buildEffectiveAcceptanceCriteria(
-      step,
+      effectiveStep,
       pipeline,
       delegatedWorkingDirectory?.path,
     );
@@ -3123,15 +3376,15 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       );
       sections.push(
         `Execution rules:
-- Execute only the assigned phase \`${step.name}\`.
+- Execute only the assigned phase \`${effectiveStep.name}\`.
 - Do not create a new multi-step plan for the broader parent request.
 - Do not attempt sibling phases or synthesize the final deliverable.
 - If the task requires tool-grounded evidence, you must use one or more allowed tools before answering.
 - If you cannot complete the phase with the allowed tools, state that you are blocked and explain exactly why.`,
       );
-      sections.push(`Objective: ${this.redactSensitiveData(step.objective)}`);
+      sections.push(`Objective: ${this.redactSensitiveData(effectiveStep.objective)}`);
       sections.push(
-        `Input contract: ${this.redactSensitiveData(step.inputContract)}`,
+        `Input contract: ${this.redactSensitiveData(effectiveStep.inputContract)}`,
       );
       if (summarizedParentRequest && summarizedParentRequest.length > 0) {
         sections.push(
@@ -3143,9 +3396,9 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           `Acceptance criteria:\n${effectiveAcceptanceCriteria.map((item) => `- ${this.redactSensitiveData(item)}`).join("\n")}`,
         );
       }
-      if (step.contextRequirements.length > 0) {
+      if (effectiveContextRequirements.length > 0) {
         sections.push(
-          `Context requirements:\n${step.contextRequirements.map((item) => `- ${this.redactSensitiveData(item)}`).join("\n")}`,
+          `Context requirements:\n${effectiveContextRequirements.map((item) => `- ${this.redactSensitiveData(item)}`).join("\n")}`,
         );
       }
       if (
@@ -3525,8 +3778,61 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     };
   }
 
+  private scoreWorkspaceEcosystem(
+    texts: readonly string[],
+    patterns: readonly { pattern: RegExp; weight: number }[],
+  ): number {
+    return patterns.reduce((total, cue) => {
+      const matched = texts.some((text) => cue.pattern.test(text));
+      return matched ? total + cue.weight : total;
+    }, 0);
+  }
+
+  private resolveWorkspaceEcosystem(
+    texts: readonly string[],
+  ): "node" | "rust" | "unknown" {
+    const normalized = texts
+      .map((text) => text.trim())
+      .filter((text) => text.length > 0);
+    if (normalized.length === 0) {
+      return "unknown";
+    }
+
+    const nodeScore = this.scoreWorkspaceEcosystem(normalized, [
+      { pattern: NODE_PACKAGE_TOOLING_RE, weight: 4 },
+      { pattern: NODE_PACKAGE_MANIFEST_PATH_RE, weight: 5 },
+      { pattern: NODE_WORKSPACE_AUTHORING_RE, weight: 2 },
+      { pattern: /\bworkspace:\*/i, weight: 3 },
+    ]);
+    const rustScore = this.scoreWorkspaceEcosystem(normalized, [
+      { pattern: RUST_WORKSPACE_TOOLING_RE, weight: 4 },
+      { pattern: /\bcargo\s+(?:build|check|run|test)\b/i, weight: 4 },
+      { pattern: /\bcargo\s+.*\s--workspace\b/i, weight: 3 },
+      { pattern: /(?:^|\/)(?:cargo\.toml|cargo\.lock)$/i, weight: 5 },
+    ]);
+
+    if (nodeScore > 0 && rustScore === 0) {
+      return "node";
+    }
+    if (rustScore > 0 && nodeScore === 0) {
+      return "rust";
+    }
+    if (nodeScore >= rustScore + 2) {
+      return "node";
+    }
+    if (rustScore >= nodeScore + 2) {
+      return "rust";
+    }
+    return "unknown";
+  }
+
+  private isNodeWorkspaceRelevant(texts: readonly string[]): boolean {
+    return this.resolveWorkspaceEcosystem(texts) === "node";
+  }
+
   private buildHostToolingPromptSection(
     step: PipelinePlannerSubagentStep,
+    pipeline: Pipeline,
     dependencyArtifactCandidates: readonly DependencyArtifactCandidate[],
   ): {
     lines: readonly string[];
@@ -3538,12 +3844,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       step.inputContract,
       ...step.acceptanceCriteria,
       ...step.contextRequirements,
+      pipeline.plannerContext?.parentRequest ?? "",
       ...dependencyArtifactCandidates.map((candidate) => candidate.path),
     ];
-    const relevant = stepTexts.some((text) =>
-      NODE_PACKAGE_TOOLING_RE.test(text) ||
-      NODE_PACKAGE_MANIFEST_PATH_RE.test(text)
-    );
+    const relevant = this.isNodeWorkspaceRelevant(stepTexts);
     if (!relevant) {
       return {
         lines: [],
@@ -3829,6 +4133,9 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
   private resolveEffectiveMaxCumulativeTokensPerRequestTree(
     plannerSteps: readonly PipelinePlannerStep[],
   ): number {
+    if (this.maxCumulativeTokensPerRequestTree <= 0) {
+      return 0;
+    }
     if (this.maxCumulativeTokensPerRequestTreeExplicitlyConfigured) {
       return this.maxCumulativeTokensPerRequestTree;
     }
@@ -4043,33 +4350,31 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     step: PipelinePlannerSubagentStep,
     pipeline: Pipeline,
   ): readonly string[] {
+    const delegatedWorkingDirectory = this.resolvePlannerStepWorkingDirectory(
+      step,
+      pipeline,
+    );
+    const downstreamRootScripts = this.collectDownstreamRootNpmScripts(
+      step,
+      pipeline,
+      delegatedWorkingDirectory?.path,
+    );
     const stepTexts = [
       step.name,
       step.objective,
       step.inputContract,
       ...step.acceptanceCriteria,
       ...step.contextRequirements,
+      pipeline.plannerContext?.parentRequest ?? "",
+      ...downstreamRootScripts.map((script) => `npm run ${script}`),
     ];
-    const relevant = stepTexts.some((text) =>
-      NODE_PACKAGE_TOOLING_RE.test(text) ||
-      /(?:manifest|scaffold|workspace|package\.json|tsconfig|vite\.config)/i.test(text)
-    );
+    const relevant =
+      downstreamRootScripts.length > 0 ||
+      this.isNodeWorkspaceRelevant(stepTexts);
     if (!relevant) {
       return [];
     }
 
-    const delegatedWorkingDirectory = this.resolveEffectiveDelegatedWorkingDirectory({
-      task: step.name,
-      objective: step.objective,
-      inputContract: step.inputContract,
-      acceptanceCriteria: step.acceptanceCriteria,
-      contextRequirements: step.contextRequirements,
-    });
-    const downstreamRootScripts = this.collectDownstreamRootNpmScripts(
-      step,
-      pipeline,
-      delegatedWorkingDirectory?.path,
-    );
     if (downstreamRootScripts.length === 0) {
       return [];
     }
@@ -4133,33 +4438,34 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     pipeline: Pipeline,
     delegatedWorkingDirectory?: string,
   ): readonly string[] {
+    const downstreamRootScripts = this.collectDownstreamRootNpmScripts(
+      step,
+      pipeline,
+      delegatedWorkingDirectory,
+    );
     const stepTexts = [
       step.name,
       step.objective,
       step.inputContract,
       ...step.acceptanceCriteria,
       ...step.contextRequirements,
+      pipeline.plannerContext?.parentRequest ?? "",
+      ...downstreamRootScripts.map((script) => `npm run ${script}`),
     ];
-    const relevant = stepTexts.some((text) =>
-      NODE_PACKAGE_TOOLING_RE.test(text) ||
-      NODE_PACKAGE_MANIFEST_PATH_RE.test(text)
-    );
+    const relevant =
+      downstreamRootScripts.length > 0 ||
+      this.isNodeWorkspaceRelevant(stepTexts);
     if (!relevant) {
       return [];
     }
 
     const criteria: string[] = [];
-    const downstreamRootScripts = this.collectDownstreamRootNpmScripts(
-      step,
-      pipeline,
-      delegatedWorkingDirectory,
-    );
     if (downstreamRootScripts.length > 0) {
       criteria.push(
         `Root package.json authored with npm scripts for ${downstreamRootScripts.join(", ")}.`,
       );
     }
-    if (this.stepAuthorsNodeWorkspaceManifestOrConfig(step)) {
+    if (this.stepAuthorsNodeWorkspaceManifestOrConfig(step, pipeline)) {
       criteria.push(
         "Buildable TypeScript workspace packages use package-local tsconfig/project references or equivalent so `npm run build --workspace=<workspace-name>` verifies the targeted package without compiling sibling packages.",
       );
@@ -4182,6 +4488,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
 
   private stepAuthorsNodeWorkspaceManifestOrConfig(
     step: PipelinePlannerSubagentStep,
+    pipeline?: Pipeline,
   ): boolean {
     const combined = [
       step.name,
@@ -4190,7 +4497,10 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       ...step.acceptanceCriteria,
       ...step.contextRequirements,
     ].join(" ");
-    const hasNodeWorkspaceCue = NODE_PACKAGE_TOOLING_RE.test(combined);
+    const hasNodeWorkspaceCue = this.isNodeWorkspaceRelevant([
+      combined,
+      pipeline?.plannerContext?.parentRequest ?? "",
+    ]);
     const hasManifestOrConfigTarget =
       /\b(?:manifest|config|package\.json|tsconfig(?:\.[a-z]+)?\.json|vite\.config(?:\.[a-z]+)?|vitest\.config(?:\.[a-z]+)?|readme|workspace|workspaces|dependencies|devdependencies|scripts?|bin)\b/i
         .test(combined);
@@ -4217,7 +4527,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       ...step.acceptanceCriteria,
       ...step.contextRequirements,
     ].join(" ");
-    return NODE_PACKAGE_TOOLING_RE.test(combined);
+    return this.isNodeWorkspaceRelevant([combined]);
   }
 
   private hasReachableNodeInstallStep(
@@ -5152,6 +5462,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     const normalized = path.trim().toLowerCase();
     if (normalized.length === 0) return false;
     if (
+      RUST_GENERATED_ARTIFACT_PATH_RE.test(normalized) ||
       normalized.includes("/node_modules/") ||
       normalized.startsWith("node_modules/") ||
       normalized.includes("/dist/") ||
@@ -5160,7 +5471,7 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
     ) {
       return false;
     }
-    return /\.(?:[cm]?[jt]sx?|json|md|txt)$/i.test(normalized);
+    return /\.(?:[cm]?[jt]sx?|json|md|txt|toml|lock|ya?ml)$/i.test(normalized);
   }
 
   private allocateContextGroupBudgets(
@@ -5490,8 +5801,13 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
             : undefined;
         if ((name === "system.writeFile" || name === "system.appendFile") && args) {
           const path = typeof args.path === "string" ? args.path.trim() : "";
-          if (path.length > 0 && !modifiedFiles.includes(path)) {
-            modifiedFiles.push(path);
+          const normalizedPath = this.normalizeDependencyArtifactPath(path);
+          if (
+            normalizedPath.length > 0 &&
+            this.isDependencyArtifactPathCandidate(normalizedPath) &&
+            !modifiedFiles.includes(normalizedPath)
+          ) {
+            modifiedFiles.push(normalizedPath);
           }
         }
         if (name === "system.bash" || name === "desktop.bash") {
@@ -5589,7 +5905,11 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
 
   private resolveParentSessionId(pipelineId: string): string {
     if (!pipelineId.startsWith("planner:")) return pipelineId;
-    const segments = pipelineId.split(":");
-    return segments[1] ?? pipelineId;
+    const encodedParentSessionId = pipelineId.slice("planner:".length);
+    const separatorIndex = encodedParentSessionId.lastIndexOf(":");
+    if (separatorIndex <= 0) {
+      return encodedParentSessionId || pipelineId;
+    }
+    return encodedParentSessionId.slice(0, separatorIndex);
   }
 }

--- a/runtime/src/gateway/tool-handler-factory.test.ts
+++ b/runtime/src/gateway/tool-handler-factory.test.ts
@@ -122,6 +122,56 @@ describe("createSessionToolHandler", () => {
     });
   });
 
+  it("marks non-zero exitCode tool results as isError in client and subagent lifecycle events", async () => {
+    const sentMessages: ControlResponse[] = [];
+    const send = vi.fn((msg: ControlResponse): void => {
+      sentMessages.push(msg);
+    });
+    const lifecycleEvents: Array<Record<string, unknown>> = [];
+    const lifecycleEmitter = {
+      emit: vi.fn((event: Record<string, unknown>) => {
+        lifecycleEvents.push(event);
+      }),
+    };
+
+    const handler = createSessionToolHandler({
+      sessionId: "subagent:test-session",
+      baseHandler: vi.fn(async () =>
+        JSON.stringify({ stdout: "", stderr: "build failed", exitCode: 1 })
+      ),
+      routerId: "router-a",
+      send,
+      delegation: () => ({
+        subAgentManager: null,
+        policyEngine: null,
+        verifier: null,
+        lifecycleEmitter: lifecycleEmitter as any,
+      }),
+    });
+
+    await handler("system.bash", {
+      command: "npm",
+      args: ["run", "build"],
+    });
+
+    const resultPayload = sentMessages.find((msg) => msg.type === "tools.result")
+      ?.payload as
+      | { isError?: boolean; toolName?: string }
+      | undefined;
+    expect(resultPayload).toMatchObject({
+      toolName: "system.bash",
+      isError: true,
+    });
+
+    const lifecyclePayload = lifecycleEvents.find(
+      (event) => event.type === "subagents.tool.result",
+    )?.payload as
+      | { isError?: boolean; toolCallId?: string }
+      | undefined;
+    expect(lifecyclePayload?.isError).toBe(true);
+    expect(lifecyclePayload?.toolCallId).toBeDefined();
+  });
+
   it("does not block same-turn Doom follow-up calls after a failed launch", async () => {
     const sentMessages: ControlResponse[] = [];
     const send = vi.fn((msg: ControlResponse): void => {
@@ -320,6 +370,30 @@ describe("createSessionToolHandler", () => {
     });
   });
 
+  it("rebases relative desktop text editor paths under the delegated working directory", async () => {
+    const baseHandler = vi.fn(async () => '{"ok":true}');
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler,
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: "/tmp/project-root",
+      scopedFilesystemRoot: "/tmp/project-root",
+    });
+
+    await handler("desktop.text_editor", {
+      command: "create",
+      path: "src/store.ts",
+      file_text: "export const ok = true;\n",
+    });
+
+    expect(baseHandler).toHaveBeenCalledWith("desktop.text_editor", {
+      command: "create",
+      path: "/tmp/project-root/src/store.ts",
+      file_text: "export const ok = true;\n",
+    });
+  });
+
   it("injects a default cwd for structured shell tools and resolves relative cwd values", async () => {
     const workspaceRoot = createTempDir("agenc-tool-handler-");
     const baseHandler = vi.fn(async () => '{"stdout":"","exitCode":0}');
@@ -345,6 +419,32 @@ describe("createSessionToolHandler", () => {
       command: "npm",
       args: ["test"],
       cwd: `${workspaceRoot}/packages/app`,
+    });
+  });
+
+  it("injects the delegated cwd into desktop bash commands", async () => {
+    const workspaceRoot = createTempDir("agenc-tool-handler-desktop-bash-");
+    const baseHandler = vi.fn(async () => '{"stdout":"","exitCode":0}');
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler,
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: workspaceRoot,
+      scopedFilesystemRoot: workspaceRoot,
+    });
+
+    try {
+      await handler("desktop.bash", {
+        command: "npm run build",
+      });
+    } finally {
+      rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+
+    expect(baseHandler).toHaveBeenCalledWith("desktop.bash", {
+      command: "npm run build",
+      cwd: workspaceRoot,
     });
   });
 
@@ -615,6 +715,28 @@ describe("createSessionToolHandler", () => {
         "Delegated workspace root violation: shell mode command references a path outside the delegated workspace root. Keep all filesystem paths under /home/tetsuo/agent-test/terrain-router-ts-1.",
     });
     expect(baseHandler).not.toHaveBeenCalled();
+  });
+
+  it("allows shell-mode redirect targets that use /dev/null under a delegated workspace root", async () => {
+    const baseHandler = vi.fn(async () => '{"stdout":"","exitCode":0}');
+    const handler = createSessionToolHandler({
+      sessionId: "session-1",
+      baseHandler,
+      routerId: "router-a",
+      send: vi.fn(),
+      defaultWorkingDirectory: "/home/tetsuo/agent-test/terrain-router-ts-1",
+      scopedFilesystemRoot: "/home/tetsuo/agent-test/terrain-router-ts-1",
+    });
+
+    const result = await handler("system.bash", {
+      command: "echo ok > /dev/null",
+    });
+
+    expect(JSON.parse(result)).toEqual({
+      stdout: "",
+      exitCode: 0,
+    });
+    expect(baseHandler).toHaveBeenCalledTimes(1);
   });
 
   it("does not treat sed expressions as escaped filesystem paths in delegated bash commands", async () => {
@@ -2610,6 +2732,16 @@ describe("createSessionToolHandler", () => {
       success?: boolean;
       status?: string;
     };
+    const plannedEvent = lifecycleEvents.find(
+      (event) => event.type === "subagents.planned",
+    ) as
+      | {
+        payload?: {
+          decisionThreshold?: number;
+          objective?: string;
+        };
+      }
+      | undefined;
     const bypassEvent = lifecycleEvents.find(
       (event) => event.type === "subagents.policy_bypassed",
     ) as
@@ -2618,16 +2750,22 @@ describe("createSessionToolHandler", () => {
           unsafeBenchmarkMode?: boolean;
           matchedRule?: string;
           decisionThreshold?: number;
+          objective?: string;
         };
       }
       | undefined;
 
     expect(parsed.success).toBe(true);
     expect(parsed.status).toBe("completed");
+    expect(plannedEvent?.payload).toMatchObject({
+      decisionThreshold: 0.2,
+      objective: "Scaffold the workspace and validate npm install",
+    });
     expect(bypassEvent?.payload).toMatchObject({
       unsafeBenchmarkMode: true,
       matchedRule: "unsafe_benchmark_bypass",
       decisionThreshold: 0.2,
+      objective: "Scaffold the workspace and validate npm install",
     });
   });
 
@@ -2677,7 +2815,7 @@ describe("createSessionToolHandler", () => {
     expect(subAgentManager.spawn).not.toHaveBeenCalled();
   });
 
-  it("recovers execute_with_agent child tools to desktop-safe semantic fallback tools", async () => {
+  it("keeps execute_with_agent explicit child tools exact instead of widening them", async () => {
     const subAgentManager = {
       spawn: vi.fn(async () => "subagent:spawned"),
       getResult: vi
@@ -2733,17 +2871,19 @@ describe("createSessionToolHandler", () => {
       inputContract: "JSON output with created files",
       tools: ["system.bash", "system.writeFile"],
     });
-    const parsed = JSON.parse(result) as { success?: boolean };
+    const parsed = JSON.parse(result) as {
+      success?: boolean;
+      error?: string;
+      removedByPolicy?: string[];
+    };
 
-    expect(parsed.success).toBe(true);
-    expect(subAgentManager.spawn).toHaveBeenCalledWith(
-      expect.objectContaining({
-        tools: [
-          "desktop.bash",
-          "desktop.text_editor",
-        ],
-      }),
-    );
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toContain("No permitted child tools remain");
+    expect(parsed.removedByPolicy).toEqual([
+      "system.bash",
+      "system.writeFile",
+    ]);
+    expect(subAgentManager.spawn).not.toHaveBeenCalled();
   });
 
   it("keeps the explicit execute_with_agent delegation spec while promoting an objective-rich child prompt", async () => {

--- a/runtime/src/gateway/tool-handler-factory.ts
+++ b/runtime/src/gateway/tool-handler-factory.ts
@@ -43,10 +43,12 @@ const TOOL_NAME_ALIASES: Readonly<Record<string, string>> = {
 };
 const TOOL_DEFAULT_CWD_NAMES = new Set([
   "system.bash",
+  "desktop.bash",
   "system.processStart",
   "system.serverStart",
 ]);
 const TOOL_PATH_ARG_KEYS: Readonly<Record<string, readonly string[]>> = {
+  "desktop.text_editor": ["path"],
   "system.readFile": ["path"],
   "system.writeFile": ["path"],
   "system.appendFile": ["path"],
@@ -751,6 +753,10 @@ function extractDirectCommandPathArgs(
   }
 }
 
+function isAllowedOutOfRootShellSinkPath(candidatePath: string): boolean {
+  return candidatePath === "/dev/null";
+}
+
 function validateScopedFilesystemRoot(
   toolName: string,
   args: Record<string, unknown>,
@@ -802,6 +808,9 @@ function validateScopedFilesystemRoot(
   ) {
     for (const arg of extractDirectCommandPathArgs(args.command, args.args)) {
       const candidatePath = normalizeScopedPathCandidate(arg);
+      if (isAllowedOutOfRootShellSinkPath(candidatePath)) {
+        continue;
+      }
       if (!isWithinRoot(normalizedRoot, candidatePath)) {
         return buildScopedRootViolationMessage(
           "command arguments reference a path outside the delegated workspace root",
@@ -818,6 +827,9 @@ function validateScopedFilesystemRoot(
   ) {
     for (const pathValue of extractAbsoluteShellPaths(args.command)) {
       const candidatePath = normalizeScopedPathCandidate(pathValue);
+      if (isAllowedOutOfRootShellSinkPath(candidatePath)) {
+        continue;
+      }
       if (!isWithinRoot(normalizedRoot, candidatePath)) {
         return buildScopedRootViolationMessage(
           "shell mode command references a path outside the delegated workspace root",
@@ -980,6 +992,16 @@ function buildApprovalMessage(params: {
     `Sub-agent session: ${sessionId}\n` +
     `Delegated task: ${taskPreview}`
   );
+}
+
+function extractDelegationObjective(
+  args: Record<string, unknown>,
+): string | undefined {
+  const task =
+    typeof args.task === "string"
+      ? args.task.trim()
+      : "";
+  return task || undefined;
 }
 
 function sendImmediateToolError(params: {
@@ -1354,6 +1376,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     }
 
     const toolCallId = nextToolCallId();
+    const delegationObjective = extractDelegationObjective(normalizedArgs);
 
     if (
       lifecycleEmitter &&
@@ -1368,6 +1391,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
         toolName: name,
         payload: {
           decisionThreshold: policyEngine.snapshot().spawnDecisionThreshold,
+          ...(delegationObjective ? { objective: delegationObjective } : {}),
         },
       });
     }
@@ -1397,6 +1421,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
             matchedRule: decision.matchedRule,
             decisionThreshold: decision.threshold,
             isSubAgentSession,
+            ...(delegationObjective ? { objective: delegationObjective } : {}),
           },
         });
       }
@@ -1562,6 +1587,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
     }
     const durationMs = Date.now() - start;
     result = canonicalizeToolFailureResult(toolName, result);
+    const isError = didToolCallFail(false, result);
 
     if (launchKey && shouldMarkGuiLaunchSeen(result)) {
       seenGuiLaunches.add(launchKey);
@@ -1574,6 +1600,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
         toolName,
         result,
         durationMs,
+        isError,
         toolCallId,
         ...(isSubAgentSession ? { subagentSessionId: sessionId } : {}),
       },
@@ -1589,6 +1616,7 @@ export function createSessionToolHandler(config: SessionToolHandlerConfig): Tool
         payload: {
           result,
           durationMs,
+          isError,
           toolCallId,
           verifyRequested: verifier?.shouldVerifySubAgentResult() ?? false,
         },

--- a/runtime/src/llm/chat-executor-recovery.ts
+++ b/runtime/src/llm/chat-executor-recovery.ts
@@ -20,6 +20,7 @@ import type {
   DelegationTrajectoryFinalReward,
   DelegationTrajectoryRecord,
 } from "./delegation-learning.js";
+import { createLLMStatefulFallbackReasonCounts } from "./types.js";
 import { SHELL_BUILTIN_COMMANDS } from "./chat-executor-constants.js";
 import {
   didToolCallFail,
@@ -371,6 +372,23 @@ function isDuplicateExportFailure(failureText: string): boolean {
   return extractDuplicateExportName(failureText) !== undefined || /ts2308/i.test(failureText);
 }
 
+function isJsonEscapedSourceLiteralFailure(failureText: string): boolean {
+  const lower = failureText.toLowerCase();
+  const hasCompilerStylePath =
+    /(?:^|\s|["'`])[^"'`\s]+\.(?:rs|c|cc|cpp|h|hpp|ts|tsx|js|jsx|py):\d+/i.test(
+      failureText,
+    );
+  const hasEscapeTokenSignal =
+    lower.includes("unknown start of token: \\") ||
+    lower.includes("unknown character escape") ||
+    lower.includes("unterminated double quote string");
+  const hasEscapedLiteralSignal =
+    failureText.includes('\\"') ||
+    failureText.includes("\\n") ||
+    failureText.includes("\\t");
+  return hasCompilerStylePath && hasEscapeTokenSignal && hasEscapedLiteralSignal;
+}
+
 function isPackagePathNotExportedFailure(failureTextLower: string): boolean {
   return (
     failureTextLower.includes("err_package_path_not_exported") ||
@@ -400,6 +418,65 @@ function hasExtendedGrepPatternWithoutFlag(
   });
 }
 
+function collectDirectGrepOperands(
+  args: Record<string, unknown> | undefined,
+): string[] {
+  const rawArgs = Array.isArray(args?.args)
+    ? args.args.filter((value): value is string => typeof value === "string")
+    : [];
+  const operands: string[] = [];
+  const flagsWithSeparateValue = new Set([
+    "-A",
+    "-B",
+    "-C",
+    "-D",
+    "-d",
+    "-e",
+    "-f",
+    "-m",
+    "--after-context",
+    "--before-context",
+    "--binary-files",
+    "--color",
+    "--colour",
+    "--context",
+    "--devices",
+    "--directories",
+    "--exclude",
+    "--exclude-dir",
+    "--file",
+    "--include",
+    "--label",
+    "--max-count",
+    "--regexp",
+  ]);
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const value = rawArgs[index];
+    if (!value || value === "--") continue;
+    if (flagsWithSeparateValue.has(value)) {
+      index += 1;
+      continue;
+    }
+    if (value.startsWith("--include=") || value.startsWith("--exclude=")) {
+      continue;
+    }
+    if (value.startsWith("--exclude-dir=")) {
+      continue;
+    }
+    if (value.startsWith("-")) {
+      continue;
+    }
+    operands.push(value);
+  }
+  return operands;
+}
+
+function hasGrepPatternWithoutSearchScope(
+  args: Record<string, unknown> | undefined,
+): boolean {
+  return collectDirectGrepOperands(args).length <= 1;
+}
+
 function isLikelyGrepOperandShapeFailure(
   call: ToolCallRecord,
   failureTextLower: string,
@@ -408,7 +485,8 @@ function isLikelyGrepOperandShapeFailure(
   const command = String(call.args?.command ?? "");
   if (commandBasename(command) !== "grep") return false;
   if (failureTextLower.includes("no such file or directory")) return true;
-  return hasExtendedGrepPatternWithoutFlag(call.args);
+  if (hasExtendedGrepPatternWithoutFlag(call.args)) return true;
+  return hasGrepPatternWithoutSearchScope(call.args);
 }
 
 function isLikelyLiteralGlobFailure(
@@ -475,12 +553,8 @@ export function summarizeStateful(
     );
   if (entries.length === 0) return undefined;
 
-  const fallbackReasons: Record<LLMStatefulFallbackReason, number> = {
-    missing_previous_response_id: 0,
-    provider_retrieval_failure: 0,
-    state_reconciliation_mismatch: 0,
-    unsupported: 0,
-  };
+  const fallbackReasons: Record<LLMStatefulFallbackReason, number> =
+    createLLMStatefulFallbackReasonCounts();
   let attemptedCalls = 0;
   let continuedCalls = 0;
   let fallbackCalls = 0;
@@ -853,6 +927,16 @@ export function inferRecoveryHint(
           "After editing the module, rerun the failing build/test command and only continue once it passes.",
       };
     }
+    if (isJsonEscapedSourceLiteralFailure(failureText)) {
+      return {
+        key: "system-bash-json-escaped-source-literal",
+        message:
+          "The compiler output suggests JSON escape sequences like `\\\\\"` or `\\\\n` were written into source code. " +
+          "Re-read the failing source file, replace the escaped string-literal text with raw source code, " +
+          "and when using write/edit tools pass the file contents directly instead of a JSON-encoded representation. " +
+          "Only rerun the compile/test command after the source file itself is fixed.",
+      };
+    }
     if (isPackagePathNotExportedFailure(failureTextLower)) {
       return {
         key: usesCommonJsRequireSnippet(call)
@@ -879,7 +963,8 @@ export function inferRecoveryHint(
         key: "system-bash-grep-shape",
         message:
           "For code/text search, prefer `rg PATTERN PATH`. If you use `grep` in direct mode, pass exactly one pattern followed by file paths, " +
-          "and add `-E` (or use shell mode) when the pattern uses alternation like `foo|bar`. Extra non-flag args after the pattern are treated as file paths.",
+          "and add `-E` (or use shell mode) when the pattern uses alternation like `foo|bar`. Direct-mode `grep` with only a pattern reads stdin instead of searching files, " +
+          "so pair `--include` with `-r` and a directory path (for example `grep -r -E --include='*.cpp' 'foo|bar' src include`) or just use `rg PATTERN src include`.",
       };
     }
     if (isDesktopBiasedSystemCommandFailure(command, failureTextLower)) {

--- a/runtime/src/llm/chat-executor.test.ts
+++ b/runtime/src/llm/chat-executor.test.ts
@@ -1049,6 +1049,155 @@ describe("ChatExecutor", () => {
       expect(result.toolCalls).toEqual([]);
     });
 
+    it("retries plan-only execution responses before accepting a coding turn", async () => {
+      const events: Record<string, unknown>[] = [];
+      const toolHandler = vi.fn().mockResolvedValue("wrote file");
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "**Plan**\n1. Create `main.c`\n2. Compile with gcc\n3. Run the binary\n\nStarting execution.",
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-1",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/tmp/tui-smoke/main.c",
+                    content: "int main(void) { return 0; }\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "Created `main.c` and continued execution with tools.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: ["system.writeFile", "system.bash"],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "In /tmp/tui-smoke only, create main.c, compile it with gcc, run it, and verify the output.",
+          ),
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toContain("continued execution");
+      expect(toolHandler).toHaveBeenCalledWith("system.writeFile", {
+        path: "/tmp/tui-smoke/main.c",
+        content: "int main(void) { return 0; }\n",
+      });
+      expect(provider.chat).toHaveBeenCalledTimes(3);
+      expect(
+        (provider.chat as ReturnType<typeof vi.fn>).mock.calls[1]?.[1]?.toolChoice,
+      ).toBe("required");
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "initial",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "retry",
+            }),
+          }),
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "accept",
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it("fails coding turns that return only plans after the retry", async () => {
+      const events: Record<string, unknown>[] = [];
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "**Plan**\n1. Create `main.c`\n2. Compile with gcc\n3. Run the binary\n\nStarting execution.",
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "**Plan**\n1. Write the code\n2. Compile it\n3. Verify it\n\nStarting execution.",
+            }),
+          ),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn(),
+        allowedTools: ["system.writeFile", "system.bash"],
+      });
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "In /tmp/tui-smoke only, create main.c, compile it with gcc, run it, and verify the output.",
+          ),
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(2);
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.stopReasonDetail).toContain("plan without grounded tool work");
+      expect(result.content).toContain("plan without grounded tool work");
+      expect(result.toolCalls).toEqual([]);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "initial",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "retry",
+            }),
+          }),
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "initial",
+            payload: expect.objectContaining({
+              gate: "plan_only_execution",
+              decision: "fail",
+            }),
+          }),
+        ]),
+      );
+    });
+
     it("uses a toolless correction retry when delegated evidence exists but the result contract is malformed", async () => {
       const provider = createMockProvider("primary", {
         chat: vi
@@ -1200,6 +1349,7 @@ describe("ChatExecutor", () => {
       );
 
       expect(result.stopReason).toBe("validation_error");
+      expect(result.validationCode).toBe("contradictory_completion_claim");
       expect(result.stopReasonDetail).toContain(
         "claimed completion while still reporting unresolved work",
       );
@@ -1218,6 +1368,140 @@ describe("ChatExecutor", () => {
         "system.writeFile",
         "system.bash",
       ]);
+    });
+
+    it("fails delegated corrections that still answer blocked after a contradictory completion retry", async () => {
+      const events: Record<string, unknown>[] = [];
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-write-initial",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/workspace/space-colony/src/simulation.ts",
+                    content:
+                      "export function generateAsteroidSurface() {\n" +
+                      "  // placeholder stub\n" +
+                      "  return [];\n" +
+                      "}\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "**implement_core_drones complete** Updated `src/simulation.ts`. " +
+                "Note: `src/simulation.ts` still contains placeholder stub lines " +
+                "that need follow-up cleanup before the phase is really complete.",
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "tc-write-fixed",
+                  name: "system.writeFile",
+                  arguments: safeJson({
+                    path: "/workspace/space-colony/src/simulation.ts",
+                    content:
+                      "export function generateAsteroidSurface() {\n" +
+                      "  return [];\n" +
+                      "}\n",
+                  }),
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "**Blocked** The placeholder is fixed, but the prior validation error still says this phase is blocked.",
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content:
+                "**implement_core_drones complete** Updated `src/simulation.ts` and removed the placeholder stub.",
+            }),
+          ),
+      });
+      const toolHandler = vi.fn().mockImplementation(
+        async (name: string, args: Record<string, unknown>) => {
+          if (name === "system.writeFile") {
+            return safeJson({
+              path: args.path,
+              bytesWritten: String(args.content ?? "").length,
+            });
+          }
+          throw new Error(`Unexpected tool: ${name}`);
+        },
+      );
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        allowedTools: ["system.writeFile", "system.readFile"],
+      });
+      const result = await executor.execute(
+        createParams({
+          requiredToolEvidence: {
+            maxCorrectionAttempts: 1,
+            delegationSpec: {
+              task: "assess_core_drones",
+              objective:
+                "Inspect src/simulation.ts and confirm whether the placeholder stub is gone",
+              inputContract: "src/simulation.ts exists",
+              acceptanceCriteria: [
+                "Report whether src/simulation.ts still contains placeholder comments",
+              ],
+            },
+          },
+          toolRouting: {
+            routedToolNames: ["system.writeFile", "system.readFile"],
+            expandedToolNames: ["system.writeFile", "system.readFile"],
+          },
+          trace: {
+            onExecutionTraceEvent: (event) => {
+              events.push(event as unknown as Record<string, unknown>);
+            },
+          },
+        }),
+      );
+
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.validationCode).toBeDefined();
+      expect(toolHandler).not.toHaveBeenCalled();
+      expect(provider.chat).toHaveBeenCalledTimes(4);
+      expect(events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              decision: "retry",
+              validationCode: "contradictory_completion_claim",
+            }),
+          }),
+          expect.objectContaining({
+            type: "completion_gate_checked",
+            phase: "tool_followup",
+            payload: expect.objectContaining({
+              decision: "fail",
+              validationCode: "blocked_phase_output",
+            }),
+          }),
+        ]),
+      );
     });
 
     it("fails when delegated browser research only uses low-signal about:blank tab checks", async () => {
@@ -1278,6 +1562,7 @@ describe("ChatExecutor", () => {
       );
 
       expect(result.stopReason).toBe("validation_error");
+      expect(result.validationCode).toBe("low_signal_browser_evidence");
       expect(result.stopReasonDetail).toContain("browser-grounded evidence");
       expect(result.toolCalls).toHaveLength(1);
       expect(
@@ -1535,7 +1820,6 @@ describe("ChatExecutor", () => {
       expect(firstOptions?.toolRouting?.allowedToolNames).toEqual([
         "system.readFile",
         "system.writeFile",
-        "system.bash",
       ]);
       expect(secondOptions?.toolRouting?.allowedToolNames).toEqual([
         "system.bash",
@@ -2604,30 +2888,39 @@ describe("ChatExecutor", () => {
       expect(result.toolCalls).toHaveLength(2);
     });
 
-    it("per-call maxModelRecalls overrides constructor default", async () => {
+    it("per-call maxModelRecalls=0 removes the recall cap", async () => {
       const toolHandler = vi.fn().mockResolvedValue("ok");
       const provider = createMockProvider("primary", {
-        chat: vi.fn().mockResolvedValue(
-          mockResponse({
-            content: "looping",
-            finishReason: "tool_calls",
-            toolCalls: [{ id: "tc-1", name: "tool", arguments: "{}" }],
-          }),
-        ),
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "looping",
+              finishReason: "tool_calls",
+              toolCalls: [{ id: "tc-1", name: "tool", arguments: "{}" }],
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "done",
+              finishReason: "stop",
+            }),
+          ),
       });
 
       const executor = new ChatExecutor({
         providers: [provider],
         toolHandler,
-        maxModelRecallsPerRequest: 3,
+        maxModelRecallsPerRequest: 1,
       });
       const result = await executor.execute(
         createParams({ maxModelRecallsPerRequest: 0 }),
       );
 
-      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(provider.chat).toHaveBeenCalledTimes(2);
       expect(result.toolCalls).toHaveLength(1);
-      expect(result.stopReason).toBe("budget_exceeded");
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toBe("done");
     });
 
     it("per-call toolBudgetPerRequest overrides constructor default", async () => {
@@ -4095,7 +4388,51 @@ describe("ChatExecutor", () => {
       );
       expect(injectedHint).toBeDefined();
       expect(String(injectedHint?.content)).toContain("add `-E`");
-      expect(String(injectedHint?.content)).toContain("treated as file paths");
+      expect(String(injectedHint?.content)).toContain("reads stdin instead of searching files");
+    });
+
+    it("injects a recovery hint after grep is given a pattern but no search path", async () => {
+      const toolHandler = vi.fn().mockResolvedValue(
+        '{"exitCode":1,"stdout":"","stderr":"","timedOut":false}',
+      );
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "system.bash",
+                  arguments:
+                    '{"command":"grep","args":["-E","enemy|combat|attack","--include=*.{h,cpp}"]}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("Direct-mode `grep` with only a pattern reads stdin"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("pair `--include` with `-r`");
+      expect(String(injectedHint?.content)).toContain("`rg PATTERN src include`");
     });
 
     it("injects a recovery hint when npm run targets a missing script", async () => {
@@ -4327,6 +4664,50 @@ describe("ChatExecutor", () => {
       expect(injectedHint).toBeDefined();
       expect(String(injectedHint?.content)).toContain("export { Scheduler }");
       expect(String(injectedHint?.content)).toContain("rerun the failing build/test");
+    });
+
+    it("injects a recovery hint for JSON-escaped source content written into a compiler target", async () => {
+      const toolHandler = vi.fn().mockResolvedValue(
+        '{"exitCode":101,"stdout":"","stderr":"error: unknown start of token: \\\\\\n --> gridforge-core/src/lib.rs:48:15\\n  |\\n48 |     let map = \\\\\\"S#G\\\\\\";\\n  |               ^\\n\\nerror[E0765]: unterminated double quote string\\n --> gridforge-core/src/lib.rs:48:16\\n  |\\n48 |     let map = \\\\\\"S#G\\\\\\";\\n  |                ^^^^^^^^^\\n\\nerror: could not compile `gridforge-core` due to 2 previous errors"}',
+      );
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "",
+              finishReason: "tool_calls",
+              toolCalls: [
+                {
+                  id: "call-1",
+                  name: "system.bash",
+                  arguments:
+                    '{"command":"cargo","args":["test","--workspace","--quiet"]}',
+                },
+              ],
+            }),
+          )
+          .mockResolvedValueOnce(mockResponse({ content: "recovered" })),
+      });
+
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler,
+        maxToolRounds: 4,
+      });
+      await executor.execute(createParams());
+
+      const secondCallMessages = (provider.chat as ReturnType<typeof vi.fn>)
+        .mock.calls[1][0] as LLMMessage[];
+      const injectedHint = secondCallMessages.find(
+        (msg) =>
+          msg.role === "system" &&
+          typeof msg.content === "string" &&
+          msg.content.includes("JSON escape sequences"),
+      );
+      expect(injectedHint).toBeDefined();
+      expect(String(injectedHint?.content)).toContain("raw source code");
+      expect(String(injectedHint?.content)).toContain("JSON-encoded representation");
     });
 
     it("replaces stale recovery hints with the latest timeout hint and traces the active keys", async () => {
@@ -6669,6 +7050,7 @@ describe("ChatExecutor", () => {
         toolHandler: vi.fn().mockResolvedValue("unused"),
         plannerEnabled: true,
         pipelineExecutor: pipelineExecutor as any,
+        maxModelRecallsPerRequest: 1,
         delegationDecision: {
           enabled: true,
           scoreThreshold: 0,
@@ -9670,6 +10052,100 @@ describe("ChatExecutor", () => {
       ]);
     });
 
+    it("falls back to a deterministic summary when planner synthesis times out after a completed pipeline", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: safeJson({
+                reason: "delegated_investigation",
+                requiresSynthesis: true,
+                steps: [
+                  {
+                    name: "prep",
+                    step_type: "deterministic_tool",
+                    tool: "system.bash",
+                    args: { command: "pwd" },
+                  },
+                  {
+                    name: "delegate_logs",
+                    step_type: "subagent_task",
+                    objective: "Inspect flaky test logs",
+                    input_contract: "Return a JSON object with findings",
+                    acceptance_criteria: ["Include grounded log findings"],
+                    required_tool_capabilities: ["system.readFile"],
+                    context_requirements: ["ci_logs"],
+                    max_budget_hint: "2m",
+                    can_run_parallel: false,
+                    depends_on: ["prep"],
+                  },
+                  {
+                    name: "finalize",
+                    step_type: "synthesis",
+                    objective: "Summarize the findings",
+                    depends_on: ["delegate_logs"],
+                  },
+                ],
+              }),
+            }),
+          )
+          .mockRejectedValue(new LLMTimeoutError("grok", 60_000)),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          context: {
+            results: {
+              prep: '{"exitCode":0,"stdout":"/tmp\\n"}',
+              delegate_logs:
+                '{"status":"completed","output":"Clustered failures around request timeouts."}',
+            },
+          },
+          completedSteps: 2,
+          totalSteps: 2,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "First run setup checks, then delegate deeper research, then synthesize results.",
+          ),
+        }),
+      );
+
+      expect((provider.chat as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(result.stopReason).toBe("completed");
+      expect(result.content).toContain(
+        "Completed the requested workflow, but the final synthesis model call failed.",
+      );
+      expect(result.content).toContain(
+        "delegate_logs [source:delegate_logs]",
+      );
+      expect(result.content).toContain(
+        "planner_synthesis model call failed (timeout)",
+      );
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "planner_synthesis_fallback_applied",
+          }),
+        ]),
+      );
+    });
+
     it("runs bounded verifier rounds for child outputs and retries low-confidence delegation once", async () => {
       const events: Array<Record<string, unknown>> = [];
       const provider = createMockProvider("primary", {
@@ -10281,6 +10757,89 @@ describe("ChatExecutor", () => {
 
       expect(result.stopReason).toBe("timeout");
       expect(result.stopReasonDetail).toContain("planner pipeline execution");
+      expect(provider.chat).toHaveBeenCalledTimes(1);
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses unlimited end-to-end timeout by default", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "completed without end-to-end timeout",
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({
+        providers: [provider],
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage("Reply with a completion."),
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
+      const providerOptions = (provider.chat as ReturnType<typeof vi.fn>).mock
+        .calls[0]?.[1] as LLMChatOptions | undefined;
+      expect(providerOptions?.timeoutMs).toBeUndefined();
+    });
+
+    it("treats requestTimeoutMs=0 as unlimited during planner execution", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: safeJson({
+              reason: "unlimited_timeout_guard",
+              requiresSynthesis: false,
+              steps: [
+                {
+                  name: "run_long_pipeline",
+                  step_type: "deterministic_tool",
+                  tool: "system.readFile",
+                  args: { path: "ci.log" },
+                },
+              ],
+            }),
+          }),
+        ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              setTimeout(() => {
+                resolve({
+                  status: "completed",
+                  context: {
+                    results: {
+                      run_long_pipeline: safeJson({ stdout: "ok" }),
+                    },
+                  },
+                  completedSteps: 1,
+                  totalSteps: 1,
+                });
+              }, 60);
+            }),
+        ),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        requestTimeoutMs: 0,
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Run the deterministic planner pipeline and return the result.",
+          ),
+        }),
+      );
+
+      expect(result.stopReason).toBe("completed");
       expect(provider.chat).toHaveBeenCalledTimes(1);
       expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
     });
@@ -12340,6 +12899,118 @@ describe("ChatExecutor", () => {
       );
     });
 
+    it("rejects planner retries that keep dropping explicit acceptance commands", async () => {
+      const invalidPlan = safeJson({
+        reason: "regexkit_project",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "setup_codebase",
+            step_type: "subagent_task",
+            objective: "Author the regex toolkit source files, tests, and README.",
+            input_contract: "Empty scratch directory.",
+            acceptance_criteria: [
+              "package.json exists and uses ESM",
+              "src contains parser, compiler, matcher, and CLI files",
+            ],
+            required_tool_capabilities: [
+              "system.writeFile",
+              "system.readFile",
+              "system.listDir",
+            ],
+            context_requirements: ["cwd=/tmp/agenc-codegen/regexkit"],
+            max_budget_hint: "6m",
+          },
+          {
+            name: "run_tests",
+            step_type: "deterministic_tool",
+            depends_on: ["setup_codebase"],
+            tool: "system.bash",
+            args: {
+              command: "node",
+              args: ["--test"],
+              cwd: "/tmp/agenc-codegen/regexkit",
+            },
+          },
+          {
+            name: "final_synthesis",
+            step_type: "synthesis",
+            depends_on: ["run_tests"],
+          },
+        ],
+      });
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: invalidPlan,
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: invalidPlan,
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: "direct fallback should not run",
+            }),
+          ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn(),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue("unused"),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Build regexkit in /tmp/agenc-codegen/regexkit.\n" +
+              "Acceptance criteria:\n" +
+              "- `node --test` passes from `/tmp/agenc-codegen/regexkit`.\n" +
+              "- `node src/cli.mjs match 'a(b|c)+d' 'abbd'` reports a match.\n" +
+              "- `node src/cli.mjs grep 'colou?r' fixtures/sample.txt` returns only matching lines.\n" +
+              "- `node src/cli.mjs explain 'ab|cd*'` prints a useful structured explanation.\n",
+          ),
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(2);
+      expect(pipelineExecutor.execute).not.toHaveBeenCalled();
+      expect(result.stopReason).toBe("validation_error");
+      expect(result.content).toContain("Missing acceptance commands");
+      expect(result.plannerSummary?.routeReason).toBe(
+        "planner_verification_requirements_unmet",
+      );
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            category: "validation",
+            code: "planner_verification_requirements_missing",
+            details: expect.objectContaining({
+              missingCommands: expect.stringContaining(
+                "node src/cli.mjs match 'a(b|c)+d' 'abbd'",
+              ),
+            }),
+          }),
+          expect.objectContaining({
+            category: "policy",
+            code: "planner_verification_requirements_retry",
+          }),
+        ]),
+      );
+    });
+
     it("accepts a refined workspace planner plan that keeps scaffolding source-free and package verification bounded", async () => {
       const refinedPlan = safeJson({
         reason: "refined_workspace_project",
@@ -12559,6 +13230,214 @@ describe("ChatExecutor", () => {
             code: "subagent_step_needs_decomposition",
             details: expect.objectContaining({
               stepName: "implement_cli",
+            }),
+          }),
+        ]),
+      );
+    });
+
+    it("grants extra planner retries for repeated decomposition-only scaffold violations", async () => {
+      const invalidPlanOne = safeJson({
+        reason: "workspace_project",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "create_root_directory",
+            step_type: "deterministic_tool",
+            tool: "system.bash",
+            args: {
+              command: "mkdir",
+              args: ["-p", "/tmp/galaxy-factory"],
+            },
+            onError: "abort",
+          },
+          {
+            name: "scaffold_project",
+            step_type: "subagent_task",
+            depends_on: ["create_root_directory"],
+            objective:
+              "Author workspace package.json and tsconfig files, create package src directories, and write starter index.ts entry files for the galaxy factory project.",
+            input_contract: "Empty target directory.",
+            acceptance_criteria: [
+              "Workspace manifests and tsconfig files authored",
+              "package src directories created",
+              "starter index.ts entry files implemented",
+            ],
+            required_tool_capabilities: [
+              "system.writeFile",
+              "system.readFile",
+              "system.bash",
+            ],
+            context_requirements: ["cwd=/tmp/galaxy-factory"],
+            max_budget_hint: "6m",
+          },
+          {
+            name: "final_synthesis",
+            step_type: "synthesis",
+            depends_on: ["scaffold_project"],
+            objective: "Summarize the completed workspace.",
+          },
+        ],
+      });
+      const invalidPlanTwo = safeJson({
+        reason: "workspace_project_refined",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "create_root_directory",
+            step_type: "deterministic_tool",
+            tool: "system.bash",
+            args: {
+              command: "mkdir",
+              args: ["-p", "/tmp/galaxy-factory"],
+            },
+            onError: "abort",
+          },
+          {
+            name: "scaffold_environment",
+            step_type: "subagent_task",
+            depends_on: ["create_root_directory"],
+            objective:
+              "Set up workspace manifests and tsconfigs, create src directories, and implement starter entry files for core and cli packages.",
+            input_contract: "Empty target directory.",
+            acceptance_criteria: [
+              "Workspace manifests and configs exist",
+              "src directories created",
+              "starter entry files implemented",
+            ],
+            required_tool_capabilities: [
+              "system.writeFile",
+              "system.readFile",
+              "system.bash",
+            ],
+            context_requirements: ["cwd=/tmp/galaxy-factory"],
+            max_budget_hint: "6m",
+          },
+          {
+            name: "final_synthesis",
+            step_type: "synthesis",
+            depends_on: ["scaffold_environment"],
+            objective: "Summarize the completed workspace.",
+          },
+        ],
+      });
+      const invalidPlanThree = safeJson({
+        reason: "workspace_project_still_overloaded",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "create_root_directory",
+            step_type: "deterministic_tool",
+            tool: "system.bash",
+            args: {
+              command: "mkdir",
+              args: ["-p", "/tmp/galaxy-factory"],
+            },
+            onError: "abort",
+          },
+          {
+            name: "scaffold_environment",
+            step_type: "subagent_task",
+            depends_on: ["create_root_directory"],
+            objective:
+              "Prepare package manifests and tsconfigs, create source directories, and implement initial entry files for the simulation packages in one pass.",
+            input_contract: "Empty target directory.",
+            acceptance_criteria: [
+              "Workspace manifests authored",
+              "source directories created",
+              "initial entry files complete",
+            ],
+            required_tool_capabilities: [
+              "system.writeFile",
+              "system.readFile",
+              "system.bash",
+            ],
+            context_requirements: ["cwd=/tmp/galaxy-factory"],
+            max_budget_hint: "6m",
+          },
+          {
+            name: "final_synthesis",
+            step_type: "synthesis",
+            depends_on: ["scaffold_environment"],
+            objective: "Summarize the completed workspace.",
+          },
+        ],
+      });
+      const validPlan = safeJson({
+        reason: "refined_workspace_project",
+        requiresSynthesis: false,
+        steps: [
+          {
+            name: "inspect_workspace",
+            step_type: "deterministic_tool",
+            tool: "system.listDir",
+            args: { path: "/tmp/galaxy-factory" },
+            onError: "abort",
+          },
+        ],
+      });
+      const provider = createMockProvider("primary", {
+        chat: vi
+          .fn()
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: invalidPlanOne,
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: invalidPlanTwo,
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: invalidPlanThree,
+            }),
+          )
+          .mockResolvedValueOnce(
+            mockResponse({
+              content: validPlan,
+            }),
+          ),
+      });
+      const pipelineExecutor = {
+        execute: vi.fn().mockResolvedValue({
+          status: "completed",
+          context: { results: { inspect_workspace: '{"entries":[]}' } },
+          completedSteps: 1,
+          totalSteps: 1,
+        }),
+      };
+      const executor = new ChatExecutor({
+        providers: [provider],
+        toolHandler: vi.fn().mockResolvedValue('{"entries":[]}'),
+        plannerEnabled: true,
+        pipelineExecutor: pipelineExecutor as any,
+        delegationDecision: {
+          enabled: true,
+          scoreThreshold: 0,
+        },
+      });
+
+      const result = await executor.execute(
+        createParams({
+          message: createMessage(
+            "Build a TypeScript workspace project in /tmp/galaxy-factory with multiple packages and verification.",
+          ),
+        }),
+      );
+
+      expect(provider.chat).toHaveBeenCalledTimes(4);
+      expect(pipelineExecutor.execute).toHaveBeenCalledTimes(1);
+      expect(result.stopReason).toBe("completed");
+      expect(result.plannerSummary?.plannerCalls).toBe(4);
+      expect(result.plannerSummary?.diagnostics).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            category: "policy",
+            code: "planner_refinement_retry",
+            details: expect.objectContaining({
+              decompositionRetry: "true",
             }),
           }),
         ]),
@@ -14471,6 +15350,43 @@ describe("ChatExecutor", () => {
       expect(
         result.statefulSummary?.fallbackReasons.provider_retrieval_failure,
       ).toBe(1);
+    });
+
+    it("tracks store-disabled stateful fallbacks in the result summary", async () => {
+      const provider = createMockProvider("primary", {
+        chat: vi.fn().mockResolvedValue(
+          mockResponse({
+            content: "ok",
+            stateful: {
+              enabled: true,
+              attempted: false,
+              continued: false,
+              store: false,
+              fallbackToStateless: true,
+              fallbackReason: "store_disabled",
+              events: [
+                {
+                  type: "stateful_fallback",
+                  reason: "store_disabled",
+                },
+              ],
+            },
+          }),
+        ),
+      });
+      const executor = new ChatExecutor({ providers: [provider] });
+      const message = { ...createMessage("stateful"), sessionId: "stateful-store-disabled" };
+
+      const result = await executor.execute(
+        createParams({
+          message,
+          sessionId: "stateful-store-disabled",
+        }),
+      );
+
+      expect(result.statefulSummary).toBeDefined();
+      expect(result.statefulSummary?.fallbackReasons.store_disabled).toBe(1);
+      expect(result.statefulSummary?.attemptedCalls).toBe(0);
     });
   });
 });

--- a/runtime/src/llm/grok/adapter.test.ts
+++ b/runtime/src/llm/grok/adapter.test.ts
@@ -1441,6 +1441,60 @@ describe("GrokProvider", () => {
     expect(second.stateful?.responseId).toBe("resp_2");
   });
 
+  it("defaults stateful Responses requests to store=false and replays locally", async () => {
+    mockCreate
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_default_store_1",
+          output_text: "Hello",
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeCompletion({
+          id: "resp_default_store_2",
+          output_text: "Follow-up",
+        }),
+      );
+
+    const provider = new GrokProvider({
+      apiKey: "test-key",
+      statefulResponses: {
+        enabled: true,
+        fallbackToStateless: true,
+      },
+    });
+
+    await provider.chat(
+      [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "hello" },
+      ],
+      { stateful: { sessionId: "sess-default-store" } },
+    );
+    const second = await provider.chat(
+      [
+        { role: "system", content: "You are helpful." },
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "Hello" },
+        { role: "user", content: "follow up" },
+      ],
+      { stateful: { sessionId: "sess-default-store" } },
+    );
+
+    const firstParams = mockCreate.mock.calls[0][0];
+    const secondParams = mockCreate.mock.calls[1][0];
+    expect(firstParams.store).toBe(false);
+    expect(secondParams.store).toBe(false);
+    expect(secondParams.previous_response_id).toBeUndefined();
+    expect(second.stateful?.attempted).toBe(false);
+    expect(second.stateful?.continued).toBe(false);
+    expect(second.stateful?.fallbackReason).toBe("store_disabled");
+    expect(
+      second.stateful?.events?.some((event) => event.reason === "store_disabled"),
+    ).toBe(true);
+    expect(second.stateful?.responseId).toBe("resp_default_store_2");
+  });
+
   it("does not persist previous_response_id anchors for empty assistant turns", async () => {
     mockCreate
       .mockResolvedValueOnce(

--- a/runtime/src/llm/grok/adapter.ts
+++ b/runtime/src/llm/grok/adapter.ts
@@ -1144,6 +1144,7 @@ export class GrokProvider implements LLMProvider {
         : undefined
     );
     const forceStateless = overrides?.forceStateless === true;
+    const providerContinuationEnabled = this.statefulConfig.store === true;
     let attempted = false;
     let continued = false;
     let previousResponseId: string | undefined;
@@ -1153,7 +1154,14 @@ export class GrokProvider implements LLMProvider {
     const historyCompacted = options?.stateful?.historyCompacted === true;
     let compactedHistoryTrusted = false;
 
-    if (!forceStateless && anchor?.responseId) {
+    if (!forceStateless && continuationTurn && !providerContinuationEnabled) {
+      fallbackReason = "store_disabled";
+      appendStatefulEvent(events, "stateful_fallback", {
+        reason: "store_disabled",
+        detail:
+          "provider continuation disabled because store=false; replaying local history instead",
+      });
+    } else if (!forceStateless && anchor?.responseId) {
       attempted = true;
       previousResponseId = anchor.responseId;
       appendStatefulEvent(events, "stateful_continuation_attempt", {

--- a/runtime/src/llm/provider-capabilities.test.ts
+++ b/runtime/src/llm/provider-capabilities.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveLLMStatefulResponsesConfig } from "./provider-capabilities.js";
+
+describe("resolveLLMStatefulResponsesConfig", () => {
+  it("defaults store=false when stateful responses are enabled without an explicit store override", () => {
+    expect(
+      resolveLLMStatefulResponsesConfig({
+        enabled: true,
+        fallbackToStateless: true,
+      }),
+    ).toMatchObject({
+      enabled: true,
+      store: false,
+      fallbackToStateless: true,
+    });
+  });
+
+  it("preserves explicit store=true overrides", () => {
+    expect(
+      resolveLLMStatefulResponsesConfig({
+        enabled: true,
+        store: true,
+      }),
+    ).toMatchObject({
+      enabled: true,
+      store: true,
+    });
+  });
+});

--- a/runtime/src/llm/provider-capabilities.ts
+++ b/runtime/src/llm/provider-capabilities.ts
@@ -36,7 +36,7 @@ export function resolveLLMStatefulResponsesConfig(
   const enabled = config?.enabled === true;
   return {
     enabled,
-    store: config?.store ?? enabled,
+    store: config?.store ?? false,
     fallbackToStateless: config?.fallbackToStateless ?? true,
     reconciliationWindow: Math.min(
       MAX_STATEFUL_RECONCILIATION_WINDOW,

--- a/runtime/src/llm/types.ts
+++ b/runtime/src/llm/types.ts
@@ -114,11 +114,25 @@ export interface LLMRequestMetrics {
 /**
  * Stateful response fallback reasons when continuation cannot be used.
  */
+export const LLM_STATEFUL_FALLBACK_REASONS = [
+  "missing_previous_response_id",
+  "store_disabled",
+  "provider_retrieval_failure",
+  "state_reconciliation_mismatch",
+  "unsupported",
+] as const;
+
 export type LLMStatefulFallbackReason =
-  | "missing_previous_response_id"
-  | "provider_retrieval_failure"
-  | "state_reconciliation_mismatch"
-  | "unsupported";
+  (typeof LLM_STATEFUL_FALLBACK_REASONS)[number];
+
+export function createLLMStatefulFallbackReasonCounts(): Record<
+  LLMStatefulFallbackReason,
+  number
+> {
+  return Object.fromEntries(
+    LLM_STATEFUL_FALLBACK_REASONS.map((reason) => [reason, 0]),
+  ) as Record<LLMStatefulFallbackReason, number>;
+}
 
 /**
  * Structured stateful event types for trace logging/diagnostics.


### PR DESCRIPTION
# Summary
Harden the runtime paths exercised by live delegated code-generation probes so Grok stateful follow-ups, subagent lifecycle events, and tool-result diagnostics stay consistent under real isolated daemon runs.

# Changes
- gate Grok `previous_response_id` continuation behind `store: true` and emit `store_disabled` fallback diagnostics for local-replay mode
- surface `isError` on tool lifecycle results and tighten subagent retry/completion/failure event semantics
- centralize stateful fallback-reason defaults and add targeted regression coverage
- record the isolated daemon probe learnings in `.claude/notes`

# Testing
- [x] `npm --prefix runtime exec vitest run src/gateway/llm-stateful-defaults.test.ts src/llm/provider-capabilities.test.ts src/llm/grok/adapter.test.ts src/gateway/tool-handler-factory.test.ts src/gateway/subagent-orchestrator.test.ts`
- [x] `npm --prefix runtime exec vitest run src/llm/chat-executor.test.ts src/llm/grok/adapter.test.ts src/llm/provider-capabilities.test.ts src/gateway/llm-stateful-defaults.test.ts`
- [x] Live isolated daemon/harness verification against throwaway `/workspace` sandboxes
- [ ] anchor test (N/A)
- [ ] cargo fmt --check (N/A)
- [ ] cargo clippy (N/A)
- [ ] cargo test (N/A)

# Security / Risk
- [x] PDA seeds/constraints reviewed (N/A, runtime-only changes)
- [x] No authority bypass introduced
- [x] Escrow/funds safety considered (N/A, no on-chain fund flow changes)

# Checklist
- [x] Tests added/updated (or N/A)
- [x] Docs updated (if needed)

# Issue link(s)
- None