### PR TITLE
docs: PROOF_OF_FEDERATION + umbrella pin-check tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,4 @@ __pycache__/
 **/.agenc/
 .pytest_cache/
 **/.pytest_cache/
+.canary-keys

--- a/docs/PROOF_OF_FEDERATION.md
+++ b/docs/PROOF_OF_FEDERATION.md
@@ -1,0 +1,90 @@
+# PROOF OF FEDERATION — mainnet 4-way settlement canary
+
+**Date:** 2026-07-02
+**Program:** `HJsZ53Zb27b8QMRbQpuDngE44AdwCGxvEZr61Zmxw1xK` (agenc-coordination, Solana mainnet)
+**WP:** B2 (the thesis proof) — protocol-level scope. See `../PLAN.md` §4.
+
+## What this proves
+
+A single service hire settled on Solana **mainnet** with all four economic legs
+paid **atomically in one instruction** — the exact mechanic the "every
+marketplace is a node in one global economy" thesis rests on:
+
+- **Worker** keeps the majority (85%).
+- **Operator** leg (supply-side marketplace cut) paid to an independent payee.
+- **Referrer** leg (demand-side marketplace cut) paid to a different independent payee.
+- **Protocol** fee paid to the AgenC treasury.
+
+The operator and referrer payees are distinct wallets that never signed — they
+only received — modelling two different marketplaces earning from one hire.
+
+## The settlement (the money shot)
+
+**accept_task_result:** [`5UdesDncXkAUpYRuEoUhDUUVKLrVWyBTf83cRWTRgVTa2QBeeWXyLgx8JBpzF6mgoMKUbCCdDA7dxKVk1mnYibkJ`](https://solscan.io/tx/5UdesDncXkAUpYRuEoUhDUUVKLrVWyBTf83cRWTRgVTa2QBeeWXyLgx8JBpzF6mgoMKUbCCdDA7dxKVk1mnYibkJ)
+
+Reward: 5,000,000 lamports (0.005 SOL). Live `protocol_fee_bps = 500` (5%),
+`operator_fee_bps = 500` (5%), `referrer_fee_bps = 500` (5%).
+
+| Leg | Payee | Amount | Verified delta |
+| --- | --- | --- | --- |
+| Worker (85%) | provider `Fv1pBRo5JKwiB4kE71W3Yw5caegMBio7ANNTQva28wmS` | 4,250,000 | escrow drained to worker |
+| Operator (5%) | `A2ULnbvEBGQyj8SqcJnEE9N4KFTPg7P329BvZ1SZR6ho` | 250,000 | **+250,000 confirmed** |
+| Referrer (5%) | `FgRHaC1i94aHM5ZvhPJrgEaxkzMghhpSLroZjykj36xu` | 250,000 | **+250,000 confirmed** |
+| Protocol (5%) | treasury `4tA32m8FRM1mVKTasuiEvbRksBJTGBvwF9jsT4WLM84n` | 250,000 | **+250,000 confirmed** |
+
+Shareable receipt (WP-H1): `https://agenc.ag/receipt/5UdesDncXkAUpYRuEoUhDUUVKLrVWyBTf83cRWTRgVTa2QBeeWXyLgx8JBpzF6mgoMKUbCCdDA7dxKVk1mnYibkJ`
+
+## Full lifecycle (every mainnet transaction)
+
+| Step | Instruction | Signature |
+| --- | --- | --- |
+| 1 | register_agent (provider) | `5X6MaNgPnp6HTgbAhweXgSkfwQmw8thf5XMNbVGsDkb3Z4vwbWhzUNL8qXKRMvUVdbDgdgSHZ5cGTCZknzyKutg5` |
+| 2 | register_agent (buyer) | `2fiZS9TExqdCPo5Zr7UHzGybxwcyQAaLV82eLgocqAxqykqBT3t3bQE9fMYT1aN8wH1SpHHF28SxKD9DiM3PZWfv` |
+| 3 | create_service_listing (**operator leg**) | `5Qx6MhYs7VRxZeWuzkTTprpK3p7gy3kW35pHRU1kTapQcS38r29Gn125M2HQrhd9PKCUugJV8RQun1kiT7edV2WE` |
+| 4 | record_listing_moderation (self-signed) | `46KkeDtZbcEcf6NtLmkkxwLPbiAKsKBymvm768Gh8FnPQREZY4iwbTA9hujE3FeqgtDqK1u3ZXtCHFhXQzD2msg2` |
+| 5 | hire_from_listing_humanless (**referrer leg** + escrow) | `5AFgjd5ygwE3rULhYFeWiYe9LcK3CfyUGX8jjSBSU5LaJ7uZGD86MWVkqSbQ9HLzZJx7RXRZ1uFvv5FvtqoPq1kf` |
+| 6 | record_task_moderation (self-signed) | `4qRXJaSK96yaZuHaatB6TpTTsKVKeSEUGpTLKC1c2F2RBWoeSLLJBGv14wDTKd9cwmyEfr1QRNkmaZUrm5s5jarz` |
+| 7 | set_task_job_spec (activate) | `3HckuWhjnsc6xrTWbG895vfhViY8q88hFPmX7PqTiM1SWBmrZf4sHVN9GbdWt53hS9kDo7MhqT27GDERkyoH5K8A` |
+| 8 | claim_task_with_job_spec | `BDDqVeCKaAZPT2oZbfACCzdhiGxTJTC66rYtzmWVG88bZUWfmaty2whf7c3fd6MGtbo8AyuNXVj2KvTHUpvPV1s` |
+| 9 | submit_task_result | `2prGvu9VWAQUGNk3REXcRk1pvKDhDT9ghmVXDfGPYQFcgXwgbnaeucNNgBkM4XnqPfgRjSkCaT5TnsJUFd5JhhCP` |
+| 10 | **accept_task_result (4-way split)** | `5UdesDncXkAUpYRuEoUhDUUVKLrVWyBTf83cRWTRgVTa2QBeeWXyLgx8JBpzF6mgoMKUbCCdDA7dxKVk1mnYibkJ` |
+| 11 | rate_hire | `532JfQ4EPtr8tqj61NisjRa5hVoxo5TGR84JdKg2UvmpCVXJy8cXik2ioBfjxiQXSf7G4yBsuXAFpaCHmFBakJ5p` |
+| 12 | close_task | `2fnRS3j41naCbEUvAqUdhNx2vmLR2na6WoGxV3hfvkqvNQHncakwhzUkbihK8pTVyHkHricSg1xfBnjqtmxX9uyA` |
+
+Key on-chain accounts: listing `5K3qmQxiKvdnVUNGB8wBo46Uyp2Vq2frYyxP3pszmv7b` · task
+`BT5TRMrqcgch6BYbSsYLG98JTw2LcWwrshJo4Wevgz2d` (closed) · hire record
+`FbfpeZwHyNUtTEZsntHBWNkcsrstuCksNkMBas95VLQ9`.
+
+## How it was run
+
+SDK-driven (`@tetsuo-ai/marketplace-sdk` 0.6.1) via a phase-structured executor
+with a double-armed broadcast gate; every transaction previewed (full account
+list) before broadcast, and the accept step's operator/referrer/treasury payees
+verified present + writable before settlement. Signers were throwaway plain
+keypairs funded from the operator's own wallet — the real encrypted vaults and
+the program upgrade authority were never used to sign a marketplace instruction.
+Moderation was self-signed by the on-chain moderation authority key
+(operator-supervised first-party path; the public attestation API is WP-C1).
+
+## Finding surfaced (real, feeds the plan)
+
+**Fee-leg payees must be rent-exempt.** The first settlement attempt failed with
+`insufficient funds for rent` — the operator and referrer payees started at 0
+lamports and a 250,000-lamport fee leg is below the 890,880-lamport
+rent-exemption floor for a system account, so the Solana runtime rejected the
+otherwise-successful settlement. Fix here was pre-funding the payees. Product
+implication (tracked for the SDK/docs and operator onboarding): a brand-new
+0-balance operator/referrer payee wallet cannot receive a small fee leg — the
+create/hire flows or docs must ensure fee payees are rent-exempt (real operator
+wallets normally are, but a freshly generated payee is not).
+
+## Scope / honesty
+
+This is the **protocol-level** federation proof: the 4-way split settles
+atomically on mainnet with independent operator and referrer payees. It does
+**not** yet include the full product path (a store scaffolded from
+`create-agenc-store` hiring an agenc.ag listing through the browser, both
+directions, moderation via the public WP-C1 API, agenc.ag prod deploy). Those
+remain the fuller WP-B2 product proof. What the thesis's core economic claim
+needed — "operator keeps its cut, referrer keeps its cut, protocol takes a
+slice, worker keeps the rest, all in one settlement" — is now demonstrated live.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "bootstrap:repos": "./scripts/bootstrap-agenc-repos.sh",
     "check:public-contract-boundary": "node scripts/check-public-contract-boundary.mjs",
-    "check:sibling-package-pins": "node agenc-core/scripts/check-sibling-package-pins.mjs --root .",
+    "check:sibling-package-pins": "node scripts/check-sibling-package-pins.mjs --root .",
     "check:umbrella-boundary": "node scripts/check-umbrella-boundary.mjs",
     "check:public-examples": "./scripts/smoke-test-examples.sh",
     "example:helius-webhook:server": "npm run server --workspace agenc-helius-webhook",

--- a/scripts/check-sibling-package-pins.mjs
+++ b/scripts/check-sibling-package-pins.mjs
@@ -1,0 +1,370 @@
+#!/usr/bin/env node
+// Warn when sibling package.json files pin stale @tetsuo-ai/* package versions.
+// Vendored into the umbrella repo 2026-07-02 from agenc-core@6baf0baec
+// (scripts/check-sibling-package-pins.mjs, deleted upstream in 7274fd9ed —
+// the umbrella owns its own validation now; --root . walks every sibling).
+
+import { spawnSync } from "node:child_process";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const DEPENDENCY_FIELDS = ["dependencies", "devDependencies"];
+const SKIP_DIRS = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  "dist",
+  "build",
+  "coverage",
+  "node_modules",
+]);
+const NPM_VIEW_TIMEOUT_MS = 15_000;
+
+export function isExactVersion(spec) {
+  if (typeof spec !== "string") return false;
+  try {
+    parseVersion(spec);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function compareVersions(left, right) {
+  const a = parseVersion(left);
+  const b = parseVersion(right);
+  for (let i = 0; i < 3; i += 1) {
+    if (a.core[i] < b.core[i]) return -1;
+    if (a.core[i] > b.core[i]) return 1;
+  }
+  return comparePrerelease(a.prerelease, b.prerelease);
+}
+
+export function findPackageJsonFiles(root) {
+  const out = [];
+  walk(root, out);
+  return out.sort((a, b) => relativePath(root, a).localeCompare(relativePath(root, b)));
+}
+
+export function collectPinnedTetsuoDependencies(root) {
+  const packages = [];
+  for (const packageJsonPath of findPackageJsonFiles(root)) {
+    let parsed;
+    try {
+      parsed = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    } catch (error) {
+      throw new Error(`could not parse ${relativePath(root, packageJsonPath)}: ${error.message}`);
+    }
+    for (const field of DEPENDENCY_FIELDS) {
+      const deps = parsed[field];
+      if (!deps || typeof deps !== "object") continue;
+      for (const [name, spec] of Object.entries(deps)) {
+        if (!name.startsWith("@tetsuo-ai/")) continue;
+        if (!isExactVersion(spec)) continue;
+        packages.push({
+          packageJsonPath,
+          packageDir: path.dirname(packageJsonPath),
+          field,
+          name,
+          spec,
+        });
+      }
+    }
+  }
+  return packages;
+}
+
+export function buildPinStalenessReport(options = {}) {
+  const root = path.resolve(options.root ?? resolveUmbrellaRoot(process.cwd()));
+  const seededLatestVersions = options.latestVersions ?? new Map();
+  const latestVersions =
+    seededLatestVersions instanceof Map
+      ? new Map(seededLatestVersions)
+      : new Map(Object.entries(seededLatestVersions));
+  const lookupLatest = options.lookupLatest ?? getLatestPublishedVersion;
+  const pins = collectPinnedTetsuoDependencies(root);
+  const stalePins = [];
+  // Packages that never resolve on the registry (unpublished/private workspace
+  // internals, e.g. the kit's @tetsuo-ai/marketplace-policy) are skipped with a
+  // note instead of failing the whole sweep — this umbrella mixes public and
+  // private repos.
+  const unresolvedPackages = new Map();
+
+  for (const pin of pins) {
+    if (unresolvedPackages.has(pin.name)) continue;
+    let latest = latestVersions.get(pin.name);
+    if (!latest) {
+      try {
+        latest = lookupLatest(pin.name);
+      } catch (error) {
+        unresolvedPackages.set(pin.name, error.message);
+        continue;
+      }
+      latestVersions.set(pin.name, latest);
+    }
+    if (compareVersions(pin.spec, latest) < 0) {
+      stalePins.push({
+        ...pin,
+        latest,
+        packageJson: relativePath(root, pin.packageJsonPath),
+        packageDirRelative: relativePath(root, pin.packageDir),
+        fixCommand: fixCommandForPin(root, pin, latest),
+      });
+    }
+  }
+
+  return {
+    root,
+    checkedPins: pins.length,
+    stalePins,
+    unresolvedPackages: Object.fromEntries(unresolvedPackages),
+  };
+}
+
+function parseVersion(version) {
+  const match =
+    /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(
+      version,
+    );
+  if (!match) throw new Error(`not a semver version: ${version}`);
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split(".") : [],
+  };
+}
+
+function comparePrerelease(left, right) {
+  if (left.length === 0 && right.length === 0) return 0;
+  if (left.length === 0) return 1;
+  if (right.length === 0) return -1;
+
+  const max = Math.max(left.length, right.length);
+  for (let i = 0; i < max; i += 1) {
+    const a = left[i];
+    const b = right[i];
+    if (a === undefined) return -1;
+    if (b === undefined) return 1;
+    if (a === b) continue;
+
+    const aNumeric = /^\d+$/.test(a);
+    const bNumeric = /^\d+$/.test(b);
+    if (aNumeric && bNumeric) {
+      const aNumber = Number(a);
+      const bNumber = Number(b);
+      if (aNumber < bNumber) return -1;
+      if (aNumber > bNumber) return 1;
+      continue;
+    }
+    if (aNumeric) return -1;
+    if (bNumeric) return 1;
+    return a < b ? -1 : 1;
+  }
+
+  return 0;
+}
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === "package.json") {
+      const file = path.join(dir, entry.name);
+      if (statSync(file).isFile()) out.push(file);
+      continue;
+    }
+    if (!entry.isDirectory()) continue;
+    if (SKIP_DIRS.has(entry.name)) continue;
+    if (entry.name.startsWith(".") && entry.name !== ".agenc") continue;
+    walk(path.join(dir, entry.name), out);
+  }
+}
+
+export function getLatestPublishedVersion(packageName, options = {}) {
+  const timeoutMs = options.timeoutMs ?? NPM_VIEW_TIMEOUT_MS;
+  const spawn = options.spawnSyncFn ?? spawnSync;
+  const result = spawn("npm", ["view", packageName, "version", "--silent"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: timeoutMs,
+  });
+  if (result.error) {
+    if (result.error.code === "ETIMEDOUT" || result.signal === "SIGTERM") {
+      throw new Error(`npm view ${packageName} version timed out after ${timeoutMs}ms`);
+    }
+    throw new Error(`npm view ${packageName} version failed to start: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `npm view ${packageName} version failed: ${(result.stderr || result.stdout).trim()}`,
+    );
+  }
+  const version = result.stdout.trim();
+  if (!isExactVersion(version)) {
+    throw new Error(`npm view ${packageName} returned invalid version: ${version}`);
+  }
+  return version;
+}
+
+function fixCommandForPin(root, pin, latest) {
+  const saveFlag = pin.field === "devDependencies" ? "--save-dev" : "--save-prod";
+  return [
+    "npm",
+    "install",
+    `${pin.name}@${latest}`,
+    "--save-exact",
+    saveFlag,
+    "--prefix",
+    shellQuote(relativePath(root, pin.packageDir)),
+  ].join(" ");
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) return value;
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function relativePath(root, file) {
+  return path.relative(root, file).split(path.sep).join("/") || ".";
+}
+
+function resolveUmbrellaRoot(cwd) {
+  const explicit = process.env.AGENC_UMBRELLA_ROOT;
+  if (explicit) return explicit;
+
+  const commonDir = gitCommonDir(cwd);
+  if (commonDir && path.basename(commonDir) === ".git") {
+    const mainCheckout = path.dirname(commonDir);
+    const parent = path.dirname(mainCheckout);
+    if (existsSync(path.join(parent, "package.json"))) return parent;
+  }
+
+  for (const candidate of [cwd, path.resolve(cwd, ".."), path.resolve(cwd, "..", "..")]) {
+    if (existsSync(path.join(candidate, "package.json"))) return candidate;
+  }
+  throw new Error("could not locate AgenC umbrella root; pass --root <path>");
+}
+
+function gitCommonDir(cwd) {
+  const result = spawnSync("git", ["rev-parse", "--git-common-dir"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) return null;
+  return path.resolve(cwd, result.stdout.trim());
+}
+
+function loadLatestVersions(filePath) {
+  const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+  return new Map(Object.entries(parsed));
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    root: undefined,
+    latestVersions: undefined,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--root") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--root requires a value");
+      parsed.root = value;
+      i += 1;
+    } else if (arg === "--latest-json") {
+      const value = argv[i + 1];
+      if (!value) throw new Error("--latest-json requires a value");
+      parsed.latestVersions = loadLatestVersions(value);
+      i += 1;
+    } else if (arg === "--json") {
+      parsed.json = true;
+    } else if (arg === "--help" || arg === "-h") {
+      usage();
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+function usage() {
+  process.stderr.write(
+    [
+      "Usage: node scripts/check-sibling-package-pins.mjs [--root <umbrella-root>] [--latest-json <file>] [--json]",
+      "",
+      "Warns when package.json dependencies/devDependencies pin stale @tetsuo-ai/* versions.",
+    ].join("\n") + "\n",
+  );
+}
+
+function printReport(report) {
+  const unresolved = Object.entries(report.unresolvedPackages ?? {});
+  for (const [name, reason] of unresolved) {
+    process.stdout.write(
+      `note: ${name} not resolvable on the registry (unpublished/private?) — pins skipped. (${reason.split("\n")[0]})\n`,
+    );
+  }
+  if (report.stalePins.length === 0) {
+    process.stdout.write(
+      `checked ${report.checkedPins} pinned @tetsuo-ai package(s); no stale pins found\n`,
+    );
+    return;
+  }
+  for (const pin of report.stalePins) {
+    process.stdout.write(
+      [
+        `warning: ${pin.packageJson} ${pin.field}.${pin.name} pins ${pin.spec}; latest published is ${pin.latest}.`,
+        `fix: ${pin.fixCommand}`,
+      ].join("\n") + "\n",
+    );
+  }
+  process.stdout.write(
+    `checked ${report.checkedPins} pinned @tetsuo-ai package(s); ${report.stalePins.length} stale pin(s) warned\n`,
+  );
+}
+
+async function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const report = buildPinStalenessReport(args);
+    if (args.json) {
+      process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    } else {
+      printReport(report);
+    }
+    process.exit(0);
+  } catch (error) {
+    process.stderr.write(`sibling package pin check failed: ${error.message}\n`);
+    process.exit(2);
+  }
+}
+
+function isMainModule() {
+  if (!process.argv[1]) return false;
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url)) ===
+      realpathSync(path.resolve(process.argv[1]))
+    );
+  } catch {
+    return fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
+  }
+}
+
+if (isMainModule()) {
+  await main();
+}


### PR DESCRIPTION
Two finished deliverables from the docs branch:

1. **docs/PROOF_OF_FEDERATION.md** — the WP-B2 mainnet canary proof: a 4-way
   split (worker 85% / operator 5% / referrer 5% / protocol 5%) settled
   atomically on mainnet with independent operator/referrer payees, every leg
   balance-verified on-chain (accept `5UdesDnc…`). Written as a public proof
   document. Also ignores `.canary-keys`.

2. **scripts/check-sibling-package-pins.mjs** — the sibling pin-staleness
   checker, vendored into the umbrella's own scripts/ (agenc-core deleted the
   original upstream in 7274fd9ed, leaving `check:sibling-package-pins`
   dangling) and hardened to skip unpublished/private packages instead of
   aborting. Verified with a full workspace run: 32 exact pins checked, 6
   stale warned (kit tools/mcp pins = the FD5 name-squat, deliberately not
   bumped; agenc-prover/admin-tools pins are that repo's own follow-up).

Internal planning documents are intentionally NOT part of this PR — this repo
is public.