### PR TITLE
docs: add public Project Manager agent overview and index links

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you are working on AgenC as a developer, use this doc set first:
 - [docs/DOCS_INDEX.md](docs/DOCS_INDEX.md) - where the active docs live across the project
 - [docs/REPOSITORY_TOPOLOGY.md](docs/REPOSITORY_TOPOLOGY.md) - ownership and boundary reference
 - [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) - first-run setup for the workspace
+- [docs/PROJECT_MANAGER_AGENT.md](docs/PROJECT_MANAGER_AGENT.md) - PM intake agent (public overview; deploy-specific prompts stay private)
 
 ## Workspace At A Glance
 

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -14,6 +14,7 @@ This file points to the active documentation across the full AgenC project.
 - [PLUGIN_KIT.md](./PLUGIN_KIT.md) - plugin-kit quick reference
 - [VERSION_DOCS_MAP.md](./VERSION_DOCS_MAP.md) - package/doc ownership map
 - [examples/README.md](../examples/README.md) - public example index
+- [PROJECT_MANAGER_AGENT.md](./PROJECT_MANAGER_AGENT.md) - PM intake agent: public overview and deployment notes (no proprietary prompts)
 
 ## `agenc-core` Docs
 

--- a/docs/PROJECT_MANAGER_AGENT.md
+++ b/docs/PROJECT_MANAGER_AGENT.md
@@ -1,0 +1,49 @@
+# Project Manager agent (public overview)
+
+This document describes a **Project Manager (PM) intake** style assistant used with AgenC-aligned teams. It is a behavioral and operational overview only. **Detailed system prompts, scoring weights, and internal routing policies are deliberately not published**; those belong in private deployment configuration.
+
+## Purpose
+
+Help operators turn vague goals into **one clear next action**, lane focus, ownership, and a practical success check—without long lectures or generic planning theater.
+
+## Public capabilities (behavioral)
+
+- Structured intake for execution and weekly-style resets
+- Clarifying questions when the ask is ambiguous
+- Adaptive tone: guided coaching vs. direct “here’s the next step”
+- Support for common work tracks (e.g. content, distribution, learning, repo execution, cross-platform reach)—described at a high level only
+- Meta-question handling (“why would I…”, “what does that mean?”) without resetting the whole flow
+
+## Deployment model (typical)
+
+- Hosted service (e.g. managed platform + HTTPS endpoint)
+- Channel integration such as **X (Twitter) DMs** for message intake and replies
+- **Polling** or webhooks for delivery, depending on API product availability and reliability
+
+Do not commit API keys, tokens, or full prompt text to this repository.
+
+## Configuration surface (public)
+
+Operators configure the service with environment variables, for example:
+
+- Channel/API credentials
+- **Optional:** `PM_SYSTEM_PROMPT` (or equivalent) for proprietary policy text kept **only** in the deployment environment
+- Polling interval, per-request limits, and session / throughput controls
+- Allowlisted conversation or thread identifiers when limiting scope
+
+Exact names and defaults depend on the implementation you deploy.
+
+## Reliability and API limits
+
+- HTTP **429** rate limits are normal under load; services should **back off** using vendor reset headers when available
+- Tuning polling frequency and batch size is the primary stability lever
+
+## Relationship to AgenC
+
+This agent type is intended to **improve execution hygiene** for contributors working on protocol/marketplace/repo tasks: clearer lane choice, fewer dropped commitments, and faster unblock. It does not replace on-chain agents or runtime tooling; it complements operator workflow.
+
+## Security and privacy
+
+- Treat prompts and credentials as **secrets**
+- Prefer **minimal** public documentation that describes outcomes, not proprietary internals
+- Rotate credentials if anything was ever pasted into a ticket, chat, or screenshot


### PR DESCRIPTION
# Project Manager Agent (Public Overview)

## Purpose
The Project Manager agent supports execution coaching over X DMs by helping operators select a focus lane, define clear next actions, and maintain momentum with concise follow-up guidance.

## Public Capabilities
- Structured intake flow for execution planning
- Clarifying-question handling for ambiguous user requests
- Adaptive coaching tone (direct steps vs guided learning)
- Workflow support for distribution/raids and repository execution tracks
- Operational resilience through polling-based message handling and rate-limit backoff

## Deployment Model (Public)
- Hosted as a managed service
- Integrates with X DM APIs for message intake and response
- Uses polling fallback with backoff under API rate limits

## Configuration Surface (Public)
The service is configured via environment variables for:
- API credentials
- Polling cadence and limits
- Session behavior and response controls

Exact internal prompt policies, scoring logic, and decision thresholds are intentionally not published.

## Reliability Notes
- Handles API `429` responses using reset-aware backoff
- Recovers automatically after rate-limit windows reset
- Supports configurable polling parameters for stability/performance tradeoffs

## Security and Privacy Notes
- No credentials or tokens are stored in repository docs
- Proprietary policy logic remains in private runtime configuration
- Public docs describe behavior and operations, not private internals
