### PR TITLE
fix: helius webhook auth + agenc-core in public bootstrap set

### DIFF
--- a/docs/COMMANDS_AND_VALIDATION.md
+++ b/docs/COMMANDS_AND_VALIDATION.md
@@ -119,14 +119,11 @@ Public-only:
 ./scripts/bootstrap-agenc-repos.sh --root /path/to/agenc
 ```
 
-Adding `agenc-core` and `agenc-prover`:
+Adding `agenc-prover` (the only repo that requires private access):
 
 ```bash
 ./scripts/bootstrap-agenc-repos.sh --root /path/to/agenc --private
 ```
-
-Of the two `--private` repos, only `agenc-prover` currently requires private
-access.
 
 ## Related Docs
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -84,14 +84,13 @@ by side:
 ./scripts/bootstrap-agenc-repos.sh --root /path/to/agenc
 ```
 
-To also include `agenc-core` and `agenc-prover`:
+To also include `agenc-prover`, the only repo that requires private access:
 
 ```bash
 ./scripts/bootstrap-agenc-repos.sh --root /path/to/agenc --private
 ```
 
-Of the bootstrap set, only `agenc-prover` currently requires private access;
-skip it (or the `--private` flag) if you do not have org credentials.
+Skip the `--private` flag if you do not have org credentials.
 
 ## Install The Root Workspace
 

--- a/examples/helius-webhook/README.md
+++ b/examples/helius-webhook/README.md
@@ -157,32 +157,18 @@ async function emitTaskCompletion(event: TaskCompletionEvent) {
 Without `HELIUS_WEBHOOK_SECRET`, no command will run, and the webhook server
 in particular cannot verify that requests originate from Helius.
 
-### Known gap: `create` never sends the secret to Helius
+### How delivery verification works
 
-The `create` command registers the webhook without an `authHeader`, so Helius
-has nothing to attach to deliveries and the server's signature check rejects
-every real delivery with 401. To close the gap, add one line to the request
-body in `createWebhook()` in `index.ts`:
-
-```typescript
-body: JSON.stringify({
-  webhookURL: webhookUrl,
-  transactionTypes: ['ANY'],
-  accountAddresses: [ROUTER_PROGRAM_ID, VERIFIER_PROGRAM_ID, AGENC_PROGRAM_ID],
-  webhookType: 'enhanced',
-  txnStatus: 'success',
-  authHeader: process.env.HELIUS_WEBHOOK_SECRET, // add this line
-}),
-```
-
-Per the current
+The `create` command registers the webhook with `authHeader` set to
+`HELIUS_WEBHOOK_SECRET`. Per the
 [Helius create-webhook API reference](https://www.helius.dev/docs/api-reference/webhooks/create-webhook),
-`authHeader` is an authorization header value included verbatim in webhook
-deliveries for verifying the sender; Helius does not compute a per-payload
-HMAC. The shipped server instead expects a hex HMAC of the body in an
-`x-helius-signature` header, so after adding `authHeader`, also update
-`verifyWebhookSignature()` to timing-safe-compare the header Helius actually
-sends against the shared secret.
+Helius includes that value verbatim in the `Authorization` header of every
+delivery; it does not compute a per-payload HMAC. The server's
+`verifyWebhookAuth()` timing-safe-compares the delivered header against the
+shared secret and rejects everything else with 401.
+
+If you rotate `HELIUS_WEBHOOK_SECRET`, delete and re-create the webhook so
+Helius starts sending the new value.
 
 ```bash
 # Production deployment

--- a/examples/helius-webhook/index.ts
+++ b/examples/helius-webhook/index.ts
@@ -124,26 +124,28 @@ function checkRateLimit(ip: string): boolean {
 }
 
 /**
- * Verify Helius webhook signature
+ * Verify the Helius webhook auth header
  * SECURITY: Prevents webhook spoofing attacks
- * @see https://docs.helius.xyz/webhooks/webhook-security
+ *
+ * The webhook is registered with `authHeader` set to HELIUS_WEBHOOK_SECRET,
+ * and Helius includes that value verbatim in the Authorization header of
+ * every delivery. Helius does not compute a per-payload HMAC.
+ * @see https://www.helius.dev/docs/api-reference/webhooks/create-webhook
  */
-function verifyWebhookSignature(payload: string, signature: string | undefined): boolean {
-  if (!signature) {
+function verifyWebhookAuth(authHeader: string | undefined): boolean {
+  if (!authHeader) {
     return false;
   }
 
-  const expectedSignature = crypto
-    .createHmac('sha256', VERIFIED_HELIUS_WEBHOOK_SECRET)
-    .update(payload)
-    .digest('hex');
+  const received = Buffer.from(authHeader);
+  const expected = Buffer.from(VERIFIED_HELIUS_WEBHOOK_SECRET);
+  if (received.length !== expected.length) {
+    return false;
+  }
 
   // Use timing-safe comparison to prevent timing attacks
   try {
-    return crypto.timingSafeEqual(
-      Buffer.from(signature),
-      Buffer.from(expectedSignature)
-    );
+    return crypto.timingSafeEqual(received, expected);
   } catch {
     return false;
   }
@@ -233,6 +235,7 @@ async function createWebhook(webhookUrl: string): Promise<string> {
       accountAddresses: [ROUTER_PROGRAM_ID, VERIFIER_PROGRAM_ID, AGENC_PROGRAM_ID],
       webhookType: 'enhanced',
       txnStatus: 'success',
+      authHeader: VERIFIED_HELIUS_WEBHOOK_SECRET,
     }),
   });
 
@@ -465,12 +468,12 @@ function handleWebhookRequest(req: Request, res: Response): void {
     return;
   }
 
-  const signature = req.headers['x-helius-signature'] as string | undefined;
+  const authHeader = req.headers['authorization'] as string | undefined;
   const rawBody = readRawRequestBody(req.body);
 
-  if (!verifyWebhookSignature(rawBody.toString('utf8'), signature)) {
-    console.warn(chalk.red('Invalid webhook signature from IP:'), clientIp);
-    res.status(401).json({ error: 'Invalid signature' });
+  if (!verifyWebhookAuth(authHeader)) {
+    console.warn(chalk.red('Invalid webhook auth header from IP:'), clientIp);
+    res.status(401).json({ error: 'Unauthorized' });
     return;
   }
 

--- a/scripts/bootstrap-agenc-repos.sh
+++ b/scripts/bootstrap-agenc-repos.sh
@@ -11,7 +11,7 @@ directory.
 Options:
   --root <dir>  Destination parent directory. Defaults to the parent of the
                 current AgenC checkout.
-  --private     Include private repositories (`agenc-core`, `agenc-prover`).
+  --private     Include private repositories (`agenc-prover`).
   --help        Show this help text.
 EOF
 }
@@ -50,10 +50,10 @@ PUBLIC_REPOS=(
   "agenc-sdk"
   "agenc-protocol"
   "agenc-plugin-kit"
+  "agenc-core"
 )
 
 PRIVATE_REPOS=(
-  "agenc-core"
   "agenc-prover"
 )
 


### PR DESCRIPTION
Follow-up to #1569, closing the two code items the docs refresh documented but did not change:

- **helius-webhook**: `create` now registers the webhook with `authHeader: HELIUS_WEBHOOK_SECRET`, and the server verifies the `Authorization` header Helius actually sends (timing-safe compare) instead of expecting a per-payload HMAC in `x-helius-signature` that Helius never computes. Real deliveries no longer 401. README's "known gap" section replaced with the implemented behavior.
- **bootstrap**: `agenc-core` is public on GitHub now, so `scripts/bootstrap-agenc-repos.sh` clones it in the default public set; `--private` covers only `agenc-prover`. GETTING_STARTED and COMMANDS_AND_VALIDATION synced.

Verified: `bash -n` on the script, helius example typechecks, `npm run validate:umbrella` exit 0.

https://claude.ai/code/session_012zTgDskmX3VcxinZL9PNvq