### PR TITLE
docs(concordia): clarify event_stream.py shim role and redirect imports

### DIFF
--- a/concordia_bridge/event_stream.py
+++ b/concordia_bridge/event_stream.py
@@ -1,8 +1,11 @@
 """
-Compatibility shim for the original event stream module.
+Compatibility shim — do not add logic here.
 
-`SimulationEvent` remains defined in `bridge_types.py`; this module preserves
-the import path referenced by the Concordia implementation plan.
+``SimulationEvent`` is defined in ``bridge_types.py``; this module exists solely
+to preserve the import path (``concordia_bridge.event_stream``) referenced by
+the original Concordia implementation plan (see CONCORDIA_TODO.MD).
+
+New code should import directly from ``concordia_bridge.bridge_types``.
 """
 
 from concordia_bridge.bridge_types import SimulationEvent


### PR DESCRIPTION
## Summary

\`event_stream.py\` is a compatibility shim that preserves the import path
referenced by the original Concordia implementation plan. The existing docstring
explains this, but doesn't warn against adding logic to the file or direct
contributors to the correct import path.

This change extends the docstring to:
- Explicitly mark the file as a shim with a "do not add logic here" guard
- Point to \`CONCORDIA_TODO.MD\` as the source of the original plan reference
- Guide new code toward importing directly from \`bridge_types.py\`

Noted as a Medium/Backlog item in \`.claude/notes/techdebt-2026-04-01.md\`.

## Changes
- \`concordia_bridge/event_stream.py\` — docstring only, no logic changes