### PR TITLE
feat(runtime): add agenc init workflow

### DIFF
--- a/runtime/src/cli/agenc.test.ts
+++ b/runtime/src/cli/agenc.test.ts
@@ -127,6 +127,7 @@ describe("agenc launcher CLI", () => {
 
     expect(code).toBe(0);
     expect(stdout.data()).toContain("agenc [console]");
+    expect(stdout.data()).toContain("agenc init");
     expect(stdout.data()).toContain("agenc status");
     expect(runOperatorConsole).not.toHaveBeenCalled();
     expect(runCli).not.toHaveBeenCalled();

--- a/runtime/src/cli/agenc.ts
+++ b/runtime/src/cli/agenc.ts
@@ -49,6 +49,7 @@ function buildHelp(): string {
     "  agenc",
     "  agenc --config ~/.agenc/config.json",
     "  agenc console --yolo",
+    "  agenc init",
     "  agenc status",
     "  agenc start --foreground",
     "  agenc-runtime --help",

--- a/runtime/src/cli/index.ts
+++ b/runtime/src/cli/index.ts
@@ -71,6 +71,7 @@ import {
   runConfigValidateCommand,
   runConfigShowCommand,
 } from "./wizard.js";
+import { runInitCommand } from "./init.js";
 import { runSessionsListCommand, runSessionsKillCommand } from "./sessions.js";
 import { runLogsCommand } from "./logs.js";
 import { getDefaultConfigPath } from "../gateway/config-watcher.js";
@@ -81,6 +82,7 @@ import type {
   DaemonStatusOptions,
   ServiceInstallOptions,
   WizardOptions,
+  InitOptions,
   ConfigValidateOptions,
   ConfigShowOptions,
   SessionsListOptions,
@@ -265,6 +267,7 @@ const SERVICE_COMMAND_OPTIONS = new Set(["macos", "yolo"]);
 const JOBS_COMMAND_OPTIONS = new Set<string>([]);
 
 const CONFIG_INIT_OPTIONS = new Set(["non-interactive", "force"]);
+const INIT_COMMAND_OPTIONS = new Set(["force", "path"]);
 const CONFIG_VALIDATE_OPTIONS = new Set<string>([]);
 const CONFIG_SHOW_OPTIONS = new Set<string>([]);
 const SESSIONS_OPTIONS = new Set(["pid-path", "port"]);
@@ -507,6 +510,7 @@ function buildHelp(): string {
     "health [--help] [options]",
     "doctor [--help] [options]",
     "doctor security [--help] [options]",
+    "init [--help] [options]",
     "config <init|validate|show> [--help] [options]",
     "start [--help] [options]",
     "stop [--help] [options]",
@@ -525,6 +529,7 @@ function buildHelp(): string {
     "  health    Report RPC, store, wallet, and config status",
     "  doctor    Run all health checks and provide remediation guidance",
     "  doctor security  Security posture checks",
+    "  init      Generate an AGENC.md contributor guide for the current repo",
     "",
     "Config commands:",
     "  config init      Generate gateway config and scaffold workspace",
@@ -647,6 +652,10 @@ function buildHelp(): string {
     "      --non-interactive                     Skip interactive prompts (CI-friendly)",
     "      --force                               Overwrite existing config file",
     "",
+    "init options:",
+    "      --force                               Overwrite an existing AGENC.md",
+    "      --path <dir>                          Target project root (default: current working directory)",
+    "",
     "sessions options:",
     "      --pid-path <path>                         Custom PID file path",
     "      --port <port>                             Override control plane port",
@@ -681,6 +690,8 @@ function buildHelp(): string {
     "  agenc-runtime health --deep",
     "  agenc-runtime doctor --deep --fix",
     "  agenc-runtime doctor security --deep --fix",
+    "  agenc-runtime init",
+    "  agenc-runtime init --force",
     "  agenc-runtime replay backfill --to-slot 12345 --page-size 500",
     "  agenc-runtime replay compare --local-trace-path ./trace.json --task-pda AGENTpda",
     "  agenc-runtime replay incident --task-pda AGENTpda --from-slot 100 --to-slot 200",
@@ -1997,6 +2008,27 @@ async function dispatchBootstrapCommands(
       };
 
       return await runOnboardCommand(context, onboardOpts);
+    } catch (error) {
+      return reportCliError(context, error);
+    }
+  }
+
+  if (parsed.positional[0] === "init") {
+    try {
+      validateUnknownStandaloneOptions(parsed.flags, INIT_COMMAND_OPTIONS);
+      if (parsed.positional.length > 1) {
+        throw createCliError(
+          "init does not accept positional arguments; use --path <dir> instead",
+          ERROR_CODES.INVALID_VALUE,
+        );
+      }
+      const { global } = resolveLenientGlobalFlags(parsed);
+      const initOpts: InitOptions = {
+        ...global,
+        force: normalizeCommandFlag(parsed.flags.force),
+        path: parseOptionalString(parsed.flags.path),
+      };
+      return await runInitCommand(context, initOpts);
     } catch (error) {
       return reportCliError(context, error);
     }

--- a/runtime/src/cli/init.test.ts
+++ b/runtime/src/cli/init.test.ts
@@ -1,0 +1,94 @@
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createContextCapture } from "./test-utils.js";
+import { runInitCommand } from "./init.js";
+import type { InitOptions } from "./types.js";
+
+function baseOptions(): InitOptions {
+  return {
+    help: false,
+    outputFormat: "json",
+    strictMode: false,
+    storeType: "sqlite",
+    idempotencyWindow: 900,
+    force: false,
+  };
+}
+
+describe("init CLI command", () => {
+  const workspaces: string[] = [];
+
+  afterEach(() => {
+    for (const workspace of workspaces.splice(0)) {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("creates AGENC.md for the target project root", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "agenc-cli-init-"));
+    workspaces.push(workspace);
+    writeFileSync(
+      join(workspace, "package.json"),
+      JSON.stringify({ scripts: { build: "tsc -b" } }, null, 2),
+      "utf-8",
+    );
+
+    const { context, outputs, errors } = createContextCapture();
+    const code = await runInitCommand(context, {
+      ...baseOptions(),
+      path: workspace,
+    });
+
+    expect(code).toBe(0);
+    expect(errors).toHaveLength(0);
+    expect(existsSync(join(workspace, "AGENC.md"))).toBe(true);
+    expect(outputs[0]).toMatchObject({
+      command: "init",
+      result: "created",
+      projectRoot: workspace,
+    });
+  });
+
+  it("reports skipped when AGENC.md already exists and force is not set", async () => {
+    const workspace = mkdtempSync(join(tmpdir(), "agenc-cli-init-skip-"));
+    workspaces.push(workspace);
+    writeFileSync(join(workspace, "AGENC.md"), "# Existing\n", "utf-8");
+
+    const { context, outputs, errors } = createContextCapture();
+    const code = await runInitCommand(context, {
+      ...baseOptions(),
+      path: workspace,
+    });
+
+    expect(code).toBe(0);
+    expect(errors).toHaveLength(0);
+    expect(outputs[0]).toMatchObject({
+      command: "init",
+      result: "skipped",
+    });
+  });
+
+  it("returns an error when the target path does not exist", async () => {
+    const { context, outputs, errors } = createContextCapture();
+    const missingPath = join(tmpdir(), "agenc-cli-init-missing", "repo");
+    const code = await runInitCommand(context, {
+      ...baseOptions(),
+      path: missingPath,
+    });
+
+    expect(code).toBe(1);
+    expect(outputs).toHaveLength(0);
+    expect(errors[0]).toMatchObject({
+      command: "init",
+      status: "error",
+      projectRoot: missingPath,
+    });
+  });
+});

--- a/runtime/src/cli/init.ts
+++ b/runtime/src/cli/init.ts
@@ -1,0 +1,37 @@
+import { resolve as resolvePath } from "node:path";
+import { writeProjectGuide } from "../project-doc.js";
+import type {
+  CliRuntimeContext,
+  CliStatusCode,
+  InitOptions,
+} from "./types.js";
+
+export async function runInitCommand(
+  context: CliRuntimeContext,
+  options: InitOptions,
+): Promise<CliStatusCode> {
+  const projectRoot = resolvePath(options.path ?? process.cwd());
+
+  try {
+    const result = await writeProjectGuide(projectRoot, {
+      force: options.force,
+    });
+    context.output({
+      status: "ok",
+      command: "init",
+      projectRoot,
+      filePath: result.filePath,
+      result: result.status,
+      force: options.force === true,
+    });
+    return 0;
+  } catch (error) {
+    context.error({
+      status: "error",
+      command: "init",
+      projectRoot,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return 1;
+  }
+}

--- a/runtime/src/cli/types.ts
+++ b/runtime/src/cli/types.ts
@@ -239,6 +239,13 @@ export interface WizardOptions extends BaseCliOptions {
   configPath?: string;
 }
 
+export interface InitOptions extends BaseCliOptions {
+  /** Overwrite an existing AGENC.md file. */
+  force?: boolean;
+  /** Target directory to inspect. Defaults to the current working directory. */
+  path?: string;
+}
+
 export interface ConfigValidateOptions extends BaseCliOptions {
   configPath?: string;
 }

--- a/runtime/src/gateway/commands.test.ts
+++ b/runtime/src/gateway/commands.test.ts
@@ -396,9 +396,9 @@ describe("SlashCommandRegistry", () => {
 });
 
 describe("createDefaultCommands", () => {
-  it("returns 14 default commands", () => {
+  it("returns 15 default commands", () => {
     const commands = createDefaultCommands();
-    expect(commands).toHaveLength(14);
+    expect(commands).toHaveLength(15);
   });
 
   it("includes all expected command names", () => {
@@ -408,6 +408,7 @@ describe("createDefaultCommands", () => {
     expect(names).toContain("help");
     expect(names).toContain("status");
     expect(names).toContain("new");
+    expect(names).toContain("init");
     expect(names).toContain("reset");
     expect(names).toContain("stop");
     expect(names).toContain("start");
@@ -440,7 +441,7 @@ describe("createDefaultCommands", () => {
     for (const cmd of commands) {
       registry.register(cmd);
     }
-    expect(registry.size).toBe(14);
+    expect(registry.size).toBe(15);
   });
 
   it("registry without defaults starts empty", () => {
@@ -493,5 +494,11 @@ describe("createDefaultCommands", () => {
     const helpLine = `/${model.name}${model.args ? ` ${model.args}` : ""} — ${model.description}`;
 
     expect(helpLine).toContain("/model [name]");
+  });
+
+  it("/init has args pattern [--force]", () => {
+    const commands = createDefaultCommands();
+    const init = commands.find((c) => c.name === "init");
+    expect(init!.args).toBe("[--force]");
   });
 });

--- a/runtime/src/gateway/commands.ts
+++ b/runtime/src/gateway/commands.ts
@@ -275,6 +275,17 @@ export function createDefaultCommands(): SlashCommandDef[] {
       },
     },
     {
+      name: "init",
+      description: "Generate an AGENC.md contributor guide",
+      args: "[--force]",
+      global: true,
+      handler: async (ctx) => {
+        await ctx.reply(
+          "Project guide init is not wired in this surface yet.",
+        );
+      },
+    },
+    {
       name: "reset",
       description: "Reset session and clear context",
       global: true,

--- a/runtime/src/gateway/daemon.ts
+++ b/runtime/src/gateway/daemon.ts
@@ -222,6 +222,7 @@ import { formatForChannel } from "./format.js";
 import type { ChannelPlugin } from "./channel.js";
 import type { ProactiveCommunicator } from "./proactive.js";
 import { ToolRouter, type ToolRoutingDecision } from "./tool-routing.js";
+import { writeProjectGuide } from "../project-doc.js";
 import {
   filterLlmToolsByEnvironment,
   filterNamedToolsByEnvironment,
@@ -6303,6 +6304,33 @@ export class DaemonManager {
           progressTracker,
         });
         await ctx.reply("Session reset. Starting fresh conversation.");
+      },
+    });
+    commandRegistry.register({
+      name: "init",
+      description: "Generate an AGENC.md contributor guide",
+      args: "[--force]",
+      global: true,
+      handler: async (ctx) => {
+        const force = ctx.argv.includes("--force");
+        const workspaceRoot =
+          (typeof this._webChatChannel?.loadSessionWorkspaceRoot === "function"
+            ? await this._webChatChannel.loadSessionWorkspaceRoot(ctx.sessionId)
+            : undefined) ??
+          this._hostWorkspacePath ??
+          process.cwd();
+
+        const result = await writeProjectGuide(workspaceRoot, { force });
+        if (result.status === "skipped") {
+          await ctx.reply(
+            `AGENC.md already exists at ${result.filePath}. Use /init --force to overwrite it.`,
+          );
+          return;
+        }
+
+        await ctx.reply(
+          `${result.status === "updated" ? "Updated" : "Created"} AGENC.md at ${result.filePath}.`,
+        );
       },
     });
     commandRegistry.register({

--- a/runtime/src/gateway/subagent-orchestrator.ts
+++ b/runtime/src/gateway/subagent-orchestrator.ts
@@ -2359,11 +2359,12 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
       }
     }
 
-    if (candidates.size === 1) {
+    const dependencyCandidateCount = candidates.size;
+    if (dependencyCandidateCount === 1) {
       return [...candidates.values()][0];
     }
 
-    if (candidates.size === 0) {
+    if (dependencyCandidateCount === 0) {
       for (const plannerStep of plannerSteps) {
         if (plannerStep.stepType !== "subagent_task") continue;
         const candidate = this.normalizeAnchoredDelegatedWorkingDirectory(
@@ -2379,7 +2380,8 @@ export class SubAgentOrchestrator implements DeterministicPipelineExecutor {
           candidates.set(candidate.path, candidate);
         }
       }
-      if (candidates.size === 1) {
+      const globalCandidateCount = candidates.size;
+      if (globalCandidateCount === 1) {
         return [...candidates.values()][0];
       }
     }

--- a/runtime/src/llm/chat-executor-planner.test.ts
+++ b/runtime/src/llm/chat-executor-planner.test.ts
@@ -4,6 +4,7 @@ import {
   assessPlannerDecision,
   buildPipelineFailureRepairRefinementHint,
   buildPlannerMessages,
+  buildPlannerSynthesisFallbackContent,
   buildPlannerVerificationRequirementsFailureMessage,
   buildPlannerVerificationRequirementsRefinementHint,
   extractPlannerVerificationCommandRequirements,
@@ -642,6 +643,46 @@ describe("chat-executor-planner explicit orchestration requirements", () => {
       forcePlanner: true,
       exactResponseLiteral: "A1_R1_DONE",
     });
+  });
+
+  it("renders verifier rounds in planner synthesis fallback content from the summary state", () => {
+    const content = buildPlannerSynthesisFallbackContent(
+      {
+        reason: "delegated_investigation",
+        requiresSynthesis: true,
+        steps: [
+          {
+            name: "delegate_logs",
+            stepType: "subagent_task",
+          },
+        ],
+      } as any,
+      {
+        status: "completed",
+        context: {
+          results: {
+            delegate_logs: JSON.stringify({
+              status: "completed",
+              output: "Collected evidence",
+            }),
+          },
+        },
+        completedSteps: 1,
+        totalSteps: 1,
+      } as any,
+      {
+        overall: "pass",
+        confidence: 0.92,
+        unresolvedItems: [],
+        steps: [],
+        source: "model",
+      },
+      2,
+      "planner_synthesis model call failed (timeout)",
+    );
+
+    expect(content).toContain("Verifier: pass (2 rounds)");
+    expect(content).toContain("delegate_logs [source:delegate_logs]");
   });
 
   it("treats execute_with_agent as the explicit parent tool when child tool usage is nested", () => {

--- a/runtime/src/llm/chat-executor-planner.ts
+++ b/runtime/src/llm/chat-executor-planner.ts
@@ -3986,6 +3986,7 @@ export function buildPlannerSynthesisFallbackContent(
   plannerPlan: PlannerPlan,
   pipelineResult: PipelineResult,
   verificationDecision?: SubagentVerifierDecision,
+  verifierRounds?: number,
   failureDetail?: string,
 ): string {
   const deterministicSteps = plannerPlan.steps
@@ -4026,7 +4027,11 @@ export function buildPlannerSynthesisFallbackContent(
           .join(", ")}`
       : null,
     verificationDecision
-      ? `Verifier: ${verificationDecision.overall} (${verificationDecision.rounds} round${verificationDecision.rounds === 1 ? "" : "s"})`
+      ? (
+          typeof verifierRounds === "number" && verifierRounds > 0
+            ? `Verifier: ${verificationDecision.overall} (${verifierRounds} round${verifierRounds === 1 ? "" : "s"})`
+            : `Verifier: ${verificationDecision.overall}`
+        )
       : null,
     unresolvedItems.length > 0
       ? `Unresolved: ${unresolvedItems.join(", ")}`

--- a/runtime/src/llm/chat-executor.ts
+++ b/runtime/src/llm/chat-executor.ts
@@ -4121,6 +4121,7 @@ export class ChatExecutor {
                 plannerPlan,
                 pipelineResult,
                 verificationDecision,
+                verifierRounds,
                 failureDetail,
               );
             } else {

--- a/runtime/src/project-doc.test.ts
+++ b/runtime/src/project-doc.test.ts
@@ -1,0 +1,144 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  REPOSITORY_GUIDELINES_FILENAME,
+  buildRepositoryGuidelines,
+  inspectRepository,
+  writeProjectGuide,
+} from "./project-doc.js";
+
+describe("project-doc", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length > 0) {
+      rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  function createWorkspace(): string {
+    const dir = mkdtempSync(join(tmpdir(), "agenc-project-doc-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it("inspects common repository signals", async () => {
+    const workspace = createWorkspace();
+    writeFileSync(
+      join(workspace, "package.json"),
+      JSON.stringify(
+        {
+          scripts: {
+            build: "tsup src/index.ts",
+            test: "vitest run",
+            typecheck: "tsc --noEmit",
+          },
+          devDependencies: {
+            typescript: "^5.0.0",
+            vitest: "^4.0.0",
+            eslint: "^9.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    writeFileSync(join(workspace, "package-lock.json"), "{}\n", "utf-8");
+    writeFileSync(join(workspace, "README.md"), "# Demo\n", "utf-8");
+    writeFileSync(join(workspace, "Cargo.toml"), "[package]\nname = \"demo\"\n", "utf-8");
+    writeFileSync(join(workspace, "Makefile"), "build:\n\t@echo ok\n", "utf-8");
+
+    const snapshot = await inspectRepository(workspace, {
+      listRecentCommitSubjects: () => [
+        "feat(runtime): add project init",
+        "fix(cli): tighten path handling",
+      ],
+    });
+
+    expect(snapshot.packageManager).toBe("npm");
+    expect(snapshot.commands.map((entry) => entry.command)).toContain("npm run build");
+    expect(snapshot.commands.map((entry) => entry.command)).toContain("cargo test");
+    expect(snapshot.styleTools).toContain("TypeScript type checking");
+    expect(snapshot.testingFrameworks).toContain("Vitest");
+    expect(snapshot.commitStyle).toBe("conventional");
+  });
+
+  it("builds concise repository guidelines markdown", () => {
+    const content = buildRepositoryGuidelines({
+      rootPath: "/repo",
+      topDirectories: ["runtime/", "sdk/", "tests/"],
+      topFiles: ["package.json", "README.md"],
+      manifests: ["package.json"],
+      packageManager: "npm",
+      languages: ["JavaScript/TypeScript", "Rust"],
+      styleTools: ["ESLint", "rustfmt"],
+      testingFrameworks: ["Vitest", "cargo test"],
+      testLocations: ["tests/", "package-manager test scripts"],
+      commands: [
+        {
+          command: "npm run build",
+          description: "build the project artifacts",
+        },
+        {
+          command: "npm test",
+          description: "run the default automated test suite",
+        },
+      ],
+      commitStyle: "conventional",
+    });
+
+    expect(content).toContain("# Repository Guidelines");
+    expect(content).toContain("## Project Structure & Module Organization");
+    expect(content).toContain("`runtime/`, `sdk/`, `tests/`");
+    expect(content).toContain("`npm run build`");
+    expect(content).toContain("Conventional Commits");
+  });
+
+  it("writes AGENC.md and skips overwrite unless forced", async () => {
+    const workspace = createWorkspace();
+    writeFileSync(
+      join(workspace, "package.json"),
+      JSON.stringify({ scripts: { test: "vitest run" } }, null, 2),
+      "utf-8",
+    );
+
+    const created = await writeProjectGuide(
+      workspace,
+      {},
+      {
+        listRecentCommitSubjects: () => [],
+      },
+    );
+
+    expect(created.status).toBe("created");
+    const targetPath = join(workspace, REPOSITORY_GUIDELINES_FILENAME);
+    expect(readFileSync(targetPath, "utf-8")).toContain("# Repository Guidelines");
+
+    writeFileSync(targetPath, "# Existing\n", "utf-8");
+    const skipped = await writeProjectGuide(workspace, {}, {
+      listRecentCommitSubjects: () => [],
+    });
+    expect(skipped.status).toBe("skipped");
+    expect(readFileSync(targetPath, "utf-8")).toBe("# Existing\n");
+
+    const overwritten = await writeProjectGuide(
+      workspace,
+      {
+        force: true,
+      },
+      {
+        listRecentCommitSubjects: () => [],
+      },
+    );
+    expect(overwritten.status).toBe("updated");
+    expect(readFileSync(targetPath, "utf-8")).toContain("# Repository Guidelines");
+  });
+});

--- a/runtime/src/project-doc.ts
+++ b/runtime/src/project-doc.ts
@@ -1,0 +1,504 @@
+/**
+ * Shared repository-guide generation for Codex-style repo-guide scaffolding.
+ *
+ * AgenC uses a deterministic repository snapshot instead of a live model call,
+ * but the section layout mirrors Codex's `/init` output target: short,
+ * actionable contributor guidance rooted in the current workspace.
+ *
+ * @module
+ */
+
+import { spawnSync } from "node:child_process";
+import { constants } from "node:fs";
+import { access, lstat, readFile, readdir, writeFile } from "node:fs/promises";
+import { join, resolve as resolvePath } from "node:path";
+
+export const REPOSITORY_GUIDELINES_FILENAME = "AGENC.md";
+export const PROJECT_GUIDE_FILE_NAME = REPOSITORY_GUIDELINES_FILENAME;
+
+const TOP_LEVEL_EXCLUDES = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "build",
+  "coverage",
+  "target",
+  ".next",
+  ".turbo",
+  ".cache",
+]);
+const KNOWN_TEST_DIRS = new Set([
+  "test",
+  "tests",
+  "__tests__",
+  "spec",
+  "specs",
+]);
+const COMMAND_SCRIPT_ORDER = [
+  "build",
+  "test",
+  "test:fast",
+  "test:unit",
+  "lint",
+  "typecheck",
+  "check",
+  "dev",
+  "start",
+] as const;
+const KNOWN_MANIFESTS = [
+  "package.json",
+  "pnpm-workspace.yaml",
+  "Cargo.toml",
+  "pyproject.toml",
+  "go.mod",
+  "Makefile",
+  "docker-compose.yml",
+] as const;
+
+type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+type CommitStyle = "conventional" | "generic" | "unknown";
+
+export interface RepositoryCommandHint {
+  readonly command: string;
+  readonly description: string;
+}
+
+export interface RepositorySnapshot {
+  readonly rootPath: string;
+  readonly topDirectories: readonly string[];
+  readonly topFiles: readonly string[];
+  readonly manifests: readonly string[];
+  readonly packageManager?: PackageManager;
+  readonly languages: readonly string[];
+  readonly styleTools: readonly string[];
+  readonly testingFrameworks: readonly string[];
+  readonly testLocations: readonly string[];
+  readonly commands: readonly RepositoryCommandHint[];
+  readonly commitStyle: CommitStyle;
+}
+
+export interface InitRepositoryGuidelinesOptions {
+  readonly rootPath: string;
+  readonly force?: boolean;
+}
+
+export interface InitRepositoryGuidelinesResult {
+  readonly status: "created" | "overwritten" | "skipped";
+  readonly rootPath: string;
+  readonly outputPath: string;
+  readonly content: string;
+  readonly snapshot: RepositorySnapshot;
+}
+
+export type ProjectGuideSnapshot = RepositorySnapshot;
+
+export interface WriteProjectGuideOptions {
+  readonly force?: boolean;
+}
+
+export interface WriteProjectGuideResult {
+  readonly filePath: string;
+  readonly status: "created" | "updated" | "skipped";
+  readonly content: string;
+  readonly snapshot: ProjectGuideSnapshot;
+}
+
+interface InspectRepositoryDeps {
+  readonly listRecentCommitSubjects?: (
+    rootPath: string,
+  ) => readonly string[] | Promise<readonly string[]>;
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return Array.from(new Set(values)).sort((left, right) =>
+    left.localeCompare(right),
+  );
+}
+
+function topLevelNameList(input: readonly string[], max = 6): string[] {
+  return input.slice(0, max);
+}
+
+function formatPathList(input: readonly string[]): string {
+  return input.map((value) => `\`${value}\``).join(", ");
+}
+
+function pathExists(path: string): Promise<boolean> {
+  return access(path, constants.F_OK)
+    .then(() => true)
+    .catch(() => false);
+}
+
+function inferPackageManager(fileNames: readonly string[]): PackageManager | undefined {
+  if (fileNames.includes("pnpm-lock.yaml")) return "pnpm";
+  if (fileNames.includes("yarn.lock")) return "yarn";
+  if (fileNames.includes("bun.lockb") || fileNames.includes("bun.lock")) {
+    return "bun";
+  }
+  if (fileNames.includes("package-lock.json") || fileNames.includes("package.json")) {
+    return "npm";
+  }
+  return undefined;
+}
+
+function formatPackageScriptCommand(
+  scriptName: string,
+  packageManager: PackageManager,
+): string {
+  if (packageManager === "npm") {
+    return scriptName === "test" ? "npm test" : `npm run ${scriptName}`;
+  }
+  if (packageManager === "yarn") {
+    return scriptName === "test" ? "yarn test" : `yarn ${scriptName}`;
+  }
+  if (packageManager === "pnpm") {
+    return scriptName === "test" ? "pnpm test" : `pnpm ${scriptName}`;
+  }
+  return scriptName === "test" ? "bun test" : `bun run ${scriptName}`;
+}
+
+function commandDescription(scriptName: string): string {
+  switch (scriptName) {
+    case "build":
+      return "build the project artifacts";
+    case "test":
+      return "run the default automated test suite";
+    case "test:fast":
+      return "run the fast or smoke-style test suite";
+    case "test:unit":
+      return "run unit-focused tests";
+    case "lint":
+      return "run the configured linter";
+    case "typecheck":
+      return "run static type checking";
+    case "check":
+      return "run aggregate validation checks";
+    case "dev":
+      return "start the local development workflow";
+    case "start":
+      return "run the primary app or service entrypoint";
+    default:
+      return `run the \`${scriptName}\` script`;
+  }
+}
+
+function inferCommitStyle(subjects: readonly string[]): CommitStyle {
+  if (subjects.length === 0) return "unknown";
+  const conventionalCount = subjects.filter((subject) =>
+    /^[a-z]+(?:\([^)]+\))?!?:\s+\S/i.test(subject.trim()),
+  ).length;
+  return conventionalCount / subjects.length >= 0.6 ? "conventional" : "generic";
+}
+
+function readRecentCommitSubjects(rootPath: string): readonly string[] {
+  const result = spawnSync(
+    "git",
+    ["-C", rootPath, "log", "-n", "12", "--format=%s"],
+    {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+  if (result.status !== 0 || typeof result.stdout !== "string") {
+    return [];
+  }
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+function packageRecord(
+  value: unknown,
+): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+async function readPackageJson(rootPath: string): Promise<Record<string, unknown> | null> {
+  const filePath = join(rootPath, "package.json");
+  if (!(await pathExists(filePath))) {
+    return null;
+  }
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+export async function inspectRepository(
+  rootPath: string,
+  deps: InspectRepositoryDeps = {},
+): Promise<RepositorySnapshot> {
+  const resolvedRoot = resolvePath(rootPath);
+  const stats = await lstat(resolvedRoot);
+  if (!stats.isDirectory()) {
+    throw new Error(`init target must be a directory: ${resolvedRoot}`);
+  }
+
+  const entries = await readdir(resolvedRoot, { withFileTypes: true });
+  const visibleEntries = entries
+    .filter((entry) => !TOP_LEVEL_EXCLUDES.has(entry.name))
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const topDirectories = visibleEntries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `${entry.name}/`);
+  const topFiles = visibleEntries
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name);
+  const manifests = KNOWN_MANIFESTS.filter((name) => topFiles.includes(name));
+  const packageManager = inferPackageManager(topFiles);
+
+  const packageJson = await readPackageJson(resolvedRoot);
+  const packageScripts = packageRecord(packageJson?.scripts);
+  const packageDeps = uniqueSorted([
+    ...Object.keys(packageRecord(packageJson?.dependencies)),
+    ...Object.keys(packageRecord(packageJson?.devDependencies)),
+  ]);
+
+  const commands: RepositoryCommandHint[] = [];
+  if (packageManager) {
+    for (const scriptName of COMMAND_SCRIPT_ORDER) {
+      if (packageScripts[scriptName] === undefined) continue;
+      commands.push({
+        command: formatPackageScriptCommand(scriptName, packageManager),
+        description: commandDescription(scriptName),
+      });
+    }
+  }
+  if (manifests.includes("Cargo.toml")) {
+    commands.push(
+      {
+        command: "cargo build",
+        description: "compile Rust crates from the workspace root",
+      },
+      {
+        command: "cargo test",
+        description: "run the Rust test suite",
+      },
+    );
+  }
+  if (manifests.includes("Makefile")) {
+    commands.push({
+      command: "make <target>",
+      description: "run repository-defined make targets when they exist",
+    });
+  }
+
+  const languages = uniqueSorted([
+    ...(packageJson ? ["JavaScript/TypeScript"] : []),
+    ...(manifests.includes("Cargo.toml") ? ["Rust"] : []),
+    ...(manifests.includes("pyproject.toml") ? ["Python"] : []),
+    ...(manifests.includes("go.mod") ? ["Go"] : []),
+  ]);
+
+  const styleTools = uniqueSorted([
+    ...(packageDeps.includes("typescript") ? ["TypeScript type checking"] : []),
+    ...(packageDeps.includes("eslint") ? ["ESLint"] : []),
+    ...(packageDeps.includes("prettier") ? ["Prettier"] : []),
+    ...(packageDeps.includes("biome") ? ["Biome"] : []),
+    ...(manifests.includes("Cargo.toml") ? ["rustfmt", "clippy"] : []),
+  ]);
+
+  const testingFrameworks = uniqueSorted([
+    ...(packageDeps.includes("vitest") ? ["Vitest"] : []),
+    ...(packageDeps.includes("jest") ? ["Jest"] : []),
+    ...(packageDeps.includes("mocha") ? ["Mocha"] : []),
+    ...(packageDeps.includes("playwright") ? ["Playwright"] : []),
+    ...(manifests.includes("Cargo.toml") ? ["cargo test"] : []),
+  ]);
+
+  const testLocations = uniqueSorted([
+    ...topDirectories
+      .filter((directory) =>
+        KNOWN_TEST_DIRS.has(directory.slice(0, -1).toLowerCase()),
+      )
+      .map((directory) => directory),
+    ...(Object.keys(packageScripts).some((name) => name.startsWith("test"))
+      ? ["package-manager test scripts"]
+      : []),
+  ]);
+
+  const commitSubjects = uniqueSorted(
+    await Promise.resolve(
+      deps.listRecentCommitSubjects?.(resolvedRoot) ??
+        readRecentCommitSubjects(resolvedRoot),
+    ),
+  );
+
+  return {
+    rootPath: resolvedRoot,
+    topDirectories,
+    topFiles,
+    manifests,
+    packageManager,
+    languages,
+    styleTools,
+    testingFrameworks,
+    testLocations,
+    commands,
+    commitStyle: inferCommitStyle(commitSubjects),
+  };
+}
+
+export function buildRepositoryGuidelines(snapshot: RepositorySnapshot): string {
+  const lines: string[] = ["# Repository Guidelines", ""];
+
+  lines.push("## Project Structure & Module Organization");
+  if (snapshot.topDirectories.length > 0) {
+    lines.push(
+      `- Top-level directories: ${formatPathList(topLevelNameList(snapshot.topDirectories))}. Add new code in the closest existing feature or package folder instead of creating parallel one-off roots.`,
+    );
+  } else {
+    lines.push(
+      "- Keep source, tests, and docs grouped by feature so contributors can trace a change without hunting across the tree.",
+    );
+  }
+  if (snapshot.manifests.length > 0) {
+    lines.push(
+      `- Root manifests/config to check first: ${formatPathList(snapshot.manifests)}.`,
+    );
+  }
+  if (snapshot.topFiles.length > 0) {
+    lines.push(
+      `- Important root files: ${formatPathList(topLevelNameList(snapshot.topFiles.filter((file) => !snapshot.manifests.includes(file)), 4))}.`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Build, Test, and Development Commands");
+  if (snapshot.commands.length > 0) {
+    for (const hint of snapshot.commands.slice(0, 6)) {
+      lines.push(`- \`${hint.command}\`: ${hint.description}.`);
+    }
+  } else {
+    lines.push(
+      "- Document and prefer the repository's existing build/test entrypoints from the root manifest or task runner before inventing new scripts.",
+    );
+  }
+  lines.push("");
+
+  lines.push("## Coding Style & Naming Conventions");
+  if (snapshot.languages.length > 0) {
+    lines.push(
+      `- Primary languages: ${snapshot.languages.join(", ")}. Match the style of surrounding files and keep edits local to the relevant module.`,
+    );
+  } else {
+    lines.push(
+      "- Follow the formatting and naming patterns already present in touched files; avoid opportunistic style rewrites.",
+    );
+  }
+  if (snapshot.styleTools.length > 0) {
+    lines.push(
+      `- Quality tools detected: ${snapshot.styleTools.join(", ")}. Run the applicable checks before handing work off.`,
+    );
+  }
+  lines.push("");
+
+  lines.push("## Testing Guidelines");
+  if (snapshot.testingFrameworks.length > 0) {
+    lines.push(
+      `- Test frameworks/tooling: ${snapshot.testingFrameworks.join(", ")}.`,
+    );
+  }
+  if (snapshot.testLocations.length > 0) {
+    lines.push(
+      `- Existing test entrypoints/locations: ${snapshot.testLocations.map((value) => `\`${value}\``).join(", ")}.`,
+    );
+  }
+  lines.push(
+    "- Add regression coverage for behavior changes and prefer the narrowest test command that exercises the touched area before running full-suite checks.",
+  );
+  lines.push("");
+
+  lines.push("## Commit & Pull Request Guidelines");
+  if (snapshot.commitStyle === "conventional") {
+    lines.push(
+      "- Use Conventional Commits when writing subjects (for example `feat(scope): summary` or `fix(scope): summary`).",
+    );
+  } else {
+    lines.push(
+      "- Keep commit subjects short, imperative, and consistent with the existing git history for this repository.",
+    );
+  }
+  lines.push(
+    "- Pull requests should describe the user-visible change, list validation performed, and call out config, migration, or rollout risk when applicable.",
+  );
+
+  return lines.join("\n");
+}
+
+export function renderProjectGuide(snapshot: ProjectGuideSnapshot): string {
+  return buildRepositoryGuidelines(snapshot);
+}
+
+export async function initRepositoryGuidelines(
+  options: InitRepositoryGuidelinesOptions,
+  deps: InspectRepositoryDeps = {},
+): Promise<InitRepositoryGuidelinesResult> {
+  const rootPath = resolvePath(options.rootPath);
+  const outputPath = join(rootPath, REPOSITORY_GUIDELINES_FILENAME);
+  const snapshot = await inspectRepository(rootPath, deps);
+  const content = buildRepositoryGuidelines(snapshot);
+  const exists = await pathExists(outputPath);
+
+  if (exists && options.force !== true) {
+    return {
+      status: "skipped",
+      rootPath,
+      outputPath,
+      content,
+      snapshot,
+    };
+  }
+
+  await writeFile(outputPath, content, "utf-8");
+
+  return {
+    status: exists ? "overwritten" : "created",
+    rootPath,
+    outputPath,
+    content,
+    snapshot,
+  };
+}
+
+export async function inspectProjectGuideWorkspace(
+  rootPath: string,
+  deps: InspectRepositoryDeps = {},
+): Promise<ProjectGuideSnapshot> {
+  return inspectRepository(rootPath, deps);
+}
+
+export async function writeProjectGuide(
+  rootPath: string,
+  options: WriteProjectGuideOptions = {},
+  deps: InspectRepositoryDeps = {},
+): Promise<WriteProjectGuideResult> {
+  const result = await initRepositoryGuidelines(
+    {
+      rootPath,
+      force: options.force,
+    },
+    deps,
+  );
+  return {
+    filePath: result.outputPath,
+    status: result.status === "overwritten" ? "updated" : result.status,
+    content: result.content,
+    snapshot: result.snapshot,
+  };
+}

--- a/scripts/agenc-watch-commands.test.mjs
+++ b/scripts/agenc-watch-commands.test.mjs
@@ -28,6 +28,7 @@ function createCommandHarness(overrides = {}) {
       { name: "/help", usage: "/help", description: "show help", aliases: [] },
       { name: "/clear", usage: "/clear", description: "clear console", aliases: [] },
       { name: "/export", usage: "/export", description: "export view", aliases: [] },
+      { name: "/init", usage: "/init", description: "init guide", aliases: [] },
     ],
     parseWatchSlashCommand(value) {
       const trimmed = String(value ?? "").trim();
@@ -40,6 +41,7 @@ function createCommandHarness(overrides = {}) {
           "/help",
           "/clear",
           "/export",
+          "/init",
           "/status",
           "/logs",
           "/new",
@@ -151,4 +153,25 @@ test("command controller serves daemon logs locally for /logs", () => {
 
   assert.ok(calls.some((entry) => entry.type === "logs" && entry.lines === 5));
   assert.ok(calls.some((entry) => entry.type === "event" && entry.kind === "logs"));
+});
+
+test("command controller forwards /init to the daemon chat surface", () => {
+  const { controller, calls } = createCommandHarness();
+
+  assert.equal(controller.dispatchOperatorInput("/init --force"), true);
+
+  assert.ok(
+    calls.some(
+      (entry) =>
+        entry.type === "send" &&
+        entry.frameType === "chat.message" &&
+        entry.payload?.content === "/init --force",
+    ),
+  );
+  assert.ok(
+    calls.some(
+      (entry) =>
+        entry.type === "event" && entry.title === "Project Guide Init",
+    ),
+  );
 });

--- a/scripts/agenc-watch-helpers.test.mjs
+++ b/scripts/agenc-watch-helpers.test.mjs
@@ -79,6 +79,7 @@ test("matchWatchCommands filters by prefix and aliases", () => {
     matchWatchCommands("/se").map((command) => command.name),
     ["/session", "/sessions"],
   );
+  assert.equal(findWatchCommandDefinition("/init")?.name, "/init");
   assert.equal(findWatchCommandDefinition("/commands")?.name, "/help");
   assert.equal(findWatchCommandDefinition("/copy")?.name, "/export");
   assert.equal(findWatchCommandDefinition("/models")?.name, "/model");

--- a/scripts/lib/agenc-watch-commands.mjs
+++ b/scripts/lib/agenc-watch-commands.mjs
@@ -176,6 +176,17 @@ export function createWatchCommandController(dependencies = {}) {
         return true;
       }
 
+      if (canonicalName === "/init") {
+        pushEvent(
+          "operator",
+          "Project Guide Init",
+          "Requested AGENC.md generation for the active workspace.",
+          "teal",
+        );
+        send("chat.message", authPayload({ content: value }));
+        return true;
+      }
+
       if (canonicalName === "/new") {
         resetLiveRunSurface();
         resetDelegationState();

--- a/scripts/lib/agenc-watch-helpers.mjs
+++ b/scripts/lib/agenc-watch-helpers.mjs
@@ -13,6 +13,11 @@ export const WATCH_COMMANDS = Object.freeze([
     description: "Start a fresh chat session.",
   }),
   Object.freeze({
+    name: "/init",
+    usage: "/init [--force]",
+    description: "Generate an AGENC.md contributor guide for this repo.",
+  }),
+  Object.freeze({
     name: "/sessions",
     usage: "/sessions",
     description: "List resumable chat sessions for this operator.",


### PR DESCRIPTION
# Summary
Add a Codex-style init workflow for AgenC that generates `AGENC.md`, expose it through the runtime CLI and watch/TUI slash-command surfaces, and fix the runtime planner typecheck regressions uncovered while landing the feature.

# Changes
- add deterministic repo inspection and `AGENC.md` guide generation in `runtime/src/project-doc.ts`
- add `agenc init` / `agenc-runtime init` support plus focused CLI tests
- add daemon and watch `/init` command support with updated help/registry coverage
- fix planner fallback/verifier typing and the subagent working-directory branch that was blocking `runtime` typecheck
- add regression coverage for the planner fallback verifier summary

# Testing
- [x] `node --test scripts/agenc-watch-helpers.test.mjs scripts/agenc-watch-commands.test.mjs`
- [x] `npm --prefix runtime test -- src/project-doc.test.ts src/cli/init.test.ts src/cli/agenc.test.ts src/gateway/commands.test.ts`
- [x] `npm --prefix runtime test -- src/llm/chat-executor-planner.test.ts`
- [x] `npm --prefix runtime run typecheck`
- [x] anchor test (N/A, no Rust changes)
- [x] cargo fmt --check (N/A, no Rust changes)
- [x] cargo clippy (N/A, no Rust changes)
- [x] cargo test (N/A, no Rust changes)

# Security / Risk
- [x] PDA seeds/constraints reviewed (N/A, no on-chain changes)
- [x] No authority bypass introduced
- [x] Escrow/funds safety considered (N/A, no funds logic changes)

# Checklist
- [x] Tests added/updated (or N/A)
- [x] Docs updated (if needed)

# Issue link(s)
- Fixes #1467